### PR TITLE
Enable and apply PyUpgrade rules

### DIFF
--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+from collections.abc import Sequence
 from uuid import UUID
 
 import stripe.error as stripe_lib_error
@@ -192,7 +192,7 @@ class AccountService(ResourceService[Account, AccountCreate, AccountUpdate]):
     def get_balance(
         self,
         account: Account,
-    ) -> Tuple[str, int] | None:
+    ) -> tuple[str, int] | None:
         if account.account_type != AccountType.stripe:
             return None
         assert account.stripe_id is not None

--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -1,5 +1,6 @@
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, TypedDict
+from typing import TypedDict
 
 import structlog
 from fastapi import Depends, FastAPI

--- a/server/polar/context.py
+++ b/server/polar/context.py
@@ -1,6 +1,6 @@
 from contextvars import ContextVar
 from types import TracebackType
-from typing import ClassVar, Optional, Type
+from typing import ClassVar
 
 
 class PolarContext:
@@ -27,9 +27,9 @@ class ExecutionContext:
     # def __exit__(self, type_, value, traceback) -> None:
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         ExecutionContext._contextvar.reset(self.token)
 

--- a/server/polar/dashboard/endpoints.py
+++ b/server/polar/dashboard/endpoints.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence, Union
+from collections.abc import Sequence
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -47,11 +47,11 @@ router = APIRouter(tags=["dashboard"])
 async def get_personal_dashboard(
     auth: UserRequiredAuth,
     issue_list_type: IssueListType = IssueListType.issues,  # TODO: remove
-    status: Union[List[IssueStatus], None] = Query(
+    status: list[IssueStatus] | None = Query(
         default=None
     ),  # TODO: remove, replace with show_closed
-    q: Union[str, None] = Query(default=None),
-    sort: Union[IssueSortBy, None] = Query(default=None),
+    q: str | None = Query(default=None),
+    sort: IssueSortBy | None = Query(default=None),
     only_pledged: bool = Query(default=False),
     only_badged: bool = Query(default=False),
     page: int = Query(default=1),
@@ -80,13 +80,13 @@ async def get_personal_dashboard(
 async def get_dashboard(
     platform: Platforms,
     org_name: str,
-    repo_name: Union[str, None] = Query(default=None),
+    repo_name: str | None = Query(default=None),
     issue_list_type: IssueListType = IssueListType.issues,  # TODO: remove
-    status: Union[List[IssueStatus], None] = Query(
+    status: list[IssueStatus] | None = Query(
         default=None
     ),  # TODO: remove, replace with show_closed
-    q: Union[str, None] = Query(default=None),
-    sort: Union[IssueSortBy, None] = Query(default=None),
+    q: str | None = Query(default=None),
+    sort: IssueSortBy | None = Query(default=None),
     only_pledged: bool = Query(default=False),
     only_badged: bool = Query(default=False),
     page: int = Query(default=1),
@@ -160,7 +160,7 @@ async def get_dashboard(
 
 def default_sort(
     issue_list_type: IssueListType,
-    q: Union[str, None] = None,
+    q: str | None = None,
 ) -> IssueSortBy:
     if q:
         return IssueSortBy.relevance
@@ -180,8 +180,8 @@ async def dashboard(
     authz: Authz,
     in_repos: Sequence[Repository] = [],
     issue_list_type: IssueListType = IssueListType.issues,
-    q: Union[str, None] = None,
-    sort: Union[IssueSortBy, None] = None,
+    q: str | None = None,
+    sort: IssueSortBy | None = None,
     for_org: Organization | None = None,
     for_user: User | None = None,
     only_pledged: bool = False,
@@ -298,7 +298,7 @@ async def dashboard(
 
     next_page = page + 1 if total_issue_count > page * limit else None
 
-    data: List[Entry] = [
+    data: list[Entry] = [
         Entry(
             id=i.id,
             type="issue",

--- a/server/polar/dashboard/schemas.py
+++ b/server/polar/dashboard/schemas.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List
 from uuid import UUID
 
 from polar.funding.schemas import PledgesTypeSummaries
@@ -57,7 +56,7 @@ class Entry(Schema):
 
 
 class ListResponse(Schema):
-    data: List[Entry]
+    data: list[Entry]
 
 
 class PaginationResponse(Schema):

--- a/server/polar/email/renderer.py
+++ b/server/polar/email/renderer.py
@@ -50,13 +50,13 @@ class EmailRenderer:
     ) -> tuple[str, str]:
         rendered_subject = self.env.from_string(subject).render(context).strip()
 
-        wrapped_body = """
+        wrapped_body = f"""
         {{% extends 'base.html' %}}
 
         {{% block body %}}
             {body}
         {{% endblock %}}
-        """.format(body=body)
+        """
 
         rendered_body = self.env.from_string(wrapped_body).render(context).strip()
         return rendered_subject, rendered_body

--- a/server/polar/eventstream/endpoints.py
+++ b/server/polar/eventstream/endpoints.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, Request

--- a/server/polar/integrations/github/cache.py
+++ b/server/polar/integrations/github/cache.py
@@ -12,13 +12,13 @@ class RedisCache(BaseCache):
     def __init__(self) -> None:
         pass
 
-    def get(self, key: str) -> Optional[str]:
+    def get(self, key: str) -> str | None:
         val = sync_redis.get("githubkit:" + key)
         if val:
             return str(val)
         return None
 
-    async def aget(self, key: str) -> Optional[str]:
+    async def aget(self, key: str) -> str | None:
         return self.get(key)
 
     def set(self, key: str, value: str, ex: datetime.timedelta) -> None:

--- a/server/polar/integrations/github/client.py
+++ b/server/polar/integrations/github/client.py
@@ -106,10 +106,10 @@ class RefreshAccessToken(rest.GitHubRestModel):
     expires_in: int = Field(
         default=...
     )  # The number of seconds until access_token expires (will always be 28800)
-    refresh_token: Union[str, None] = Field(
+    refresh_token: str | None = Field(
         default=...
     )  # A new refres token (is only set if the app is using expiring refresh tokens)
-    refresh_token_expires_in: Union[int, None] = Field(default=...)
+    refresh_token_expires_in: int | None = Field(default=...)
     scope: str = Field(default=...)  # Always an empty string
     token_type: str = Field(default=...)  # Always "bearer"
 

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Tuple
+from typing import Literal
 from uuid import UUID
 
 import structlog
@@ -97,7 +97,7 @@ async def github_callback(
     request: Request,
     response: Response,
     session: AsyncSession = Depends(get_db_session),
-    access_token_state: Tuple[OAuth2Token, Optional[str]] = Depends(
+    access_token_state: tuple[OAuth2Token, str | None] = Depends(
         oauth2_authorize_callback
     ),
     auth: Auth = Depends(Auth.optional_user),

--- a/server/polar/integrations/github/service/api.py
+++ b/server/polar/integrations/github/service/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, TypeVar
 
 from githubkit import GitHub, Response
 from githubkit.rest.models import BasicError
@@ -33,8 +33,8 @@ class GitHubApi:
         self,
         client: GitHub[Any],
         url: str,
-        response_model: Type[T],
-        params: Optional[QueryParamTypes] = None,
+        response_model: type[T],
+        params: QueryParamTypes | None = None,
         etag: str | None = None,
     ) -> Response[T]:
         headers = {

--- a/server/polar/integrations/github/service/dependency.py
+++ b/server/polar/integrations/github/service/dependency.py
@@ -58,7 +58,7 @@ class GitHubIssueDependenciesService:
                 # sync it
                 continue
 
-            lock_key = "sync_external_{0}_{1}_{2}".format(
+            lock_key = "sync_external_{}_{}_{}".format(
                 dependency.owner, dependency.repo, dependency.number
             )
             async with locker.lock(lock_key, timeout=10.0, blocking_timeout=10.0):

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-from typing import Any, Awaitable, Literal, Sequence, Tuple, Union
+from collections.abc import Awaitable, Sequence
+from typing import Any, Literal
 from uuid import UUID
 
 import structlog
@@ -59,13 +60,11 @@ class GithubIssueService(IssueService):
         self,
         session: AsyncSession,
         *,
-        data: Union[
-            github.webhooks.IssuesOpenedPropIssue,
-            github.webhooks.IssuesClosedPropIssue,
-            github.webhooks.IssuesReopenedPropIssue,
-            github.webhooks.Issue,
-            github.rest.Issue,
-        ],
+        data: github.webhooks.IssuesOpenedPropIssue
+        | github.webhooks.IssuesClosedPropIssue
+        | github.webhooks.IssuesReopenedPropIssue
+        | github.webhooks.Issue
+        | github.rest.Issue,
         organization: Organization,
         repository: Repository,
         autocommit: bool = True,
@@ -84,37 +83,31 @@ class GithubIssueService(IssueService):
         session: AsyncSession,
         *,
         data: list[
-            Union[
-                github.webhooks.IssuesOpenedPropIssue,
-                github.webhooks.IssuesClosedPropIssue,
-                github.webhooks.IssuesReopenedPropIssue,
-                github.webhooks.Issue,
-                github.rest.Issue,
-            ],
+            github.webhooks.IssuesOpenedPropIssue
+            | github.webhooks.IssuesClosedPropIssue
+            | github.webhooks.IssuesReopenedPropIssue
+            | github.webhooks.Issue
+            | github.rest.Issue,
         ],
         organization: Organization,
         repository: Repository,
         autocommit: bool = True,
     ) -> Sequence[Issue]:
         def parse(
-            issue: Union[
-                github.webhooks.IssuesOpenedPropIssue,
-                github.webhooks.IssuesClosedPropIssue,
-                github.webhooks.IssuesReopenedPropIssue,
-                github.webhooks.Issue,
-                github.rest.Issue,
-            ],
+            issue: github.webhooks.IssuesOpenedPropIssue
+            | github.webhooks.IssuesClosedPropIssue
+            | github.webhooks.IssuesReopenedPropIssue
+            | github.webhooks.Issue
+            | github.rest.Issue,
         ) -> IssueCreate:
             return IssueCreate.from_github(issue, organization, repository)
 
         def filter(
-            issue: Union[
-                github.webhooks.IssuesOpenedPropIssue,
-                github.webhooks.IssuesClosedPropIssue,
-                github.webhooks.IssuesReopenedPropIssue,
-                github.webhooks.Issue,
-                github.rest.Issue,
-            ],
+            issue: github.webhooks.IssuesOpenedPropIssue
+            | github.webhooks.IssuesClosedPropIssue
+            | github.webhooks.IssuesReopenedPropIssue
+            | github.webhooks.Issue
+            | github.rest.Issue,
         ) -> bool:
             if issue.pull_request:
                 log.error(
@@ -490,10 +483,7 @@ class GithubIssueService(IssueService):
         session: AsyncSession,
         issue: Issue,
         repository: Repository,
-        github_labels: Union[
-            list[Label],
-            list[WebhookLabel],
-        ],
+        github_labels: list[Label] | list[WebhookLabel],
     ) -> Issue:
         labels = github.jsonify(github_labels)
         issue.labels = labels

--- a/server/polar/integrations/github/service/paginated.py
+++ b/server/polar/integrations/github/service/paginated.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Coroutine, List, Literal, Union
+from collections.abc import Callable, Coroutine
+from typing import Any, Literal
 
 import structlog
 from githubkit import Paginator
@@ -33,7 +34,7 @@ class GitHubPaginatedService:
         repository: Repository,
         resource_type: Literal["issue", "pull_request"],
         skip_condition: Callable[
-            [Union[github.rest.Issue, github.rest.PullRequestSimple]], bool
+            [github.rest.Issue | github.rest.PullRequestSimple], bool
         ]
         | None = None,
         on_sync_signal: Hook[SyncedHook] | None = None,

--- a/server/polar/integrations/github/service/pull_request.py
+++ b/server/polar/integrations/github/service/pull_request.py
@@ -1,4 +1,5 @@
-from typing import Any, Literal, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, Literal
 
 import structlog
 from githubkit import GitHub
@@ -76,9 +77,8 @@ class GithubPullRequestService(PullRequestService):
     async def store_full(
         self,
         session: AsyncSession,
-        data: Union[
-            github.rest.PullRequest, github.webhooks.PullRequestOpenedPropPullRequest
-        ],
+        data: github.rest.PullRequest
+        | github.webhooks.PullRequestOpenedPropPullRequest,
         organization: Organization,
         repository: Repository,
     ) -> PullRequest:
@@ -94,25 +94,21 @@ class GithubPullRequestService(PullRequestService):
         self,
         session: AsyncSession,
         data: Sequence[
-            Union[
-                github.rest.PullRequest,
-                github.webhooks.PullRequest,
-                github.webhooks.PullRequestOpenedPropPullRequest,
-                github.webhooks.PullRequestClosedPropPullRequest,
-                github.webhooks.PullRequestReopenedPropPullRequest,
-            ],
+            github.rest.PullRequest
+            | github.webhooks.PullRequest
+            | github.webhooks.PullRequestOpenedPropPullRequest
+            | github.webhooks.PullRequestClosedPropPullRequest
+            | github.webhooks.PullRequestReopenedPropPullRequest,
         ],
         organization: Organization,
         repository: Repository,
     ) -> Sequence[PullRequest]:
         def parse(
-            pr: Union[
-                github.rest.PullRequest,
-                github.webhooks.PullRequest,
-                github.webhooks.PullRequestOpenedPropPullRequest,
-                github.webhooks.PullRequestClosedPropPullRequest,
-                github.webhooks.PullRequestReopenedPropPullRequest,
-            ],
+            pr: github.rest.PullRequest
+            | github.webhooks.PullRequest
+            | github.webhooks.PullRequestOpenedPropPullRequest
+            | github.webhooks.PullRequestClosedPropPullRequest
+            | github.webhooks.PullRequestReopenedPropPullRequest,
         ) -> FullPullRequestCreate:
             return FullPullRequestCreate.full_pull_request_from_github(
                 pr, organization, repository

--- a/server/polar/integrations/github/service/reference.py
+++ b/server/polar/integrations/github/service/reference.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Set, Union
+from typing import Any
 from uuid import UUID
 
 import structlog
@@ -45,31 +45,31 @@ class UnknownIssueEvent(github.rest.GitHubRestModel):
     event: str = Field(default=...)
 
 
-TimelineEventType = Union[
-    github.rest.LabeledIssueEvent,
-    github.rest.UnlabeledIssueEvent,
-    github.rest.MilestonedIssueEvent,
-    github.rest.DemilestonedIssueEvent,
-    github.rest.RenamedIssueEvent,
-    github.rest.ReviewRequestedIssueEvent,
-    github.rest.ReviewRequestRemovedIssueEvent,
-    github.rest.ReviewDismissedIssueEvent,
-    github.rest.LockedIssueEvent,
-    github.rest.AddedToProjectIssueEvent,
-    github.rest.MovedColumnInProjectIssueEvent,
-    github.rest.RemovedFromProjectIssueEvent,
-    github.rest.ConvertedNoteToIssueIssueEvent,
-    github.rest.TimelineCommentEvent,
-    github.rest.TimelineCrossReferencedEvent,
-    github.rest.TimelineCommittedEvent,
-    github.rest.TimelineReviewedEvent,
-    github.rest.TimelineLineCommentedEvent,
-    github.rest.TimelineCommitCommentedEvent,
-    github.rest.TimelineAssignedIssueEvent,
-    github.rest.TimelineUnassignedIssueEvent,
-    github.rest.StateChangeIssueEvent,
-    UnknownIssueEvent,
-]
+TimelineEventType = (
+    github.rest.LabeledIssueEvent
+    | github.rest.UnlabeledIssueEvent
+    | github.rest.MilestonedIssueEvent
+    | github.rest.DemilestonedIssueEvent
+    | github.rest.RenamedIssueEvent
+    | github.rest.ReviewRequestedIssueEvent
+    | github.rest.ReviewRequestRemovedIssueEvent
+    | github.rest.ReviewDismissedIssueEvent
+    | github.rest.LockedIssueEvent
+    | github.rest.AddedToProjectIssueEvent
+    | github.rest.MovedColumnInProjectIssueEvent
+    | github.rest.RemovedFromProjectIssueEvent
+    | github.rest.ConvertedNoteToIssueIssueEvent
+    | github.rest.TimelineCommentEvent
+    | github.rest.TimelineCrossReferencedEvent
+    | github.rest.TimelineCommittedEvent
+    | github.rest.TimelineReviewedEvent
+    | github.rest.TimelineLineCommentedEvent
+    | github.rest.TimelineCommitCommentedEvent
+    | github.rest.TimelineAssignedIssueEvent
+    | github.rest.TimelineUnassignedIssueEvent
+    | github.rest.StateChangeIssueEvent
+    | UnknownIssueEvent
+)
 
 
 class GitHubIssueReferencesService:
@@ -124,7 +124,7 @@ class GitHubIssueReferencesService:
             name=repo.name,
         )
 
-        triggered_ids: Set[int] = set()
+        triggered_ids: set[int] = set()
 
         for page in range(1, 100):  # Maximum 100 pages
             res = await client.rest.issues.async_list_events_for_repo(
@@ -173,9 +173,9 @@ class GitHubIssueReferencesService:
         return None
 
     def external_issue_ids_to_sync(
-        self, events: List[github.rest.IssueEvent]
-    ) -> Set[int]:
-        res: Set[int] = set()
+        self, events: list[github.rest.IssueEvent]
+    ) -> set[int]:
+        res: set[int] = set()
 
         for event in events:
             if event.event == "referenced" and event.issue:
@@ -192,7 +192,7 @@ class GitHubIssueReferencesService:
         per_page: int = 30,
         page: int = 1,
         etag: str | None = None,
-    ) -> Response[List[TimelineEventType]]:
+    ) -> Response[list[TimelineEventType]]:
         url = f"/repos/{owner}/{repo}/issues/{issue_number}/timeline"
 
         params = {
@@ -205,7 +205,7 @@ class GitHubIssueReferencesService:
             url=url,
             params=exclude_unset(params),
             etag=etag,
-            response_model=List[TimelineEventType],
+            response_model=list[TimelineEventType],
         )
 
     async def sync_issue_references(

--- a/server/polar/integrations/github/service/repository.py
+++ b/server/polar/integrations/github/service/repository.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import structlog
 from githubkit import Response

--- a/server/polar/integrations/github/service/user.py
+++ b/server/polar/integrations/github/service/user.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 import structlog
 
@@ -436,7 +436,7 @@ class GithubUserService(UserService):
 
     async def fetch_user_accessible_installations(
         self, session: AsyncSession, user: User
-    ) -> List[github.rest.Installation]:
+    ) -> list[github.rest.Installation]:
         """
         Load user accessible installations from GitHub API
         Finds the union between app installations and the users user-to-server token.

--- a/server/polar/integrations/github/tasks/utils.py
+++ b/server/polar/integrations/github/tasks/utils.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union
+from collections.abc import Sequence
 from uuid import UUID
 
 import structlog
@@ -37,11 +37,9 @@ async def get_organization_and_repo(
 async def remove_repositories(
     session: AsyncSession,
     repositories: Sequence[
-        Union[
-            github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems,
-            github.webhooks.InstallationRepositoriesAddedPropRepositoriesRemovedItems,
-            github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems,
-        ]
+        github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems
+        | github.webhooks.InstallationRepositoriesAddedPropRepositoriesRemovedItems
+        | github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems
     ],
 ) -> None:
     for repo in repositories:
@@ -56,19 +54,17 @@ async def remove_repositories(
 
 async def get_event_org_repo(
     session: AsyncSession,
-    event: Union[
-        github.webhooks.IssuesOpened,
-        github.webhooks.IssuesEdited,
-        github.webhooks.IssuesClosed,
-        github.webhooks.IssuesDeleted,
-        github.webhooks.PullRequestOpened,
-        github.webhooks.PullRequestEdited,
-        github.webhooks.PullRequestClosed,
-        github.webhooks.PullRequestReopened,
-        github.webhooks.PullRequestSynchronize,
-        github.webhooks.IssuesReopened,
-    ],
-) -> Union[tuple[Organization, Repository], None]:
+    event: github.webhooks.IssuesOpened
+    | github.webhooks.IssuesEdited
+    | github.webhooks.IssuesClosed
+    | github.webhooks.IssuesDeleted
+    | github.webhooks.PullRequestOpened
+    | github.webhooks.PullRequestEdited
+    | github.webhooks.PullRequestClosed
+    | github.webhooks.PullRequestReopened
+    | github.webhooks.PullRequestSynchronize
+    | github.webhooks.IssuesReopened,
+) -> tuple[Organization, Repository] | None:
     repository_id = event.repository.id
     owner_id = event.repository.owner.id
 
@@ -89,25 +85,21 @@ async def get_event_org_repo(
 
 async def get_event_issue(
     session: AsyncSession,
-    event: Union[
-        github.webhooks.IssuesOpened,
-        github.webhooks.IssuesEdited,
-        github.webhooks.IssuesClosed,
-        github.webhooks.IssuesDeleted,
-    ],
+    event: github.webhooks.IssuesOpened
+    | github.webhooks.IssuesEdited
+    | github.webhooks.IssuesClosed
+    | github.webhooks.IssuesDeleted,
 ) -> Issue | None:
     return await service.github_issue.get_by_external_id(session, event.issue.id)
 
 
 async def upsert_issue(
     session: AsyncSession,
-    event: Union[
-        github.webhooks.IssuesOpened,
-        github.webhooks.IssuesEdited,
-        github.webhooks.IssuesClosed,
-        github.webhooks.IssuesDeleted,
-        github.webhooks.IssuesReopened,
-    ],
+    event: github.webhooks.IssuesOpened
+    | github.webhooks.IssuesEdited
+    | github.webhooks.IssuesClosed
+    | github.webhooks.IssuesDeleted
+    | github.webhooks.IssuesReopened,
 ) -> Issue | None:
     owner_id = event.repository.owner.id
     repository_id = event.repository.id
@@ -131,13 +123,11 @@ async def upsert_issue(
 
 async def upsert_pull_request(
     session: AsyncSession,
-    event: Union[
-        github.webhooks.PullRequestOpened,
-        github.webhooks.PullRequestEdited,
-        github.webhooks.PullRequestClosed,
-        github.webhooks.PullRequestReopened,
-        github.webhooks.PullRequestSynchronize,
-    ],
+    event: github.webhooks.PullRequestOpened
+    | github.webhooks.PullRequestEdited
+    | github.webhooks.PullRequestClosed
+    | github.webhooks.PullRequestReopened
+    | github.webhooks.PullRequestSynchronize,
 ) -> PullRequest | None:
     owner_id = event.repository.owner.id
     repository_id = event.repository.id

--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence, Union
+from collections.abc import Sequence
+from typing import Any
 from uuid import UUID
 
 import structlog
@@ -122,19 +123,15 @@ async def organizations_renamed(
 
 async def repositories_changed(
     session: AsyncSession,
-    event: Union[
-        github.webhooks.InstallationRepositoriesAdded,
-        github.webhooks.InstallationRepositoriesRemoved,
-        github.webhooks.InstallationCreated,
-    ],
+    event: github.webhooks.InstallationRepositoriesAdded
+    | github.webhooks.InstallationRepositoriesRemoved
+    | github.webhooks.InstallationCreated,
 ) -> None:
     with ExecutionContext(is_during_installation=True):
         removed: Sequence[
-            Union[
-                github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems,
-                github.webhooks.InstallationRepositoriesAddedPropRepositoriesRemovedItems,
-                github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems,
-            ]
+            github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems
+            | github.webhooks.InstallationRepositoriesAddedPropRepositoriesRemovedItems
+            | github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems
         ] = (
             []
             if isinstance(event, github.webhooks.InstallationCreated)
@@ -160,16 +157,11 @@ async def repositories_changed(
 
 async def create_from_installation(
     session: AsyncSession,
-    installation: Union[
-        github.rest.Installation,
-        github.webhooks.Installation,
-    ],
+    installation: github.rest.Installation | github.webhooks.Installation,
     removed: Sequence[
-        Union[
-            github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems,
-            github.webhooks.InstallationRepositoriesAddedPropRepositoriesRemovedItems,
-            github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems,
-        ]
+        github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems
+        | github.webhooks.InstallationRepositoriesAddedPropRepositoriesRemovedItems
+        | github.webhooks.InstallationRepositoriesRemovedPropRepositoriesRemovedItems
     ],
 ) -> Organization:
     account = installation.account
@@ -333,12 +325,10 @@ async def repositories_transferred(
 
 async def repository_updated(
     session: AsyncSession,
-    event: Union[
-        github.webhooks.PublicEvent,
-        github.webhooks.RepositoryRenamed,
-        github.webhooks.RepositoryEdited,
-        github.webhooks.RepositoryArchived,
-    ],
+    event: github.webhooks.PublicEvent
+    | github.webhooks.RepositoryRenamed
+    | github.webhooks.RepositoryEdited
+    | github.webhooks.RepositoryArchived,
 ) -> dict[str, Any]:
     with ExecutionContext(is_during_installation=True):
         if not event.installation:
@@ -425,13 +415,11 @@ async def handle_issue(
     session: AsyncSession,
     scope: str,
     action: str,
-    event: Union[
-        github.webhooks.IssuesOpened,
-        github.webhooks.IssuesEdited,
-        github.webhooks.IssuesClosed,
-        github.webhooks.IssuesReopened,
-        github.webhooks.IssuesDeleted,
-    ],
+    event: github.webhooks.IssuesOpened
+    | github.webhooks.IssuesEdited
+    | github.webhooks.IssuesClosed
+    | github.webhooks.IssuesReopened
+    | github.webhooks.IssuesDeleted,
 ) -> Issue:
     issue = await upsert_issue(session, event)
     if not issue:
@@ -697,10 +685,7 @@ async def issue_labeled_async(
     session: AsyncSession,
     scope: str,
     action: str,
-    event: Union[
-        github.webhooks.IssuesLabeled,
-        github.webhooks.IssuesUnlabeled,
-    ],
+    event: github.webhooks.IssuesLabeled | github.webhooks.IssuesUnlabeled,
 ) -> None:
     issue = await service.github_issue.get_by_external_id(session, event.issue.id)
     if not issue:
@@ -778,10 +763,7 @@ async def issue_assigned_async(
     session: AsyncSession,
     scope: str,
     action: str,
-    event: Union[
-        github.webhooks.IssuesAssigned,
-        github.webhooks.IssuesUnassigned,
-    ],
+    event: github.webhooks.IssuesAssigned | github.webhooks.IssuesUnassigned,
 ) -> None:
     issue = await service.github_issue.get_by_external_id(session, event.issue.id)
     if not issue:
@@ -813,13 +795,11 @@ async def handle_pull_request(
     session: AsyncSession,
     scope: str,
     action: str,
-    event: Union[
-        github.webhooks.PullRequestOpened,
-        github.webhooks.PullRequestEdited,
-        github.webhooks.PullRequestClosed,
-        github.webhooks.PullRequestReopened,
-        github.webhooks.PullRequestSynchronize,
-    ],
+    event: github.webhooks.PullRequestOpened
+    | github.webhooks.PullRequestEdited
+    | github.webhooks.PullRequestClosed
+    | github.webhooks.PullRequestReopened
+    | github.webhooks.PullRequestSynchronize,
 ) -> None:
     await upsert_pull_request(session, event)
 

--- a/server/polar/integrations/stripe/schemas.py
+++ b/server/polar/integrations/stripe/schemas.py
@@ -13,8 +13,8 @@ class PaymentIntentSuccessWebhook(Schema):
     id: str  # A payment intent id (pi_)
     amount: int
     amount_received: int
-    customer: Optional[str] = None
-    invoice: Optional[str] = None  # A invoice ID (in_)
+    customer: str | None = None
+    invoice: str | None = None  # A invoice ID (in_)
     latest_charge: str  # A charge ID (ch_)
     status: str  # "succeeded"
 

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Tuple, TypedDict, Unpack
+from typing import Any, Literal, TypedDict, Unpack
 from uuid import UUID
 
 import stripe as stripe_lib
@@ -145,7 +145,7 @@ class StripeService:
     def retrieve_account(self, id: str) -> stripe_lib.Account:
         return stripe_lib.Account.retrieve(id)
 
-    def retrieve_balance(self, id: str) -> Tuple[str, int]:
+    def retrieve_balance(self, id: str) -> tuple[str, int]:
         # Return available balance in the account's default currency (we assume that
         # there is no balance in other currencies for now)
         account = stripe_lib.Account.retrieve(id)

--- a/server/polar/issue/schemas.py
+++ b/server/polar/issue/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Literal, Self, Type, Union
+from typing import Literal, Self
 from uuid import UUID
 
 import structlog
@@ -233,21 +233,19 @@ class Base(Schema):
 class IssueAndPullRequestBase(Base):
     @classmethod
     def get_normalized_github_issue(
-        cls: Type[Self],
-        data: Union[
-            github.rest.Issue,
-            github.webhooks.Issue,
-            github.webhooks.IssuesOpenedPropIssue,
-            github.webhooks.IssuesOpenedPropIssue,
-            github.webhooks.IssuesClosedPropIssue,
-            github.webhooks.IssuesReopenedPropIssue,
-            github.rest.PullRequest,
-            github.rest.PullRequestSimple,
-            github.webhooks.PullRequest,
-            github.webhooks.PullRequestOpenedPropPullRequest,
-            github.webhooks.PullRequestClosedPropPullRequest,
-            github.webhooks.PullRequestReopenedPropPullRequest,
-        ],
+        cls: type[Self],
+        data: github.rest.Issue
+        | github.webhooks.Issue
+        | github.webhooks.IssuesOpenedPropIssue
+        | github.webhooks.IssuesOpenedPropIssue
+        | github.webhooks.IssuesClosedPropIssue
+        | github.webhooks.IssuesReopenedPropIssue
+        | github.rest.PullRequest
+        | github.rest.PullRequestSimple
+        | github.webhooks.PullRequest
+        | github.webhooks.PullRequestOpenedPropPullRequest
+        | github.webhooks.PullRequestClosedPropPullRequest
+        | github.webhooks.PullRequestReopenedPropPullRequest,
         organization: OrganizationModel,
         repository: RepositoryModel,
     ) -> Self:
@@ -317,13 +315,11 @@ class IssueCreate(IssueAndPullRequestBase):
     @classmethod
     def from_github(
         cls,
-        data: Union[
-            github.rest.Issue,
-            github.webhooks.Issue,
-            github.webhooks.IssuesOpenedPropIssue,
-            github.webhooks.IssuesClosedPropIssue,
-            github.webhooks.IssuesReopenedPropIssue,
-        ],
+        data: github.rest.Issue
+        | github.webhooks.Issue
+        | github.webhooks.IssuesOpenedPropIssue
+        | github.webhooks.IssuesClosedPropIssue
+        | github.webhooks.IssuesReopenedPropIssue,
         organization: OrganizationModel,
         repository: RepositoryModel,
     ) -> Self:
@@ -422,9 +418,7 @@ class IssueReferenceRead(Schema):
     pull_request_reference: PullRequestReference | None = None
     external_github_pull_request_reference: (
         ExternalGitHubPullRequestReference | None
-    ) = (  # noqa: E501
-        None
-    )
+    ) = None
     external_github_commit_reference: ExternalGitHubCommitReference | None = None
 
     @classmethod

--- a/server/polar/issue/service.py
+++ b/server/polar/issue/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import timedelta
-from typing import List, Sequence, Tuple
 from uuid import UUID
 
 import structlog
@@ -94,7 +94,7 @@ class IssueService(ResourceService[Issue, IssueCreate, IssueUpdate]):
         return issues
 
     async def list_by_repository_and_numbers(
-        self, session: AsyncSession, repository_id: UUID, numbers: List[int]
+        self, session: AsyncSession, repository_id: UUID, numbers: list[int]
     ) -> Sequence[Issue]:
         statement = (
             sql.select(Issue)
@@ -125,7 +125,7 @@ class IssueService(ResourceService[Issue, IssueCreate, IssueUpdate]):
         github_milestone_number: int | None = None,
         show_closed: bool = False,
         show_closed_if_needs_action: bool = False,
-    ) -> Tuple[Sequence[Issue], int]:  # (issues, total_issue_count)
+    ) -> tuple[Sequence[Issue], int]:  # (issues, total_issue_count)
         pledge_by_organization = aliased(Organization)
         issue_repository = aliased(Repository)
         issue_organization = aliased(Organization, name="pledge_organization")

--- a/server/polar/kit/db/models/mixins/active_record.py
+++ b/server/polar/kit/db/models/mixins/active_record.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from functools import cache
-from typing import Any, ClassVar, Self, Sequence, TypeVar
+from typing import Any, ClassVar, Self
 
 from sqlalchemy import Column
 from sqlalchemy.orm import (

--- a/server/polar/kit/hook.py
+++ b/server/polar/kit/hook.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Coroutine, Generic, TypeVar
+from collections.abc import Callable, Coroutine
+from typing import Any, Generic, TypeVar
 
 T = TypeVar("T")
 HookFunc = Callable[[T], Coroutine[Any, Any, Any]]

--- a/server/polar/kit/services.py
+++ b/server/polar/kit/services.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import Any, Generic, TypeVar
 from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute

--- a/server/polar/kit/template.py
+++ b/server/polar/kit/template.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Tuple
 
 import structlog
 from jinja2 import BaseLoader, Environment, TemplateNotFound
@@ -13,7 +13,7 @@ class PolarLoader(BaseLoader):
 
     def get_source(
         self, environment: "Environment", template: str
-    ) -> Tuple[str, str | None, Callable[[], bool] | None]:
+    ) -> tuple[str, str | None, Callable[[], bool] | None]:
         path = Path(self.path, template)
         if not path.exists():
             raise TemplateNotFound(template)

--- a/server/polar/kit/utils.py
+++ b/server/polar/kit/utils.py
@@ -1,9 +1,9 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 
 def utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def generate_uuid() -> uuid.UUID:

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -105,10 +105,7 @@ class Organization(RecordModel):
 
     @property
     def polar_site_url(self) -> str:
-        return "{base}/{slug}".format(
-            base=settings.FRONTEND_BASE_URL,
-            slug=self.name,
-        )
+        return f"{settings.FRONTEND_BASE_URL}/{self.name}"
 
     @property
     def safe_installation_id(self) -> int:

--- a/server/polar/notifications/service.py
+++ b/server/polar/notifications/service.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union
+from collections.abc import Sequence
 from uuid import UUID
 
 import structlog
@@ -150,16 +150,16 @@ class NotificationsService:
 
     def parse_payload(
         self, n: Notification
-    ) -> Union[
-        MaintainerPledgeCreatedNotification,
-        MaintainerPledgeConfirmationPendingNotification,
-        MaintainerPledgePendingNotification,
-        MaintainerPledgePaidNotification,
-        PledgerPledgePendingNotification,
-        RewardPaidNotification,
-        MaintainerPledgedIssueConfirmationPendingNotification,
-        MaintainerPledgedIssuePendingNotification,
-    ]:
+    ) -> (
+        MaintainerPledgeCreatedNotification
+        | MaintainerPledgeConfirmationPendingNotification
+        | MaintainerPledgePendingNotification
+        | MaintainerPledgePaidNotification
+        | PledgerPledgePendingNotification
+        | RewardPaidNotification
+        | MaintainerPledgedIssueConfirmationPendingNotification
+        | MaintainerPledgedIssuePendingNotification
+    ):
         match n.type:
             case "MaintainerPledgeCreatedNotification":
                 return parse_obj_as(MaintainerPledgeCreatedNotification, n.payload)

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Self, Sequence
+from typing import Self
 from uuid import UUID
 
 from pydantic import Field

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timezone
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import UTC, datetime
 from uuid import UUID
 
 import structlog
@@ -124,7 +124,7 @@ class OrganizationService(
             organization.billing_email = settings.billing_email
 
         if organization.onboarded_at is None:
-            organization.onboarded_at = datetime.now(timezone.utc)
+            organization.onboarded_at = datetime.now(UTC)
 
         if settings.set_default_upfront_split_to_contributors:
             organization.default_upfront_split_to_contributors = (

--- a/server/polar/personal_access_token/service.py
+++ b/server/polar/personal_access_token/service.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from datetime import timedelta
-from typing import Sequence
 from uuid import UUID
 
 from sqlalchemy.orm import joinedload

--- a/server/polar/pledge/service.py
+++ b/server/polar/pledge/service.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import datetime
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import timedelta
-from typing import Any, Awaitable, Callable, List, Sequence
+from typing import Any
 from uuid import UUID
 
 import stripe as stripe_lib
@@ -200,7 +201,7 @@ class PledgeService(ResourceServiceReader[Pledge]):
     async def get_by_issue_ids(
         self,
         session: AsyncSession,
-        issue_ids: List[UUID],
+        issue_ids: list[UUID],
     ) -> Sequence[Pledge]:
         if not issue_ids:
             return []

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 
 from fastapi import Depends, Request
 

--- a/server/polar/pull_request/schemas.py
+++ b/server/polar/pull_request/schemas.py
@@ -106,14 +106,12 @@ class MinimalPullRequestCreate(IssueAndPullRequestBase):
     @classmethod
     def minimal_pull_request_from_github(
         cls,
-        pr: Union[
-            github.rest.PullRequestSimple,
-            github.rest.PullRequest,
-            github.webhooks.PullRequestOpenedPropPullRequest,
-            github.webhooks.PullRequest,
-            github.webhooks.PullRequestClosedPropPullRequest,
-            github.webhooks.PullRequestReopenedPropPullRequest,
-        ],
+        pr: github.rest.PullRequestSimple
+        | github.rest.PullRequest
+        | github.webhooks.PullRequestOpenedPropPullRequest
+        | github.webhooks.PullRequest
+        | github.webhooks.PullRequestClosedPropPullRequest
+        | github.webhooks.PullRequestReopenedPropPullRequest,
         organization: Organization,
         repository: Repository,
     ) -> Self:
@@ -158,13 +156,11 @@ class FullPullRequestCreate(MinimalPullRequestCreate):
     @classmethod
     def full_pull_request_from_github(
         cls,
-        pr: Union[
-            github.rest.PullRequest,
-            github.webhooks.PullRequestOpenedPropPullRequest,
-            github.webhooks.PullRequest,
-            github.webhooks.PullRequestClosedPropPullRequest,
-            github.webhooks.PullRequestReopenedPropPullRequest,
-        ],
+        pr: github.rest.PullRequest
+        | github.webhooks.PullRequestOpenedPropPullRequest
+        | github.webhooks.PullRequest
+        | github.webhooks.PullRequestClosedPropPullRequest
+        | github.webhooks.PullRequestReopenedPropPullRequest,
         organization: Organization,
         repository: Repository,
     ) -> Self:

--- a/server/polar/pull_request/service.py
+++ b/server/polar/pull_request/service.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 from uuid import UUID
 
 import structlog

--- a/server/polar/repository/service.py
+++ b/server/polar/repository/service.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 from uuid import UUID
 
 import structlog

--- a/server/polar/reward/service.py
+++ b/server/polar/reward/service.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple
+from collections.abc import Sequence
 from uuid import UUID
 
 import structlog
@@ -29,7 +29,7 @@ class RewardService:
         reward_org_id: UUID | None = None,
         reward_user_id: UUID | None = None,
         is_transfered: bool | None = None,
-    ) -> Sequence[Tuple[Pledge, IssueReward, PledgeTransaction]]:
+    ) -> Sequence[tuple[Pledge, IssueReward, PledgeTransaction]]:
         statement = (
             (
                 sql.select(Pledge, IssueReward, PledgeTransaction)
@@ -92,7 +92,7 @@ class RewardService:
         session: AsyncSession,
         pledge_id: UUID,
         issue_reward_id: UUID,
-    ) -> Tuple[Pledge, IssueReward, PledgeTransaction] | None:
+    ) -> tuple[Pledge, IssueReward, PledgeTransaction] | None:
         statement = (
             sql.select(Pledge, IssueReward, PledgeTransaction)
             .join(Pledge.issue)

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 from uuid import UUID
 
 import structlog

--- a/server/polar/worker.py
+++ b/server/polar/worker.py
@@ -1,12 +1,10 @@
 import functools
 import types
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import (
     Any,
-    Awaitable,
-    Callable,
     ParamSpec,
     TypedDict,
     TypeVar,

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -82,7 +82,7 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]  # See: https://github
 
 [tool.ruff]
 target-version = "py311"
-extend-select = ["I"]
+extend-select = ["I", "UP"]
 ignore = [
     "F401", # remove unused import
     "F841", # remove unused variables

--- a/server/scripts/dev_github.py
+++ b/server/scripts/dev_github.py
@@ -1,6 +1,6 @@
 import asyncio
+from collections.abc import Sequence
 from functools import wraps
-from typing import Sequence
 
 import typer
 from sqlalchemy.orm import joinedload
@@ -64,7 +64,7 @@ async def get_issues(session: AsyncSession, org: Organization) -> Sequence[Issue
 
 
 async def do_delete_issues(session: AsyncSession, org: Organization) -> None:
-    query = sql.delete(Issue).where((Issue.organization_id == org.id))
+    query = sql.delete(Issue).where(Issue.organization_id == org.id)
     await session.execute(query)
     await session.commit()
 

--- a/server/scripts/transfer_fix.py
+++ b/server/scripts/transfer_fix.py
@@ -55,7 +55,7 @@ def typer_async(f):  # type: ignore
 @cli.command()
 @typer_async
 async def organizations_renamed(
-    organizations: Optional[list[str]] = typer.Argument(None),
+    organizations: list[str] | None = typer.Argument(None),
     dry_run: bool = typer.Option(
         False, help="If `True`, changes won't be commited to the database."
     ),
@@ -129,7 +129,7 @@ async def organizations_renamed(
 @cli.command()
 @typer_async
 async def repositories_transferred(
-    organizations: Optional[list[str]] = typer.Argument(None),
+    organizations: list[str] | None = typer.Argument(None),
     dry_run: bool = typer.Option(
         False, help="If `True`, changes won't be commited to the database."
     ),
@@ -214,7 +214,7 @@ async def repositories_transferred(
 @cli.command()
 @typer_async
 async def issues_transferred(
-    repositories: Optional[list[str]] = typer.Argument(None),
+    repositories: list[str] | None = typer.Argument(None),
     dry_run: bool = typer.Option(
         False, help="If `True`, changes won't be commited to the database."
     ),

--- a/server/tests/fixtures/base.py
+++ b/server/tests/fixtures/base.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator
 
 import pytest
 import pytest_asyncio

--- a/server/tests/fixtures/vcr.py
+++ b/server/tests/fixtures/vcr.py
@@ -5,6 +5,6 @@ from typing import Any
 # Homegrown and simple version of VCR
 def read_cassette(filename: str) -> dict[str, Any]:
     filename = f"tests/fixtures/cassettes/{filename}"
-    with open(filename, "r") as fp:
+    with open(filename) as fp:
         cassette: dict[str, Any] = json.loads(fp.read())
         return cassette

--- a/server/tests/fixtures/webhook.py
+++ b/server/tests/fixtures/webhook.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest_asyncio
 from httpx import AsyncClient, Response

--- a/server/tests/integrations/github/service/test_reference.py
+++ b/server/tests/integrations/github/service/test_reference.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import List
 
 import pytest
 from pydantic import parse_obj_as
@@ -23,7 +22,7 @@ from tests.fixtures.vcr import read_cassette
 @pytest.mark.asyncio
 async def test_parse_repository_issues() -> None:
     raw = read_cassette("github/references/repo_issue_events.json")
-    payload = parse_obj_as(List[github.rest.IssueEvent], raw)
+    payload = parse_obj_as(list[github.rest.IssueEvent], raw)
     issues_to_sync = github_reference.external_issue_ids_to_sync(payload)
     assert issues_to_sync == {1634181886}
 
@@ -33,7 +32,7 @@ async def test_parse_issue_timeline(
     session: AsyncSession,
 ) -> None:
     raw = read_cassette("github/references/issue_timeline.json")
-    payload = parse_obj_as(List[TimelineEventType], raw)
+    payload = parse_obj_as(list[TimelineEventType], raw)
 
     # Create Org/Repo/Issue
     org = Organization(

--- a/server/tests/integrations/github/tasks/test_integration.py
+++ b/server/tests/integrations/github/tasks/test_integration.py
@@ -55,7 +55,6 @@ async def test_installation_no_notifications(
 
     with open(
         "tests/integrations/github/tasks/testdata/github_webhook_installation_created_open-testing.json",
-        "r",
     ) as fp:
         cassette: dict[str, Any] = json.loads(fp.read())
 

--- a/server/tests/integrations/open_collective/test_service.py
+++ b/server/tests/integrations/open_collective/test_service.py
@@ -30,7 +30,7 @@ async def test_get_collective_collective_not_found(
     open_collective_graphql_mock: respx.Route,
 ) -> None:
     with open(
-        "tests/fixtures/cassettes/open_collective/collective/not_found.json", "r"
+        "tests/fixtures/cassettes/open_collective/collective/not_found.json"
     ) as f:
         cassette = json.loads(f.read())
     open_collective_graphql_mock.mock(return_value=httpx.Response(200, json=cassette))
@@ -42,9 +42,7 @@ async def test_get_collective_collective_not_found(
 async def test_get_collective(
     open_collective_graphql_mock: respx.Route,
 ) -> None:
-    with open(
-        "tests/fixtures/cassettes/open_collective/collective/eligible.json", "r"
-    ) as f:
+    with open("tests/fixtures/cassettes/open_collective/collective/eligible.json") as f:
         cassette = json.loads(f.read())
     open_collective_graphql_mock.mock(return_value=httpx.Response(200, json=cassette))
     collective = await open_collective.get_collective("babel")

--- a/server/tests/magic_link/test_service.py
+++ b/server/tests/magic_link/test_service.py
@@ -109,7 +109,7 @@ async def test_send(
         with open(record_file_name, "w+") as f:
             f.write(expected_content)
 
-    with open(record_file_name, "r") as f:
+    with open(record_file_name) as f:
         content = f.read()
         assert content == expected_content
 

--- a/server/tests/notifications/test_email.py
+++ b/server/tests/notifications/test_email.py
@@ -1,7 +1,6 @@
 import inspect
 import os
 import uuid
-from typing import Any, Tuple
 
 import pytest
 
@@ -19,7 +18,7 @@ from polar.notifications.notification import (
 from polar.pledge.schemas import PledgeType
 
 
-async def check_diff(email: Tuple[str, str]) -> None:
+async def check_diff(email: tuple[str, str]) -> None:
     (subject, body) = email
     expected = f"{subject}\n<hr>\n{body}"
 
@@ -33,7 +32,7 @@ async def check_diff(email: Tuple[str, str]) -> None:
             f.write(expected)
             return
 
-    with open(f"./tests/notifications/testdata/{name}.html", "r") as f:
+    with open(f"./tests/notifications/testdata/{name}.html") as f:
         content = f.read()
         assert content == expected
 


### PR DESCRIPTION
Those rules allow us to check that we're using the most up-to-date syntax for our version of Python (3.11).

Most changes are related to typing, in particular places where we were still using `typing.Union`, `typing.List`, etc.