### PR TITLE
server/badge: add newline between <a> and <picture>

### DIFF
--- a/server/polar/integrations/github/badge.py
+++ b/server/polar/integrations/github/badge.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
+
 import structlog
+from githubkit import AppInstallationAuthStrategy, GitHub
 
 from polar.config import settings
-from polar.models import Organization, Repository, Issue
-from githubkit import GitHub, AppInstallationAuthStrategy
+from polar.models import Issue, Organization, Repository
+
 from . import client as github
 
 log = structlog.get_logger()
@@ -99,8 +101,11 @@ class GithubBadge:
         if message:
             message += "\n\n"
 
+        # Note: the newline between <a> and <picture> is important. GitHubs markdown
+        # parser freaks out if it isn't there!
         return f"""{PLEDGE_BADGE_COMMENT_START}
-{message}<a href="{funding_url}"><picture>
+{message}<a href="{funding_url}">
+<picture>
   <source media="(prefers-color-scheme: dark)" srcset="{darkmode_url}">
   <img alt="Fund with Polar" src="{lightmode_url}">
 </picture>

--- a/server/tests/integrations/github/test_badge.py
+++ b/server/tests/integrations/github/test_badge.py
@@ -1,22 +1,23 @@
 from unittest.mock import patch
+
 import pytest
 from pytest_mock import MockerFixture
-from polar.config import settings
 
+from polar.config import settings
 from polar.integrations.github.badge import GithubBadge
+from polar.integrations.github.service.issue import github_issue
 from polar.kit.utils import utc_now
 from polar.models.issue import Issue
 from polar.models.organization import Organization
 from polar.models.repository import Repository
 from polar.postgres import AsyncSession
-from polar.integrations.github.service.issue import github_issue
 from tests.fixtures.random_objects import create_issue
-
 
 BADGED_BODY = """Hello my issue
 
 <!-- POLAR PLEDGE BADGE START -->
-<a href="http://127.0.0.1:3000/testorg/testrepo/issues/123"><picture>
+<a href="http://127.0.0.1:3000/testorg/testrepo/issues/123">
+<picture>
   <source media="(prefers-color-scheme: dark)" srcset="http://127.0.0.1:3000/api/github/testorg/testrepo/issues/123/pledge.svg?darkmode=1">
   <img alt="Fund with Polar" src="http://127.0.0.1:3000/api/github/testorg/testrepo/issues/123/pledge.svg">
 </picture>
@@ -63,7 +64,8 @@ async def test_add_badge_custom_content(
 <!-- POLAR PLEDGE BADGE START -->
 Hello, please sponsor me.
 
-<a href="http://127.0.0.1:3000/testorg/testrepo/issues/123"><picture>
+<a href="http://127.0.0.1:3000/testorg/testrepo/issues/123">
+<picture>
   <source media="(prefers-color-scheme: dark)" srcset="http://127.0.0.1:3000/api/github/testorg/testrepo/issues/123/pledge.svg?darkmode=1">
   <img alt="Fund with Polar" src="http://127.0.0.1:3000/api/github/testorg/testrepo/issues/123/pledge.svg">
 </picture>
@@ -105,7 +107,8 @@ async def test_remove_badge_custom_content(
 Hello, please sponsor me.
 Anything can go here!
 
-<a href="http://127.0.0.1:3000/testorg/testrepo/issues/123"><picture>
+<a href="http://127.0.0.1:3000/testorg/testrepo/issues/123">
+<picture>
   <source media="(prefers-color-scheme: dark)" srcset="http://127.0.0.1:3000/api/github/testorg/testrepo/issues/123/pledge.svg?darkmode=1">
   <img alt="Fund with Polar" src="http://127.0.0.1:3000/api/github/testorg/testrepo/issues/123/pledge.svg">
 </picture>


### PR DESCRIPTION
Without this, GitHub links to the image and not to the pledge page

Fixes #778 