### PR TITLE
clients/stories: disable BadgeRepositories in chromatic

### DIFF
--- a/clients/apps/web/src/stories/BadgeRepositories.stories.ts
+++ b/clients/apps/web/src/stories/BadgeRepositories.stories.ts
@@ -48,12 +48,20 @@ export const Default: Story = {
     showControls: false,
     isSettingPage: false,
   },
+  parameters: {
+    // Disable chromatic for this component as it's using animations
+    chromatic: { disableSnapshot: true },
+  },
 }
 
 export const ShowControls: Story = {
   args: {
     ...Default.args,
     showControls: true,
+  },
+  parameters: {
+    // Disable chromatic for this component as it's using animations
+    chromatic: { disableSnapshot: true },
   },
 }
 


### PR DESCRIPTION
This components uses a lot of animations which is hard to test reliably with chromatic
