### PR TITLE
server: migrate away from union types

### DIFF
--- a/server/polar/notifications/schemas.py
+++ b/server/polar/notifications/schemas.py
@@ -3,6 +3,8 @@ from enum import Enum
 from typing import Self, Union
 from uuid import UUID
 
+from pydantic import Field
+
 from polar.kit.schemas import Schema
 from polar.notifications.notification import (
     MaintainerPledgeConfirmationPendingNotification,
@@ -41,6 +43,7 @@ class NotificationRead(Schema):
     id: UUID
     type: NotificationType
     created_at: datetime
+
     payload: Union[
         MaintainerPledgePaidNotification,
         MaintainerPledgeConfirmationPendingNotification,
@@ -50,7 +53,22 @@ class NotificationRead(Schema):
         RewardPaidNotification,
         MaintainerPledgedIssueConfirmationPendingNotification,
         MaintainerPledgedIssuePendingNotification,
-    ]
+    ] = Field(deprecated=True)
+
+    maintainerPledgePaid: MaintainerPledgePaidNotification | None = None
+    maintainerPledgeConfirmationPending: MaintainerPledgeConfirmationPendingNotification | None = (  # noqa: E501
+        None
+    )
+    maintainerPledgePending: MaintainerPledgePendingNotification | None = None
+    maintainerPledgeCreated: MaintainerPledgeCreatedNotification | None = None
+    pledgerPledgePending: PledgerPledgePendingNotification | None = None
+    rewardPaid: RewardPaidNotification | None = None
+    maintainerPledgedIssueConfirmationPending: MaintainerPledgedIssueConfirmationPendingNotification | None = (  # noqa: E501
+        None
+    )
+    maintainerPledgedIssuePending: MaintainerPledgedIssuePendingNotification | None = (
+        None
+    )
 
 
 class NotificationsList(Schema):


### PR DESCRIPTION
Support for unions/anyOf is not the greatest in OpenAPI. The spec supports it fine, but not all generators (and target languages) do. In particular, the generator that I'm planning to introduce in #1405 does not support unions types.

This PR deprecates the union types, and adds the fields from the union as fields on the parent object instead. This honestly makes the generated code soo much nicer to work with, even if it doesn't use unions.