### PR TITLE
Use publish branch option when pushing new version of SDK to NPM

### DIFF
--- a/.github/workflows/publish_sdk.yaml
+++ b/.github/workflows/publish_sdk.yaml
@@ -30,6 +30,6 @@ jobs:
 
         - name: Publish SDK
           working-directory: ./clients/packages/sdk
-          run: pnpm publish
+          run: pnpm publish --publish-branch main
           env:
             NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use --publish-branch option when pushing new version of SDK to NPM.