### PR TITLE
server/worker: reuse arq pool

### DIFF
--- a/server/polar/worker.py
+++ b/server/polar/worker.py
@@ -112,10 +112,12 @@ async def enqueue_job(name: str, *args: Any, **kwargs: Any) -> Job | None:
     kwargs["polar_context"] = PolarWorkerContext(
         is_during_installation=ctx.is_during_installation,
     )
+    return await _enqueue_job(name, *args, **kwargs)
 
+
+async def _enqueue_job(name: str, *args: Any, **kwargs: Any) -> Job | None:
     if not arq_pool:
         raise Exception("arq_pool is not initialized")
-
     return await arq_pool.enqueue_job(name, *args, **kwargs)
 
 

--- a/server/tests/integrations/github/tasks/test_integration.py
+++ b/server/tests/integrations/github/tasks/test_integration.py
@@ -42,7 +42,7 @@ async def test_installation_no_notifications(
         pytest -k test_installation_no_notifications --record-mode=rewrite
     """
 
-    async def in_process_enqueue_job(pool, name, *args, **kwargs) -> None:  # type: ignore  # noqa: E501
+    async def in_process_enqueue_job(name, *args, **kwargs) -> None:  # type: ignore  # noqa: E501
         if name == "github.repo.sync.issues":
             return await tasks.repo.sync_repository_issues(
                 kwargs["polar_context"], *args, **kwargs
@@ -70,7 +70,7 @@ async def test_installation_no_notifications(
     ) as fp:
         cassette: dict[str, Any] = json.loads(fp.read())
 
-    mocker.patch("arq.connections.ArqRedis.enqueue_job", new=in_process_enqueue_job)
+    mocker.patch("polar.worker._enqueue_job", new=in_process_enqueue_job)
 
     async with AsyncSessionLocal() as session:
         # Create user to match requesting user

--- a/server/tests/issue/test_endpoints.py
+++ b/server/tests/issue/test_endpoints.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi.encoders import jsonable_encoder
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
 
 from polar.app import app
 from polar.config import settings
@@ -273,7 +274,10 @@ async def test_confirm_solved(
     pledge: Pledge,
     session: AsyncSession,
     user_organization: UserOrganization,  # makes User a member of Organization
+    mocker: MockerFixture,
 ) -> None:
+    mocker.patch("polar.worker._enqueue_job")
+
     user_organization.is_admin = True
     await user_organization.save(session)
 

--- a/server/tests/notifications/test_pledge_notifications.py
+++ b/server/tests/notifications/test_pledge_notifications.py
@@ -80,6 +80,7 @@ async def test_deduplicate(
     mocker: MockerFixture,
 ) -> None:
     spy = mocker.spy(NotificationsService, "send_to_org")
+    mocker.patch("polar.worker._enqueue_job")
 
     pledge = await Pledge.create(
         session=session,

--- a/server/tests/reward/test_endpoints.py
+++ b/server/tests/reward/test_endpoints.py
@@ -30,6 +30,8 @@ async def test_search(
     mocker: MockerFixture,
     auth_jwt: str,
 ) -> None:
+    mocker.patch("polar.worker._enqueue_job")
+
     user_organization.is_admin = True
     await user_organization.save(session)
 


### PR DESCRIPTION
We've previously relied on the GC to cleanup old arq pool objects and redis connections. With this we're using FastAPI and ARQ lifespans themselves to manage the pool for us.

This updates #873, and should allow us to update the redis library.