### PR TITLE
server/references: catch all only event

### DIFF
--- a/server/polar/integrations/github/service/reference.py
+++ b/server/polar/integrations/github/service/reference.py
@@ -42,9 +42,6 @@ class UnknownIssueEvent(github.rest.GitHubRestModel):
     This is a catch-all event for events that we're unable to parse.
     """
 
-    id: int = Field(default=...)
-    node_id: str = Field(default=...)
-    url: str = Field(default=...)
     event: str = Field(default=...)
 
 


### PR DESCRIPTION
The event field seems to be the only field that is always there
