### PR TITLE
Sync non-admin memberships

### DIFF
--- a/clients/apps/web/src/app/maintainer/page.tsx
+++ b/clients/apps/web/src/app/maintainer/page.tsx
@@ -4,12 +4,12 @@ import LoadingScreen from '@/components/Dashboard/LoadingScreen'
 import { useAuth } from '@/hooks'
 import { useRouter } from 'next/navigation'
 import { CONFIG } from 'polarkit/config'
-import { useListOrganizations } from 'polarkit/hooks'
+import { useListAdminOrganizations } from 'polarkit/hooks'
 import { useEffect } from 'react'
 
 export default function Page() {
   const { authenticated, hasChecked } = useAuth()
-  const listOrganizationsQuery = useListOrganizations()
+  const listOrganizationsQuery = useListAdminOrganizations()
 
   const router = useRouter()
   const orgs = listOrganizationsQuery?.data?.items

--- a/clients/apps/web/src/components/Auth/Redirector.tsx
+++ b/clients/apps/web/src/components/Auth/Redirector.tsx
@@ -3,12 +3,12 @@
 import LoadingScreen from '@/components/Dashboard/LoadingScreen'
 import { useAuth } from '@/hooks/auth'
 import { useRouter } from 'next/navigation'
-import { useListOrganizations } from 'polarkit/hooks'
+import { useListAdminOrganizations } from 'polarkit/hooks'
 import { useEffect } from 'react'
 
 export const useLoginRedirect = () => {
   const { currentUser, hasChecked } = useAuth()
-  const listOrganizationsQuery = useListOrganizations()
+  const listOrganizationsQuery = useListAdminOrganizations()
   const router = useRouter()
   const orgs = listOrganizationsQuery?.data?.items
 

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -5,7 +5,7 @@ import { Repository } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { CONFIG } from 'polarkit'
 import { LogoType } from 'polarkit/components/brand'
-import { useListOrganizations } from 'polarkit/hooks'
+import { useListAdminOrganizations } from 'polarkit/hooks'
 import { classNames } from 'polarkit/utils'
 import { Suspense } from 'react'
 import SidebarNavigation from '../Dashboard/MaintainerNavigation'
@@ -16,7 +16,7 @@ import ProfileSelection from '../Shared/ProfileSelection'
 const DashboardLayout = (props: { children: React.ReactNode }) => {
   const { currentUser, hydrated } = useAuth()
 
-  const listOrganizationQuery = useListOrganizations()
+  const listOrganizationQuery = useListAdminOrganizations()
 
   const orgs = listOrganizationQuery?.data?.items
   const showConnectUsell = orgs && orgs.length === 0

--- a/clients/apps/web/src/components/Pledge/OnBehalfOf.tsx
+++ b/clients/apps/web/src/components/Pledge/OnBehalfOf.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from 'polarkit/components/ui/select'
-import { useListOrganizations } from 'polarkit/hooks'
+import { useListAllOrganizations } from 'polarkit/hooks'
 import { useState } from 'react'
 
 const OnBehalfOf = ({
@@ -22,7 +22,7 @@ const OnBehalfOf = ({
     Organization | undefined
   >(undefined)
 
-  const organizations = useListOrganizations()
+  const organizations = useListAllOrganizations()
 
   const canAttributeAsOrganizations = (organizations.data?.items || []).filter(
     (o) => o.name !== currentUser?.username,

--- a/clients/apps/web/src/components/Shared/ProfileSelection.tsx
+++ b/clients/apps/web/src/components/Shared/ProfileSelection.tsx
@@ -4,7 +4,7 @@ import { AddOutlined, InfoOutlined, LogoutOutlined } from '@mui/icons-material'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { CONFIG } from 'polarkit/config'
-import { useListOrganizations } from 'polarkit/hooks'
+import { useListAdminOrganizations } from 'polarkit/hooks'
 import { classNames, clsx, useOutsideClick } from 'polarkit/utils'
 import React, { useMemo, useRef, useState } from 'react'
 import { useAuth } from '../../hooks'
@@ -21,7 +21,7 @@ const ProfileSelection = ({
     className,
   )
   const { currentUser: loggedUser, logout } = useAuth()
-  const listOrganizationQuery = useListOrganizations()
+  const listOrganizationQuery = useListAdminOrganizations()
 
   const [isOpen, setOpen] = useState<boolean>(false)
 

--- a/clients/apps/web/src/hooks/org.ts
+++ b/clients/apps/web/src/hooks/org.ts
@@ -2,7 +2,7 @@
 
 import type { Organization, Repository } from '@polar-sh/sdk'
 import { useParams, useSearchParams } from 'next/navigation'
-import { useListOrganizations, useListRepositories } from 'polarkit/hooks'
+import { useListAdminOrganizations, useListRepositories } from 'polarkit/hooks'
 import { useStore } from 'polarkit/store'
 import { useEffect, useState } from 'react'
 
@@ -21,7 +21,7 @@ export const useCurrentOrgAndRepoFromURL = (): {
   const search = useSearchParams()
   const searchRepo = search?.get('repo')
 
-  const listOrganizationsQuery = useListOrganizations()
+  const listOrganizationsQuery = useListAdminOrganizations()
   const listRepositoriesQuery = useListRepositories()
 
   const [org, setOrg] = useState<Organization | undefined>(undefined)

--- a/clients/packages/sdk/src/client/apis/OrganizationsApi.ts
+++ b/clients/packages/sdk/src/client/apis/OrganizationsApi.ts
@@ -32,6 +32,10 @@ export interface OrganizationsApiGetBadgeSettingsRequest {
     id: string;
 }
 
+export interface OrganizationsApiListRequest {
+    isAdminOnly?: boolean;
+}
+
 export interface OrganizationsApiLookupRequest {
     platform?: Platforms;
     organizationName?: string;
@@ -139,8 +143,12 @@ export class OrganizationsApi extends runtime.BaseAPI {
      * List organizations that the authenticated user is a member of. Requires authentication.
      * List organizations (Public API)
      */
-    async listRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListResourceOrganization>> {
+    async listRaw(requestParameters: OrganizationsApiListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListResourceOrganization>> {
         const queryParameters: any = {};
+
+        if (requestParameters.isAdminOnly !== undefined) {
+            queryParameters['is_admin_only'] = requestParameters.isAdminOnly;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -166,8 +174,8 @@ export class OrganizationsApi extends runtime.BaseAPI {
      * List organizations that the authenticated user is a member of. Requires authentication.
      * List organizations (Public API)
      */
-    async list(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListResourceOrganization> {
-        const response = await this.listRaw(initOverrides);
+    async list(requestParameters: OrganizationsApiListRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListResourceOrganization> {
+        const response = await this.listRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/clients/packages/sdk/src/client/apis/RepositoriesApi.ts
+++ b/clients/packages/sdk/src/client/apis/RepositoriesApi.ts
@@ -83,7 +83,7 @@ export class RepositoriesApi extends runtime.BaseAPI {
     }
 
     /**
-     * List repositories in organizations that the authenticated user is a member of. Requires authentication.
+     * List repositories in organizations that the authenticated user is a admin of. Requires authentication.
      * List repositories (Public API)
      */
     async listRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListResourceRepository>> {
@@ -110,7 +110,7 @@ export class RepositoriesApi extends runtime.BaseAPI {
     }
 
     /**
-     * List repositories in organizations that the authenticated user is a member of. Requires authentication.
+     * List repositories in organizations that the authenticated user is a admin of. Requires authentication.
      * List repositories (Public API)
      */
     async list(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListResourceRepository> {

--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -152,7 +152,7 @@ async def repositories_changed(
             session, event.sender.id
         )
         if sender:
-            await service.github_user.sync_github_admin_orgs(session, user=sender)
+            await service.github_user.sync_github_orgs(session, user=sender)
 
         # send after members have been added
         await organization_upserted.call(OrganizationHook(session, org))

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -45,7 +45,10 @@ class OrganizationService(
         return await self.get_by(session, platform=platform, name=name)
 
     async def list_all_orgs_by_user_id(
-        self, session: AsyncSession, user_id: UUID
+        self,
+        session: AsyncSession,
+        user_id: UUID,
+        is_admin_only: bool,
     ) -> Sequence[Organization]:
         statement = (
             sql.select(Organization)
@@ -55,6 +58,10 @@ class OrganizationService(
                 Organization.deleted_at.is_(None),
             )
         )
+
+        if is_admin_only:
+            statement = statement.where(UserOrganization.is_admin.is_(True))
+
         res = await session.execute(statement)
         return res.scalars().unique().all()
 

--- a/server/polar/repository/endpoints.py
+++ b/server/polar/repository/endpoints.py
@@ -25,7 +25,7 @@ router = APIRouter(tags=["repositories"])
     "/repositories",
     response_model=ListResource[RepositorySchema],
     tags=[Tags.PUBLIC],
-    description="List repositories in organizations that the authenticated user is a member of. Requires authentication.",  # noqa: E501
+    description="List repositories in organizations that the authenticated user is a admin of. Requires authentication.",  # noqa: E501
     summary="List repositories (Public API)",
     status_code=200,
 )
@@ -33,7 +33,12 @@ async def list(
     auth: UserRequiredAuth,
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[RepositorySchema]:
-    orgs = await organization_service.list_all_orgs_by_user_id(session, auth.user.id)
+    orgs = await organization_service.list_all_orgs_by_user_id(
+        session,
+        auth.user.id,
+        is_admin_only=True,
+    )
+
     repos = await repository.list_by(
         session, org_ids=[o.id for o in orgs], load_organization=True
     )


### PR DESCRIPTION
* Syncs non-admin memberships, and marks them as `is_admin=False`
* Updates the organization listing API to allow filtering by admin status.
* Use admin-only filtering everywhere where we previously listed organisations, and all-orgs listing in `<OnBehalfOf />`-pledging.