### PR TITLE
server/onboarding: fix jumping processed numbers

### DIFF
--- a/server/polar/eventstream/endpoints.py
+++ b/server/polar/eventstream/endpoints.py
@@ -21,13 +21,13 @@ async def subscribe(redis: Redis, channels: list[str]):
         await pubsub.subscribe(*channels)
 
         while True:
-            message = await pubsub.get_message(ignore_subscribe_messages=True)
+            message = await pubsub.get_message(
+                ignore_subscribe_messages=True, timeout=30.0
+            )
+
             if message is not None:
                 log.info("redis.pubsub", message=message["data"])
                 yield message["data"]
-
-            # TODO: Move this to a configuration setting
-            await asyncio.sleep(0.1)
 
 
 @router.get("/user/stream")

--- a/server/polar/integrations/github/tasks/repo.py
+++ b/server/polar/integrations/github/tasks/repo.py
@@ -51,7 +51,9 @@ async def sync_repository_pull_requests(
             session, organization_id, repository_id
         )
         await service.github_repository.sync_pull_requests(
-            session, organization=organization, repository=repository
+            session,
+            organization=organization,
+            repository=repository,
         )
         await enqueue_job(
             "github.repo.sync.issue_references", organization.id, repository.id

--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -41,7 +41,6 @@ async def repositories_changed(
     if not event.installation:
         return dict(success=False)
 
-    # TODO: Verify that this works even for personal Github accounts?
     organization = await service.github_organization.get_by_external_id(
         session, event.installation.account.id
     )
@@ -308,7 +307,6 @@ async def installation_created(
         raise Exception("unexpected webhook payload")
 
     async with AsyncSessionLocal() as session:
-
         # TODO: Remove this once the following issue is resolved:
         # https://github.com/yanyongyu/githubkit/issues/14
         if event.requester is None:

--- a/server/polar/notifications/service.py
+++ b/server/polar/notifications/service.py
@@ -334,7 +334,6 @@ class NotificationsService:
         )
         res = await session.execute(stmt)
         await session.commit()
-        # print(res.)
 
 
 def get_cents_in_dollar_string(cents: int) -> str:

--- a/server/polar/receivers/onboarding.py
+++ b/server/polar/receivers/onboarding.py
@@ -16,18 +16,16 @@ from polar.postgres import AsyncSession
 log = structlog.get_logger()
 
 
-@repository_issue_synced.connect  # type: ignore
+@repository_issue_synced.connect
 async def on_issue_synced(
     session: AsyncSession,
     *,
     repository: Repository,
     organization: Organization,
     record: Issue,
-    created: bool,
     processed: int,
-    synced: int,
 ) -> None:
-    log.info("issue.synced", issue=record.id, title=record.title)
+    log.info("issue.synced", issue=record.id, title=record.title, processed=processed)
     await publish(
         "issue.synced",
         {
@@ -37,29 +35,26 @@ async def on_issue_synced(
             },
             "expected": repository.open_issues or 0,
             "processed": processed,
-            "synced": synced,
             "repository_id": repository.id,
         },
         organization_id=organization.id,
     )
 
 
-@repository_issues_sync_completed.connect  # type: ignore
+@repository_issues_sync_completed.connect
 async def on_issue_sync_completed(
     session: AsyncSession,
     *,
     repository: Repository,
     organization: Organization,
     processed: int,
-    synced: int,
 ) -> None:
-    log.info("issue.sync.completed", repository=repository.id, synced=synced)
+    log.info("issue.sync.completed", repository=repository.id, processed=processed)
     await publish(
         "issue.sync.completed",
         {
             "expected": repository.open_issues or 0,
             "processed": processed,
-            "synced": synced,
             "repository_id": repository.id,
         },
         organization_id=organization.id,
@@ -71,7 +66,7 @@ async def on_issue_sync_completed(
 ###############################################################################
 
 
-@issue_created.connect  # type: ignore
+@issue_created.connect
 async def on_issue_created(issue: Issue, session: AsyncSession) -> None:
     await publish(
         "issue.created",
@@ -81,7 +76,7 @@ async def on_issue_created(issue: Issue, session: AsyncSession) -> None:
     )
 
 
-@issue_updated.connect  # type: ignore
+@issue_updated.connect
 async def on_issue_updated(issue: Issue, session: AsyncSession) -> None:
     await publish(
         "issue.updated",
@@ -95,7 +90,7 @@ async def on_issue_updated(issue: Issue, session: AsyncSession) -> None:
     )
 
 
-@pull_request_created.connect  # type: ignore
+@pull_request_created.connect
 async def on_pull_request_created(pr: PullRequest, session: AsyncSession) -> None:
     await publish(
         "pull_request.created",
@@ -105,7 +100,7 @@ async def on_pull_request_created(pr: PullRequest, session: AsyncSession) -> Non
     )
 
 
-@pull_request_updated.connect  # type: ignore
+@pull_request_updated.connect
 async def on_pull_request_updated(pr: PullRequest, session: AsyncSession) -> None:
     await publish(
         "pull_request.updated",


### PR DESCRIPTION
The issue happened because we where triggering message updates both for the PR and the issues syncing. We only need to do it for issues. Also took the liberty to clean some things up.

Fixes #194 (again!)