### PR TITLE
Disable hiding funding amount

### DIFF
--- a/clients/apps/web/src/components/Settings/Badge/index.tsx
+++ b/clients/apps/web/src/components/Settings/Badge/index.tsx
@@ -32,6 +32,13 @@ interface SSEIssueSyncEvent {
   repository_id: string
 }
 
+/**
+ * Since 2023-10-24 we always default new accounts to show amount.
+ *
+ * We should migrate existing accounts to this new standard for simplicity.
+ * However, we'll do that as a separate effort and therefore the setting
+ * remains (default: true) here even though it's not exposed.
+ */
 interface MappedRepoSettings {
   show_amount: boolean
   minimum_amount: number
@@ -293,55 +300,39 @@ const BadgeSetup = ({
               }}
               canSetFundingGoal={false}
               title="Badge defaults"
-              subtitle="You can change the settings per issue or configure a deault value"
+              subtitle="You can override these settings later per issue too"
               upfrontSplit={upfrontSplitValue}
             />
-
-            <div className="flex flex-row items-center">
-              <div className="grow">
-                <SettingsCheckbox
-                  id="show-raised"
-                  title="Show amount pledged"
-                  isChecked={settings.show_amount}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setSettings((prev) => {
-                      return {
-                        ...prev,
-                        show_amount: e.target.checked,
-                      }
-                    })
-                    setAnyBadgeSettingChanged(true)
-                  }}
-                />
-              </div>
-
-              <div className="w-fit">
-                <div className="flex flex-row items-center text-right">
-                  <label htmlFor="minimum-pledge" className="mr-4 w-64 text-sm">
-                    Minimum pledge
-                  </label>
-                  <div className="">
-                    <MoneyInput
-                      id="minimum-pledge"
-                      name="minimum-pledge"
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        let amount = parseInt(e.target.value)
-                        if (isNaN(amount)) {
-                          amount = 0
-                        }
-
-                        setSettings((prev) => {
-                          return {
-                            ...prev,
-                            minimum_amount: amount * 100,
-                          }
-                        })
-                        setAnyBadgeSettingChanged(true)
-                      }}
-                      placeholder={settings.minimum_amount}
-                      value={settings.minimum_amount}
-                    />
+            <div className="flex w-full flex-col space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="dark:text-polar-100 text-sm font-medium text-gray-900">
+                    Minimum funding amount
                   </div>
+                  <div className="dark:text-polar-400 mt-1 text-xs text-gray-600"></div>
+                </div>
+
+                <div>
+                  <MoneyInput
+                    id="minimum-pledge"
+                    name="minimum-pledge"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      let amount = parseInt(e.target.value)
+                      if (isNaN(amount)) {
+                        amount = 0
+                      }
+
+                      setSettings((prev) => {
+                        return {
+                          ...prev,
+                          minimum_amount: amount * 100,
+                        }
+                      })
+                      setAnyBadgeSettingChanged(true)
+                    }}
+                    placeholder={settings.minimum_amount}
+                    value={settings.minimum_amount}
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Hiding the funding amount is not a feature anyone we've chatted to actually wants. It adds complexity and is many ways is a bit strange and confusing to the backer. So we're removing it. Starting with hiding the setting now at first. It's been defaulting to `true` for quite some time.

We'll then separately migrate historic accounts with it as `false` (once that was the default in the beginning) pending activity from them. We can then clean up all references to it in the codebase.


**Before**
<img width="1527" alt="image" src="https://github.com/polarsource/polar/assets/281715/796c0978-1bbc-4792-a40e-9071f089271b">

**After**
<img width="1534" alt="image" src="https://github.com/polarsource/polar/assets/281715/e1475e19-b66d-4ceb-a1ad-b5fc592eff87">
