### PR TITLE
clients/feed: add onboarding splash if user have no pledges

### DIFF
--- a/clients/apps/web/src/components/Onboarding/OnboardingConnectPersonalDashboard.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingConnectPersonalDashboard.tsx
@@ -42,11 +42,10 @@ const OnboardingConnectPersonalDashboard = () => {
             <div className="flex-1 text-sm text-gray-500 dark:text-gray-400">
               <p>
                 Interested in getting backers behind your open source efforts?
-                Or looking to track issues you&apos;re dependent on and pledge
-                behind them? Connect your repositories to get started.
+                Connect your repositories to get started.
               </p>
             </div>
-            <div className="flex items-center justify-between gap-4 pt-2 lg:justify-start">
+            <div className="flex items-center justify-between gap-4 pt-2 xl:justify-start">
               <PrimaryButton
                 color="blue"
                 classNames="pl-3.5"
@@ -75,7 +74,7 @@ const OnboardingConnectPersonalDashboard = () => {
             </div>
           </div>
         </div>
-        <div className="relative hidden flex-1 lg:block">
+        <div className="relative hidden flex-1 xl:block">
           <Image
             src={screenshot}
             alt="Polar dashboard screenshot"

--- a/clients/apps/web/src/components/Onboarding/OnboardingConnectReposToGetStarted.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingConnectReposToGetStarted.tsx
@@ -14,9 +14,8 @@ const OnboardingConnectReposToGetStarted = () => {
     <div className="flex flex-col items-center space-y-4 pt-24">
       <h2 className="text-2xl">Connect repos to get started</h2>
       <p className="max-w-3xl text-center text-gray-500 dark:text-gray-400">
-        Regardless of if you’re an open source maintainer seeking funding or a
-        company looking to track issues you’re dependent on, the first step is
-        to connect repositories.
+        Interested in getting backers behind your open source efforts? Connect
+        your repositories to get started.
       </p>
       <div className="py-2">
         <PrimaryButton

--- a/clients/apps/web/src/pages/feed.tsx
+++ b/clients/apps/web/src/pages/feed.tsx
@@ -3,6 +3,7 @@ import Gatekeeper from '@/components/Dashboard/Gatekeeper/Gatekeeper'
 import IssueList from '@/components/Dashboard/IssueList'
 import { DashboardFilters } from '@/components/Dashboard/filters'
 import BackerLayout from '@/components/Layout/BackerLayout'
+import OnboardingConnectReposToGetStarted from '@/components/Onboarding/OnboardingConnectReposToGetStarted'
 import { useAuth } from '@/hooks'
 import type { NextLayoutComponentType } from 'next'
 import { IssueListType, IssueStatus } from 'polarkit/api/client'
@@ -35,6 +36,15 @@ const Page: NextLayoutComponentType = () => {
   )
   const dashboard = dashboardQuery.data
   const totalCount = dashboard?.pages[0].pagination.total_count || undefined
+
+  // Onboarding splashscreen
+  if (!dashboardQuery.isLoading && totalCount === 0) {
+    return (
+      <BackerLayout>
+        <OnboardingConnectReposToGetStarted />
+      </BackerLayout>
+    )
+  }
 
   return (
     <BackerLayout>

--- a/clients/apps/web/src/stories/OnboardingConnectDashboard.stories.ts
+++ b/clients/apps/web/src/stories/OnboardingConnectDashboard.stories.ts
@@ -1,15 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import OnboardingConnectDashboard from '../components/Onboarding/OnboardingConnectDashboard'
+import OnboardingConnectPersonalDashboard from '@/components/Onboarding/OnboardingConnectPersonalDashboard'
 
-const meta: Meta<typeof OnboardingConnectDashboard> = {
-  title: 'Organisms/OnboardingConnectDashboard',
-  component: OnboardingConnectDashboard,
+const meta: Meta<typeof OnboardingConnectPersonalDashboard> = {
+  title: 'Organisms/OnboardingConnectPersonalDashboard',
+  component: OnboardingConnectPersonalDashboard,
   tags: ['autodocs'],
 }
 
 export default meta
 
-type Story = StoryObj<typeof OnboardingConnectDashboard>
+type Story = StoryObj<typeof OnboardingConnectPersonalDashboard>
 
 export const Default: Story = {}


### PR DESCRIPTION
Recycling components from the previous website design.

Temporary workaround for #981