### PR TITLE
client/web: stricter tsconfig import paths

### DIFF
--- a/clients/apps/web/tsconfig.json
+++ b/clients/apps/web/tsconfig.json
@@ -8,6 +8,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "next.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Spotted this when trying to improve the suggested import paths by vscode in the monorepo
