### PR TITLE
clients/reposelection: fix bug with misaligned repo picker popover

### DIFF
--- a/clients/apps/web/src/components/Organization/RepoSelection.tsx
+++ b/clients/apps/web/src/components/Organization/RepoSelection.tsx
@@ -89,7 +89,7 @@ export function RepoSelection(props: {
       )}
       {open && (
         <>
-          <div>
+          <div className="relative">
             <Command
               value={value}
               onValueChange={onValueChange}


### PR DESCRIPTION
Makes sure that we relative-position repository picker popover.

<img width="1186" alt="image" src="https://github.com/polarsource/polar/assets/10053249/4dfde0e0-935a-42b6-975e-bd65e9a1a7ad">
