### PR TITLE
clients/dashboard: remove Chrome Extension upsell

### DIFF
--- a/clients/apps/web/src/app/maintainer/[organization]/issues/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/issues/ClientPage.tsx
@@ -11,7 +11,6 @@ import {
   RepoPickerHeader,
 } from '@/components/Layout/DashboardLayout'
 import OnboardingAddBadge from '@/components/Onboarding/OnboardingAddBadge'
-import OnboardingInstallChromeExtension from '@/components/Onboarding/OnboardingInstallChromeExtension'
 import { useToast } from '@/components/Toast/use-toast'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
@@ -273,7 +272,6 @@ const OrganizationIssues = ({
 
       <DashboardBody>
         <div className="space-y-4">
-          <OnboardingInstallChromeExtension />
           {showAddBadgeBanner && <OnboardingAddBadge />}
 
           <IssueList


### PR DESCRIPTION
I'm surprised to see that this was still live. The extension doesn't work anymore, and is unmaintained, removing for now.