### PR TITLE
clients/feed: fix onboarding splash

### DIFF
--- a/clients/apps/web/src/app/(backer)/feed/page.tsx
+++ b/clients/apps/web/src/app/(backer)/feed/page.tsx
@@ -5,7 +5,6 @@ import {
   DashboardFilters,
   DefaultFilters,
 } from '@/components/Dashboard/filters'
-import BackerLayout from '@/components/Layout/BackerLayout'
 import FundAGithubIssue from '@/components/Onboarding/FundAGithubIssue'
 import OnboardingConnectReposToGetStarted from '@/components/Onboarding/OnboardingConnectReposToGetStarted'
 import { useAuth } from '@/hooks'
@@ -37,14 +36,15 @@ export default function Page() {
     filters.onlyBadged,
   )
   const dashboard = dashboardQuery.data
-  const totalCount = dashboard?.pages[0].pagination.total_count || undefined
+  const totalCount = dashboard?.pages[0].pagination.total_count ?? undefined
 
   // Onboarding splashscreen
   if (!dashboardQuery.isLoading && totalCount === 0) {
     return (
-      <BackerLayout>
-        <OnboardingConnectReposToGetStarted />
-      </BackerLayout>
+      <div className="mt-2 space-y-5">
+        <FundAGithubIssue />
+        <OnboardingConnectReposToGetStarted />{' '}
+      </div>
     )
   }
 

--- a/clients/apps/web/src/components/Onboarding/OnboardingConnectReposToGetStarted.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingConnectReposToGetStarted.tsx
@@ -12,7 +12,7 @@ const OnboardingConnectReposToGetStarted = () => {
 
   return (
     <div className="flex flex-col items-center space-y-4 pt-24">
-      <h2 className="text-2xl">Connect repos to get started</h2>
+      <h2 className="text-2xl">Get funded</h2>
       <p className="max-w-3xl text-center text-gray-500 dark:text-gray-400">
         Interested in getting backers behind your open source efforts? Connect
         your repositories to get started.


### PR DESCRIPTION
It now looks like this:

<img width="1263" alt="Screenshot 2023-09-04 at 09 16 20" src="https://github.com/polarsource/polar/assets/47952/04e15e05-39ff-47e5-9988-98c426278b10">


<img width="1263" alt="Screenshot 2023-09-04 at 09 16 58" src="https://github.com/polarsource/polar/assets/47952/f763b089-dff4-4c1b-b1e4-e8741f956553">
