### PR TITLE
clients/badge: Clarify fees

### DIFF
--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -396,7 +396,7 @@ export const Badge = ({
                 marginLeft: '-5px',
               }}
             >
-              {`rewards contributors ${upfront_split_to_contributors}% - fees`}
+              {`rewards contributors ${upfront_split_to_contributors}% after fees`}
             </div>
             <div
               style={{

--- a/clients/packages/polarkit/src/components/badge/Badge.tsx
+++ b/clients/packages/polarkit/src/components/badge/Badge.tsx
@@ -396,8 +396,7 @@ export const Badge = ({
                 marginLeft: '-5px',
               }}
             >
-              {`rewards contributors ${upfront_split_to_contributors}% of received
-              funds`}
+              {`rewards contributors ${upfront_split_to_contributors}% - fees`}
             </div>
             <div
               style={{

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -176,7 +176,7 @@ const IssueCard = ({
                   <HeartIcon className="mr-2 h-5 w-5 text-blue-300 dark:text-blue-700" />
                   <div className="inline">
                     <span className="font-bold">Rewards</span> contributors{' '}
-                    <span className="font-bold">{upfrontSplit}%</span> of
+                    <span className="font-bold">{upfrontSplit}%</span> - fees of
                     received funds
                   </div>
                 </div>

--- a/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
+++ b/clients/packages/polarkit/src/components/pledge/IssueCard.tsx
@@ -175,9 +175,9 @@ const IssueCard = ({
                 <div className="flex items-center">
                   <HeartIcon className="mr-2 h-5 w-5 text-blue-300 dark:text-blue-700" />
                   <div className="inline">
-                    <span className="font-bold">Rewards</span> contributors{' '}
-                    <span className="font-bold">{upfrontSplit}%</span> - fees of
-                    received funds
+                    <span className="font-bold">Contributors</span> get{' '}
+                    <span className="font-bold">{upfrontSplit}%</span> of
+                    received funds after fees
                   </div>
                 </div>
               </Alert>


### PR DESCRIPTION
Make sure we clarify upfront in the badge and the pledge page that rewards are specified on the total, but subject to fees so that the expectation is not 1:1 with the total funding amount