### PR TITLE
Badge: show avatars of pledgers

### DIFF
--- a/clients/apps/web/src/app/api/github/[org]/[repo]/issues/[number]/pledge-injected.svg/route.tsx
+++ b/clients/apps/web/src/app/api/github/[org]/[repo]/issues/[number]/pledge-injected.svg/route.tsx
@@ -24,6 +24,7 @@ const renderBadge = async (badge: GithubBadgeRead, isDarkmode: boolean) => {
       showAmountRaised={hasAmount}
       darkmode={isDarkmode}
       funding={badge.funding}
+      avatarsUrls={[]}
     />,
     {
       height: 60,

--- a/clients/apps/web/src/app/api/github/[org]/[repo]/issues/[number]/pledge.svg/route.tsx
+++ b/clients/apps/web/src/app/api/github/[org]/[repo]/issues/[number]/pledge.svg/route.tsx
@@ -44,6 +44,7 @@ const renderBadge = async (badge: GithubBadgeRead, isDarkmode: boolean) => {
       showAmountRaised={hasAmount}
       darkmode={isDarkmode}
       funding={badge.funding}
+      avatarsUrls={[]}
     />,
     {
       height: 60,

--- a/clients/apps/web/src/app/api/github/[org]/[repo]/issues/[number]/pledge.svg/route.tsx
+++ b/clients/apps/web/src/app/api/github/[org]/[repo]/issues/[number]/pledge.svg/route.tsx
@@ -13,6 +13,7 @@ type Data = {
 const lookupIssue = (externalUrl: string): Promise<Issue> =>
   fetch(`${getServerURL()}/api/v1/issues/lookup?external_url=${externalUrl}`, {
     method: 'GET',
+    next: { revalidate: 60 },
   }).then((response) => {
     if (!response.ok) {
       throw new Error(`Unexpected ${response.status} status code`)
@@ -23,6 +24,7 @@ const lookupIssue = (externalUrl: string): Promise<Issue> =>
 const searchPledges = (issueId: string): Promise<ListResource_Pledge_> =>
   fetch(`${getServerURL()}/api/v1/pledges/search?issue_id=${issueId}`, {
     method: 'GET',
+    next: { revalidate: 60 },
   }).then((response) => {
     if (!response.ok) {
       throw new Error(`Unexpected ${response.status} status code`)

--- a/clients/apps/web/src/components/Dashboard/BadgeMessageForm.tsx
+++ b/clients/apps/web/src/components/Dashboard/BadgeMessageForm.tsx
@@ -1,4 +1,3 @@
-import { useRequireAuth } from '@/hooks'
 import { Marked } from '@ts-stack/markdown'
 import { useTheme } from 'next-themes'
 import { CurrencyAmount, Funding } from 'polarkit/api/client'
@@ -20,8 +19,6 @@ const BadgeMessageForm = (props: {
   canSetFundingGoal: boolean
   funding: Funding
 }) => {
-  const { currentUser } = useRequireAuth()
-
   const [message, setMessage] = useState('')
 
   const [descriptionMode, setDescirptionMode] = useState('View')
@@ -105,13 +102,7 @@ const BadgeMessageForm = (props: {
               showAmountRaised={props.showAmountRaised}
               darkmode={resolvedTheme === 'dark'}
               funding={funding}
-              avatarsUrls={[
-                currentUser?.avatar_url || '',
-                currentUser?.avatar_url || '',
-                currentUser?.avatar_url || '',
-                currentUser?.avatar_url || '',
-                currentUser?.avatar_url || '',
-              ]}
+              avatarsUrls={[]}
             />
           </>
         )}

--- a/clients/apps/web/src/components/Dashboard/BadgeMessageForm.tsx
+++ b/clients/apps/web/src/components/Dashboard/BadgeMessageForm.tsx
@@ -1,3 +1,4 @@
+import { useRequireAuth } from '@/hooks'
 import { Marked } from '@ts-stack/markdown'
 import { useTheme } from 'next-themes'
 import { CurrencyAmount, Funding } from 'polarkit/api/client'
@@ -19,6 +20,8 @@ const BadgeMessageForm = (props: {
   canSetFundingGoal: boolean
   funding: Funding
 }) => {
+  const { currentUser } = useRequireAuth()
+
   const [message, setMessage] = useState('')
 
   const [descriptionMode, setDescirptionMode] = useState('View')
@@ -92,7 +95,7 @@ const BadgeMessageForm = (props: {
       <div
         className={classNames(
           props.innerClassNames,
-          'rounded-xl bg-white py-3.5 px-5 dark:bg-gray-800 dark:ring-1 dark:ring-gray-600',
+          'rounded-xl bg-white px-5 py-3.5 dark:bg-gray-800 dark:ring-1 dark:ring-gray-600',
         )}
       >
         {descriptionMode === 'View' && (
@@ -102,6 +105,13 @@ const BadgeMessageForm = (props: {
               showAmountRaised={props.showAmountRaised}
               darkmode={resolvedTheme === 'dark'}
               funding={funding}
+              avatarsUrls={[
+                currentUser?.avatar_url || '',
+                currentUser?.avatar_url || '',
+                currentUser?.avatar_url || '',
+                currentUser?.avatar_url || '',
+                currentUser?.avatar_url || '',
+              ]}
             />
           </>
         )}

--- a/clients/apps/web/src/components/Onboarding/OnboardingAddDependency.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingAddDependency.tsx
@@ -28,6 +28,7 @@ const OnboardingAddDependency = () => {
     platform: Platforms.GITHUB,
     name: 'x',
     pledge_minimum_amount: 2000,
+    pledge_badge_show_amount: true,
   }
   const demoRepo: Repository = {
     platform: Platforms.GITHUB,

--- a/clients/apps/web/src/components/Settings/FakePullRequest.tsx
+++ b/clients/apps/web/src/components/Settings/FakePullRequest.tsx
@@ -52,6 +52,7 @@ const PolarBadge = ({ showAmount }: { showAmount: boolean }) => {
         pledges_sum: { currency: 'USD', amount: 2500 },
       }}
       darkmode={resolvedTheme === 'dark' ? true : false}
+      avatarsUrls={[]}
     />
   )
 }

--- a/clients/apps/web/src/stories/FinancePage.stories.tsx
+++ b/clients/apps/web/src/stories/FinancePage.stories.tsx
@@ -9,7 +9,7 @@ import {
   Reward,
   RewardState,
 } from 'polarkit/api/client'
-import { issue, org, orgPrivate } from './testdata'
+import { issue, org } from './testdata'
 
 type Story = StoryObj<typeof Finance>
 
@@ -93,7 +93,7 @@ const rewards = [
 export const Default: Story = {
   args: {
     pledges: all_pledge_states,
-    org: orgPrivate,
+    org: org,
     tab: 'current',
     accounts: [],
     rewards: rewards,

--- a/clients/apps/web/src/stories/PledgeBadge.stories.tsx
+++ b/clients/apps/web/src/stories/PledgeBadge.stories.tsx
@@ -30,6 +30,7 @@ export const Default: Story = {
         ></link>
 
         <Badge {...args} />
+        <Badge {...args} darkmode={true} />
       </div>
     )
   },

--- a/clients/apps/web/src/stories/PledgeBadge.stories.tsx
+++ b/clients/apps/web/src/stories/PledgeBadge.stories.tsx
@@ -19,7 +19,28 @@ type Story = StoryObj<typeof Badge>
 
 export const Default: Story = {
   args: {},
+  render: (args) => {
+    return (
+      <div className="font-sans">
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+          rel="stylesheet"
+        ></link>
+
+        <Badge {...args} />
+      </div>
+    )
+  },
 }
+
+const avatars = [
+  'https://avatars.githubusercontent.com/u/1144727?v=4',
+  'https://avatars.githubusercontent.com/u/47952?v=4',
+  'https://avatars.githubusercontent.com/u/281715?v=4',
+  'https://avatars.githubusercontent.com/u/1426460?v=4',
+]
 
 export const AmountRaised: Story = {
   ...Default,
@@ -29,6 +50,50 @@ export const AmountRaised: Story = {
     funding: {
       pledges_sum: { currency: 'USD', amount: 5000 },
     },
+    avatarsUrls: avatars,
+  },
+}
+
+export const AmountRaisedSingleAvatar: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    showAmountRaised: true,
+    funding: {
+      pledges_sum: { currency: 'USD', amount: 5000 },
+    },
+    avatarsUrls: [avatars[0]],
+  },
+}
+
+export const AmountRaisedFiveAvatars: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    showAmountRaised: true,
+    funding: {
+      pledges_sum: { currency: 'USD', amount: 5000 },
+    },
+    avatarsUrls: [...avatars, ...avatars].slice(0, 5),
+  },
+}
+
+export const AmountRaisedTwentyAvatars: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    showAmountRaised: true,
+    funding: {
+      pledges_sum: { currency: 'USD', amount: 5000 },
+    },
+    avatarsUrls: [
+      ...avatars,
+      ...avatars,
+      ...avatars,
+      ...avatars,
+      ...avatars,
+      ...avatars,
+    ].slice(0, 20),
   },
 }
 

--- a/clients/apps/web/src/stories/PledgeBadge.stories.tsx
+++ b/clients/apps/web/src/stories/PledgeBadge.stories.tsx
@@ -121,6 +121,31 @@ export const FundingGoal: Story = {
   },
 }
 
+export const FundingGoalAvatars: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    showAmountRaised: true,
+    funding: {
+      funding_goal: { currency: 'USD', amount: 12000 },
+      pledges_sum: { currency: 'USD', amount: 6000 },
+    },
+    avatarsUrls: [...avatars, ...avatars],
+  },
+}
+export const FundingGoalAvatarsVeryWide: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    showAmountRaised: true,
+    funding: {
+      funding_goal: { currency: 'USD', amount: 1200000000 },
+      pledges_sum: { currency: 'USD', amount: 600000000 },
+    },
+    avatarsUrls: [...avatars, ...avatars],
+  },
+}
+
 export const FundingGoalZero: Story = {
   ...Default,
   args: {

--- a/clients/apps/web/src/stories/testdata.ts
+++ b/clients/apps/web/src/stories/testdata.ts
@@ -41,6 +41,7 @@ export const org: Organization = {
   avatar_url: 'https://avatars.githubusercontent.com/u/110818415?s=48&v=4',
   pledge_minimum_amount: 2000,
   pretty_name: 'Pydantic',
+  pledge_badge_show_amount: true,
 }
 
 export const orgPrivate: OrganizationPrivateRead = {

--- a/clients/packages/polarkit/src/api/client/models/Organization.ts
+++ b/clients/packages/polarkit/src/api/client/models/Organization.ts
@@ -17,5 +17,6 @@ export type Organization = {
   email?: string;
   twitter_username?: string;
   pledge_minimum_amount: number;
+  pledge_badge_show_amount: boolean;
 };
 

--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -19,11 +19,13 @@ export const Badge = ({
   // amountRaised = undefined,
   darkmode = false,
   funding = undefined,
+  avatarsUrls = [],
 }: {
   showAmountRaised?: boolean
   // amountRaised?: string
   darkmode: boolean
   funding?: Funding
+  avatarsUrls: string[]
 }) => {
   const showFundingGoal =
     funding &&
@@ -42,6 +44,10 @@ export const Badge = ({
           1, // Min 1
         )
       : 0
+
+  const showAvatars =
+    avatarsUrls.length > 4 ? avatarsUrls.slice(0, 3) : avatarsUrls
+  const extraAvatarsCount = avatarsUrls.length - showAvatars.length
 
   return (
     <>
@@ -85,7 +91,7 @@ export const Badge = ({
               flexShrink: '0',
             }}
           >
-            Fund this issue
+            Fund
           </div>
 
           {showAmount && funding?.pledges_sum?.amount !== undefined && (
@@ -210,6 +216,47 @@ export const Badge = ({
                 </div>
               </div>
             )}
+
+          {showAvatars.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                marginRight: '8px',
+              }}
+            >
+              {showAvatars.map((url, idx) => (
+                <img
+                  key={idx}
+                  src={url}
+                  style={{
+                    height: 20,
+                    width: 20,
+                    borderRadius: 20,
+                    border: '1px solid white',
+                    marginLeft: idx > 0 ? '-6px' : '',
+                  }}
+                />
+              ))}
+
+              {extraAvatarsCount > 0 && (
+                <div
+                  style={{
+                    backgroundColor: '#C9DBF4',
+                    color: '#4667CA',
+                    height: 20,
+                    width: 20,
+                    borderRadius: 20,
+                    marginLeft: '-6px',
+                    textAlign: 'center',
+                    fontSize: '10px',
+                    lineHeight: '20px',
+                  }}
+                >
+                  +{extraAvatarsCount}
+                </div>
+              )}
+            </div>
+          )}
 
           <div
             style={{

--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -238,7 +238,7 @@ export const Badge = ({
                     height: 22,
                     width: 22,
                     borderRadius: 22,
-                    border: darkmode ? '1px solid #374e96' : '1px solid white',
+                    border: darkmode ? '1px solid #3E3F43' : '1px solid white',
                     marginLeft: idx > 0 ? '-6px' : '',
                     flexShrink: '0',
                   }}
@@ -257,7 +257,7 @@ export const Badge = ({
                     textAlign: 'center',
                     fontSize: '8px',
                     lineHeight: '20px',
-                    border: darkmode ? '1px solid #374e96' : '1px solid white',
+                    border: darkmode ? '1px solid #3E3F43' : '1px solid white',
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-around',

--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -49,6 +49,8 @@ export const Badge = ({
     avatarsUrls.length > 4 ? avatarsUrls.slice(0, 3) : avatarsUrls
   const extraAvatarsCount = avatarsUrls.length - showAvatars.length
 
+  const title = showFundingGoal || showAmount ? 'Fund' : 'Fund this issue'
+
   return (
     <>
       <div
@@ -91,7 +93,7 @@ export const Badge = ({
               flexShrink: '0',
             }}
           >
-            {showAmount ? 'Fund' : 'Fund this issue'}
+            {title}
           </div>
 
           {showAmount && funding?.pledges_sum?.amount !== undefined && (
@@ -144,6 +146,7 @@ export const Badge = ({
                 style={{
                   display: 'flex',
                   flexDirection: 'column',
+                  overflow: 'hidden',
                   marginRight: 12,
                   marginLeft: 6,
                   fontSize: 12,
@@ -222,6 +225,9 @@ export const Badge = ({
               style={{
                 display: 'flex',
                 marginRight: '8px',
+                overflow: 'hidden',
+                height: '22px',
+                flexWrap: 'wrap',
               }}
             >
               {showAvatars.map((url, idx) => (
@@ -229,11 +235,12 @@ export const Badge = ({
                   key={idx}
                   src={url}
                   style={{
-                    height: 20,
-                    width: 20,
-                    borderRadius: 20,
+                    height: 22,
+                    width: 22,
+                    borderRadius: 22,
                     border: darkmode ? '1px solid #374e96' : '1px solid white',
                     marginLeft: idx > 0 ? '-6px' : '',
+                    flexShrink: '0',
                   }}
                 />
               ))}
@@ -243,9 +250,9 @@ export const Badge = ({
                   style={{
                     backgroundColor: darkmode ? '#2e4070' : '#C9DBF4',
                     color: darkmode ? '#a6c7ea' : '#4667CA',
-                    height: 20,
-                    width: 20,
-                    borderRadius: 20,
+                    height: 22,
+                    width: 22,
+                    borderRadius: 22,
                     marginLeft: '-6px',
                     textAlign: 'center',
                     fontSize: '8px',
@@ -254,6 +261,7 @@ export const Badge = ({
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-around',
+                    flexShrink: '0',
                   }}
                 >
                   <span>+{extraAvatarsCount}</span>

--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -248,11 +248,15 @@ export const Badge = ({
                     borderRadius: 20,
                     marginLeft: '-6px',
                     textAlign: 'center',
-                    fontSize: '10px',
+                    fontSize: '8px',
                     lineHeight: '20px',
+                    border: '1px solid white',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-around',
                   }}
                 >
-                  +{extraAvatarsCount}
+                  <span>+{extraAvatarsCount}</span>
                 </div>
               )}
             </div>

--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -91,7 +91,7 @@ export const Badge = ({
               flexShrink: '0',
             }}
           >
-            Fund
+            {showAmount ? 'Fund' : 'Fund this issue'}
           </div>
 
           {showAmount && funding?.pledges_sum?.amount !== undefined && (
@@ -232,7 +232,7 @@ export const Badge = ({
                     height: 20,
                     width: 20,
                     borderRadius: 20,
-                    border: '1px solid white',
+                    border: darkmode ? '1px solid #374e96' : '1px solid white',
                     marginLeft: idx > 0 ? '-6px' : '',
                   }}
                 />
@@ -241,8 +241,8 @@ export const Badge = ({
               {extraAvatarsCount > 0 && (
                 <div
                   style={{
-                    backgroundColor: '#C9DBF4',
-                    color: '#4667CA',
+                    backgroundColor: darkmode ? '#2e4070' : '#C9DBF4',
+                    color: darkmode ? '#a6c7ea' : '#4667CA',
                     height: 20,
                     width: 20,
                     borderRadius: 20,
@@ -250,7 +250,7 @@ export const Badge = ({
                     textAlign: 'center',
                     fontSize: '8px',
                     lineHeight: '20px',
-                    border: '1px solid white',
+                    border: darkmode ? '1px solid #374e96' : '1px solid white',
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-around',

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -378,4 +378,10 @@ class Authz:
         ):
             return True
 
+        # If admin of receiving org
+        if object.organization_id and await self._is_member_and_admin(
+            subject.id, object.organization_id
+        ):
+            return True
+
         return False

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -157,7 +157,7 @@ class Authz:
         # Pledge
         #
         if isinstance(subject, Anonymous) and isinstance(object, Pledge):
-            return False
+            return await self._can_anonymous_read_pledge(object)
 
         if (
             isinstance(subject, User)
@@ -361,24 +361,11 @@ class Authz:
     # Pledge
     #
 
+    async def _can_anonymous_read_pledge(self, object: Pledge) -> bool:
+        return True
+
     async def _can_user_read_pledge(self, subject: User, object: Pledge) -> bool:
-        # If pledged by this user
-        if object.by_user_id and object.by_user_id == subject.id:
-            return True
-
-        # If member of pledging org
-        if object.by_organization_id and await self._is_member(
-            subject.id, object.by_organization_id
-        ):
-            return True
-
-        # If member of receiving org
-        if object.organization_id and await self._is_member(
-            subject.id, object.organization_id
-        ):
-            return True
-
-        return False
+        return True
 
     async def _can_user_write_pledge(self, subject: User, object: Pledge) -> bool:
         # If pledged by this user

--- a/server/polar/backoffice/endpoints.py
+++ b/server/polar/backoffice/endpoints.py
@@ -52,7 +52,7 @@ async def pledges(
 def r(
     pledge: PledgeModel, reward: IssueReward, transaction: PledgeTransactionModel
 ) -> BackofficeReward:
-    r = reward_to_resource(pledge, reward, transaction)
+    r = reward_to_resource(pledge, reward, transaction, include_admin_fields=True)
     return BackofficeReward(
         pledge=r.pledge,
         user=r.user,
@@ -129,7 +129,9 @@ async def get_pledge(session: AsyncSession, pledge_id: UUID) -> BackofficePledge
             status_code=404,
             detail="Pledge not found",
         )
-    return BackofficePledge.from_db(pledge)
+    return BackofficePledge.from_db(
+        pledge,
+    )
 
 
 class PledgeRewardTransfer(Schema):

--- a/server/polar/backoffice/schemas.py
+++ b/server/polar/backoffice/schemas.py
@@ -25,8 +25,8 @@ class BackofficePledge(PledgeSchema):
     pledger_email: str | None
 
     @classmethod
-    def from_db(cls, o: Pledge) -> Self:
-        p = PledgeSchema.from_db(o)
+    def from_db(cls, o: Pledge, include_admin_fields: bool = False) -> Self:
+        p = PledgeSchema.from_db(o, include_admin_fields=include_admin_fields)
 
         return cls(
             id=p.id,
@@ -43,6 +43,7 @@ class BackofficePledge(PledgeSchema):
             dispute_reason=o.dispute_reason,
             disputed_at=o.disputed_at,
             disputed_by_user_id=o.disputed_by_user_id,
+            hosted_invoice_url=p.hosted_invoice_url,
         )
 
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -29,6 +29,7 @@ class Organization(Schema):
     twitter_username: str | None
 
     pledge_minimum_amount: int
+    pledge_badge_show_amount: bool
 
     @classmethod
     def from_db(cls, o: OrganizationModel) -> Self:
@@ -45,6 +46,7 @@ class Organization(Schema):
             email=o.email,
             twitter_username=o.twitter_username,
             pledge_minimum_amount=o.pledge_minimum_amount,
+            pledge_badge_show_amount=o.pledge_badge_show_amount,
         )
 
 

--- a/server/polar/pledge/endpoints.py
+++ b/server/polar/pledge/endpoints.py
@@ -62,7 +62,7 @@ async def search(
     issue_id: UUID
     | None = Query(default=None, description="Search pledges to this issue"),
     session: AsyncSession = Depends(get_db_session),
-    auth: Auth = Depends(Auth.current_user),
+    auth: Auth = Depends(Auth.optional_user),
     authz: Authz = Depends(Authz.authz),
 ) -> ListResource[PledgeSchema]:
     list_by_orgs: list[UUID] = []

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -154,7 +154,7 @@ class Pledge(Schema):
     hosted_invoice_url: str | None = Field(description="URL of invoice for this pledge")
 
     @classmethod
-    def from_db(cls, o: PledgeModel) -> Pledge:
+    def from_db(cls, o: PledgeModel, include_admin_fields: bool = False) -> Pledge:
         pledger: Pledger | None = None
 
         if o.by_organization_id:
@@ -177,11 +177,11 @@ class Pledge(Schema):
             amount=CurrencyAmount(currency="USD", amount=o.amount),
             state=PledgeState.from_str(o.state),
             type=PledgeType.from_str(o.type),
-            refunded_at=o.refunded_at,
-            scheduled_payout_at=o.scheduled_payout_at,
+            refunded_at=o.refunded_at if include_admin_fields else None,
+            scheduled_payout_at=o.scheduled_payout_at if include_admin_fields else None,
             issue=Issue.from_db(o.issue),
             pledger=pledger,
-            hosted_invoice_url=o.invoice_hosted_url,
+            hosted_invoice_url=o.invoice_hosted_url if include_admin_fields else None,
         )
 
 

--- a/server/tests/pledge/test_endpoints.py
+++ b/server/tests/pledge/test_endpoints.py
@@ -81,7 +81,7 @@ async def test_get_pledge_not_member(
         cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
     )
 
-    assert response.status_code == 401
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_search_pledge_no_member(
     )
 
     assert response.status_code == 200
-    assert response.json()["items"] == []
+    assert len(response.json()["items"]) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

* Changes `Pledges` to be **public**. Some fields (refunded_at, scheduled_payout_at, hosted_invoice_url) are only shown to users with write access to the pledge.
* Added `pledge_badge_show_amount` to the public `Organization` object
* Show avatars of pledgers (max 4 shown) in the SVG badge

### Screenshots

![](https://snapshots.chromatic.com/snapshots/646dd122a99fb9a2fe564ec3-6508589df02683772f113b02/capture-73d535e5.png)

![](https://snapshots.chromatic.com/snapshots/646dd122a99fb9a2fe564ec3-6508589df02683772f113b03/capture-efa9d243.png)

![](https://snapshots.chromatic.com/snapshots/646dd122a99fb9a2fe564ec3-6508589df02683772f113b04/capture-857fd51c.png)

![](https://snapshots.chromatic.com/snapshots/646dd122a99fb9a2fe564ec3-6508589df02683772f113b05/capture-1c82798d.png)

![](https://snapshots.chromatic.com/snapshots/646dd122a99fb9a2fe564ec3-6508589df02683772f113b06/capture-cb4d59bf.png)

![](https://snapshots.chromatic.com/snapshots/646dd122a99fb9a2fe564ec3-6508589df02683772f113b09/capture-77260c36.png)