### PR TITLE
server/reward: set an order_by clause to RewardService.list

### DIFF
--- a/server/polar/reward/service.py
+++ b/server/polar/reward/service.py
@@ -30,19 +30,23 @@ class RewardService:
         is_transfered: bool | None = None,
     ) -> Sequence[Tuple[Pledge, IssueReward, PledgeTransaction]]:
         statement = (
-            sql.select(Pledge, IssueReward, PledgeTransaction)
-            .join(Pledge.issue)
-            .join(IssueReward, Issue.id == IssueReward.issue_id)
-            .join(
-                PledgeTransaction,
-                and_(
-                    PledgeTransaction.pledge_id == Pledge.id,
-                    PledgeTransaction.issue_reward_id == IssueReward.id,
-                    PledgeTransaction.type == PledgeTransactionType.transfer,
-                ),
-                isouter=True,
+            (
+                sql.select(Pledge, IssueReward, PledgeTransaction)
+                .join(Pledge.issue)
+                .join(IssueReward, Issue.id == IssueReward.issue_id)
+                .join(
+                    PledgeTransaction,
+                    and_(
+                        PledgeTransaction.pledge_id == Pledge.id,
+                        PledgeTransaction.issue_reward_id == IssueReward.id,
+                        PledgeTransaction.type == PledgeTransactionType.transfer,
+                    ),
+                    isouter=True,
+                )
             )
-        ).where(Pledge.state.in_(PledgeState.active_states()))
+            .where(Pledge.state.in_(PledgeState.active_states()))
+            .order_by(Pledge.created_at)
+        )
 
         if pledge_org_id:
             statement = statement.where(Pledge.organization_id == pledge_org_id)

--- a/server/tests/reward/test_service.py
+++ b/server/tests/reward/test_service.py
@@ -180,8 +180,8 @@ async def test_list_rewards_to_user(
     rewards = await reward_service.list(session, reward_user_id=user.id)
     assert len(rewards) == 2
 
-    assert rewards[0][0].amount == 2000
+    assert rewards[0][0].amount == 1000
     assert rewards[0][1].user_id == user.id
 
-    assert rewards[1][0].amount == 1000
+    assert rewards[1][0].amount == 2000
     assert rewards[1][1].user_id == user.id


### PR DESCRIPTION
Prevents the test `test_list_rewards_to_user` to be flaky (the DB was not always returningt the Pledges in the same order)