### PR TITLE
Pledge confirmation pending state

### DIFF
--- a/clients/apps/chrome-extension/src/components/CachedIssueListItemDecoration.tsx
+++ b/clients/apps/chrome-extension/src/components/CachedIssueListItemDecoration.tsx
@@ -73,6 +73,11 @@ const CachedIssueListItemDecoration = ({
                   issueNumber={number}
                   pledges={value.pledges}
                   references={value.references}
+                  showConfirmPledgeAction={false}
+                  showDisputeAction={false}
+                  onConfirmPledges={async () => {}}
+                  onDispute={() => {}}
+                  confirmPledgeIsLoading={false}
                 />
               </div>
             )

--- a/clients/apps/chrome-extension/src/components/CachedIssueListItemDecoration.tsx
+++ b/clients/apps/chrome-extension/src/components/CachedIssueListItemDecoration.tsx
@@ -70,6 +70,7 @@ const CachedIssueListItemDecoration = ({
                 <IssueListItemDecoration
                   orgName={orgName}
                   repoName={repoName}
+                  issueNumber={number}
                   pledges={value.pledges}
                   references={value.references}
                 />

--- a/clients/apps/web/src/components/Dashboard/IssueListItem.tsx
+++ b/clients/apps/web/src/components/Dashboard/IssueListItem.tsx
@@ -269,6 +269,7 @@ const IssueListItem = (props: {
             <IssueListItemDecoration
               orgName={props.org.name}
               repoName={props.repo.name}
+              issueNumber={props.issue.number}
               pledges={mergedPledges}
               references={props.references}
               showDisputeAction={true}

--- a/clients/apps/web/src/components/Dashboard/IssueListItem.tsx
+++ b/clients/apps/web/src/components/Dashboard/IssueListItem.tsx
@@ -10,6 +10,7 @@ import {
   IssueReferenceRead,
   IssueStatus,
   OrganizationPublicRead,
+  Platforms,
   RepositoryPublicRead,
   RepositoryRead,
   type PledgeRead,
@@ -21,6 +22,7 @@ import {
   generateMarkdownTitle,
 } from 'polarkit/components/Issue'
 import { PolarTimeAgo, PrimaryButton } from 'polarkit/components/ui'
+import { useIssueMarkConfirmed } from 'polarkit/hooks'
 import { getCentsInDollarString, githubIssueUrl } from 'polarkit/utils'
 import { ChangeEvent, useState } from 'react'
 import PledgeNow from '../Pledge/PledgeNow'
@@ -141,6 +143,21 @@ const IssueListItem = (props: {
   }
 
   const [isHovered, setIsHovered] = useState(false)
+
+  const markConfirmed = useIssueMarkConfirmed()
+
+  const onConfirmPledge = async (
+    orgName: string,
+    repoName: string,
+    issueNumber: number,
+  ) => {
+    await markConfirmed.mutateAsync({
+      platform: Platforms.GITHUB,
+      orgName,
+      repoName,
+      issueNumber,
+    })
+  }
 
   return (
     <>
@@ -274,6 +291,9 @@ const IssueListItem = (props: {
               references={props.references}
               showDisputeAction={true}
               onDispute={onDispute}
+              showConfirmPledgeAction={true}
+              onConfirmPledges={onConfirmPledge}
+              confirmPledgeIsLoading={markConfirmed.isLoading}
             />
           </IssueActivityBox>
         )}

--- a/clients/apps/web/src/components/Notifications/Popover.tsx
+++ b/clients/apps/web/src/components/Notifications/Popover.tsx
@@ -14,6 +14,7 @@ import { GitMergeIcon } from 'polarkit/components/icons'
 import { PolarTimeAgo, PrimaryButton } from 'polarkit/components/ui'
 import {
   useGetPledge,
+  useIssueMarkConfirmed,
   useNotifications,
   useNotificationsMarkRead,
 } from 'polarkit/hooks'
@@ -212,12 +213,25 @@ const MaintainerPledgeConfirmationPendingWrapper = ({
     return pledge.data?.state === PledgeState.PENDING
   }, [pledge])
 
+  const markSolved = useIssueMarkConfirmed()
+
+  const onMarkSolved = async () => {
+    await markSolved.mutateAsync({
+      platform: Platforms.GITHUB,
+      orgName: payload.issue_org_name,
+      repoName: payload.issue_repo_name,
+      issueNumber: payload.issue_number,
+    })
+  }
+
   return (
     <MaintainerPledgeConfirmationPending
       n={n}
       payload={payload}
       canMarkSolved={canMarkSolved}
       isMarkedSolved={isMarkedSolved}
+      isLoading={markSolved.isLoading}
+      onMarkSoved={onMarkSolved}
     />
   )
 }
@@ -227,11 +241,15 @@ export const MaintainerPledgeConfirmationPending = ({
   payload,
   canMarkSolved,
   isMarkedSolved,
+  isLoading,
+  onMarkSoved,
 }: {
   n: NotificationRead
   payload: MaintainerPledgeConfirmationPendingNotification
   canMarkSolved: boolean
   isMarkedSolved: boolean
+  isLoading: boolean
+  onMarkSoved: () => Promise<void>
 }) => {
   return (
     <Item
@@ -253,7 +271,13 @@ export const MaintainerPledgeConfirmationPending = ({
             </div>
             <div>
               {canMarkSolved && (
-                <PrimaryButton fullWidth={false}>
+                <PrimaryButton
+                  fullWidth={false}
+                  size="small"
+                  loading={isLoading}
+                  disabled={isLoading}
+                  onClick={onMarkSoved}
+                >
                   <span>Mark as solved</span>
                 </PrimaryButton>
               )}

--- a/clients/apps/web/src/components/Notifications/Popover.tsx
+++ b/clients/apps/web/src/components/Notifications/Popover.tsx
@@ -222,7 +222,7 @@ const MaintainerPledgeConfirmationPendingWrapper = ({
   )
 }
 
-const MaintainerPledgeConfirmationPending = ({
+export const MaintainerPledgeConfirmationPending = ({
   n,
   payload,
   canMarkSolved,
@@ -240,7 +240,7 @@ const MaintainerPledgeConfirmationPending = ({
     >
       {{
         text: (
-          <div className="flex flex-col space-y-2">
+          <div className="flex flex-col space-y-1">
             <div>
               Confirm that{' '}
               <Link href={payload.issue_url}>
@@ -257,7 +257,11 @@ const MaintainerPledgeConfirmationPending = ({
                   <span>Mark as solved</span>
                 </PrimaryButton>
               )}
-              {isMarkedSolved && <>Confirmed!</>}
+              {isMarkedSolved && (
+                <div className="font-medium text-green-600">
+                  Marked as solved
+                </div>
+              )}
             </div>
           </div>
         ),

--- a/clients/apps/web/src/stories/BadgePromotionModal.stories.tsx
+++ b/clients/apps/web/src/stories/BadgePromotionModal.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { BadgePromotionModal } from '@/components/Dashboard/IssuePromotionModal'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from 'polarkit'
 import { IssueDashboardRead, OrganizationPublicRead } from 'polarkit/api/client'
 import { issue, org, repo, user } from './testdata'
 
@@ -26,6 +28,13 @@ const meta: Meta<typeof BadgePromotionModal> = {
     isShown: true,
     toggle: () => {},
     user: user,
+  },
+  render: (args) => {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <BadgePromotionModal {...args} />
+      </QueryClientProvider>
+    )
   },
 }
 

--- a/clients/apps/web/src/stories/IssueListItem.stories.tsx
+++ b/clients/apps/web/src/stories/IssueListItem.stories.tsx
@@ -452,6 +452,8 @@ export const PledgeDisputableMultiple: Story = {
 export const PledgeConfirmationPending: Story = {
   args: {
     ...Default.args,
+    issue: issueClosed,
+    references: referencesMerged,
     pledges: [
       {
         ...pledge,

--- a/clients/apps/web/src/stories/IssueListItem.stories.tsx
+++ b/clients/apps/web/src/stories/IssueListItem.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from 'polarkit'
 import {
   ExternalGitHubCommitReference,
   IssueDashboardRead,
@@ -13,7 +15,7 @@ import {
 } from 'polarkit/api/client'
 import { IssueReadWithRelations } from 'polarkit/api/types'
 import IssueListItem from '../components/Dashboard/IssueListItem'
-import { addDays, addHours, issue, org, repo } from './testdata'
+import { addDays, addHours, issue, org, pledge, repo } from './testdata'
 
 type Story = StoryObj<typeof IssueListItem>
 
@@ -323,6 +325,13 @@ const meta: Meta<typeof IssueListItem> = {
     org: org,
     issue: dashboardIssue,
   },
+  render: (args) => {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <IssueListItem {...args} />
+      </QueryClientProvider>
+    )
+  },
 }
 
 export default meta
@@ -440,12 +449,25 @@ export const PledgeDisputableMultiple: Story = {
   },
 }
 
+export const PledgeConfirmationPending: Story = {
+  args: {
+    ...Default.args,
+    pledges: [
+      {
+        ...pledge,
+        state: PledgeState.CONFIRMATION_PENDING,
+      },
+    ],
+  },
+}
+
 export const Dependency: Story = {
   args: {
     ...Default.args,
     dependents: [dependents],
   },
 }
+
 export const DependencyMultiple: Story = {
   args: {
     ...Default.args,

--- a/clients/apps/web/src/stories/IssueListItem.stories.tsx
+++ b/clients/apps/web/src/stories/IssueListItem.stories.tsx
@@ -43,6 +43,7 @@ const pledgeDisputable: PledgeRead[] = [
     state: PledgeState.PENDING,
     scheduled_payout_at: addDays(new Date(), 7).toISOString(),
     authed_user_can_admin: true,
+    authed_user_can_admin_sender: true,
     pledger_name: 'zz',
   },
 ]
@@ -58,6 +59,7 @@ const pledgeDisputableToday: PledgeRead[] = [
     state: PledgeState.PENDING,
     scheduled_payout_at: addHours(new Date(), 2).toISOString(),
     authed_user_can_admin: true,
+    authed_user_can_admin_sender: true,
     pledger_name: 'zz',
   },
 ]
@@ -73,6 +75,7 @@ const pledgeDisputableYesterday: PledgeRead[] = [
     state: PledgeState.PENDING,
     scheduled_payout_at: addDays(new Date(), -1).toISOString(),
     authed_user_can_admin: true,
+    authed_user_can_admin_sender: true,
     pledger_name: 'zz',
   },
 ]
@@ -87,6 +90,7 @@ const pledgeDisputed: PledgeRead[] = [
     organization_id: 'yy',
     state: PledgeState.DISPUTED,
     authed_user_can_admin: true,
+    authed_user_can_admin_sender: true,
     pledger_name: 'zz',
   },
 ]
@@ -100,7 +104,7 @@ const pledgeDisputedByOther: PledgeRead[] = [
     repository_id: 'xx',
     organization_id: 'yy',
     state: PledgeState.DISPUTED,
-    authed_user_can_admin: false,
+    authed_user_can_admin_received: true,
     pledger_name: 'zz',
   },
 ]
@@ -458,6 +462,22 @@ export const PledgeConfirmationPending: Story = {
       {
         ...pledge,
         state: PledgeState.CONFIRMATION_PENDING,
+        authed_user_can_admin_received: true,
+      },
+    ],
+  },
+}
+
+export const PledgeConfirmationPendingConfirmed: Story = {
+  args: {
+    ...Default.args,
+    issue: issueClosed,
+    references: referencesMerged,
+    pledges: [
+      {
+        ...pledge,
+        state: PledgeState.PENDING,
+        authed_user_can_admin_received: true,
       },
     ],
   },

--- a/clients/apps/web/src/stories/Notification.stories.ts
+++ b/clients/apps/web/src/stories/Notification.stories.ts
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { Notification } from '../components/Notifications/Popover'
 import {
+  MaintainerPledgeConfirmationPending,
+  Notification,
+} from '../components/Notifications/Popover'
+import {
+  notification_maintainerPledgeConfirmationPendingNotification,
   notification_maintainerPledgeCreatedNotification,
   notification_maintainerPledgePaidNotification,
   notification_maintainerPledgePendingNotification,
@@ -41,3 +45,14 @@ export const PledgerPledgePendingNotificationItem: Story = {
     n: notification_pledgerPledgePendingNotification,
   },
 }
+
+type StoryConfirmationPending = StoryObj<
+  typeof MaintainerPledgeConfirmationPending
+>
+
+export const MaintainerPledgeConfirmationPendingNotificationItem: StoryConfirmationPending =
+  {
+    args: {
+      n: notification_maintainerPledgeConfirmationPendingNotification,
+    },
+  }

--- a/clients/apps/web/src/stories/Notification.stories.tsx
+++ b/clients/apps/web/src/stories/Notification.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from 'polarkit'
 import {
   MaintainerPledgeConfirmationPending,
   Notification,
@@ -15,7 +17,6 @@ import {
 const meta: Meta<typeof Notification> = {
   title: 'Organisms/Notification',
   component: Notification,
-  tags: ['autodocs'],
 }
 
 export default meta
@@ -54,5 +55,34 @@ export const MaintainerPledgeConfirmationPendingNotificationItem: StoryConfirmat
   {
     args: {
       n: notification_maintainerPledgeConfirmationPendingNotification,
+      payload:
+        notification_maintainerPledgeConfirmationPendingNotification.payload,
+      canMarkSolved: false,
+      isMarkedSolved: false,
+    },
+    render: (args) => {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <MaintainerPledgeConfirmationPending {...args} />
+        </QueryClientProvider>
+      )
+    },
+  }
+
+export const MaintainerPledgeConfirmationPendingNotificationItemCanSolve: StoryConfirmationPending =
+  {
+    ...MaintainerPledgeConfirmationPendingNotificationItem,
+    args: {
+      ...MaintainerPledgeConfirmationPendingNotificationItem.args,
+      canMarkSolved: true,
+    },
+  }
+
+export const MaintainerPledgeConfirmationPendingNotificationItemIsSolved: StoryConfirmationPending =
+  {
+    ...MaintainerPledgeConfirmationPendingNotificationItem,
+    args: {
+      ...MaintainerPledgeConfirmationPendingNotificationItem.args,
+      isMarkedSolved: true,
     },
   }

--- a/clients/apps/web/src/stories/Notification.stories.tsx
+++ b/clients/apps/web/src/stories/Notification.stories.tsx
@@ -59,6 +59,7 @@ export const MaintainerPledgeConfirmationPendingNotificationItem: StoryConfirmat
         notification_maintainerPledgeConfirmationPendingNotification.payload,
       canMarkSolved: false,
       isMarkedSolved: false,
+      onMarkSoved: async () => {},
     },
     render: (args) => {
       return (
@@ -75,6 +76,16 @@ export const MaintainerPledgeConfirmationPendingNotificationItemCanSolve: StoryC
     args: {
       ...MaintainerPledgeConfirmationPendingNotificationItem.args,
       canMarkSolved: true,
+    },
+  }
+
+export const MaintainerPledgeConfirmationPendingNotificationItemLoading: StoryConfirmationPending =
+  {
+    ...MaintainerPledgeConfirmationPendingNotificationItem,
+    args: {
+      ...MaintainerPledgeConfirmationPendingNotificationItem.args,
+      canMarkSolved: true,
+      isLoading: true,
     },
   }
 

--- a/clients/apps/web/src/stories/OrganizationPublicPage.stories.tsx
+++ b/clients/apps/web/src/stories/OrganizationPublicPage.stories.tsx
@@ -1,6 +1,8 @@
 import PublicLayout from '@/components/Layout/PublicLayout'
 import OrganizationPublicPage from '@/components/Organization/OrganizationPublicPage'
 import type { Meta, StoryObj } from '@storybook/react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from 'polarkit'
 import { issue, org, repo } from './testdata'
 
 const meta: Meta<typeof OrganizationPublicPage> = {
@@ -54,9 +56,11 @@ export const Default: Story = {
   },
   render: (args) => {
     return (
-      <PublicLayout>
-        <OrganizationPublicPage {...args} />
-      </PublicLayout>
+      <QueryClientProvider client={queryClient}>
+        <PublicLayout>
+          <OrganizationPublicPage {...args} />
+        </PublicLayout>
+      </QueryClientProvider>
     )
   },
 }

--- a/clients/apps/web/src/stories/PrimaryButton.stories.tsx
+++ b/clients/apps/web/src/stories/PrimaryButton.stories.tsx
@@ -18,10 +18,18 @@ export const Primary: Story = {
   },
 }
 
-export const PrimarySkinny: Story = {
+export const PrimaryNonFullWidth: Story = {
   args: {
-    children: 'Click me',
+    children: <span>Click me</span>,
     fullWidth: false,
+  },
+}
+
+export const PrimaryNonFullWidthSizeSmall: Story = {
+  args: {
+    children: <span>Click me</span>,
+    fullWidth: false,
+    size: 'small',
   },
 }
 

--- a/clients/apps/web/src/stories/RepositoryPublicPage.stories.tsx
+++ b/clients/apps/web/src/stories/RepositoryPublicPage.stories.tsx
@@ -1,6 +1,8 @@
 import PublicLayout from '@/components/Layout/PublicLayout'
 import RepositoryPublicPage from '@/components/Organization/RepositoryPublicPage'
 import type { Meta, StoryObj } from '@storybook/react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from 'polarkit'
 import { issue, org, repo } from './testdata'
 
 const meta: Meta<typeof RepositoryPublicPage> = {
@@ -41,9 +43,11 @@ export const Default: Story = {
   },
   render: (args) => {
     return (
-      <PublicLayout>
-        <RepositoryPublicPage {...args} />
-      </PublicLayout>
+      <QueryClientProvider client={queryClient}>
+        <PublicLayout>
+          <RepositoryPublicPage {...args} />
+        </PublicLayout>
+      </QueryClientProvider>
     )
   },
 }

--- a/clients/apps/web/src/stories/testdata.ts
+++ b/clients/apps/web/src/stories/testdata.ts
@@ -1,5 +1,6 @@
 import {
   IssueRead,
+  MaintainerPledgeConfirmationPendingNotification,
   MaintainerPledgeCreatedNotification,
   MaintainerPledgePaidNotification,
   MaintainerPledgePendingNotification,
@@ -123,6 +124,18 @@ const maintainerPledgeCreatedNotification: MaintainerPledgeCreatedNotification =
     maintainer_has_stripe_account: false,
   }
 
+const maintainerPledgeConfirmationPendingNotification: MaintainerPledgeConfirmationPendingNotification =
+  {
+    pledger_name: 'xx',
+    pledge_amount: '123.50',
+    issue_url: '#',
+    issue_title: 'Hello World',
+    issue_org_name: 'polarsource',
+    issue_repo_name: 'polar',
+    issue_number: 123,
+    maintainer_has_stripe_account: false,
+  }
+
 const maintainerPledgePendingNotification: MaintainerPledgePendingNotification =
   {
     pledger_name: 'xx',
@@ -161,6 +174,12 @@ export const notification_maintainerPledgeCreatedNotification: NotificationRead 
     type: NotificationType.MAINTAINER_PLEDGE_CREATED_NOTIFICATION,
     payload: maintainerPledgeCreatedNotification,
   }
+
+export const notification_maintainerPledgeConfirmationPendingNotification = {
+  ...notification_maintainerPledgeCreatedNotification,
+  type: NotificationType.MAINTAINER_PLEDGE_CONFIRMATION_PENDING_NOTIFICATION,
+  payload: maintainerPledgeConfirmationPendingNotification,
+}
 
 export const notification_maintainerPledgePendingNotification = {
   ...notification_maintainerPledgeCreatedNotification,

--- a/clients/packages/polarkit/src/api/client/index.ts
+++ b/clients/packages/polarkit/src/api/client/index.ts
@@ -38,6 +38,7 @@ export { IssueStatus } from './models/IssueStatus';
 export type { IssueUpdateBadgeMessage } from './models/IssueUpdateBadgeMessage';
 export type { LoginResponse } from './models/LoginResponse';
 export type { LogoutResponse } from './models/LogoutResponse';
+export type { MaintainerPledgeConfirmationPendingNotification } from './models/MaintainerPledgeConfirmationPendingNotification';
 export type { MaintainerPledgeCreatedNotification } from './models/MaintainerPledgeCreatedNotification';
 export type { MaintainerPledgePaidNotification } from './models/MaintainerPledgePaidNotification';
 export type { MaintainerPledgePendingNotification } from './models/MaintainerPledgePendingNotification';

--- a/clients/packages/polarkit/src/api/client/index.ts
+++ b/clients/packages/polarkit/src/api/client/index.ts
@@ -15,6 +15,7 @@ export type { AccountRead } from './models/AccountRead';
 export { AccountType } from './models/AccountType';
 export type { AuthorizationResponse } from './models/AuthorizationResponse';
 export type { BackofficePledgeRead } from './models/BackofficePledgeRead';
+export type { ConfirmPledgesResponse } from './models/ConfirmPledgesResponse';
 export type { Entry_Any_ } from './models/Entry_Any_';
 export type { Entry_IssueDashboardRead_ } from './models/Entry_IssueDashboardRead_';
 export type { ExternalGitHubCommitReference } from './models/ExternalGitHubCommitReference';

--- a/clients/packages/polarkit/src/api/client/models/BackofficePledgeRead.ts
+++ b/clients/packages/polarkit/src/api/client/models/BackofficePledgeRead.ts
@@ -16,6 +16,8 @@ export type BackofficePledgeRead = {
   pledger_avatar?: string;
   authed_user_can_admin?: boolean;
   scheduled_payout_at?: string;
+  authed_user_can_admin_sender?: boolean;
+  authed_user_can_admin_received?: boolean;
   payment_id?: string;
   transfer_id?: string;
   receiver_org_name: string;

--- a/clients/packages/polarkit/src/api/client/models/ConfirmPledgesResponse.ts
+++ b/clients/packages/polarkit/src/api/client/models/ConfirmPledgesResponse.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ConfirmPledgesResponse = {
+};
+

--- a/clients/packages/polarkit/src/api/client/models/MaintainerPledgeConfirmationPendingNotification.ts
+++ b/clients/packages/polarkit/src/api/client/models/MaintainerPledgeConfirmationPendingNotification.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type MaintainerPledgePaidNotification = {
-  paid_out_amount: string;
+export type MaintainerPledgeConfirmationPendingNotification = {
+  pledger_name: string;
+  pledge_amount: string;
   issue_url: string;
   issue_title: string;
   issue_org_name: string;
   issue_repo_name: string;
   issue_number: number;
+  maintainer_has_stripe_account: boolean;
   pledge_id?: string;
 };
 

--- a/clients/packages/polarkit/src/api/client/models/MaintainerPledgeCreatedNotification.ts
+++ b/clients/packages/polarkit/src/api/client/models/MaintainerPledgeCreatedNotification.ts
@@ -11,5 +11,6 @@ export type MaintainerPledgeCreatedNotification = {
   issue_repo_name: string;
   issue_number: number;
   maintainer_has_stripe_account: boolean;
+  pledge_id?: string;
 };
 

--- a/clients/packages/polarkit/src/api/client/models/MaintainerPledgePendingNotification.ts
+++ b/clients/packages/polarkit/src/api/client/models/MaintainerPledgePendingNotification.ts
@@ -11,5 +11,6 @@ export type MaintainerPledgePendingNotification = {
   issue_repo_name: string;
   issue_number: number;
   maintainer_has_stripe_account: boolean;
+  pledge_id?: string;
 };
 

--- a/clients/packages/polarkit/src/api/client/models/NotificationRead.ts
+++ b/clients/packages/polarkit/src/api/client/models/NotificationRead.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { MaintainerPledgeConfirmationPendingNotification } from './MaintainerPledgeConfirmationPendingNotification';
 import type { MaintainerPledgeCreatedNotification } from './MaintainerPledgeCreatedNotification';
 import type { MaintainerPledgePaidNotification } from './MaintainerPledgePaidNotification';
 import type { MaintainerPledgePendingNotification } from './MaintainerPledgePendingNotification';
@@ -12,6 +13,6 @@ export type NotificationRead = {
   id: string;
   type: NotificationType;
   created_at: string;
-  payload: (MaintainerPledgePaidNotification | MaintainerPledgePendingNotification | MaintainerPledgeCreatedNotification | PledgerPledgePendingNotification);
+  payload: (MaintainerPledgePaidNotification | MaintainerPledgeConfirmationPendingNotification | MaintainerPledgePendingNotification | MaintainerPledgeCreatedNotification | PledgerPledgePendingNotification);
 };
 

--- a/clients/packages/polarkit/src/api/client/models/NotificationType.ts
+++ b/clients/packages/polarkit/src/api/client/models/NotificationType.ts
@@ -7,6 +7,7 @@
  */
 export enum NotificationType {
   MAINTAINER_PLEDGE_PAID_NOTIFICATION = 'MaintainerPledgePaidNotification',
+  MAINTAINER_PLEDGE_CONFIRMATION_PENDING_NOTIFICATION = 'MaintainerPledgeConfirmationPendingNotification',
   MAINTAINER_PLEDGE_PENDING_NOTIFICATION = 'MaintainerPledgePendingNotification',
   MAINTAINER_PLEDGE_CREATED_NOTIFICATION = 'MaintainerPledgeCreatedNotification',
   PLEDGER_PLEDGE_PENDING_NOTIFICATION = 'PledgerPledgePendingNotification',

--- a/clients/packages/polarkit/src/api/client/models/PledgeRead.ts
+++ b/clients/packages/polarkit/src/api/client/models/PledgeRead.ts
@@ -16,5 +16,7 @@ export type PledgeRead = {
   pledger_avatar?: string;
   authed_user_can_admin?: boolean;
   scheduled_payout_at?: string;
+  authed_user_can_admin_sender?: boolean;
+  authed_user_can_admin_received?: boolean;
 };
 

--- a/clients/packages/polarkit/src/api/client/models/PledgeState.ts
+++ b/clients/packages/polarkit/src/api/client/models/PledgeState.ts
@@ -8,6 +8,7 @@
 export enum PledgeState {
   INITIATED = 'initiated',
   CREATED = 'created',
+  CONFIRMATION_PENDING = 'confirmation_pending',
   PENDING = 'pending',
   PAID = 'paid',
   REFUNDED = 'refunded',

--- a/clients/packages/polarkit/src/api/client/models/PledgerPledgePendingNotification.ts
+++ b/clients/packages/polarkit/src/api/client/models/PledgerPledgePendingNotification.ts
@@ -10,5 +10,6 @@ export type PledgerPledgePendingNotification = {
   issue_org_name: string;
   issue_repo_name: string;
   pledge_date: string;
+  pledge_id?: string;
 };
 

--- a/clients/packages/polarkit/src/api/client/services/PledgesService.ts
+++ b/clients/packages/polarkit/src/api/client/services/PledgesService.ts
@@ -91,6 +91,40 @@ export class PledgesService {
   }
 
   /**
+   * Get Pledge
+   * @returns PledgeRead Successful Response
+   * @throws ApiError
+   */
+  public getPledge({
+    platform,
+    orgName,
+    repoName,
+    number,
+    pledgeId,
+  }: {
+    platform: Platforms,
+    orgName: string,
+    repoName: string,
+    number: number,
+    pledgeId: string,
+  }): CancelablePromise<PledgeRead> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/api/v1/{platform}/{org_name}/{repo_name}/issues/{number}/pledges/{pledge_id}',
+      path: {
+        'platform': platform,
+        'org_name': orgName,
+        'repo_name': repoName,
+        'number': number,
+        'pledge_id': pledgeId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+
+  /**
    * Update Pledge
    * @returns PledgeMutationResponse Successful Response
    * @throws ApiError

--- a/clients/packages/polarkit/src/api/client/services/PledgesService.ts
+++ b/clients/packages/polarkit/src/api/client/services/PledgesService.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ConfirmPledgesResponse } from '../models/ConfirmPledgesResponse';
 import type { Platforms } from '../models/Platforms';
 import type { PledgeCreate } from '../models/PledgeCreate';
 import type { PledgeMutationResponse } from '../models/PledgeMutationResponse';
@@ -136,6 +137,37 @@ export class PledgesService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v1/me/pledges',
+    });
+  }
+
+  /**
+   * Confirm Pledges
+   * @returns ConfirmPledgesResponse Successful Response
+   * @throws ApiError
+   */
+  public confirmPledges({
+    platform,
+    orgName,
+    repoName,
+    number,
+  }: {
+    platform: Platforms,
+    orgName: string,
+    repoName: string,
+    number: number,
+  }): CancelablePromise<ConfirmPledgesResponse> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/api/v1/{platform}/{org_name}/{repo_name}/issues/{number}/confirm_pledges',
+      path: {
+        'platform': platform,
+        'org_name': orgName,
+        'repo_name': repoName,
+        'number': number,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
     });
   }
 

--- a/clients/packages/polarkit/src/api/index.ts
+++ b/clients/packages/polarkit/src/api/index.ts
@@ -1,8 +1,7 @@
-import { QueryClient } from '@tanstack/react-query'
 import { CancelablePromise, PolarAPI } from './client'
 export { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-
-export const queryClient = new QueryClient()
+export { queryClient } from './query'
+export { CancelablePromise }
 
 export const getServerURL = (path?: string): string => {
   path = path !== undefined ? path : ''
@@ -15,5 +14,3 @@ export const api = new PolarAPI({
   BASE: getServerURL(),
   WITH_CREDENTIALS: true,
 })
-
-export { CancelablePromise }

--- a/clients/packages/polarkit/src/components/Issue/IssueConfirmButton.tsx
+++ b/clients/packages/polarkit/src/components/Issue/IssueConfirmButton.tsx
@@ -1,10 +1,10 @@
 const IssueConfirmButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <button
-      className="mt-2 w-full cursor-pointer rounded-lg bg-blue-600 px-2 py-1 text-sm font-medium text-gray-100 transition-colors duration-200 hover:bg-blue-500"
+      className="text-sm font-medium text-blue-600 hover:text-blue-500"
       onClick={onClick}
     >
-      Confirm
+      Mark as solved
     </button>
   )
 }

--- a/clients/packages/polarkit/src/components/Issue/IssueConfirmButton.tsx
+++ b/clients/packages/polarkit/src/components/Issue/IssueConfirmButton.tsx
@@ -1,0 +1,12 @@
+const IssueConfirmButton = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <button
+      className="mt-2 w-full cursor-pointer rounded-lg bg-blue-600 px-2 py-1 text-sm font-medium text-gray-100 transition-colors duration-200 hover:bg-blue-500"
+      onClick={onClick}
+    >
+      Confirm
+    </button>
+  )
+}
+
+export default IssueConfirmButton

--- a/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
+++ b/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
@@ -71,12 +71,12 @@ const IssuePledge = (props: Props) => {
           <>
             {isConfirmed && (
               <span className="text-sm font-medium text-gray-600 dark:text-gray-500">
-                Confirmed
+                Solved
               </span>
             )}
             {confirmPledgeIsLoading && (
-              <span className="text-sm font-medium text-gray-600  dark:text-gray-500">
-                Confirming...
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-500">
+                Loading...
               </span>
             )}
             {confirmable && <IssueConfirmButton onClick={confirmPledges} />}

--- a/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
+++ b/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
@@ -1,5 +1,5 @@
-import { api } from 'polarkit/api'
 import { Platforms, PledgeRead, PledgeState } from 'polarkit/api/client'
+import { useIssueMarkConfirmed } from 'polarkit/hooks'
 import { getCentsInDollarString } from 'polarkit/utils'
 import IssueConfirmButton from './IssueConfirmButton'
 
@@ -11,6 +11,8 @@ interface Props {
 }
 
 const IssuePledge = (props: Props) => {
+  const markConfirmed = useIssueMarkConfirmed()
+
   const { orgName, repoName, issueNumber, pledges } = props
 
   const totalPledgeAmount = pledges.reduce(
@@ -23,11 +25,11 @@ const IssuePledge = (props: Props) => {
   )
 
   const confirmPledges = async () => {
-    await api.pledges.confirmPledges({
+    markConfirmed.mutate({
       platform: Platforms.GITHUB,
       orgName,
       repoName,
-      number: issueNumber,
+      issueNumber,
     })
   }
 

--- a/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
+++ b/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
@@ -35,15 +35,15 @@ const IssuePledge = (props: Props) => {
 
   return (
     <>
-      <div className="flex items-center gap-2">
-        <p className="space-x-1 rounded-2xl bg-blue-800 px-3 py-1 text-sm text-blue-300 dark:bg-blue-200 dark:text-blue-700">
+      <div className="flex flex-row items-center justify-center space-x-4">
+        <p className="flex-shrink-0 rounded-2xl bg-blue-800 px-3 py-1 text-sm text-blue-300 dark:bg-blue-200 dark:text-blue-700">
           ${' '}
-          <span className="text-blue-100 dark:text-blue-900">
+          <span className="whitespace-nowrap text-blue-100 dark:text-blue-900">
             {getCentsInDollarString(totalPledgeAmount)}
           </span>
         </p>
+        {confirmable && <IssueConfirmButton onClick={confirmPledges} />}
       </div>
-      {confirmable && <IssueConfirmButton onClick={confirmPledges} />}
     </>
   )
 }

--- a/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
+++ b/clients/packages/polarkit/src/components/Issue/IssuePledge.tsx
@@ -1,27 +1,48 @@
-import { PledgeRead } from 'polarkit/api/client'
+import { api } from 'polarkit/api'
+import { Platforms, PledgeRead, PledgeState } from 'polarkit/api/client'
 import { getCentsInDollarString } from 'polarkit/utils'
+import IssueConfirmButton from './IssueConfirmButton'
 
 interface Props {
+  orgName: string
+  repoName: string
+  issueNumber: number
   pledges: PledgeRead[]
 }
 
 const IssuePledge = (props: Props) => {
-  const { pledges } = props
+  const { orgName, repoName, issueNumber, pledges } = props
 
   const totalPledgeAmount = pledges.reduce(
     (accumulator, pledge) => accumulator + pledge.amount,
     0,
   )
 
+  const confirmable = pledges.some(
+    (p) => p.state === PledgeState.CONFIRMATION_PENDING,
+  )
+
+  const confirmPledges = async () => {
+    await api.pledges.confirmPledges({
+      platform: Platforms.GITHUB,
+      orgName,
+      repoName,
+      number: issueNumber,
+    })
+  }
+
   return (
-    <div className="flex items-center gap-2">
-      <p className="space-x-1 rounded-2xl bg-blue-800 px-3 py-1 text-sm text-blue-300 dark:bg-blue-200 dark:text-blue-700">
-        ${' '}
-        <span className="text-blue-100 dark:text-blue-900">
-          {getCentsInDollarString(totalPledgeAmount)}
-        </span>
-      </p>
-    </div>
+    <>
+      <div className="flex items-center gap-2">
+        <p className="space-x-1 rounded-2xl bg-blue-800 px-3 py-1 text-sm text-blue-300 dark:bg-blue-200 dark:text-blue-700">
+          ${' '}
+          <span className="text-blue-100 dark:text-blue-900">
+            {getCentsInDollarString(totalPledgeAmount)}
+          </span>
+        </p>
+      </div>
+      {confirmable && <IssueConfirmButton onClick={confirmPledges} />}
+    </>
   )
 }
 

--- a/clients/packages/polarkit/src/components/Issue/ListItemDecoration.tsx
+++ b/clients/packages/polarkit/src/components/Issue/ListItemDecoration.tsx
@@ -29,14 +29,24 @@ const IssueListItemDecoration = ({
   references,
   showDisputeAction,
   onDispute,
+  onConfirmPledges,
+  showConfirmPledgeAction,
+  confirmPledgeIsLoading,
 }: {
   orgName: string
   repoName: string
   issueNumber: number
   pledges: PledgeRead[]
   references: IssueReferenceRead[]
-  showDisputeAction?: boolean
-  onDispute?: (pledge: PledgeRead) => void
+  showDisputeAction: boolean
+  onDispute: (pledge: PledgeRead) => void
+  onConfirmPledges: (
+    orgName: string,
+    repoName: string,
+    issueNumber: number,
+  ) => Promise<void>
+  showConfirmPledgeAction: boolean
+  confirmPledgeIsLoading: boolean
 }) => {
   const showPledges = pledges && pledges.length > 0
 
@@ -58,7 +68,7 @@ const IssueListItemDecoration = ({
     pledges
       ?.filter(
         (p) =>
-          p.authed_user_can_admin &&
+          p.authed_user_can_admin_sender &&
           p.scheduled_payout_at &&
           p.state === PledgeState.PENDING &&
           remainingDays(p) >= 0,
@@ -80,7 +90,7 @@ const IssueListItemDecoration = ({
     pledges &&
     pledges.find(
       (p) =>
-        p.authed_user_can_admin &&
+        p.authed_user_can_admin_sender &&
         p.scheduled_payout_at &&
         p.state === PledgeState.PENDING &&
         remainingDays(p) >= 0,
@@ -113,6 +123,9 @@ const IssueListItemDecoration = ({
               repoName={repoName}
               issueNumber={issueNumber}
               pledges={pledges}
+              onConfirmPledges={onConfirmPledges}
+              showConfirmPledgeAction={showConfirmPledgeAction}
+              confirmPledgeIsLoading={confirmPledgeIsLoading}
             />
           </div>
         )}
@@ -174,7 +187,7 @@ const IssueListItemDecoration = ({
           {disputedPledges.map((p) => {
             return (
               <div key={p.id}>
-                {p.authed_user_can_admin && (
+                {p.authed_user_can_admin_sender && (
                   <span className="text-sm text-gray-500">
                     You've disputed your pledge{' '}
                     {disputeBoxShowAmount && (
@@ -183,7 +196,7 @@ const IssueListItemDecoration = ({
                   </span>
                 )}
 
-                {!p.authed_user_can_admin && (
+                {p.authed_user_can_admin_received && (
                   <span className="text-sm text-gray-500">
                     {p.pledger_name} disputed their pledge{' '}
                     {disputeBoxShowAmount && (

--- a/clients/packages/polarkit/src/components/Issue/ListItemDecoration.tsx
+++ b/clients/packages/polarkit/src/components/Issue/ListItemDecoration.tsx
@@ -24,6 +24,7 @@ export const getExpectedHeight = ({
 const IssueListItemDecoration = ({
   orgName,
   repoName,
+  issueNumber,
   pledges,
   references,
   showDisputeAction,
@@ -31,6 +32,7 @@ const IssueListItemDecoration = ({
 }: {
   orgName: string
   repoName: string
+  issueNumber: number
   pledges: PledgeRead[]
   references: IssueReferenceRead[]
   showDisputeAction?: boolean
@@ -106,7 +108,12 @@ const IssueListItemDecoration = ({
       <div className="flex flex-row items-center px-4 py-3">
         {showPledges && (
           <div className="stretch mr-4 flex-none">
-            <IssuePledge pledges={pledges} />
+            <IssuePledge
+              orgName={orgName}
+              repoName={repoName}
+              issueNumber={issueNumber}
+              pledges={pledges}
+            />
           </div>
         )}
 

--- a/clients/packages/polarkit/src/components/ui/PrimaryButton.tsx
+++ b/clients/packages/polarkit/src/components/ui/PrimaryButton.tsx
@@ -66,12 +66,14 @@ const TinyLoadingSpinner = (props: { disabled: boolean }) => {
 }
 
 type Color = 'blue' | 'gray' | 'red' | 'green' | 'lightblue'
+type Size = 'normal' | 'small'
 
 type ButtonProps = {
   children: React.ReactNode
   href?: string
   color: Color
   fullWidth: boolean
+  size: Size
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 } & typeof defaultProps
 
@@ -79,6 +81,7 @@ const defaultProps = {
   disabled: false,
   loading: false,
   color: 'blue' as Color,
+  size: 'normal' as Size,
   fullWidth: true,
   classNames: '',
 }
@@ -130,13 +133,21 @@ const text = (color: Color, loading: boolean, disabled: boolean) => {
   return 'text-white'
 }
 
+const size = (size: Size) => {
+  if (size === 'small') {
+    return 'px-3 py-1.5 min-h-6'
+  }
+  return 'px-5 py-2 min-h-6'
+}
+
 const PrimaryButton = (props: ButtonProps) => {
   const disabled = props.disabled ? props.disabled : false
   let classes = classNames(
     bg(props.color, props.loading, disabled),
     text(props.color, props.loading, disabled),
+    size(props.size),
     props.fullWidth ? 'w-full' : '',
-    'rounded-lg px-5 py-2 min-h-6 text-center text-sm font-medium inline-flex items-center space-x-2 transition-colors duration-100 justify-center',
+    'rounded-lg  text-center text-sm font-medium inline-flex items-center space-x-2 transition-colors duration-100 justify-center',
     props.classNames,
   )
   return (

--- a/clients/packages/polarkit/src/hooks/queries/dashboard.ts
+++ b/clients/packages/polarkit/src/hooks/queries/dashboard.ts
@@ -65,7 +65,8 @@ export const usePersonalDashboard = (
 ): UseInfiniteQueryResult<IssueListResponse> =>
   useInfiniteQuery({
     queryKey: [
-      'personalDashboard',
+      'dashboard',
+      'personal',
       tab,
       q,
       JSON.stringify(status), // Array as cache key,

--- a/clients/packages/polarkit/src/hooks/queries/index.ts
+++ b/clients/packages/polarkit/src/hooks/queries/index.ts
@@ -140,3 +140,23 @@ export const useNotificationsMarkRead = () =>
       queryClient.invalidateQueries(['notifications'])
     },
   })
+
+export const useIssueMarkConfirmed = () =>
+  useMutation({
+    mutationFn: (variables: {
+      platform: string
+      orgName: string
+      repoName: string
+      issueNumber: number
+    }) => {
+      return api.pledges.confirmPledges({
+        platform: Platforms.GITHUB,
+        orgName: variables.orgName,
+        repoName: variables.repoName,
+        number: variables.issueNumber,
+      })
+    },
+    onSuccess: (result, variables, ctx) => {
+      queryClient.invalidateQueries(['dashboard'])
+    },
+  })

--- a/clients/packages/polarkit/src/hooks/queries/index.ts
+++ b/clients/packages/polarkit/src/hooks/queries/index.ts
@@ -140,23 +140,3 @@ export const useNotificationsMarkRead = () =>
       queryClient.invalidateQueries(['notifications'])
     },
   })
-
-export const useIssueMarkConfirmed = () =>
-  useMutation({
-    mutationFn: (variables: {
-      platform: string
-      orgName: string
-      repoName: string
-      issueNumber: number
-    }) => {
-      return api.pledges.confirmPledges({
-        platform: Platforms.GITHUB,
-        orgName: variables.orgName,
-        repoName: variables.repoName,
-        number: variables.issueNumber,
-      })
-    },
-    onSuccess: (result, variables, ctx) => {
-      queryClient.invalidateQueries(['dashboard'])
-    },
-  })

--- a/clients/packages/polarkit/src/hooks/queries/pledges.ts
+++ b/clients/packages/polarkit/src/hooks/queries/pledges.ts
@@ -1,8 +1,54 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { api } from '../../api'
+import { Platforms } from '../../api/client'
+import { queryClient } from '../../api/query'
 import { defaultRetry } from './retry'
 
 export const useListPersonalPledges = () =>
   useQuery(['listPersonalPledges'], () => api.pledges.listPersonalPledges(), {
     retry: defaultRetry,
+  })
+
+export const useGetPledge = (
+  platform: Platforms,
+  orgName: string,
+  repoName: string,
+  number: number,
+  pledgeId: string | undefined,
+) =>
+  useQuery(
+    ['pledge', pledgeId],
+    () =>
+      api.pledges.getPledge({
+        platform,
+        orgName,
+        repoName,
+        number,
+        pledgeId: pledgeId || '',
+      }),
+    {
+      enabled: !!pledgeId,
+      retry: defaultRetry,
+    },
+  )
+
+export const useIssueMarkConfirmed = () =>
+  useMutation({
+    mutationFn: (variables: {
+      platform: string
+      orgName: string
+      repoName: string
+      issueNumber: number
+    }) => {
+      return api.pledges.confirmPledges({
+        platform: Platforms.GITHUB,
+        orgName: variables.orgName,
+        repoName: variables.repoName,
+        number: variables.issueNumber,
+      })
+    },
+    onSuccess: (result, variables, ctx) => {
+      queryClient.invalidateQueries(['dashboard'])
+      queryClient.invalidateQueries(['pledge'])
+    },
   })

--- a/clients/packages/polarkit/src/hooks/queries/pledges.ts
+++ b/clients/packages/polarkit/src/hooks/queries/pledges.ts
@@ -47,8 +47,9 @@ export const useIssueMarkConfirmed = () =>
         number: variables.issueNumber,
       })
     },
-    onSuccess: (result, variables, ctx) => {
-      queryClient.invalidateQueries(['dashboard'])
-      queryClient.invalidateQueries(['pledge'])
+    onSuccess: async (result, variables, ctx) => {
+      await queryClient.invalidateQueries(['dashboard'])
+      await queryClient.invalidateQueries(['pledge'])
+      await queryClient.invalidateQueries(['listPersonalPledges'])
     },
   })

--- a/clients/packages/polarkit/src/hooks/sse/organizations.ts
+++ b/clients/packages/polarkit/src/hooks/sse/organizations.ts
@@ -1,4 +1,4 @@
-import { queryClient } from '../../api'
+import { queryClient } from '../../..'
 
 export const onOrganizationUpdated = async (params: {
   organization_id: string

--- a/server/polar/dashboard/endpoints.py
+++ b/server/polar/dashboard/endpoints.py
@@ -162,8 +162,6 @@ async def dashboard(
     limit = 100
     offset = (page - 1) * limit
 
-    print("STATUS", status)
-
     #
     # Select top level issues
     #
@@ -184,8 +182,6 @@ async def dashboard(
         limit=limit,
         offset=offset,
     )
-
-    print('ISSUES COUNT', len(issues), total_issue_count)
 
     issue_organizations = list(
         (

--- a/server/polar/dashboard/endpoints.py
+++ b/server/polar/dashboard/endpoints.py
@@ -162,6 +162,8 @@ async def dashboard(
     limit = 100
     offset = (page - 1) * limit
 
+    print("STATUS", status)
+
     #
     # Select top level issues
     #
@@ -182,6 +184,8 @@ async def dashboard(
         limit=limit,
         offset=offset,
     )
+
+    print('ISSUES COUNT', len(issues), total_issue_count)
 
     issue_organizations = list(
         (

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -1,5 +1,5 @@
-from uuid import UUID
 from typing import Any, Literal, Optional, Tuple
+from uuid import UUID
 
 import structlog
 from fastapi import (
@@ -11,32 +11,32 @@ from fastapi import (
 )
 from httpx_oauth.clients.github import GitHubOAuth2
 from httpx_oauth.integrations.fastapi import OAuth2AuthorizeCallback
+from httpx_oauth.oauth2 import OAuth2Token
 from pydantic import BaseModel, ValidationError
-from polar.context import ExecutionContext
 
-from polar.kit import jwt
 from polar.auth.dependencies import Auth
+from polar.auth.service import AuthService, LoginResponse
 from polar.config import settings
+from polar.context import ExecutionContext
 from polar.enums import Platforms
 from polar.integrations.github import client as github
+from polar.kit import jwt
 from polar.models import Organization
 from polar.organization.schemas import OrganizationPrivateRead
-from polar.postgres import AsyncSession, get_db_session
-from polar.worker import enqueue_job
-from polar.auth.service import AuthService, LoginResponse
-from httpx_oauth.oauth2 import OAuth2Token
 from polar.pledge.service import pledge as pledge_service
+from polar.postgres import AsyncSession, get_db_session
 from polar.posthog.service import posthog_service
+from polar.worker import enqueue_job
 
-from .service.organization import github_organization
-from .service.repository import github_repository
-from .service.issue import github_issue
-from .service.user import github_user
 from .schemas import (
-    GithubBadgeRead,
     AuthorizationResponse,
+    GithubBadgeRead,
     OAuthAccessToken,
 )
+from .service.issue import github_issue
+from .service.organization import github_organization
+from .service.repository import github_repository
+from .service.user import github_user
 
 log = structlog.get_logger()
 
@@ -209,6 +209,7 @@ IMPLEMENTED_WEBHOOKS = {
     "issues.edited",
     "issues.closed",
     "issues.deleted",
+    "issues.reopened",
     "issues.labeled",
     "issues.unlabeled",
     "issues.assigned",

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -1,28 +1,30 @@
 from __future__ import annotations
-import datetime
 
+import datetime
 from typing import Any, Sequence, Union
 from uuid import UUID
-from githubkit import GitHub, Response
-from githubkit.rest.models import Issue as GitHubIssue, Label
-from githubkit.webhooks.models import Label as WebhookLabel
-from githubkit.exception import RequestFailed
-from sqlalchemy import asc, or_
 
 import structlog
-from polar.dashboard.schemas import IssueListType, IssueSortBy
-from polar.kit.extensions.sqlalchemy import sql
+from githubkit import GitHub, Response
+from githubkit.exception import RequestFailed
+from githubkit.rest.models import Issue as GitHubIssue
+from githubkit.rest.models import Label
+from githubkit.webhooks.models import Label as WebhookLabel
+from sqlalchemy import asc, or_
 
-from polar.kit.utils import utc_now
-from polar.issue.schemas import IssueCreate
-from polar.issue.service import IssueService
-from polar.models import Issue, Organization, Repository
+from polar.dashboard.schemas import IssueListType, IssueSortBy
 from polar.enums import Platforms
-from polar.models.user import User
-from polar.postgres import AsyncSession
 from polar.integrations.github import client as github
 from polar.integrations.github.service.api import github_api
-from polar.issue.hooks import issue_upserted, IssueHook
+from polar.issue.hooks import IssueHook, issue_upserted
+from polar.issue.schemas import IssueCreate
+from polar.issue.service import IssueService
+from polar.kit.extensions.sqlalchemy import sql
+from polar.kit.utils import utc_now
+from polar.models import Issue, Organization, Repository
+from polar.models.user import User
+from polar.postgres import AsyncSession
+
 from ..badge import GithubBadge
 
 log = structlog.get_logger()
@@ -41,6 +43,7 @@ class GithubIssueService(IssueService):
         data: Union[
             github.webhooks.IssuesOpenedPropIssue,
             github.webhooks.IssuesClosedPropIssue,
+            github.webhooks.IssuesReopenedPropIssue,
             github.webhooks.Issue,
             github.rest.Issue,
         ],
@@ -63,6 +66,7 @@ class GithubIssueService(IssueService):
             Union[
                 github.webhooks.IssuesOpenedPropIssue,
                 github.webhooks.IssuesClosedPropIssue,
+                github.webhooks.IssuesReopenedPropIssue,
                 github.webhooks.Issue,
                 github.rest.Issue,
             ],
@@ -74,6 +78,7 @@ class GithubIssueService(IssueService):
             issue: Union[
                 github.webhooks.IssuesOpenedPropIssue,
                 github.webhooks.IssuesClosedPropIssue,
+                github.webhooks.IssuesReopenedPropIssue,
                 github.webhooks.Issue,
                 github.rest.Issue,
             ],

--- a/server/polar/integrations/github/tasks/utils.py
+++ b/server/polar/integrations/github/tasks/utils.py
@@ -1,11 +1,12 @@
 from typing import Sequence, Union
 from uuid import UUID
+
 import structlog
 
-from polar.integrations.github import service
-from polar.models import Organization, Repository, Issue, PullRequest
-from polar.postgres import AsyncSession
 from polar.integrations.github import client as github
+from polar.integrations.github import service
+from polar.models import Issue, Organization, PullRequest, Repository
+from polar.postgres import AsyncSession
 from polar.pull_request.schemas import FullPullRequestCreate
 
 log = structlog.get_logger()
@@ -65,6 +66,7 @@ async def get_event_org_repo(
         github.webhooks.PullRequestClosed,
         github.webhooks.PullRequestReopened,
         github.webhooks.PullRequestSynchronize,
+        github.webhooks.IssuesReopened,
     ],
 ) -> Union[tuple[Organization, Repository], None]:
     repository_id = event.repository.id
@@ -104,6 +106,7 @@ async def upsert_issue(
         github.webhooks.IssuesEdited,
         github.webhooks.IssuesClosed,
         github.webhooks.IssuesDeleted,
+        github.webhooks.IssuesReopened,
     ],
 ) -> Issue | None:
     owner_id = event.repository.owner.id

--- a/server/polar/issue/schemas.py
+++ b/server/polar/issue/schemas.py
@@ -1,32 +1,35 @@
 from __future__ import annotations
-from enum import Enum
 
-from uuid import UUID
 from datetime import datetime
+from enum import Enum
 from typing import Self, Type, Union
-from pydantic import parse_obj_as
+from uuid import UUID
 
 import structlog
-from polar.dashboard.schemas import IssueStatus
+from pydantic import parse_obj_as
 
+from polar.dashboard.schemas import IssueStatus
+from polar.enums import Platforms
 from polar.integrations.github import client as github
 from polar.integrations.github.badge import GithubBadge
-from polar.kit.schemas import Schema
-from polar.models.issue import Issue
-from polar.enums import Platforms
-from polar.models.issue_reference import (
-    IssueReference,
-    ReferenceType,
-    ExternalGitHubPullRequestReference as ExternalGitHubPullRequestReferenceModel,
-    ExternalGitHubCommitReference as ExternalGitHubCommitReferenceModel,
-)
-from polar.types import JSONAny
-
 from polar.integrations.github.types import (
     GithubIssue,
     GithubPullRequestFull,
     GithubPullRequestSimple,
 )
+from polar.kit.schemas import Schema
+from polar.models.issue import Issue
+from polar.models.issue_reference import (
+    ExternalGitHubCommitReference as ExternalGitHubCommitReferenceModel,
+)
+from polar.models.issue_reference import (
+    ExternalGitHubPullRequestReference as ExternalGitHubPullRequestReferenceModel,
+)
+from polar.models.issue_reference import (
+    IssueReference,
+    ReferenceType,
+)
+from polar.types import JSONAny
 
 log = structlog.get_logger()
 
@@ -95,6 +98,7 @@ class IssueAndPullRequestBase(Base):
             github.webhooks.PullRequestReopenedPropPullRequest,
             github.webhooks.IssuesOpenedPropIssue,
             github.webhooks.IssuesClosedPropIssue,
+            github.webhooks.IssuesReopenedPropIssue,
             github.webhooks.Issue,
         ],
         organization_id: UUID,
@@ -148,6 +152,7 @@ class IssueCreate(IssueAndPullRequestBase):
             GithubIssue,
             github.webhooks.IssuesOpenedPropIssue,
             github.webhooks.IssuesClosedPropIssue,
+            github.webhooks.IssuesReopenedPropIssue,
             github.webhooks.Issue,
         ],
         organization_id: UUID,

--- a/server/polar/issue/service.py
+++ b/server/polar/issue/service.py
@@ -331,6 +331,10 @@ class IssueService(ResourceService[Issue, IssueCreate, IssueUpdate]):
         total_count = rows[0][1] if len(rows) > 0 else 0
         issues = [r[0] for r in rows]
 
+        print([i.id for i in issues])
+        print("ANOTHER ISSUE INCLUDED?", len([i for i in issues if str(i.id) == '6371a104-c2b3-4b94-bc77-bfec3a36548e']) > 0)
+        print("ISSUE INCLUDED?", len([i for i in issues if str(i.id) == 'd0be7709-dcb7-430a-986d-467db37452e0']) > 0)
+
         return (issues, total_count)
 
     async def list_issue_references(

--- a/server/polar/issue/service.py
+++ b/server/polar/issue/service.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
     and_,
     asc,
     desc,
-    distinct,
     func,
     not_,
     nullslast,
@@ -330,10 +329,6 @@ class IssueService(ResourceService[Issue, IssueCreate, IssueUpdate]):
 
         total_count = rows[0][1] if len(rows) > 0 else 0
         issues = [r[0] for r in rows]
-
-        print([i.id for i in issues])
-        print("ANOTHER ISSUE INCLUDED?", len([i for i in issues if str(i.id) == '6371a104-c2b3-4b94-bc77-bfec3a36548e']) > 0)
-        print("ISSUE INCLUDED?", len([i for i in issues if str(i.id) == 'd0be7709-dcb7-430a-986d-467db37452e0']) > 0)
 
         return (issues, total_count)
 

--- a/server/polar/notifications/notification.py
+++ b/server/polar/notifications/notification.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from typing import Tuple
+from uuid import UUID
 
 from jinja2 import StrictUndefined
 from jinja2.nativetypes import NativeEnvironment
@@ -41,6 +42,7 @@ class MaintainerPledgeCreatedNotification(NotificationBase):
     issue_repo_name: str
     issue_number: int
     maintainer_has_stripe_account: bool
+    pledge_id: UUID | None  # Added 2022-06-26
 
     def subject(self) -> str:
         return "New ${{pledge_amount}} pledge for {{issue_org_name}}/{{issue_repo_name}}#{{issue_number}}"  # noqa: E501
@@ -68,6 +70,7 @@ class MaintainerPledgeConfirmationPendingNotification(NotificationBase):
     issue_repo_name: str
     issue_number: int
     maintainer_has_stripe_account: bool
+    pledge_id: UUID | None  # Added 2022-06-26
 
     def subject(self) -> str:
         return "Please confirm that {{issue_org_name}}/{{issue_repo_name}}#{{issue_number}} is completed"  # noqa: E501
@@ -95,6 +98,7 @@ class MaintainerPledgePendingNotification(NotificationBase):
     issue_repo_name: str
     issue_number: int
     maintainer_has_stripe_account: bool
+    pledge_id: UUID | None  # Added 2022-06-26
 
     def subject(self) -> str:
         return "You have ${{pledge_amount}} in pending pledges for {{issue_org_name}}/{{issue_repo_name}}#{{issue_number}}!"  # noqa: E501
@@ -120,6 +124,7 @@ class MaintainerPledgePaidNotification(NotificationBase):
     issue_org_name: str
     issue_repo_name: str
     issue_number: int
+    pledge_id: UUID | None  # Added 2022-06-26
 
     def subject(self) -> str:
         return "${{paid_out_amount}} transferred for {{issue_org_name}}/{{issue_repo_name}}#{{issue_number}}"  # noqa: E501
@@ -145,6 +150,7 @@ class PledgerPledgePendingNotification(NotificationBase):
     issue_org_name: str
     issue_repo_name: str
     pledge_date: str
+    pledge_id: UUID | None  # Added 2022-06-26
 
     def subject(self) -> str:
         return "{{issue_org_name}}/{{issue_repo_name}}#{{issue_number}} is completed"

--- a/server/polar/notifications/notification.py
+++ b/server/polar/notifications/notification.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
 from typing import Tuple
-from jinja2.nativetypes import NativeEnvironment
+
 from jinja2 import StrictUndefined
+from jinja2.nativetypes import NativeEnvironment
+from pydantic import BaseModel
 
 from polar.models.user import User
-from pydantic import BaseModel
 
 
 class NotificationBase(BaseModel):

--- a/server/polar/notifications/notification.py
+++ b/server/polar/notifications/notification.py
@@ -59,6 +59,33 @@ You&apos;ll receive the funds once {{issue_org_name}}/{{issue_repo_name}}#{{issu
 """  # noqa: E501
 
 
+class MaintainerPledgeConfirmationPendingNotification(NotificationBase):
+    pledger_name: str
+    pledge_amount: str
+    issue_url: str
+    issue_title: str
+    issue_org_name: str
+    issue_repo_name: str
+    issue_number: int
+    maintainer_has_stripe_account: bool
+
+    def subject(self) -> str:
+        return "Please confirm that {{issue_org_name}}/{{issue_repo_name}}#{{issue_number}} is completed"  # noqa: E501
+
+    def body(self) -> str:
+        return """Hi,<br><br>
+
+Your backers have pledged ${{pledge_amount}} behind <a href="{{issue_url}}">{{issue_org_name}}/{{issue_repo_name}}#{{issue_number}}</a> which which has now been closed.<br><br>
+
+Before you can receive the money, please verify that the issue is completed on <a href="https://polar.sh/dashboard/{{issue_org_name}}?statuses=backlog%2Ctriaged%2Cin_progress%2Cpull_request%2Cclosed&tab=issues&onlyPledged=1">your Polar dashboard</a>.<br><br>
+
+{% if not maintainer_has_stripe_account %}
+Create a Stripe account with Polar today to ensure we can transfer the funds directly once the review period is completed.<br>
+<a href="https://polar.sh/dashboard/{{issue_org_name}}">polar.sh/dashboard/{{issue_org_name}}</a>
+{% endif %}
+"""  # noqa: E501
+
+
 class MaintainerPledgePendingNotification(NotificationBase):
     pledger_name: str
     pledge_amount: str

--- a/server/polar/notifications/schemas.py
+++ b/server/polar/notifications/schemas.py
@@ -1,11 +1,11 @@
 from datetime import datetime
+from enum import Enum
 from typing import Self, Union
 from uuid import UUID
 
 from polar.kit.schemas import Schema
-from enum import Enum
-
 from polar.notifications.notification import (
+    MaintainerPledgeConfirmationPendingNotification,
     MaintainerPledgeCreatedNotification,
     MaintainerPledgePaidNotification,
     MaintainerPledgePendingNotification,
@@ -15,6 +15,9 @@ from polar.notifications.notification import (
 
 class NotificationType(str, Enum):
     MaintainerPledgePaidNotification = "MaintainerPledgePaidNotification"
+    MaintainerPledgeConfirmationPendingNotification = (
+        "MaintainerPledgeConfirmationPendingNotification"
+    )
     MaintainerPledgePendingNotification = "MaintainerPledgePendingNotification"
     MaintainerPledgeCreatedNotification = "MaintainerPledgeCreatedNotification"
     PledgerPledgePendingNotification = "PledgerPledgePendingNotification"
@@ -30,6 +33,7 @@ class NotificationRead(Schema):
     created_at: datetime
     payload: Union[
         MaintainerPledgePaidNotification,
+        MaintainerPledgeConfirmationPendingNotification,
         MaintainerPledgePendingNotification,
         MaintainerPledgeCreatedNotification,
         PledgerPledgePendingNotification,

--- a/server/polar/pledge/hooks.py
+++ b/server/polar/pledge/hooks.py
@@ -22,6 +22,7 @@ class PledgePaidHook:
 # (not the same as created in the initiated state)
 pledge_created: Hook[PledgeHook] = Hook()
 pledge_disputed: Hook[PledgeHook] = Hook()
+pledge_confirmation_pending: Hook[PledgeHook] = Hook()
 pledge_pending: Hook[PledgeHook] = Hook()
 pledge_paid: Hook[PledgePaidHook] = Hook()
 pledge_updated: Hook[PledgeHook] = Hook()

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -136,8 +136,14 @@ class PledgeRead(Schema):
     pledger_name: str | None
     pledger_avatar: str | None
 
-    authed_user_can_admin: bool = False
+    authed_user_can_admin: bool = False  # deprecated
     scheduled_payout_at: datetime | None = None
+
+    # If the user can admin the _sending_ of the pledge (disputing, etc)
+    authed_user_can_admin_sender: bool = False
+
+    # If the user can admin the _receiving_ of the pledge (confirm it, manage payouts, ...)  # noqa: E501
+    authed_user_can_admin_received: bool = False
 
     @classmethod
     def from_db(cls, o: Pledge) -> PledgeRead:

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -164,3 +164,7 @@ class PledgeResources(Schema):
     issue: IssueRead | None
     organization: OrganizationPublicRead | None
     repository: RepositoryRead | None
+
+
+class ConfirmPledgesResponse(Schema):
+    ...

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -16,7 +16,9 @@ class PledgeState(str, Enum):
     initiated = "initiated"
     # Polar has received the money.
     created = "created"
-    # The issue has been closed, but the pledge has not been paid.
+    # The issue has been closed, awaiting maintainer to confirm the issue is fixed.
+    confirmation_pending = "confirmation_pending"
+    # The fix was confirmed, but the pledge has not been paid.
     pending = "pending"
     # The pledge has been paid out to the maintainer.
     paid = "paid"
@@ -30,10 +32,11 @@ class PledgeState(str, Enum):
     # The states in which this pledge is "active", i.e. is listed on the issue
     @classmethod
     def active_states(cls) -> list[PledgeState]:
-        return [cls.created, cls.pending, cls.paid, cls.disputed]
+        return [cls.created, cls.confirmation_pending,
+                cls.pending, cls.paid, cls.disputed]
 
     # Happy path:
-    # initiated -> created -> pending -> paid
+    # initiated -> created -> confirmation_pending -> pending -> paid
 
     @classmethod
     def to_created_states(cls) -> list[PledgeState]:
@@ -43,11 +46,18 @@ class PledgeState(str, Enum):
         return [cls.initiated]
 
     @classmethod
+    def to_confirmation_pending_states(cls) -> list[PledgeState]:
+        """
+        Allowed states to move into confirmation pending from
+        """
+        return [cls.created, cls.disputed]
+
+    @classmethod
     def to_pending_states(cls) -> list[PledgeState]:
         """
         Allowed states to move into pending from
         """
-        return [cls.created, cls.disputed]
+        return [cls.confirmation_pending]
 
     @classmethod
     def to_disputed_states(cls) -> list[PledgeState]:

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from uuid import UUID
 from datetime import datetime
 from enum import Enum
+from uuid import UUID
 
+from polar.issue.schemas import IssueRead
 from polar.kit.schemas import Schema
 from polar.models.pledge import Pledge
 from polar.organization.schemas import OrganizationPublicRead
 from polar.repository.schemas import RepositoryRead
-from polar.issue.schemas import IssueRead
 
 
 class PledgeState(str, Enum):
@@ -32,8 +32,13 @@ class PledgeState(str, Enum):
     # The states in which this pledge is "active", i.e. is listed on the issue
     @classmethod
     def active_states(cls) -> list[PledgeState]:
-        return [cls.created, cls.confirmation_pending,
-                cls.pending, cls.paid, cls.disputed]
+        return [
+            cls.created,
+            cls.confirmation_pending,
+            cls.pending,
+            cls.paid,
+            cls.disputed,
+        ]
 
     # Happy path:
     # initiated -> created -> confirmation_pending -> pending -> paid
@@ -43,14 +48,14 @@ class PledgeState(str, Enum):
         """
         Allowed states to move into initiated from
         """
-        return [cls.initiated]
+        return [cls.initiated, cls.confirmation_pending]
 
     @classmethod
     def to_confirmation_pending_states(cls) -> list[PledgeState]:
         """
         Allowed states to move into confirmation pending from
         """
-        return [cls.created, cls.disputed]
+        return [cls.created]
 
     @classmethod
     def to_pending_states(cls) -> list[PledgeState]:
@@ -64,7 +69,7 @@ class PledgeState(str, Enum):
         """
         Allowed states to move into disputed from
         """
-        return [cls.created, cls.pending]
+        return [cls.created, cls.confirmation_pending, cls.pending]
 
     @classmethod
     def to_paid_states(cls) -> list[PledgeState]:

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -57,7 +57,7 @@ class PledgeState(str, Enum):
         """
         Allowed states to move into pending from
         """
-        return [cls.confirmation_pending]
+        return [cls.created, cls.confirmation_pending]
 
     @classmethod
     def to_disputed_states(cls) -> list[PledgeState]:

--- a/server/polar/pledge/service.py
+++ b/server/polar/pledge/service.py
@@ -400,12 +400,12 @@ class PledgeService(ResourceServiceReader[Pledge]):
         backer.invite_only_approved = True
         await backer.save(session)
 
-    async def mark_pending_by_issue_id(
+    async def mark_confirmation_pending_by_issue_id(
         self, session: AsyncSession, issue_id: UUID
     ) -> None:
         get = sql.select(Pledge).where(
             Pledge.issue_id == issue_id,
-            Pledge.state.in_(PledgeState.to_pending_states()),
+            Pledge.state.in_(PledgeState.to_confirmation_pending_states()),
         )
 
         res = await session.execute(get)
@@ -417,11 +417,11 @@ class PledgeService(ResourceServiceReader[Pledge]):
                 sql.update(Pledge)
                 .where(
                     Pledge.id == pledge.id,
-                    Pledge.state.in_(PledgeState.to_pending_states()),
+                    Pledge.state.in_(PledgeState.to_confirmation_pending_states()),
                 )
                 .values(
-                    state=PledgeState.pending,
-                    scheduled_payout_at=utc_now() + timedelta(days=14),
+                    state=PledgeState.confirmation_pending,
+                    # scheduled_payout_at=utc_now() + timedelta(days=14),
                 )
                 .returning(Pledge)
             )

--- a/server/polar/receivers/pledges.py
+++ b/server/polar/receivers/pledges.py
@@ -35,14 +35,15 @@ from polar.issue.hooks import IssueHook, issue_upserted
 log = structlog.get_logger()
 
 
-async def mark_pledges_pending_on_issue_close(
+async def mark_pledges_confirmation_pending_on_issue_close(
     hook: IssueHook,
 ) -> None:
     if hook.issue.state == "closed":
-        await pledge_service.mark_pending_by_issue_id(hook.session, hook.issue.id)
+        await pledge_service.mark_confirmation_pending_by_issue_id(
+            hook.session, hook.issue.id)
 
 
-issue_upserted.add(mark_pledges_pending_on_issue_close)
+issue_upserted.add(mark_pledges_confirmation_pending_on_issue_close)
 
 
 async def pledge_created_discord_alert(hook: PledgeHook) -> None:

--- a/server/polar/receivers/pledges.py
+++ b/server/polar/receivers/pledges.py
@@ -150,6 +150,7 @@ async def pledge_created_notification(pledge: Pledge, session: AsyncSession) -> 
         issue_repo_name=repo.name,
         issue_number=issue.number,
         maintainer_has_stripe_account=True if org.account else False,
+        pledge_id=pledge.id,
     )
 
     await notification_service.send_to_org(
@@ -188,6 +189,7 @@ async def pledge_confirmation_pending_notification(
         issue_repo_name=repo.name,
         issue_number=issue.number,
         maintainer_has_stripe_account=True if org.account else False,
+        pledge_id=pledge.id,
     )
 
     await notification_service.send_to_org(
@@ -224,6 +226,7 @@ async def pledge_pending_notification(pledge: Pledge, session: AsyncSession) -> 
         issue_repo_name=repo.name,
         issue_number=issue.number,
         maintainer_has_stripe_account=True if org.account else False,
+        pledge_id=pledge.id,
     )
 
     await notification_service.send_to_org(
@@ -243,6 +246,7 @@ async def pledge_pending_notification(pledge: Pledge, session: AsyncSession) -> 
         issue_org_name=org.name,
         issue_repo_name=repo.name,
         issue_number=issue.number,
+        pledge_id=pledge.id,
     )
 
     await notification_service.send_to_pledger(
@@ -279,6 +283,7 @@ async def pledge_paid_notification(
         issue_repo_name=repo.name,
         issue_number=issue.number,
         paid_out_amount=get_cents_in_dollar_string(transaction.amount),
+        pledge_id=pledge.id,
     )
 
     await notification_service.send_to_org(

--- a/server/polar/receivers/pledges.py
+++ b/server/polar/receivers/pledges.py
@@ -25,6 +25,7 @@ from polar.pledge.hooks import (
     PledgeHook,
     PledgePaidHook,
     pledge_created as pledge_created_hook,
+    pledge_confirmation_pending as pledge_confirmation_pending_hook,
     pledge_pending as pledge_pending_hook,
     pledge_paid as pledge_paid_hook,
     pledge_updated as pledge_updated_hook,
@@ -139,6 +140,13 @@ async def pledge_created_notification(pledge: Pledge, session: AsyncSession) -> 
     )
 
 
+async def pledge_confirmation_pending_notification(
+    pledge: Pledge,
+    session: AsyncSession
+) -> None:
+    ... # TODO: implement
+
+
 async def pledge_pending_notification(pledge: Pledge, session: AsyncSession) -> None:
     issue = await issue_service.get_by_id(session, pledge.issue_id)
     if not issue:
@@ -237,6 +245,15 @@ async def hook_pledge_created_notifications(hook: PledgeHook) -> None:
 
 
 pledge_created_hook.add(hook_pledge_created_notifications)
+
+
+async def hook_pledge_confirmation_pending_notifications(hook: PledgeHook) -> None:
+    session = hook.session
+    pledge = hook.pledge
+    await pledge_confirmation_pending_notification(pledge, session)
+
+
+pledge_confirmation_pending_hook.add(hook_pledge_confirmation_pending_notifications)
 
 
 async def hook_pledge_pending_notifications(hook: PledgeHook) -> None:

--- a/server/polar/receivers/pledges.py
+++ b/server/polar/receivers/pledges.py
@@ -10,6 +10,7 @@ from polar.models.pledge import Pledge
 from polar.models.pledge_transaction import PledgeTransaction
 from polar.models.repository import Repository
 from polar.notifications.notification import (
+    MaintainerPledgeConfirmationPendingNotification,
     MaintainerPledgeCreatedNotification,
     MaintainerPledgePaidNotification,
     MaintainerPledgePendingNotification,
@@ -53,10 +54,12 @@ async def mark_pledges_confirmation_pending_on_issue_close(
     hook: IssueHook,
 ) -> None:
     if hook.issue.state == "closed":
+        # Mark pledges in "created" as "confirmation_pending"
         await pledge_service.mark_confirmation_pending_by_issue_id(
             hook.session, hook.issue.id
         )
     else:
+        # Mark pledges in "confirmation_pending" as "created"
         await pledge_service.mark_confirmation_pending_as_created_by_issue_id(
             hook.session, hook.issue.id
         )
@@ -159,10 +162,41 @@ async def pledge_created_notification(pledge: Pledge, session: AsyncSession) -> 
 
 
 async def pledge_confirmation_pending_notification(
-    pledge: Pledge,
-    session: AsyncSession
+    pledge: Pledge, session: AsyncSession
 ) -> None:
-    ... # TODO: implement
+    issue = await issue_service.get_by_id(session, pledge.issue_id)
+    if not issue:
+        log.error("pledge_confirmation_pending_notification.no_issue_found")
+        return
+
+    org = await organization_service.get(session, issue.organization_id)
+    if not org:
+        log.error("pledge_confirmation_pending_notification.no_org_found")
+        return
+
+    repo = await repository_service.get(session, issue.repository_id)
+    if not repo:
+        log.error("pledge_confirmation_pending_notification.no_repo_found")
+        return
+
+    n = MaintainerPledgeConfirmationPendingNotification(
+        pledger_name=pledger_name(pledge),
+        pledge_amount=get_cents_in_dollar_string(pledge.amount),
+        issue_url=issue_url(org, repo, issue),
+        issue_title=issue.title,
+        issue_org_name=org.name,
+        issue_repo_name=repo.name,
+        issue_number=issue.number,
+        maintainer_has_stripe_account=True if org.account else False,
+    )
+
+    await notification_service.send_to_org(
+        session=session,
+        org_id=org.id,
+        notif=PartialNotification(
+            issue_id=pledge.issue_id, pledge_id=pledge.id, payload=n
+        ),
+    )
 
 
 async def pledge_pending_notification(pledge: Pledge, session: AsyncSession) -> None:

--- a/server/tests/notifications/test_email.py
+++ b/server/tests/notifications/test_email.py
@@ -1,14 +1,17 @@
+import inspect
 import os
 from typing import Any, Tuple
+
 import pytest
+
 from polar.models.user import User
 from polar.notifications.notification import (
+    MaintainerPledgeConfirmationPendingNotification,
     MaintainerPledgeCreatedNotification,
     MaintainerPledgePaidNotification,
     MaintainerPledgePendingNotification,
     PledgerPledgePendingNotification,
 )
-import inspect
 
 
 async def check_diff(email: Tuple[str, str]) -> None:
@@ -53,6 +56,42 @@ async def test_MaintainerPledgeCreatedNotification_with_stripe(
     predictable_user: User,
 ) -> None:
     n = MaintainerPledgeCreatedNotification(
+        pledger_name="pledging_org",
+        issue_url="https://github.com/testorg/testrepo/issues/123",
+        issue_title="issue title",
+        issue_number=123,
+        pledge_amount="123.45",
+        issue_org_name="testorg",
+        issue_repo_name="testrepo",
+        maintainer_has_stripe_account=True,
+    )
+
+    await check_diff(n.render(predictable_user))
+
+
+@pytest.mark.asyncio
+async def test_MaintainerPledgeConfirmationPendingdNotification_no_stripe(
+    predictable_user: User,
+) -> None:
+    n = MaintainerPledgeConfirmationPendingNotification(
+        pledger_name="pledging_org",
+        issue_url="https://github.com/testorg/testrepo/issues/123",
+        issue_title="issue title",
+        issue_number=123,
+        pledge_amount="123.45",
+        issue_org_name="testorg",
+        issue_repo_name="testrepo",
+        maintainer_has_stripe_account=False,
+    )
+
+    await check_diff(n.render(predictable_user))
+
+
+@pytest.mark.asyncio
+async def test_MaintainerPledgeConfirmationPendingdNotification_with_stripe(
+    predictable_user: User,
+) -> None:
+    n = MaintainerPledgeConfirmationPendingNotification(
         pledger_name="pledging_org",
         issue_url="https://github.com/testorg/testrepo/issues/123",
         issue_title="issue title",

--- a/server/tests/notifications/test_pledge_notifications.py
+++ b/server/tests/notifications/test_pledge_notifications.py
@@ -1,5 +1,8 @@
 from unittest.mock import ANY
+
 import pytest
+from pytest_mock import MockerFixture
+
 from polar.kit.extensions.sqlalchemy import sql
 from polar.models.issue import Issue
 from polar.models.notification import Notification
@@ -11,9 +14,8 @@ from polar.notifications.notification import MaintainerPledgeCreatedNotification
 from polar.notifications.schemas import NotificationType
 from polar.notifications.service import NotificationsService, PartialNotification
 from polar.pledge.schemas import PledgeState
-from polar.postgres import AsyncSession
-from pytest_mock import MockerFixture
 from polar.pledge.service import pledge as pledge_service
+from polar.postgres import AsyncSession
 
 
 @pytest.mark.asyncio
@@ -53,6 +55,7 @@ async def test_create_pledge_from_created(
             issue_id=issue.id,
             pledge_id=pledge.id,
             payload=MaintainerPledgeCreatedNotification(
+                pledge_id=pledge.id,
                 pledger_name=organization.name,
                 pledge_amount="123",
                 issue_url=f"https://github.com/{organization.name}/{repository.name}/issues/{issue.number}",

--- a/server/tests/notifications/testdata/test_MaintainerPledgeConfirmationPendingdNotification_no_stripe.html
+++ b/server/tests/notifications/testdata/test_MaintainerPledgeConfirmationPendingdNotification_no_stripe.html
@@ -1,0 +1,11 @@
+Please confirm that testorg/testrepo#123 is completed
+<hr>
+Hi,<br><br>
+
+Your backers have pledged $123.45 behind <a href="https://github.com/testorg/testrepo/issues/123">testorg/testrepo#123</a> which which has now been closed.<br><br>
+
+Before you can receive the money, please verify that the issue is completed on <a href="https://polar.sh/dashboard/testorg?statuses=backlog%2Ctriaged%2Cin_progress%2Cpull_request%2Cclosed&tab=issues&onlyPledged=1">your Polar dashboard</a>.<br><br>
+
+
+Create a Stripe account with Polar today to ensure we can transfer the funds directly once the review period is completed.<br>
+<a href="https://polar.sh/dashboard/testorg">polar.sh/dashboard/testorg</a>

--- a/server/tests/notifications/testdata/test_MaintainerPledgeConfirmationPendingdNotification_with_stripe.html
+++ b/server/tests/notifications/testdata/test_MaintainerPledgeConfirmationPendingdNotification_with_stripe.html
@@ -1,0 +1,7 @@
+Please confirm that testorg/testrepo#123 is completed
+<hr>
+Hi,<br><br>
+
+Your backers have pledged $123.45 behind <a href="https://github.com/testorg/testrepo/issues/123">testorg/testrepo#123</a> which which has now been closed.<br><br>
+
+Before you can receive the money, please verify that the issue is completed on <a href="https://polar.sh/dashboard/testorg?statuses=backlog%2Ctriaged%2Cin_progress%2Cpull_request%2Cclosed&tab=issues&onlyPledged=1">your Polar dashboard</a>.<br><br>

--- a/server/tests/pledge/test_service.py
+++ b/server/tests/pledge/test_service.py
@@ -40,6 +40,66 @@ async def test_mark_pending_by_pledge_id(
 
 
 @pytest.mark.asyncio
+async def test_mark_confirmation_pending_by_issue_id(
+    session: AsyncSession,
+    organization: Organization,
+    repository: Repository,
+    issue: Issue,
+    user: User,
+    pledging_organization: Organization,
+    mocker: MockerFixture,
+) -> None:
+    confirmation_pending_notif = \
+        mocker.patch("polar.receivers.pledges.pledge_confirmation_pending_notification")
+
+    amount = 2000
+    fee = 200
+
+    # create multiple pledges
+    pledges: list[Pledge] = [
+        await Pledge.create(
+            session=session,
+            id=uuid.uuid4(),
+            by_organization_id=pledging_organization.id,
+            issue_id=issue.id,
+            repository_id=repository.id,
+            organization_id=organization.id,
+            amount=amount,
+            fee=fee,
+            state=PledgeState.created,
+        )
+        for x in range(4)
+    ]
+    await session.commit()
+
+    # Mark one of the pledges as refunded
+    pledges[0].state = PledgeState.refunded
+    await pledges[0].save(session)
+
+    await pledge_service.mark_confirmation_pending_by_issue_id(session, issue.id)
+
+    get_pledges = [(await pledge_service.get(session, p.id)) for p in pledges]
+    states = [p.state for p in get_pledges if p]
+
+    assert states == [
+        PledgeState.refunded,  # not modified
+        PledgeState.confirmation_pending,
+        PledgeState.confirmation_pending,
+        PledgeState.confirmation_pending,
+    ]
+
+    # get
+    # got = await pledge_service.get(session, pledge.id)
+    # assert got is not None
+    # assert got.state == PledgeState.pending
+
+    # pending_notif.assert_called_once
+    # paid_notif.assert_not_called
+
+    assert confirmation_pending_notif.call_count == 3
+
+
+@pytest.mark.asyncio
 async def test_mark_pending_by_issue_id(
     session: AsyncSession,
     organization: Organization,
@@ -66,7 +126,7 @@ async def test_mark_pending_by_issue_id(
             organization_id=organization.id,
             amount=amount,
             fee=fee,
-            state=PledgeState.created,
+            state=PledgeState.confirmation_pending,
         )
         for x in range(4)
     ]

--- a/server/tests/pledge/test_service.py
+++ b/server/tests/pledge/test_service.py
@@ -1,9 +1,11 @@
-from dataclasses import dataclass
-from datetime import timedelta
 import re
 import uuid
+from dataclasses import dataclass
+from datetime import timedelta
+
 import pytest
 from pytest_mock import MockerFixture
+
 from polar.enums import AccountType
 from polar.kit.utils import utc_now
 from polar.models.account import Account
@@ -13,10 +15,8 @@ from polar.models.pledge import Pledge
 from polar.models.repository import Repository
 from polar.models.user import User
 from polar.pledge.schemas import PledgeState
-
-from polar.postgres import AsyncSession
-
 from polar.pledge.service import pledge as pledge_service
+from polar.postgres import AsyncSession
 
 
 @pytest.mark.asyncio
@@ -49,8 +49,9 @@ async def test_mark_confirmation_pending_by_issue_id(
     pledging_organization: Organization,
     mocker: MockerFixture,
 ) -> None:
-    confirmation_pending_notif = \
-        mocker.patch("polar.receivers.pledges.pledge_confirmation_pending_notification")
+    confirmation_pending_notif = mocker.patch(
+        "polar.receivers.pledges.pledge_confirmation_pending_notification"
+    )
 
     amount = 2000
     fee = 200
@@ -87,14 +88,6 @@ async def test_mark_confirmation_pending_by_issue_id(
         PledgeState.confirmation_pending,
         PledgeState.confirmation_pending,
     ]
-
-    # get
-    # got = await pledge_service.get(session, pledge.id)
-    # assert got is not None
-    # assert got.state == PledgeState.pending
-
-    # pending_notif.assert_called_once
-    # paid_notif.assert_not_called
 
     assert confirmation_pending_notif.call_count == 3
 
@@ -147,14 +140,6 @@ async def test_mark_pending_by_issue_id(
         PledgeState.pending,
         PledgeState.pending,
     ]
-
-    # get
-    # got = await pledge_service.get(session, pledge.id)
-    # assert got is not None
-    # assert got.state == PledgeState.pending
-
-    # pending_notif.assert_called_once
-    # paid_notif.assert_not_called
 
     assert pending_notif.call_count == 3
     paid_notif.assert_not_called()


### PR DESCRIPTION
- [x] New `confirmation_pending` state on pledge
- [x] Move pledge to confirmation pending instead of pending on issue close
- [x] How to deal with backoffice "mark pending"? After discussion with @zegl, we keep it, and allow bypassing confirmation pending. @birkjernstrom says no-op though.
- [x] API method for confirming pledge (i.e. mark as the new pending). Don't forget to set `scheduled_payout_at`
- [x] Notification to maintainer for `confirmation_pending`
- [x] ~~Will there be a notification to the pledger on `confirmation_pending`?~~ No
- [x] Button for confirming pledge in UI (see https://github.com/polarsource/polar/issues/664#issuecomment-1590657758)
- [x] Update button design according to https://github.com/polarsource/polar/pull/750#issuecomment-1592985840
- [x] Reload issue list when button is pressed (use a mutation for the API call, do something like this https://github.com/polarsource/polar/blob/main/clients/packages/polarkit/src/hooks/queries/index.ts#LL139C1-L139C1)
- [x] Make sure extension at least works (it fails because the confirm pledges API call can't be done in the extension because of axios). Perhaps remove the confirmation button altogether?
- [x] Storybook tests fail because `IssueListItem` now uses a query mutation

Fixes #664 

Some screenshots:

![Screenshot 2023-06-27 at 11 02 29](https://github.com/polarsource/polar/assets/47952/4ce179fc-02ba-4944-917f-e618cd404909)
![Screenshot 2023-06-27 at 10 38 05](https://github.com/polarsource/polar/assets/47952/e203fc0f-8a95-43df-943e-d7d3c9c7a541)
![Screenshot 2023-06-27 at 10 38 02](https://github.com/polarsource/polar/assets/47952/4a703304-eb93-4ba6-993b-f19ee59492f1)
![Screenshot 2023-06-27 at 10 29 11](https://github.com/polarsource/polar/assets/47952/31c8dcd5-d897-4c01-929d-6dcf1af596c2)
