### PR TITLE
WIP: Dataclass SQLAlchemy Models

### DIFF
--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -109,8 +109,7 @@ class AccountService(ResourceService[Account, AccountCreate, AccountUpdate]):
         except stripe_lib_error.StripeError as e:
             raise AccountServiceError(e.user_message) from e
 
-        return await Account.create(
-            session=session,
+        return await Account(
             organization_id=organization_id,
             user_id=user_id,
             admin_id=admin_id,
@@ -124,6 +123,8 @@ class AccountService(ResourceService[Account, AccountCreate, AccountUpdate]):
             is_payouts_enabled=stripe_account.payouts_enabled,
             business_type=stripe_account.business_type,
             data=stripe_account.to_dict(),
+        ).save(
+            session=session,
         )
 
     async def _create_open_collective_account(
@@ -149,8 +150,7 @@ class AccountService(ResourceService[Account, AccountCreate, AccountUpdate]):
                 "You can use Stripe instead."
             )
 
-        return await Account.create(
-            session=session,
+        return await Account(
             organization_id=organization_id,
             admin_id=admin_id,
             account_type=account.account_type,
@@ -164,7 +164,7 @@ class AccountService(ResourceService[Account, AccountCreate, AccountUpdate]):
             is_payouts_enabled=True,
             business_type="fiscal_host",
             data={},
-        )
+        ).save(session)
 
     async def onboarding_link(self, account: Account) -> AccountLink | None:
         if account.account_type == AccountType.stripe:

--- a/server/polar/integrations/github/service/reference.py
+++ b/server/polar/integrations/github/service/reference.py
@@ -449,6 +449,9 @@ class GitHubIssueReferencesService:
             is_merged=True if i.pull_request.merged_at else False,
         )
 
+        if not i.pull_request.html_url:
+            return None
+
         ref = IssueReference(
             issue_id=issue.id,
             external_id=i.pull_request.html_url,

--- a/server/polar/kit/db/models/base.py
+++ b/server/polar/kit/db/models/base.py
@@ -38,14 +38,21 @@ class Model(
     metadata = my_metadata
 
 
-class TimestampedModel(Model, MappedAsDataclass):
+class TimestampedModel(Model, MappedAsDataclass, kw_only=True):
     __abstract__ = True
 
     created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False, default=utc_now
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=None,
+        insert_default=utc_now,
+        # init=False,
     )
     modified_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), onupdate=utc_now, nullable=True, default=None
+        TIMESTAMP(timezone=True),
+        onupdate=utc_now,
+        nullable=True,
+        default=None,
     )
     deleted_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True, default=None
@@ -56,5 +63,9 @@ class RecordModel(TimestampedModel, MappedAsDataclass):
     __abstract__ = True
 
     id: MappedColumn[UUID] = mapped_column(
-        PostgresUUID, primary_key=True, default=generate_uuid
+        PostgresUUID,
+        primary_key=True,
+        init=False,
+        # default=generate_uuid,
+        insert_default=generate_uuid,
     )

--- a/server/polar/kit/db/models/base.py
+++ b/server/polar/kit/db/models/base.py
@@ -2,7 +2,13 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, MetaData
-from sqlalchemy.orm import DeclarativeBase, Mapped, MappedColumn, mapped_column
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    MappedColumn,
+    mapped_column,
+)
 
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 from polar.kit.utils import generate_uuid, utc_now
@@ -20,13 +26,19 @@ my_metadata = MetaData(
 )
 
 
-class Model(DeclarativeBase, ActiveRecordMixin, SerializeMixin):
+class Model(
+    MappedAsDataclass,
+    DeclarativeBase,
+    ActiveRecordMixin,
+    SerializeMixin,
+    kw_only=True,
+):
     __abstract__ = True
 
     metadata = my_metadata
 
 
-class TimestampedModel(Model):
+class TimestampedModel(Model, MappedAsDataclass):
     __abstract__ = True
 
     created_at: Mapped[datetime] = mapped_column(
@@ -40,7 +52,7 @@ class TimestampedModel(Model):
     )
 
 
-class RecordModel(TimestampedModel):
+class RecordModel(TimestampedModel, MappedAsDataclass):
     __abstract__ = True
 
     id: MappedColumn[UUID] = mapped_column(

--- a/server/polar/kit/db/models/base.py
+++ b/server/polar/kit/db/models/base.py
@@ -69,3 +69,37 @@ class RecordModel(TimestampedModel, MappedAsDataclass):
         # default=generate_uuid,
         insert_default=generate_uuid,
     )
+
+
+# same as above, but without dataclass
+class RecordModelNoDataClass(
+    DeclarativeBase,
+    ActiveRecordMixin,
+    SerializeMixin,
+):
+    __abstract__ = True
+
+    metadata = my_metadata
+
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=utc_now,
+    )
+
+    modified_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        onupdate=utc_now,
+        nullable=True,
+        default=None,
+    )
+
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, default=None
+    )
+
+    id: MappedColumn[UUID] = mapped_column(
+        PostgresUUID,
+        primary_key=True,
+        default=generate_uuid,
+    )

--- a/server/polar/kit/db/models/mixins/active_record.py
+++ b/server/polar/kit/db/models/mixins/active_record.py
@@ -17,17 +17,16 @@ from polar.postgres import AsyncSession, sql
 class ActiveRecordMixin:
     __table__: ClassVar[FromClause]
 
-    @classmethod
-    async def create(
-        cls,
-        session: AsyncSession,
-        autocommit: bool = True,
-        **values: Any,
-    ) -> Self:
-        instance = cls()
-        instance.fill(**values)
-
-        return await instance.save(session, autocommit=autocommit)
+    # @classmethod
+    # async def create(
+    #     cls,
+    #     session: AsyncSession,
+    #     autocommit: bool = True,
+    #     **values: Any,
+    # ) -> Self:
+    #     instance = cls()
+    #     instance.fill(**values)
+    #     return await instance.save(session, autocommit=autocommit)
 
     def fill(self, **values: Any) -> Self:
         for col, value in values.items():

--- a/server/polar/kit/services.py
+++ b/server/polar/kit/services.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlalchemy.orm import InstrumentedAttribute
 from typing_extensions import deprecated
 
+from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.utils import utc_now
 
 from .db.models import RecordModel
@@ -14,6 +15,7 @@ from .db.postgres import AsyncSession, sql
 from .schemas import Schema
 
 ModelType = TypeVar("ModelType", bound=RecordModel)
+ModelTypeNoDataClass = TypeVar("ModelTypeNoDataClass", bound=RecordModelNoDataClass)
 CreateSchemaType = TypeVar("CreateSchemaType", bound=Schema)
 UpdateSchemaType = TypeVar("UpdateSchemaType", bound=Schema)
 SchemaType = TypeVar("SchemaType", bound=Schema)
@@ -58,16 +60,6 @@ class ResourceService(
     # Ideally, actions would only contain class methods since there is
     # no state to retain. Unable to achieve this with mapping the model
     # and schema as class attributes though without breaking typing.
-
-    # async def create(
-    #     self,
-    #     session: AsyncSession,
-    #     create_schema: CreateSchemaType,
-    #     autocommit: bool = True,
-    # ) -> ModelType:
-    #     return await self.model.create(
-    #         session, **create_schema.dict(), autocommit=autocommit
-    #     )
 
     # TODO: Investigate new bulk methods in SQLALchemy 2.0 for upsert_many
     async def upsert_many(
@@ -165,6 +157,144 @@ class ResourceService(
         exclude_unset: bool = False,
         autocommit: bool = True,
     ) -> ModelType:
+        return await source.update(
+            session,
+            autocommit=autocommit,
+            **update_schema.dict(
+                include=include, exclude=exclude, exclude_unset=exclude_unset
+            ),
+        )
+
+
+class ResourceServiceNoDataClass(
+    Generic[ModelTypeNoDataClass, CreateSchemaType, UpdateSchemaType],
+):
+    def __init__(self, model: type[ModelTypeNoDataClass]) -> None:
+        self.model = model
+
+    async def get(
+        self, session: AsyncSession, id: UUID, allow_deleted: bool = False
+    ) -> ModelTypeNoDataClass | None:
+        query = sql.select(self.model).where(self.model.id == id)
+        if not allow_deleted:
+            query = query.where(self.model.deleted_at.is_(None))
+        res = await session.execute(query)
+        return res.scalars().unique().one_or_none()
+
+    async def get_by(
+        self, session: AsyncSession, **clauses: Any
+    ) -> ModelTypeNoDataClass | None:
+        query = sql.select(self.model).filter_by(**clauses)
+        res = await session.execute(query)
+        return res.scalars().unique().one_or_none()
+
+    async def soft_delete(self, session: AsyncSession, id: UUID) -> None:
+        stmt = (
+            sql.update(self.model)
+            .where(self.model.id == id, self.model.deleted_at.is_(None))
+            .values(
+                deleted_at=utc_now(),
+            )
+        )
+        await session.execute(stmt)
+        await session.commit()
+
+    # TODO: Investigate new bulk methods in SQLALchemy 2.0 for upsert_many
+    async def upsert_many(
+        self,
+        session: AsyncSession,
+        create_schemas: list[CreateSchemaType],
+        constraints: list[InstrumentedAttribute[Any]],
+        mutable_keys: set[str],
+        autocommit: bool = True,
+    ) -> Sequence[ModelTypeNoDataClass]:
+        return await self._db_upsert_many(
+            session,
+            create_schemas,
+            constraints=constraints,
+            mutable_keys=mutable_keys,
+            autocommit=autocommit,
+        )
+
+    async def upsert(
+        self,
+        session: AsyncSession,
+        create_schema: CreateSchemaType,
+        constraints: list[InstrumentedAttribute[Any]],
+        mutable_keys: set[str],
+        autocommit: bool = True,
+    ) -> ModelTypeNoDataClass:
+        return await self._db_upsert(
+            session,
+            create_schema,
+            constraints=constraints,
+            mutable_keys=mutable_keys,
+            autocommit=autocommit,
+        )
+
+    async def _db_upsert_many(
+        self,
+        session: AsyncSession,
+        objects: list[CreateSchemaType],
+        constraints: list[InstrumentedAttribute[Any]],
+        mutable_keys: set[str],
+        autocommit: bool = True,
+    ) -> Sequence[ModelTypeNoDataClass]:
+        values = [obj.dict() for obj in objects]
+        if not values:
+            raise ValueError("Zero values provided")
+
+        insert_stmt = sql.insert(self.model).values(values)
+
+        # Update the insert statement with what to update on conflict, i.e mutable keys.
+        upsert_stmt = (
+            insert_stmt.on_conflict_do_update(
+                index_elements=constraints,
+                set_={k: getattr(insert_stmt.excluded, k) for k in mutable_keys},
+            )
+            .returning(self.model)
+            .execution_options(populate_existing=True)
+        )
+
+        res = await session.execute(upsert_stmt)
+        instances = res.scalars().all()
+        if autocommit:
+            await session.commit()
+        return instances
+
+    async def _db_upsert(
+        self,
+        session: AsyncSession,
+        obj: CreateSchemaType,
+        constraints: list[InstrumentedAttribute[Any]],
+        mutable_keys: set[str],
+        autocommit: bool = True,
+    ) -> ModelTypeNoDataClass:
+        """
+        Usage of upsert is deprecated.
+        If you need an upsert, add the functionality in the service instead of relying
+        active record.
+        """
+
+        upserted: Sequence[ModelTypeNoDataClass] = await self._db_upsert_many(
+            session,
+            [obj],
+            constraints=constraints,
+            mutable_keys=mutable_keys,
+            autocommit=autocommit,
+        )
+        return upserted[0]
+
+    async def update(
+        self,
+        session: AsyncSession,
+        source: ModelTypeNoDataClass,
+        update_schema: UpdateSchemaType,
+        include: set[str] | None = None,
+        exclude: set[str] | None = None,
+        exclude_unset: bool = False,
+        autocommit: bool = True,
+    ) -> ModelTypeNoDataClass:
         return await source.update(
             session,
             autocommit=autocommit,

--- a/server/polar/kit/services.py
+++ b/server/polar/kit/services.py
@@ -5,6 +5,7 @@ from typing import Any, Generic, TypeVar
 from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
+from typing_extensions import deprecated
 
 from polar.kit.utils import utc_now
 
@@ -58,15 +59,15 @@ class ResourceService(
     # no state to retain. Unable to achieve this with mapping the model
     # and schema as class attributes though without breaking typing.
 
-    async def create(
-        self,
-        session: AsyncSession,
-        create_schema: CreateSchemaType,
-        autocommit: bool = True,
-    ) -> ModelType:
-        return await self.model.create(
-            session, **create_schema.dict(), autocommit=autocommit
-        )
+    # async def create(
+    #     self,
+    #     session: AsyncSession,
+    #     create_schema: CreateSchemaType,
+    #     autocommit: bool = True,
+    # ) -> ModelType:
+    #     return await self.model.create(
+    #         session, **create_schema.dict(), autocommit=autocommit
+    #     )
 
     # TODO: Investigate new bulk methods in SQLALchemy 2.0 for upsert_many
     async def upsert_many(

--- a/server/polar/models/account.py
+++ b/server/polar/models/account.py
@@ -50,8 +50,8 @@ class Account(RecordModel, MappedAsDataclass, kw_only=True):
 
     email: Mapped[str | None] = mapped_column(String(254), nullable=True, default=None)
 
-    country: Mapped[str | None] = mapped_column(String(2))
-    currency: Mapped[str | None] = mapped_column(String(3))
+    country: Mapped[str] = mapped_column(String(2))
+    currency: Mapped[str] = mapped_column(String(3))
 
     is_details_submitted: Mapped[bool] = mapped_column(Boolean, nullable=False)
     is_charges_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False)
@@ -65,7 +65,9 @@ class Account(RecordModel, MappedAsDataclass, kw_only=True):
         StringEnum(Status), nullable=False, default=Status.CREATED
     )
 
-    data: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    data: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=None, insert_default=dict
+    )
 
     @declared_attr
     def organization(cls) -> Mapped[Organization | None]:

--- a/server/polar/models/account.py
+++ b/server/polar/models/account.py
@@ -4,7 +4,13 @@ from uuid import UUID
 
 from sqlalchemy import Boolean, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.enums import AccountType
 from polar.kit.db.models import RecordModel
@@ -12,7 +18,7 @@ from polar.kit.extensions.sqlalchemy import PostgresUUID, StringEnum
 from polar.models.organization import Organization
 
 
-class Account(RecordModel):
+class Account(RecordModel, MappedAsDataclass, kw_only=True):
     class Status(str, Enum):
         CREATED = "created"
         ONBOARDING_STARTED = "onboarding_started"
@@ -22,7 +28,11 @@ class Account(RecordModel):
     account_type: Mapped[AccountType] = mapped_column(String(255), nullable=False)
 
     organization_id: Mapped[UUID | None] = mapped_column(
-        PostgresUUID, ForeignKey("organizations.id"), unique=True, nullable=True
+        PostgresUUID,
+        ForeignKey("organizations.id"),
+        unique=True,
+        nullable=True,
+        default=None,
     )
 
     user_id: Mapped[UUID | None] = mapped_column(

--- a/server/polar/models/invites.py
+++ b/server/polar/models/invites.py
@@ -1,32 +1,43 @@
+from typing import Self
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, String
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models.base import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 from polar.models.user import User
 
 
-class Invite(RecordModel):
+class Invite(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "invites"
 
     created_by: Mapped[UUID] = mapped_column(
         PostgresUUID, ForeignKey("users.id"), nullable=False
     )
 
-    claimed_by: Mapped[UUID] = mapped_column(
-        PostgresUUID, ForeignKey("users.id"), nullable=True
+    claimed_by: Mapped[UUID | None] = mapped_column(
+        PostgresUUID, ForeignKey("users.id"), nullable=True, default=None
     )
 
     code: Mapped[str] = mapped_column(String, nullable=False, index=True, unique=True)
 
     @declared_attr
-    def claimed_by_user(cls) -> Mapped[User]:
-        return relationship(User, lazy="raise", primaryjoin=User.id == cls.claimed_by)
+    def claimed_by_user(cls) -> Mapped[User | None]:
+        return relationship(
+            User, lazy="raise", primaryjoin=User.id == "Invite.claimed_by"
+        )
 
     @declared_attr
     def created_by_user(cls) -> Mapped[User]:
-        return relationship(User, lazy="raise", primaryjoin=User.id == cls.created_by)
+        return relationship(
+            User, lazy="raise", primaryjoin=User.id == "Invite.created_by"
+        )
 
     note: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/server/polar/models/invites.py
+++ b/server/polar/models/invites.py
@@ -30,14 +30,10 @@ class Invite(RecordModel, MappedAsDataclass, kw_only=True):
 
     @declared_attr
     def claimed_by_user(cls) -> Mapped[User | None]:
-        return relationship(
-            User, lazy="raise", primaryjoin=User.id == "Invite.claimed_by"
-        )
+        return relationship(User, lazy="raise", foreign_keys="[Invite.claimed_by]")
 
     @declared_attr
     def created_by_user(cls) -> Mapped[User]:
-        return relationship(
-            User, lazy="raise", primaryjoin=User.id == "Invite.created_by"
-        )
+        return relationship(User, lazy="raise", foreign_keys="[Invite.created_by]")
 
     note: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/server/polar/models/issue.py
+++ b/server/polar/models/issue.py
@@ -59,7 +59,7 @@ class IssueFields(MappedAsDataclass, kw_only=True):
 
     @declared_attr
     def organization(cls) -> "Mapped[Organization]":
-        return relationship("Organization", lazy="raise")
+        return relationship("Organization", lazy="raise", init=False)
 
     repository_id: "MappedColumn[UUID]" = mapped_column(
         PostgresUUID,
@@ -70,52 +70,52 @@ class IssueFields(MappedAsDataclass, kw_only=True):
 
     @declared_attr
     def repository(cls) -> "Mapped[Repository]":
-        return relationship("Repository", lazy="raise")
+        return relationship("Repository", lazy="raise", init=False)
 
     number: Mapped[int] = mapped_column(Integer, nullable=False)
 
     title: Mapped[str] = mapped_column(String, nullable=False)
-    body: Mapped[str | None] = mapped_column(Text, nullable=True, default=True)
-    comments: Mapped[int | None] = mapped_column(Integer, nullable=True, default=True)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    comments: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
 
     author: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     author_association: Mapped[str | None] = mapped_column(
-        String, nullable=True, default=True
+        String, nullable=True, default=None
     )
     labels: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     assignee: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     assignees: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     milestone: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     closed_by: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     reactions: Mapped[JSONAny] = mapped_column(
-        JSONB(none_as_null=True), nullable=True, default=True
+        JSONB(none_as_null=True), nullable=True, default=None
     )
 
     state: Mapped[str] = mapped_column(StringEnum(State), nullable=False)
     state_reason: Mapped[str | None] = mapped_column(
-        String, nullable=True, default=True
+        String, nullable=True, default=None
     )
 
     issue_closed_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=True, default=True
+        TIMESTAMP(timezone=True), nullable=True, default=None
     )
     issue_created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
     )
     issue_modified_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=True, default=True
+        TIMESTAMP(timezone=True), nullable=True, default=None
     )
 
     @declared_attr
@@ -123,6 +123,7 @@ class IssueFields(MappedAsDataclass, kw_only=True):
         return mapped_column(
             TSVectorType("title", regconfig="simple"),
             sa.Computed("to_tsvector('simple', \"title\")", persisted=True),
+            init=False,
         )
 
 

--- a/server/polar/models/issue_dependency.py
+++ b/server/polar/models/issue_dependency.py
@@ -1,14 +1,20 @@
 from uuid import UUID
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import TimestampedModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 from polar.models.issue import Issue
 
 
-class IssueDependency(TimestampedModel):
+class IssueDependency(TimestampedModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "issue_dependencies"
 
     organization_id: Mapped[UUID] = mapped_column(
@@ -39,7 +45,7 @@ class IssueDependency(TimestampedModel):
             Issue,
             uselist=False,
             lazy="raise",
-            primaryjoin=Issue.id == cls.dependent_issue_id,
+            primaryjoin=Issue.id == "IssueDependency.dependent_issue_id",
         )
 
     @declared_attr
@@ -48,5 +54,5 @@ class IssueDependency(TimestampedModel):
             Issue,
             uselist=False,
             lazy="raise",
-            primaryjoin=Issue.id == cls.dependency_issue_id,
+            primaryjoin=Issue.id == "IssueDependency.dependency_issue_id",
         )

--- a/server/polar/models/issue_dependency.py
+++ b/server/polar/models/issue_dependency.py
@@ -45,7 +45,7 @@ class IssueDependency(TimestampedModel, MappedAsDataclass, kw_only=True):
             Issue,
             uselist=False,
             lazy="raise",
-            primaryjoin=Issue.id == "IssueDependency.dependent_issue_id",
+            foreign_keys="[IssueDependency.dependent_issue_id]",
         )
 
     @declared_attr
@@ -54,5 +54,5 @@ class IssueDependency(TimestampedModel, MappedAsDataclass, kw_only=True):
             Issue,
             uselist=False,
             lazy="raise",
-            primaryjoin=Issue.id == "IssueDependency.dependency_issue_id",
+            foreign_keys="[IssueDependency.dependency_issue_id]",
         )

--- a/server/polar/models/issue_reference.py
+++ b/server/polar/models/issue_reference.py
@@ -3,7 +3,13 @@ from uuid import UUID
 
 from sqlalchemy import ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import TimestampedModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
@@ -50,7 +56,7 @@ class ReferenceType(str, enum.Enum):
     EXTERNAL_GITHUB_COMMIT = "external_github_commit"
 
 
-class IssueReference(TimestampedModel):
+class IssueReference(TimestampedModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "issue_references"
 
     issue_id: Mapped[UUID] = mapped_column(

--- a/server/polar/models/issue_reward.py
+++ b/server/polar/models/issue_reward.py
@@ -1,7 +1,13 @@
 from uuid import UUID
 
 from sqlalchemy import BigInteger, ForeignKey, String, UniqueConstraint
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
@@ -9,7 +15,7 @@ from polar.models.organization import Organization
 from polar.models.user import User
 
 
-class IssueReward(RecordModel):
+class IssueReward(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "issue_rewards"
 
     __table_args__ = (

--- a/server/polar/models/magic_link.py
+++ b/server/polar/models/magic_link.py
@@ -26,7 +26,10 @@ class MagicLink(RecordModel, MappedAsDataclass, kw_only=True):
 
     token_hash: Mapped[str] = mapped_column(String, index=True, nullable=False)
     expires_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False, default=get_expires_at
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=None,
+        insert_default=get_expires_at,
     )
 
     user_email: Mapped[str] = mapped_column(String, nullable=False)

--- a/server/polar/models/magic_link.py
+++ b/server/polar/models/magic_link.py
@@ -2,7 +2,13 @@ from datetime import datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, ForeignKey, String
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.config import settings
 from polar.kit.db.models import RecordModel
@@ -15,7 +21,7 @@ def get_expires_at() -> datetime:
     return utc_now() + timedelta(seconds=settings.MAGIC_LINK_TTL_SECONDS)
 
 
-class MagicLink(RecordModel):
+class MagicLink(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "magic_links"
 
     token_hash: Mapped[str] = mapped_column(String, index=True, nullable=False)

--- a/server/polar/models/notification.py
+++ b/server/polar/models/notification.py
@@ -41,4 +41,4 @@ class Notification(RecordModel, MappedAsDataclass, kw_only=True):
         PostgresUUID, ForeignKey("pull_requests.id"), nullable=True, default=None
     )
 
-    payload: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=dict)
+    payload: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=None)

--- a/server/polar/models/notification.py
+++ b/server/polar/models/notification.py
@@ -2,14 +2,14 @@ from uuid import UUID
 
 from sqlalchemy import ForeignKey, Index, String
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 from polar.types import JSONDict
 
 
-class Notification(RecordModel):
+class Notification(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "notifications"
     __table_args__ = (
         Index(
@@ -18,8 +18,10 @@ class Notification(RecordModel):
         ),
     )
 
-    user_id: Mapped[UUID] = mapped_column(PostgresUUID, nullable=True)
-    email_addr: Mapped[str] = mapped_column(String, nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        PostgresUUID, nullable=True, default=None
+    )
+    email_addr: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
 
     organization_id: Mapped[UUID] = mapped_column(
         PostgresUUID, nullable=True, default=None
@@ -27,16 +29,16 @@ class Notification(RecordModel):
 
     type: Mapped[str] = mapped_column(String, nullable=False)
 
-    issue_id: Mapped[UUID] = mapped_column(
-        PostgresUUID, ForeignKey("issues.id"), nullable=True
+    issue_id: Mapped[UUID | None] = mapped_column(
+        PostgresUUID, ForeignKey("issues.id"), nullable=True, default=None
     )
 
-    pledge_id: Mapped[UUID] = mapped_column(
-        PostgresUUID, ForeignKey("pledges.id"), nullable=True
+    pledge_id: Mapped[UUID | None] = mapped_column(
+        PostgresUUID, ForeignKey("pledges.id"), nullable=True, default=None
     )
 
-    pull_request_id: Mapped[UUID] = mapped_column(
-        PostgresUUID, ForeignKey("pull_requests.id"), nullable=True
+    pull_request_id: Mapped[UUID | None] = mapped_column(
+        PostgresUUID, ForeignKey("pull_requests.id"), nullable=True, default=None
     )
 
     payload: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=dict)

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from citext import CIText
 from sqlalchemy import TIMESTAMP, Boolean, Integer, String, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 from polar.config import settings
 from polar.enums import Platforms
@@ -18,7 +18,7 @@ class NotInstalledOrganization(PolarError):
         super().__init__("This organization is not installed.")
 
 
-class Organization(RecordModel):
+class Organization(RecordModel, MappedAsDataclass, kw_only=True):
     class Status(Enum):
         INACTIVE = "inactive"
         ACTIVE = "active"

--- a/server/polar/models/personal_access_token.py
+++ b/server/polar/models/personal_access_token.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from sqlalchemy import TIMESTAMP, ForeignKey, String
 from sqlalchemy.orm import (
     Mapped,
+    MappedAsDataclass,
     declared_attr,
     mapped_column,
     relationship,
@@ -14,7 +15,7 @@ from polar.kit.extensions.sqlalchemy import PostgresUUID
 from polar.models.user import User
 
 
-class PersonalAccessToken(RecordModel):
+class PersonalAccessToken(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "personal_access_tokens"
 
     user_id: Mapped[UUID] = mapped_column(

--- a/server/polar/models/pledge.py
+++ b/server/polar/models/pledge.py
@@ -2,7 +2,13 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, BigInteger, ForeignKey, String
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.exceptions import PolarError
 from polar.kit.db.models import RecordModel
@@ -20,7 +26,7 @@ class PledgeWithoutPledgerError(PolarError):
         super().__init__(message)
 
 
-class Pledge(RecordModel):
+class Pledge(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "pledges"
 
     issue_id: Mapped[UUID] = mapped_column(
@@ -141,7 +147,7 @@ class Pledge(RecordModel):
     def by_organization(cls) -> Mapped[Organization]:
         return relationship(
             Organization,
-            primaryjoin=Organization.id == cls.by_organization_id,
+            primaryjoin=Organization.id == "Pledge.by_organization_id",
             lazy="raise",
         )
 
@@ -149,30 +155,34 @@ class Pledge(RecordModel):
     def on_behalf_of_organization(cls) -> Mapped[Organization]:
         return relationship(
             Organization,
-            primaryjoin=Organization.id == cls.on_behalf_of_organization_id,
+            primaryjoin=Organization.id == "Pledge.on_behalf_of_organization_id",
             lazy="raise",
         )
 
     @declared_attr
     def to_repository(cls) -> Mapped[Repository]:
         return relationship(
-            Repository, primaryjoin=Repository.id == cls.repository_id, lazy="raise"
+            Repository,
+            primaryjoin=Repository.id == "Pledge.repository_id",
+            lazy="raise",
         )
 
     @declared_attr
     def to_organization(cls) -> Mapped[Organization]:
         return relationship(
             Organization,
-            primaryjoin=Organization.id == cls.organization_id,
+            primaryjoin=Organization.id == "Pledge.organization_id",
             lazy="raise",
         )
 
     @declared_attr
     def created_by_user(cls) -> Mapped[User | None]:
         return relationship(
-            User, primaryjoin=User.id == cls.created_by_user_id, lazy="raise"
+            User, primaryjoin=User.id == "Pledge.created_by_user_id", lazy="raise"
         )
 
     @declared_attr
     def issue(cls) -> Mapped[Issue]:
-        return relationship(Issue, primaryjoin=Issue.id == cls.issue_id, lazy="raise")
+        return relationship(
+            Issue, primaryjoin=Issue.id == "Pledge.issue_id", lazy="raise"
+        )

--- a/server/polar/models/pledge.py
+++ b/server/polar/models/pledge.py
@@ -141,13 +141,13 @@ class Pledge(RecordModel, MappedAsDataclass, kw_only=True):
 
     @declared_attr
     def user(cls) -> Mapped[User | None]:
-        return relationship(User, primaryjoin=User.id == cls.by_user_id, lazy="raise")
+        return relationship(User, foreign_keys="Pledge.by_user_id", lazy="raise")
 
     @declared_attr
     def by_organization(cls) -> Mapped[Organization]:
         return relationship(
             Organization,
-            primaryjoin=Organization.id == "Pledge.by_organization_id",
+            foreign_keys="Pledge.by_organization_id",
             lazy="raise",
         )
 
@@ -155,7 +155,7 @@ class Pledge(RecordModel, MappedAsDataclass, kw_only=True):
     def on_behalf_of_organization(cls) -> Mapped[Organization]:
         return relationship(
             Organization,
-            primaryjoin=Organization.id == "Pledge.on_behalf_of_organization_id",
+            foreign_keys="Pledge.on_behalf_of_organization_id",
             lazy="raise",
         )
 
@@ -163,7 +163,7 @@ class Pledge(RecordModel, MappedAsDataclass, kw_only=True):
     def to_repository(cls) -> Mapped[Repository]:
         return relationship(
             Repository,
-            primaryjoin=Repository.id == "Pledge.repository_id",
+            foreign_keys="Pledge.repository_id",
             lazy="raise",
         )
 
@@ -171,18 +171,22 @@ class Pledge(RecordModel, MappedAsDataclass, kw_only=True):
     def to_organization(cls) -> Mapped[Organization]:
         return relationship(
             Organization,
-            primaryjoin=Organization.id == "Pledge.organization_id",
+            foreign_keys="Pledge.organization_id",
             lazy="raise",
         )
 
     @declared_attr
     def created_by_user(cls) -> Mapped[User | None]:
         return relationship(
-            User, primaryjoin=User.id == "Pledge.created_by_user_id", lazy="raise"
+            User,
+            foreign_keys="Pledge.created_by_user_id",
+            lazy="raise",
         )
 
     @declared_attr
     def issue(cls) -> Mapped[Issue]:
         return relationship(
-            Issue, primaryjoin=Issue.id == "Pledge.issue_id", lazy="raise"
+            Issue,
+            foreign_keys="Pledge.issue_id",
+            lazy="raise",
         )

--- a/server/polar/models/pledge_transaction.py
+++ b/server/polar/models/pledge_transaction.py
@@ -1,7 +1,13 @@
 from uuid import UUID
 
 from sqlalchemy import BigInteger, ForeignKey, String
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
@@ -9,7 +15,7 @@ from polar.models.issue_reward import IssueReward
 from polar.models.pledge import Pledge
 
 
-class PledgeTransaction(RecordModel):
+class PledgeTransaction(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "pledge_transactions"
 
     pledge_id: Mapped[UUID] = mapped_column(

--- a/server/polar/models/pull_request.py
+++ b/server/polar/models/pull_request.py
@@ -26,10 +26,10 @@ class PullRequest(IssueFields, RecordModel, MappedAsDataclass, kw_only=True):
     changed_files: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     requested_reviewers: Mapped[JSONList | None] = mapped_column(
-        JSONB, nullable=True, default=list
+        JSONB, nullable=True, default=None, insert_default=list
     )
     requested_teams: Mapped[JSONList | None] = mapped_column(
-        JSONB, nullable=True, default=list
+        JSONB, nullable=True, default=None, insert_default=list
     )
 
     # Part of Full Pull Request object, must be nullable

--- a/server/polar/models/pull_request.py
+++ b/server/polar/models/pull_request.py
@@ -2,14 +2,14 @@ from datetime import datetime
 
 from sqlalchemy import TIMESTAMP, Boolean, Index, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 from polar.kit.db.models import RecordModel
 from polar.models.issue import IssueFields
 from polar.types import JSONDict, JSONList
 
 
-class PullRequest(IssueFields, RecordModel):
+class PullRequest(IssueFields, RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "pull_requests"
     __table_args__ = (
         UniqueConstraint("external_id"),
@@ -33,25 +33,37 @@ class PullRequest(IssueFields, RecordModel):
     )
 
     # Part of Full Pull Request object, must be nullable
-    is_draft: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    is_rebaseable: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    is_draft: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=None)
+    is_rebaseable: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
 
-    review_comments: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    review_comments: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
 
-    maintainer_can_modify: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    maintainer_can_modify: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
 
-    is_mergeable: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    mergeable_state: Mapped[str | None] = mapped_column(String, nullable=True)
-    auto_merge: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_mergeable: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    mergeable_state: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
+    auto_merge: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
     is_merged: Mapped[bool] = mapped_column(Boolean, nullable=True)
     merged_by: Mapped[JSONDict | None] = mapped_column(
-        JSONB, nullable=True, default=dict
+        JSONB, nullable=True, default=None
     )
     merged_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=True
+        TIMESTAMP(timezone=True), nullable=True, default=None
     )
-    merge_commit_sha: Mapped[str | None] = mapped_column(String, nullable=True)
+    merge_commit_sha: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
 
     # TODO: Storing these for now, but need to trim them down
-    head: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=dict)
-    base: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=dict)
+    head: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=None)
+    base: Mapped[JSONDict | None] = mapped_column(JSONB, nullable=True, default=None)

--- a/server/polar/models/repository.py
+++ b/server/polar/models/repository.py
@@ -55,7 +55,7 @@ class Repository(RecordModel, MappedAsDataclass, kw_only=True):
 
     main_branch: Mapped[str | None] = mapped_column(String, nullable=True)
     topics: Mapped[list[str] | None] = mapped_column(
-        JSONB, nullable=False, default=list
+        JSONB, nullable=False, default=None, insert_default=list
     )
 
     license: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/server/polar/models/repository.py
+++ b/server/polar/models/repository.py
@@ -13,7 +13,13 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.config import settings
 from polar.enums import Platforms
@@ -22,7 +28,7 @@ from polar.kit.extensions.sqlalchemy import PostgresUUID, StringEnum
 from polar.models.organization import Organization
 
 
-class Repository(RecordModel):
+class Repository(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "repositories"
     __table_args__ = (
         UniqueConstraint("external_id"),

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import (
 )
 
 from polar.kit.db.models import RecordModel
-from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 if TYPE_CHECKING:
@@ -30,7 +29,7 @@ class SubscriptionStatus(StrEnum):
     unpaid = "unpaid"
 
 
-class Subscription(RecordModelNoDataClass):
+class Subscription(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscriptions"
 
     stripe_subscription_id: Mapped[str] = mapped_column(

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import (
 )
 
 from polar.kit.db.models import RecordModel
+from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ class SubscriptionStatus(StrEnum):
     unpaid = "unpaid"
 
 
-class Subscription(RecordModel, MappedAsDataclass, kw_only=True):
+class Subscription(RecordModelNoDataClass):
     __tablename__ = "subscriptions"
 
     stripe_subscription_id: Mapped[str] = mapped_column(

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Integer, String
 from sqlalchemy.orm import (
     Mapped,
+    MappedAsDataclass,
     declared_attr,
     mapped_column,
     relationship,
@@ -28,7 +29,7 @@ class SubscriptionStatus(StrEnum):
     unpaid = "unpaid"
 
 
-class Subscription(RecordModel):
+class Subscription(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscriptions"
 
     stripe_subscription_id: Mapped[str] = mapped_column(

--- a/server/polar/models/subscription_benefit.py
+++ b/server/polar/models/subscription_benefit.py
@@ -57,7 +57,7 @@ class SubscriptionBenefitBuiltinProperties(SubscriptionBenefitProperties):
 M = TypeVar("M", bound=SubscriptionBenefitProperties)
 
 
-class SubscriptionBenefit(RecordModelNoDataClass):
+class SubscriptionBenefit(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_benefits"
 
     type: Mapped[SubscriptionBenefitType] = mapped_column(

--- a/server/polar/models/subscription_benefit.py
+++ b/server/polar/models/subscription_benefit.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import (
 
 from polar.exceptions import PolarError
 from polar.kit.db.models import RecordModel
+from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 if TYPE_CHECKING:
@@ -56,7 +57,7 @@ class SubscriptionBenefitBuiltinProperties(SubscriptionBenefitProperties):
 M = TypeVar("M", bound=SubscriptionBenefitProperties)
 
 
-class SubscriptionBenefit(RecordModel, MappedAsDataclass, kw_only=True):
+class SubscriptionBenefit(RecordModelNoDataClass):
     __tablename__ = "subscription_benefits"
 
     type: Mapped[SubscriptionBenefitType] = mapped_column(

--- a/server/polar/models/subscription_benefit.py
+++ b/server/polar/models/subscription_benefit.py
@@ -68,7 +68,7 @@ class SubscriptionBenefit(RecordModel, MappedAsDataclass, kw_only=True):
     )
 
     properties: Mapped[SubscriptionBenefitProperties] = mapped_column(
-        "properties", JSONB, nullable=False, default=dict
+        "properties", JSONB, nullable=False, default=None, insert_default=dict
     )
 
     organization_id: Mapped[UUID | None] = mapped_column(
@@ -98,7 +98,7 @@ class SubscriptionBenefit(RecordModel, MappedAsDataclass, kw_only=True):
 
 class SubscriptionBenefitCustom(SubscriptionBenefit):
     properties: Mapped[SubscriptionBenefitCustomProperties] = mapped_column(
-        use_existing_column=True, default=dict
+        use_existing_column=True, default=None, insert_default=dict
     )
 
     __mapper_args__ = {
@@ -109,7 +109,7 @@ class SubscriptionBenefitCustom(SubscriptionBenefit):
 
 class SubscriptionBenefitBuiltin(SubscriptionBenefit):
     properties: Mapped[SubscriptionBenefitCustomProperties] = mapped_column(
-        use_existing_column=True, default=dict
+        use_existing_column=True, default=None, insert_default=dict
     )
 
     __mapper_args__ = {

--- a/server/polar/models/subscription_benefit.py
+++ b/server/polar/models/subscription_benefit.py
@@ -67,9 +67,9 @@ class SubscriptionBenefit(RecordModel, MappedAsDataclass, kw_only=True):
         Boolean, nullable=False, default=False
     )
 
-    @declared_attr
-    def properties(cls) -> Mapped[SubscriptionBenefitProperties]:
-        return mapped_column("properties", JSONB, nullable=False, default=dict)
+    properties: Mapped[SubscriptionBenefitProperties] = mapped_column(
+        "properties", JSONB, nullable=False, default=dict
+    )
 
     organization_id: Mapped[UUID | None] = mapped_column(
         PostgresUUID,
@@ -97,9 +97,9 @@ class SubscriptionBenefit(RecordModel, MappedAsDataclass, kw_only=True):
 
 
 class SubscriptionBenefitCustom(SubscriptionBenefit):
-    @declared_attr
-    def properties(cls) -> Mapped[SubscriptionBenefitCustomProperties]:
-        return mapped_column(use_existing_column=True)
+    properties: Mapped[SubscriptionBenefitCustomProperties] = mapped_column(
+        use_existing_column=True, default=dict
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": SubscriptionBenefitType.custom,
@@ -108,9 +108,9 @@ class SubscriptionBenefitCustom(SubscriptionBenefit):
 
 
 class SubscriptionBenefitBuiltin(SubscriptionBenefit):
-    @declared_attr
-    def properties(cls) -> Mapped[SubscriptionBenefitBuiltinProperties]:
-        return mapped_column(use_existing_column=True)
+    properties: Mapped[SubscriptionBenefitCustomProperties] = mapped_column(
+        use_existing_column=True, default=dict
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": SubscriptionBenefitType.builtin,

--- a/server/polar/models/subscription_benefit_grant.py
+++ b/server/polar/models/subscription_benefit_grant.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from polar.models import Subscription, SubscriptionBenefit
 
 
-class SubscriptionBenefitGrant(RecordModelNoDataClass):
+class SubscriptionBenefitGrant(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_benefit_grants"
 
     granted_at: Mapped[datetime | None] = mapped_column(

--- a/server/polar/models/subscription_benefit_grant.py
+++ b/server/polar/models/subscription_benefit_grant.py
@@ -4,7 +4,13 @@ from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, Boolean, ColumnElement, ForeignKey, type_coerce
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
@@ -13,14 +19,14 @@ if TYPE_CHECKING:
     from polar.models import Subscription, SubscriptionBenefit
 
 
-class SubscriptionBenefitGrant(RecordModel):
+class SubscriptionBenefitGrant(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_benefit_grants"
 
     granted_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=True
+        TIMESTAMP(timezone=True), nullable=True, default=None
     )
     revoked_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=True
+        TIMESTAMP(timezone=True), nullable=True, default=None
     )
 
     subscription_id: Mapped[UUID] = mapped_column(

--- a/server/polar/models/subscription_benefit_grant.py
+++ b/server/polar/models/subscription_benefit_grant.py
@@ -13,13 +13,14 @@ from sqlalchemy.orm import (
 )
 
 from polar.kit.db.models import RecordModel
+from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 if TYPE_CHECKING:
     from polar.models import Subscription, SubscriptionBenefit
 
 
-class SubscriptionBenefitGrant(RecordModel, MappedAsDataclass, kw_only=True):
+class SubscriptionBenefitGrant(RecordModelNoDataClass):
     __tablename__ = "subscription_benefit_grants"
 
     granted_at: Mapped[datetime | None] = mapped_column(

--- a/server/polar/models/subscription_tier.py
+++ b/server/polar/models/subscription_tier.py
@@ -4,7 +4,13 @@ from uuid import UUID
 
 from sqlalchemy import Boolean, ForeignKey, Integer, String, Text
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
@@ -24,7 +30,7 @@ class SubscriptionTierType(StrEnum):
     business = "business"
 
 
-class SubscriptionTier(RecordModel):
+class SubscriptionTier(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_tiers"
 
     type: Mapped[SubscriptionTierType] = mapped_column(

--- a/server/polar/models/subscription_tier.py
+++ b/server/polar/models/subscription_tier.py
@@ -46,9 +46,11 @@ class SubscriptionTier(RecordModel, MappedAsDataclass, kw_only=True):
     is_archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     stripe_product_id: Mapped[str | None] = mapped_column(
-        String, nullable=True, index=True
+        String, nullable=True, index=True, default=None
     )
-    stripe_price_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    stripe_price_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
 
     organization_id: Mapped[UUID | None] = mapped_column(
         PostgresUUID,
@@ -70,14 +72,19 @@ class SubscriptionTier(RecordModel, MappedAsDataclass, kw_only=True):
     def repository(cls) -> Mapped["Repository | None"]:
         return relationship("Repository", lazy="raise")
 
-    subscription_tier_benefits: Mapped[list["SubscriptionTierBenefit"]] = relationship(
-        lazy="selectin",
-        order_by="SubscriptionTierBenefit.order",
-        cascade="all, delete-orphan",
-    )
+    @declared_attr
+    def subscription_tier_benefits(cls) -> Mapped[list["SubscriptionTierBenefit"]]:
+        return relationship(
+            "SubscriptionTierBenefit",
+            lazy="selectin",
+            order_by="SubscriptionTierBenefit.order",
+            cascade="all, delete-orphan",
+        )
 
     benefits: AssociationProxy[list["SubscriptionBenefit"]] = association_proxy(
-        "subscription_tier_benefits", "subscription_benefit"
+        "subscription_tier_benefits",
+        "subscription_benefit",
+        init=False,
     )
 
     @property

--- a/server/polar/models/subscription_tier.py
+++ b/server/polar/models/subscription_tier.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import (
 )
 
 from polar.kit.db.models import RecordModel
+from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ class SubscriptionTierType(StrEnum):
     business = "business"
 
 
-class SubscriptionTier(RecordModel, MappedAsDataclass, kw_only=True):
+class SubscriptionTier(RecordModelNoDataClass):
     __tablename__ = "subscription_tiers"
 
     type: Mapped[SubscriptionTierType] = mapped_column(
@@ -84,7 +85,6 @@ class SubscriptionTier(RecordModel, MappedAsDataclass, kw_only=True):
     benefits: AssociationProxy[list["SubscriptionBenefit"]] = association_proxy(
         "subscription_tier_benefits",
         "subscription_benefit",
-        init=False,
     )
 
     @property

--- a/server/polar/models/subscription_tier.py
+++ b/server/polar/models/subscription_tier.py
@@ -31,7 +31,7 @@ class SubscriptionTierType(StrEnum):
     business = "business"
 
 
-class SubscriptionTier(RecordModelNoDataClass):
+class SubscriptionTier(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_tiers"
 
     type: Mapped[SubscriptionTierType] = mapped_column(
@@ -77,7 +77,8 @@ class SubscriptionTier(RecordModelNoDataClass):
     def subscription_tier_benefits(cls) -> Mapped[list["SubscriptionTierBenefit"]]:
         return relationship(
             "SubscriptionTierBenefit",
-            lazy="selectin",
+            # lazy="selectin",
+            lazy="raise",
             order_by="SubscriptionTierBenefit.order",
             cascade="all, delete-orphan",
         )
@@ -85,6 +86,7 @@ class SubscriptionTier(RecordModelNoDataClass):
     benefits: AssociationProxy[list["SubscriptionBenefit"]] = association_proxy(
         "subscription_tier_benefits",
         "subscription_benefit",
+        init=False,
     )
 
     @property

--- a/server/polar/models/subscription_tier_benefit.py
+++ b/server/polar/models/subscription_tier_benefit.py
@@ -12,13 +12,14 @@ from sqlalchemy.orm import (
 )
 
 from polar.kit.db.models import RecordModel
+from polar.kit.db.models.base import RecordModelNoDataClass
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 if TYPE_CHECKING:
     from polar.models import SubscriptionBenefit
 
 
-class SubscriptionTierBenefit(RecordModel, MappedAsDataclass, kw_only=True):
+class SubscriptionTierBenefit(RecordModelNoDataClass):
     __tablename__ = "subscription_tier_benefits"
     __table_args__ = (UniqueConstraint("subscription_tier_id", "order"),)
 
@@ -36,4 +37,4 @@ class SubscriptionTierBenefit(RecordModel, MappedAsDataclass, kw_only=True):
 
     @declared_attr
     def subscription_benefit(cls) -> Mapped["SubscriptionBenefit"]:
-        return relationship("SubscriptionBenefit", lazy="joined")
+        return relationship("SubscriptionBenefit", lazy="raise")

--- a/server/polar/models/subscription_tier_benefit.py
+++ b/server/polar/models/subscription_tier_benefit.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from polar.models import SubscriptionBenefit
 
 
-class SubscriptionTierBenefit(RecordModelNoDataClass):
+class SubscriptionTierBenefit(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_tier_benefits"
     __table_args__ = (UniqueConstraint("subscription_tier_id", "order"),)
 

--- a/server/polar/models/subscription_tier_benefit.py
+++ b/server/polar/models/subscription_tier_benefit.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from sqlalchemy import ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import (
     Mapped,
+    MappedAsDataclass,
     declared_attr,
     mapped_column,
     relationship,
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from polar.models import SubscriptionBenefit
 
 
-class SubscriptionTierBenefit(RecordModel):
+class SubscriptionTierBenefit(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "subscription_tier_benefits"
     __table_args__ = (UniqueConstraint("subscription_tier_id", "order"),)
 

--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -4,7 +4,13 @@ from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, Boolean, Column, ForeignKey, Integer, String, func
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 from sqlalchemy.schema import Index, UniqueConstraint
 
 from polar.enums import Platforms
@@ -12,7 +18,7 @@ from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID, StringEnum
 
 
-class OAuthAccount(RecordModel):
+class OAuthAccount(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "oauth_accounts"
     __table_args__ = (
         UniqueConstraint(
@@ -35,10 +41,12 @@ class OAuthAccount(RecordModel):
         nullable=False,
     )
 
-    user: Mapped["User"] = relationship("User", back_populates="oauth_accounts")
+    @declared_attr
+    def user(cls) -> Mapped["User"]:
+        return relationship("User", back_populates="oauth_accounts")
 
 
-class User(RecordModel):
+class User(RecordModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "users"
     __table_args__ = (
         Index(

--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -62,7 +62,10 @@ class User(RecordModel, MappedAsDataclass, kw_only=True):
     )
 
     profile: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default=None, nullable=True, insert_default={}
+        JSONB,
+        nullable=True,
+        default=None,
+        insert_default=dict,
     )
 
     @declared_attr

--- a/server/polar/models/user_notification.py
+++ b/server/polar/models/user_notification.py
@@ -1,13 +1,13 @@
 from uuid import UUID
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 from polar.kit.db.models import Model
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 
-class UserNotification(Model):
+class UserNotification(Model, MappedAsDataclass, kw_only=True):
     __tablename__ = "user_notifications"
 
     user_id: Mapped[UUID] = mapped_column(

--- a/server/polar/models/user_organization.py
+++ b/server/polar/models/user_organization.py
@@ -1,7 +1,13 @@
 from uuid import UUID
 
 from sqlalchemy import Boolean, ForeignKey
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 
 from polar.kit.db.models import TimestampedModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
@@ -9,7 +15,7 @@ from polar.models.organization import Organization
 from polar.models.user import User
 
 
-class UserOrganization(TimestampedModel):
+class UserOrganization(TimestampedModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "user_organizations"
 
     user_id: Mapped[UUID] = mapped_column(

--- a/server/polar/models/user_organization_settings.py
+++ b/server/polar/models/user_organization_settings.py
@@ -1,13 +1,13 @@
 from uuid import UUID
 
 from sqlalchemy import Boolean, ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 from polar.kit.db.models import TimestampedModel
 from polar.kit.extensions.sqlalchemy import PostgresUUID
 
 
-class UserOrganizationSettings(TimestampedModel):
+class UserOrganizationSettings(TimestampedModel, MappedAsDataclass, kw_only=True):
     __tablename__ = "user_organization_settings"
 
     user_id: Mapped[UUID] = mapped_column(

--- a/server/polar/notifications/tasks/email.py
+++ b/server/polar/notifications/tasks/email.py
@@ -37,6 +37,9 @@ async def notifications_send(
             # TODO: support sending to "notif.email_addr"
 
             # Get users to send to
+            if not notif.user_id:
+                return
+
             user = await user_service.get(session, notif.user_id)
             if not user:
                 log.warning("notifications.send.user_not_found", user_id=notif.user_id)

--- a/server/polar/pledge/payment_intent_service.py
+++ b/server/polar/pledge/payment_intent_service.py
@@ -189,8 +189,7 @@ class PaymentIntentService:
             else PledgeState.initiated
         )
 
-        pledge = await Pledge.create(
-            session=session,
+        pledge = await Pledge(
             payment_id=payment_intent_id,
             issue_id=issue.id,
             repository_id=repo.id,
@@ -202,7 +201,11 @@ class PaymentIntentService:
             type=PledgeType.pay_upfront,
             by_user_id=user_id,
             by_organization_id=None,
-            on_behalf_of_organization_id=metadata.on_behalf_of_organization_id,
+            on_behalf_of_organization_id=metadata.on_behalf_of_organization_id
+            if metadata.on_behalf_of_organization_id
+            else None,
+        ).save(
+            session=session,
         )
 
         if state == PledgeState.created:

--- a/server/polar/subscription/service/subscription_benefit_grant.py
+++ b/server/polar/subscription/service/subscription_benefit_grant.py
@@ -24,7 +24,8 @@ class SubscriptionBenefitGrantService(ResourceServiceReader[SubscriptionBenefitG
 
         if grant is None:
             grant = SubscriptionBenefitGrant(
-                subscription=subscription, subscription_benefit=subscription_benefit
+                subscription_id=subscription.id,
+                subscription_benefit_id=subscription_benefit.id,
             )
         elif grant.is_granted:
             return grant
@@ -53,7 +54,8 @@ class SubscriptionBenefitGrantService(ResourceServiceReader[SubscriptionBenefitG
 
         if grant is None:
             grant = SubscriptionBenefitGrant(
-                subscription=subscription, subscription_benefit=subscription_benefit
+                subscription_id=subscription.id,
+                subscription_benefit_id=subscription_benefit.id,
             )
         elif grant.is_revoked:
             return grant

--- a/server/polar/subscription/service/subscription_tier.py
+++ b/server/polar/subscription/service/subscription_tier.py
@@ -14,7 +14,7 @@ from polar.integrations.stripe.service import ProductUpdateKwargs, StripeError
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import PaginationParams, paginate
-from polar.kit.services import ResourceService
+from polar.kit.services import ResourceService, ResourceServiceNoDataClass
 from polar.models import (
     Account,
     Organization,
@@ -85,7 +85,9 @@ class NoAssociatedPayoutAccount(SubscriptionTierError):
 
 
 class SubscriptionTierService(
-    ResourceService[SubscriptionTier, SubscriptionTierCreate, SubscriptionTierUpdate]
+    ResourceServiceNoDataClass[
+        SubscriptionTier, SubscriptionTierCreate, SubscriptionTierUpdate
+    ]
 ):
     async def create(
         self,

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -27,7 +27,6 @@ class UserBase(Schema):
     username: str = Field(..., max_length=50)
     email: EmailStr
     avatar_url: str | None
-    profile: dict[str, Any]
 
     class Config:
         orm_mode = True
@@ -47,7 +46,7 @@ class UserRead(UserBase, TimestampedSchema):
     accepted_terms_of_service: bool
     email_newsletters_and_changelogs: bool
     email_promotions_and_events: bool
-    oauth_accounts: list[OAuthAccountRead]
+    oauth_accounts: list[OAuthAccountRead] = []
 
 
 # TODO: remove

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -50,7 +50,7 @@ class UserService(ResourceService[User, UserCreate, UserUpdate]):
         return user
 
     async def signup_by_email(self, session: AsyncSession, email: str) -> User:
-        user = User(username=email, email=email)
+        user = User(username=email, email=email, profile={})
         session.add(user)
         await session.commit()
 

--- a/server/scripts/dev_github.py
+++ b/server/scripts/dev_github.py
@@ -224,11 +224,10 @@ async def add_external_repo(
             session, user_id=user.id, organization_id=organization.id
         )
         if not uc:
-            uc = await UserOrganization.create(
-                session=session,
+            uc = await UserOrganization(
                 organization_id=organization.id,
                 user_id=user.id,
-            )
+            ).save(session)
             print("Added user to org", uc)
 
         # return

--- a/server/tests/fixtures/database.py
+++ b/server/tests/fixtures/database.py
@@ -18,7 +18,9 @@ class TestModel(Model):
 
     __tablename__ = "test_model"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, default=None)
-    uuid: Mapped[UUID] = mapped_column(PostgresUUID, default=generate_uuid)
+    uuid: Mapped[UUID] = mapped_column(
+        PostgresUUID, default=None, insert_default=generate_uuid
+    )
     int_column: Mapped[int | None] = mapped_column(Integer, default=None, nullable=True)
     str_column: Mapped[str | None] = mapped_column(String, default=None, nullable=True)
 

--- a/server/tests/fixtures/predictable_objects.py
+++ b/server/tests/fixtures/predictable_objects.py
@@ -85,7 +85,6 @@ async def predictable_issue(
     predictable_repository: Repository,
 ) -> Issue:
     issue = await Issue(
-        id=uuid.uuid4(),
         organization_id=predictable_organization.id,
         repository_id=predictable_repository.id,
         title="issue title",
@@ -111,7 +110,6 @@ async def predictable_user(
     session: AsyncSession,
 ) -> User:
     user = await User(
-        id=uuid.uuid4(),
         username="foobar",
         email="test@example.com",
     ).save(
@@ -131,7 +129,6 @@ async def predictable_pledge(
     predictable_pledging_organization: Organization,
 ) -> Pledge:
     pledge = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=predictable_pledging_organization.id,
         issue_id=predictable_issue.id,
         repository_id=predictable_repository.id,
@@ -154,7 +151,6 @@ async def predictable_pull_request(
     predictable_repository: Repository,
 ) -> PullRequest:
     pr = await PullRequest(
-        id=uuid.uuid4(),
         repository_id=predictable_repository.id,
         organization_id=predictable_organization.id,
         number=5555,

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -112,7 +112,6 @@ async def create_issue(
     session: AsyncSession, organization: Organization, repository: Repository
 ) -> Issue:
     issue = await Issue(
-        id=uuid.uuid4(),
         organization_id=organization.id,
         repository_id=repository.id,
         title="issue title",
@@ -144,7 +143,6 @@ async def create_user(
     session: AsyncSession,
 ) -> User:
     user = await User(
-        id=uuid.uuid4(),
         username=rstr("testuser"),
         email=rstr("test") + "@example.com",
         avatar_url="https://avatars.githubusercontent.com/u/47952?v=4",
@@ -159,7 +157,6 @@ async def user_second(
     session: AsyncSession,
 ) -> User:
     user = await User(
-        id=uuid.uuid4(),
         username=rstr("testuser"),
         email=rstr("test") + "@example.com",
         avatar_url="https://avatars.githubusercontent.com/u/47952?v=4",
@@ -184,7 +181,6 @@ async def create_pledge(
     amount = secrets.randbelow(100000) + 1
     fee = round(amount * 0.05)
     pledge = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=pledging_organization.id,
         issue_id=issue.id,
         repository_id=repository.id,
@@ -224,7 +220,6 @@ async def pledge_by_user(
     amount = secrets.randbelow(100000) + 1
     fee = round(amount * 0.05)
     pledge = await Pledge(
-        id=uuid.uuid4(),
         issue_id=issue.id,
         repository_id=repository.id,
         organization_id=organization.id,
@@ -248,7 +243,6 @@ async def pull_request(
     repository: Repository,
 ) -> PullRequest:
     pr = await PullRequest(
-        id=uuid.uuid4(),
         repository_id=repository.id,
         organization_id=organization.id,
         number=secrets.randbelow(5000),

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -146,6 +146,7 @@ async def create_user(
         username=rstr("testuser"),
         email=rstr("test") + "@example.com",
         avatar_url="https://avatars.githubusercontent.com/u/47952?v=4",
+        profile={},
     ).save(session=session)
 
     await session.commit()
@@ -160,6 +161,7 @@ async def user_second(
         username=rstr("testuser"),
         email=rstr("test") + "@example.com",
         avatar_url="https://avatars.githubusercontent.com/u/47952?v=4",
+        profile={},
     ).save(
         session=session,
     )

--- a/server/tests/issue/test_service.py
+++ b/server/tests/issue/test_service.py
@@ -29,7 +29,6 @@ async def test_list_by_repository_type_and_status_sorting(
 ) -> None:
     # create testdata
     issue_1 = await Issue(
-        id=uuid.uuid4(),
         organization_id=organization.id,
         repository_id=repository.id,
         title="issue_1",
@@ -44,7 +43,6 @@ async def test_list_by_repository_type_and_status_sorting(
     ).save(session)
 
     issue_2 = await Issue(
-        id=uuid.uuid4(),
         organization_id=organization.id,
         repository_id=repository.id,
         title="issue_2",
@@ -61,7 +59,6 @@ async def test_list_by_repository_type_and_status_sorting(
     ).save(session)
 
     issue_3 = await Issue(
-        id=uuid.uuid4(),
         organization_id=organization.id,
         repository_id=repository.id,
         title="issue_3",
@@ -78,7 +75,6 @@ async def test_list_by_repository_type_and_status_sorting(
     ).save(session)
 
     issue_4 = await Issue(
-        id=uuid.uuid4(),
         organization_id=organization.id,
         repository_id=repository.id,
         title="issue_4",
@@ -186,7 +182,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge(
 
     # Create pledge
     pledge = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=organization.id,
         issue_id=third_party_issue.id,
         repository_id=third_party_repo.id,
@@ -198,7 +193,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge(
 
     # Create other pledge to this issue (not by the org)
     pledge_other = await Pledge(
-        id=uuid.uuid4(),
         issue_id=third_party_issue.id,
         repository_id=third_party_repo.id,
         organization_id=third_party_org.id,
@@ -209,7 +203,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge(
 
     # pledges to issue 3
     pledge_issue_3_user = await Pledge(
-        id=uuid.uuid4(),
         issue_id=third_party_issue_3.id,
         repository_id=third_party_repo.id,
         organization_id=third_party_org.id,
@@ -220,7 +213,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge(
     ).save(session)
 
     pledge_issue_3_org = await Pledge(
-        id=uuid.uuid4(),
         issue_id=third_party_issue_3.id,
         repository_id=third_party_repo.id,
         organization_id=third_party_org.id,
@@ -290,7 +282,6 @@ async def test_list_by_repository_type_and_status_dependencies_pledge_state(
 
         # Create pledge
         pledge = await Pledge(
-            id=uuid.uuid4(),
             by_organization_id=organization.id,
             issue_id=third_party_issue.id,
             repository_id=third_party_repo.id,
@@ -335,7 +326,6 @@ async def test_list_by_github_milestone_number(
             url="http://example.com/",
             html_url="http://example.com/",
             labels_url="http://example.com/",
-            id=1233333,
             node_id="xxxyyyyzzz",
             number=number,
             state="open",

--- a/server/tests/issue/test_service.py
+++ b/server/tests/issue/test_service.py
@@ -323,6 +323,7 @@ async def test_list_by_github_milestone_number(
         )
 
         ms = github.rest.Milestone(
+            id=123,
             url="http://example.com/",
             html_url="http://example.com/",
             labels_url="http://example.com/",

--- a/server/tests/magic_link/test_service.py
+++ b/server/tests/magic_link/test_service.py
@@ -122,7 +122,7 @@ async def test_send(
 async def test_authenticate_existing_user(
     session: AsyncSession, generate_magic_link_token: GenerateMagicLinkToken
 ) -> None:
-    user = User(username="user@example.com", email="user@example.com")
+    user = User(username="user@example.com", email="user@example.com", profile={})
     session.add(user)
     await session.commit()
 
@@ -140,7 +140,7 @@ async def test_authenticate_existing_user(
 async def test_authenticate_existing_user_unlinked_from_magic_token(
     session: AsyncSession, generate_magic_link_token: GenerateMagicLinkToken
 ) -> None:
-    user = User(username="user@example.com", email="user@example.com")
+    user = User(username="user@example.com", email="user@example.com", profile={})
     session.add(user)
     await session.commit()
 

--- a/server/tests/notifications/test_pledge_notifications.py
+++ b/server/tests/notifications/test_pledge_notifications.py
@@ -33,8 +33,7 @@ async def test_create_pledge_from_created(
 
     payment_id = "xxx-1"
 
-    pledge = await Pledge.create(
-        session=session,
+    pledge = await Pledge(
         issue_id=issue.id,
         repository_id=repository.id,
         organization_id=organization.id,
@@ -43,6 +42,8 @@ async def test_create_pledge_from_created(
         by_organization_id=organization.id,
         state=PledgeState.initiated,
         payment_id=payment_id,
+    ).save(
+        session=session,
     )
     await pledge_service.mark_created_by_payment_id(
         session,
@@ -90,8 +91,7 @@ async def test_create_pledge_from_created_by_user(
 
     payment_id = "xxx-1"
 
-    pledge = await Pledge.create(
-        session=session,
+    pledge = await Pledge(
         issue_id=issue.id,
         repository_id=repository.id,
         organization_id=organization.id,
@@ -100,6 +100,8 @@ async def test_create_pledge_from_created_by_user(
         by_user_id=user.id,
         state=PledgeState.initiated,
         payment_id=payment_id,
+    ).save(
+        session=session,
     )
     await pledge_service.mark_created_by_payment_id(
         session,
@@ -147,8 +149,7 @@ async def test_create_pledge_from_created_on_behalf_of(
 
     payment_id = "xxx-1"
 
-    pledge = await Pledge.create(
-        session=session,
+    pledge = await Pledge(
         issue_id=issue.id,
         repository_id=repository.id,
         organization_id=organization.id,
@@ -158,6 +159,8 @@ async def test_create_pledge_from_created_on_behalf_of(
         by_user_id=user.id,
         state=PledgeState.initiated,
         payment_id=payment_id,
+    ).save(
+        session=session,
     )
     await pledge_service.mark_created_by_payment_id(
         session,
@@ -209,8 +212,7 @@ async def test_deduplicate(
     spy = mocker.spy(NotificationsService, "send_to_org_admins")
     mocker.patch("polar.worker._enqueue_job")
 
-    pledge = await Pledge.create(
-        session=session,
+    pledge = await Pledge(
         issue_id=issue.id,
         repository_id=repository.id,
         organization_id=organization.id,
@@ -219,6 +221,8 @@ async def test_deduplicate(
         by_organization_id=organization.id,
         state=PledgeState.initiated,
         payment_id="xxx-2",
+    ).save(
+        session=session,
     )
 
     # Check notifictions

--- a/server/tests/pledge/test_endpoints.py
+++ b/server/tests/pledge/test_endpoints.py
@@ -275,7 +275,6 @@ async def test_search_pledge_by_issue_id(
     )
 
     other_pledge = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=pledging_organization.id,
         issue_id=other_issue.id,
         repository_id=repository.id,
@@ -288,7 +287,6 @@ async def test_search_pledge_by_issue_id(
     )
 
     other_pledge_2 = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=pledging_organization.id,
         issue_id=other_issue.id,
         repository_id=repository.id,

--- a/server/tests/pledge/test_service.py
+++ b/server/tests/pledge/test_service.py
@@ -95,7 +95,6 @@ async def test_mark_pending_by_issue_id(
     # create multiple pledges
     pledges: list[Pledge] = [
         await Pledge(
-            id=uuid.uuid4(),
             by_organization_id=pledging_organization.id,
             issue_id=issue.id,
             repository_id=repository.id,
@@ -120,7 +119,6 @@ async def test_mark_pending_by_issue_id(
 
     # Create a pay on completion pledge
     await Pledge(
-        id=uuid.uuid4(),
         by_user_id=user.id,
         issue_id=issue.id,
         repository_id=repository.id,
@@ -188,7 +186,6 @@ async def test_mark_pending_already_pending_no_notification(
     # create multiple pledges
     pledges: list[Pledge] = [
         await Pledge(
-            id=uuid.uuid4(),
             by_organization_id=pledging_organization.id,
             issue_id=issue.id,
             repository_id=repository.id,
@@ -683,7 +680,6 @@ async def test_generate_pledge_testdata(
     pledges = [
         [
             await Pledge(
-                id=uuid.uuid4(),
                 # by_organization_id=pledging_organization.id,
                 issue_id=issue.id,
                 repository_id=issue.repository_id,
@@ -694,7 +690,6 @@ async def test_generate_pledge_testdata(
                 email="pledger@example.com",
             ).save(session),
             await Pledge(
-                id=uuid.uuid4(),
                 by_organization_id=pledging_org.id,
                 issue_id=issue.id,
                 repository_id=issue.repository_id,

--- a/server/tests/reward/test_service.py
+++ b/server/tests/reward/test_service.py
@@ -127,7 +127,6 @@ async def test_list_rewards_to_user(
 
     # create two pledges
     pledge_1 = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=pledging_organization.id,
         issue_id=issue.id,
         repository_id=repository.id,
@@ -140,7 +139,6 @@ async def test_list_rewards_to_user(
     ).save(session)
 
     pledge_2 = await Pledge(
-        id=uuid.uuid4(),
         by_organization_id=pledging_organization.id,
         issue_id=issue.id,
         repository_id=repository.id,

--- a/server/tests/subscription/conftest.py
+++ b/server/tests/subscription/conftest.py
@@ -108,9 +108,8 @@ async def add_subscription_benefits(
             subscription_benefit_id=subscription_benefit.id,
             order=order,
         )
-        # session.add(benefit)???
-
-        subscription_tier.subscription_tier_benefits.append(benefit)
+        session.add(benefit)
+        # subscription_tier.subscription_tier_benefits.append(benefit)
     session.add(subscription_tier)
     await session.commit()
     return subscription_tier

--- a/server/tests/subscription/conftest.py
+++ b/server/tests/subscription/conftest.py
@@ -101,7 +101,7 @@ async def add_subscription_benefits(
     subscription_tier: SubscriptionTier,
     subscription_benefits: list[SubscriptionBenefit],
 ) -> SubscriptionTier:
-    subscription_tier.subscription_tier_benefits = []
+    # subscription_tier_benefits = []
     for order, subscription_benefit in enumerate(subscription_benefits):
         benefit = SubscriptionTierBenefit(
             subscription_tier_id=subscription_tier.id,

--- a/server/tests/subscription/conftest.py
+++ b/server/tests/subscription/conftest.py
@@ -65,7 +65,7 @@ async def create_subscription_tier(
         repository_id=repository.id if repository is not None else None,
         stripe_product_id="PRODUCT_ID",
         stripe_price_id="PRICE_ID",
-        subscription_tier_benefits=[],
+        # subscription_tier_benefits=[],
         description="x",
     )
     session.add(subscription_tier)

--- a/server/tests/subscription/conftest.py
+++ b/server/tests/subscription/conftest.py
@@ -24,6 +24,9 @@ from polar.models.subscription_benefit import SubscriptionBenefitType
 from polar.models.subscription_tier import SubscriptionTierType
 from polar.postgres import AsyncSession
 from polar.subscription.endpoints import is_feature_flag_enabled
+from polar.subscription.service.subscription_tier import (
+    subscription_tier as subscription_tier_service,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +73,12 @@ async def create_subscription_tier(
     )
     session.add(subscription_tier)
     await session.commit()
-    return subscription_tier
+
+    res = await subscription_tier_service.get(session, subscription_tier.id)
+    if not res:
+        raise Exception("not found")
+
+    return res
 
 
 async def create_subscription_benefit(
@@ -112,7 +120,14 @@ async def add_subscription_benefits(
         # subscription_tier.subscription_tier_benefits.append(benefit)
     session.add(subscription_tier)
     await session.commit()
-    return subscription_tier
+
+    res = await subscription_tier_service.get(session, subscription_tier.id)
+    if not res:
+        raise Exception("not found")
+
+    return res
+
+    # return subscription_tier
 
 
 async def create_subscription(

--- a/server/tests/subscription/service/test_subscription_benefit_grant.py
+++ b/server/tests/subscription/service/test_subscription_benefit_grant.py
@@ -184,22 +184,22 @@ class TestEnqueueBenefitGrantUpdates:
         subscription_benefit_service_mock: MagicMock,
     ) -> None:
         granted_grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         granted_grant.set_granted()
         session.add(granted_grant)
 
         revoked_grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         revoked_grant.set_revoked()
         session.add(revoked_grant)
 
         other_benefit_grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_repository,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_repository.id,
         )
         other_benefit_grant.set_granted()
         session.add(other_benefit_grant)
@@ -233,8 +233,8 @@ class TestUpdateBenefitGrant:
         subscription_benefit_service_mock: MagicMock,
     ) -> None:
         grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         grant.set_revoked()
         session.add(grant)
@@ -255,8 +255,8 @@ class TestUpdateBenefitGrant:
         subscription_benefit_service_mock: MagicMock,
     ) -> None:
         grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         grant.set_granted()
         session.add(grant)
@@ -282,22 +282,22 @@ class TestEnqueueBenefitGrantDeletions:
         subscription_benefit_repository: SubscriptionBenefit,
     ) -> None:
         granted_grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         granted_grant.set_granted()
         session.add(granted_grant)
 
         revoked_grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         revoked_grant.set_revoked()
         session.add(revoked_grant)
 
         other_benefit_grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_repository,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_repository.id,
         )
         other_benefit_grant.set_granted()
         session.add(other_benefit_grant)
@@ -328,8 +328,8 @@ class TestDeleteBenefitGrant:
         subscription_benefit_service_mock: MagicMock,
     ) -> None:
         grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         grant.set_revoked()
         session.add(grant)
@@ -350,8 +350,8 @@ class TestDeleteBenefitGrant:
         subscription_benefit_service_mock: MagicMock,
     ) -> None:
         grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         grant.set_granted()
         session.add(grant)

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -179,8 +179,8 @@ class TestSubscriptionBenefitUpdate:
         subscription_benefit_organization: SubscriptionBenefit,
     ) -> None:
         grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         grant.set_granted()
         session.add(grant)
@@ -220,8 +220,8 @@ class TestSubscriptionBenefitDelete:
         subscription_benefit_organization: SubscriptionBenefit,
     ) -> None:
         grant = SubscriptionBenefitGrant(
-            subscription=subscription,
-            subscription_benefit=subscription_benefit_organization,
+            subscription_id=subscription.id,
+            subscription_benefit_id=subscription_benefit_organization.id,
         )
         grant.set_granted()
         session.add(grant)


### PR DESCRIPTION
This PR builds on top of #1640, #1643, and #1646. 

This change adds type hints and type-safety to the SQLAlchemy model constructors.

Changes:

* All models now extend `MappedAsDataclass` with `kw_only=True`
* `relationship()`s are now defined in `@declared_attr` class methods
* We're now differentiating between `default` and `insert_default`

