### PR TITLE
Redirect to login on unauthenticated

### DIFF
--- a/clients/apps/web/src/components/Dashboard/Gatekeeper/Gatekeeper.tsx
+++ b/clients/apps/web/src/components/Dashboard/Gatekeeper/Gatekeeper.tsx
@@ -1,20 +1,9 @@
 import InviteOnly from '@/components/Dashboard/Gatekeeper/InviteOnly'
-import { useAuth } from '@/hooks'
-import { useEffect, useState } from 'react'
+import { useRequireAuth } from '@/hooks'
 import AcceptTerms from './AcceptTerms'
 
 const Gatekeeper = (props: { children: React.ReactElement }) => {
-  const { currentUser } = useAuth()
-
-  // TODO: make use of serverside props instead, and we wouldn't need this workaround
-  const [ready, setReady] = useState(false)
-  useEffect(() => {
-    setReady(true)
-  })
-
-  if (!ready) {
-    return <></>
-  }
+  const { currentUser } = useRequireAuth()
 
   if (!currentUser) {
     return <></>

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -14,6 +14,7 @@ export const useAuth = (): UserState & {
   const login = useStore((state) => state.login)
   const logout = useStore((state) => state.logout)
 
+  const [hydrated, setHydrated] = useState(false)
   const [hasChecked, setHasChecked] = useState(false)
   const [isChecking, setIsChecking] = useState(false)
 
@@ -26,6 +27,7 @@ export const useAuth = (): UserState & {
   }, [setIsChecking, setHasChecked, login])
 
   useEffect(() => {
+    setHydrated(true)
     if (hasChecked || authenticated) {
       return
     }
@@ -36,7 +38,19 @@ export const useAuth = (): UserState & {
         request.cancel()
       }
     }
-  }, [authenticated, hasChecked, getAuthenticatedUser])
+  }, [authenticated, hasChecked, getAuthenticatedUser, hydrated])
+
+  if (!hydrated) {
+    return {
+      authenticated: false,
+      currentUser: undefined,
+      hasChecked: false,
+      isChecking: false,
+      login,
+      logout,
+      reloadUser: getAuthenticatedUser,
+    }
+  }
 
   return {
     authenticated,

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -72,17 +72,15 @@ export const useRequireAuth = (): UserState & {
 
   if (!session.authenticated && session.hasChecked) {
     let redirectPath = CONFIG.LOGIN_PATH
-    if (typeof window !== 'undefined') {
-      const currentURL = new URL(window.location.href)
-      const redirectURL = new URL(window.location.origin + redirectPath)
+    const currentURL = new URL(window.location.href)
+    const redirectURL = new URL(window.location.origin + redirectPath)
 
-      if (currentURL.pathname !== redirectPath) {
-        redirectURL.searchParams.set(
-          'goto_url',
-          currentURL.toString().replace(window.location.origin, ''),
-        )
-        redirectPath = redirectURL.toString()
-      }
+    if (currentURL.pathname !== redirectPath) {
+      redirectURL.searchParams.set(
+        'goto_url',
+        currentURL.toString().replace(window.location.origin, ''),
+      )
+      redirectPath = redirectURL.toString()
     }
 
     router.push(redirectPath)

--- a/clients/apps/web/src/pages/dashboard/settings/[organization]/index.tsx
+++ b/clients/apps/web/src/pages/dashboard/settings/[organization]/index.tsx
@@ -12,7 +12,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useOrganization, useUserOrganizations } from 'polarkit/hooks'
 import { useStore } from 'polarkit/store'
-import { ReactElement, useEffect, useMemo, useRef } from 'react'
+import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react'
 
 const SettingsPage: NextLayoutComponentType = () => {
   const router = useRouter()
@@ -45,7 +45,7 @@ const SettingsPage: NextLayoutComponentType = () => {
     return orgData.data && handle !== 'personal'
   }, [orgData, handle])
 
-  const showPersonalSettings = useMemo(() => {
+  const showPersonalSettings = useCallback(() => {
     return handle === 'personal' || handle === currentUser?.username
   }, [handle])
 

--- a/clients/apps/web/src/pages/dashboard/settings/[organization]/index.tsx
+++ b/clients/apps/web/src/pages/dashboard/settings/[organization]/index.tsx
@@ -12,7 +12,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useOrganization, useUserOrganizations } from 'polarkit/hooks'
 import { useStore } from 'polarkit/store'
-import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react'
+import { ReactElement, useEffect, useMemo, useRef } from 'react'
 
 const SettingsPage: NextLayoutComponentType = () => {
   const router = useRouter()
@@ -45,9 +45,9 @@ const SettingsPage: NextLayoutComponentType = () => {
     return orgData.data && handle !== 'personal'
   }, [orgData, handle])
 
-  const showPersonalSettings = useCallback(() => {
+  const showPersonalSettings = useMemo(() => {
     return handle === 'personal' || handle === currentUser?.username
-  }, [handle])
+  }, [handle, currentUser])
 
   const showBadgeSettings = useMemo(() => {
     return showOrgSettings

--- a/clients/packages/polarkit/src/store/userContext.ts
+++ b/clients/packages/polarkit/src/store/userContext.ts
@@ -16,9 +16,7 @@ export interface UserState {
   login: (
     callback?: (authenticated: boolean) => void,
   ) => CancelablePromise<UserRead>
-  logout: (
-    callback?: (authenticated: boolean) => void,
-  ) => CancelablePromise<any>
+  logout: () => CancelablePromise<any>
 }
 
 export interface OnboardingState {


### PR DESCRIPTION
Fix #633

Move hydration check to useAuth. Thereby allowing Gatekeeper to use useRequireAuth and
automatically redirect unauthenticated users appropriately.

- clients/web: Gatekeeper to require auth + centralize auth hydration fix
- clients/polarkit: Remove unused logout callback handler
- clients/web: useRequireAuth always run clientside – no need to check
