### PR TITLE
clients/badge: replace shadow with border

### DIFF
--- a/clients/packages/polarkit/src/components/Badge.tsx
+++ b/clients/packages/polarkit/src/components/Badge.tsx
@@ -25,7 +25,6 @@ export const Badge = ({
       <div
         style={{
           display: 'flex',
-          padding: 2,
         }}
       >
         <div
@@ -36,9 +35,7 @@ export const Badge = ({
             alignItems: 'center',
             backgroundColor: darkmode ? '#3E3F42' /*gray-700*/ : 'white',
             borderRadius: 11,
-            margin: 5,
-            boxShadow:
-              '0px 1px 8px rgba(0, 0, 0, 0.07), 0px 0.5px 2.5px rgba(0, 0, 0, 0.2)',
+            border: '1px solid rgba(0, 0, 0, 0.07)',
             fontFamily: 'Inter',
             overflow: 'hidden',
           }}


### PR DESCRIPTION
Remove shadow and margins to align button with text.

I have no strong opinion about this, so I'll leave the decision up to you two @birkjernstrom  @petterheterjag.

## After

<img width="1499" alt="Screenshot 2023-05-24 at 09 44 16" src="https://github.com/polarsource/polar/assets/47952/5776cfcf-4f22-4fe2-a290-b982a4f40c28">

## Before

<img width="1499" alt="Screenshot 2023-05-24 at 09 52 01" src="https://github.com/polarsource/polar/assets/47952/3f1b4eec-7ebf-4ce0-993d-69d85081afe3">

Fixes #539