### PR TITLE
clients/settings: move /dashboard/settings to /settings

### DIFF
--- a/clients/apps/web/src/components/Shared/DashboardTopbar.tsx
+++ b/clients/apps/web/src/components/Shared/DashboardTopbar.tsx
@@ -12,7 +12,7 @@ import Topbar from './Topbar'
 import TopbarPill from './TopbarPill'
 
 const SettingsLink = ({ orgSlug }: { orgSlug?: string }) => {
-  let path = '/dashboard/settings'
+  let path = '/settings'
   if (orgSlug) {
     path += `/${orgSlug}`
   }

--- a/clients/apps/web/src/pages/settings/[organization]/index.tsx
+++ b/clients/apps/web/src/pages/settings/[organization]/index.tsx
@@ -143,8 +143,8 @@ const SettingsTopbar = () => {
               showRepositories={false}
               showConnectMore={false}
               currentOrg={currentOrg}
-              onSelectOrg={(org) => router.push(`/dashboard/settings/${org}`)}
-              onSelectUser={() => router.push(`/dashboard/settings/personal`)}
+              onSelectOrg={(org) => router.push(`/settings/${org}`)}
+              onSelectUser={() => router.push(`/settings/personal`)}
               currentUser={currentUser}
               organizations={userOrgQuery.data}
               defaultToUser={true}

--- a/clients/apps/web/src/pages/settings/index.tsx
+++ b/clients/apps/web/src/pages/settings/index.tsx
@@ -8,7 +8,7 @@ import { ReactElement, useEffect } from 'react'
 const Page: NextPageWithLayout = () => {
   const router = useRouter()
   useEffect(() => {
-    router.push(`/dashboard/settings/personal`)
+    router.push(`/settings/personal`)
   })
 
   return (


### PR DESCRIPTION
Not moving the extensions token page for now, as it's referenced by the chrome extension.