### PR TITLE
clients/badge: tweak rewards for long org names

### DIFF
--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -373,34 +373,31 @@ export const Badge = ({
             }}
           >
             <Heart />
+
+            <div
+              style={{
+                alignItems: 'center',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+                fontWeight: 'bold',
+              }}
+            >
+              {`@${orgName}`}
+            </div>
+
             <div
               style={{
                 flexGrow: 1,
                 display: 'flex',
                 alignItems: 'center',
-                gap: '1px',
                 overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                marginLeft: '-5px',
               }}
             >
-              <div
-                style={{
-                  fontWeight: 'bold',
-                  display: 'flex',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                @{orgName}&nbsp;
-              </div>
-              <div
-                style={{
-                  display: 'flex',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                }}
-              >
-                rewards contributors {upfront_split_to_contributors}% of
-                received funds
-              </div>
+              {`rewards contributors ${upfront_split_to_contributors}% of received
+              funds`}
             </div>
             <div
               style={{


### PR DESCRIPTION
Handle overflows in the rewards banner in the Badge SVG.

Overflow with ellipsis instead of overflowing.

#### Before

<img width="738" alt="Screenshot 2023-10-11 at 15 28 37" src="https://github.com/polarsource/polar/assets/47952/cc7610de-c61e-4da4-914c-69e29eed9527">


#### After

<img width="1696" alt="Screenshot 2023-10-11 at 15 24 58" src="https://github.com/polarsource/polar/assets/47952/3dc36aa3-25d0-417e-8517-dca138afcf88">
<img width="1651" alt="Screenshot 2023-10-11 at 15 25 45" src="https://github.com/polarsource/polar/assets/47952/646beed1-d372-4158-a0dc-01388c1622c9">
