### PR TITLE
Align badge with text in pull request

### DIFF
--- a/clients/packages/polarkit/src/components/Badge.tsx
+++ b/clients/packages/polarkit/src/components/Badge.tsx
@@ -25,7 +25,7 @@ export const Badge = ({
       <div
         style={{
           display: 'flex',
-          padding: 2,
+          paddingBottom: 2,
         }}
       >
         <div
@@ -36,9 +36,10 @@ export const Badge = ({
             alignItems: 'center',
             backgroundColor: darkmode ? '#3E3F42' /*gray-700*/ : 'white',
             borderRadius: 11,
-            margin: 5,
-            boxShadow:
-              '0px 1px 8px rgba(0, 0, 0, 0.07), 0px 0.5px 2.5px rgba(0, 0, 0, 0.2)',
+            boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.06)',
+            border: darkmode
+              ? '1px solid rgba(255, 255, 255, 0.08)'
+              : '1px solid rgba(0, 0, 0, 0.11)',
             fontFamily: 'Inter',
             overflow: 'hidden',
           }}


### PR DESCRIPTION
Removed padding/margin and instead made the shadow shorter and with less blur so that it doesn't get cut off on the sides.

<img width="647" alt="Screenshot 2023-05-24 at 16 02 16" src="https://github.com/polarsource/polar/assets/1426460/bfe697d6-76b7-4063-a711-c9259bb28c00">

Closes #539 