### PR TITLE
ci: build server docker image and publish to ghcr.io

### DIFF
--- a/.github/workflows/build_server.yaml
+++ b/.github/workflows/build_server.yaml
@@ -1,0 +1,39 @@
+name: Server Build and Release
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  linters:
+    name: "Server: Build 🐳"
+    timeout-minutes: 15
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v4.0.0
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ghcr.io/polarsource/polar:latest
+          context: ./server
+          platforms: linux/amd64,linux/arm64/v8
+


### PR DESCRIPTION
This will enable us to use custom built docker images on Render.com
