### PR TITLE
Implement new design of issue page's left part

### DIFF
--- a/clients/apps/web/src/app/(pledge)/[organization]/[repo]/issues/[number]/(create)/page.tsx
+++ b/clients/apps/web/src/app/(pledge)/[organization]/[repo]/issues/[number]/(create)/page.tsx
@@ -71,11 +71,14 @@ export default async function Page({
   params: { organization: string; repo: string; number: string }
 }) {
   let issue: Issue | undefined
+  let issueHTMLBody: string | undefined
 
   try {
-    issue = await authedApi().issues.lookup({
+    const api = authedApi()
+    issue = await api.issues.lookup({
       externalUrl: `https://github.com/${params.organization}/${params.repo}/issues/${params.number}`,
     })
+    issueHTMLBody = await api.issues.getBody({ id: issue.id })
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) {
       notFound()
@@ -88,7 +91,7 @@ export default async function Page({
 
   return (
     <>
-      <Pledge issue={issue} gotoURL={undefined} />
+      <Pledge issue={issue} htmlBody={issueHTMLBody} gotoURL={undefined} />
     </>
   )
 }

--- a/clients/apps/web/src/components/Organization/RepositoryPublicPage.tsx
+++ b/clients/apps/web/src/components/Organization/RepositoryPublicPage.tsx
@@ -1,5 +1,6 @@
 import { Issue, Organization, Repository } from 'polarkit/api/client'
-import { abbrStars, prettyURL } from '.'
+import { formatStarsNumber } from 'polarkit/utils'
+import { prettyURL } from '.'
 import HowItWorks from '../Pledge/HowItWorks'
 import Footer from './Footer'
 import Header from './Header'
@@ -40,7 +41,7 @@ const RepositoryPublicPage = ({
         <div className="flex flex-wrap items-center space-x-4 text-gray-600">
           {repository.license && <p>{repository.license}</p>}
 
-          <p>{abbrStars(repository.stars || 0)} stars</p>
+          <p>{formatStarsNumber(repository.stars || 0)} stars</p>
 
           {repository.homepage && (
             <a

--- a/clients/apps/web/src/components/Organization/index.ts
+++ b/clients/apps/web/src/components/Organization/index.ts
@@ -1,12 +1,3 @@
-export const abbrStars = (stars: number): string => {
-  if (stars < 1000) {
-    return stars.toString()
-  }
-
-  stars /= 1000
-  return stars.toFixed(1) + 'k'
-}
-
 export const prettyURL = (url: string): string => {
   if (url.indexOf('https://') === 0) {
     url = url.substring(8)

--- a/clients/apps/web/src/components/Pledge/PaymentForm.tsx
+++ b/clients/apps/web/src/components/Pledge/PaymentForm.tsx
@@ -217,7 +217,7 @@ const PaymentForm = ({
   }
 
   return (
-    <div className="border-t pt-5 dark:border-gray-500">
+    <div className="flex flex-col gap-4 border-t pt-5 dark:border-gray-500">
       {!paymentMethod && (
         <PaymentElement
           onChange={onStripeFormChange}
@@ -248,9 +248,6 @@ const PaymentForm = ({
               >
                 Save payment method on file
               </label>
-              <p className="text-muted-foreground text-sm">
-                Fund future issues easily. Stored securely with Stripe.
-              </p>
             </div>
           </div>
         )}

--- a/clients/apps/web/src/components/Pledge/Pledge.tsx
+++ b/clients/apps/web/src/components/Pledge/Pledge.tsx
@@ -10,7 +10,15 @@ import Footer from '../Organization/Footer'
 import HowItWorks from './HowItWorks'
 import PledgeForm from './PledgeForm'
 
-const Pledge = ({ issue, gotoURL }: { issue: Issue; gotoURL?: string }) => {
+const Pledge = ({
+  issue,
+  htmlBody,
+  gotoURL,
+}: {
+  issue: Issue
+  htmlBody?: string
+  gotoURL?: string
+}) => {
   const [amount, setAmount] = useState(0)
   const onAmountChange = (amount: number) => {
     setAmount(amount)
@@ -41,7 +49,11 @@ const Pledge = ({ issue, gotoURL }: { issue: Issue; gotoURL?: string }) => {
       <div className="grid grid-cols-1 gap-12 lg:grid-cols-2">
         {/* Left side */}
         <div className="mt-12">
-          <IssueCard issue={issue} currentPledgeAmount={amount} />
+          <IssueCard
+            issue={issue}
+            htmlBody={htmlBody}
+            currentPledgeAmount={amount}
+          />
         </div>
 
         {/* Right side */}

--- a/clients/apps/web/src/components/Pledge/Pledge.tsx
+++ b/clients/apps/web/src/components/Pledge/Pledge.tsx
@@ -38,48 +38,22 @@ const Pledge = ({ issue, gotoURL }: { issue: Issue; gotoURL?: string }) => {
         </Banner>
       )}
 
-      <div className="flex flex-col items-center ">
-        <img
-          src={issue.repository.organization.avatar_url}
-          className="h-16 w-16 rounded-full border-2 border-white shadow"
-        />
-        <div className="text-center text-lg font-medium text-gray-900 dark:text-gray-300">
-          {issue.repository.organization.pretty_name ||
-            issue.repository.organization.name}
+      <div className="grid grid-cols-1 gap-12 lg:grid-cols-2">
+        {/* Left side */}
+        <div className="mt-12">
+          <IssueCard issue={issue} currentPledgeAmount={amount} />
         </div>
-        <div className="text-center text-gray-500 dark:text-gray-400">
-          {issue.repository.description}
-        </div>
-        <h1 className="pt-4 text-center text-3xl text-gray-900 dark:text-gray-300 md:text-4xl">
-          Fund{' '}
-          {issue.repository.organization.pretty_name ||
-            issue.repository.organization.name}
-          &apos;s work on this issue
-        </h1>
-      </div>
 
-      <div className="flex flex-col">
-        <WhiteCard
-          className="flex flex-col items-stretch rounded-none p-2 text-center md:flex-row md:rounded-xl md:pr-0"
-          padding={false}
-        >
-          <div className="md:w-1/2">
-            <IssueCard
+        {/* Right side */}
+        <div>
+          <WhiteCard padding>
+            <PledgeForm
               issue={issue}
-              className="bg-grid-pattern dark:bg-grid-pattern-dark border-blue-100 bg-blue-50 bg-[12px_12px] dark:border-blue-500/20 dark:bg-blue-500/20"
-              currentPledgeAmount={amount}
+              gotoURL={gotoURL}
+              onAmountChange={onAmountChange}
             />
-          </div>
-          <div className="text-left md:w-1/2">
-            <div className="px-3 py-5 md:px-6 ">
-              <PledgeForm
-                issue={issue}
-                gotoURL={gotoURL}
-                onAmountChange={onAmountChange}
-              />
-            </div>
-          </div>
-        </WhiteCard>
+          </WhiteCard>
+        </div>
       </div>
 
       <HowItWorks />

--- a/clients/apps/web/src/components/Pledge/Subtotal.tsx
+++ b/clients/apps/web/src/components/Pledge/Subtotal.tsx
@@ -11,7 +11,7 @@ const Subtotal = ({
   const amountIncludingFee = paymentIntent?.amount_including_fee || 0
 
   return (
-    <>
+    <div>
       <div className="flex w-full text-sm text-gray-500 dark:text-gray-400">
         <div className="w-full">Funding amount</div>
         <div className="w-full text-right">
@@ -43,7 +43,7 @@ const Subtotal = ({
           ${getCentsInDollarString(amountIncludingFee, true)}
         </div>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/clients/apps/web/src/stories/IssueCard.stories.tsx
+++ b/clients/apps/web/src/stories/IssueCard.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { IssueCard } from 'polarkit/components/pledge'
-import { issue } from './testdata'
+import { issue, issueBodyHTML } from './testdata'
 
 const meta: Meta<typeof IssueCard> = {
   title: 'Organisms/IssueCard',
   component: IssueCard,
   args: {
     issue: issue,
+    htmlBody: issueBodyHTML,
   },
   tags: ['autodocs'],
 }

--- a/clients/apps/web/src/stories/IssueCard.stories.tsx
+++ b/clients/apps/web/src/stories/IssueCard.stories.tsx
@@ -75,3 +75,30 @@ export const FundingGoalPlusCurrent: Story = {
     currentPledgeAmount: 800,
   },
 }
+
+export const UpfrontSplit: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    issue: {
+      ...issue,
+      upfront_split_to_contributors: 75,
+    },
+  },
+}
+
+export const LongAuthorName: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    issue: {
+      ...issue,
+      author: issue.author
+        ? {
+            ...issue.author,
+            login: 'ASuperLongUsername',
+          }
+        : undefined,
+    },
+  },
+}

--- a/clients/apps/web/src/stories/PledgePage.stories.tsx
+++ b/clients/apps/web/src/stories/PledgePage.stories.tsx
@@ -69,3 +69,19 @@ export const FundingGoal: Story = {
     },
   },
 }
+
+export const LongAuthorName: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    issue: {
+      ...issue,
+      author: issue.author
+        ? {
+            ...issue.author,
+            login: 'ASuperLongUsername',
+          }
+        : undefined,
+    },
+  },
+}

--- a/clients/apps/web/src/stories/PledgePage.stories.tsx
+++ b/clients/apps/web/src/stories/PledgePage.stories.tsx
@@ -71,6 +71,17 @@ export const FundingGoal: Story = {
   },
 }
 
+export const UpfrontSplit: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    issue: {
+      ...issue,
+      upfront_split_to_contributors: 75,
+    },
+  },
+}
+
 export const LongAuthorName: Story = {
   ...Default,
   args: {

--- a/clients/apps/web/src/stories/PledgePage.stories.tsx
+++ b/clients/apps/web/src/stories/PledgePage.stories.tsx
@@ -3,13 +3,14 @@ import type { Meta, StoryObj } from '@storybook/react'
 import PublicLayout from '@/components/Layout/PublicLayout'
 import { QueryClientProvider, queryClient } from 'polarkit/api'
 import Pledge from '../components/Pledge/Pledge'
-import { issue } from './testdata'
+import { issue, issueBodyHTML } from './testdata'
 
 const meta: Meta<typeof Pledge> = {
   title: 'Pages/Pledge',
   component: Pledge,
   args: {
     issue: issue,
+    htmlBody: issueBodyHTML,
   },
   parameters: {
     nextjs: {

--- a/clients/apps/web/src/stories/Pledgers.stories.tsx
+++ b/clients/apps/web/src/stories/Pledgers.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Pledgers } from 'polarkit/components/pledge'
+import { pledger } from './testdata'
+
+const meta: Meta<typeof Pledgers> = {
+  title: 'Organisms/Pledgers',
+  component: Pledgers,
+  tags: ['autodocs'],
+  args: {
+    pledgers: Array(10)
+      .fill(0)
+      .map(() => pledger),
+    size: 'md',
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Pledgers>
+
+export const Default: Story = {}
+
+export const OnePledger: Story = {
+  args: {
+    pledgers: [pledger],
+  },
+}
+
+export const TwoPledgers: Story = {
+  args: {
+    pledgers: [pledger, pledger],
+  },
+}

--- a/clients/apps/web/src/stories/testdata.ts
+++ b/clients/apps/web/src/stories/testdata.ts
@@ -15,6 +15,7 @@ import {
   PledgeRead,
   PledgeState,
   PledgeType,
+  Pledger,
   PledgerPledgePendingNotification,
   Repository,
   RewardPaidNotification,
@@ -130,6 +131,12 @@ export const pledge: PledgeRead = {
   // pledger_avatar?: string;
   // authed_user_can_admin?: boolean;
   //scheduled_payout_at?: string;
+}
+
+export const pledger: Pledger = {
+  name: 'zegl',
+  github_username: 'zegl',
+  avatar_url: 'https://avatars.githubusercontent.com/u/47952?v=4',
 }
 
 // PublicAPI

--- a/clients/apps/web/src/stories/testdata.ts
+++ b/clients/apps/web/src/stories/testdata.ts
@@ -110,6 +110,14 @@ export const issue: Issue = {
   needs_confirmation_solved: false,
 }
 
+export const issueBodyHTML = `<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat. <strong>Duis aute irure dolor</strong> in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.</p>`
+
 export const pledge: PledgeRead = {
   id: 'pppp',
   created_at: addDays(new Date(), -7).toISOString(),

--- a/clients/apps/web/src/stories/testdata.ts
+++ b/clients/apps/web/src/stories/testdata.ts
@@ -76,6 +76,7 @@ export const repo: Repository = {
   description: 'Data validation using Python type hints',
   homepage: 'https://docs.pydantic.dev/latest/',
   organization: org,
+  stars: 26000,
 }
 
 // Public API
@@ -83,6 +84,13 @@ export const issue: Issue = {
   platform: Platforms.GITHUB,
   number: 222,
   title: 'SecretStr comparison fails when field is defined with Field',
+  author: {
+    id: 123,
+    login: 'zegl',
+    avatar_url: 'https://avatars.githubusercontent.com/u/47952?v=4',
+    html_url: 'https://github.com/zegl',
+  },
+  comments: 5,
   reactions: {
     total_count: 3,
     plus_one: 3,

--- a/clients/packages/polarkit/src/api/client/index.ts
+++ b/clients/packages/polarkit/src/api/client/index.ts
@@ -13,6 +13,7 @@ export type { Account } from './models/Account';
 export type { AccountCreate } from './models/AccountCreate';
 export type { AccountLink } from './models/AccountLink';
 export { AccountType } from './models/AccountType';
+export type { Author } from './models/Author';
 export type { AuthorizationResponse } from './models/AuthorizationResponse';
 export { BackofficeBadge } from './models/BackofficeBadge';
 export { BackofficeBadgeResponse } from './models/BackofficeBadgeResponse';

--- a/clients/packages/polarkit/src/api/client/models/Author.ts
+++ b/clients/packages/polarkit/src/api/client/models/Author.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Author = {
+  id: number;
+  login: string;
+  html_url: string;
+  avatar_url: string;
+};
+

--- a/clients/packages/polarkit/src/api/client/models/Issue.ts
+++ b/clients/packages/polarkit/src/api/client/models/Issue.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { Author } from './Author';
 import type { Funding } from './Funding';
 import type { Label } from './Label';
 import type { Platforms } from './Platforms';
@@ -31,6 +32,10 @@ export type Issue = {
    */
   comments?: number;
   labels?: Array<Label>;
+  /**
+   * GitHub author
+   */
+  author?: Author;
   /**
    * Github reactions
    */

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -5,6 +5,7 @@ import { Alert, IssueBodyRenderer, PolarTimeAgo } from 'polarkit/components/ui'
 import { getCentsInDollarString } from 'polarkit/money'
 import { formatStarsNumber } from 'polarkit/utils'
 import { useMemo } from 'react'
+import { Pledgers } from '.'
 import { Funding, Issue } from '../../api/client'
 import { githubIssueUrl } from '../../github'
 
@@ -214,16 +215,7 @@ const FundingGoal = ({
 
       {/* Pledgers */}
       <div className="mt-2 flex items-center justify-center sm:mt-0 sm:justify-end">
-        {[1, 2, 3].map(() => (
-          <img
-            src="https://placehold.co/50/darkgray/white?text=F"
-            className="-ml-2 h-5 w-5 rounded-full border border-gray-50 dark:border-gray-950"
-            alt="Pledger"
-          />
-        ))}
-        <div className="-ml-2 flex h-5 w-5 items-center justify-center rounded-full border border-gray-50 bg-blue-600 text-[10px] text-blue-200 dark:border-gray-950">
-          +4
-        </div>
+        <Pledgers pledgers={[]} size="sm" />
       </div>
     </div>
   )

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -1,8 +1,11 @@
 import { ChatBubbleLeftIcon } from '@heroicons/react/24/outline'
+import { StarIcon } from '@heroicons/react/24/solid'
+import { generateMarkdownTitle } from 'polarkit/components/Issue'
 import { PolarTimeAgo } from 'polarkit/components/ui'
 import { getCentsInDollarString } from 'polarkit/money'
+import { formatStarsNumber } from 'polarkit/utils'
 import { useMemo } from 'react'
-import { Issue } from '../../api/client'
+import { Funding, Issue } from '../../api/client'
 import { githubIssueUrl } from '../../github'
 
 const IssueCard = ({
@@ -11,116 +14,207 @@ const IssueCard = ({
   currentPledgeAmount,
 }: {
   issue: Issue
-  className: string
   currentPledgeAmount: number
+  className?: string
 }) => {
   const url = githubIssueUrl(
     issue.repository.organization.name,
     issue.repository.name,
     issue.number,
   )
-
-  const fundingProgress =
-    'funding' in issue && 'repository' in issue ? (
-      <FundingGoal issue={issue} currentPledgeAmount={currentPledgeAmount} />
-    ) : null
+  const { repository } = issue
+  const { organization } = repository
 
   return (
     <>
-      <div
-        className={`flex h-full flex-col content-center justify-center rounded-lg border border-gray-200 px-6 ${className}`}
-      >
-        <div className="flex-1"></div>
-
-        <div className="pt-8 pb-8">
-          <strong className="text-sm font-medium text-gray-500 dark:text-gray-400">
-            Issue to be fixed
-          </strong>
-          <h1 className="my-2.5 text-xl font-normal">{issue.title}</h1>
-          <p className="text-sm font-normal text-gray-500 dark:text-gray-400">
-            <a href={url}>#{issue.number}</a> opened{' '}
+      <h1 className="mb-4 text-center text-4xl text-gray-900 dark:text-gray-300 sm:text-left">
+        {generateMarkdownTitle(issue.title)}
+      </h1>
+      {/* Issue details */}
+      <div className="grid grid-cols-1 text-gray-600 dark:text-gray-400 sm:grid-cols-3">
+        {/* Left part */}
+        <div className="col-span-1 flex	flex-row items-center justify-center gap-2 sm:col-span-2 sm:justify-start	">
+          <div>
+            <a href={url}>#{issue.number}</a>
+          </div>
+          {issue.author && (
+            <div>
+              <a
+                href={issue.author.html_url}
+                className="flex flex-row items-center gap-2"
+                title={`@${issue.author.login}`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={issue.author.avatar_url}
+                  alt={issue.author.login}
+                  className="h-5 w-5 rounded-full"
+                />
+                <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+                  @{issue.author.login}
+                </div>
+              </a>
+            </div>
+          )}
+          <div className="whitespace-nowrap text-gray-400 dark:text-gray-600">
             <PolarTimeAgo date={new Date(issue.issue_created_at)} />
-          </p>
-          <div className="mt-3 flex flex-row justify-center space-x-2">
-            <p className="w-16 text-sm text-gray-600 dark:text-gray-400">
-              <span className="mr-2">👍</span> {issue?.reactions?.plus_one || 0}
-            </p>
-            <p className="h-4 w-16 text-sm text-gray-500 dark:text-gray-400">
-              <span className="relative top-1 mr-2 inline-block h-4">
-                <ChatBubbleLeftIcon className="h-4 w-4" />
-              </span>{' '}
-              {issue.comments}
-            </p>
           </div>
         </div>
-
-        <div className="flex-1"></div>
-
-        {fundingProgress}
+        {/* Right part */}
+        <div className="flex flex-row items-center justify-center gap-2 sm:justify-end">
+          {issue.comments !== undefined && (
+            <div className="flex flex-row items-center gap-1">
+              <ChatBubbleLeftIcon className="h-5 w-5" />
+              {issue.comments}
+            </div>
+          )}
+          {issue.reactions !== undefined && (
+            <div className="flex flex-row items-center gap-1">
+              <div>👍</div>
+              {issue.reactions.plus_one}
+            </div>
+          )}
+        </div>
+      </div>
+      <hr className="my-4 dark:border-gray-600" />
+      {/* Funding goal */}
+      <FundingGoal
+        funding={issue.funding}
+        currentPledgeAmount={currentPledgeAmount}
+      />
+      <hr className="my-4 dark:border-gray-600" />
+      {/* Issue description */}
+      <div className="text-gray-600 dark:text-gray-400">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Amet
+          cursus sit amet dictum sit amet justo donec enim. Tempus iaculis urna
+          id volutpat lacus laoreet non curabitur. Sed ullamcorper morbi
+          tincidunt ornare. Velit dignissim sodales ut eu sem integer vitae
+          justo eget. In egestas erat imperdiet sed euismod nisi porta lorem.
+          Nunc scelerisque viverra mauris in aliquam. Volutpat blandit aliquam
+          etiam erat velit scelerisque in dictum. Euismod quis viverra nibh cras
+          pulvinar mattis. Sed viverra ipsum nunc aliquet bibendum enim
+          facilisis gravida neque. Lobortis feugiat vivamus at augue eget arcu.
+        </p>
+        <div className="mt-2">
+          <a href={url} className="text-blue-500">
+            Read more
+          </a>
+        </div>
+      </div>
+      <hr className="my-4 dark:border-gray-600" />
+      {/* Repository */}
+      <div className="grid grid-cols-1 text-gray-600 dark:text-gray-400 sm:grid-cols-3">
+        {/* Name/description */}
+        <div className="col-span-1 flex flex-row items-center justify-center gap-2 sm:col-span-2 sm:justify-start">
+          <div className="min-w-max">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={organization.avatar_url}
+              alt={organization.name}
+              className="h-8 w-8 rounded-full"
+            />
+          </div>
+          <div className="text-gray-400 dark:text-gray-600">
+            <div>
+              {organization.name}&nbsp;/&nbsp;
+              <span className="font-medium text-gray-600 dark:text-gray-400">
+                {repository.name}
+              </span>
+            </div>
+            {repository.description && <div>{repository.description}</div>}
+          </div>
+        </div>
+        {/* Stars */}
+        {repository.stars !== undefined && (
+          <div className="flex flex-row items-center justify-center gap-1 sm:justify-end">
+            <StarIcon className="h-5 w-5 text-yellow-500" />
+            {formatStarsNumber(repository.stars)}
+          </div>
+        )}
       </div>
     </>
   )
 }
 
-const FundingGoal = ({
-  issue,
-  currentPledgeAmount,
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.max(Math.min(value, max), min)
+}
+
+const FundingGoalProgress = ({
+  sum,
+  goal,
+  current,
 }: {
-  issue: Issue
-  currentPledgeAmount: number
+  sum: number
+  goal: number
+  current: number
 }) => {
-  if (
-    !issue.funding ||
-    !issue.funding.pledges_sum ||
-    !issue.funding.funding_goal
-  ) {
-    return <></>
-  }
+  const progress = useMemo(() => clamp((sum / goal) * 100, 1, 100), [sum, goal])
 
-  const clamp = (value: number, min: number, max: number): number => {
-    return Math.max(Math.min(value, max), min)
-  }
-
-  const progress = clamp(
-    (issue.funding.pledges_sum.amount / issue.funding.funding_goal.amount) *
-      100,
-    1,
-    100,
+  const currentPledgeProgress = useMemo(
+    () => clamp((current / goal) * 100, 1, 100 - progress),
+    [current, progress, goal],
   )
 
-  const currentPledgeProgress = useMemo(() => {
-    if (!issue?.funding?.funding_goal?.amount) {
-      return 0
-    }
+  return (
+    <div className="mt-1 flex w-full overflow-hidden rounded-md">
+      <div className="h-1 bg-blue-700" style={{ width: `${progress}%` }}></div>
+      {currentPledgeProgress > 0 && (
+        <div
+          className="h-1 animate-pulse bg-blue-500"
+          style={{ width: `${currentPledgeProgress}%` }}
+        ></div>
+      )}
+      <div className="h-1 flex-1 bg-blue-200 dark:bg-blue-800"></div>
+    </div>
+  )
+}
 
-    return clamp(
-      (currentPledgeAmount / issue.funding.funding_goal.amount) * 100,
-      1,
-      100 - progress,
-    )
-  }, [currentPledgeAmount])
+const FundingGoal = ({
+  funding,
+  currentPledgeAmount,
+}: {
+  funding: Funding
+  currentPledgeAmount: number
+}) => {
+  const { pledges_sum, funding_goal } = funding
 
   return (
-    <div className="-mt-4 flex flex-col items-center space-y-2 pb-4">
-      <div className="text-gray-500 dark:text-gray-400">
-        <span className="font-medium text-gray-700 dark:text-gray-200">
-          ${getCentsInDollarString(issue.funding.pledges_sum.amount)}
-        </span>{' '}
-        / ${getCentsInDollarString(issue.funding.funding_goal.amount)} pledged
+    <div className="grid grid-cols-1 sm:grid-cols-2">
+      {/* Funding amount and goal */}
+      <div className="flex flex-col items-center sm:items-start">
+        <div className="text-lg text-gray-900 dark:text-gray-300">
+          ${getCentsInDollarString(pledges_sum?.amount || 0)}{' '}
+          <span className="text-gray-400 dark:text-gray-600">
+            {!funding_goal && 'pledged'}
+            {funding_goal &&
+              `/ ${getCentsInDollarString(funding_goal.amount)} pledged`}
+          </span>
+        </div>
+
+        {funding_goal && pledges_sum && (
+          <FundingGoalProgress
+            sum={pledges_sum.amount}
+            goal={funding_goal.amount}
+            current={currentPledgeAmount}
+          />
+        )}
       </div>
 
-      <div className="flex w-full overflow-hidden rounded-md">
-        <div
-          className="h-2 bg-blue-700"
-          style={{ width: `${progress}%` }}
-        ></div>
-        {currentPledgeProgress > 0 && (
-          <div
-            className="h-2 animate-pulse bg-blue-500"
-            style={{ width: `${currentPledgeProgress}%` }}
-          ></div>
-        )}
-        <div className="h-2 flex-1 bg-blue-200 dark:bg-blue-800"></div>
+      {/* Pledgers */}
+      <div className="mt-2 flex items-center justify-center sm:mt-0 sm:justify-end">
+        {[1, 2, 3].map(() => (
+          <img
+            src="https://placehold.co/50/darkgray/white?text=F"
+            className="-ml-2 h-5 w-5 rounded-full border border-gray-50 dark:border-gray-950"
+            alt="Pledger"
+          />
+        ))}
+        <div className="-ml-2 flex h-5 w-5 items-center justify-center rounded-full border border-gray-50 bg-blue-600 text-[10px] text-blue-200 dark:border-gray-950">
+          +4
+        </div>
       </div>
     </div>
   )

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -1,7 +1,7 @@
 import { ChatBubbleLeftIcon } from '@heroicons/react/24/outline'
-import { StarIcon } from '@heroicons/react/24/solid'
+import { HeartIcon, StarIcon } from '@heroicons/react/24/solid'
 import { generateMarkdownTitle } from 'polarkit/components/Issue'
-import { IssueBodyRenderer, PolarTimeAgo } from 'polarkit/components/ui'
+import { Alert, IssueBodyRenderer, PolarTimeAgo } from 'polarkit/components/ui'
 import { getCentsInDollarString } from 'polarkit/money'
 import { formatStarsNumber } from 'polarkit/utils'
 import { useMemo } from 'react'
@@ -126,6 +126,23 @@ const IssueCard = ({
           </div>
         )}
       </div>
+      {/* Rewards */}
+      {issue.upfront_split_to_contributors && (
+        <div className="my-4">
+          <Alert color="blue">
+            <div className="flex items-center">
+              <HeartIcon className="mr-2 h-5 w-5 text-blue-300 dark:text-blue-700" />
+              <div className="inline">
+                <span className="font-bold">Rewards</span> contributors{' '}
+                <span className="font-bold">
+                  {issue.upfront_split_to_contributors}%
+                </span>{' '}
+                of received funds
+              </div>
+            </div>
+          </Alert>
+        </div>
+      )}
     </>
   )
 }

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -87,20 +87,22 @@ const IssueCard = ({
       />
       <hr className="my-4 dark:border-gray-600" />
       {/* Issue description */}
-      <div className="relative max-h-80 overflow-hidden">
-        {htmlBody && <IssueBodyRenderer html={htmlBody} />}
-        <div className="absolute bottom-0 left-0 h-12 w-full bg-gradient-to-b from-transparent to-gray-50 dark:to-gray-950"></div>
+      <div className="hidden sm:block">
+        <div className="relative max-h-80 overflow-hidden">
+          {htmlBody && <IssueBodyRenderer html={htmlBody} />}
+          <div className="absolute bottom-0 left-0 h-12 w-full bg-gradient-to-b from-transparent to-gray-50 dark:to-gray-950"></div>
+        </div>
+        <div className="mt-2">
+          <a href={url} className="text-blue-500">
+            Read more
+          </a>
+        </div>
+        <hr className="my-4 dark:border-gray-600" />
       </div>
-      <div className="mt-2">
-        <a href={url} className="text-blue-500">
-          Read more
-        </a>
-      </div>
-      <hr className="my-4 dark:border-gray-600" />
       {/* Repository */}
       <div className="grid grid-cols-1 text-gray-600 dark:text-gray-400 sm:grid-cols-3">
         {/* Name/description */}
-        <div className="col-span-1 flex flex-row items-center justify-center gap-2 sm:col-span-2 sm:justify-start">
+        <div className="col-span-1 flex flex-row items-center gap-2 sm:col-span-2">
           <div className="min-w-max">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -121,7 +123,7 @@ const IssueCard = ({
         </div>
         {/* Stars */}
         {repository.stars !== undefined && (
-          <div className="flex flex-row items-center justify-center gap-1 sm:justify-end">
+          <div className="hidden flex-row items-center justify-end gap-1 sm:flex">
             <StarIcon className="h-5 w-5 text-yellow-500" />
             {formatStarsNumber(repository.stars)}
           </div>
@@ -129,7 +131,7 @@ const IssueCard = ({
       </div>
       {/* Rewards */}
       {issue.upfront_split_to_contributors && (
-        <div className="my-4">
+        <div className="my-4 hidden sm:block">
           <Alert color="blue">
             <div className="flex items-center">
               <HeartIcon className="mr-2 h-5 w-5 text-blue-300 dark:text-blue-700" />
@@ -214,9 +216,7 @@ const FundingGoal = ({
       </div>
 
       {/* Pledgers */}
-      <div className="mt-2 flex items-center justify-center sm:mt-0 sm:justify-end">
-        <Pledgers pledgers={[]} size="sm" />
-      </div>
+      <Pledgers pledgers={[]} size="sm" />
     </div>
   )
 }

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -1,7 +1,7 @@
 import { ChatBubbleLeftIcon } from '@heroicons/react/24/outline'
 import { StarIcon } from '@heroicons/react/24/solid'
 import { generateMarkdownTitle } from 'polarkit/components/Issue'
-import { PolarTimeAgo } from 'polarkit/components/ui'
+import { IssueBodyRenderer, PolarTimeAgo } from 'polarkit/components/ui'
 import { getCentsInDollarString } from 'polarkit/money'
 import { formatStarsNumber } from 'polarkit/utils'
 import { useMemo } from 'react'
@@ -10,10 +10,12 @@ import { githubIssueUrl } from '../../github'
 
 const IssueCard = ({
   issue,
-  className,
+  htmlBody,
   currentPledgeAmount,
+  className,
 }: {
   issue: Issue
+  htmlBody?: string
   currentPledgeAmount: number
   className?: string
 }) => {
@@ -84,24 +86,14 @@ const IssueCard = ({
       />
       <hr className="my-4 dark:border-gray-600" />
       {/* Issue description */}
-      <div className="text-gray-600 dark:text-gray-400">
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Amet
-          cursus sit amet dictum sit amet justo donec enim. Tempus iaculis urna
-          id volutpat lacus laoreet non curabitur. Sed ullamcorper morbi
-          tincidunt ornare. Velit dignissim sodales ut eu sem integer vitae
-          justo eget. In egestas erat imperdiet sed euismod nisi porta lorem.
-          Nunc scelerisque viverra mauris in aliquam. Volutpat blandit aliquam
-          etiam erat velit scelerisque in dictum. Euismod quis viverra nibh cras
-          pulvinar mattis. Sed viverra ipsum nunc aliquet bibendum enim
-          facilisis gravida neque. Lobortis feugiat vivamus at augue eget arcu.
-        </p>
-        <div className="mt-2">
-          <a href={url} className="text-blue-500">
-            Read more
-          </a>
-        </div>
+      <div className="relative max-h-80 overflow-hidden">
+        {htmlBody && <IssueBodyRenderer html={htmlBody} />}
+        <div className="absolute bottom-0 left-0 h-12 w-full bg-gradient-to-b from-transparent to-gray-50 dark:to-gray-950"></div>
+      </div>
+      <div className="mt-2">
+        <a href={url} className="text-blue-500">
+          Read more
+        </a>
       </div>
       <hr className="my-4 dark:border-gray-600" />
       {/* Repository */}

--- a/clients/packages/polarkit/src/components/pledge/Pledgers.tsx
+++ b/clients/packages/polarkit/src/components/pledge/Pledgers.tsx
@@ -1,0 +1,70 @@
+import { Pledger } from 'polarkit/api/client'
+import { useMemo } from 'react'
+
+interface PledgersProps {
+  pledgers: Pledger[]
+  maxShown?: number
+  size: 'xs' | 'sm' | 'md' | 'lg'
+}
+
+const Pledgers: React.FC<PledgersProps> = ({ pledgers, maxShown, size }) => {
+  const shownPledgers = useMemo(
+    () => pledgers.slice(0, maxShown),
+    [pledgers, maxShown],
+  )
+  const hiddenPledgersCount = useMemo(
+    () => pledgers.length - shownPledgers.length,
+    [pledgers, shownPledgers],
+  )
+  const sizeClasses = useMemo(() => {
+    switch (size) {
+      case 'xs':
+        return 'h-6 w-6 text-xs'
+      case 'sm':
+        return 'h-8 w-8 text-base'
+      case 'md':
+        return 'h-10 w-10 text-lg'
+      case 'lg':
+        return 'h-12 w-12 text-xl'
+    }
+  }, [size])
+  const marginClasses = useMemo(() => {
+    switch (size) {
+      case 'xs':
+        return '-ml-2'
+      case 'sm':
+        return '-ml-3 border-2'
+      case 'md':
+        return '-ml-3 border-2'
+      case 'lg':
+        return '-ml-4 border-2'
+    }
+  }, [size])
+
+  return (
+    <div className="mt-2 flex items-center justify-center sm:mt-0 sm:justify-end">
+      {shownPledgers.map((pledger) => (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          key={pledger.name}
+          src={pledger.avatar_url}
+          className={`rounded-full border border-gray-50 dark:border-gray-950 ${marginClasses} ${sizeClasses}`}
+          alt={pledger.name}
+        />
+      ))}
+      {hiddenPledgersCount > 0 && (
+        <div
+          className={`flex aspect-square items-center justify-center rounded-full border border-gray-50 bg-blue-600 text-blue-200 dark:border-gray-950 ${marginClasses} ${sizeClasses}`}
+        >
+          +{hiddenPledgersCount}
+        </div>
+      )}
+    </div>
+  )
+}
+
+Pledgers.defaultProps = {
+  maxShown: 3,
+}
+
+export default Pledgers

--- a/clients/packages/polarkit/src/components/pledge/RepositoryCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/RepositoryCard.tsx
@@ -1,15 +1,7 @@
+import { formatStarsNumber } from 'polarkit/utils'
 import { Organization, type Repository } from '../../api/client'
 import { githubRepoUrl } from '../../github'
 import { GrayCard } from '../ui/Cards'
-
-const abbrStars = (stars: number): string => {
-  if (stars < 1000) {
-    return stars.toString()
-  }
-
-  stars /= 1000
-  return stars.toFixed(1) + 'k'
-}
 
 const prettyURL = (url: string): string => {
   if (url.indexOf('https://') === 0) {
@@ -47,7 +39,9 @@ const RepositoryCard = ({
         <div className="flex flex-row items-center justify-center space-x-4">
           {typeof repository.stars === 'number' && (
             <p className="inline-flex items-center space-x-1 text-xs text-gray-600 dark:text-gray-400">
-              <span className="font-medium">{abbrStars(repository.stars)}</span>
+              <span className="font-medium">
+                {formatStarsNumber(repository.stars)}
+              </span>
               <span>stars</span>
             </p>
           )}

--- a/clients/packages/polarkit/src/components/pledge/index.ts
+++ b/clients/packages/polarkit/src/components/pledge/index.ts
@@ -1,4 +1,5 @@
 import IssueCard from './IssueCard'
+import Pledgers from './Pledgers'
 import RepositoryCard from './RepositoryCard'
 
-export { IssueCard, RepositoryCard }
+export { IssueCard, Pledgers, RepositoryCard }

--- a/clients/packages/polarkit/src/components/ui/Cards/types.ts
+++ b/clients/packages/polarkit/src/components/ui/Cards/types.ts
@@ -2,7 +2,7 @@ import React from 'react'
 
 export interface CardProperties {
   children: React.ReactNode
-  className: string
+  className?: string
   border?: boolean
   padding?: boolean
 }

--- a/clients/packages/polarkit/src/components/ui/atoms/Alert.stories.tsx
+++ b/clients/packages/polarkit/src/components/ui/atoms/Alert.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Alert } from '.'
+
+const meta: Meta<typeof Alert> = {
+  title: 'Atoms/Alert',
+  component: Alert,
+  render: (args) => {
+    return <Alert {...args}>This is an alert message!</Alert>
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Alert>
+
+export const Blue: Story = {
+  args: {
+    color: 'blue',
+  },
+}
+
+export const Gray: Story = {
+  args: {
+    color: 'gray',
+  },
+}
+
+export const Red: Story = {
+  args: {
+    color: 'red',
+  },
+}
+
+export const Green: Story = {
+  args: {
+    color: 'green',
+  },
+}

--- a/clients/packages/polarkit/src/components/ui/atoms/Alert.tsx
+++ b/clients/packages/polarkit/src/components/ui/atoms/Alert.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+
+interface AlertProps {
+  color: 'blue' | 'gray' | 'red' | 'green'
+}
+
+const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
+  children,
+  color,
+}) => {
+  const colorClasses = useMemo(() => {
+    switch (color) {
+      case 'blue':
+        return 'bg-blue-50 border border-blue-100 text-blue-600 dark:bg-blue-950 dark:border-blue-900 dark:text-blue-400'
+      case 'gray':
+        return 'bg-gray-50 border border-gray-100 text-gray-600 dark:bg-gray-950 dark:border-gray-900 dark:text-gray-400'
+      case 'red':
+        return 'bg-red-50 border border-red-100 text-red-600 dark:bg-red-950 dark:border-red-900 dark:text-red-400'
+      case 'green':
+        return 'bg-green-50 border border-green-100 text-green-600 dark:bg-green-950 dark:border-green-900 dark:text-green-400'
+    }
+  }, [color])
+
+  return <div className={`rounded-lg p-2 ${colorClasses}`}>{children}</div>
+}
+
+export default Alert

--- a/clients/packages/polarkit/src/components/ui/atoms/IssueBodyRenderer.stories.tsx
+++ b/clients/packages/polarkit/src/components/ui/atoms/IssueBodyRenderer.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { IssueBodyRenderer } from '.'
+
+const meta: Meta<typeof IssueBodyRenderer> = {
+  title: 'Atoms/IssueBodyRenderer',
+  component: IssueBodyRenderer,
+}
+
+export default meta
+
+type Story = StoryObj<typeof IssueBodyRenderer>
+
+export const Default: Story = {
+  args: {
+    html: `<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+    nisi ut aliquip ex ea commodo consequat. <strong>Duis aute irure dolor</strong> in
+    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+    deserunt mollit anim id est laborum.</p>`,
+  },
+}
+
+export const GitHubIssue: Story = {
+  args: {
+    html: `<h2 dir="auto">This is a heading</h2>
+          <ul dir="auto">
+          <li>This is easy...</li>
+          <li>...for now!</li>
+          </ul>
+          <p dir="auto">Now let's add some <strong>emphasized</strong> <em>content</em> and inline code: <code class="notranslate">$ curl -X GET https://example.com</code></p>
+          <h2 dir="auto">To-do list</h2>
+          <ul class="contains-task-list">
+          <li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> Item 1</li>
+          <li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> Item 2</li>
+          <li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> Item 3</li>
+          </ul>
+          <h2 dir="auto">References</h2>
+          <p dir="auto">We can make a reference to another issue: <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1903016495" data-permission-text="Title is private" data-url="https://github.com/frankie567-test-org-renamed/test-repo-two/issues/6" data-hovercard-type="issue" data-hovercard-url="/frankie567-test-org-renamed/test-repo-two/issues/6/hovercard" href="https://github.com/frankie567-test-org-renamed/test-repo-two/issues/6">#6</a>. But we can also <a href="https://example.com" rel="nofollow">make links</a>.</p>
+          <h2 dir="auto">Code block</h2>
+          <div class="highlight highlight-source-python" dir="auto"><pre class="notranslate"><span class="pl-k">def</span> <span class="pl-en">add</span>(<span class="pl-s1">a</span>: <span class="pl-s1">int</span>, <span class="pl-s1">b</span>:<span class="pl-s1">int</span>) <span class="pl-c1">-&gt;</span> <span class="pl-s1">int</span>:
+              <span class="pl-k">return</span> <span class="pl-s1">a</span> <span class="pl-c1">+</span> <span class="pl-s1">b</span></pre></div>
+          <h2 dir="auto">Code embed from repo</h2>
+          <p dir="auto"></p><div class="Box Box--condensed my-2">
+            <div class="Box-header f6">
+              <p class="mb-0 text-bold">
+                <a href="https://github.com/frankie567-test-org-renamed/test-repo-two/blob/3934492f58cbf9fd4c4e03a5deffb2b10d801fc9/README.md?plain=1#L1-L3">test-repo-two/README.md</a>
+              </p>
+              <p class="mb-0 color-fg-muted">
+                  Lines 1 to 3
+                in
+                <a data-pjax="true" class="commit-tease-sha" href="/frankie567-test-org-renamed/test-repo-two/commit/3934492f58cbf9fd4c4e03a5deffb2b10d801fc9">3934492</a>
+              </p>
+            </div>
+            <div itemprop="text" class="Box-body p-0 blob-wrapper blob-wrapper-embedded data">
+              <table class="highlight tab-size mb-0 js-file-line-container" data-tab-size="8" data-paste-markdown-skip="">
+          
+                  <tbody><tr class="border-0">
+                    <td id="L1" class="blob-num border-0 px-3 py-0 color-bg-default" data-line-number="1"></td>
+                    <td id="LC1" class="blob-code border-0 px-3 py-0 color-bg-default blob-code-inner js-file-line"> <span class="pl-mh"># <span class="pl-en">test-repo-two</span></span> </td>
+                  </tr>
+          
+                  <tr class="border-0">
+                    <td id="L2" class="blob-num border-0 px-3 py-0 color-bg-default" data-line-number="2"></td>
+                    <td id="LC2" class="blob-code border-0 px-3 py-0 color-bg-default blob-code-inner js-file-line">  </td>
+                  </tr>
+          
+                  <tr class="border-0">
+                    <td id="L3" class="blob-num border-0 px-3 py-0 color-bg-default" data-line-number="3"></td>
+                    <td id="LC3" class="blob-code border-0 px-3 py-0 color-bg-default blob-code-inner js-file-line"> This is a test README! </td>
+                  </tr>
+              </tbody></table>
+            </div>
+          </div>
+          <p></p>`,
+  },
+}

--- a/clients/packages/polarkit/src/components/ui/atoms/IssueBodyRenderer.tsx
+++ b/clients/packages/polarkit/src/components/ui/atoms/IssueBodyRenderer.tsx
@@ -1,0 +1,14 @@
+interface IssueBodyRendererProps {
+  html: string
+}
+
+const IssueBodyRenderer: React.FC<IssueBodyRendererProps> = ({ html }) => {
+  /* See: https://tailwindcss.com/docs/typography-plugin */
+  return (
+    <div className="prose dark:prose-invert prose-headings:my-2 prose-pre:bg-gray-100 prose-pre:text-black dark:prose-pre:bg-gray-700 dark:prose-pre:text-white prose-code:before:content-[''] prose-code:after:content-[''] prose-code:bg-gray-100 dark:prose-code:bg-gray-700 prose-code:font-normal prose-code:p-1 prose-code:rounded max-w-none">
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  )
+}
+
+export default IssueBodyRenderer

--- a/clients/packages/polarkit/src/components/ui/atoms/index.ts
+++ b/clients/packages/polarkit/src/components/ui/atoms/index.ts
@@ -2,6 +2,7 @@ import CopyToClipboardInput from './CopyToClipboardInput'
 import CountryPicker from './CountryPicker'
 import FormattedDateTime from './FormattedDateTime'
 import Input from './Input'
+import IssueBodyRenderer from './IssueBodyRenderer'
 import LabeledRadioButton from './LabeledRadioButton'
 import LabeledSeparator from './LabeledSeparator'
 import MoneyInput from './MoneyInput'
@@ -17,6 +18,7 @@ export {
   ShadowListGroup,
   FormattedDateTime,
   Input,
+  IssueBodyRenderer,
   PolarTimeAgo,
   CountryPicker,
   CopyToClipboardInput,

--- a/clients/packages/polarkit/src/components/ui/atoms/index.ts
+++ b/clients/packages/polarkit/src/components/ui/atoms/index.ts
@@ -1,3 +1,4 @@
+import Alert from './Alert'
 import CopyToClipboardInput from './CopyToClipboardInput'
 import CountryPicker from './CountryPicker'
 import FormattedDateTime from './FormattedDateTime'
@@ -13,6 +14,7 @@ import ShadowBoxOnLg from './ShadowBoxOnLg'
 import ShadowListGroup from './ShadowListGroup'
 
 export {
+  Alert,
   ShadowBox,
   ShadowBoxOnLg,
   ShadowListGroup,

--- a/clients/packages/polarkit/src/utils/index.ts
+++ b/clients/packages/polarkit/src/utils/index.ts
@@ -7,3 +7,12 @@ export const getServerURL = (path?: string): string => {
   const baseWithPath = `${baseURL}${path}`
   return baseWithPath
 }
+
+export const formatStarsNumber = (stars: number): string => {
+  if (stars < 1000) {
+    return stars.toString()
+  }
+
+  stars /= 1000
+  return stars.toFixed(1) + 'k'
+}

--- a/server/polar/issue/schemas.py
+++ b/server/polar/issue/schemas.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import structlog
 from fastapi.encoders import jsonable_encoder
-from pydantic import Field, parse_obj_as
+from pydantic import Field, HttpUrl, parse_obj_as
 
 from polar.currency.schemas import CurrencyAmount
 from polar.dashboard.schemas import IssueStatus
@@ -54,6 +54,13 @@ class Label(Schema):
     color: str
 
 
+class Author(Schema):
+    id: int
+    login: str
+    html_url: HttpUrl
+    avatar_url: HttpUrl
+
+
 # Public API
 class Issue(Schema):
     id: UUID
@@ -66,6 +73,7 @@ class Issue(Schema):
     )
     labels: list[Label] = []
 
+    author: Author | None = Field(description="GitHub author")
     reactions: Reactions | None = Field(description="Github reactions")
 
     state: Literal["OPEN", "CLOSED"]
@@ -122,6 +130,7 @@ class Issue(Schema):
             issue_created_at=i.issue_created_at,
             needs_confirmation_solved=i.needs_confirmation_solved,
             confirmed_solved_at=i.confirmed_solved_at,
+            author=parse_obj_as(Author, i.author) if i.author else None,
             reactions=parse_obj_as(Reactions, i.reactions) if i.reactions else None,
             funding=funding,
             repository=Repository.from_db(i.repository),


### PR DESCRIPTION
I've implemented the first bits of the new issue presentation on the Pledge page.

Related to #1201 and #1200 

## Screenshots

<img width="800" alt="Capture d’écran 2023-09-21 à 15 04 03" src="https://github.com/polarsource/polar/assets/1144727/47ba7673-9d49-4a31-9a66-bc22796a3c43">

<img width="800" alt="Capture d’écran 2023-09-21 à 15 04 10" src="https://github.com/polarsource/polar/assets/1144727/286caa3c-f966-497e-be02-c713b37ea912">

## What we have ✅

* General presentation of the issue (title, number, author, number of comments and reactions)
* Current pledge and optional goal
* Rendered issue description ✨
* Repository details with number of stars
* Optional upfront rewards split notice

## What we miss compared to the design 😞

* Pledgers avatars
    * Component is ready, but still unsure about the API to retrieve them (cf our discussions related to #1210)
* List of rewarded people
    * Feature is not yet implemented AFAIK?
* List of linked PR 
    * We should implement an API to retrieve this data for an issue

## Next steps

What I propose is to merge and deploy those changes, even if we have some holes compared to the design, and address them in follow-up improvements.

The page looks already quite good and it can be a good first-step. What do you think @birkjernstrom?