### PR TITLE
server/badge: add/remove based on what label changed

### DIFF
--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -491,14 +491,15 @@ async def issue_labeled_async(
         )
         return
 
-    embedded_before_update = issue.has_pledge_badge_label
-
     issue = await service.github_issue.set_labels(session, issue, event.issue.labels)
 
-    should_embed = issue.has_pledge_badge_label
-    if embedded_before_update != should_embed:
-        # Only remove or add badge in case of label change
-        await update_issue_embed(session, issue=issue, embed=should_embed)
+    log.debug("issue_labeled_async", label=event.label, issue_id=issue.id)
+
+    # Add/remove polar badge if label has changed
+    if event.label == "polar":
+        await update_issue_embed(
+            session, issue=issue, embed=issue.has_pledge_badge_label
+        )
 
 
 @task("github.webhook.issues.assigned")


### PR DESCRIPTION
We have this information in the webhook, no need to try to detect it ourselves.

This fixes a race condition where it was possible for the badge to not get embedded if we had already updated the issue from somewhere else.