### PR TITLE
server/dashboard: change Triaged definition

### DIFF
--- a/server/polar/dashboard/endpoints.py
+++ b/server/polar/dashboard/endpoints.py
@@ -397,7 +397,7 @@ def issue_progress(issue: Issue) -> IssueStatus:
         return IssueStatus.in_progress
 
     # triaged
-    if issue.labels or issue.assignee or issue.assignees:
+    if issue.assignee or issue.assignees:
         return IssueStatus.triaged
 
     # backlog

--- a/server/polar/issue/service.py
+++ b/server/polar/issue/service.py
@@ -176,7 +176,6 @@ class IssueService(ResourceService[Issue, IssueCreate, IssueUpdate]):
 
             is_triaged = and_(
                 or_(
-                    Issue.labels.is_not(None),
                     Issue.assignee.is_not(None),
                     Issue.assignees.is_not(None),
                 ),


### PR DESCRIPTION
Only assigning an issue will count as triaged from now. Having a label will not count as triaged.

Fixes #549