### PR TITLE
Fix pledge 404

### DIFF
--- a/clients/apps/web/src/pages/[organization]/[repo]/issues/[number]/index.tsx
+++ b/clients/apps/web/src/pages/[organization]/[repo]/issues/[number]/index.tsx
@@ -126,12 +126,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       return { props: {} }
     }
 
-    const res = await api.pledges.getPledgeWithResources({
+    const res = await api.issues.getOrSyncExternal({
       platform: Platforms.GITHUB,
       orgName: context.params.organization,
       repoName: context.params.repo,
       number: parseInt(context.params.number),
-      include: 'issue,organization,repository',
+      include: 'organization,repository',
     })
     const { organization, repository, issue } = res
     return { props: { organization, repository, issue, query: context.query } }

--- a/clients/packages/polarkit/src/api/client/index.ts
+++ b/clients/packages/polarkit/src/api/client/index.ts
@@ -33,6 +33,7 @@ export type { IssuePublicRead } from './models/IssuePublicRead';
 export type { IssueRead } from './models/IssueRead';
 export type { IssueReferenceRead } from './models/IssueReferenceRead';
 export { IssueReferenceType } from './models/IssueReferenceType';
+export type { IssueResources } from './models/IssueResources';
 export { IssueSortBy } from './models/IssueSortBy';
 export { IssueStatus } from './models/IssueStatus';
 export type { IssueUpdateBadgeMessage } from './models/IssueUpdateBadgeMessage';

--- a/clients/packages/polarkit/src/api/client/models/IssueResources.ts
+++ b/clients/packages/polarkit/src/api/client/models/IssueResources.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { IssueRead } from './IssueRead';
+import type { OrganizationPublicRead } from './OrganizationPublicRead';
+import type { RepositoryRead } from './RepositoryRead';
+
+export type IssueResources = {
+  issue: IssueRead;
+  organization?: OrganizationPublicRead;
+  repository?: RepositoryRead;
+};
+

--- a/clients/packages/polarkit/src/api/client/services/IssuesService.ts
+++ b/clients/packages/polarkit/src/api/client/services/IssuesService.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 import type { IssueRead } from '../models/IssueRead';
 import type { IssueReferenceRead } from '../models/IssueReferenceRead';
+import type { IssueResources } from '../models/IssueResources';
 import type { IssueUpdateBadgeMessage } from '../models/IssueUpdateBadgeMessage';
 import type { Platforms } from '../models/Platforms';
 import type { PostIssueComment } from '../models/PostIssueComment';
@@ -13,6 +14,42 @@ import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 export class IssuesService {
 
   constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+  /**
+   * Get Or Sync External
+   * @returns IssueResources Successful Response
+   * @throws ApiError
+   */
+  public getOrSyncExternal({
+    platform,
+    orgName,
+    repoName,
+    number,
+    include = 'organization,repository',
+  }: {
+    platform: Platforms,
+    orgName: string,
+    repoName: string,
+    number: number,
+    include?: string,
+  }): CancelablePromise<IssueResources> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/api/v1/{platform}/{org_name}/{repo_name}/issues/{number}',
+      path: {
+        'platform': platform,
+        'org_name': orgName,
+        'repo_name': repoName,
+        'number': number,
+      },
+      query: {
+        'include': include,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
 
   /**
    * Get Repository Issues
@@ -97,37 +134,6 @@ export class IssuesService {
         'org_name': orgName,
         'repo_name': repoName,
         'issue_number': issueNumber,
-      },
-      errors: {
-        422: `Validation Error`,
-      },
-    });
-  }
-
-  /**
-   * Get Public Issue
-   * @returns IssueRead Successful Response
-   * @throws ApiError
-   */
-  public getPublicIssue({
-    platform,
-    orgName,
-    repoName,
-    number,
-  }: {
-    platform: Platforms,
-    orgName: string,
-    repoName: string,
-    number: number,
-  }): CancelablePromise<IssueRead> {
-    return this.httpRequest.request({
-      method: 'GET',
-      url: '/api/v1/{platform}/{org_name}/{repo_name}/issues/{number}',
-      path: {
-        'platform': platform,
-        'org_name': orgName,
-        'repo_name': repoName,
-        'number': number,
       },
       errors: {
         422: `Validation Error`,

--- a/clients/packages/polarkit/src/api/client/services/PledgesService.ts
+++ b/clients/packages/polarkit/src/api/client/services/PledgesService.ts
@@ -33,7 +33,7 @@ export class PledgesService {
     orgName: string,
     repoName: string,
     number: number,
-    pledgeId?: string,
+    pledgeId: string,
     include?: string,
   }): CancelablePromise<PledgeResources> {
     return this.httpRequest.request({

--- a/server/polar/pledge/endpoints.py
+++ b/server/polar/pledge/endpoints.py
@@ -6,10 +6,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from polar.auth.dependencies import Auth
 from polar.enums import Platforms
 from polar.exceptions import NotPermitted, ResourceNotFound
-from polar.integrations.github.client import get_polar_client
-from polar.integrations.github.service.organization import (
-    github_organization as gh_organization,
-)
 from polar.issue.schemas import IssueRead
 from polar.models import Pledge, Repository
 from polar.organization.schemas import OrganizationPublicRead
@@ -70,15 +66,14 @@ async def get_pledge_with_resources(
     session: AsyncSession = Depends(get_db_session),
 ) -> PledgeResources:
     includes = include.split(",")
-    client = get_polar_client()
 
     try:
-        org, repo, issue = await gh_organization.sync_external_org_with_repo_and_issue(
+        org, repo, issue = await organization_service.get_with_repo_and_issue(
             session,
-            client=client,
+            platform=platform,
             org_name=org_name,
             repo_name=repo_name,
-            issue_number=number,
+            issue=number,
         )
     except ResourceNotFound:
         raise HTTPException(

--- a/server/polar/pledge/endpoints.py
+++ b/server/polar/pledge/endpoints.py
@@ -12,8 +12,6 @@ from polar.integrations.github.service.organization import (
 )
 from polar.issue.schemas import IssueRead
 from polar.models import Pledge, Repository
-from polar.models.user import User
-from polar.models.user_organization import UserOrganization
 from polar.organization.schemas import OrganizationPublicRead
 from polar.organization.service import organization as organization_service
 from polar.postgres import AsyncSession, get_db_session
@@ -66,7 +64,7 @@ async def get_pledge_with_resources(
     org_name: str,
     repo_name: str,
     number: int,
-    pledge_id: UUID | None = None,
+    pledge_id: UUID,
     # Mimic JSON-API's include query format
     include: str = "organization,repository,issue",
     session: AsyncSession = Depends(get_db_session),
@@ -88,13 +86,12 @@ async def get_pledge_with_resources(
             detail="Organization, repo and issue combination not found",
         )
 
-    if pledge_id:
-        pledge = await get_pledge_or_404(
-            session,
-            pledge_id=pledge_id,
-            for_repository=repo,
-        )
-        included_pledge = PledgeRead.from_db(pledge)
+    pledge = await get_pledge_or_404(
+        session,
+        pledge_id=pledge_id,
+        for_repository=repo,
+    )
+    included_pledge = PledgeRead.from_db(pledge)
 
     included_org = None
     if "organization" in includes:


### PR DESCRIPTION
We used one endpoint for two jobs which got messy & confusing + caused 404 on the issue pledge page.

**Issue page**: E.g _polar.sh/polarsource/polar/issues/123_
- Get internal resources OR sync them from Github (supporting polar.new)
- Does not include `pledge` and has a different type (new)

**Status page**: E.g post pledge completion
- Get internal resources only. No need to potentially sync from Github in such cases.
- Does include `pledge` resource & requires it
