### PR TITLE
fix: re-order commands

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,6 +5,9 @@
 ```bash
 # Run these commands in this directory (./server)
 #
+# Create a .env file and edit it
+cp .env.template .env
+
 # Start PostgreSQL and Redis
 docker compose up -d
 
@@ -17,9 +20,6 @@ poetry run task --list
 
 # Use our VSCode workspace (extensions, settings etc)
 code polar.code-workspace
-
-# Create a .env file and edit it
-cp .env.template .env
 
 # Run database migrations
 poetry run task db_migrate


### PR DESCRIPTION
### Why this change?

I wanted to just see if I could get the tests running and noticed `docker compose` commands were failing:

```bash
$ docker compose up -d
WARN[0000] The "POLAR_REDIS_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_REDIS_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_USER" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_PWD" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_DATABASE" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_DATABASE" variable is not set. Defaulting to a blank string.
WARN[0000] The "POLAR_POSTGRES_USER" variable is not set. Defaulting to a blank string.
1 error(s) decoding:

* error decoding 'ports': No port specified: :<empty>

```

The solution was to make sure the `.env` file exists prior to building/running the container (since docker compose reads this automagically). So I here suggest you can change the order of the commands in the README. 😄 


### What was changed?

- Re-ordered existing commands in README.

### Concerns, side effects, notes etc

- Feels cheap with a README-only commit 😉 
- After this change, tests ran just fine on my machine™ from within Neovim with neotest and neotest-python. 👍 

![Screenshot 2023-06-21 at 15 02 02](https://github.com/polarsource/polar/assets/994357/adfd95b4-6443-42da-8fb4-bed03da36ebe)
