### PR TITLE
Set installation context on all paths

### DIFF
--- a/server/polar/context.py
+++ b/server/polar/context.py
@@ -9,6 +9,11 @@ class PolarContext:
 class ExecutionContext:
     _contextvar: ClassVar[ContextVar] = ContextVar("ExecutionContext")
 
+    # is_during_installation is True this is an event (or request) triggered by the app
+    # or repository installation flow.
+    #
+    # It allows us to, for example, prevent creating notifications for objects
+    # found during the initial syncing.
     is_during_installation: bool
 
     def __init__(self, is_during_installation=False):

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -12,6 +12,7 @@ from fastapi import (
 from httpx_oauth.clients.github import GitHubOAuth2
 from httpx_oauth.integrations.fastapi import OAuth2AuthorizeCallback
 from pydantic import BaseModel, ValidationError
+from polar.context import ExecutionContext
 
 from polar.kit import jwt
 from polar.auth.dependencies import Auth
@@ -156,9 +157,10 @@ async def install(
     session: AsyncSession = Depends(get_db_session),
     auth: Auth = Depends(Auth.current_user),
 ) -> Organization | None:
-    organization = await github_organization.install(
-        session, auth.user, installation_id=installation.external_id
-    )
+    with ExecutionContext(is_during_installation=True) as context:
+        organization = await github_organization.install(
+            session, auth.user, installation_id=installation.external_id
+        )
 
     return organization
 

--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -386,7 +386,7 @@ async def installation_created(
     payload: dict[str, Any],
     polar_context: PolarWorkerContext,
 ) -> dict[str, Any]:
-    with polar_context.to_execution_context() as context:
+    with ExecutionContext(is_during_installation=True) as context:
         event = github.webhooks.parse_obj(scope, payload)
         if not isinstance(event, github.webhooks.InstallationCreated):
             log.error("github.webhook.unexpected_type")


### PR DESCRIPTION
Fixes #303

This took wayyyy too long to find and debug. The triggering endpoint is many layers of magic away from the action of creating the notification. `Repository.upsert_many` schedules full crawl/sync jobs, that in turn schedules other jobs, and finally deep down the notifications are created 😅.

I also fund that we're triggering two concurrent full syncs of repositories (once from the webhook, and once from the API) during installation, can we limit it to one somehow?

I ended up creating my own very hacky tracing library to even track this condition down.