### PR TITLE
server/dx: fix ARQ logging configuration override to not swallow its logs

### DIFF
--- a/server/run_worker.py
+++ b/server/run_worker.py
@@ -3,7 +3,7 @@ from polar.sentry import configure_sentry
 
 # Expose a dummy logger config dictionary to be used by the arq CLI.
 # This way, we can get rid of its default configuration.
-silent_logger_config_dict = {"version": 1, "disable_existing_loggers": True}
+silent_logger_config_dict = {"version": 1, "disable_existing_loggers": False}
 
 polar.logging.configure()
 configure_sentry()


### PR DESCRIPTION
Fix #1158