### PR TITLE
server: Use fixed version of redis (4.5.5)

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -1630,13 +1630,13 @@ files = [
 
 [[package]]
 name = "redis"
-version = "4.6.0"
+version = "4.5.5"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c"},
-    {file = "redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d"},
+    {file = "redis-4.5.5-py3-none-any.whl", hash = "sha256:77929bc7f5dab9adf3acba2d3bb7d7658f1e0c2f1cafe7eb36434e751c471119"},
+    {file = "redis-4.5.5.tar.gz", hash = "sha256:dc87a0bdef6c8bfe1ef1e1c40be7034390c2ae02d92dcd0c7ca1729443899880"},
 ]
 
 [package.dependencies]
@@ -2095,13 +2095,13 @@ cryptography = ">=35.0.0"
 
 [[package]]
 name = "types-redis"
-version = "4.6.0.2"
+version = "4.5.5.2"
 description = "Typing stubs for redis"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-redis-4.6.0.2.tar.gz", hash = "sha256:d0efcd96f65fd2036437c29d8c12566cfdc549345d73eddacb0488b81aff9f9e"},
-    {file = "types_redis-4.6.0.2-py3-none-any.whl", hash = "sha256:a98f3386f44d045057696f3efc8869c53dda0060610e0fe3d8a4d391e2a8916a"},
+    {file = "types-redis-4.5.5.2.tar.gz", hash = "sha256:2fe82f374d9dddf007deaf23d81fddcfd9523d9522bf11523c5c43bc5b27099e"},
+    {file = "types_redis-4.5.5.2-py3-none-any.whl", hash = "sha256:bf8692252038dbe03b007ca4fde87d3ae8e10610854a6858e3bf5d01721a7c4b"},
 ]
 
 [package.dependencies]
@@ -2536,4 +2536,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "fc98e74a0b2b2eb8df748c610a1fb5cb650d2bd675f8a6270f33a68cf4d6eeb9"
+content-hash = "ce0590cd472c7a6e5f1bea4cd59fe886a1226364b29504796731d07963f1aa72"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -16,7 +16,7 @@ sqlalchemy = {extras = ["asyncio"], version = "^2.0.9"}
 greenlet = "^2.0.2"  # Need to be explicit, M1 Mac issue (https://github.com/python-poetry/poetry/issues/5429)
 structlog = "^22.3.0"
 githubkit = {extras = ["auth-app"], version = "^0.10.6"}
-redis = "^4.5.4"
+redis = "4.5.5"
 sse-starlette = "^1.4.0"
 arq = "^0.25.0"
 stripe = "^5.2.0"
@@ -46,7 +46,7 @@ sqlalchemy-utils = "^0.40.0"
 ruff = "^0.0.253"
 pytest-asyncio = "^0.20.3"
 taskipy = "^1.10.3"
-types-redis = "^4.5.2.0"
+types-redis = "4.5.5.2"
 pytest-subtests = "^0.10.0"
 types-stripe = "^3.5.2.8"
 pytest-recording = "^0.12.2"


### PR DESCRIPTION
4.6.0 is causing connection leakage with arq and eventually the pool to
run out. Need to investigate before we upgrade. Until then, let's make
sure we don't run into this again by accident.
+redis = "4.5.5"
+types-redis = "4.5.5.2"
