### PR TITLE
server/issues: remove dependencies dashboards

### DIFF
--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -441,7 +441,6 @@ class GithubIssueService(IssueService):
         (issues, _) = await self.list_by_repository_type_and_status(
             session=session,
             repository_ids=[repository.id],
-            issue_list_type=IssueListType.issues,
             sort_by=IssueSortBy.recently_updated,
         )
 
@@ -467,7 +466,6 @@ class GithubIssueService(IssueService):
         (issues, _) = await self.list_by_repository_type_and_status(
             session=session,
             repository_ids=[repository.id],
-            issue_list_type=IssueListType.issues,
             sort_by=IssueSortBy.recently_updated,
         )
 

--- a/server/polar/issue/endpoints.py
+++ b/server/polar/issue/endpoints.py
@@ -122,7 +122,6 @@ async def search(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session=session,
         repository_ids=issues_in_repos_ids,
-        issue_list_type=IssueListType.issues,
         sort_by=sort,
         limit=50,
         include_statuses=[

--- a/server/tests/issue/test_service.py
+++ b/server/tests/issue/test_service.py
@@ -93,7 +93,6 @@ async def test_list_by_repository_type_and_status_sorting(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
     )
 
@@ -104,7 +103,6 @@ async def test_list_by_repository_type_and_status_sorting(
     (issues, _) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.recently_updated,
     )
 
@@ -114,7 +112,6 @@ async def test_list_by_repository_type_and_status_sorting(
     (issues, _) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.least_recently_updated,
     )
 
@@ -124,7 +121,6 @@ async def test_list_by_repository_type_and_status_sorting(
     (issues, _) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.most_positive_reactions,
     )
 
@@ -139,7 +135,6 @@ async def test_list_by_repository_type_and_status_sorting(
     (issues, _) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.issues_default,
     )
 
@@ -149,7 +144,6 @@ async def test_list_by_repository_type_and_status_sorting(
     (issues, _) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.most_engagement,
     )
 
@@ -325,7 +319,6 @@ async def test_list_by_repository_type_and_status_filter_triaged(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
         include_statuses=[IssueStatus.backlog, IssueStatus.triaged],
     )
@@ -339,7 +332,6 @@ async def test_list_by_repository_type_and_status_filter_triaged(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
         include_statuses=[IssueStatus.triaged],
     )
@@ -355,7 +347,6 @@ async def test_list_by_repository_type_and_status_filter_triaged(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
         include_statuses=[IssueStatus.in_progress],
     )
@@ -371,7 +362,6 @@ async def test_list_by_repository_type_and_status_filter_triaged(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
         include_statuses=[IssueStatus.pull_request],
     )
@@ -388,7 +378,6 @@ async def test_list_by_repository_type_and_status_filter_triaged(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
         include_statuses=[IssueStatus.closed],
     )
@@ -405,7 +394,6 @@ async def test_list_by_repository_type_and_status_filter_triaged(
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
         repository_ids=[repository.id],
-        issue_list_type=IssueListType.issues,
         sort_by=IssueSortBy.newest,
         include_statuses=[IssueStatus.backlog],
     )
@@ -497,8 +485,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge(
 
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
-        repository_ids=[repository.id],
-        issue_list_type=IssueListType.dependencies,
         sort_by=IssueSortBy.newest,
         pledged_by_org=organization.id,
         pledged_by_user=user.id,
@@ -567,8 +553,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge_state(
 
     (issues, count) = await issue_service.list_by_repository_type_and_status(
         session,
-        repository_ids=[repository.id],
-        issue_list_type=IssueListType.dependencies,
         sort_by=IssueSortBy.newest,
         pledged_by_org=organization.id,
         pledged_by_user=user.id,
@@ -581,51 +565,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge_state(
         "pledged_towards_PledgeState.disputed",
         "pledged_towards_PledgeState.created",
     ]
-
-
-@pytest.mark.asyncio
-async def test_list_by_repository_type_and_status_dependencies_dependency(
-    session: AsyncSession,
-    repository: Repository,
-    organization: Organization,
-    issue: Issue,
-    user: User,
-) -> None:
-    # Third party issue
-
-    third_party_org = await random_objects.create_organization(session)
-    third_party_repo = await random_objects.create_repository(session, third_party_org)
-    third_party_issue = await random_objects.create_issue(
-        session, third_party_org, third_party_repo
-    )
-    third_party_issue.title = "is_a_dependency"
-    await third_party_issue.save(session)
-
-    # Create dependency
-    dep = await IssueDependency.create(
-        session=session,
-        organization_id=organization.id,
-        repository_id=repository.id,
-        dependent_issue_id=issue.id,
-        dependency_issue_id=third_party_issue.id,
-    )
-
-    (issues, count) = await issue_service.list_by_repository_type_and_status(
-        session,
-        repository_ids=[repository.id],
-        issue_list_type=IssueListType.dependencies,
-        sort_by=IssueSortBy.newest,
-        pledged_by_org=organization.id,
-        pledged_by_user=user.id,
-        load_pledges=True,
-    )
-
-    # assert count == 1
-    names = [i.title for i in issues]
-    assert names == ["is_a_dependency"]
-
-    # only the pledges by pledged_by_org/pledged_by_user should be included
-    # assert len(issues[0].issue.pledges_zegl) == 1
 
 
 @pytest.mark.asyncio
@@ -679,7 +618,6 @@ async def test_list_by_github_milestone_number(
         (issues, count) = await issue_service.list_by_repository_type_and_status(
             session,
             repository_ids=[repository.id],
-            issue_list_type=IssueListType.issues,
             sort_by=IssueSortBy.newest,
             github_milestone_number=milestone,
         )


### PR DESCRIPTION
Either issues in directly owned repos, or issues that have been pledged towards.

These endpoints are not used.