### PR TITLE
Fix SSE

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -81,6 +81,8 @@ class Settings(BaseSettings):
 
     POSTHOG_PROJECT_API_KEY: str = ""
 
+    SSE_SLEEP_INTERVAL: float = 0.001
+
     class Config:
         env_prefix = "polar_"
         env_file_encoding = "utf-8"

--- a/server/polar/eventstream/endpoints.py
+++ b/server/polar/eventstream/endpoints.py
@@ -4,7 +4,6 @@ from typing import Any, AsyncGenerator
 import structlog
 from fastapi import APIRouter, Depends
 from sse_starlette.sse import EventSourceResponse
-from fastapi import Request
 
 
 from polar.enums import Platforms
@@ -24,16 +23,11 @@ log = structlog.get_logger()
 async def subscribe(
     redis: Redis,
     channels: list[str],
-    request: Request,
 ) -> AsyncGenerator[Any, Any]:
     async with redis.pubsub() as pubsub:
         await pubsub.subscribe(*channels)
 
         while True:
-            if await request.is_disconnected():
-                await pubsub.close()
-                break
-
             try:
                 message = await pubsub.get_message(
                     ignore_subscribe_messages=True,
@@ -52,24 +46,22 @@ async def subscribe(
 
 @router.get("/user/stream")
 async def user_stream(
-    request: Request,
     auth: Auth = Depends(Auth.current_user),
     redis: Redis = Depends(get_redis),
 ) -> EventSourceResponse:
     receivers = Receivers(user_id=auth.user.id)
-    return EventSourceResponse(subscribe(redis, receivers.get_channels(), request))
+    return EventSourceResponse(subscribe(redis, receivers.get_channels()))
 
 
 @router.get("/{platform}/{org_name}/stream")
 async def user_org_stream(
     platform: Platforms,
     org_name: str,
-    request: Request,
     auth: Auth = Depends(Auth.user_with_org_access),
     redis: Redis = Depends(get_redis),
 ) -> EventSourceResponse:
     receivers = Receivers(user_id=auth.user.id, organization_id=auth.organization.id)
-    return EventSourceResponse(subscribe(redis, receivers.get_channels(), request))
+    return EventSourceResponse(subscribe(redis, receivers.get_channels()))
 
 
 @router.get("/{platform}/{org_name}/{repo_name}/stream")
@@ -77,7 +69,6 @@ async def user_org_repo_stream(
     platform: Platforms,
     org_name: str,
     repo_name: str,
-    request: Request,
     auth: Auth = Depends(Auth.user_with_org_and_repo_access),
     redis: Redis = Depends(get_redis),
 ) -> EventSourceResponse:
@@ -86,4 +77,4 @@ async def user_org_repo_stream(
         organization_id=auth.organization.id,
         repository_id=auth.repository.id,
     )
-    return EventSourceResponse(subscribe(redis, receivers.get_channels(), request))
+    return EventSourceResponse(subscribe(redis, receivers.get_channels()))


### PR DESCRIPTION
Root cause was using & awaiting request.is_disconnected().

It uses anyio.CancelScope to await/receive cancellations. It crashed
silently when it ran inside of our infinite SSE loop.

As I dug deeper into redis-py, sse-starlette and starlette investigating this,
I saw that all examples had a short sleep to spare CPU even with get_message() being
non-blocking. Since it polls constantly using select. Nice to have a tiny breather in-between.

- server/sse: Remove usage of Starlette request.is_disconnected
- server/sse: Add minimal sleep
