### PR TITLE
server/dashboard: filter by badged

### DIFF
--- a/clients/packages/polarkit/src/api/client/PolarAPI.ts
+++ b/clients/packages/polarkit/src/api/client/PolarAPI.ts
@@ -47,7 +47,7 @@ export class PolarAPI {
 
   constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
     this.request = new HttpRequest({
-      BASE: config?.BASE ?? '',
+      BASE: config?.BASE ?? 'https://api.polar.sh',
       VERSION: config?.VERSION ?? '0.1.0',
       WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
       CREDENTIALS: config?.CREDENTIALS ?? 'include',

--- a/clients/packages/polarkit/src/api/client/core/OpenAPI.ts
+++ b/clients/packages/polarkit/src/api/client/core/OpenAPI.ts
@@ -19,7 +19,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-  BASE: '',
+  BASE: 'https://api.polar.sh',
   VERSION: '0.1.0',
   WITH_CREDENTIALS: false,
   CREDENTIALS: 'include',

--- a/clients/packages/polarkit/src/api/client/services/DashboardService.ts
+++ b/clients/packages/polarkit/src/api/client/services/DashboardService.ts
@@ -25,6 +25,7 @@ export class DashboardService {
     q,
     sort,
     onlyPledged = false,
+    onlyBadged = false,
     page = 1,
   }: {
     issueListType?: IssueListType,
@@ -32,6 +33,7 @@ export class DashboardService {
     q?: string,
     sort?: IssueSortBy,
     onlyPledged?: boolean,
+    onlyBadged?: boolean,
     page?: number,
   }): CancelablePromise<IssueListResponse> {
     return this.httpRequest.request({
@@ -43,6 +45,7 @@ export class DashboardService {
         'q': q,
         'sort': sort,
         'only_pledged': onlyPledged,
+        'only_badged': onlyBadged,
         'page': page,
       },
       errors: {
@@ -65,6 +68,7 @@ export class DashboardService {
     q,
     sort,
     onlyPledged = false,
+    onlyBadged = false,
     page = 1,
   }: {
     platform: Platforms,
@@ -75,6 +79,7 @@ export class DashboardService {
     q?: string,
     sort?: IssueSortBy,
     onlyPledged?: boolean,
+    onlyBadged?: boolean,
     page?: number,
   }): CancelablePromise<IssueListResponse> {
     return this.httpRequest.request({
@@ -91,6 +96,7 @@ export class DashboardService {
         'q': q,
         'sort': sort,
         'only_pledged': onlyPledged,
+        'only_badged': onlyBadged,
         'page': page,
       },
       errors: {

--- a/server/polar/dashboard/endpoints.py
+++ b/server/polar/dashboard/endpoints.py
@@ -48,6 +48,7 @@ async def get_personal_dashboard(
     q: Union[str, None] = Query(default=None),
     sort: Union[IssueSortBy, None] = Query(default=None),
     only_pledged: bool = Query(default=False),
+    only_badged: bool = Query(default=False),
     page: int = Query(default=1),
     auth: Auth = Depends(Auth.current_user),
     session: AsyncSession = Depends(get_db_session),
@@ -62,6 +63,7 @@ async def get_personal_dashboard(
         page=page,
         for_user=auth.user,
         only_pledged=only_pledged,
+        only_badged=only_badged,
     )
 
 
@@ -78,6 +80,7 @@ async def get_dashboard(
     q: Union[str, None] = Query(default=None),
     sort: Union[IssueSortBy, None] = Query(default=None),
     only_pledged: bool = Query(default=False),
+    only_badged: bool = Query(default=False),
     page: int = Query(default=1),
     auth: Auth = Depends(Auth.user_with_org_access),
     session: AsyncSession = Depends(get_db_session),
@@ -130,6 +133,7 @@ async def get_dashboard(
         for_org=auth.organization,
         for_user=show_pledges_for_user,
         only_pledged=only_pledged,
+        only_badged=only_badged,
         page=page,
     )
 
@@ -160,6 +164,7 @@ async def dashboard(
     for_org: Organization | None = None,
     for_user: User | None = None,
     only_pledged: bool = False,
+    only_badged: bool = False,
     page: int = 1,
 ) -> IssueListResponse:
     # Default sorting
@@ -184,6 +189,7 @@ async def dashboard(
         if for_user and IssueListType.dependencies
         else None,
         have_pledge=True if only_pledged else None,
+        have_polar_badge=True if only_badged else None,
         load_references=True,
         load_pledges=True,
         load_repository=True,

--- a/server/tests/dashboard/test_endpoints.py
+++ b/server/tests/dashboard/test_endpoints.py
@@ -1,13 +1,15 @@
-from httpx import AsyncClient
 import pytest
+from httpx import AsyncClient
+
+from polar.app import app
+from polar.config import settings
 from polar.models.issue import Issue
 from polar.models.organization import Organization
 from polar.models.pledge import Pledge
 from polar.models.repository import Repository
 from polar.models.user import User
-from polar.app import app
-from polar.config import settings
 from polar.models.user_organization import UserOrganization
+from polar.postgres import AsyncSession
 
 
 @pytest.mark.asyncio
@@ -91,3 +93,109 @@ async def test_get_with_pledge(
     assert len(pledges) == 1
     assert pledges[0]["id"] == rel_pledged["id"]
     assert pledges[0]["attributes"]["pledger_name"] == pledging_organization.name
+
+
+@pytest.mark.asyncio
+async def test_get_only_pledged_with_pledge(
+    user: User,
+    organization: Organization,
+    repository: Repository,
+    user_organization: UserOrganization,  # makes User a member of Organization
+    pledging_organization: Organization,
+    pledge: Pledge,
+    issue: Issue,
+    auth_jwt: str,
+) -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get(
+            f"/api/v1/dashboard/github/{organization.name}?only_pledged=True",
+            cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
+        )
+
+    assert response.status_code == 200
+    res = response.json()
+
+    assert len(res["data"]) == 1
+    assert res["data"][0]["id"] == str(issue.id)
+    assert len(res["data"][0]["relationships"]["pledges"]["data"]) == 1
+    rel_pledged = res["data"][0]["relationships"]["pledges"]["data"][0]
+
+    pledges = [x for x in res["included"] if x["type"] == "pledge"]
+    assert len(pledges) == 1
+    assert pledges[0]["id"] == rel_pledged["id"]
+    assert pledges[0]["attributes"]["pledger_name"] == pledging_organization.name
+
+
+@pytest.mark.asyncio
+async def test_get_only_pledged_no_pledge(
+    user: User,
+    organization: Organization,
+    repository: Repository,
+    user_organization: UserOrganization,  # makes User a member of Organization
+    # pledging_organization: Organization,
+    # pledge: Pledge,
+    issue: Issue,
+    auth_jwt: str,
+) -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get(
+            f"/api/v1/dashboard/github/{organization.name}?only_pledged=True",
+            cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
+        )
+
+    assert response.status_code == 200
+    res = response.json()
+
+    assert len(res["data"]) == 0
+    pledges = [x for x in res["included"] if x["type"] == "pledge"]
+    assert len(pledges) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_only_badged_no_badge(
+    user: User,
+    organization: Organization,
+    repository: Repository,
+    user_organization: UserOrganization,  # makes User a member of Organization
+    pledging_organization: Organization,
+    # pledge: Pledge,
+    issue: Issue,
+    auth_jwt: str,
+) -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get(
+            f"/api/v1/dashboard/github/{organization.name}?only_badged=True",
+            cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
+        )
+
+    assert response.status_code == 200
+    res = response.json()
+
+    assert len(res["data"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_only_badged_is_badged(
+    user: User,
+    organization: Organization,
+    repository: Repository,
+    user_organization: UserOrganization,  # makes User a member of Organization
+    pledging_organization: Organization,
+    # pledge: Pledge,
+    issue: Issue,
+    auth_jwt: str,
+    session: AsyncSession,
+) -> None:
+    issue.pledge_badge_currently_embedded = True
+    await issue.save(session)
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get(
+            f"/api/v1/dashboard/github/{organization.name}?only_badged=True",
+            cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
+        )
+
+    assert response.status_code == 200
+    res = response.json()
+
+    assert len(res["data"]) == 1


### PR DESCRIPTION
Adds a filter to the (private) dashboard API to allow filtering by badged status.

Part of #903