### PR TITLE
Don't crawl stuff if rate limit is low

### DIFF
--- a/server/polar/integrations/github/service/api.py
+++ b/server/polar/integrations/github/service/api.py
@@ -5,10 +5,26 @@ from githubkit.typing import QueryParamTypes
 from githubkit.utils import UNSET, exclude_unset
 from githubkit.rest.models import BasicError
 
+from polar.kit.schemas import Schema
+
 T = TypeVar("T")
 
+class RateLimit(Schema):
+    limit: int
+    remaining: int
+    used: int
+    reset: int
 
 class GitHubApi:
+    async def get_rate_limit(self, client: GitHub[Any]) -> RateLimit:
+        r = await client.rest.meta.async_get_octocat()
+        return RateLimit(
+            limit=int(r.headers["X-RateLimit-Limit"]),
+            remaining=int(r.headers["X-RateLimit-Remaining"]),
+            used=int(r.headers["X-RateLimit-Used"]),
+            reset=int(r.headers["X-RateLimit-Reset"]),
+        )
+
     # Support for custom headers
     # TODO: https://github.com/yanyongyu/githubkit/issues/29
     async def async_request_with_headers(

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -265,6 +265,7 @@ class GithubIssueService(IssueService):
     async def list_issues_to_crawl_issue(
         self,
         session: AsyncSession,
+        organization: Organization,
     ) -> Sequence[Issue]:
         current_time = datetime.datetime.utcnow()
         one_hour_ago = current_time - datetime.timedelta(hours=1)
@@ -282,9 +283,10 @@ class GithubIssueService(IssueService):
                 Organization.deleted_at.is_(None),
                 Repository.deleted_at.is_(None),
                 Organization.installation_id.is_not(None),
+                Organization.id == organization.id,
             )
             .order_by(asc(Issue.github_issue_fetched_at))
-            .limit(1000)
+            .limit(100)
         )
 
         res = await session.execute(stmt)
@@ -294,6 +296,7 @@ class GithubIssueService(IssueService):
     async def list_issues_to_crawl_timeline(
         self,
         session: AsyncSession,
+        organization: Organization,
     ) -> Sequence[Issue]:
         current_time = datetime.datetime.utcnow()
         one_hour_ago = current_time - datetime.timedelta(hours=1)
@@ -311,9 +314,10 @@ class GithubIssueService(IssueService):
                 Organization.deleted_at.is_(None),
                 Repository.deleted_at.is_(None),
                 Organization.installation_id.is_not(None),
+                Organization.id == organization.id,
             )
             .order_by(asc(Issue.github_timeline_fetched_at))
-            .limit(1000)
+            .limit(100)
         )
 
         res = await session.execute(stmt)

--- a/server/polar/integrations/github/tasks/issue.py
+++ b/server/polar/integrations/github/tasks/issue.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 import structlog
 from polar.integrations.github import service
+from polar.integrations.github.client import get_app_installation_client
 
 from polar.worker import JobContext, PolarWorkerContext, enqueue_job, interval, task
 from polar.postgres import AsyncSessionLocal
@@ -8,6 +9,7 @@ from polar.postgres import AsyncSessionLocal
 from .utils import get_organization_and_repo
 from ..service.issue import github_issue
 from ..service.api import github_api
+from polar.organization.service import organization as organization_service
 
 log = structlog.get_logger()
 
@@ -111,15 +113,30 @@ async def issue_sync_issue_dependencies(
 )
 async def cron_refresh_issues(ctx: JobContext) -> None:
     async with AsyncSessionLocal() as session:
-        issues = await github_issue.list_issues_to_crawl_issue(session)
+        orgs = await organization_service.list_installed(session)
+        for org in orgs:
+            client = get_app_installation_client(org.installation_id)
+            rate_limit = await github_api.get_rate_limit(client)
 
-        log.info(
-            "github.issue.sync.cron_refresh_issues",
-            found_count=len(issues),
-        )
+            if rate_limit.remaining < 1000:
+                log.info(
+                    "github.issue.sync.cron_refresh_issues.rate_limit_almost_exhausted",
+                    org_name=org.name,
+                    rate_limit_remaining=rate_limit.remaining,
+                )
+                return
 
-        for issue in issues:
-            await enqueue_job("github.issue.sync", issue.id)
+            issues = await github_issue.list_issues_to_crawl_issue(session, org)
+
+            log.info(
+                "github.issue.sync.cron_refresh_issues",
+                org_name=org.name,
+                found_count=len(issues),
+                rate_limit_remaining=rate_limit.remaining,
+            )
+
+            for issue in issues:
+                await enqueue_job("github.issue.sync", issue.id)
 
 
 @interval(
@@ -128,12 +145,27 @@ async def cron_refresh_issues(ctx: JobContext) -> None:
 )
 async def cron_refresh_issue_timelines(ctx: JobContext) -> None:
     async with AsyncSessionLocal() as session:
-        issues = await github_issue.list_issues_to_crawl_timeline(session)
+        orgs = await organization_service.list_installed(session)
+        for org in orgs:
+            client = get_app_installation_client(org.installation_id)
+            rate_limit = await github_api.get_rate_limit(client)
 
-        log.info(
-            "github.issue.sync.cron_refresh_issue_timelines",
-            found_count=len(issues),
-        )
+            if rate_limit.remaining < 1000:
+                log.info(
+                    "github.issue.sync.cron_refresh_issue_timelines.rate_limit_almost_exhausted",
+                    org_name=org.name,
+                    rate_limit_remaining=rate_limit.remaining,
+                )
+                return
 
-        for issue in issues:
-            await enqueue_job("github.issue.sync.issue_references", issue.id)
+            issues = await github_issue.list_issues_to_crawl_timeline(session, org)
+
+            log.info(
+                "github.issue.sync.cron_refresh_issue_timelines",
+                org_name=org.name,
+                found_count=len(issues),
+                rate_limit_remaining=rate_limit.remaining,
+            )
+
+            for issue in issues:
+                await enqueue_job("github.issue.sync.issue_references", issue.id)

--- a/server/polar/integrations/github/tasks/issue.py
+++ b/server/polar/integrations/github/tasks/issue.py
@@ -7,6 +7,7 @@ from polar.postgres import AsyncSessionLocal
 
 from .utils import get_organization_and_repo
 from ..service.issue import github_issue
+from ..service.api import github_api
 
 log = structlog.get_logger()
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -38,6 +38,17 @@ class OrganizationService(
     def upsert_constraints(self) -> list[InstrumentedAttribute[int]]:
         return [self.model.external_id]
 
+    async def list_installed(self, session: AsyncSession) -> Sequence[Organization]:
+        stmt = (
+            sql.select(Organization)
+            .where(
+                Organization.deleted_at.is_(None),
+                Organization.installation_id.is_not(None),
+            )
+        )
+        res = await session.execute(stmt)
+        return res.scalars().all()
+
     async def get_by_platform(
         self, session: AsyncSession, platform: Platforms, external_id: int
     ) -> Organization | None:


### PR DESCRIPTION
If we're rate limited to less than 1000 requests left for an org, don't run the two cron:ed crawl jobs for those orgs.

Do this instead of trying to be smarted about how to crawl, as #674 tried.

Fixes #654
Closes #674 