### PR TITLE
server/dx: improve typing of Auth by using Annotated approach

### DIFF
--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import Annotated, Self
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request
@@ -28,6 +28,9 @@ async def current_user_required(
 
 
 class Auth:
+    subject: Subject
+    user: User | None
+
     def __init__(
         self,
         *,
@@ -150,3 +153,11 @@ class Auth:
             )
 
         return cls(subject=user, user=user)
+
+
+class AuthRequired(Auth):
+    subject: User
+    user: User
+
+
+UserRequiredAuth = Annotated[AuthRequired, Depends(Auth.current_user)]

--- a/server/polar/dashboard/endpoints.py
+++ b/server/polar/dashboard/endpoints.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import joinedload
 
-from polar.auth.dependencies import Auth
+from polar.auth.dependencies import Auth, UserRequiredAuth
 from polar.authz.service import AccessType, Authz
 from polar.dashboard.schemas import (
     Entry,
@@ -43,6 +43,7 @@ router = APIRouter(tags=["dashboard"])
     response_model=IssueListResponse,
 )
 async def get_personal_dashboard(
+    auth: UserRequiredAuth,
     issue_list_type: IssueListType = IssueListType.issues,
     status: Union[List[IssueStatus], None] = Query(default=None),
     q: Union[str, None] = Query(default=None),
@@ -50,7 +51,6 @@ async def get_personal_dashboard(
     only_pledged: bool = Query(default=False),
     only_badged: bool = Query(default=False),
     page: int = Query(default=1),
-    auth: Auth = Depends(Auth.current_user),
     session: AsyncSession = Depends(get_db_session),
 ) -> IssueListResponse:
     return await dashboard(

--- a/server/polar/eventstream/endpoints.py
+++ b/server/polar/eventstream/endpoints.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from redis.exceptions import ConnectionError
 from sse_starlette.sse import EventSourceResponse
 
-from polar.auth.dependencies import Auth
+from polar.auth.dependencies import Auth, UserRequiredAuth
 from polar.enums import Platforms
 from polar.redis import Redis, get_redis
 
@@ -49,12 +49,9 @@ async def subscribe(
 @router.get("/user/stream")
 async def user_stream(
     request: Request,
-    auth: Auth = Depends(Auth.current_user),
+    auth: UserRequiredAuth,
     redis: Redis = Depends(get_redis),
 ) -> EventSourceResponse:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     receivers = Receivers(user_id=auth.user.id)
     return EventSourceResponse(subscribe(redis, receivers.get_channels(), request))
 

--- a/server/polar/personal_access_token/endpoints.py
+++ b/server/polar/personal_access_token/endpoints.py
@@ -3,7 +3,7 @@ from uuid import UUID
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
 
-from polar.auth.dependencies import Auth
+from polar.auth.dependencies import UserRequiredAuth
 from polar.auth.service import AuthService
 from polar.postgres import AsyncSession, get_db_session
 from polar.tags.api import Tags
@@ -31,12 +31,9 @@ router = APIRouter(tags=["personal_access_token"])
 )
 async def delete(
     id: UUID,
-    auth: Auth = Depends(Auth.current_user),
+    auth: UserRequiredAuth,
     session: AsyncSession = Depends(get_db_session),
 ) -> PersonalAccessToken:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     pat = await personal_access_token_service.get(session, id)
     if not pat:
         raise HTTPException(status_code=404, detail="PAT not found")
@@ -58,12 +55,9 @@ async def delete(
     status_code=200,
 )
 async def list(
-    auth: Auth = Depends(Auth.current_user),
+    auth: UserRequiredAuth,
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[PersonalAccessToken]:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     pats = await personal_access_token_service.list_for_user(session, auth.user.id)
 
     return ListResource(
@@ -82,12 +76,9 @@ async def list(
 )
 async def create(
     payload: CreatePersonalAccessToken,
-    auth: Auth = Depends(Auth.current_user),
+    auth: UserRequiredAuth,
     session: AsyncSession = Depends(get_db_session),
 ) -> CreatePersonalAccessTokenResponse:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     pat = await personal_access_token_service.create(
         session, user_id=auth.user.id, comment=payload.comment
     )

--- a/server/polar/reward/endpoints.py
+++ b/server/polar/reward/endpoints.py
@@ -2,8 +2,8 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from polar.auth.dependencies import Auth
-from polar.authz.service import AccessType, Authz, Subject
+from polar.auth.dependencies import UserRequiredAuth
+from polar.authz.service import AccessType, Authz
 from polar.currency.schemas import CurrencyAmount
 from polar.models.issue_reward import IssueReward
 from polar.models.pledge import Pledge as PledgeModel
@@ -30,6 +30,7 @@ router = APIRouter(tags=["rewards"])
     status_code=200,
 )
 async def search(
+    auth: UserRequiredAuth,
     pledges_to_organization: UUID
     | None = Query(
         default=None,
@@ -46,7 +47,6 @@ async def search(
         description="Search rewards to organization.",
     ),
     session: AsyncSession = Depends(get_db_session),
-    auth: Auth = Depends(Auth.current_user),
     authz: Authz = Depends(Authz.authz),
 ) -> ListResource[Reward]:
     if not pledges_to_organization and not rewards_to_user and not rewards_to_org:

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, Response
 
-from polar.auth.dependencies import Auth
+from polar.auth.dependencies import UserRequiredAuth
 from polar.auth.service import AuthService, LoginResponse, LogoutResponse
 from polar.models import User
 from polar.postgres import AsyncSession, get_db_session
@@ -12,33 +12,25 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 
 @router.get("/me", response_model=UserRead)
-async def get_authenticated(auth: Auth = Depends(Auth.current_user)) -> User:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+async def get_authenticated(auth: UserRequiredAuth) -> User:
     return auth.user
 
 
 @router.post("/me/token")
-async def create_token(auth: Auth = Depends(Auth.current_user)) -> LoginResponse:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+async def create_token(auth: UserRequiredAuth) -> LoginResponse:
     return AuthService.generate_login_json_response(user=auth.user)
 
 
 @router.put("/me", response_model=UserRead)
 async def update_preferences(
     settings: UserUpdateSettings,
-    auth: Auth = Depends(Auth.current_user),
+    auth: UserRequiredAuth,
     session: AsyncSession = Depends(get_db_session),
 ) -> User:
-    if not auth.user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
     user = await user_service.update_preferences(session, auth.user, settings)
     return user
 
 
 @router.get("/logout")
-async def logout(
-    response: Response, auth: Auth = Depends(Auth.current_user)
-) -> LogoutResponse:
+async def logout(response: Response, auth: UserRequiredAuth) -> LogoutResponse:
     return AuthService.generate_logout_response(response=response)


### PR DESCRIPTION
I was a bit annoyed by the fact that `Auth.current_user` would return us a class instance typed with an optional user (`User | None`), while we *know* by using this constructor that the user is there and not `None`.

So, I've played a bit with typing and the new fancy [`Annotated` approach](https://fastapi.tiangolo.com/tutorial/dependencies/#share-annotated-dependencies) to help us improve this.

I've implemented this in a single endpoint for now. As we see, it helps us get rid of unneeded `if not auth.user` checks.

I would very like your feedback on this, @zegl, before generalizing it.