### PR TITLE
clients/issues: responsive header

### DIFF
--- a/clients/apps/web/src/components/Dashboard/IssueList.tsx
+++ b/clients/apps/web/src/components/Dashboard/IssueList.tsx
@@ -247,10 +247,10 @@ export const Header = (props: {
   return (
     <>
       <form
-        className="flex flex-col justify-between space-y-2 border-b bg-gray-100/50 pr-2  backdrop-blur dark:bg-gray-700/50 lg:flex-row lg:items-center lg:space-x-4 lg:space-y-0"
+        className="flex flex-col justify-between space-y-2 border-b bg-gray-100/50 bg-white p-2 !pr-2 backdrop-blur-none dark:bg-gray-700/50	lg:flex-row lg:items-center lg:space-x-4 lg:space-y-0 lg:bg-transparent lg:p-0 lg:backdrop-blur"
         onSubmit={onSubmit}
       >
-        <div className="flex h-full w-full items-center space-x-4">
+        <div className="flex h-full w-full flex-col items-stretch space-y-2 lg:flex-row lg:items-center lg:space-x-4">
           <MaintainerRepoSelection />
           <div className="relative w-full py-2 lg:max-w-[500px]">
             <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 ">

--- a/clients/apps/web/src/components/Dashboard/MaintainerRepoSelection.tsx
+++ b/clients/apps/web/src/components/Dashboard/MaintainerRepoSelection.tsx
@@ -21,7 +21,7 @@ const MaintainerRepoSelection = () => {
   )
 
   return (
-    <div className="relative flex h-full h-14 shrink-0 border-r">
+    <div className="relative flex w-full shrink-0 lg:w-fit lg:border-r">
       <RepoSelection
         selectedClassNames="pl-2"
         openClassNames="left-2 top-2"

--- a/clients/apps/web/src/components/Dropdown/index.tsx
+++ b/clients/apps/web/src/components/Dropdown/index.tsx
@@ -85,7 +85,7 @@ export const SelectedBox = ({
   return (
     <div
       className={clsx(
-        'flex h-full max-w-[360px] cursor-pointer items-center justify-between space-x-2  p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700',
+        'flex h-full cursor-pointer items-center justify-between space-x-2 p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700',
         classNames,
       )}
       onClick={onClick}

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -35,7 +35,7 @@ const DashboardLayout = (props: {
           )}
           <div
             className={classNames(
-              props.header ? 'pt-48 lg:pt-36' : 'pt-24',
+              props.header ? 'pt-64 lg:pt-36' : 'pt-24',
               'relative mx-auto max-w-screen-2xl px-4 pt-24 pb-6 sm:px-6 md:px-8',
             )}
           >

--- a/clients/apps/web/src/components/Organization/RepoSelection.tsx
+++ b/clients/apps/web/src/components/Organization/RepoSelection.tsx
@@ -58,7 +58,7 @@ export function RepoSelection(props: {
     setOpen(false)
   })
 
-  const width = 'min-w-[320px] max-w-[500px]'
+  const width = 'lg:min-w-[320px] lg:max-w-[500px]'
 
   const sortedRepositories = repositories.sort((a, b) =>
     a.name < b.name ? -1 : 1,
@@ -70,7 +70,7 @@ export function RepoSelection(props: {
       onClick={(e) => {
         e.stopPropagation()
       }}
-      className="h-full"
+      className="h-full w-full lg:w-fit"
     >
       {props.value && (
         <SelectedRepository
@@ -156,7 +156,7 @@ const SelectedRepository = ({
 }) => {
   return (
     <SelectedBox onClick={onClick} classNames={classNames}>
-      <div className="flex items-center justify-between space-x-2 ">
+      <div className="flex items-center justify-between space-x-2">
         <RepoIcon />
         <div className="flex items-center space-x-1 overflow-hidden ">
           <span className="overflow-hidden text-ellipsis whitespace-nowrap text-gray-900 dark:text-gray-200">


### PR DESCRIPTION
<img width="1635" alt="Screenshot 2023-08-21 at 11 41 53" src="https://github.com/polarsource/polar/assets/47952/60fe5fcf-2375-4d59-b480-df8f5885be7f">
<img width="1067" alt="Screenshot 2023-08-21 at 11 41 57" src="https://github.com/polarsource/polar/assets/47952/21e8094b-03f7-436f-80a3-61bdb26c8bb4">

Removed blur on small devices, split the search/filters on three rows.