### PR TITLE
api/organization: Support authentication by org id

### DIFF
--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -9,7 +9,7 @@ from polar.organization.service import organization as organization_service
 from .service import AuthService
 
 
-async def must_current_active_user(
+async def current_user_required(
     request: Request,
     session: AsyncSession = Depends(get_db_session),
 ) -> User:
@@ -19,7 +19,7 @@ async def must_current_active_user(
     return user
 
 
-async def optional_current_active_user(
+async def current_user_optional(
     request: Request,
     session: AsyncSession = Depends(get_db_session),
 ) -> User | None:
@@ -64,15 +64,11 @@ class Auth:
     ###############################################################################
 
     @classmethod
-    async def current_user(
-        cls, user: User = Depends(must_current_active_user)
-    ) -> "Auth":
+    async def current_user(cls, user: User = Depends(current_user_required)) -> "Auth":
         return Auth(user=user)
 
     @classmethod
-    async def optional_user(
-        cls, user: User = Depends(optional_current_active_user)
-    ) -> "Auth":
+    async def optional_user(cls, user: User = Depends(current_user_optional)) -> "Auth":
         return Auth(user=user)
 
     @classmethod
@@ -82,7 +78,7 @@ class Auth:
         platform: Platforms,
         org_name: str,
         session: AsyncSession = Depends(get_db_session),
-        user: User = Depends(must_current_active_user),
+        user: User = Depends(current_user_required),
     ) -> "Auth":
         organization = await organization_service.get_for_user(
             session,
@@ -104,7 +100,7 @@ class Auth:
         org_name: str,
         repo_name: str,
         session: AsyncSession = Depends(get_db_session),
-        user: User = Depends(must_current_active_user),
+        user: User = Depends(current_user_required),
     ) -> "Auth":
         try:
             org, repo = await organization_service.get_with_repo_for_user(
@@ -125,7 +121,7 @@ class Auth:
     async def backoffice_user(
         cls,
         *,
-        user: User = Depends(must_current_active_user),
+        user: User = Depends(current_user_required),
     ) -> "Auth":
         allowed = ["zegl", "birkjernstrom", "hult", "petterheterjag"]
 

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import Request, HTTPException, Depends
 
 from polar.models import User, Organization, Repository
@@ -84,6 +86,25 @@ class Auth:
             session,
             platform=platform,
             org_name=org_name,
+            user_id=user.id,
+        )
+        if not organization:
+            raise HTTPException(
+                status_code=404, detail="Organization not found for user"
+            )
+        return Auth(user=user, organization=organization)
+
+    @classmethod
+    async def user_with_org_access_by_id(
+        cls,
+        *,
+        id: UUID,
+        session: AsyncSession = Depends(get_db_session),
+        user: User = Depends(current_user_required),
+    ) -> "Auth":
+        organization = await organization_service.get_by_id_for_user(
+            session,
+            org_id=id,
             user_id=user.id,
         )
         if not organization:

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -141,19 +141,11 @@ async def update(
     id: UUID,
     update: UpdateOrganization,
     session: AsyncSession = Depends(get_db_session),
-    auth: Auth = Depends(Auth.current_user),
+    auth: Auth = Depends(Auth.user_with_org_access_by_id),
 ) -> OrganizationSchema:
-    org = await organization.get(session, id)
-
-    if not org:
-        raise HTTPException(
-            status_code=404,
-            detail="Organization not found",
-        )
-
-    # TODO: Auth
-
     updated = False
+    # TODO:Raise 404 on org not found vs. 403 on forbidden
+    org = auth.organization
 
     if update.default_funding_goal:
         if update.default_funding_goal.currency != "USD":

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -172,6 +172,22 @@ async def test_get_organization_deleted(
 
 
 @pytest.mark.asyncio
+async def test_update_organization_permission(
+    session: AsyncSession,
+    organization: Organization,
+    auth_jwt: str,
+) -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            f"/api/v1/organizations/{organization.id}",
+            json={"default_funding_goal": {"currency": "USD", "amount": 12000}},
+            cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_update_default_funding_goal(
     organization: Organization,
     auth_jwt: str,


### PR DESCRIPTION
- server/auth: Rename current user dependencies
- api/organization: Raise HTTP 404 w/o proper permissions
