### PR TITLE
server/dx: implement `request_correlation_id` in tasks logs

### DIFF
--- a/server/tests/integrations/github/tasks/test_integration.py
+++ b/server/tests/integrations/github/tasks/test_integration.py
@@ -44,20 +44,18 @@ async def test_installation_no_notifications(
 
     async def in_process_enqueue_job(name, *args, **kwargs) -> None:  # type: ignore  # noqa: E501
         if name == "github.repo.sync.issues":
-            return await tasks.repo.sync_repository_issues(
-                kwargs["polar_context"], *args, **kwargs
-            )
+            return await tasks.repo.sync_repository_issues(FAKE_CTX, *args, **kwargs)
         if name == "github.repo.sync.pull_requests":
             return await tasks.repo.sync_repository_pull_requests(
-                kwargs["polar_context"], *args, **kwargs
+                FAKE_CTX, *args, **kwargs
             )
         elif name == "github.issue.sync.issue_references":
             return await tasks.issue.issue_sync_issue_references(
-                kwargs["polar_context"], *args, **kwargs
+                FAKE_CTX, *args, **kwargs
             )
         elif name == "github.repo.sync.issue_references":
             return await tasks.repo.repo_sync_issue_references(
-                kwargs["polar_context"], *args, **kwargs
+                FAKE_CTX, *args, **kwargs
             )
         elif name == "github.issue.sync.issue_dependencies":
             return None  # skip


### PR DESCRIPTION
We had to move out the `on_job_start`/`on_job_end` approach.

Unfortunately, we don't have access to task arguments in this hook.

This prevents us to implement things like common arguments handling,
as we do for `request_correlation_id`.

To circumvent this limitation, we implement this behavior
through the `task_hooks` decorator.