### PR TITLE
server/auth: remove data loader and authorisation helpers

### DIFF
--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -1,15 +1,12 @@
 from enum import Enum, auto
 from typing import Annotated, Self
-from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from polar.authz.service import Anonymous, Subject
 from polar.config import settings
-from polar.enums import Platforms
-from polar.models import Organization, Repository, User
-from polar.organization.service import organization as organization_service
+from polar.models import User
 from polar.postgres import AsyncSession, get_db_session
 
 from .service import AuthService
@@ -73,32 +70,10 @@ class Auth:
         subject: Subject,
         user: User | None = None,
         auth_method: AuthMethod | None = None,
-        organization: Organization | None = None,
-        repository: Repository | None = None,
     ):
         self.subject = subject
         self.user = user
         self.auth_method = auth_method
-        self._organization = organization
-        self._repository = repository
-
-    @property
-    def organization(self) -> Organization:
-        if self._organization:
-            return self._organization
-
-        raise AttributeError(
-            "No organization set. Use Auth.current_user_with_org_access()."
-        )
-
-    @property
-    def repository(self) -> Repository:
-        if self._repository:
-            return self._repository
-
-        raise AttributeError(
-            "No repository set. Use Auth.current_user_with_org_and_repo_access()."
-        )
 
     ###############################################################################
     # FastAPI dependency methods
@@ -123,78 +98,6 @@ class Auth:
             return cls(subject=user, user=user, auth_method=auth_method)
         else:
             return cls(subject=Anonymous())
-
-    @classmethod
-    async def user_with_org_access(
-        cls,
-        *,
-        platform: Platforms,
-        org_name: str,
-        session: AsyncSession = Depends(get_db_session),
-        user_auth_method: tuple[User, AuthMethod] = Depends(_current_user_required),
-    ) -> Self:
-        user, auth_method = user_auth_method
-        organization = await organization_service.get_for_user(
-            session,
-            platform=platform,
-            org_name=org_name,
-            user_id=user.id,
-        )
-        if not organization:
-            raise HTTPException(
-                status_code=404, detail="Organization not found for user"
-            )
-        return cls(
-            subject=user, user=user, auth_method=auth_method, organization=organization
-        )
-
-    @classmethod
-    async def user_with_org_access_by_id(
-        cls,
-        *,
-        id: UUID,
-        session: AsyncSession = Depends(get_db_session),
-        user_auth_method: tuple[User, AuthMethod] = Depends(_current_user_required),
-    ) -> Self:
-        user, auth_method = user_auth_method
-        organization = await organization_service.get_by_id_for_user(
-            session,
-            org_id=id,
-            user_id=user.id,
-        )
-        if not organization:
-            raise HTTPException(
-                status_code=404, detail="Organization not found for user"
-            )
-        return cls(
-            subject=user, user=user, auth_method=auth_method, organization=organization
-        )
-
-    @classmethod
-    async def user_with_org_and_repo_access(
-        cls,
-        *,
-        platform: Platforms,
-        org_name: str,
-        repo_name: str,
-        session: AsyncSession = Depends(get_db_session),
-        user_auth_method: tuple[User, AuthMethod] = Depends(_current_user_required),
-    ) -> Self:
-        user, auth_method = user_auth_method
-        org, repo = await organization_service.get_with_repo_for_user(
-            session,
-            platform=platform,
-            org_name=org_name,
-            repo_name=repo_name,
-            user_id=user.id,
-        )
-        return cls(
-            subject=user,
-            user=user,
-            auth_method=auth_method,
-            organization=org,
-            repository=repo,
-        )
 
     @classmethod
     async def backoffice_user(

--- a/server/tests/dashboard/test_endpoints.py
+++ b/server/tests/dashboard/test_endpoints.py
@@ -59,7 +59,7 @@ async def test_get_no_member(
         cookies={settings.AUTH_COOKIE_KEY: auth_jwt},
     )
 
-    assert response.status_code == 404
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Removes the last few use cases of `Auth.user_with_org_access` and `Auth.user_with_org_and_repo_access`.

The authentication library now only does authentication. Authorization and data loading is done else where, like in the `Authz` library.