### PR TITLE
Remove Poppins from Tailwind config

### DIFF
--- a/clients/apps/web/src/app/layout.tsx
+++ b/clients/apps/web/src/app/layout.tsx
@@ -45,17 +45,12 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
           crossOrigin={''}
         />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Poppins:wght@400&display=swap"
-          rel="stylesheet"
-        ></link>
         <link href="/favicon.png" rel="icon"></link>
       </head>
 

--- a/clients/apps/web/tailwind.config.js
+++ b/clients/apps/web/tailwind.config.js
@@ -68,7 +68,6 @@ module.exports = {
       },
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
-        display: ['Poppins', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         blue: {
@@ -207,7 +206,7 @@ module.exports = {
       const utilityStyles = {
         '.text-4xl': {
           fontWeight: '400',
-          fontFamily: ['Poppins', defaultTheme.fontFamily.sans].toString(),
+          fontFamily: ['Inter var', defaultTheme.fontFamily.sans].toString(),
         },
       }
       utilityStyles['.text-5xl'] = utilityStyles['.text-4xl']


### PR DESCRIPTION
Removes Poppins and fallbacks to Inter for display typography.

Fixes #1466.