### PR TITLE
server/pledge: restrict read access

### DIFF
--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -362,10 +362,26 @@ class Authz:
     #
 
     async def _can_anonymous_read_pledge(self, object: Pledge) -> bool:
-        return True
+        return False
 
     async def _can_user_read_pledge(self, subject: User, object: Pledge) -> bool:
-        return True
+        # If pledged by this user
+        if object.by_user_id and object.by_user_id == subject.id:
+            return True
+
+        # If member of pledging org
+        if object.by_organization_id and await self._is_member(
+            subject.id, object.by_organization_id
+        ):
+            return True
+
+        # If member of receiving org
+        if object.organization_id and await self._is_member(
+            subject.id, object.organization_id
+        ):
+            return True
+
+        return False
 
     async def _can_user_write_pledge(self, subject: User, object: Pledge) -> bool:
         # If pledged by this user

--- a/server/tests/authz/test_service.py
+++ b/server/tests/authz/test_service.py
@@ -494,11 +494,11 @@ async def test_can_read_pledge(
 
     for idx, tc in enumerate(
         [
-            TestCase(subject=Anonymous(), expected=True),
+            TestCase(subject=Anonymous(), expected=False),
             TestCase(
                 subject=await create_user(session),
                 is_pledging_user=False,
-                expected=True,
+                expected=False,
             ),
             TestCase(
                 subject=await create_user(session),
@@ -509,7 +509,7 @@ async def test_can_read_pledge(
                 subject=await create_user(session),
                 is_pledging_org_member=False,
                 is_pledging_org_member_admin=False,
-                expected=True,
+                expected=False,
             ),
             TestCase(
                 subject=await create_user(session),

--- a/server/tests/pledge/test_endpoints.py
+++ b/server/tests/pledge/test_endpoints.py
@@ -81,7 +81,7 @@ async def test_get_pledge_not_member(
         cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_search_pledge_no_member(
     )
 
     assert response.status_code == 200
-    assert len(response.json()["items"]) == 1
+    assert len(response.json()["items"]) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Restricts read access to:

* The pledging users
* Members of the org that received the pledge
* Members of the org that made the pledge

Fixes #1210