### PR TITLE
Wider issue list on large screens

### DIFF
--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -41,7 +41,7 @@ const DashboardLayout = (props: {
         <div className={bodyClasses}>
           <main className="flex-1">
             <div className="py-6">
-              <div className="mx-auto max-w-7xl px-4 sm:px-6 md:px-8">
+              <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8">
                 {children}
               </div>
             </div>


### PR DESCRIPTION
Let's use the space.

Before:
<img width="2658" alt="Screenshot 2023-06-27 at 14 38 14" src="https://github.com/polarsource/polar/assets/1426460/3331d600-3c90-4b51-8bb6-59ad6e9daef8">

After:
<img width="2658" alt="Screenshot 2023-06-27 at 14 38 21" src="https://github.com/polarsource/polar/assets/1426460/841c6acc-1e5e-458d-b906-416e80592bbd">

Solves #796 
