### PR TITLE
server/auth: do not use secure cookies on localhost

### DIFF
--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -117,7 +117,7 @@ async def github_callback(
     goto_url = state_data.get("goto_url", None)
 
     return AuthService.generate_login_cookie_response(
-        response=response, user=user, goto_url=goto_url
+        request=request, response=response, user=user, goto_url=goto_url
     )
 
 


### PR DESCRIPTION
Safari does not consider localhost/127.0.0.1 to be a "secure" context, and does not store secure cookies on this domain.

Fixes #607 