### PR TITLE
clients/web: server-side redirection for logged-in/out users

### DIFF
--- a/clients/apps/web/next.config.js
+++ b/clients/apps/web/next.config.js
@@ -22,10 +22,16 @@ const nextConfig = {
         source: '/',
         destination: 'https://splendid-help-401117.framer.app/',
         missing: [
+          // Do not rewrite for polar.new, polar.new has another rule below
           {
             type: 'host',
-            value: 'polar.new', // do not rewrite for polar.new, polar.new has another rule below
+            value: 'polar.new',
           },
+          // Do not rewrite if user is logged in, they'll be redirected to the app
+          {
+            type: 'cookie',
+            key: 'polar',
+          }
         ],
       },
       {
@@ -68,6 +74,7 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      // dashboard.polar.sh redirections
       {
         source: '/',
         destination: '/login/init',
@@ -87,6 +94,53 @@ const nextConfig = {
             type: 'host',
             value: 'dashboard.polar.sh',
           },
+        ],
+        permanent: false,
+      },
+
+      // Logged-out user redirection
+      {
+        source: '/(feed|for-you|rewards|settings|backoffice|maintainer|team)(.*)',
+        destination: '/login/init',
+        missing: [
+          {
+            type: 'cookie',
+            key: 'polar',
+          },
+          {
+            type: 'host',
+            value: 'polar.new',
+          },
+        ],
+        permanent: false,
+      },
+
+      // Logged-in user redirections
+      {
+        source: '/',
+        destination: '/feed',
+        has: [
+          {
+            type: 'cookie',
+            key: 'polar',
+          }
+        ],
+        missing: [
+          {
+            type: 'host',
+            value: 'polar.new',
+          },
+        ],
+        permanent: false,
+      },
+      {
+        source: '/login(.*)',
+        destination: '/feed',
+        has: [
+          {
+            type: 'cookie',
+            key: 'polar',
+          }
         ],
         permanent: false,
       },

--- a/clients/apps/web/src/components/Shared/ProfileSelection.tsx
+++ b/clients/apps/web/src/components/Shared/ProfileSelection.tsx
@@ -44,7 +44,7 @@ const ProfileSelection = ({
 
   const onLogout = async () => {
     await logout()
-    router.push('/')
+    window.location.href = '/'
   }
 
   if (!loggedUser) {

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -92,6 +92,7 @@ class AuthService:
         is_localhost = request.url.hostname in ["127.0.0.1", "localhost"]
         secure = False if is_localhost else True
 
+        cls._clear_subdomain_cookie(response=response)
         cls.set_auth_cookie(response=response, value=token, secure=secure)
         return LoginResponse(success=True, expires_at=expires_at, goto_url=goto_url)
 
@@ -139,5 +140,31 @@ class AuthService:
 
     @classmethod
     def generate_logout_response(cls, *, response: Response) -> LogoutResponse:
+        cls._clear_subdomain_cookie(response=response)
         cls.set_auth_cookie(response=response, value="", expires=0)
         return LogoutResponse(success=True)
+
+    @classmethod
+    def _clear_subdomain_cookie(cls, *, response: Response) -> Response:
+        """
+        FIXME: Temporary fix that can be removed on November 19th 2023.
+
+        We used to issue cookie without a domain,
+        so they were tied to our API subdomain, `api.polar.sh`.
+
+        Then, we changed this to issue cookie for the root domain `.polar.sh`.
+
+        However, old cookies are still in the nature and we need to explicitly get
+        rid of them on login/logout, otherwise they take precedence over the new one.
+        """
+        response.set_cookie(
+            settings.AUTH_COOKIE_KEY,
+            value="",
+            expires=0,
+            path="/",
+            domain=None,
+            secure=True,
+            httponly=True,
+            samesite="lax",
+        )
+        return response


### PR DESCRIPTION
The idea is to leverage Next.js server-side redirects to automatically redirect the user if they are logged-in or not.

The good thing is that it'll save us some "flashing" states when accessing login page while authenticated and vice versa.

Ultimately, this might allow us to remove the `Gatekeeper` component.

As a bonus, when accessing `polar.sh`, the user is automatically redirected to `polar.sh/feed` is they are logged in (not sure if desired, but I personally like the behavior. Can remove it otherwise).

---

To make this work, we simply check for the existence of our session cookie, `polar`, which I made a root domain cookie (see https://github.com/polarsource/polar/commit/11cac1d451cb935a87defe739241b69c3dfbbb65) 