### PR TITLE
clients/subscriptions: add public tier view for subscriptions

### DIFF
--- a/clients/apps/web/src/app/(public)/[organization]/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/subscriptions/page.tsx
@@ -1,0 +1,131 @@
+import Header from '@/components/Organization/Header'
+import PageNotFound from '@/components/Shared/PageNotFound'
+import OrganizationSubscriptionsPublicPage from '@/components/Subscriptions/OrganizationSubscriptionsPublicPage'
+import { getServerSideAPI } from '@/utils/api'
+import {
+  Organization,
+  Platforms,
+  ResponseError,
+  SubscriptionTier,
+} from '@polar-sh/sdk'
+import type { Metadata, ResolvingMetadata } from 'next'
+import { notFound } from 'next/navigation'
+import { api } from 'polarkit/api'
+
+const cacheConfig = {
+  next: {
+    revalidate: 30, // 30 seconds
+  },
+}
+
+export async function generateMetadata(
+  {
+    params,
+  }: {
+    params: { organization: string }
+  },
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  let organization: Organization | undefined
+
+  try {
+    organization = await api.organizations.lookup(
+      {
+        platform: Platforms.GITHUB,
+        organizationName: params.organization,
+      },
+      cacheConfig,
+    )
+  } catch (e) {
+    if (e instanceof ResponseError && e.response.status === 404) {
+      notFound()
+    }
+  }
+
+  if (!organization) {
+    notFound()
+  }
+
+  return {
+    title: `${organization.name}`, // " | Polar is added by the template"
+    openGraph: {
+      title: `${organization.name} seeks funding for issues`,
+      description: `${organization.name} seeks funding for issues on Polar`,
+      siteName: 'Polar',
+
+      images: [
+        {
+          url: `https://polar.sh/og?org=${organization.name}`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: {
+      images: [
+        {
+          url: `https://polar.sh/og?org=${organization.name}`,
+          width: 1200,
+          height: 630,
+          alt: `${organization.name} seeks funding for issues`,
+        },
+      ],
+      card: 'summary_large_image',
+      title: `${organization.name} seeks funding for issues`,
+      description: `${organization.name} seeks funding for issues on Polar`,
+    },
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: { organization: string }
+}) {
+  const api = getServerSideAPI()
+  const organization = await api.organizations.lookup(
+    {
+      platform: Platforms.GITHUB,
+      organizationName: params.organization,
+    },
+    cacheConfig,
+  )
+
+  const repositories = await api.repositories.search(
+    {
+      platform: Platforms.GITHUB,
+      organizationName: params.organization,
+    },
+    cacheConfig,
+  )
+
+  let subscriptionTiers: SubscriptionTier[] = []
+  try {
+    const subscriptionGroupsResponse =
+      await api.subscriptions.searchSubscriptionTiers(
+        {
+          platform: Platforms.GITHUB,
+          organizationName: organization.name,
+        },
+        cacheConfig,
+      )
+    subscriptionTiers = subscriptionGroupsResponse.items ?? []
+  } catch (err) {}
+
+  if (organization === undefined || subscriptionTiers.length === 0) {
+    return <PageNotFound />
+  }
+
+  return (
+    <>
+      <Header
+        organization={organization}
+        repositories={repositories.items ?? []}
+      />
+      <OrganizationSubscriptionsPublicPage
+        organization={organization}
+        subscriptionTiers={subscriptionTiers}
+      />
+    </>
+  )
+}

--- a/clients/apps/web/src/components/Organization/OrganizationPublicPage.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationPublicPage.tsx
@@ -75,6 +75,7 @@ const OrganizationPublicPage = ({
 
       {subscriptionTiers.length > 0 && (
         <PublicSubscriptionUpsell
+          organization={organization}
           subscriptionTiers={subscriptionTiers}
           subscribePath="/subscribe"
         />

--- a/clients/apps/web/src/components/Subscriptions/OrganizationSubscriptionsPublicPage.tsx
+++ b/clients/apps/web/src/components/Subscriptions/OrganizationSubscriptionsPublicPage.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import {
+  Organization,
+  SubscriptionTier,
+  SubscriptionTierType,
+} from '@polar-sh/sdk'
+import { Separator } from 'polarkit/components/ui/separator'
+import React, { useMemo } from 'react'
+import SubscriptionGroupPublic from './SubscriptionGroupPublic'
+import { getSubscriptionTiersByType } from './utils'
+
+interface OrganizationSubscriptionsPublicPageProps {
+  subscriptionTiers: SubscriptionTier[]
+  organization: Organization
+}
+
+const OrganizationSubscriptionsPublicPage: React.FC<
+  OrganizationSubscriptionsPublicPageProps
+> = ({ subscriptionTiers, organization }) => {
+  const subscriptionTiersByType = useMemo(
+    () => getSubscriptionTiersByType(subscriptionTiers ?? []),
+    [subscriptionTiers],
+  )
+
+  return (
+    <div className="dark:divide-polar-700 flex flex-col gap-12">
+      <SubscriptionGroupPublic
+        title="Hobby"
+        description="Tiers for individuals & fans who want to say thanks"
+        type={SubscriptionTierType.HOBBY}
+        tiers={subscriptionTiersByType.hobby}
+        subscribePath="/subscribe"
+      />
+      <Separator />
+      <SubscriptionGroupPublic
+        title="Pro"
+        description="Tiers best suited for indie hackers & startups"
+        type={SubscriptionTierType.PRO}
+        tiers={subscriptionTiersByType?.pro}
+        subscribePath="/subscribe"
+      />
+      <Separator />
+      <SubscriptionGroupPublic
+        title="Business"
+        description="Your most exclusive tiers for business customers"
+        type={SubscriptionTierType.BUSINESS}
+        tiers={subscriptionTiersByType?.business}
+        subscribePath="/subscribe"
+      />
+    </div>
+  )
+}
+
+export default OrganizationSubscriptionsPublicPage

--- a/clients/apps/web/src/components/Subscriptions/PublicSubscriptionUpsell.tsx
+++ b/clients/apps/web/src/components/Subscriptions/PublicSubscriptionUpsell.tsx
@@ -1,14 +1,16 @@
-import { SubscriptionTier } from '@polar-sh/sdk'
+import { Organization, SubscriptionTier } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { PrimaryButton } from 'polarkit/components/ui/atoms'
 import SubscriptionTierCard from './SubscriptionTierCard'
 
 interface PublicSubscriptionUpsellProps {
+  organization: Organization
   subscriptionTiers: SubscriptionTier[]
   subscribePath: string
 }
 
 const PublicSubscriptionUpsell: React.FC<PublicSubscriptionUpsellProps> = ({
+  organization,
   subscriptionTiers,
   subscribePath,
 }) => {
@@ -16,12 +18,14 @@ const PublicSubscriptionUpsell: React.FC<PublicSubscriptionUpsellProps> = ({
     <div className="flex flex-col py-6">
       <div className="flex flex-row items-center justify-between">
         <div className="flex flex-col">
-          <h2 className="text-2xl">Subscriptions</h2>
+          <h2 className="text-xl">Subscriptions</h2>
           <p className="dark:text-polar-400 mt-3 text-gray-400">
             Say thanks with a subscription & gain benefits as a bonus
           </p>
         </div>
-        <PrimaryButton fullWidth={false}>View all Tiers</PrimaryButton>
+        <Link href={{ pathname: `/${organization.name}/subscriptions` }}>
+          <PrimaryButton fullWidth={false}>View all Tiers</PrimaryButton>
+        </Link>
       </div>
       <div className="flex flex-row gap-6 pb-6 pt-10">
         {subscriptionTiers

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionGroup.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionGroup.tsx
@@ -46,14 +46,18 @@ const SubscriptionGroup: React.FC<SubscriptionGroupProps> = ({
         </div>
         <p className="dark:text-polar-500 mt-4 text-gray-400">{description}</p>
       </div>
-      <div className="grid auto-cols-[320px] grid-flow-col gap-6">
+      <div className="grid grid-cols-4 gap-6">
         {tiers.map((tier) => (
           <Link
             className="transition-opacity hover:opacity-50  dark:hover:opacity-80"
             key={tier.id}
             href={`/maintainer/${organization.name}/subscriptions/tiers/${tier.id}`}
           >
-            <SubscriptionTierCard key={tier.id} subscriptionTier={tier} />
+            <SubscriptionTierCard
+              className="h-full"
+              key={tier.id}
+              subscriptionTier={tier}
+            />
           </Link>
         ))}
       </div>

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionGroupPublic.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionGroupPublic.tsx
@@ -1,0 +1,61 @@
+import { SubscriptionTier, SubscriptionTierType } from '@polar-sh/sdk'
+import Link from 'next/link'
+import { PrimaryButton } from 'polarkit/components/ui/atoms'
+import SubscriptionGroupIcon from './SubscriptionGroupIcon'
+import SubscriptionTierCard from './SubscriptionTierCard'
+
+interface SubscriptionGroupPublicProps {
+  title: string
+  description: string
+  type: SubscriptionTierType
+  tiers: SubscriptionTier[]
+  subscribePath: string
+}
+
+const SubscriptionGroupPublic = ({
+  title,
+  description,
+  type,
+  tiers,
+  subscribePath,
+}: SubscriptionGroupPublicProps) => {
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <div className="flex items-center justify-between">
+          <h2 className="flex flex-row items-center text-2xl">
+            <SubscriptionGroupIcon type={type} className="!h-6 !w-6" />
+            <span className="dark:text-polar-50 ml-3">{title}</span>
+          </h2>
+        </div>
+        <p className="dark:text-polar-500 mt-4 text-gray-400">{description}</p>
+      </div>
+      <div className="grid grid-cols-3 gap-6">
+        {tiers.map((tier) => (
+          <SubscriptionTierCard
+            className="h-full"
+            key={tier.id}
+            subscriptionTier={tier}
+          >
+            <Link
+              className="w-full"
+              href={{
+                pathname: subscribePath,
+                query: { tier: tier.id },
+              }}
+            >
+              <PrimaryButton
+                classNames="bg-[--var-border-color] dark:bg-[--var-dark-border-color] text-[--var-fg-color] dark:hover:bg-[--var-dark-fg-color] hover:bg-[--var-fg-color] dark:text-[--var-dark-fg-color] transition-colors hover:text-white dark:hover:text-white"
+                fullWidth
+              >
+                Subscribe
+              </PrimaryButton>
+            </Link>
+          </SubscriptionTierCard>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default SubscriptionGroupPublic

--- a/clients/apps/web/src/components/Subscriptions/TiersPage.tsx
+++ b/clients/apps/web/src/components/Subscriptions/TiersPage.tsx
@@ -4,26 +4,15 @@ import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import {
   ListResourceSubscriptionTier,
   Organization,
-  SubscriptionTier,
   SubscriptionTierType,
 } from '@polar-sh/sdk'
 import React, { useMemo } from 'react'
 import SubscriptionGroup from './SubscriptionGroup'
 import { getSubscriptionTiersByType } from './utils'
 
-type SubscriptionTiersByType = {
-  [key in SubscriptionTierType]: SubscriptionTier[]
-}
-
 interface TiersPageProps {
   subscriptionTiers: ListResourceSubscriptionTier
   organization: Organization
-}
-
-const defaultSubscriptionTiersByType: SubscriptionTiersByType = {
-  [SubscriptionTierType.HOBBY]: [],
-  [SubscriptionTierType.PRO]: [],
-  [SubscriptionTierType.BUSINESS]: [],
 }
 
 const TiersPage: React.FC<TiersPageProps> = ({


### PR DESCRIPTION
Implements a public `/{organization}/subscriptions` route which shows all tiers given a certain organization.