### PR TITLE
dx: tweak VS Code settings

### DIFF
--- a/clients/.vscode/settings.json
+++ b/clients/.vscode/settings.json
@@ -23,5 +23,4 @@
   "editor.rulers": [
     120
   ],
-  "mypy.enabled": false
 }

--- a/polar.code-workspace
+++ b/polar.code-workspace
@@ -1,17 +1,25 @@
 {
 	"folders": [
 		{
-			"path": "clients"
+			"path": "clients",
+			"name": "clients"
 		},
 		{
-			"path": "server"
+			"path": "server",
+			"name": "server"
 		},
 		{
-			"path": "docs"
+			"path": "docs",
+			"name": "docs"
 		},
 		{
+			"path": ".",
 			"name": "root",
-			"path": "."
 		}
-	]
+	],
+	"settings": {
+		// Set the Python interpreter globally, so VS Code stops complaining about invalid interpreter on other folders
+		// Also fix the Ruff extension
+		"python.defaultInterpreterPath": "${workspaceFolder:server}/.venv/bin/python",
+	}
 }

--- a/server/.vscode/extensions.json
+++ b/server/.vscode/extensions.json
@@ -2,7 +2,7 @@
     "recommendations": [
         "ms-python.black-formatter",
         "charliermarsh.ruff",
-        "matangover.mypy",
+        "ms-python.mypy-type-checker",
         "littlefoxteam.vscode-python-test-adapter"
     ]
 }

--- a/server/.vscode/settings.json
+++ b/server/.vscode/settings.json
@@ -1,22 +1,15 @@
 {
   "python.analysis.typeCheckingMode": "basic",
   "python.envFile": "${workspaceFolder}/.env.testing",
-  "python.defaultInterpreterPath": "${workspaceFolder}/server/.venv/bin/python",
   "python.terminal.activateEnvironment": true,
   "python.terminal.activateEnvInCurrentTerminal": true,
-  "python.linting.pylintEnabled": false,
-  "python.linting.mypyEnabled": true,
-  "editor.formatOnSave": true,
-  "python.linting.enabled": true,
-  "python.formatting.provider": "black",
-  "_python.testing.pytestArgs": ["tests"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "[python]": {
-    "editor.codeActionsOnSave": {
-      "source.organizeImports.ruff": true,
-      "source.fixAll": true
-    }
+  "editor.defaultFormatter": "ms-python.black-formatter",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.ruff": true,
+    "source.fixAll": true
   },
   "files.exclude": {
     "**/.git": true,
@@ -27,7 +20,6 @@
     "**/.ruff_cache": true
   },
   "editor.rulers": [88],
-  "mypy.dmypyExecutable": "${workspaceFolder}/.venv/bin/dmypy",
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.testing.cwd": "${workspaceFolder}",
 }


### PR DESCRIPTION
Various upgrades of VS Code settings to keep a nice and productive dev environment.

* Built-in Python linting has been deprecated by VS Code in favor of extensions, in particular for Black.
* Switch to the official mypy extension instead of `matangover.mypy`
    * ⚠️ This means you'll need to install a new recommended extension
* Set the Python interpreter globally on the Code Workspace
    * Makes Ruff actually working
    * Prevents annoying "Invalid Python interpreter selected" warning when switching to `clients` folder