### PR TITLE
clients/web: make pledge page and status responsive

### DIFF
--- a/clients/apps/web/src/components/Website/Pledge/index.tsx
+++ b/clients/apps/web/src/components/Website/Pledge/index.tsx
@@ -15,10 +15,10 @@ const Pledge = ({
     <>
       <div className="my-14 flex flex-col">
         <WhiteCard
-          className="flex flex-row items-stretch p-2 text-center"
+          className="flex flex-col items-stretch p-2 text-center md:flex-row"
           padding={false}
         >
-          <div className="w-1/2">
+          <div className="md:w-1/2">
             <IssueCard
               issue={issue}
               className="bg-blue-50"
@@ -26,7 +26,7 @@ const Pledge = ({
               repository={repository}
             />
           </div>
-          <div className="w-1/2 text-left">
+          <div className="text-left md:w-1/2">
             <div className="py-5 px-6">
               <PledgeForm
                 organization={organization}

--- a/clients/apps/web/src/pages/[organization]/[repo]/issues/[number]/index.tsx
+++ b/clients/apps/web/src/pages/[organization]/[repo]/issues/[number]/index.tsx
@@ -10,7 +10,7 @@ const HowItWorks: NextLayoutComponentType = () => {
     <>
       <div className="text-center">
         <h4 className="text-lg font-normal text-gray-600">How does it work?</h4>
-        <ul className="mt-8 flex flex-row justify-center space-x-16">
+        <ul className="mt-8 flex flex-col items-center justify-center space-y-8 md:flex-row md:space-y-0 md:space-x-16">
           <li className="flex w-56 flex-col text-center">
             <div className="mx-auto w-7 rounded-full border-2 border-blue-800">
               <span className="text-sm font-bold text-blue-800">1</span>
@@ -67,7 +67,7 @@ const PledgePage: NextPage = ({
       <Head>
         <title>Polar | {issue.title}</title>
       </Head>
-      <div className="mx-auto mt-24 w-[826px]">
+      <div className="mx-auto mt-24 md:w-[826px]">
         <h1 className="text-center text-4xl font-normal text-gray-800">
           Complete your backing
         </h1>

--- a/clients/apps/web/src/pages/[organization]/[repo]/issues/[number]/status.tsx
+++ b/clients/apps/web/src/pages/[organization]/[repo]/issues/[number]/status.tsx
@@ -29,7 +29,7 @@ const PledgeStatusPage: NextLayoutComponentType = ({
 
   return (
     <>
-      <div className="mx-auto mt-24 w-[768px]">
+      <div className="mx-auto p-4 md:mt-24 md:w-[768px] md:p-0">
         <div className="flex flex-row items-center">
           <h1 className="w-1/2 text-2xl font-normal text-gray-800">
             <CheckCircleIcon className="inline-block h-10 w-10 text-blue-500" />{' '}
@@ -53,12 +53,12 @@ const PledgeStatusPage: NextLayoutComponentType = ({
         {!currentUser && (
           <>
             <WhiteCard className="mt-11 flex flex-row" padding={false}>
-              <div className="w-2/5 p-5">
+              <div className="flex flex-col space-y-5 p-5 md:w-2/5">
                 <h2 className="text-lg text-gray-900">Sign up to Polar</h2>
                 <GithubLoginButton pledgeId={pledge.id} />
 
                 <ul>
-                  <li className="mt-5 flex flex-row items-center">
+                  <li className="flex flex-row items-center">
                     <svg
                       className="mr-3 h-6 w-6"
                       viewBox="0 0 24 24"
@@ -137,7 +137,7 @@ const PledgeStatusPage: NextLayoutComponentType = ({
                   </li>
                 </ul>
               </div>
-              <div className="w-3/5 border-l border-gray-200 bg-gray-50"></div>
+              <div className="hidden w-3/5  border-l border-gray-200 bg-gray-50 md:block"></div>
             </WhiteCard>
           </>
         )}


### PR DESCRIPTION
![Farmer_meme_with_apostrophe](https://github.com/polarsource/polar/assets/47952/b50eafde-3985-4762-99bf-fee719105b1b)


<img width="612" alt="Screenshot 2023-05-10 at 09 02 21" src="https://github.com/polarsource/polar/assets/47952/33ae0591-ea50-4d55-960f-bf319f2530b5">
<img width="612" alt="Screenshot 2023-05-10 at 09 02 29" src="https://github.com/polarsource/polar/assets/47952/fcb0799d-ceee-43a2-83d6-be731861d230">

Fixes #215 