### PR TITLE
server/auth: set auth cookie domain

### DIFF
--- a/server/.env.testing
+++ b/server/.env.testing
@@ -12,6 +12,7 @@ POLAR_GITHUB_CLIENT_ID="Iv1.fakefakefake"
 POLAR_GITHUB_CLIENT_SECRET="fakefakefakefakefakefakefakefakefakefake"
 
 POLAR_CORS_ORIGINS='["http://127.0.0.1:3000", "http://localhost:3000", "http://test"]'
+POLAR_AUTH_COOKIE_DOMAIN="test"
 
 POLAR_DEBUG="false"
 POLAR_TESTING=1

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -48,7 +48,7 @@ class AuthService:
             value=value,
             expires=expires,
             path="/",
-            domain=None,
+            domain=settings.AUTH_COOKIE_DOMAIN,
             secure=secure,
             httponly=True,
             samesite="lax",

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     # Auth cookie
     AUTH_COOKIE_KEY: str = "polar"
     AUTH_COOKIE_TTL_SECONDS: int = 60 * 60 * 24 * 31  # 31 days
+    AUTH_COOKIE_DOMAIN: str = "127.0.0.1"
 
     # Magic link
     MAGIC_LINK_TTL_SECONDS: int = 60 * 30  # 30 minutes


### PR DESCRIPTION
It allows us to set a root domain as cookie domain.
This way, we can forward the cookie to Next.js Server that'll proxy it towards the API.