### PR TITLE
Implement new dashboard layout

### DIFF
--- a/clients/apps/web/next.config.js
+++ b/clients/apps/web/next.config.js
@@ -151,6 +151,11 @@ const nextConfig = {
         destination: '/maintainer',
         permanent: false,
       },
+      {
+        source: '/maintainer/:organization/promote',
+        destination: '/maintainer/:organization/promote/issues',
+        permanent: false
+      },
 
       // Access tokens redirect
       {

--- a/clients/apps/web/package.json
+++ b/clients/apps/web/package.json
@@ -16,7 +16,11 @@
     "node": ">= 18 <20"
   },
   "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
     "@heroicons/react": "^2.0.16",
+    "@mui/icons-material": "^5.14.12",
+    "@mui/material": "^5.14.12",
     "@radix-ui/react-dropdown-menu": "^2.0.5",
     "@radix-ui/react-toast": "^1.1.3",
     "@sentry/nextjs": "^7.48.0",

--- a/clients/apps/web/src/app/backoffice/layout.tsx
+++ b/clients/apps/web/src/app/backoffice/layout.tsx
@@ -4,8 +4,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Topbar
-        customLogoTitle="Backoffice"
-        logoPosition="center"
+        logo={{ title: 'Backoffice', position: 'center' }}
         isFixed={false}
         hideProfile={true}
         useOrgFromURL={false}

--- a/clients/apps/web/src/components/Dashboard/BackerNavigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/BackerNavigation.tsx
@@ -1,29 +1,13 @@
-import clsx from 'clsx'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { classNames } from 'polarkit/utils'
+import { backerRoutes } from './navigation'
 
-const BackerNavigation = (props: { classNames: string }) => {
+const BackerNavigation = (props: { classNames?: string }) => {
   const path = usePathname()
 
   // All routes and conditions
-  const navs = [
-    {
-      id: 'active-issues',
-      title: 'Active Issues',
-      link: `/feed`,
-    },
-    {
-      id: 'rewards',
-      title: 'Rewards',
-      link: `/rewards`,
-    },
-    {
-      id: 'settings',
-      title: 'Settings',
-      link: `/settings`,
-    },
-  ]
+  const navs = backerRoutes
 
   // Filter routes, set isActive, and if subs should be expanded
   const filteredNavs = navs.map((n) => {
@@ -35,25 +19,23 @@ const BackerNavigation = (props: { classNames: string }) => {
   })
 
   return (
-    <div className={clsx('bg-gray-50 py-3 dark:bg-gray-800', props.classNames)}>
-      <div className="flex flex-row items-center justify-center gap-8 text-sm">
-        {filteredNavs.map((n) => (
-          <>
-            <Link
-              className={classNames(
-                'hover:text-blue-700 dark:hover:text-blue-800',
-                n.isActive
-                  ? 'text-blue-600'
-                  : 'text-gray-600 dark:text-gray-400',
-              )}
-              key={n.title}
-              href={n.link}
-            >
-              <span className="font-medium ">{n.title}</span>
-            </Link>
-          </>
-        ))}
-      </div>
+    <div className="flex flex-col gap-2 px-4 py-6">
+      {filteredNavs.map((n) => (
+        <div key={n.link} className="flex flex-col gap-4">
+          <Link
+            className={classNames(
+              'flex items-center gap-2 rounded-xl px-5 py-3 hover:text-blue-700 dark:hover:text-gray-200',
+              n.isActive
+                ? 'bg-blue-50 text-blue-600 dark:bg-gray-800 dark:text-gray-100'
+                : 'text-gray-900 dark:text-gray-500',
+            )}
+            href={n.link}
+          >
+            {n.icon}
+            <span className="ml-3 text-sm font-medium">{n.title}</span>
+          </Link>
+        </div>
+      ))}
     </div>
   )
 }

--- a/clients/apps/web/src/components/Dashboard/MaintainerNavigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/MaintainerNavigation.tsx
@@ -23,7 +23,7 @@ const MaintainerNavigation = () => {
 
       const subs =
         ('subs' in n &&
-          n.subs.map((s) => {
+          n.subs?.map((s) => {
             return {
               ...s,
               isActive: pathname && pathname.startsWith(s.link),

--- a/clients/apps/web/src/components/Dashboard/MaintainerRepoSelection.tsx
+++ b/clients/apps/web/src/components/Dashboard/MaintainerRepoSelection.tsx
@@ -13,7 +13,7 @@ const MaintainerRepoSelection = (props: {
   }
 
   return (
-    <div className="relative flex h-14 w-full shrink-0 lg:w-fit lg:border-r">
+    <div className="relative flex h-14 w-full shrink-0 border-gray-100 dark:border-gray-800 lg:w-fit lg:border-r">
       <RepoSelection
         selectedClassNames="pl-2"
         openClassNames="left-2 top-2"

--- a/clients/apps/web/src/components/Dashboard/navigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigation.tsx
@@ -11,79 +11,109 @@ import {
   WifiTethering,
 } from '@mui/icons-material'
 
-export const maintainerRoutes = (org?: Organization, isLoaded?: boolean) =>
-  [
-    {
-      id: 'org-issues',
-      title: 'Issues',
-      icon: <HowToVoteOutlined className="h-6 w-6" />,
-      link: `/maintainer/${org?.name}/issues`,
-      if: org && isLoaded,
-    },
-    {
-      id: 'org-finance',
-      title: 'Finance',
-      icon: <AttachMoneyOutlined className="h-6 w-6" />,
-      link: `/maintainer/${org?.name}/finance`,
-      if: org && isLoaded,
-    },
-    {
-      id: 'org-promote',
-      title: 'Promote',
-      icon: <WifiTethering className="h-6 w-6" />,
-      link: `/maintainer/${org?.name}/promote`,
-      if: org && isLoaded,
-      subs: [
-        {
-          title: 'Issues',
-          link: `/maintainer/${org?.name}/promote/issues`,
-        },
-        {
-          title: 'Embeds',
-          link: `/maintainer/${org?.name}/promote/embeds`,
-        },
-      ],
-    },
-    {
-      id: 'public-site',
-      title: 'Public site',
-      link: `/${org?.name}`,
-      postIcon: <ArrowUpRightIcon className="h-4 w-4" />,
-      if: org && isLoaded,
-    },
+export type SubRoute = {
+  readonly title: string
+  readonly link: string
+}
 
-    // Non org navigation
-    {
-      id: 'personal-dependencies',
-      title: 'Dependencies',
-      icon: <CubeIcon className="h-6 w-6" />,
-      link: `/feed`,
-      if: !org && isLoaded,
-    },
-  ] as const
+export type Route = {
+  readonly id: string
+  readonly title: string
+  readonly icon?: React.ReactElement
+  readonly postIcon?: React.ReactElement
+  readonly link: string
+  readonly if: boolean | undefined
+  readonly subs?: SubRoute[]
+}
 
-export const backerRoutes = [
+export const maintainerRoutes = (
+  org?: Organization,
+  isLoaded?: boolean,
+): Route[] => [
+  {
+    id: 'org-issues',
+    title: 'Issues',
+    icon: <HowToVoteOutlined className="h-6 w-6" />,
+    postIcon: undefined,
+    link: `/maintainer/${org?.name}/issues`,
+    if: org && isLoaded,
+    subs: undefined,
+  },
+  {
+    id: 'org-finance',
+    title: 'Finance',
+    icon: <AttachMoneyOutlined className="h-6 w-6" />,
+    postIcon: undefined,
+    link: `/maintainer/${org?.name}/finance`,
+    if: org && isLoaded,
+    subs: undefined,
+  },
+  {
+    id: 'org-promote',
+    title: 'Promote',
+    icon: <WifiTethering className="h-6 w-6" />,
+    postIcon: undefined,
+    link: `/maintainer/${org?.name}/promote`,
+    if: org && isLoaded,
+    subs: [
+      {
+        title: 'Issues',
+        link: `/maintainer/${org?.name}/promote/issues`,
+      },
+      {
+        title: 'Embeds',
+        link: `/maintainer/${org?.name}/promote/embeds`,
+      },
+    ],
+  },
+  {
+    id: 'public-site',
+    title: 'Public site',
+    link: `/${org?.name}`,
+    icon: undefined,
+    postIcon: <ArrowUpRightIcon className="h-4 w-4" />,
+    if: org && isLoaded,
+    subs: undefined,
+  },
+
+  // Non org navigation
+  {
+    id: 'personal-dependencies',
+    title: 'Dependencies',
+    icon: <CubeIcon className="h-6 w-6" />,
+    postIcon: undefined,
+    link: `/feed`,
+    if: !org && isLoaded,
+    subs: undefined,
+  },
+]
+
+export const backerRoutes: Route[] = [
   {
     id: 'funding',
     title: 'Funding',
     link: `/feed`,
     icon: <FavoriteBorderOutlined className="h-6 w-6" />,
+    postIcon: undefined,
+    if: true,
+    subs: undefined,
   },
   {
     id: 'rewards',
     title: 'Rewards',
     link: `/rewards`,
     icon: <CardGiftcardOutlined className="h-6 w-6" />,
+    postIcon: undefined,
+    if: true,
+    subs: undefined,
   },
   {
     id: 'settings',
     title: 'Settings',
     link: `/settings`,
     icon: <TuneOutlined className="h-6 w-6" />,
+    postIcon: undefined,
+    if: true,
+    subs: undefined,
   },
-] as const
-
-export type Route = {
-  title: string
-  link: string
-}
+]

--- a/clients/apps/web/src/components/Dashboard/navigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigation.tsx
@@ -1,0 +1,89 @@
+import { Organization } from 'polarkit/api/client'
+
+import { ArrowUpRightIcon } from '@heroicons/react/20/solid'
+import { CubeIcon } from '@heroicons/react/24/outline'
+import {
+  AttachMoneyOutlined,
+  CardGiftcardOutlined,
+  FavoriteBorderOutlined,
+  HowToVoteOutlined,
+  TuneOutlined,
+  WifiTethering,
+} from '@mui/icons-material'
+
+export const maintainerRoutes = (org?: Organization, isLoaded?: boolean) =>
+  [
+    {
+      id: 'org-issues',
+      title: 'Issues',
+      icon: <HowToVoteOutlined className="h-6 w-6" />,
+      link: `/maintainer/${org?.name}/issues`,
+      if: org && isLoaded,
+    },
+    {
+      id: 'org-finance',
+      title: 'Finance',
+      icon: <AttachMoneyOutlined className="h-6 w-6" />,
+      link: `/maintainer/${org?.name}/finance`,
+      if: org && isLoaded,
+    },
+    {
+      id: 'org-promote',
+      title: 'Promote',
+      icon: <WifiTethering className="h-6 w-6" />,
+      link: `/maintainer/${org?.name}/promote`,
+      if: org && isLoaded,
+      subs: [
+        {
+          title: 'Issues',
+          link: `/maintainer/${org?.name}/promote/issues`,
+        },
+        {
+          title: 'Embeds',
+          link: `/maintainer/${org?.name}/promote/embeds`,
+        },
+      ],
+    },
+    {
+      id: 'public-site',
+      title: 'Public site',
+      link: `/${org?.name}`,
+      postIcon: <ArrowUpRightIcon className="h-4 w-4" />,
+      if: org && isLoaded,
+    },
+
+    // Non org navigation
+    {
+      id: 'personal-dependencies',
+      title: 'Dependencies',
+      icon: <CubeIcon className="h-6 w-6" />,
+      link: `/feed`,
+      if: !org && isLoaded,
+    },
+  ] as const
+
+export const backerRoutes = [
+  {
+    id: 'funding',
+    title: 'Funding',
+    link: `/feed`,
+    icon: <FavoriteBorderOutlined className="h-6 w-6" />,
+  },
+  {
+    id: 'rewards',
+    title: 'Rewards',
+    link: `/rewards`,
+    icon: <CardGiftcardOutlined className="h-6 w-6" />,
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    link: `/settings`,
+    icon: <TuneOutlined className="h-6 w-6" />,
+  },
+] as const
+
+export type Route = {
+  title: string
+  link: string
+}

--- a/clients/apps/web/src/components/Layout/BackerLayout.stories.tsx
+++ b/clients/apps/web/src/components/Layout/BackerLayout.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from 'polarkit'
 import BackerLayout from './BackerLayout'
 
 const meta: Meta<typeof BackerLayout> = {
@@ -16,9 +18,11 @@ export const Default: Story = {
     padding: 'p-0 m-0',
   },
   render: (args) => (
-    <BackerLayout {...args}>
-      <div className="bg-red-200 text-black">Content</div>
-    </BackerLayout>
+    <QueryClientProvider client={queryClient}>
+      <BackerLayout {...args}>
+        <div className="bg-red-200 text-black">Content</div>
+      </BackerLayout>
+    </QueryClientProvider>
   ),
 }
 

--- a/clients/apps/web/src/components/Layout/BackerLayout.tsx
+++ b/clients/apps/web/src/components/Layout/BackerLayout.tsx
@@ -1,13 +1,18 @@
+import ProfileSelection from '@/components/Shared/ProfileSelection'
+import { useAuth } from '@/hooks/auth'
+import { LogoType } from 'polarkit/components/brand'
 import { useStore } from 'polarkit/store'
 import { classNames } from 'polarkit/utils'
 import { useMemo } from 'react'
 import BackerConnectUpsell from '../Dashboard/BackerConnectUpsell'
+import SidebarNavigation from '../Dashboard/BackerNavigation'
 import Topbar from '../Shared/Topbar'
 
 const BackerLayout = (props: {
   children: React.ReactNode
   disableOnboardingBanner?: boolean
 }) => {
+  const { currentUser, hydrated } = useAuth()
   const isBackerConnectUpsellSkiped = useStore(
     (store) => store.onboardingMaintainerConnectRepositoriesSkip,
   )
@@ -16,22 +21,38 @@ const BackerLayout = (props: {
     !isBackerConnectUpsellSkiped && !props.disableOnboardingBanner
 
   const fixedHeight = useMemo(() => {
-    return showBanner ? 37 : 0 // BackerConnectUpsell
+    return showBanner ? 127 : 90 // BackerConnectUpsell
   }, [showBanner])
 
-  return (
-    <div className="relative flex flex-col">
-      <Topbar isFixed={true} useOrgFromURL={false} />
+  if (!hydrated) {
+    return <></>
+  }
 
-      <div className="flex flex-col bg-gray-50 pt-16 dark:bg-gray-950">
+  return (
+    <div className="relative flex w-full flex-row">
+      <aside className="h-screen w-[320px] flex-shrink-0 border-r border-r-gray-100 bg-white dark:border-r-gray-800 dark:bg-gray-900">
+        <a
+          href="/"
+          className="mt-10 flex-shrink-0 items-center space-x-2 px-9 font-semibold text-gray-700 md:inline-flex"
+        >
+          <LogoType />
+        </a>
+        <div className="mt-8 flex px-4 py-2">
+          {currentUser && <ProfileSelection useOrgFromURL={true} />}
+        </div>
+        <SidebarNavigation />
+      </aside>
+
+      <div className="relative flex h-screen w-full translate-x-0 flex-row bg-gray-50 dark:bg-gray-950">
+        <Topbar isFixed={true} useOrgFromURL={false} />
         <nav className="fixed z-10 w-full ">
           {showBanner && <BackerConnectUpsell />}
         </nav>
 
-        <main className={classNames('relative w-full')}>
+        <main className={classNames('relative h-full w-full overflow-y-auto')}>
           <div
             className={classNames(
-              'relative mx-auto max-w-screen-2xl px-4 pb-6 pt-4 md:px-16',
+              'relative mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8',
             )}
             style={{
               marginTop: `${fixedHeight}px`,

--- a/clients/apps/web/src/components/Layout/BackerLayout.tsx
+++ b/clients/apps/web/src/components/Layout/BackerLayout.tsx
@@ -3,10 +3,9 @@ import { useAuth } from '@/hooks/auth'
 import { LogoType } from 'polarkit/components/brand'
 import { useStore } from 'polarkit/store'
 import { classNames } from 'polarkit/utils'
-import { useMemo } from 'react'
 import BackerConnectUpsell from '../Dashboard/BackerConnectUpsell'
 import SidebarNavigation from '../Dashboard/BackerNavigation'
-import Topbar from '../Shared/Topbar'
+import DashboardTopbar from '../Shared/DashboardTopbar'
 
 const BackerLayout = (props: {
   children: React.ReactNode
@@ -20,10 +19,6 @@ const BackerLayout = (props: {
   const showBanner =
     !isBackerConnectUpsellSkiped && !props.disableOnboardingBanner
 
-  const fixedHeight = useMemo(() => {
-    return showBanner ? 127 : 90 // BackerConnectUpsell
-  }, [showBanner])
-
   if (!hydrated) {
     return <></>
   }
@@ -33,18 +28,24 @@ const BackerLayout = (props: {
       <aside className="h-screen w-[320px] flex-shrink-0 border-r border-r-gray-100 bg-white dark:border-r-gray-800 dark:bg-gray-900">
         <a
           href="/"
-          className="mt-10 flex-shrink-0 items-center space-x-2 px-9 font-semibold text-gray-700 md:inline-flex"
+          className="mt-8 flex-shrink-0 items-center space-x-2 px-9 font-semibold text-gray-700 md:inline-flex"
         >
           <LogoType />
         </a>
         <div className="mt-8 flex px-4 py-2">
-          {currentUser && <ProfileSelection useOrgFromURL={true} />}
+          {currentUser && (
+            <ProfileSelection
+              useOrgFromURL={true}
+              className="shadow-xl"
+              narrow={false}
+            />
+          )}
         </div>
         <SidebarNavigation />
       </aside>
 
       <div className="relative flex h-screen w-full translate-x-0 flex-row bg-gray-50 dark:bg-gray-950">
-        <Topbar isFixed={true} useOrgFromURL={false} />
+        <DashboardTopbar isFixed={true} useOrgFromURL={false} />
         <nav className="fixed z-10 w-full ">
           {showBanner && <BackerConnectUpsell />}
         </nav>
@@ -55,7 +56,7 @@ const BackerLayout = (props: {
               'relative mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8',
             )}
             style={{
-              marginTop: `${fixedHeight}px`,
+              marginTop: `107px`,
             }}
           >
             {props.children}

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -7,8 +7,8 @@ import { classNames } from 'polarkit/utils'
 import { Suspense } from 'react'
 import SidebarNavigation from '../Dashboard/MaintainerNavigation'
 import MaintainerRepoSelection from '../Dashboard/MaintainerRepoSelection'
+import DashboardTopbar from '../Shared/DashboardTopbar'
 import ProfileSelection from '../Shared/ProfileSelection'
-import Topbar from '../Shared/Topbar'
 
 const DashboardLayout = (props: {
   children: React.ReactNode
@@ -25,17 +25,23 @@ const DashboardLayout = (props: {
       <aside className="h-screen w-[320px] flex-shrink-0 border-r border-r-gray-100 bg-white dark:border-r-gray-800 dark:bg-gray-900">
         <a
           href="/"
-          className="mt-10 flex-shrink-0 items-center space-x-2 px-9 font-semibold text-gray-700 md:inline-flex"
+          className="mt-8 flex-shrink-0 items-center space-x-2 px-9 font-semibold text-gray-700 md:inline-flex"
         >
           <LogoType />
         </a>
         <div className="mt-8 flex px-4 py-2">
-          {currentUser && <ProfileSelection useOrgFromURL={true} />}
+          {currentUser && (
+            <ProfileSelection
+              useOrgFromURL={true}
+              className="shadow-xl"
+              narrow={false}
+            />
+          )}
         </div>
         <SidebarNavigation />
       </aside>
       <div className="relative flex h-screen w-full translate-x-0 flex-row bg-gray-50 dark:bg-gray-950">
-        <Topbar isFixed={true} useOrgFromURL={true} />
+        <DashboardTopbar isFixed={true} useOrgFromURL={true} />
         <main className={classNames('relative h-full w-full overflow-y-auto')}>
           <Suspense>{props.children}</Suspense>
         </main>
@@ -56,7 +62,7 @@ export const RepoPickerHeader = (props: {
   return (
     <>
       <form
-        className="flex flex-col justify-between space-y-2 border-b bg-gray-100/50 bg-white p-2 !pr-2 backdrop-blur-none dark:bg-gray-700/50 lg:flex-row lg:items-center lg:space-x-4 lg:space-y-0 lg:bg-transparent lg:p-0 lg:backdrop-blur"
+        className="flex flex-col justify-between space-y-2 border-b border-gray-100 bg-gray-100/50 bg-white p-2 !pr-2 backdrop-blur-none dark:border-gray-800 dark:bg-gray-800/50 lg:flex-row lg:items-center lg:space-x-4 lg:space-y-0 lg:bg-transparent lg:p-0 lg:backdrop-blur"
         onSubmit={onSubmit}
       >
         <MaintainerRepoSelection
@@ -71,7 +77,7 @@ export const RepoPickerHeader = (props: {
 
 export const DashboardHeader = (props: { children?: React.ReactNode }) => {
   return (
-    <div className={classNames('sticky left-[300px] right-0 top-24 z-10')}>
+    <div className={classNames('sticky left-[300px] right-0 top-20 z-10')}>
       {props.children}
     </div>
   )
@@ -81,7 +87,7 @@ export const DashboardBody = (props: { children?: React.ReactNode }) => {
   return (
     <div
       className={classNames(
-        'relative mx-auto max-w-screen-2xl px-4 pb-6 pt-32 sm:px-6 md:px-8',
+        'relative mx-auto max-w-screen-2xl px-4 pb-6 pt-28 sm:px-6 md:px-8',
       )}
     >
       {props.children}

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -1,23 +1,42 @@
+'use client'
+
+import { useAuth } from '@/hooks/auth'
 import { Repository } from 'polarkit/api/client'
+import { LogoType } from 'polarkit/components/brand'
 import { classNames } from 'polarkit/utils'
 import { Suspense } from 'react'
 import SidebarNavigation from '../Dashboard/MaintainerNavigation'
 import MaintainerRepoSelection from '../Dashboard/MaintainerRepoSelection'
+import ProfileSelection from '../Shared/ProfileSelection'
 import Topbar from '../Shared/Topbar'
 
 const DashboardLayout = (props: {
   children: React.ReactNode
   header?: React.ReactNode
 }) => {
-  return (
-    <div className="relative flex flex-col">
-      <Topbar isFixed={true} useOrgFromURL={true} />
+  const { currentUser, hydrated } = useAuth()
 
-      <div className="flex flex-row bg-gray-50 dark:bg-gray-950">
-        <aside className="bg-gray-75 fixed bottom-0 left-0 top-16 w-[300px] flex-shrink-0 border-r border-r-gray-200 dark:border-r-gray-700 dark:bg-gray-800">
-          <SidebarNavigation />
-        </aside>
-        <main className={classNames('relative ml-[300px] w-full')}>
+  if (!hydrated) {
+    return <></>
+  }
+
+  return (
+    <div className="relative flex w-full flex-row">
+      <aside className="h-screen w-[320px] flex-shrink-0 border-r border-r-gray-100 bg-white dark:border-r-gray-800 dark:bg-gray-900">
+        <a
+          href="/"
+          className="mt-10 flex-shrink-0 items-center space-x-2 px-9 font-semibold text-gray-700 md:inline-flex"
+        >
+          <LogoType />
+        </a>
+        <div className="mt-8 flex px-4 py-2">
+          {currentUser && <ProfileSelection useOrgFromURL={true} />}
+        </div>
+        <SidebarNavigation />
+      </aside>
+      <div className="relative flex h-screen w-full translate-x-0 flex-row bg-gray-50 dark:bg-gray-950">
+        <Topbar isFixed={true} useOrgFromURL={true} />
+        <main className={classNames('relative h-full w-full overflow-y-auto')}>
           <Suspense>{props.children}</Suspense>
         </main>
       </div>
@@ -52,7 +71,7 @@ export const RepoPickerHeader = (props: {
 
 export const DashboardHeader = (props: { children?: React.ReactNode }) => {
   return (
-    <div className={classNames('sticky left-[300px] right-0 top-16 z-10')}>
+    <div className={classNames('sticky left-[300px] right-0 top-24 z-10')}>
       {props.children}
     </div>
   )
@@ -62,7 +81,7 @@ export const DashboardBody = (props: { children?: React.ReactNode }) => {
   return (
     <div
       className={classNames(
-        'relative mx-auto max-w-screen-2xl px-4 pb-6 pt-24 sm:px-6 md:px-8',
+        'relative mx-auto max-w-screen-2xl px-4 pb-6 pt-32 sm:px-6 md:px-8',
       )}
     >
       {props.children}

--- a/clients/apps/web/src/components/Layout/TopbarLayout.tsx
+++ b/clients/apps/web/src/components/Layout/TopbarLayout.tsx
@@ -16,7 +16,9 @@ const TopbarLayout = ({
     <EmptyLayout>
       <>
         <Topbar
-          logoPosition={logoPosition}
+          logo={{
+            position: logoPosition
+          }}
           isFixed={isFixed}
           useOrgFromURL={false}
           hideProfile={hideProfile}

--- a/clients/apps/web/src/components/Shared/DashboardTopbar.tsx
+++ b/clients/apps/web/src/components/Shared/DashboardTopbar.tsx
@@ -5,12 +5,16 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { classNames } from 'polarkit/utils'
 import { Suspense, useMemo } from 'react'
-import { Route, backerRoutes, maintainerRoutes } from '../Dashboard/navigation'
+import {
+  SubRoute,
+  backerRoutes,
+  maintainerRoutes,
+} from '../Dashboard/navigation'
 import Popover from '../Notifications/Popover'
 
 export type LogoPosition = 'center' | 'left'
 
-const SubNav = (props: { items: (Route & { active: boolean })[] }) => {
+const SubNav = (props: { items: (SubRoute & { active: boolean })[] }) => {
   return (
     <div className="flex flex-row items-center gap-x-2 rounded-lg bg-gray-100 p-1 dark:border-gray-800 dark:bg-gray-800">
       {props.items.map((item) => {
@@ -77,12 +81,14 @@ const DashboardTopbar = ({
             </h4>
             {currentRoute &&
               'subs' in currentRoute &&
-              currentRoute.subs.length > 0 && (
+              (currentRoute.subs?.length ?? 0) > 0 && (
                 <SubNav
-                  items={currentRoute.subs.map((sub) => ({
-                    ...sub,
-                    active: sub.link === pathname,
-                  }))}
+                  items={
+                    currentRoute.subs?.map((sub) => ({
+                      ...sub,
+                      active: sub.link === pathname,
+                    })) ?? []
+                  }
                 />
               )}
           </div>

--- a/clients/apps/web/src/components/Shared/DashboardTopbar.tsx
+++ b/clients/apps/web/src/components/Shared/DashboardTopbar.tsx
@@ -1,11 +1,97 @@
-import Topbar from './Topbar'
+'use client'
 
-const DashboardTopbar = () => {
+import { useAuth, useCurrentOrgAndRepoFromURL } from '@/hooks'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { classNames } from 'polarkit/utils'
+import { Suspense, useMemo } from 'react'
+import { Route, backerRoutes, maintainerRoutes } from '../Dashboard/navigation'
+import Popover from '../Notifications/Popover'
+
+export type LogoPosition = 'center' | 'left'
+
+const SubNav = (props: { items: (Route & { active: boolean })[] }) => {
   return (
-    <>
-      <Topbar isFixed={true} useOrgFromURL={true}></Topbar>
-    </>
+    <div className="flex flex-row items-center gap-x-2 rounded-lg bg-gray-100 p-1 dark:border-gray-800 dark:bg-gray-800">
+      {props.items.map((item) => {
+        const className = classNames(
+          item.active
+            ? 'bg-white dark:bg-gray-900 shadow-md text-gray-950 dark:text-gray-300 font-medium'
+            : 'text-gray-500 dark:gray-500 hover:text-gray-950 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800',
+          'dark-bg-900 flex flex-row rounded-md px-3 py-1 text-xs transition-colors',
+        )
+
+        return (
+          <Link href={item.link} className={className}>
+            {item.title}
+          </Link>
+        )
+      })}
+    </div>
   )
 }
 
+const DashboardTopbar = ({
+  hideProfile,
+  ...props
+}: {
+  useOrgFromURL: boolean
+  hideProfile?: boolean
+  isFixed?: boolean
+}) => {
+  const { org: currentOrgFromURL, isLoaded } = useCurrentOrgAndRepoFromURL()
+  const { currentUser, hydrated } = useAuth()
+
+  const useOrgFromURL = props.useOrgFromURL
+
+  const currentOrg = useMemo(() => {
+    return currentOrgFromURL && useOrgFromURL ? currentOrgFromURL : undefined
+  }, [currentOrgFromURL, useOrgFromURL])
+
+  const routes = currentOrg
+    ? maintainerRoutes(currentOrg, isLoaded)
+    : backerRoutes
+
+  const pathname = usePathname()
+
+  const [currentRoute] = routes.filter((route) =>
+    pathname?.startsWith(route.link),
+  )
+
+  const className = classNames(
+    props.isFixed !== false ? 'fixed z-20 left-0 top-0 right-0' : '',
+    'flex h-20 w-full items-center justify-between space-x-4 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800',
+  )
+
+  if (!hydrated) {
+    return <></>
+  }
+
+  return (
+    <>
+      <div className={className}>
+        <div className="relative flex w-full flex-row items-center justify-between px-4 sm:px-6 md:px-8">
+          <div className="flex flex-row items-center gap-x-24">
+            <h4 className="text-lg font-medium dark:text-gray-300">
+              {currentRoute?.title}
+            </h4>
+            {currentRoute &&
+              'subs' in currentRoute &&
+              currentRoute.subs.length > 0 && (
+                <SubNav
+                  items={currentRoute.subs.map((sub) => ({
+                    ...sub,
+                    active: sub.link === pathname,
+                  }))}
+                />
+              )}
+          </div>
+          <div className="flex flex-row items-center gap-x-6">
+            <Suspense>{currentUser && <Popover />}</Suspense>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
 export default DashboardTopbar

--- a/clients/apps/web/src/components/Shared/ProfileSelection.tsx
+++ b/clients/apps/web/src/components/Shared/ProfileSelection.tsx
@@ -1,18 +1,28 @@
 import { useCurrentOrgAndRepoFromURL } from '@/hooks'
+import { ChevronUpDownIcon } from '@heroicons/react/24/outline'
 import {
-  ArrowRightOnRectangleIcon,
-  ChevronUpDownIcon,
-  PlusSmallIcon,
-  QuestionMarkCircleIcon,
-} from '@heroicons/react/24/outline'
+  AddOutlined,
+  ContactSupportOutlined,
+  LogoutOutlined,
+} from '@mui/icons-material'
 import Link from 'next/link'
 import { CONFIG } from 'polarkit/config'
 import { useListOrganizations } from 'polarkit/hooks'
 import { classNames, clsx, useOutsideClick } from 'polarkit/utils'
 import React, { useMemo, useRef, useState } from 'react'
 import { useAuth } from '../../hooks'
+import { backerRoutes } from '../Dashboard/navigation'
 
-const ProfileSelection = ({ useOrgFromURL = true }) => {
+const ProfileSelection = ({
+  useOrgFromURL = true,
+  className = '',
+  narrow = true,
+  showBackerLinks = false,
+}) => {
+  const classNames = clsx(
+    'relative flex w-full flex-col rounded-xl bg-white dark:bg-gray-950 hover:bg-gray-100/50 dark:shadow-none',
+    className,
+  )
   const { currentUser: loggedUser, logout } = useAuth()
   const listOrganizationQuery = useListOrganizations()
 
@@ -53,9 +63,12 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
 
   return (
     <>
-      <div className="relative flex w-full flex-col">
+      <div className={classNames}>
         <div
-          className="relative flex cursor-pointer flex-row items-center justify-between gap-x-2 rounded-2xl p-4 shadow-xl transition-colors hover:bg-gray-100/50 dark:border dark:border-transparent dark:bg-gray-950 dark:shadow-none dark:hover:border-gray-800"
+          className={clsx(
+            'relative flex cursor-pointer flex-row items-center justify-between gap-x-2 px-4 transition-colors',
+            narrow ? 'py-2' : 'py-3',
+          )}
           onClick={() => setOpen(true)}
         >
           <Profile
@@ -70,7 +83,8 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
           <div
             ref={ref}
             className={clsx(
-              'absolute left-0 top-0 w-[286px] max-w-[286px] overflow-hidden rounded-2xl bg-white py-2 shadow-xl dark:bg-gray-950',
+              'absolute left-0 w-full overflow-hidden rounded-2xl bg-white py-2 shadow-xl dark:bg-gray-950',
+              narrow ? '-top-2' : '-top-1',
             )}
           >
             <ul>
@@ -83,6 +97,22 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
                   />
                 </ListItem>
               </Link>
+
+              {showBackerLinks && (
+                <>
+                  {backerRoutes.map((n) => {
+                    return (
+                      <LinkItem href={n.link} icon={n.icon}>
+                        <span className="mx-1.5 text-gray-600 dark:text-gray-400">
+                          {n.title}
+                        </span>
+                      </LinkItem>
+                    )
+                  })}
+
+                  <hr className="my-2 ml-4 mr-4" />
+                </>
+              )}
 
               {orgs &&
                 orgs.map((org) => (
@@ -116,7 +146,7 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
               {showAddOrganization && (
                 <LinkItem
                   href={CONFIG.GITHUB_INSTALLATION_URL}
-                  icon={<PlusSmallIcon className="h-5 w-5 text-blue-600" />}
+                  icon={<AddOutlined className="text-blue-600" />}
                 >
                   <span className="mx-1.5 text-blue-600">Add organization</span>
                 </LinkItem>
@@ -127,7 +157,7 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
               <LinkItem
                 href={'https://polar.sh/faq'}
                 icon={
-                  <QuestionMarkCircleIcon className="h-5 w-5  text-gray-600 dark:text-gray-400" />
+                  <ContactSupportOutlined className="text-gray-600 dark:text-gray-400" />
                 }
               >
                 <span className="mx-1.5  text-gray-600 dark:text-gray-400">
@@ -138,7 +168,7 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
               <TextItem
                 onClick={logout}
                 icon={
-                  <ArrowRightOnRectangleIcon className="h-5 w-5  text-gray-600 dark:text-gray-400" />
+                  <LogoutOutlined className="text-gray-600 dark:text-gray-400" />
                 }
               >
                 <span className="mx-1.5  text-gray-600 dark:text-gray-400">
@@ -158,12 +188,14 @@ export default ProfileSelection
 const ListItem = (props: {
   children: React.ReactElement
   current: boolean
+  className?: string
 }) => {
   const className = classNames(
-    'animate-background duration-10 flex items-center gap-2 py-2 px-4',
+    'animate-background duration-10 flex items-center gap-2 py-2 px-4 w-full',
     props.current
       ? 'bg-blue-50 dark:bg-white/5'
       : 'hover:bg-gray-100/50 dark:hover:bg-white/5',
+    props.className ?? '',
   )
 
   return <li className={className}>{props.children}</li>
@@ -202,9 +234,13 @@ const LinkItem = (props: {
 }) => {
   return (
     <a href={props.href}>
-      <ListItem current={false}>
-        <div className="flex items-center gap-x-2 text-sm">
-          {props.icon}
+      <ListItem current={false} className="px-6">
+        <div className="flex flex-row items-center gap-x-2 text-sm">
+          <div className="text-[20px]">
+            {React.cloneElement(props.icon, {
+              fontSize: 'inherit',
+            })}
+          </div>
           {props.children}
         </div>
       </ListItem>
@@ -219,12 +255,16 @@ const TextItem = (props: {
 }) => {
   return (
     <div
-      className="flex cursor-pointer items-center text-sm hover:bg-gray-100/50 dark:hover:bg-white/5"
+      className="flex cursor-pointer items-center text-sm"
       onClick={props.onClick}
     >
-      <ListItem current={false}>
+      <ListItem current={false} className="px-6">
         <>
-          {props.icon}
+          <div className="text-[20px]">
+            {React.cloneElement(props.icon, {
+              fontSize: 'inherit',
+            })}
+          </div>
           {props.children}
         </>
       </ListItem>

--- a/clients/apps/web/src/components/Shared/ProfileSelection.tsx
+++ b/clients/apps/web/src/components/Shared/ProfileSelection.tsx
@@ -55,7 +55,7 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
     <>
       <div className="relative flex w-full flex-col">
         <div
-          className="relative flex cursor-pointer flex-row items-center justify-between gap-x-2 rounded-2xl p-4 shadow-lg transition-colors hover:bg-gray-100/50 dark:border dark:border-transparent dark:bg-gray-950 dark:shadow-none dark:hover:border-gray-800"
+          className="relative flex cursor-pointer flex-row items-center justify-between gap-x-2 rounded-2xl p-4 shadow-xl transition-colors hover:bg-gray-100/50 dark:border dark:border-transparent dark:bg-gray-950 dark:shadow-none dark:hover:border-gray-800"
           onClick={() => setOpen(true)}
         >
           <Profile

--- a/clients/apps/web/src/components/Shared/ProfileSelection.tsx
+++ b/clients/apps/web/src/components/Shared/ProfileSelection.tsx
@@ -1,16 +1,14 @@
 import { useCurrentOrgAndRepoFromURL } from '@/hooks'
 import {
   ArrowRightOnRectangleIcon,
-  Cog8ToothIcon,
-  GiftIcon,
-  HeartIcon,
+  ChevronUpDownIcon,
   PlusSmallIcon,
   QuestionMarkCircleIcon,
 } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { CONFIG } from 'polarkit/config'
 import { useListOrganizations } from 'polarkit/hooks'
-import { clsx, useOutsideClick } from 'polarkit/utils'
+import { classNames, clsx, useOutsideClick } from 'polarkit/utils'
 import React, { useMemo, useRef, useState } from 'react'
 import { useAuth } from '../../hooks'
 
@@ -53,83 +51,53 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
   const showConnectUsell = orgs && orgs.length === 0
   const showAddOrganization = !showConnectUsell
 
-  const backerLinks = [
-    {
-      href: '/feed',
-      name: 'Funding',
-      icon: <HeartIcon className="h-5 w-5  text-gray-600 dark:text-gray-400" />,
-    },
-    {
-      href: '/rewards',
-      name: 'Rewards',
-      icon: <GiftIcon className="h-5 w-5  text-gray-600 dark:text-gray-400" />,
-    },
-    {
-      href: '/settings',
-      name: 'Settings',
-      icon: (
-        <Cog8ToothIcon className="h-5 w-5  text-gray-600 dark:text-gray-400" />
-      ),
-    },
-  ]
-
   return (
     <>
-      <div className="flex flex-col">
-        {!isOpen && (
-          <div className="shadow-hidden dark:hover:shadow-hidden relative cursor-pointer rounded-lg border border-transparent px-4 py-2 hover:border-blue-100 hover:shadow hover:dark:border-gray-800 dark:hover:bg-gray-900">
-            <div onClick={() => setOpen(true)}>
-              <Profile
-                name={current.name}
-                avatar_url={current.avatar_url}
-                type={current.type}
-              />
-            </div>
-          </div>
-        )}
+      <div className="relative flex w-full flex-col">
+        <div
+          className="relative flex cursor-pointer flex-row items-center justify-between gap-x-2 rounded-2xl p-4 shadow-lg transition-colors hover:bg-gray-100/50 dark:border dark:border-transparent dark:bg-gray-950 dark:shadow-none dark:hover:border-gray-800"
+          onClick={() => setOpen(true)}
+        >
+          <Profile
+            name={current.name}
+            avatar_url={current.avatar_url}
+            type={current.type}
+          />
+          <ChevronUpDownIcon className="h-5 w-5 flex-shrink-0 text-gray-400 dark:text-gray-500" />
+        </div>
 
         {isOpen && (
           <div
             ref={ref}
             className={clsx(
-              'absolute right-4 top-4 min-w-[300px] overflow-hidden rounded-lg border border-transparent bg-white py-2 shadow hover:border-blue-100 dark:bg-gray-900 hover:dark:border-gray-800',
+              'absolute left-0 top-0 w-[286px] max-w-[286px] overflow-hidden rounded-2xl bg-white py-2 shadow-xl dark:bg-gray-950',
             )}
           >
             <ul>
-              <ListItem current={currentOrg === undefined}>
-                <Link href="/feed" className="w-full">
+              <Link href="/feed" className="w-full">
+                <ListItem current={currentOrg === undefined}>
                   <Profile
                     name={loggedUser.username}
                     avatar_url={loggedUser.avatar_url}
                     type="backer"
                   />
-                </Link>
-              </ListItem>
-
-              {backerLinks.map((l) => (
-                <LinkItem href={l.href} icon={l.icon}>
-                  <span className="mx-1.5  text-gray-600 dark:text-gray-400">
-                    {l.name}
-                  </span>
-                </LinkItem>
-              ))}
-
-              <hr className="my-2 ml-6 mr-6" />
+                </ListItem>
+              </Link>
 
               {orgs &&
                 orgs.map((org) => (
-                  <ListItem key={org.id} current={currentOrg?.id === org.id}>
-                    <Link
-                      href={`/maintainer/${org.name}/issues`}
-                      className="w-full"
-                    >
+                  <Link
+                    href={`/maintainer/${org.name}/issues`}
+                    className="w-full"
+                  >
+                    <ListItem key={org.id} current={currentOrg?.id === org.id}>
                       <Profile
                         name={org.name}
                         avatar_url={org.avatar_url}
                         type="maintainer"
                       />
-                    </Link>
-                  </ListItem>
+                    </ListItem>
+                  </Link>
                 ))}
 
               {showConnectUsell && (
@@ -154,7 +122,7 @@ const ProfileSelection = ({ useOrgFromURL = true }) => {
                 </LinkItem>
               )}
 
-              <hr className="my-2 ml-6 mr-6" />
+              <hr className="my-2 ml-4 mr-4" />
 
               <LinkItem
                 href={'https://polar.sh/faq'}
@@ -191,15 +159,14 @@ const ListItem = (props: {
   children: React.ReactElement
   current: boolean
 }) => {
-  return (
-    <li className="animate-background duration-10 flex items-center gap-2 py-2 pl-3 pr-4 hover:bg-gray-200/50 dark:hover:bg-gray-950/50">
-      {props.current && (
-        <div className="h-2 w-2 rounded-full bg-blue-600"></div>
-      )}
-      {!props.current && <div className="h-2 w-2"></div>}
-      {props.children}
-    </li>
+  const className = classNames(
+    'animate-background duration-10 flex items-center gap-2 py-2 px-4',
+    props.current
+      ? 'bg-blue-50 dark:bg-white/5'
+      : 'hover:bg-gray-100/50 dark:hover:bg-white/5',
   )
+
+  return <li className={className}>{props.children}</li>
 }
 
 const Profile = (props: {
@@ -209,16 +176,16 @@ const Profile = (props: {
 }) => {
   return (
     <>
-      <div className="flex w-full items-center justify-between text-sm">
-        <div className="flex items-center">
+      <div className="flex w-full min-w-0 shrink grow-0 items-center justify-between text-sm">
+        <div className="flex w-full min-w-0 shrink grow-0 items-center">
           {props.avatar_url && (
             <img
               src={props.avatar_url}
-              className="h-5 w-5 rounded-full"
+              className="h-8 w-8 rounded-full"
               alt={props.name}
             />
           )}
-          <p className="mx-1.5 text-gray-600 dark:text-gray-400">
+          <p className="ml-4 truncate text-gray-600 dark:text-gray-400 ">
             {props.name}
           </p>
         </div>
@@ -234,14 +201,14 @@ const LinkItem = (props: {
   children: React.ReactElement
 }) => {
   return (
-    <ListItem current={false}>
-      <a href={props.href}>
-        <div className="flex items-center text-sm ">
+    <a href={props.href}>
+      <ListItem current={false}>
+        <div className="flex items-center gap-x-2 text-sm">
           {props.icon}
           {props.children}
         </div>
-      </a>
-    </ListItem>
+      </ListItem>
+    </a>
   )
 }
 
@@ -251,15 +218,17 @@ const TextItem = (props: {
   children: React.ReactElement
 }) => {
   return (
-    <ListItem current={false}>
-      <div
-        className="flex cursor-pointer items-center text-sm"
-        onClick={props.onClick}
-      >
-        {props.icon}
-        {props.children}
-      </div>
-    </ListItem>
+    <div
+      className="flex cursor-pointer items-center text-sm hover:bg-gray-100/50 dark:hover:bg-white/5"
+      onClick={props.onClick}
+    >
+      <ListItem current={false}>
+        <>
+          {props.icon}
+          {props.children}
+        </>
+      </ListItem>
+    </div>
   )
 }
 
@@ -271,7 +240,7 @@ const ProfileBadge = (props: { type: 'backer' | 'maintainer' }) => {
           'border-green-200 bg-green-100 text-green-600 dark:border-green-600 dark:bg-green-700 dark:text-green-300',
         props.type === 'maintainer' &&
           'border-blue-200 bg-blue-100 text-blue-600 dark:border-blue-600 dark:bg-blue-700 dark:text-blue-300',
-        'rounded-lg border px-1.5 text-xs',
+        'shrink-0 rounded-lg border px-1.5 text-xs',
       )}
     >
       {props.type === 'backer' && 'Backer'}

--- a/clients/apps/web/src/components/Shared/ProfileSelection.tsx
+++ b/clients/apps/web/src/components/Shared/ProfileSelection.tsx
@@ -229,18 +229,20 @@ const Profile = (props: {
 
 const LinkItem = (props: {
   href: string
-  icon: React.ReactElement
+  icon?: React.ReactElement
   children: React.ReactElement
 }) => {
   return (
     <a href={props.href}>
       <ListItem current={false} className="px-6">
         <div className="flex flex-row items-center gap-x-2 text-sm">
-          <div className="text-[20px]">
-            {React.cloneElement(props.icon, {
-              fontSize: 'inherit',
-            })}
-          </div>
+          {props.icon && (
+            <div className="text-[20px]">
+              {React.cloneElement(props.icon, {
+                fontSize: 'inherit',
+              })}
+            </div>
+          )}
           {props.children}
         </div>
       </ListItem>

--- a/clients/apps/web/src/components/Shared/Topbar.tsx
+++ b/clients/apps/web/src/components/Shared/Topbar.tsx
@@ -70,7 +70,7 @@ const Topbar = ({
   return (
     <>
       <div className={className}>
-        <div className="mx-auto flex max-w-screen-2xl flex-row items-center justify-between px-4 sm:px-6 md:flex-1 md:px-8">
+        <div className="flex w-full flex-row items-center justify-between px-4 sm:px-6 md:px-12">
           <div className="flex flex-row items-center gap-x-24">
             <h3 className="text-xl font-medium dark:text-gray-300">
               {currentRoute?.title}

--- a/clients/apps/web/src/components/Shared/Topbar.tsx
+++ b/clients/apps/web/src/components/Shared/Topbar.tsx
@@ -1,106 +1,67 @@
-'use client'
-
-import { useCurrentOrgAndRepoFromURL } from '@/hooks'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { LogoIcon } from 'polarkit/components/brand'
+import { LogoIcon, LogoType } from 'polarkit/components/brand'
 import { classNames } from 'polarkit/utils'
-import { Suspense, useMemo } from 'react'
-import { Route, backerRoutes, maintainerRoutes } from '../Dashboard/navigation'
+import { Suspense } from 'react'
 import TopbarRight from './TopbarRight'
 
 export type LogoPosition = 'center' | 'left'
 
-const SubNav = (props: { items: (Route & { active: boolean })[] }) => {
-  return (
-    <div className="flex flex-row items-center gap-x-2 rounded-xl border border-gray-100 bg-gray-50 p-1 dark:border-gray-800 dark:bg-gray-800">
-      {props.items.map((item) => {
-        const className = classNames(
-          item.active
-            ? 'bg-white dark:bg-gray-900 shadow-lg text-gray-950 dark:text-gray-300 font-medium'
-            : 'text-gray-500 dark:gray-500 hover:text-gray-950 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800',
-          'dark-bg-900 flex flex-row rounded-lg px-4 py-2 text-xs transition-colors',
-        )
-
-        return (
-          <Link href={item.link} className={className}>
-            {item.title}
-          </Link>
-        )
-      })}
-    </div>
-  )
-}
-
-const Topbar = ({
-  hideProfile,
-  ...props
-}: {
+const Topbar = (props: {
   isFixed?: boolean
-  customLogoTitle?: string
+  logo?: {
+    title?: string
+    position?: LogoPosition
+  }
   hideProfile?: boolean
-  logoPosition?: LogoPosition
   useOrgFromURL: boolean
 }) => {
-  const { org: currentOrgFromURL, isLoaded } = useCurrentOrgAndRepoFromURL()
-
-  const useOrgFromURL = props.useOrgFromURL
-
-  const currentOrg = useMemo(() => {
-    return currentOrgFromURL && useOrgFromURL ? currentOrgFromURL : undefined
-  }, [currentOrgFromURL, useOrgFromURL])
-
-  const routes = currentOrg
-    ? maintainerRoutes(currentOrg, isLoaded)
-    : backerRoutes
-
-  const pathname = usePathname()
-
-  const [currentRoute] = routes.filter((route) =>
-    pathname?.startsWith(route.link),
+  const className = classNames(
+    props.isFixed !== false ? 'fixed z-20' : '',
+    'flex h-16 w-full items-center justify-between space-x-4 bg-white dark:bg-gray-800 px-4 drop-shadow dark:border-b dark:border-gray-700',
   )
 
-  const logoPosition: LogoPosition = props?.logoPosition || 'left'
+  const hideProfile = props?.hideProfile
 
-  const className = classNames(
-    props.isFixed !== false ? 'fixed z-20 left-0 top-0 right-0' : '',
-    'flex h-24 w-full items-center justify-between space-x-4 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800',
+  const logoPosition: LogoPosition = props?.logo?.position || 'left'
+
+  const logo = (
+    <>
+      <a
+        href="/"
+        className="flex-shrink-0 items-center space-x-2 font-semibold text-gray-700 md:inline-flex"
+      >
+        <LogoType />
+      </a>
+    </>
   )
 
   return (
     <>
       <div className={className}>
-        <div className="flex w-full flex-row items-center justify-between px-4 sm:px-6 md:px-12">
-          <div className="flex flex-row items-center gap-x-24">
-            <h3 className="text-xl font-medium dark:text-gray-300">
-              {currentRoute?.title}
-            </h3>
-            {currentRoute &&
-              'subs' in currentRoute &&
-              currentRoute.subs.length > 0 && (
-                <SubNav
-                  items={currentRoute.subs.map((sub) => ({
-                    ...sub,
-                    active: sub.link === pathname,
-                  }))}
-                />
-              )}
-          </div>
-          <div>
+        <div className="flex items-center space-x-4 md:flex-1">
+          {logoPosition === 'left' && !props.logo?.title && logo}
+          {logoPosition === 'left' && props.logo?.title && (
+            <>
+              <LogoIcon />
+              <span className="font-display text-xl">{props.logo?.title}</span>
+            </>
+          )}
+        </div>
+
+        {logoPosition == 'center' && !props.logo?.title && logo}
+        {logoPosition == 'center' && props.logo?.title && (
+          <>
+            <LogoIcon />
+            <span className="font-display text-xl">{props.logo?.title}</span>
+          </>
+        )}
+
+        <div className="flex flex-shrink-0 items-center justify-end space-x-4 md:flex-1">
+          {!hideProfile && (
             <Suspense>
               <TopbarRight useOrgFromURL={props.useOrgFromURL} />
             </Suspense>
-          </div>
+          )}
         </div>
-
-        {logoPosition == 'center' && props.customLogoTitle && (
-          <>
-            <LogoIcon />
-            <span className="font-display text-xl">
-              {props.customLogoTitle}
-            </span>
-          </>
-        )}
       </div>
     </>
   )

--- a/clients/apps/web/src/components/Shared/TopbarRight.tsx
+++ b/clients/apps/web/src/components/Shared/TopbarRight.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from '@/hooks'
 import Popover from '../Notifications/Popover'
 import GithubLoginButton from './GithubLoginButton'
+import ProfileSelection from './ProfileSelection'
 
 const TopbarRight = (props: { useOrgFromURL: boolean }) => {
   const { currentUser, hydrated } = useAuth()
@@ -14,6 +15,15 @@ const TopbarRight = (props: { useOrgFromURL: boolean }) => {
   return (
     <>
       {currentUser && <Popover />}
+      {currentUser && (
+        <div className="flex w-[280px] flex-row">
+          <ProfileSelection
+            showBackerLinks
+            useOrgFromURL={props.useOrgFromURL}
+            className="border border-gray-100 dark:border-gray-700"
+          />
+        </div>
+      )}
       {!currentUser && <GithubLoginButton text="Continue with GitHub" />}
     </>
   )

--- a/clients/apps/web/src/components/Shared/TopbarRight.tsx
+++ b/clients/apps/web/src/components/Shared/TopbarRight.tsx
@@ -3,7 +3,6 @@
 import { useAuth } from '@/hooks'
 import Popover from '../Notifications/Popover'
 import GithubLoginButton from './GithubLoginButton'
-import ProfileSelection from './ProfileSelection'
 
 const TopbarRight = (props: { useOrgFromURL: boolean }) => {
   const { currentUser, hydrated } = useAuth()
@@ -15,7 +14,6 @@ const TopbarRight = (props: { useOrgFromURL: boolean }) => {
   return (
     <>
       {currentUser && <Popover />}
-      {currentUser && <ProfileSelection useOrgFromURL={props.useOrgFromURL} />}
       {!currentUser && <GithubLoginButton text="Continue with GitHub" />}
     </>
   )

--- a/clients/apps/web/src/stories/Topbar.stories.tsx
+++ b/clients/apps/web/src/stories/Topbar.stories.tsx
@@ -23,7 +23,9 @@ export const LogoLeft: Story = {
     chromatic: { viewports: [390, 1200] },
   },
   args: {
-    logoPosition: 'left',
+    logo: {
+      position: 'left',
+    },
   },
 }
 
@@ -32,6 +34,8 @@ export const Custom: Story = {
     chromatic: { viewports: [390, 1200] },
   },
   args: {
-    customLogoTitle: 'Custom',
+    logo: {
+      title: 'Custom',
+    },
   },
 }

--- a/clients/apps/web/tailwind.config.js
+++ b/clients/apps/web/tailwind.config.js
@@ -62,6 +62,7 @@ module.exports = {
       boxShadow: {
         DEFAULT: '0 1px 8px rgb(0 0 0 / 0.07), 0 0.5px 2.5px rgb(0 0 0 / 0.16)',
         lg: '0 5px 17px rgba(0 0 0 / 0.15), 0 0px 3px rgba(0 0 0 / 0.12)',
+        xl: '0 0px 30px rgba(0 0 0 / 0.08), 0 0px 10px rgba(0 0 0 / 0.05)',
         hidden: '0 1px 8px rgb(0 0 0 / 0), 0 0.5px 2.5px rgb(0 0 0 / 0)',
         up: '-2px -2px 22px 0px rgba(61, 84, 171, 0.15)',
       },

--- a/clients/apps/web/tailwind.config.js
+++ b/clients/apps/web/tailwind.config.js
@@ -61,7 +61,7 @@ module.exports = {
       },
       boxShadow: {
         DEFAULT: '0 1px 8px rgb(0 0 0 / 0.07), 0 0.5px 2.5px rgb(0 0 0 / 0.16)',
-        lg: '0 5px 17px rgba(0 0 0 / 0.15), 0 0px 3px rgba(0 0 0 / 0.12)',
+        lg: '0 0px 17px rgba(0 0 0 / 0.15), 0 0px 3px rgba(0 0 0 / 0.08)',
         xl: '0 0px 30px rgba(0 0 0 / 0.08), 0 0px 10px rgba(0 0 0 / 0.05)',
         hidden: '0 1px 8px rgb(0 0 0 / 0), 0 0.5px 2.5px rgb(0 0 0 / 0)',
         up: '-2px -2px 22px 0px rgba(61, 84, 171, 0.15)',

--- a/clients/apps/web/tailwind.config.js
+++ b/clients/apps/web/tailwind.config.js
@@ -61,7 +61,7 @@ module.exports = {
       },
       boxShadow: {
         DEFAULT: '0 1px 8px rgb(0 0 0 / 0.07), 0 0.5px 2.5px rgb(0 0 0 / 0.16)',
-        lg: '0 0px 17px rgba(0 0 0 / 0.15), 0 0px 3px rgba(0 0 0 / 0.08)',
+        lg: '0 5px 17px rgba(0 0 0 / 0.15), 0 0px 3px rgba(0 0 0 / 0.12)',
         xl: '0 0px 30px rgba(0 0 0 / 0.08), 0 0px 10px rgba(0 0 0 / 0.05)',
         hidden: '0 1px 8px rgb(0 0 0 / 0), 0 0.5px 2.5px rgb(0 0 0 / 0)',
         up: '-2px -2px 22px 0px rgba(61, 84, 171, 0.15)',

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -108,9 +108,21 @@ importers:
 
   apps/web:
     dependencies:
+      '@emotion/react':
+        specifier: ^11.11.1
+        version: 11.11.1(@types/react@18.2.21)(react@18.2.0)
+      '@emotion/styled':
+        specifier: ^11.11.0
+        version: 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.21)(react@18.2.0)
       '@heroicons/react':
         specifier: ^2.0.16
         version: 2.0.16(react@18.2.0)
+      '@mui/icons-material':
+        specifier: ^5.14.12
+        version: 5.14.12(@mui/material@5.14.12)(@types/react@18.2.21)(react@18.2.0)
+      '@mui/material':
+        specifier: ^5.14.12
+        version: 5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.5
         version: 2.0.5(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -764,7 +776,7 @@ packages:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.10
+      '@babel/types': 7.22.11
 
   /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.11):
     resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
@@ -2890,6 +2902,12 @@ packages:
     dependencies:
       regenerator-runtime: 0.14.0
 
+  /@babel/runtime@7.23.1:
+    resolution: {integrity: sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
@@ -2991,6 +3009,36 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
+  /@emotion/babel-plugin@11.11.0:
+    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
+    dependencies:
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/runtime': 7.23.1
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/serialize': 1.1.2
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    dev: false
+
+  /@emotion/cache@11.11.0:
+    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+      '@emotion/sheet': 1.2.2
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      stylis: 4.2.0
+    dev: false
+
+  /@emotion/hash@0.9.1:
+    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+    dev: false
+
   /@emotion/is-prop-valid@0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
     requiresBuild: true
@@ -2999,11 +3047,81 @@ packages:
     dev: false
     optional: true
 
+  /@emotion/is-prop-valid@1.2.1:
+    resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+    dev: false
+
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
     requiresBuild: true
     dev: false
     optional: true
+
+  /@emotion/memoize@0.8.1:
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+    dev: false
+
+  /@emotion/react@11.11.1(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/cache': 11.11.0
+      '@emotion/serialize': 1.1.2
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      '@types/react': 18.2.21
+      hoist-non-react-statics: 3.3.2
+      react: 18.2.0
+    dev: false
+
+  /@emotion/serialize@1.1.2:
+    resolution: {integrity: sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==}
+    dependencies:
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/unitless': 0.8.1
+      '@emotion/utils': 1.2.1
+      csstype: 3.1.2
+    dev: false
+
+  /@emotion/sheet@1.2.2:
+    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
+    dev: false
+
+  /@emotion/styled@11.11.0(@emotion/react@11.11.1)(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/is-prop-valid': 1.2.1
+      '@emotion/react': 11.11.1(@types/react@18.2.21)(react@18.2.0)
+      '@emotion/serialize': 1.1.2
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@emotion/utils': 1.2.1
+      '@types/react': 18.2.21
+      react: 18.2.0
+    dev: false
+
+  /@emotion/unitless@0.8.1:
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+    dev: false
 
   /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0):
     resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
@@ -3011,7 +3129,14 @@ packages:
       react: '>=16.8.0'
     dependencies:
       react: 18.2.0
-    dev: true
+
+  /@emotion/utils@1.2.1:
+    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
+    dev: false
+
+  /@emotion/weak-memoize@0.3.1:
+    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
+    dev: false
 
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
@@ -3290,6 +3415,17 @@ packages:
       '@floating-ui/dom': 1.5.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  /@floating-ui/react-dom@2.0.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /@floating-ui/utils@0.1.1:
     resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
@@ -3644,6 +3780,184 @@ packages:
       react: 18.2.0
     dev: true
 
+  /@mui/base@5.0.0-beta.18(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-e9ZCy/ndhyt5MTshAS3qAUy/40UiO0jX+kAo6a+XirrPJE+rrQW+mKPSI0uyp+5z4Vh+z0pvNoJ2S2gSrNz3BQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@floating-ui/react-dom': 2.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@mui/types': 7.2.5(@types/react@18.2.21)
+      '@mui/utils': 5.14.12(@types/react@18.2.21)(react@18.2.0)
+      '@popperjs/core': 2.11.8
+      '@types/react': 18.2.21
+      clsx: 2.0.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@mui/core-downloads-tracker@5.14.12:
+    resolution: {integrity: sha512-WZhCkKqhrXaSVBzoC6LNcVkIawS000OOt7gmnp4g9HhyvN0PSclRXc/JrkC7EwfzUAZJh+hiK2LaVsbtOpNuOg==}
+    dev: false
+
+  /@mui/icons-material@5.14.12(@mui/material@5.14.12)(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-aFm6g/AIB3RQN9h/4MKoBoBybLZXeR3aDHWNx6KzemEpIlElUxv5uXRX5Qk1VC6v/YPkhbaPsiLLjsRSTiZF3w==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@mui/material': ^5.0.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@mui/material': 5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.21
+      react: 18.2.0
+    dev: false
+
+  /@mui/material@5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-EelF2L46VcVqhg3KjzIGBBpOtcBgRh0MMy9Efuk6Do81QdcZsFC9RebCVAflo5jIdbHiBmxBs5/l5Q9NjONozg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@emotion/react': 11.11.1(@types/react@18.2.21)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.21)(react@18.2.0)
+      '@mui/base': 5.0.0-beta.18(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/core-downloads-tracker': 5.14.12
+      '@mui/system': 5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.21)(react@18.2.0)
+      '@mui/types': 7.2.5(@types/react@18.2.21)
+      '@mui/utils': 5.14.12(@types/react@18.2.21)(react@18.2.0)
+      '@types/react': 18.2.21
+      '@types/react-transition-group': 4.4.7
+      clsx: 2.0.0
+      csstype: 3.1.2
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.2.0
+      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+    dev: false
+
+  /@mui/private-theming@5.14.12(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-TWwm+9+BgHFpoR3w04FG+IqID4ALa74A27RuKq2CEaWgxliBZB24EVeI6djfjFt5t4FYmIb8BMw2ZJEir7YjLQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@mui/utils': 5.14.12(@types/react@18.2.21)(react@18.2.0)
+      '@types/react': 18.2.21
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/styled-engine@5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0):
+    resolution: {integrity: sha512-bocxt1nDmXfB3gpLfCCmFCyJ7sVmscFs+PuheO210QagZwHVp47UIRT1AiswLDYSQo1ZqmVGn7KLEJEYK0d4Xw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.1(@types/react@18.2.21)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.21)(react@18.2.0)
+      csstype: 3.1.2
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/system@5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-6DXfjjLhW0/ia5qU3Crke7j+MnfDbMBOHlLIrqbrEqNs0AuSBv8pXniEGb+kqO0H804NJreRTEJRjCngwOX5CA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@emotion/react': 11.11.1(@types/react@18.2.21)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.21)(react@18.2.0)
+      '@mui/private-theming': 5.14.12(@types/react@18.2.21)(react@18.2.0)
+      '@mui/styled-engine': 5.14.12(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
+      '@mui/types': 7.2.5(@types/react@18.2.21)
+      '@mui/utils': 5.14.12(@types/react@18.2.21)(react@18.2.0)
+      '@types/react': 18.2.21
+      clsx: 2.0.0
+      csstype: 3.1.2
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/types@7.2.5(@types/react@18.2.21):
+    resolution: {integrity: sha512-S2BwfNczr7VwS6ki8GoAXJyARoeSJDLuxOEPs3vEMyTALlf9PrdHv+sluX7kk3iKrCg/ML2mIWwapZvWbkMCQA==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.21
+    dev: false
+
+  /@mui/utils@5.14.12(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-RFNXnhKQlzIkIUig6mmv0r5VbtjPdWoaBPYicq25LETdZux59HAqoRdWw15T7lp3c7gXOoE8y67+hTB8C64m2g==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@types/prop-types': 15.7.8
+      '@types/react': 18.2.21
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-is: 18.2.0
+    dev: false
+
   /@ndelangen/get-tarball@3.0.7:
     resolution: {integrity: sha512-NqGfTZIZpRFef1GoVaShSSRwDC3vde3ThtTeqFdcYd6ipKqnfEVhjK2hUeHjCQUcptyZr2TONqcloFXM+5QBrQ==}
     dependencies:
@@ -3814,10 +4128,14 @@ packages:
       webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.18.20)
     dev: true
 
+  /@popperjs/core@2.11.8:
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+    dev: false
+
   /@radix-ui/number@1.0.1:
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
 
   /@radix-ui/primitive@1.0.0:
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
@@ -3836,7 +4154,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -3855,7 +4173,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -3918,7 +4236,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -3933,7 +4251,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       react: 18.2.0
     dev: false
 
@@ -3946,7 +4264,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -3955,7 +4273,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       react: 18.2.0
     dev: false
 
@@ -3968,7 +4286,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -4008,7 +4326,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -4018,7 +4336,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -4057,7 +4375,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -4100,7 +4418,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       react: 18.2.0
     dev: false
 
@@ -4113,7 +4431,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -4123,7 +4441,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
@@ -4137,7 +4455,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
@@ -4158,7 +4476,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.21)(react@18.2.0)
@@ -4172,7 +4490,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -4263,7 +4581,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@floating-ui/react-dom': 0.7.2(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.2(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
@@ -4293,7 +4611,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@floating-ui/react-dom': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
@@ -4315,7 +4633,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -4346,7 +4664,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -4379,7 +4697,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@types/react': 18.2.21
@@ -4394,7 +4712,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-slot': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -4406,7 +4724,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -4425,7 +4743,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.21)(react@18.2.0)
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -4445,7 +4763,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
@@ -4513,7 +4831,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -4526,7 +4844,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -4536,7 +4854,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -4550,7 +4868,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@types/react': 18.2.21
       react: 18.2.0
@@ -4646,7 +4964,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-direction': 1.0.1(@types/react@18.2.21)(react@18.2.0)
@@ -4673,7 +4991,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.21)(react@18.2.0)
@@ -4696,7 +5014,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-direction': 1.0.1(@types/react@18.2.21)(react@18.2.0)
@@ -4728,7 +5046,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -4751,7 +5069,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@types/react': 18.2.21
       react: 18.2.0
@@ -4761,7 +5079,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -4771,7 +5089,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -4785,7 +5103,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@types/react': 18.2.21
       react: 18.2.0
@@ -4808,7 +5126,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -4821,7 +5139,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/react': 18.2.21
       react: 18.2.0
 
@@ -4830,7 +5148,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/rect': 1.0.0
       react: 18.2.0
     dev: false
@@ -4844,7 +5162,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/rect': 1.0.1
       '@types/react': 18.2.21
       react: 18.2.0
@@ -4854,7 +5172,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -4868,7 +5186,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@types/react': 18.2.21
       react: 18.2.0
@@ -4898,7 +5216,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -4908,13 +5226,13 @@ packages:
   /@radix-ui/rect@1.0.0:
     resolution: {integrity: sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
     dev: false
 
   /@radix-ui/rect@1.0.1:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
 
   /@resvg/resvg-wasm@2.4.1:
     resolution: {integrity: sha512-yi6R0HyHtsoWTRA06Col4WoDs7SvlXU3DLMNP2bdAgs7HK18dTEVl1weXgxRzi8gwLteGUbIg29zulxIB3GSdg==}
@@ -7073,7 +7391,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -7117,7 +7435,7 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.11
       '@testing-library/dom': 8.20.0
     dev: true
 
@@ -7411,7 +7729,6 @@ packages:
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-    dev: true
 
   /@types/pretty-hrtime@1.0.1:
     resolution: {integrity: sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==}
@@ -7419,6 +7736,10 @@ packages:
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+
+  /@types/prop-types@15.7.8:
+    resolution: {integrity: sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ==}
+    dev: false
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -7442,6 +7763,12 @@ packages:
     dependencies:
       '@types/react': 18.2.21
     dev: true
+
+  /@types/react-transition-group@4.4.7:
+    resolution: {integrity: sha512-ICCyBl5mvyqYp8Qeq9B5G/fyBSRC0zx3XM3sCC6KkcMsNeAHqXBKkmat4GqdJET5jtYUpZXrxI5flve5qhi2Eg==}
+    dependencies:
+      '@types/react': 18.2.21
+    dev: false
 
   /@types/react@18.2.21:
     resolution: {integrity: sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==}
@@ -8440,6 +8767,15 @@ packages:
       '@types/babel__core': 7.20.1
       '@types/babel__traverse': 7.20.1
 
+  /babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+    dependencies:
+      '@babel/runtime': 7.23.1
+      cosmiconfig: 7.1.0
+      resolve: 1.22.2
+    dev: false
+
   /babel-plugin-named-exports-order@0.0.2:
     resolution: {integrity: sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==}
     dev: true
@@ -9117,6 +9453,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /cmdk@0.2.0(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JQpKvEOb86SnvMZbYaFKYhvzFntWBeSZdyii0rZPhKJj9uwJBxu4DaVYDrRN7r3mPop56oPhRw+JYWTKs66TYw==}
     peerDependencies:
@@ -9309,7 +9650,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
-    dev: true
 
   /cosmiconfig@8.1.3:
     resolution: {integrity: sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==}
@@ -9767,6 +10107,13 @@ packages:
     dependencies:
       utila: 0.4.0
     dev: true
+
+  /dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.23.1
+      csstype: 3.1.2
+    dev: false
 
   /dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -10970,6 +11317,10 @@ packages:
       make-dir: 3.1.0
       pkg-dir: 4.2.0
     dev: true
+
+  /find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+    dev: false
 
   /find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -14255,7 +14606,7 @@ packages:
     dependencies:
       '@jest/schemas': 29.6.0
       ansi-styles: 5.2.0
-      react-is: 18.1.0
+      react-is: 18.2.0
 
   /pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
@@ -14497,7 +14848,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.11
       '@babel/generator': 7.22.10
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
       ast-types: 0.14.2
       commander: 2.20.3
       doctrine: 3.0.0
@@ -14578,6 +14929,10 @@ packages:
 
   /react-is@18.1.0:
     resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}
+    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
   /react-refresh@0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
@@ -14658,6 +15013,20 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
+    dev: false
+
+  /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.23.1
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-universal-interface@0.6.2(react@18.2.0)(tslib@2.5.0):
@@ -14818,7 +15187,7 @@ packages:
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
     dev: true
 
   /regex-parser@2.2.11:
@@ -15031,7 +15400,7 @@ packages:
   /rtl-css-js@1.16.1:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.1
     dev: false
 
   /run-parallel@1.2.0:
@@ -15403,6 +15772,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -15734,6 +16108,10 @@ packages:
 
   /stylis@4.1.3:
     resolution: {integrity: sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==}
+    dev: false
+
+  /stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
     dev: false
 
   /sucrase@3.32.0:
@@ -17171,7 +17549,6 @@ packages:
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: true
 
   /yaml@2.3.1:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}


### PR DESCRIPTION
Implements new design of the Backer & Maintainer dashboard layouts #1392.

- New Sidebar with integrated profile selection
- Subroutes now lives in the secondary nav (the page header) along with the page name
- Public topbar still has the old logic with profile selection, etc
- Updated iconography