### PR TITLE
clients/sdk: configure registry-url

### DIFF
--- a/.github/workflows/publish_sdk.yaml
+++ b/.github/workflows/publish_sdk.yaml
@@ -23,6 +23,7 @@ jobs:
             node-version: v18
             cache: 'pnpm'
             cache-dependency-path: 'clients/pnpm-lock.yaml'
+            registry-url: 'https://registry.npmjs.org'
 
         - name: Install dependencies
           working-directory: ./clients


### PR DESCRIPTION
This seems to be the missing link in why the publish is failing