### PR TITLE
clients/settings: show private repositories again

### DIFF
--- a/clients/apps/web/src/components/Settings/Badge/Repositories.tsx
+++ b/clients/apps/web/src/components/Settings/Badge/Repositories.tsx
@@ -18,10 +18,6 @@ export const BadgeRepositories = ({
   ) => void
   isSettingPage?: boolean
 }) => {
-  if (isSettingPage) {
-    repos = repos.filter((repo) => repo.is_private === false)
-  }
-
   return (
     <>
       <h2

--- a/clients/apps/web/src/stories/BadgeRepositories.stories.ts
+++ b/clients/apps/web/src/stories/BadgeRepositories.stories.ts
@@ -64,3 +64,19 @@ export const SettingsPage: Story = {
     isSettingPage: true,
   },
 }
+
+export const SettingsPageNoPublic: Story = {
+  args: {
+    ...Default.args,
+    repos: [
+      {
+        ...repo,
+        is_private: true,
+        name: 'polar-clients-ios-toolkit-framework-long-name',
+      },
+      { ...repo, is_private: true, name: 'polar_private' },
+    ],
+    showControls: true,
+    isSettingPage: true,
+  },
+}


### PR DESCRIPTION
It's a bit of a compromize, but this makes sure that the list never can be empty.
