### PR TITLE
Remove email validation

### DIFF
--- a/clients/packages/polarkit/src/api/client/services/IssuesService.ts
+++ b/clients/packages/polarkit/src/api/client/services/IssuesService.ts
@@ -49,7 +49,8 @@ export class IssuesService {
   }
 
   /**
-   * Get
+   * Get issue (Public API)
+   * Get issue
    * @returns Issue Successful Response
    * @throws ApiError
    */

--- a/clients/packages/polarkit/src/api/client/services/PledgesService.ts
+++ b/clients/packages/polarkit/src/api/client/services/PledgesService.ts
@@ -145,6 +145,9 @@ export class PledgesService {
       body: requestBody,
       mediaType: 'application/json',
       errors: {
+        400: `Bad Request`,
+        403: `Forbidden`,
+        404: `Not Found`,
         422: `Validation Error`,
       },
     });


### PR DESCRIPTION
* Remove email validation on the client, the only requirement is that the email address must contain `@`
* Gracefully handle Stripe validation errors (on both backend and frontend), for cases such as when the email is invalid according to Stripe.

Fixes #915 