### PR TITLE
server/dashboard: related resources without JSON:API

### DIFF
--- a/server/polar/funding/schemas.py
+++ b/server/polar/funding/schemas.py
@@ -1,11 +1,13 @@
+from decimal import Decimal
 from typing import Self, cast
 
 from polar.currency.schemas import CurrencyAmount
 from polar.issue.schemas import Issue
 from polar.kit.schemas import Schema
+from polar.models import Issue as IssueModel
 from polar.pledge.schemas import Pledger, PledgeType
 
-from .service import FundingResultType
+FundingResultType = tuple[IssueModel, Decimal, Decimal, Decimal, Decimal]
 
 
 # Public API

--- a/server/polar/funding/service.py
+++ b/server/polar/funding/service.py
@@ -8,6 +8,7 @@ from sqlalchemy import Select, UnaryExpression, and_, desc, func, or_, select, t
 from sqlalchemy.orm import contains_eager
 
 from polar.authz.service import Anonymous, Subject
+from polar.funding.schemas import FundingResultType
 from polar.kit.pagination import PaginationParams, paginate
 from polar.models import Issue, Organization, Pledge, Repository, UserOrganization
 from polar.pledge.schemas import PledgeState, PledgeType
@@ -19,9 +20,6 @@ class ListFundingSortBy(StrEnum):
     newest = "newest"
     most_funded = "most_funded"
     most_engagement = "most_engagement"
-
-
-FundingResultType = tuple[Issue, Decimal, Decimal, Decimal, Decimal]
 
 
 class FundingService:

--- a/server/tests/funding/test_service.py
+++ b/server/tests/funding/test_service.py
@@ -3,7 +3,8 @@ import uuid
 import pytest
 
 from polar.authz.service import Anonymous
-from polar.funding.service import FundingResultType, ListFundingSortBy
+from polar.funding.schemas import FundingResultType
+from polar.funding.service import ListFundingSortBy
 from polar.funding.service import funding as funding_service
 from polar.kit.pagination import PaginationParams
 from polar.models import Issue, Organization, Pledge, User, UserOrganization


### PR DESCRIPTION
Moving away from JSON:API to get better type safety, and to align the design of this API with our other APIs.

First step is to add all related resources to the issue object without affecting the existing response.

After this is done, we can switch the clients to remove JSON:API parsing, and then finally remove it from the backend.