### PR TITLE
server/dx: add a Poetry config to create venv in project

### DIFF
--- a/server/poetry.toml
+++ b/server/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+create = true
+in-project = true


### PR DESCRIPTION
Following what we discussed on Discord, here is a small config file to tell Poetry to always create the virtual environment in the workspace folder.

This way, it's directly in line with our VS Code config.

Ref: https://python-poetry.org/docs/configuration/#local-configuration