### PR TITLE
GitHub org/repo/issue sync improvements

### DIFF
--- a/server/polar/backoffice/endpoints.py
+++ b/server/polar/backoffice/endpoints.py
@@ -214,7 +214,7 @@ async def organization_sync(
         )
 
     await github_repository_service.install_for_organization(
-        session, org, org.installation_id
+        session, org, org.safe_installation_id
     )
 
     return org

--- a/server/polar/integrations/github/badge.py
+++ b/server/polar/integrations/github/badge.py
@@ -196,7 +196,9 @@ class GithubBadge:
 
     # TODO: Return bool and check using self.badge_is_embedded on response
     async def embed(self) -> None:
-        client = github.get_app_installation_client(self.organization.installation_id)
+        client = github.get_app_installation_client(
+            self.organization.safe_installation_id
+        )
 
         body = await self.get_current_body(client)
 
@@ -212,7 +214,9 @@ class GithubBadge:
 
     # TODO: Return bool and check using self.badge_is_embedded on response
     async def remove(self) -> None:
-        client = github.get_app_installation_client(self.organization.installation_id)
+        client = github.get_app_installation_client(
+            self.organization.safe_installation_id
+        )
 
         body = await self.get_current_body(client)
         if not self.badge_is_embedded(body):

--- a/server/polar/integrations/github/service/dependency.py
+++ b/server/polar/integrations/github/service/dependency.py
@@ -34,7 +34,7 @@ class GitHubIssueDependenciesService:
             )
             return
 
-        client = get_app_installation_client(org.installation_id)
+        client = get_app_installation_client(org.safe_installation_id)
         log.info(
             "github.sync_issue_dependencies",
             id=repo.id,

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -279,11 +279,8 @@ class GithubIssueService(IssueService):
         installation_id = (
             crawl_with_installation_id
             if crawl_with_installation_id
-            else org.installation_id
+            else org.safe_installation_id
         )
-
-        if not installation_id:
-            raise Exception("no github installation id found")
 
         client = github.get_app_installation_client(installation_id)
 
@@ -497,7 +494,7 @@ class GithubIssueService(IssueService):
         repository: Repository,
         issue: Issue,
     ) -> Issue:
-        client = github.get_app_installation_client(organization.installation_id)
+        client = github.get_app_installation_client(organization.safe_installation_id)
 
         labels = await client.rest.issues.async_add_labels(
             organization.name, repository.name, issue.number, data=["polar"]
@@ -514,7 +511,7 @@ class GithubIssueService(IssueService):
         repository: Repository,
         issue: Issue,
     ) -> Issue:
-        client = github.get_app_installation_client(organization.installation_id)
+        client = github.get_app_installation_client(organization.safe_installation_id)
 
         labels = await client.rest.issues.async_remove_label(
             organization.name, repository.name, issue.number, "polar"
@@ -631,11 +628,8 @@ class GithubIssueService(IssueService):
         installation_id = (
             crawl_with_installation_id
             if crawl_with_installation_id
-            else organization.installation_id
+            else organization.safe_installation_id
         )
-
-        if not installation_id:
-            raise Exception("no github installation id found")
 
         client = github.get_app_installation_client(installation_id)
 

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -841,7 +841,7 @@ class GithubIssueService(IssueService):
             if r.private:
                 continue
 
-            org = await github_organization.update_or_create_org_from_github(
+            org = await github_organization.create_or_update_from_github(
                 session, r.owner
             )
 

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-from typing import Any, Awaitable, Coroutine, Literal, Sequence, Tuple, Union
+from typing import Any, Awaitable, Literal, Sequence, Tuple, Union
 from uuid import UUID
 
 import structlog
@@ -27,14 +27,12 @@ from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import Issue, Organization, Repository
 from polar.models.user import User
-from polar.organization.schemas import OrganizationCreate
 from polar.postgres import AsyncSession
-from polar.redis import redis, sync_redis
+from polar.redis import redis
 from polar.repository.hooks import (
     repository_issue_synced,
     repository_issues_sync_completed,
 )
-from polar.repository.schemas import RepositoryCreate
 
 from ..badge import GithubBadge
 from .organization import github_organization
@@ -554,154 +552,55 @@ class GithubIssueService(IssueService):
         issue_number: int,
     ) -> Tuple[Organization, Repository, Issue]:
         log.info(
-            "syncing external",
+            "syncing external issue",
             org_name=org_name,
             repo_name=repo_name,
             issue_number=issue_number,
         )
 
-        organization = await github_organization.get_by_name(
-            session, Platforms.github, org_name
-        )
-
-        if not organization:
-            log.info("organization not found by name", org_name=org_name)
-
-            try:
-                repo_response = await client.rest.repos.async_get(org_name, repo_name)
-                github_repo = repo_response.parsed_data
-                owner = github_repo.owner
-                is_personal = owner.type.lower() == "user"
-            except RequestFailed as e:
-                if e.response.status_code == 404:
-                    raise ResourceNotFound()
-                if e.response.status_code == 401:
-                    raise ResourceNotFound()
-                # re-raise other status codes
-                raise e
-
-            # check if we have org with same external_id
-            organization = await github_organization.get_by_external_id(
-                session, owner.id
+        try:
+            github_repository_response = await client.rest.repos.async_get(
+                org_name, repo_name
             )
-
-        # still no organization, create it
-        if not organization:
-            log.info(
-                "organization not found by external_id, creating it",
-                org_name=org_name,
-                external_id=owner.id,
-            )
-
-            organization = await github_organization.create(
-                session,
-                OrganizationCreate(
-                    platform=Platforms.github,
-                    name=owner.login,
-                    external_id=owner.id,
-                    avatar_url=owner.avatar_url,
-                    is_personal=is_personal,
-                ),
-            )
-
-        repository = await github_repository.get_by_org_and_name(
-            session,
-            organization.id,
-            repo_name,
-        )
-
-        if not repository:
-            log.info(
-                "repository not found by name",
-                organization_id=organization.id,
-                repo_name=repo_name,
-            )
-
-            try:
-                repo_response = await client.rest.repos.async_get(org_name, repo_name)
-                github_repo = repo_response.parsed_data
-            except RequestFailed as e:
-                if e.response.status_code == 404:
-                    raise ResourceNotFound()
-                # re-raise other status codes
-                raise e
-
-            # check if we have repo with same external_id
-            repository = await github_repository.get_by_external_id(
-                session, github_repo.id
-            )
-
-        # still no repository
-        if not repository:
-            log.info(
-                "repository not found by external_id, creating it",
-                organization_id=organization.id,
-                repo_name=repo_name,
-                external_id=github_repo.id,
-            )
-
-            repository = await github_repository.create(
-                session,
-                RepositoryCreate(
-                    platform=Platforms.github,
-                    external_id=github_repo.id,
-                    organization_id=organization.id,
-                    name=github_repo.name,
-                    is_private=github_repo.private,
-                ),
-            )
-
-        issue = await github_issue.get_by_number(
-            session,
-            platform=Platforms.github,
-            organization_id=organization.id,
-            repository_id=repository.id,
-            number=issue_number,
-        )
-
-        if not issue:
-            log.info(
-                "issue not found, creating it",
-                organization_id=organization.id,
-                repository_id=repository.id,
-                number=issue_number,
-            )
-
-            try:
-                issue_response = await client.rest.issues.async_get(
-                    organization.name, repository.name, issue_number
-                )
-            except RequestFailed as e:
-                if e.response.status_code == 404:
-                    raise ResourceNotFound()
-                # re-raise other status codes
-                raise e
-
-            github_issue_data = issue_response.parsed_data
-
-            # This issue is a pull request, reject syncing it
-            if github_issue_data.pull_request:
-                log.info(
-                    "issue is pull request, skipping",
-                    organization_id=organization.id,
-                    repository_id=repository.id,
-                    number=issue_number,
-                )
+        except RequestFailed as e:
+            if e.response.status_code in [404, 401]:
                 raise ResourceNotFound()
+            raise e
 
-            issue_schema = IssueCreate.from_github(
-                github_issue_data,
-                organization_id=organization.id,
-                repository_id=repository.id,
-            )
-            issue = await github_issue.create(session, issue_schema)
+        github_repository_data = github_repository_response.parsed_data
 
-        # load repository for return
-        repository = await github_repository.get(
-            session, id=repository.id, load_organization=True
+        organization = await github_organization.create_or_update_from_github(
+            session, github_repository_data.owner
         )
-        if not repository:
+
+        repository = await github_repository.create_or_update_from_github(
+            session, organization, github_repository_data
+        )
+
+        try:
+            issue_response = await client.rest.issues.async_get(
+                organization.name, repository.name, issue_number
+            )
+        except RequestFailed as e:
+            if e.response.status_code in [404, 401]:
+                raise ResourceNotFound()
+            raise e
+
+        github_issue_data = issue_response.parsed_data
+
+        if github_issue_data.pull_request:
+            log.info(
+                "issue is pull request, skipping",
+                org_name=org_name,
+                repo_name=repo_name,
+                issue_number=issue_number,
+                external_id=github_issue_data.id,
+            )
             raise ResourceNotFound()
+
+        issue = await self.create_or_update_from_github(
+            session, organization, repository, github_issue_data
+        )
 
         return (organization, repository, issue)
 

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -845,7 +845,7 @@ class GithubIssueService(IssueService):
                 session, r.owner
             )
 
-            repo = await github_repository.get_or_create_from_github(
+            repo = await github_repository.create_or_update_from_github(
                 session,
                 org,
                 r,

--- a/server/polar/integrations/github/service/organization.py
+++ b/server/polar/integrations/github/service/organization.py
@@ -192,7 +192,7 @@ class GithubOrganizationService(OrganizationService):
     async def _populate_github_org_metadata(
         self, session: AsyncSession, org: Organization
     ) -> None:
-        client = github.get_app_installation_client(org.installation_id)
+        client = github.get_app_installation_client(org.safe_installation_id)
         github_org = client.rest.orgs.get(org.name)
 
         gh = github_org.parsed_data
@@ -210,7 +210,7 @@ class GithubOrganizationService(OrganizationService):
     async def _populate_github_user_metadata(
         self, session: AsyncSession, org: Organization
     ) -> None:
-        client = github.get_app_installation_client(org.installation_id)
+        client = github.get_app_installation_client(org.safe_installation_id)
         github_org = client.rest.users.get_by_username(org.name)
 
         gh = github_org.parsed_data

--- a/server/polar/integrations/github/service/organization.py
+++ b/server/polar/integrations/github/service/organization.py
@@ -161,7 +161,7 @@ class GithubOrganizationService(OrganizationService):
                 "organization not found by external_id, creating it",
                 external_id=data.id,
             )
-            organization = await github_organization.create(
+            organization = await self.create(
                 session, OrganizationCreate.from_github(data)
             )
         else:
@@ -169,7 +169,7 @@ class GithubOrganizationService(OrganizationService):
                 "organization found by external_id, updating it",
                 external_id=data.id,
             )
-            organization = await github_organization.update(
+            organization = await self.update(
                 session,
                 organization,
                 OrganizationUpdate.from_github(data),

--- a/server/polar/integrations/github/service/organization.py
+++ b/server/polar/integrations/github/service/organization.py
@@ -1,19 +1,21 @@
 from datetime import datetime
-from typing import Union
 from uuid import UUID
 
 import structlog
+from githubkit.rest.models import SimpleUser as GitHubSimpleUser
+from githubkit.webhooks.models import User as GitHubUser
 
 from polar.enums import Platforms
+from polar.logging import Logger
 from polar.models import Organization, User
-from polar.organization.schemas import OrganizationCreate
+from polar.organization.schemas import OrganizationCreate, OrganizationUpdate
 from polar.organization.service import OrganizationService
 from polar.postgres import AsyncSession
 
 from .. import client as github
 from .repository import github_repository
 
-log = structlog.get_logger(service="GithubOrganizationService")
+log: Logger = structlog.get_logger(service="GithubOrganizationService")
 
 
 class GithubOrganizationService(OrganizationService):
@@ -45,7 +47,26 @@ class GithubOrganizationService(OrganizationService):
         if not installations:
             return None
 
-        return [OrganizationCreate.from_github_installation(i) for i in installations]
+        organizations: list[OrganizationCreate] = []
+        for installation in installations:
+            account = installation.account
+            if account is None:
+                log.warning(
+                    "installation without associated account",
+                    installation_id=installation.id,
+                )
+                continue
+            elif not isinstance(account, GitHubSimpleUser):
+                log.warning(
+                    "unsupported installation with an Enterprise account",
+                    installation=installation.id,
+                )
+                continue
+            organizations.append(
+                OrganizationCreate.from_github(account, installation=installation)
+            )
+
+        return organizations
 
     async def install(
         self, session: AsyncSession, user: User, installation_id: int
@@ -130,80 +151,32 @@ class GithubOrganizationService(OrganizationService):
 
         await self.soft_delete(session, id=org_id)
 
-    async def update_or_create_from_github(
-        self,
-        session: AsyncSession,
-        installation: Union[
-            github.rest.Installation,
-            github.webhooks.Installation,
-        ],
+    async def create_or_update_from_github(
+        self, session: AsyncSession, data: GitHubUser | GitHubSimpleUser
     ) -> Organization:
-        account = installation.account
-        if not account:
-            raise Exception("installation has no account")
-        if isinstance(account, github.rest.Enterprise):
-            raise Exception("enterprise accounts is not supported")
+        organization = await self.get_by_external_id(session, data.id)
 
-        is_personal = account.type.lower() == "user"
-
-        if isinstance(installation.created_at, int):
-            installation.created_at = datetime.fromtimestamp(installation.created_at)
-
-        if isinstance(installation.updated_at, int):
-            installation.updated_at = datetime.fromtimestamp(installation.updated_at)
-
-        org = await self.get_by_external_id(session, installation.id)
-        if not org:
-            create_schema = OrganizationCreate(
-                platform=Platforms.github,
-                name=account.login,
-                external_id=account.id,
-                avatar_url=account.avatar_url,
-                is_personal=is_personal,
-                installation_id=installation.id,
-                installation_created_at=installation.created_at,
-                installation_updated_at=installation.updated_at,
-                installation_suspended_at=installation.suspended_at,
+        if organization is None:
+            log.debug(
+                "organization not found by external_id, creating it",
+                external_id=data.id,
             )
-            organization = await self.create_or_update(session, create_schema)
-            return organization
-
-        # update
-        org.deleted_at = None
-        org.name = account.login
-        org.avatar_url = account.avatar_url
-        org.installation_created_at = installation.created_at
-        org.installation_updated_at = installation.updated_at
-        org.installation_suspended_at = installation.suspended_at
-        await org.save(session)
-
-        return org
-
-    async def update_or_create_org_from_github(
-        self,
-        session: AsyncSession,
-        account: github.rest.SimpleUser,
-    ) -> Organization:
-        is_personal = account.type.lower() == "user"
-
-        org = await self.get_by_external_id(session, account.id)
-        if not org:
-            create_schema = OrganizationCreate(
-                platform=Platforms.github,
-                name=account.login,
-                external_id=account.id,
-                avatar_url=account.avatar_url,
-                is_personal=is_personal,
+            organization = await github_organization.create(
+                session, OrganizationCreate.from_github(data)
             )
-            organization = await self.create_or_update(session, create_schema)
-            return organization
+        else:
+            log.debug(
+                "organization found by external_id, updating it",
+                external_id=data.id,
+            )
+            organization = await github_organization.update(
+                session,
+                organization,
+                OrganizationUpdate.from_github(data),
+                exclude_unset=True,
+            )
 
-        # update
-        org.name = account.login
-        org.avatar_url = account.avatar_url
-        await org.save(session)
-
-        return org
+        return organization
 
     async def populate_org_metadata(
         self, session: AsyncSession, org: Organization

--- a/server/polar/integrations/github/service/pull_request.py
+++ b/server/polar/integrations/github/service/pull_request.py
@@ -179,11 +179,8 @@ class GithubPullRequestService(PullRequestService):
         installation_id = (
             crawl_with_installation_id
             if crawl_with_installation_id
-            else organization.installation_id
+            else organization.safe_installation_id
         )
-
-        if not installation_id:
-            raise Exception("no github installation id found")
 
         client = github.get_app_installation_client(installation_id)
 

--- a/server/polar/integrations/github/service/reference.py
+++ b/server/polar/integrations/github/service/reference.py
@@ -90,11 +90,8 @@ class GitHubIssueReferencesService:
         installation_id = (
             crawl_with_installation_id
             if crawl_with_installation_id
-            else org.installation_id
+            else org.safe_installation_id
         )
-
-        if not installation_id:
-            raise Exception("no github installation id found")
 
         client = github.get_app_installation_client(installation_id)
 
@@ -228,11 +225,8 @@ class GitHubIssueReferencesService:
         installation_id = (
             crawl_with_installation_id
             if crawl_with_installation_id
-            else org.installation_id
+            else org.safe_installation_id
         )
-
-        if not installation_id:
-            raise Exception("no github installation id found")
 
         client = github.get_app_installation_client(installation_id)
 

--- a/server/polar/integrations/github/tasks/issue.py
+++ b/server/polar/integrations/github/tasks/issue.py
@@ -5,6 +5,7 @@ import structlog
 
 from polar.integrations.github import service
 from polar.integrations.github.client import get_app_installation_client
+from polar.locker import Locker
 from polar.organization.service import organization as organization_service
 from polar.postgres import AsyncSessionLocal
 from polar.worker import JobContext, PolarWorkerContext, enqueue_job, interval, task
@@ -101,8 +102,11 @@ async def issue_sync_issue_dependencies(
                 session, issue.organization_id, issue.repository_id
             )
 
+            locker = Locker(ctx["redis"])
+
             await service.github_dependency.sync_issue_dependencies(
                 session,
+                locker,
                 org=organization,
                 repo=repository,
                 issue=issue,

--- a/server/polar/integrations/github/tasks/issue.py
+++ b/server/polar/integrations/github/tasks/issue.py
@@ -133,7 +133,7 @@ async def cron_refresh_issues(ctx: JobContext) -> None:
                 )
                 continue
 
-            client = get_app_installation_client(org.installation_id)
+            client = get_app_installation_client(org.safe_installation_id)
             try:
                 rate_limit = await github_api.get_rate_limit(client)
             except Exception as e:
@@ -192,7 +192,7 @@ async def cron_refresh_issue_timelines(ctx: JobContext) -> None:
                 )
                 continue
 
-            client = get_app_installation_client(org.installation_id)
+            client = get_app_installation_client(org.safe_installation_id)
 
             try:
                 rate_limit = await github_api.get_rate_limit(client)

--- a/server/polar/integrations/github/tasks/repo.py
+++ b/server/polar/integrations/github/tasks/repo.py
@@ -26,7 +26,7 @@ async def sync_repositories(
                 raise Exception("organization not found")
 
             await service.github_repository.install_for_organization(
-                session, organization, organization.installation_id
+                session, organization, organization.safe_installation_id
             )
 
 

--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -88,7 +88,7 @@ async def create_from_installation(
         raise Exception("enterprise accounts is not supported")
 
     organization = await service.github_organization.create_or_update_from_github(
-        session, account
+        session, account, installation=installation
     )
 
     if removed:

--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -81,9 +81,14 @@ async def create_from_installation(
         ]
     ],
 ) -> Organization:
-    organization = await service.github_organization.update_or_create_from_github(
-        session,
-        installation,
+    account = installation.account
+    if not account:
+        raise Exception("installation has no account")
+    if isinstance(account, github.rest.Enterprise):
+        raise Exception("enterprise accounts is not supported")
+
+    organization = await service.github_organization.create_or_update_from_github(
+        session, account
     )
 
     if removed:

--- a/server/polar/issue/endpoints.py
+++ b/server/polar/issue/endpoints.py
@@ -13,6 +13,7 @@ from polar.integrations.github.client import get_polar_client
 from polar.integrations.github.service.issue import github_issue as github_issue_service
 from polar.integrations.github.service.url import github_url
 from polar.kit.schemas import Schema
+from polar.locker import Locker, get_locker
 from polar.models import Issue
 from polar.organization.schemas import Organization as OrganizationSchema
 from polar.organization.service import organization as organization_service
@@ -154,6 +155,7 @@ async def lookup(
         example="https://github.com/polarsource/polar/issues/897",
     ),
     session: AsyncSession = Depends(get_db_session),
+    locker: Locker = Depends(get_locker),
 ) -> IssueSchema:
     if not external_url:
         raise HTTPException(
@@ -179,14 +181,15 @@ async def lookup(
 
         client = get_polar_client()
 
-        res = await github_issue_service.sync_external_org_with_repo_and_issue(
-            session,
-            client=client,
-            org_name=url.owner,
-            repo_name=url.repo,
-            issue_number=url.number,
-        )
-        org, repo, tmp_issue = res
+        async with locker.lock(f"sync_external_{url.owner}_{url.repo}_{url.number}"):
+            res = await github_issue_service.sync_external_org_with_repo_and_issue(
+                session,
+                client=client,
+                org_name=url.owner,
+                repo_name=url.repo,
+                issue_number=url.number,
+            )
+            _, _, tmp_issue = res
 
         # get for return
         issue = await issue_service.get_loaded(session, tmp_issue.id)

--- a/server/polar/kit/services.py
+++ b/server/polar/kit/services.py
@@ -160,12 +160,13 @@ class ResourceService(
         update_schema: UpdateSchemaType,
         include: set[str] | None = None,
         exclude: set[str] | None = None,
+        exclude_unset: bool = False,
         autocommit: bool = True,
     ) -> ModelType:
         return await source.update(
             session,
-            include=include,
-            exclude=exclude,
             autocommit=autocommit,
-            **update_schema.dict(),
+            **update_schema.dict(
+                include=include, exclude=exclude, exclude_unset=exclude_unset
+            ),
         )

--- a/server/polar/locker.py
+++ b/server/polar/locker.py
@@ -1,0 +1,48 @@
+import contextlib
+from collections.abc import AsyncGenerator
+
+import structlog
+from fastapi import Depends
+from redis.asyncio.lock import Lock
+
+from polar.logging import Logger
+from polar.redis import Redis, get_redis
+
+log: Logger = structlog.get_logger()
+
+
+class Locker:
+    def __init__(self, redis: Redis) -> None:
+        self.redis = redis
+
+    @contextlib.asynccontextmanager
+    async def lock(
+        self,
+        name: str | bytes | memoryview,
+        timeout: float | None = None,
+        sleep: float = 0.1,
+        blocking_timeout: float | None = None,
+        thread_local: bool = True,
+    ) -> AsyncGenerator[Lock, None]:
+        lock = Lock(
+            self.redis,
+            name,
+            timeout=timeout,
+            sleep=sleep,
+            blocking=True,
+            blocking_timeout=blocking_timeout,
+            thread_local=thread_local,
+        )
+
+        log.debug("try to acquire lock", name=name)
+        await lock.acquire()
+        log.debug("acquired lock", name=name)
+
+        yield lock
+
+        await lock.release()
+        log.debug("released lock", name=name)
+
+
+async def get_locker(redis: Redis = Depends(get_redis)) -> Locker:
+    return Locker(redis)

--- a/server/polar/logging.py
+++ b/server/polar/logging.py
@@ -8,6 +8,8 @@ from polar.config import settings
 
 RendererType = TypeVar("RendererType")
 
+Logger = structlog.stdlib.BoundLogger
+
 
 class Logging(Generic[RendererType]):
     """Hubben logging configurator of `structlog` and `logging`.

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -90,7 +90,9 @@ class OrganizationCreate(OrganizationPrivateBase):
         cls,
         user: github.webhooks.User | github.rest.SimpleUser,
         *,
-        installation: github.rest.Installation | None = None,
+        installation: github.rest.Installation
+        | github.webhooks.Installation
+        | None = None,
     ) -> Self:
         data: dict[str, Any] = {
             "is_personal": user.type.lower() == "user",

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -108,7 +108,7 @@ class OrganizationCreate(OrganizationPrivateBase):
                 "installation_suspended_at": installation.suspended_at,
             }
 
-        return cls(**data)
+        return cls(platform=Platforms.github, **data)
 
 
 # Internal model

--- a/server/polar/repository/schemas.py
+++ b/server/polar/repository/schemas.py
@@ -9,7 +9,6 @@ from pydantic import Field
 from polar.enums import Platforms
 from polar.integrations.github import client as github
 from polar.kit.schemas import Schema
-from polar.models import Organization as OrganizationModel
 from polar.models import Repository as RepositoryModel
 from polar.organization.schemas import Organization as OrganizationSchema
 from polar.visibility import Visibility
@@ -76,36 +75,42 @@ class RepositoryCreate(Schema):
 
     @classmethod
     def from_github(
-        cls, organization: OrganizationModel, repo: github.rest.Repository
+        cls,
+        repository: github.rest.Repository | github.rest.FullRepository,
+        organization_id: UUID,
     ) -> Self:
-        topics = repo.topics if repo.topics else None
-        license = repo.license_.name if repo.license_ and repo.license_.name else None
+        topics = repository.topics if repository.topics else None
+        license = (
+            repository.license_.name
+            if repository.license_ and repository.license_.name
+            else None
+        )
         return cls(
             platform=Platforms.github,
-            external_id=repo.id,
-            organization_id=organization.id,
-            name=repo.name,
-            description=repo.description,
-            open_issues=repo.open_issues,
-            forks=repo.forks,
-            stars=repo.stargazers_count,
-            watchers=repo.watchers_count,
-            main_branch=repo.default_branch,
+            external_id=repository.id,
+            organization_id=organization_id,
+            name=repository.name,
+            description=repository.description,
+            open_issues=repository.open_issues,
+            forks=repository.forks,
+            stars=repository.stargazers_count,
+            watchers=repository.watchers_count,
+            main_branch=repository.default_branch,
             topics=topics,
             license=license,
-            homepage=repo.homepage,
-            repository_pushed_at=repo.pushed_at,
-            repository_created_at=repo.created_at,
-            repository_modified_at=repo.updated_at,
-            is_private=repo.private,
-            is_fork=repo.fork,
-            is_issues_enabled=repo.has_issues,
-            is_projects_enabled=repo.has_projects,
-            is_wiki_enabled=repo.has_wiki,
-            is_pages_enabled=repo.has_pages,
-            is_downloads_enabled=repo.has_downloads,
-            is_archived=repo.archived,
-            is_disabled=repo.disabled,
+            homepage=repository.homepage,
+            repository_pushed_at=repository.pushed_at,
+            repository_created_at=repository.created_at,
+            repository_modified_at=repository.updated_at,
+            is_private=repository.private,
+            is_fork=repository.fork,
+            is_issues_enabled=repository.has_issues,
+            is_projects_enabled=repository.has_projects,
+            is_wiki_enabled=repository.has_wiki,
+            is_pages_enabled=repository.has_pages,
+            is_downloads_enabled=repository.has_downloads,
+            is_archived=repository.archived,
+            is_disabled=repository.disabled,
         )
 
 

--- a/server/scripts/issues.py
+++ b/server/scripts/issues.py
@@ -36,7 +36,7 @@ async def delete_invalid_issues(org_name: str) -> None:
         if not org:
             raise RuntimeError(f"Organization {org_name} not found")
 
-        client = github.get_app_installation_client(org.installation_id)
+        client = github.get_app_installation_client(org.safe_installation_id)
 
         repos = await github_repository.list_by(session, org_ids=[org.id])
 


### PR DESCRIPTION
Should eventually fix #877

This PR grow quite big (sorry), but I think it makes sense as it's all related around the external issue synchronization issue. A few highlights:

## 1. Fix typing for `Organization.installation_id`

The property `installation_id` was typed as `int`, but it should be `int | None` as it's nullable (in the case of external organization).

Making this change was causing typing issues everywhere we used it assuming it was non-null. Some places however handled it with a local `Exception`.

To improve this, I introduce a property `safe_installation_id`, which always return an `int` or raise a `NotInstalledOrganization`. This satisfies the type checker and avoid to have manual logic everywhere we use this value.

## 2. Harmonize `create_or_update` methods for Organization, Repository and Issue

We had several flavors to create organization and repositories from GitHub data. I tried to harmonize this so there is one only clear path to perform this action.

It also systematically updates it, so we can better account for cases where an repository/issue has been transferred.

## 3. Implement a shared lock mechanism with Redis

I implemented a simple lock mechanism using built-in Redis tools. This may be handy in a few cases.

Right now, I've used it around the external issue synchronization, so we avoid the race conditions we met in #877.

> Side note: from my testing, the race condition can actually happen also on the web app. Next.js makes two successive calls to `/lookup` on the issue page. That's why I was interested in switching our client from `axios` to `fetch`.

---

That's about it! I really would like your feedback on this one, as it involves trickier changes.