### PR TITLE
clients/web/Gatekeeper: lazily check and verify auth

### DIFF
--- a/clients/apps/web/src/components/Dashboard/Gatekeeper/Gatekeeper.tsx
+++ b/clients/apps/web/src/components/Dashboard/Gatekeeper/Gatekeeper.tsx
@@ -1,9 +1,18 @@
 import InviteOnly from '@/components/Dashboard/Gatekeeper/InviteOnly'
-import { useRequireAuth } from '@/hooks'
+import { useAuth } from '@/hooks/auth'
+import { useUser } from 'polarkit/hooks'
+import { useEffect } from 'react'
 import AcceptTerms from './AcceptTerms'
 
 const Gatekeeper = (props: { children: React.ReactElement }) => {
-  const { currentUser } = useRequireAuth()
+  const { currentUser, reloadUser } = useAuth()
+  const user = useUser()
+
+  useEffect(() => {
+    if (user.failureReason?.status === 401) {
+      reloadUser()
+    }
+  }, [user, reloadUser])
 
   if (currentUser && !currentUser.invite_only_approved) {
     return <InviteOnly />

--- a/clients/apps/web/src/pages/dashboard/initialize/[organization]/index.tsx
+++ b/clients/apps/web/src/pages/dashboard/initialize/[organization]/index.tsx
@@ -60,10 +60,12 @@ const Page: NextLayoutComponentType = () => {
 
 Page.getLayout = (page: ReactElement) => {
   return (
-    <>
-      <Topbar hideProfile={true} />
-      <Gatekeeper>{page}</Gatekeeper>
-    </>
+    <Gatekeeper>
+      <>
+        <Topbar hideProfile={true} />
+        {page}
+      </>
+    </Gatekeeper>
   )
 }
 

--- a/clients/apps/web/src/pages/dashboard/settings/[organization]/index.tsx
+++ b/clients/apps/web/src/pages/dashboard/settings/[organization]/index.tsx
@@ -1,3 +1,4 @@
+import Gatekeeper from '@/components/Dashboard/Gatekeeper/Gatekeeper'
 import RepoSelection from '@/components/Dashboard/RepoSelection'
 import EmptyLayout from '@/components/Layout/EmptyLayout'
 import BadgeSetup from '@/components/Settings/Badge'
@@ -243,12 +244,14 @@ const SettingsTopbar = () => {
 
 SettingsPage.getLayout = (page: ReactElement) => {
   return (
-    <EmptyLayout>
-      <>
-        <SettingsTopbar />
-        {page}
-      </>
-    </EmptyLayout>
+    <Gatekeeper>
+      <EmptyLayout>
+        <>
+          <SettingsTopbar />
+          {page}
+        </>
+      </EmptyLayout>
+    </Gatekeeper>
   )
 }
 

--- a/clients/apps/web/src/pages/dashboard/settings/extension.tsx
+++ b/clients/apps/web/src/pages/dashboard/settings/extension.tsx
@@ -1,3 +1,4 @@
+import Gatekeeper from '@/components/Dashboard/Gatekeeper/Gatekeeper'
 import LoadingScreen from '@/components/Dashboard/LoadingScreen'
 import Layout from '@/components/Layout/EmptyLayout'
 import type { NextPageWithLayout } from '@/utils/next'
@@ -38,7 +39,11 @@ const ExtensionSettingsPage: NextPageWithLayout = () => {
 }
 
 ExtensionSettingsPage.getLayout = (page: ReactElement) => {
-  return <Layout>{page}</Layout>
+  return (
+    <Gatekeeper>
+      <Layout>{page}</Layout>
+    </Gatekeeper>
+  )
 }
 
 export default ExtensionSettingsPage

--- a/clients/apps/web/src/pages/dashboard/settings/index.tsx
+++ b/clients/apps/web/src/pages/dashboard/settings/index.tsx
@@ -1,3 +1,4 @@
+import Gatekeeper from '@/components/Dashboard/Gatekeeper/Gatekeeper'
 import LoadingScreen from '@/components/Dashboard/LoadingScreen'
 import Layout from '@/components/Layout/EmptyLayout'
 import type { NextPageWithLayout } from '@/utils/next'
@@ -20,7 +21,11 @@ const Page: NextPageWithLayout = () => {
 }
 
 Page.getLayout = (page: ReactElement) => {
-  return <Layout>{page}</Layout>
+  return (
+    <Gatekeeper>
+      <Layout>{page}</Layout>
+    </Gatekeeper>
+  )
 }
 
 export default Page


### PR DESCRIPTION
If the app has a user in localStorage, but the cookie is invalid or missing, reload the user fully, and ask the user to login.

Fixes #589