### PR TITLE
server/dx: re-enable unused import rule unless in VS Code

### DIFF
--- a/server/.vscode/settings.json
+++ b/server/.vscode/settings.json
@@ -25,4 +25,5 @@
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
+  "ruff.lint.args": ["--config=ruff.vscode.toml"]
 }

--- a/server/polar/account/endpoints.py
+++ b/server/polar/account/endpoints.py
@@ -11,7 +11,6 @@ from polar.postgres import AsyncSession, get_db_session
 from polar.tags.api import Tags
 
 from .schemas import Account, AccountCreate, AccountLink
-from .service import AccountServiceError
 from .service import account as account_service
 
 router = APIRouter(tags=["accounts"])

--- a/server/polar/dashboard/schemas.py
+++ b/server/polar/dashboard/schemas.py
@@ -7,7 +7,6 @@ from polar.issue.schemas import IssueReferenceRead
 from polar.kit.schemas import Schema
 from polar.pledge.schemas import Pledge
 from polar.reward.schemas import Reward
-from polar.types import JSONAny
 
 
 class IssueListType(str, Enum):

--- a/server/polar/funding/service.py
+++ b/server/polar/funding/service.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from decimal import Decimal
 from enum import StrEnum
 from typing import Any, cast
 from uuid import UUID

--- a/server/polar/integrations/github/client.py
+++ b/server/polar/integrations/github/client.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Union
+from typing import Any
 
 import structlog
 from fastapi.encoders import jsonable_encoder

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -23,7 +23,6 @@ from polar.enums import UserSignupType
 from polar.exceptions import ResourceNotFound, Unauthorized
 from polar.integrations.github import client as github
 from polar.kit import jwt
-from polar.models import Organization
 from polar.organization.schemas import Organization as OrganizationSchema
 from polar.pledge.service import pledge as pledge_service
 from polar.postgres import AsyncSession, get_db_session

--- a/server/polar/integrations/github/schemas.py
+++ b/server/polar/integrations/github/schemas.py
@@ -1,6 +1,3 @@
-from typing import Literal
-
-from polar.funding.funding_schema import Funding
 from polar.kit.schemas import Schema
 
 

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 import structlog
-from githubkit import GitHub, Paginator, Response
+from githubkit import GitHub, Paginator
 from githubkit.exception import RequestFailed
 from githubkit.rest.models import Issue as GitHubIssue
 from githubkit.rest.models import Label
@@ -20,7 +20,6 @@ from polar.dashboard.schemas import IssueSortBy
 from polar.enums import Platforms
 from polar.exceptions import ResourceNotFound
 from polar.integrations.github import client as github
-from polar.integrations.github.service.api import github_api
 from polar.integrations.loops.service import loops as loops_service
 from polar.issue.hooks import IssueHook, issue_upserted
 from polar.issue.schemas import IssueCreate, IssueUpdate

--- a/server/polar/integrations/github/service/organization.py
+++ b/server/polar/integrations/github/service/organization.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import TypedDict
 from uuid import UUID
 
 import structlog

--- a/server/polar/integrations/github/service/reference.py
+++ b/server/polar/integrations/github/service/reference.py
@@ -12,7 +12,6 @@ from pydantic import Field, ValidationError, parse_obj_as
 
 import polar.integrations.github.client as github
 from polar.exceptions import IntegrityError
-from polar.integrations.github.service.api import github_api
 from polar.integrations.github.service.issue import github_issue
 from polar.integrations.github.service.pull_request import github_pull_request
 from polar.issue.hooks import (

--- a/server/polar/integrations/github/tasks/utils.py
+++ b/server/polar/integrations/github/tasks/utils.py
@@ -1,13 +1,10 @@
-from collections.abc import Sequence
 from uuid import UUID
 
 import structlog
 
-from polar.integrations.github import client as github
 from polar.integrations.github import service
-from polar.models import Issue, Organization, PullRequest, Repository
+from polar.models import Organization, Repository
 from polar.postgres import AsyncSession
-from polar.pull_request.schemas import FullPullRequestCreate
 
 log = structlog.get_logger()
 

--- a/server/polar/integrations/stripe/endpoints.py
+++ b/server/polar/integrations/stripe/endpoints.py
@@ -5,7 +5,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse
 
-from polar.account.schemas import AccountUpdate
 from polar.account.service import account as account_service
 from polar.config import settings
 from polar.enums import AccountType

--- a/server/polar/integrations/stripe/schemas.py
+++ b/server/polar/integrations/stripe/schemas.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal
 from uuid import UUID
 
 from polar.kit.schemas import Schema

--- a/server/polar/issue/endpoints.py
+++ b/server/polar/issue/endpoints.py
@@ -23,7 +23,6 @@ from polar.postgres import (
     get_db_session,
     get_db_sessionmaker,
 )
-from polar.repository.schemas import Repository as RepositorySchema
 from polar.repository.service import repository as repository_service
 from polar.tags.api import Tags
 from polar.user_organization.service import (

--- a/server/polar/issue/schemas.py
+++ b/server/polar/issue/schemas.py
@@ -29,7 +29,7 @@ from polar.models.issue_reference import (
 from polar.models.organization import Organization as OrganizationModel
 from polar.models.repository import Repository as RepositoryModel
 from polar.repository.schemas import Repository
-from polar.types import JSONAny, JSONDict
+from polar.types import JSONAny
 
 log = structlog.get_logger()
 

--- a/server/polar/issue/service.py
+++ b/server/polar/issue/service.py
@@ -12,13 +12,12 @@ from sqlalchemy import (
     asc,
     desc,
     func,
-    not_,
     nullslast,
     or_,
 )
-from sqlalchemy.orm import InstrumentedAttribute, aliased, contains_eager, joinedload
+from sqlalchemy.orm import aliased, contains_eager, joinedload
 
-from polar.dashboard.schemas import IssueListType, IssueSortBy, IssueStatus
+from polar.dashboard.schemas import IssueSortBy
 from polar.enums import Platforms
 from polar.kit.services import ResourceService
 from polar.kit.utils import utc_now

--- a/server/polar/kit/db/models/mixins/active_record.py
+++ b/server/polar/kit/db/models/mixins/active_record.py
@@ -2,15 +2,9 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Self
 
-from sqlalchemy import Column
-from sqlalchemy.orm import (
-    InstrumentedAttribute,
-)
-from sqlalchemy.orm.properties import MappedColumn
 from sqlalchemy.sql.selectable import FromClause
 
-from polar.kit.schemas import Schema
-from polar.postgres import AsyncSession, sql
+from polar.postgres import AsyncSession
 
 
 # Active Record-ish

--- a/server/polar/kit/utils.py
+++ b/server/polar/kit/utils.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 
 def utc_now() -> datetime:

--- a/server/polar/models/issue.py
+++ b/server/polar/models/issue.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID
 
-import sqlalchemy
 import sqlalchemy as sa
 from sqlalchemy import (
     TIMESTAMP,

--- a/server/polar/models/repository.py
+++ b/server/polar/models/repository.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from citext import CIText

--- a/server/polar/models/subscription_tier_benefit.py
+++ b/server/polar/models/subscription_tier_benefit.py
@@ -1,4 +1,3 @@
-from enum import StrEnum
 from typing import TYPE_CHECKING
 from uuid import UUID
 

--- a/server/polar/models/user_organization_settings.py
+++ b/server/polar/models/user_organization_settings.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from sqlalchemy import Boolean, ForeignKey
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 from polar.kit.db.models import TimestampedModel

--- a/server/polar/notifications/endpoints.py
+++ b/server/polar/notifications/endpoints.py
@@ -1,5 +1,5 @@
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from polar.auth.dependencies import UserRequiredAuth
 from polar.models.notification import Notification

--- a/server/polar/notifications/schemas.py
+++ b/server/polar/notifications/schemas.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from enum import Enum
-from typing import Self, Union
+from typing import Self
 from uuid import UUID
-
-from pydantic import Field
 
 from polar.kit.schemas import Schema
 from polar.notifications.notification import (

--- a/server/polar/notifications/tasks/email.py
+++ b/server/polar/notifications/tasks/email.py
@@ -3,17 +3,8 @@ from uuid import UUID
 import structlog
 
 from polar.email.sender import get_email_sender
-from polar.models.notification import Notification
-from polar.models.user import User
-from polar.notifications.schemas import (
-    NotificationType,
-)
 from polar.notifications.service import notifications
-from polar.postgres import AsyncSession
 from polar.user.service import user as user_service
-from polar.user_organization.service import (
-    user_organization as user_organization_service,
-)
 from polar.worker import AsyncSessionMaker, JobContext, PolarWorkerContext, task
 
 log = structlog.get_logger()

--- a/server/polar/payment_method/endpoints.py
+++ b/server/polar/payment_method/endpoints.py
@@ -2,7 +2,6 @@ import structlog
 from fastapi import APIRouter, Depends
 
 from polar.auth.dependencies import UserRequiredAuth
-from polar.exceptions import Unauthorized
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.pagination import ListResource, Pagination
 from polar.postgres import AsyncSession, get_db_session

--- a/server/polar/payment_method/schemas.py
+++ b/server/polar/payment_method/schemas.py
@@ -1,5 +1,4 @@
 from typing import Literal, Self
-from uuid import UUID
 
 import stripe as stripe_lib
 

--- a/server/polar/pledge/endpoints.py
+++ b/server/polar/pledge/endpoints.py
@@ -1,7 +1,6 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import desc
 
 from polar import locker
 from polar.auth.dependencies import Auth, UserRequiredAuth

--- a/server/polar/pledge/service.py
+++ b/server/polar/pledge/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import calendar
 import datetime
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import timedelta

--- a/server/polar/pull_request/endpoints.py
+++ b/server/polar/pull_request/endpoints.py
@@ -1,7 +1,6 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import Field
 
 from polar.auth.dependencies import Auth
 from polar.authz.service import AccessType, Authz

--- a/server/polar/pull_request/schemas.py
+++ b/server/polar/pull_request/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Self, Union
+from typing import Self
 from uuid import UUID
 
 import structlog

--- a/server/polar/pull_request/service.py
+++ b/server/polar/pull_request/service.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from uuid import UUID
 
 import structlog
-from sqlalchemy.orm import InstrumentedAttribute
 
 from polar.enums import Platforms
 from polar.kit.services import ResourceService

--- a/server/polar/repository/service.py
+++ b/server/polar/repository/service.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import and_, distinct
-from sqlalchemy.orm import InstrumentedAttribute, joinedload
+from sqlalchemy.orm import joinedload
 
 from polar.kit.services import ResourceService
 from polar.models import Repository

--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -13,7 +13,6 @@ from sentry_sdk.utils import Dsn
 
 from polar.auth.dependencies import Auth
 from polar.config import settings
-from polar.models import User
 from polar.posthog import posthog
 
 if TYPE_CHECKING:

--- a/server/polar/subscription/service/benefits/__init__.py
+++ b/server/polar/subscription/service/benefits/__init__.py
@@ -6,7 +6,6 @@ from polar.postgres import AsyncSession
 
 from ...schemas import SubscriptionBenefitUpdate
 from .base import (
-    SB,
     SubscriptionBenefitPreconditionError,
     SubscriptionBenefitRetriableError,
     SubscriptionBenefitServiceError,

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -81,8 +81,12 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]  # See: https://github
 target-version = "py311"
 extend-select = ["I", "UP"]
 ignore = [
-    "F401", # remove unused import
     "F841", # remove unused variables
+]
+
+[tool.ruff.lint.per-file-ignores]
+"migrations/*" = [
+    "F401", # remove unused import
 ]
 
 [tool.mypy]

--- a/server/ruff.vscode.toml
+++ b/server/ruff.vscode.toml
@@ -1,0 +1,7 @@
+# Specific Ruff overrides when running inside VS Code.
+
+extend = "./pyproject.toml"
+
+unfixable = [
+    "F401"  # Prevent to remove unused imports when saving file
+]

--- a/server/scripts/transfer_fix.py
+++ b/server/scripts/transfer_fix.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging.config
 from functools import wraps
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 import typer

--- a/server/tests/account/test_endpoints.py
+++ b/server/tests/account/test_endpoints.py
@@ -17,7 +17,6 @@ from polar.integrations.open_collective.service import (
     OpenCollectiveServiceError,
     open_collective,
 )
-from polar.kit.schemas import Schema
 from polar.models.account import Account
 from polar.models.organization import Organization
 from polar.models.user import User

--- a/server/tests/fixtures/database.py
+++ b/server/tests/fixtures/database.py
@@ -2,7 +2,7 @@ from collections.abc import AsyncIterator
 from uuid import UUID
 
 import pytest_asyncio
-from sqlalchemy import Integer, String, null
+from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import text
 

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -5,7 +5,6 @@ import uuid
 from datetime import datetime
 
 import pytest_asyncio
-from respx import add
 
 from polar.enums import Platforms
 from polar.integrations.github.service import (

--- a/server/tests/integrations/github/service/test_reference.py
+++ b/server/tests/integrations/github/service/test_reference.py
@@ -1,15 +1,11 @@
-import uuid
-
 import pytest
 from pydantic import parse_obj_as
 
 import polar.integrations.github.client as github
-from polar.enums import Platforms
 from polar.integrations.github.service.reference import (
     TimelineEventType,
     github_reference,
 )
-from polar.kit import utils
 from polar.models.issue import Issue
 from polar.models.issue_reference import ReferenceType
 from polar.models.organization import Organization

--- a/server/tests/integrations/github/tasks/test_integration.py
+++ b/server/tests/integrations/github/tasks/test_integration.py
@@ -9,9 +9,7 @@ from pytest_mock import MockerFixture
 from polar.enums import Platforms
 from polar.integrations.github import tasks
 from polar.integrations.github.tasks import webhook as webhook_tasks
-from polar.models.organization import Organization
 from polar.models.user import OAuthAccount, User
-from polar.models.user_organization import UserOrganization
 from polar.notifications.service import (
     notifications,
 )

--- a/server/tests/integrations/github/test_badge.py
+++ b/server/tests/integrations/github/test_badge.py
@@ -2,9 +2,7 @@ from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
-from pytest_mock import MockerFixture
 
-from polar.config import settings
 from polar.integrations.github.badge import GithubBadge
 from polar.integrations.github.service.issue import github_issue
 from polar.kit.utils import utc_now

--- a/server/tests/issue/test_endpoints.py
+++ b/server/tests/issue/test_endpoints.py
@@ -12,8 +12,6 @@ from polar.models.pledge import Pledge
 from polar.models.repository import Repository
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
-from polar.pledge.schemas import PledgeState
-from polar.pledge.service import pledge as pledge_service
 from polar.postgres import AsyncSession
 
 

--- a/server/tests/issue/test_service.py
+++ b/server/tests/issue/test_service.py
@@ -4,13 +4,12 @@ from datetime import datetime
 
 import pytest
 
-from polar.dashboard.schemas import IssueListType, IssueSortBy, IssueStatus
+from polar.dashboard.schemas import IssueSortBy
 from polar.enums import Platforms
 from polar.integrations.github import client as github
 from polar.issue.service import issue as issue_service
 from polar.kit.utils import utc_now
 from polar.models.issue import Issue
-from polar.models.issue_dependency import IssueDependency
 from polar.models.organization import Organization
 from polar.models.pledge import Pledge
 from polar.models.repository import Repository

--- a/server/tests/notifications/test_endpoints.py
+++ b/server/tests/notifications/test_endpoints.py
@@ -1,7 +1,6 @@
 import pytest
 from httpx import AsyncClient
 
-from polar.app import app
 from polar.config import settings
 from polar.models.issue import Issue
 from polar.models.organization import Organization

--- a/server/tests/notifications/test_pledge_notifications.py
+++ b/server/tests/notifications/test_pledge_notifications.py
@@ -12,7 +12,6 @@ from polar.models.repository import Repository
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
 from polar.notifications.notification import MaintainerPledgeCreatedNotification
-from polar.notifications.schemas import NotificationType
 from polar.notifications.service import NotificationsService, PartialNotification
 from polar.pledge.schemas import PledgeState, PledgeType
 from polar.pledge.service import pledge as pledge_service

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -6,7 +6,6 @@ from httpx import AsyncClient
 
 from polar.config import settings
 from polar.models.organization import Organization
-from polar.models.user import User
 from polar.models.user_organization import UserOrganization
 from polar.organization.schemas import Organization as OrganizationSchema
 from polar.postgres import AsyncSession

--- a/server/tests/pledge/test_service.py
+++ b/server/tests/pledge/test_service.py
@@ -5,7 +5,6 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
-from unittest.mock import ANY
 
 import pytest
 from httpx import AsyncClient
@@ -13,12 +12,9 @@ from pytest_mock import MockerFixture
 
 from polar.config import settings
 from polar.enums import AccountType, Platforms
-from polar.eventstream.service import send
 from polar.exceptions import NotPermitted
-from polar.integrations.github.service.issue import github_issue as github_issue_service
 from polar.issue.hooks import IssueHook, issue_upserted
 from polar.issue.schemas import ConfirmIssueSplit
-from polar.issue.service import issue as issue_service
 from polar.kit.utils import utc_now
 from polar.models.account import Account
 from polar.models.issue import Issue
@@ -29,16 +25,11 @@ from polar.models.pledge_transaction import PledgeTransaction
 from polar.models.repository import Repository
 from polar.models.user import OAuthAccount, User
 from polar.models.user_organization import UserOrganization
-from polar.notifications.notification import (
-    MaintainerPledgeCreatedNotification,
-    MaintainerPledgedIssueConfirmationPendingNotification,
-)
 from polar.notifications.service import PartialNotification
 from polar.pledge.hooks import PledgeHook, pledge_created
 from polar.pledge.schemas import PledgeState, PledgeTransactionType, PledgeType
 from polar.pledge.service import pledge as pledge_service
 from polar.postgres import AsyncSession
-from polar.receivers.pledges import issue_url
 from tests.fixtures.random_objects import (
     create_issue,
     create_organization,

--- a/server/tests/reward/test_endpoints.py
+++ b/server/tests/reward/test_endpoints.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import timedelta
 
 import pytest

--- a/server/tests/subscription/service/test_subscription_benefit_grant.py
+++ b/server/tests/subscription/service/test_subscription_benefit_grant.py
@@ -1,4 +1,3 @@
-from re import S
 from unittest.mock import MagicMock
 
 import pytest

--- a/server/tests/subscription/service/test_subscription_tier.py
+++ b/server/tests/subscription/service/test_subscription_tier.py
@@ -15,7 +15,6 @@ from polar.models import (
     Repository,
     SubscriptionBenefit,
     SubscriptionTier,
-    SubscriptionTierBenefit,
     User,
     UserOrganization,
 )

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -1,13 +1,8 @@
-from datetime import datetime
-
 import pytest
 from httpx import AsyncClient
 
 from polar.config import settings
-from polar.models.organization import Organization
 from polar.models.user import User
-from polar.models.user_organization import UserOrganization
-from polar.postgres import AsyncSession
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
It allows us to check for unused imports but without compromising the experience when frenetically `Cmd+S`.

More context: https://github.com/polarsource/polar/issues/847#issuecomment-1628459626