### PR TITLE
dev: start working on a devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,4 +18,8 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 RUN pipx install poetry==1.6.1
 
+RUN npm install -g pnpm
+
+
+
 # RUN mkdir -p /workspace/server/.env

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYTHON_VERSION=3.11-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/python:${PYTHON_VERSION}
+
+ENV PYTHONUNBUFFERED 1
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="18"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+RUN pipx install poetry==1.6.1
+
+# RUN mkdir -p /workspace/server/.env

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,1 +1,30 @@
 # Welcome to the Polar Devcontainer
+
+# Setup and running
+
+_This is a work in progress, as we improve on our automation to remove as many of these steps as possible._
+
+## Running the web
+
+The web can be configured from `clients/apps/web/.env`. The `$GITHUB_` variables will be automatically filled in if running on Codespaces.
+
+Run the web in the terminal with `cd /workspace/clients && pnpm dev`
+
+## Running the api
+
+The api server is configured from `server/.env.devcontainer`. You might need to change the `POLAR_GITHUB_` variables for the server to boot.
+
+Run the api in the terminal with `cd /workspace/server && poetry run task api`
+
+## Running the storybook
+
+Requires no configuration.
+
+Run the storybook in the terminal with `cd /workspace/clients && pnpm storybook`
+
+
+# Testing
+
+## Testing the api
+
+Run the server tests in the terminal with `cd /workspace/server && poetry run task test`

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,1 @@
+# Welcome to the Polar Devcontainer

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,23 @@
 
 	// Configure tool-specific properties.
 	"customizations": {
+
+		"codespaces": {
+			"openFiles": [
+			  //"README.md",
+			  //"scripts/tsconfig.json",
+			  //"docs/main/CODING_STANDARDS.md"
+			  ".devcontainer/README.md",
+			  "server/.env.devcontainer"
+			  
+			]
+		},
+
 		// Configure properties specific to VS Code.
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
-				"python.defaultInterpreterPath": "/usr/local/bin/python"
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				// 	"python.linting.enabled": true,
 				// 	"python.linting.pylintEnabled": true,
 				// 	"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
@@ -30,6 +42,9 @@
 				// 	"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
 				// 	"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
 				// 	"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
+
+				
+				"autoOpenWorkspace.enableAutoOpenAlwaysFirst": true
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
@@ -38,10 +53,12 @@
 				"ms-python.mypy-type-checker",
 				"littlefoxteam.vscode-python-test-adapter",
 				"esbenp.prettier-vscode",
-				"bradlc.vscode-tailwindcss"
+				"bradlc.vscode-tailwindcss",
+				"zoma.vscode-auto-open-workspace"
 			]
 		}
 	},
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
 	// "forwardPorts": [5000, 5432],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,21 +4,12 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 
-
-	"features": {
-		// "ghcr.io/devcontainers-contrib/features/poetry:2" : {},
-		// "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
-		// "ghcr.io/devcontainers/features/node:1": {},
-	},
-
 	// Configure tool-specific properties.
 	"customizations": {
-
+		
+		// Auto open these files whrn running on GitHub Codespaces
 		"codespaces": {
 			"openFiles": [
-			  //"README.md",
-			  //"scripts/tsconfig.json",
-			  //"docs/main/CODING_STANDARDS.md"
 			  ".devcontainer/README.md",
 			  "server/.env.devcontainer"
 			  
@@ -27,26 +18,15 @@
 
 		// Configure properties specific to VS Code.
 		"vscode": {
-			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
-				// 	"python.linting.enabled": true,
-				// 	"python.linting.pylintEnabled": true,
-				// 	"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-				// 	"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				// 	"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-				// 	"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-				// 	"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-				// 	"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-				// 	"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-				// 	"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-				// 	"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-				// 	"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
 
-				
+				// We're doing most of our configuration in the .code-workspace, instead of here.
+				// Try to auto-open the workspace
+
 				"autoOpenWorkspace.enableAutoOpenAlwaysFirst": true
 			},
-			// Add the IDs of extensions you want installed when the container is created.
+			// Extensions that are installed when the devcontainer is setup
 			"extensions": [
 				"ms-python.python",
 				"charliermarsh.ruff",
@@ -59,9 +39,7 @@
 		}
 	},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// This can be used to network with other containers or the host.
-	"forwardPorts": [3000, 6006, 8000],
+	
 	
 	"remoteUser": "vscode",
 	"postStartCommand": "bash /workspace/.devcontainer/post_start_command.sh",
@@ -70,6 +48,9 @@
 		"POLAR_ENV_FILE":".env.devcontainer"
 	},
 
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or the host.
+	"forwardPorts": [3000, 6006, 8000],
 	"portsAttributes": {
 		"3000": {
 			"label": "web"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+{
+	"name": "Polar",
+	"dockerComposeFile": "docker-compose.yaml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+
+
+	"features": {
+		// "ghcr.io/devcontainers-contrib/features/poetry:2" : {},
+		// "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
+		// "ghcr.io/devcontainers/features/node:1": {},
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"python.defaultInterpreterPath": "/usr/local/bin/python"
+				// 	"python.linting.enabled": true,
+				// 	"python.linting.pylintEnabled": true,
+				// 	"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				// 	"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				// 	"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				// 	"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				// 	"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				// 	"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				// 	"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				// 	"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				// 	"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+				// 	"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"charliermarsh.ruff",
+				"ms-python.mypy-type-checker",
+				"littlefoxteam.vscode-python-test-adapter",
+				"esbenp.prettier-vscode",
+				"bradlc.vscode-tailwindcss"
+			]
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or the host.
+	// "forwardPorts": [5000, 5432],
+	
+	"remoteUser": "vscode",
+	"postStartCommand": "bash /workspace/.devcontainer/post_start_command.sh",
+
+	"remoteEnv": {
+		"POLAR_ENV_FILE":".env.devcontainer"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,12 +61,24 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
-	// "forwardPorts": [5000, 5432],
+	"forwardPorts": [3000, 6006, 8000],
 	
 	"remoteUser": "vscode",
 	"postStartCommand": "bash /workspace/.devcontainer/post_start_command.sh",
 
 	"remoteEnv": {
 		"POLAR_ENV_FILE":".env.devcontainer"
+	},
+
+	"portsAttributes": {
+		"3000": {
+			"label": "web"
+		},
+		"6006": {
+			"label": "storybook"
+		},
+		"8000": {
+			"label": "api"
+		}
 	}
 }

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -5,13 +5,6 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-      # args:
-      #   # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-      #   # Append -bullseye or -buster to pin to an OS version.
-      #   # Use -bullseye variants on local arm64/Apple Silicon.
-      #   VARIANT: 3-bullseye
-      #   # Optional Node.js version to install
-      #   NODE_VERSION: "lts/*"
 
     volumes:
       - ..:/workspace:cached
@@ -20,15 +13,7 @@ services:
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
-
-    # Uncomment the next line to use a non-root user for all processes.
-    # user: vscode
-
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   redis:
     image: redis
@@ -42,14 +27,6 @@ services:
       POSTGRES_USER: polar
       POSTGRES_DB: polar
       POSTGRES_PASSWORD: polar
-    # healthcheck:
-    #   test: ["CMD", "pg_isready", "-q", "-d", "polar", "-U", "polar"]
-    #   timeout: 40s
-    #   interval: 2s
-    #   retries: 20
-
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:
   postgres-data: {}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ..:/workspace:cached
       - venv:/workspace/server/.venv:rw # do not mount from host
+      - node_modules:/workspace/clients/node_modules:rw # do not mount from host
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -53,3 +54,4 @@ services:
 volumes:
   postgres-data: {}
   venv: {}
+  node_modules: {}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,55 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      # args:
+      #   # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+      #   # Append -bullseye or -buster to pin to an OS version.
+      #   # Use -bullseye variants on local arm64/Apple Silicon.
+      #   VARIANT: 3-bullseye
+      #   # Optional Node.js version to install
+      #   NODE_VERSION: "lts/*"
+
+    volumes:
+      - ..:/workspace:cached
+      - venv:/workspace/server/.venv:rw # do not mount from host
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  redis:
+    image: redis
+
+  db:
+    image: postgres:15.1-bullseye
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: polar
+      POSTGRES_DB: polar
+      POSTGRES_PASSWORD: polar
+    # healthcheck:
+    #   test: ["CMD", "pg_isready", "-q", "-d", "polar", "-U", "polar"]
+    #   timeout: 40s
+    #   interval: 2s
+    #   retries: 20
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data: {}
+  venv: {}

--- a/.devcontainer/post_start_command.sh
+++ b/.devcontainer/post_start_command.sh
@@ -8,9 +8,13 @@ set -x
 sudo chown 1000:1000 /workspace/server/.venv/
 cd /workspace/server
 poetry install
-
 poetry run task db_migrate
+echo "🐻‍❄️✅ Server ready"
 
+# Clients setup
+cd /workspace/clients
+sudo chown 1000:1000 /workspace/clients/node_modules
+pnpm install
+echo "🐻‍❄️✅ Clients ready"
 
-echo "🐻‍❄️✅"
-echo "🐻‍❄️✅ Setup complete"
+echo "🐻‍❄️✅✅✅ Setup complete"

--- a/.devcontainer/post_start_command.sh
+++ b/.devcontainer/post_start_command.sh
@@ -17,4 +17,11 @@ sudo chown 1000:1000 /workspace/clients/node_modules
 pnpm install
 echo "🐻‍❄️✅ Clients ready"
 
+
+if [ ! -f "/workspace/clients/apps/web/.env" ]; then
+    echo "🐻‍❄️ /workspace/clients/apps/web/.env does not exist, creating it"
+    cp /workspace/clients/apps/web/.env.devcontainer /workspace/clients/apps/web/.env
+fi
+
+
 echo "🐻‍❄️✅✅✅ Setup complete"

--- a/.devcontainer/post_start_command.sh
+++ b/.devcontainer/post_start_command.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+# Server setup
+# 1000:1000 is vscode:vscode
+sudo chown 1000:1000 /workspace/server/.venv/
+cd /workspace/server
+poetry install
+
+poetry run task db_migrate
+
+
+echo "🐻‍❄️✅"
+echo "🐻‍❄️✅ Setup complete"

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 playground.py
 
 .DS_Store
+.pnpm-store

--- a/clients/.vscode/launch.json
+++ b/clients/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "pnpm dev",
+            "name": "Polar (clients)",
+            "request": "launch",
+            "type": "node-terminal"
+        },
+    ]
+}

--- a/server/.env.devcontainer
+++ b/server/.env.devcontainer
@@ -1,0 +1,21 @@
+POLAR_POSTGRES_USER="polar"
+POLAR_POSTGRES_PWD="polar"
+# It's a good idea to not re-use the same database as for local dev
+POLAR_POSTGRES_DATABASE="polar"
+POLAR_POSTGRES_PORT="5432"
+POLAR_POSTGRES_HOST="db"
+
+POLAR_REDIS_HOST="redis"
+POLAR_REDIS_PORT="6379"
+
+POLAR_GITHUB_APP_IDENTIFIER="100000"
+POLAR_GITHUB_APP_WEBHOOK_SECRET="xoxo"
+POLAR_GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nNOT A VALID KEY\n-----END RSA PRIVATE KEY-----"
+POLAR_GITHUB_CLIENT_ID="Iv1.fakefakefake"
+POLAR_GITHUB_CLIENT_SECRET="fakefakefakefakefakefakefakefakefakefake"
+
+POLAR_CORS_ORIGINS='["http://127.0.0.1:3000", "http://localhost:3000", "http://test"]'
+POLAR_AUTH_COOKIE_DOMAIN="test"
+
+POLAR_DEBUG="false"
+POLAR_TESTING=1

--- a/server/.vscode/launch.json
+++ b/server/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "compounds": [
         {
-            "name": "Polar",
+            "name": "Polar (Server)",
             "configurations": ["API", "Worker"],
             "stopAll": true
         }

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   redis:
@@ -21,7 +21,16 @@ services:
       - ${POLAR_POSTGRES_PORT}
     restart: always
     healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-d", "${POLAR_POSTGRES_DATABASE}", "-U", "${POLAR_POSTGRES_USER}" ]
+      test:
+        [
+          "CMD",
+          "pg_isready",
+          "-q",
+          "-d",
+          "${POLAR_POSTGRES_DATABASE}",
+          "-U",
+          "${POLAR_POSTGRES_USER}",
+        ]
       timeout: 40s
       interval: 2s
       retries: 20

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -157,5 +157,15 @@ class Settings(BaseSettings):
 
 
 env = Environment(os.getenv("POLAR_ENV", Environment.development))
-env_file = ".env.testing" if env == Environment.testing else ".env"
+
+
+env_file = ".env"
+
+if env == Environment.testing:
+    env_file = ".env.testing"
+
+override_env_file = os.getenv("POLAR_ENV_FILE", None)
+if override_env_file:
+    env_file = override_env_file
+
 settings = Settings(_env_file=env_file, ENV=env)  # type: ignore


### PR DESCRIPTION
Hacking on a dev container, as a way to support 1-click-setup for development environments. Mostly tailored for non-employees as an easy way to get started to hack on Polar.

At the current state, you can run the web app, run the server tests, and run the storybook.

The server does not boot, as it depends on a GitHub app. I'll work on that next...

Fixes #1236