### PR TITLE
Enable 'pip install .' for docs' dependencies

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,7 +5,9 @@ description = "Documentation, FAQ & Blog for Polar"
 authors = ["Polar Team <support@polar.sh>"]
 license = "Apache-2.0"
 readme = "README.md"
-packages = [{include = "polar_docs"}]
+packages = [
+  { include = "docs" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
### Why this change?

I saw @birkjernstrom 's tweet: https://twitter.com/birk/status/1673337242486558721?s=20

It's possible to install a poetry-managed pyproject.toml with pip, since poetry-core and pip has [PEP 517](https://peps.python.org/pep-0517) support:

```bash
# cd into the polar repo's docs folder (I guess this is how you want this to work)
cd polar/docs

# install
pip install .

# install as "editable" (noice for local development)
pip install -e .
```

But you've got a typo in the `packages` spec (doesn't line up with your docs folder name), and you must add an `__init__.py` into the package folder in order to make it into a Python package.

### What was changed?

- Add `__init__.py`
- Fix typo in `pyproject.toml`

### Notes

- You can check this branch out and run `pip install .` to install the mkdocs-material dep + the docs as a package itself. The versions specified in poetry.lock is supposed to be respected.
- The latter part of installing the docs package is likely redundant to you, but it is something poetry requires. Might be possible to somehow configure this to not happen 🤷  (a rabbit hole I haven't had to dive into)
- Even if you are installing the insiders version of mkdocs 🤟:100: from vercel now, you might want to consider fixing the typo and the need for this `__init__.py` if you expect users to be able to install mkdocs via this pyproject.toml file, with or without poetry. There's also an option to define e.g. [poetry dependency groups](https://python-poetry.org/docs/master/managing-dependencies/) for server, client, docs, tests etc in one central pyproject.toml file 😄 (will also remove overlap of dependencies dependabot/renovate will bug you about).