### PR TITLE
server/dx: improve unit tests isolation

### DIFF
--- a/server/tests/fixtures/base.py
+++ b/server/tests/fixtures/base.py
@@ -6,7 +6,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 
 from polar.app import app
-from polar.postgres import AsyncSession, AsyncSessionLocal, get_db_session
+from polar.postgres import AsyncSession, get_db_session
 
 
 # We used to use anyio, but it was causing garbage collection issues
@@ -28,11 +28,7 @@ def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
 
 @pytest_asyncio.fixture()
 async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
-    async def override_get_db_session() -> AsyncGenerator[AsyncSession, None]:
-        async with AsyncSessionLocal() as session:
-            yield session
-
-    app.dependency_overrides[get_db_session] = override_get_db_session
+    app.dependency_overrides[get_db_session] = lambda: session
 
     async with AsyncClient(app=app, base_url="http://test") as client:
         yield client

--- a/server/tests/fixtures/predictable_objects.py
+++ b/server/tests/fixtures/predictable_objects.py
@@ -21,7 +21,7 @@ from polar.postgres import AsyncSession
 from polar.repository.schemas import RepositoryCreate
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_organization(session: AsyncSession) -> Organization:
     create_schema = OrganizationCreate(
         platform=Platforms.github,
@@ -41,7 +41,7 @@ async def predictable_organization(session: AsyncSession) -> Organization:
     return org
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_pledging_organization(session: AsyncSession) -> Organization:
     create_schema = OrganizationCreate(
         platform=Platforms.github,
@@ -61,7 +61,7 @@ async def predictable_pledging_organization(session: AsyncSession) -> Organizati
     return org
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_repository(
     session: AsyncSession, predictable_organization: Organization
 ) -> Repository:
@@ -78,7 +78,7 @@ async def predictable_repository(
     return repo
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_issue(
     session: AsyncSession,
     predictable_organization: Organization,
@@ -102,7 +102,7 @@ async def predictable_issue(
     return issue
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_user(
     session: AsyncSession,
 ) -> User:
@@ -117,7 +117,7 @@ async def predictable_user(
     return user
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_pledge(
     session: AsyncSession,
     predictable_organization: Organization,
@@ -141,7 +141,7 @@ async def predictable_pledge(
     return pledge
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture
 async def predictable_pull_request(
     session: AsyncSession,
     predictable_organization: Organization,

--- a/server/tests/integrations/github/tasks/test_webhook.py
+++ b/server/tests/integrations/github/tasks/test_webhook.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 from unittest.mock import ANY, patch
@@ -18,7 +20,7 @@ from polar.kit.extensions.sqlalchemy import sql
 from polar.models.organization import Organization
 from polar.models.repository import Repository
 from polar.organization.schemas import OrganizationCreate
-from polar.postgres import AsyncSession, AsyncSessionLocal
+from polar.postgres import AsyncSession
 from polar.repository.schemas import RepositoryCreate
 from polar.worker import JobContext, PolarWorkerContext
 from tests.fixtures.webhook import TestWebhook, TestWebhookFactory
@@ -30,6 +32,28 @@ FAKE_CTX: JobContext = {
     "enqueue_time": datetime.utcnow(),
     "score": 0,
 }
+
+
+@pytest.fixture(autouse=True)
+def mock_async_session_local(mocker: MockerFixture, session: AsyncSession) -> None:
+    """
+    Monkey-patch to force `AsyncSessionLocal` to return our test AsyncSession.
+
+    A better way to handle this would be to dynamically inject the session maker
+    to the task, probably using the `JobContext`.
+
+    Tasks would need to be updated to use this function from the context
+    instead of calling the global `AsyncSessionLocal`.
+    """
+
+    @contextlib.asynccontextmanager
+    async def _mock_async_session_local() -> AsyncIterator[AsyncSession]:
+        yield session
+
+    mocker.patch(
+        "polar.integrations.github.tasks.webhook.AsyncSessionLocal",
+        new=_mock_async_session_local,
+    )
 
 
 async def assert_repository_deleted(
@@ -54,6 +78,7 @@ async def get_asserted_org(session: AsyncSession, **clauses: Any) -> Organizatio
 
 
 async def create_org(
+    session: AsyncSession,
     github_webhook: TestWebhookFactory,
     status: Organization.Status = Organization.Status.ACTIVE,
 ) -> Organization:
@@ -75,55 +100,57 @@ async def create_org(
         installation_updated_at=utils.utc_now(),
         installation_suspended_at=event.installation.suspended_at,
     )
-    async with AsyncSessionLocal() as session:
-        stmt = (
-            sql.insert(Organization)
-            .values(**create_schema.dict())
-            .on_conflict_do_update(
-                index_elements=[Organization.external_id], set_={**create_schema.dict()}
-            )
-            .returning(Organization)
-            .execution_options(populate_existing=True)
+    stmt = (
+        sql.insert(Organization)
+        .values(**create_schema.dict())
+        .on_conflict_do_update(
+            index_elements=[Organization.external_id], set_={**create_schema.dict()}
         )
-        res = await session.execute(stmt)
-        org = res.scalars().one()
+        .returning(Organization)
+        .execution_options(populate_existing=True)
+    )
+    res = await session.execute(stmt)
+    org = res.scalars().one()
 
-        org.status = status
-        session.add(org)
-        await session.commit()
-        return org
+    org.status = status
+    session.add(org)
+    await session.commit()
+    return org
 
 
-async def create_repositories(github_webhook: TestWebhookFactory) -> Organization:
-    org = await create_org(github_webhook, status=Organization.Status.ACTIVE)
+async def create_repositories(
+    session: AsyncSession, github_webhook: TestWebhookFactory
+) -> Organization:
+    org = await create_org(session, github_webhook, status=Organization.Status.ACTIVE)
     hook = github_webhook.create("installation_repositories.added")
 
     parsed = github.webhooks.parse_obj("installation_repositories", hook.json)
     if not isinstance(parsed, github.webhooks.InstallationRepositoriesAdded):
         raise Exception("unexpected webhook payload")
 
-    async with AsyncSessionLocal() as session:
-        for repo in parsed.repositories_added:
-            create_schema = RepositoryCreate(
-                platform=Platforms.github,
-                external_id=repo.id,
-                organization_id=org.id,
-                name=repo.name,
-                is_private=repo.private,
-            )
+    for repo in parsed.repositories_added:
+        create_schema = RepositoryCreate(
+            platform=Platforms.github,
+            external_id=repo.id,
+            organization_id=org.id,
+            name=repo.name,
+            is_private=repo.private,
+        )
 
-            stmt = (
-                sql.insert(Repository)
-                .values(**create_schema.dict())
-                .on_conflict_do_nothing()
-            )
-            await session.execute(stmt)
-            await session.commit()
+        stmt = (
+            sql.insert(Repository)
+            .values(**create_schema.dict())
+            .on_conflict_do_nothing()
+        )
+        await session.execute(stmt)
+        await session.commit()
     return org
 
 
-async def create_issue(github_webhook: TestWebhookFactory) -> TestWebhook:
-    await create_repositories(github_webhook)
+async def create_issue(
+    session: AsyncSession, github_webhook: TestWebhookFactory
+) -> TestWebhook:
+    await create_repositories(session, github_webhook)
     hook = github_webhook.create("issues.opened")
     await webhook_tasks.issue_opened(
         FAKE_CTX,
@@ -135,8 +162,10 @@ async def create_issue(github_webhook: TestWebhookFactory) -> TestWebhook:
     return hook
 
 
-async def create_pr(github_webhook: TestWebhookFactory) -> TestWebhook:
-    await create_repositories(github_webhook)
+async def create_pr(
+    session: AsyncSession, github_webhook: TestWebhookFactory
+) -> TestWebhook:
+    await create_repositories(session, github_webhook)
     hook = github_webhook.create("pull_request.opened")
     await webhook_tasks.pull_request_opened(
         FAKE_CTX,
@@ -150,14 +179,12 @@ async def create_pr(github_webhook: TestWebhookFactory) -> TestWebhook:
 
 @pytest.mark.asyncio
 async def test_webhook_installation_suspend(
-    mocker: MockerFixture,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    session: AsyncSession, mocker: MockerFixture, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
-    org = await create_org(github_webhook, status=Organization.Status.INACTIVE)
+    org = await create_org(session, github_webhook, status=Organization.Status.INACTIVE)
 
     hook = github_webhook.create("installation.suspend")
     org_id = hook["installation"]["account"]["id"]
@@ -169,21 +196,20 @@ async def test_webhook_installation_suspend(
         polar_context=PolarWorkerContext(),
     )
 
-    async with AsyncSessionLocal() as session:
-        org = await get_asserted_org(session, external_id=org_id)
-        assert org.status == org.Status.SUSPENDED
+    org = await get_asserted_org(session, external_id=org_id)
+    assert org.status == org.Status.SUSPENDED
 
 
 @pytest.mark.asyncio
 async def test_webhook_installation_unsuspend(
-    mocker: MockerFixture,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    session: AsyncSession, mocker: MockerFixture, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
-    org = await create_org(github_webhook, status=Organization.Status.SUSPENDED)
+    org = await create_org(
+        session, github_webhook, status=Organization.Status.SUSPENDED
+    )
 
     hook = github_webhook.create("installation.unsuspend")
     org_id = hook["installation"]["account"]["id"]
@@ -195,16 +221,13 @@ async def test_webhook_installation_unsuspend(
         polar_context=PolarWorkerContext(),
     )
 
-    async with AsyncSessionLocal() as session:
-        org = await get_asserted_org(session, external_id=org_id)
-        assert org.status == org.Status.ACTIVE
+    org = await get_asserted_org(session, external_id=org_id)
+    assert org.status == org.Status.ACTIVE
 
 
 @pytest.mark.asyncio
 async def test_webhook_installation_delete(
-    mocker: MockerFixture,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    session: AsyncSession, mocker: MockerFixture, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
@@ -212,7 +235,7 @@ async def test_webhook_installation_delete(
     hook = github_webhook.create("installation.deleted")
     org_id = hook["installation"]["account"]["id"]
 
-    org = await create_org(github_webhook, status=Organization.Status.ACTIVE)
+    org = await create_org(session, github_webhook, status=Organization.Status.ACTIVE)
     assert org
     assert org.external_id == org_id
 
@@ -224,18 +247,17 @@ async def test_webhook_installation_delete(
         polar_context=PolarWorkerContext(),
     )
 
-    async with AsyncSessionLocal() as session:
-        fetched = await service.github_organization.get_by(session, external_id=org_id)
-        assert fetched is not None
-        assert fetched.deleted_at is not None
+    fetched = await service.github_organization.get_by(session, external_id=org_id)
+    assert fetched is not None
+    assert fetched.deleted_at is not None
 
-        # Normal get should fail
-        fetched_get = await service.github_organization.get(session, fetched.id)
-        assert fetched_get is None
+    # Normal get should fail
+    fetched_get = await service.github_organization.get(session, fetched.id)
+    assert fetched_get is None
 
-        # un-delete (fixes other tests)
-        fetched.deleted_at = None
-        await fetched.save(session)
+    # un-delete (fixes other tests)
+    fetched.deleted_at = None
+    await fetched.save(session)
 
 
 def hook_as_obj(
@@ -379,10 +401,7 @@ def hook_as_obj(
 
 @pytest.mark.asyncio
 async def test_webhook_repositories_added(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
@@ -427,10 +446,7 @@ async def test_webhook_repositories_added(
 
 @pytest.mark.asyncio
 async def test_webhook_repositories_removed(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
@@ -438,7 +454,7 @@ async def test_webhook_repositories_removed(
     hook = github_webhook.create("installation_repositories.removed")
     delete_repo = hook["repositories_removed"][0]
 
-    await create_repositories(github_webhook)
+    await create_repositories(session, github_webhook)
     await assert_repository_exists(session, delete_repo)
 
     # fake it
@@ -477,15 +493,12 @@ async def test_webhook_repositories_removed(
 
 @pytest.mark.asyncio
 async def test_webhook_issues_opened(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
-    await create_repositories(github_webhook)
+    await create_repositories(session, github_webhook)
     hook = github_webhook.create("issues.opened")
     issue_id = hook["issue"]["id"]
 
@@ -506,16 +519,13 @@ async def test_webhook_issues_opened(
 
 @pytest.mark.asyncio
 async def test_webhook_issues_closed(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
     # create issue
-    await create_repositories(github_webhook)
+    await create_repositories(session, github_webhook)
     hook = github_webhook.create("issues.opened")
     issue_id = hook["issue"]["id"]
 
@@ -548,21 +558,18 @@ async def test_webhook_issues_closed(
 
 @pytest.mark.asyncio
 async def test_webhook_issues_labeled(
-    mocker: MockerFixture,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    session: AsyncSession, mocker: MockerFixture, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
-    await create_repositories(github_webhook)
-    hook = await create_issue(github_webhook)
+    await create_repositories(session, github_webhook)
+    hook = await create_issue(session, github_webhook)
 
     issue_id = hook["issue"]["id"]
-    async with AsyncSessionLocal() as session:
-        issue = await service.github_issue.get_by_external_id(session, issue_id)
-        assert issue is not None
-        assert issue.labels is None
+    issue = await service.github_issue.get_by_external_id(session, issue_id)
+    assert issue is not None
+    assert issue.labels is None
 
     hook = github_webhook.create("issues.labeled")
     await webhook_tasks.issue_labeled(
@@ -573,20 +580,16 @@ async def test_webhook_issues_labeled(
         polar_context=PolarWorkerContext(),
     )
 
-    async with AsyncSessionLocal() as session:
-        issue = await service.github_issue.get_by_external_id(session, issue_id)
-        assert issue is not None
-        assert issue.labels is not None
-        assert isinstance(issue.labels, list)
-        assert issue.labels[0]["name"] == hook["issue"]["labels"][0]["name"]
+    issue = await service.github_issue.get_by_external_id(session, issue_id)
+    assert issue is not None
+    assert issue.labels is not None
+    assert isinstance(issue.labels, list)
+    assert issue.labels[0]["name"] == hook["issue"]["labels"][0]["name"]
 
 
 @pytest.mark.asyncio
 async def test_webhook_pull_request_opened(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
@@ -597,7 +600,7 @@ async def test_webhook_pull_request_opened(
     pr = await service.github_pull_request.get_by_external_id(session, pr_id)
     assert pr is None
 
-    await create_pr(github_webhook)
+    await create_pr(session, github_webhook)
 
     pr = await service.github_pull_request.get_by_external_id(session, pr_id)
     assert pr is not None
@@ -608,10 +611,7 @@ async def test_webhook_pull_request_opened(
 
 @pytest.mark.asyncio
 async def test_webhook_pull_request_edited(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
@@ -622,7 +622,7 @@ async def test_webhook_pull_request_edited(
     pr = await service.github_pull_request.get_by_external_id(session, pr_id)
     assert pr is None
 
-    await create_repositories(github_webhook)
+    await create_repositories(session, github_webhook)
     hook = github_webhook.create("pull_request.edited")
     await webhook_tasks.pull_request_edited(
         FAKE_CTX,
@@ -635,21 +635,18 @@ async def test_webhook_pull_request_edited(
 
 @pytest.mark.asyncio
 async def test_webhook_pull_request_synchronize(
-    mocker: MockerFixture,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    session: AsyncSession, mocker: MockerFixture, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
-    await create_pr(github_webhook)
+    await create_pr(session, github_webhook)
     hook = github_webhook.create("pull_request.synchronize")
     pr_id = hook["pull_request"]["id"]
 
-    async with AsyncSessionLocal() as session:
-        pr = await service.github_pull_request.get_by_external_id(session, pr_id)
-        assert pr is not None
-        assert pr.merge_commit_sha is None
+    pr = await service.github_pull_request.get_by_external_id(session, pr_id)
+    assert pr is not None
+    assert pr.merge_commit_sha is None
 
     await webhook_tasks.pull_request_synchronize(
         FAKE_CTX,
@@ -659,23 +656,19 @@ async def test_webhook_pull_request_synchronize(
         polar_context=PolarWorkerContext(),
     )
 
-    async with AsyncSessionLocal() as session:
-        pr = await service.github_pull_request.get_by_external_id(session, pr_id)
-        assert pr is not None
-        assert pr.merge_commit_sha is not None
+    pr = await service.github_pull_request.get_by_external_id(session, pr_id)
+    assert pr is not None
+    assert pr.merge_commit_sha is not None
 
 
 @pytest.mark.asyncio
 async def test_webhook_issues_deleted(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
 
-    await create_repositories(github_webhook)
+    await create_repositories(session, github_webhook)
 
     # first create an issue
     hook = github_webhook.create("issues.opened")
@@ -725,10 +718,7 @@ async def test_webhook_issues_deleted(
 @pytest.mark.asyncio
 @patch("polar.config.settings.GITHUB_BADGE_EMBED", True)
 async def test_webhook_opened_with_label(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     # Capture and prevent any calls to enqueue_job
     mocker.patch("polar.worker._enqueue_job")
@@ -737,7 +727,7 @@ async def test_webhook_opened_with_label(
         "polar.integrations.github.service.github_issue.embed_badge"
     )
 
-    org = await create_repositories(github_webhook)
+    org = await create_repositories(session, github_webhook)
     org.onboarded_at = utils.utc_now()
     await org.save(session)
 
@@ -778,10 +768,7 @@ async def test_webhook_opened_with_label(
 @pytest.mark.asyncio
 @patch("polar.config.settings.GITHUB_BADGE_EMBED", True)
 async def test_webhook_labeled_remove_badge_body(
-    mocker: MockerFixture,
-    session: AsyncSession,
-    github_webhook: TestWebhookFactory,
-    initialize_test_database_function: None,  # reset db before running test
+    mocker: MockerFixture, session: AsyncSession, github_webhook: TestWebhookFactory
 ) -> None:
     async def in_process_enqueue_job(name, *args, **kwargs) -> None:  # type: ignore  # noqa: E501
         if name == "github.issue.sync.issue_references":
@@ -799,7 +786,7 @@ async def test_webhook_labeled_remove_badge_body(
         "polar.integrations.github.service.github_issue.embed_badge"
     )
 
-    org = await create_repositories(github_webhook)
+    org = await create_repositories(session, github_webhook)
     org.onboarded_at = utils.utc_now()
     await org.save(session)
 


### PR DESCRIPTION
This is a revamping of the database fixtures so they behave like the following:

* Database initialization `initialize_test_database` is done only once for the test session
* A session fixture is generated for each test.
    * Under the hood, we start a transaction that we rollback at the end.
    * This way, each test starts with a fresh DB, without garbage from previous tests

Then, we make sure in the FastAPI test to override `get_db_session` so it returns this test session.

This allows us to get rid of the `initialize_test_database_function` fixture.

It's worth to note that isolation is still not complete: worker tasks are implemented so they generate a DB session from the global session maker, `AsyncSessionLocal`.

In a follow-up improvement, it could be worth to include the session maker dynamically in the job context.

**Bonus**: tests seem to pass ~2x faster