### PR TITLE
clients/pledge: connect pledge after login

### DIFF
--- a/clients/apps/web/src/components/Pledge/Status.tsx
+++ b/clients/apps/web/src/components/Pledge/Status.tsx
@@ -77,7 +77,7 @@ export const Status = (props: { pledge: Pledge }) => {
           />
         </GrayCard>
 
-        {!currentUser && <ThankYouUpsell pledge={pledge} />}
+        {!currentUser && <ThankYouUpsell />}
       </div>
     </>
   )

--- a/clients/apps/web/src/components/Pledge/ThankYouUpsell.tsx
+++ b/clients/apps/web/src/components/Pledge/ThankYouUpsell.tsx
@@ -5,12 +5,10 @@ import {
   CurrencyDollarIcon,
 } from '@heroicons/react/24/outline'
 import Image from 'next/image'
-import { Pledge } from 'polarkit/api/client'
 import { WhiteCard } from 'polarkit/components/ui/Cards'
 import screenshot from './dashboard.png'
 
-const ThankYouUpsell = (props: { pledge: Pledge }) => {
-  const { pledge } = props
+const ThankYouUpsell = () => {
   return (
     <>
       <WhiteCard
@@ -21,7 +19,6 @@ const ThankYouUpsell = (props: { pledge: Pledge }) => {
           <h2 className="text-xl">Sign up to Polar</h2>
           <GithubLoginButton
             text="Continue with Github"
-            pledgeId={pledge.id}
             size="large"
             posthogProps={{
               view: 'Thank You Page',

--- a/clients/apps/web/src/components/Shared/GithubLoginButton.tsx
+++ b/clients/apps/web/src/components/Shared/GithubLoginButton.tsx
@@ -1,17 +1,19 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { api } from 'polarkit'
 import posthog from 'posthog-js'
 import { MouseEvent } from 'react'
 
 const GithubLoginButton = (props: {
-  pledgeId?: string
   gotoUrl?: string
   size?: 'large' | 'small'
   fullWidth?: boolean
   posthogProps?: object
   text: string
 }) => {
+  const search = useSearchParams()
+
   const signin = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     e.stopPropagation()
@@ -22,7 +24,7 @@ const GithubLoginButton = (props: {
     })
 
     const res = await api.integrations.githubAuthorize({
-      pledgeId: props.pledgeId,
+      paymentIntentId: search.get('payment_intent_id') ?? undefined,
       gotoUrl: props.gotoUrl,
     })
 

--- a/clients/packages/polarkit/src/api/client/models/OAuthAccountRead.ts
+++ b/clients/packages/polarkit/src/api/client/models/OAuthAccountRead.ts
@@ -6,7 +6,7 @@ import type { Platforms } from './Platforms';
 
 export type OAuthAccountRead = {
   created_at: string;
-  modified_at: string;
+  modified_at?: string;
   platform: Platforms;
   account_id: string;
   account_email: string;

--- a/clients/packages/polarkit/src/api/client/models/UserRead.ts
+++ b/clients/packages/polarkit/src/api/client/models/UserRead.ts
@@ -6,7 +6,7 @@ import type { OAuthAccountRead } from './OAuthAccountRead';
 
 export type UserRead = {
   created_at: string;
-  modified_at: string;
+  modified_at?: string;
   username: string;
   email: string;
   avatar_url?: string;

--- a/clients/packages/polarkit/src/api/client/services/IntegrationsService.ts
+++ b/clients/packages/polarkit/src/api/client/services/IntegrationsService.ts
@@ -24,17 +24,17 @@ export class IntegrationsService {
    * @throws ApiError
    */
   public githubAuthorize({
-    pledgeId,
+    paymentIntentId,
     gotoUrl,
   }: {
-    pledgeId?: string,
+    paymentIntentId?: string,
     gotoUrl?: string,
   }): CancelablePromise<AuthorizationResponse> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v1/integrations/github/authorize',
       query: {
-        'pledge_id': pledgeId,
+        'payment_intent_id': paymentIntentId,
         'goto_url': gotoUrl,
       },
       errors: {

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -61,13 +61,13 @@ oauth2_authorize_callback = OAuth2AuthorizeCallback(
 
 @router.get("/authorize")
 async def github_authorize(
-    pledge_id: UUID | None = None,
+    payment_intent_id: str | None = None,
     goto_url: str | None = None,
     auth: Auth = Depends(Auth.optional_user),
 ) -> AuthorizationResponse:
     state = {}
-    if pledge_id:
-        state["pledge_id"] = str(pledge_id)
+    if payment_intent_id:
+        state["payment_intent_id"] = payment_intent_id
 
     if goto_url:
         # Ensure we have a full URL and within Polar only
@@ -126,9 +126,11 @@ async def github_callback(
     else:
         user = await github_user.login_or_signup(session, tokens=tokens)
 
-    pledge_id = state_data.get("pledge_id")
-    if pledge_id:
-        await pledge_service.connect_backer(session, pledge_id=pledge_id, backer=user)
+    payment_intent_id = state_data.get("payment_intent_id")
+    if payment_intent_id:
+        await pledge_service.connect_backer(
+            session, payment_intent_id=payment_intent_id, backer=user
+        )
 
     # connect dangling rewards
     await reward_service.connect_by_username(session, user)

--- a/server/polar/pledge/service.py
+++ b/server/polar/pledge/service.py
@@ -189,12 +189,18 @@ class PledgeService(ResourceServiceReader[Pledge]):
     async def connect_backer(
         self,
         session: AsyncSession,
-        pledge_id: UUID,
+        payment_intent_id: str,
         backer: User,
     ) -> None:
-        pledge = await self.get(session, id=pledge_id)
+        pledge = await self.get_by_payment_id(session, payment_id=payment_intent_id)
         if not pledge:
-            raise ResourceNotFound(f"Pledge not found with id: {pledge_id}")
+            raise ResourceNotFound(
+                f"Pledge not found with payment_id: {payment_intent_id}"
+            )
+
+        # This pledge is already connected
+        if pledge.by_user_id or pledge.by_organization_id:
+            return None
 
         pledge.by_user_id = backer.id
         await pledge.save(session)


### PR DESCRIPTION
Change to use the payment_intent_id as the connection token, as it's only known to the pledger, and never known to the public.

All github login buttons on a page with payment_intent_id in the search params automatically forwards the token.

Fixes #1128