### PR TITLE
clients/sdk: add anyOf support to OpenAPI generator

### DIFF
--- a/clients/packages/sdk/generate
+++ b/clients/packages/sdk/generate
@@ -16,6 +16,7 @@ docker run \
     openapitools/openapi-generator-cli:v7.0.1 \
     generate \
     -i /sdk/openapi/updated.json \
+    -t /sdk/openapi_templates \
     -g typescript-fetch \
     -o /sdk/src/client \
     --skip-validate-spec \

--- a/clients/packages/sdk/openapi_templates/modelAnyOfInterfaces.mustache
+++ b/clients/packages/sdk/openapi_templates/modelAnyOfInterfaces.mustache
@@ -1,0 +1,15 @@
+/**
+ * @type {{classname}}{{#description}}
+ * {{{.}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#discriminator}}{{!
+
+discriminator with mapped models - TypeScript discriminating union
+}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{!
+
+discriminator only - fallback to not use the discriminator. Default model names are available but possibility of having null/nullable values could introduce more edge cases
+}}{{^mappedModels}}{{#anyOf}}{{{.}}}{{^-last}} | {{/-last}}{{/anyOf}}{{/mappedModels}}{{/discriminator}}{{!
+
+plain anyOf
+}}{{^discriminator}}{{#anyOf}}{{{.}}}{{^-last}} | {{/-last}}{{/anyOf}}{{/discriminator}};

--- a/clients/packages/sdk/openapi_templates/models.index.mustache
+++ b/clients/packages/sdk/openapi_templates/models.index.mustache
@@ -1,0 +1,36 @@
+/* tslint:disable */
+/* eslint-disable */
+{{#models}}
+{{#model}}
+{{^withoutRuntimeChecks}}
+export * from './{{{ classFilename }}}{{importFileExtension}}';
+{{#useSagaAndRecords}}
+{{^isEnum}}
+export * from './{{{ classFilename }}}Record{{importFileExtension}}';
+{{/isEnum}}
+{{/useSagaAndRecords}}
+{{/withoutRuntimeChecks}}
+{{#withoutRuntimeChecks}}
+{{#isEnum}}
+{{>modelEnumInterfaces}}
+{{/isEnum}}
+{{^isEnum}}
+{{#oneOf}}
+{{#-first}}
+{{>modelOneOfInterfaces}}
+{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
+{{#anyOf}}
+{{#-first}}
+{{>modelAnyOfInterfaces}}
+{{/-first}}
+{{/anyOf}}
+{{^anyOf}}
+{{>modelGenericInterfaces}}
+{{/anyOf}}
+{{/oneOf}}
+{{/isEnum}}
+{{/withoutRuntimeChecks}}
+{{/model}}
+{{/models}}


### PR DESCRIPTION
So, I digged up a bit and found that we can [actually override templates locally](https://openapi-generator.tech/docs/templating), so it was a good start to try out things.

It turns out that the generator already has all the required metadata to make it work, it's "just" a matter of adapting the templates. I took inspiration from what was done here: https://github.com/OpenAPITools/openapi-generator/pull/14241

And... It works! There are probably edge cases, but it looks to work pretty well for basic union types. Here is what it outputs for a `Union` type:

```ts
/**
 * @type SubscriptionBenefitCreate
 * @export
 */
export type SubscriptionBenefitCreate = SubscriptionBenefitBuiltinCreate | SubscriptionBenefitCustomCreate;
```
