### PR TITLE
clients/settings: add link to stripe customer portal

### DIFF
--- a/clients/apps/web/src/components/Settings/PaymentMethodSettings.tsx
+++ b/clients/apps/web/src/components/Settings/PaymentMethodSettings.tsx
@@ -1,5 +1,11 @@
-import { CreditCardIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import {
+  ArrowTopRightOnSquareIcon,
+  CreditCardIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline'
+import { api } from 'polarkit/api'
 import { PaymentMethod } from 'polarkit/api/client'
+import { PrimaryButton } from 'polarkit/components/ui/atoms'
 import {
   useDetachPaymentMethodMutation,
   useListPaymentMethods,
@@ -10,6 +16,19 @@ import Spinner from '../Shared/Spinner'
 
 const PaymentMethodSettings = () => {
   const paymentMethods = useListPaymentMethods()
+
+  const [stripePortalLoading, setStripePortalLoading] = useState(false)
+
+  const onGotoStripeCustomerPortal = async () => {
+    setStripePortalLoading(true)
+
+    const portal = await api.users.createStripeCustomerPortal()
+    if (portal) {
+      window.location.href = portal.url
+    }
+
+    setStripePortalLoading(false)
+  }
 
   return (
     <div className="flex w-full flex-col divide-y rounded-md border text-gray-900 dark:text-gray-200">
@@ -23,6 +42,18 @@ const PaymentMethodSettings = () => {
       {paymentMethods.data?.items?.map((pm) => (
         <PaymentMethodItem key={pm.stripe_payment_method_id} pm={pm} />
       ))}
+
+      <div className="dark:text-gray:300 space-y-2 p-4 text-sm text-gray-500">
+        <PrimaryButton
+          fullWidth={false}
+          classNames=""
+          loading={stripePortalLoading}
+          onClick={onGotoStripeCustomerPortal}
+        >
+          <ArrowTopRightOnSquareIcon className="mr-2 h-5 w-5" />
+          <span>Invoice settings and receipts</span>
+        </PrimaryButton>
+      </div>
     </div>
   )
 }

--- a/clients/packages/polarkit/src/api/client/index.ts
+++ b/clients/packages/polarkit/src/api/client/index.ts
@@ -108,6 +108,7 @@ export type { SummaryPledge } from './models/SummaryPledge';
 export type { UpdateIssue } from './models/UpdateIssue';
 export type { User } from './models/User';
 export type { UserRead } from './models/UserRead';
+export type { UserStripePortalSession } from './models/UserStripePortalSession';
 export type { UserUpdateSettings } from './models/UserUpdateSettings';
 export type { ValidationError } from './models/ValidationError';
 export { Visibility } from './models/Visibility';

--- a/clients/packages/polarkit/src/api/client/models/PledgerPledgePendingNotification.ts
+++ b/clients/packages/polarkit/src/api/client/models/PledgerPledgePendingNotification.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { PledgeType } from './PledgeType';
+
 export type PledgerPledgePendingNotification = {
   pledge_amount: string;
   issue_url: string;
@@ -11,5 +13,6 @@ export type PledgerPledgePendingNotification = {
   issue_repo_name: string;
   pledge_date: string;
   pledge_id?: string;
+  pledge_type?: PledgeType;
 };
 

--- a/clients/packages/polarkit/src/api/client/models/UserStripePortalSession.ts
+++ b/clients/packages/polarkit/src/api/client/models/UserStripePortalSession.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UserStripePortalSession = {
+  url: string;
+};
+

--- a/clients/packages/polarkit/src/api/client/services/UsersService.ts
+++ b/clients/packages/polarkit/src/api/client/services/UsersService.ts
@@ -4,6 +4,7 @@
 import type { LoginResponse } from '../models/LoginResponse';
 import type { LogoutResponse } from '../models/LogoutResponse';
 import type { UserRead } from '../models/UserRead';
+import type { UserStripePortalSession } from '../models/UserStripePortalSession';
 import type { UserUpdateSettings } from '../models/UserUpdateSettings';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -67,6 +68,18 @@ export class UsersService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v1/users/logout',
+    });
+  }
+
+  /**
+   * Create Stripe Customer Portal
+   * @returns UserStripePortalSession Successful Response
+   * @throws ApiError
+   */
+  public createStripeCustomerPortal(): CancelablePromise<UserStripePortalSession> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/api/v1/users/me/stripe_customer_portal',
     });
   }
 

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -256,5 +256,19 @@ Thank you for your support!
 
         return sent_invoice
 
+    async def create_portal_session(
+        self,
+        session: AsyncSession,
+        user: User,
+    ) -> stripe_lib.billing_portal.Session | None:
+        customer = await self.get_or_create_user_customer(session, user)
+        if not customer:
+            return None
+
+        return stripe_lib.billing_portal.Session.create(
+            customer=customer.id,
+            return_url=f"{settings.FRONTEND_BASE_URL}/settings",
+        )
+
 
 stripe = StripeService()

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -63,3 +63,7 @@ class UserUpdate(UserBase):
 class UserUpdateSettings(Schema):
     email_newsletters_and_changelogs: bool | None = None
     email_promotions_and_events: bool | None = None
+
+
+class UserStripePortalSession(Schema):
+    url: str


### PR DESCRIPTION
Adds a link to the Stripe-hosted customer dashboard. From there, the user can view past and upcoming invoices and manage their payment details.

<img width="1495" alt="Screenshot 2023-09-29 at 14 41 50" src="https://github.com/polarsource/polar/assets/47952/5055eaeb-f85a-4d16-815c-d1ef95e1b521">

<img width="1495" alt="Screenshot 2023-09-29 at 14 43 26" src="https://github.com/polarsource/polar/assets/47952/9fed42e8-b51a-44f7-8507-d1d384c3df9b">
