### PR TITLE
server/dx: set application name on PostgreSQL connection

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -57,7 +57,7 @@ class State(TypedDict):
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     async with worker.lifespan():
-        engine = create_engine()
+        engine = create_engine("app")
         sessionmaker = create_sessionmaker(engine)
 
         log.info("Polar API started")

--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -10,11 +8,16 @@ from sqlalchemy.ext.asyncio import (
 from ..extensions.sqlalchemy import sql
 
 
-def create_engine(*, dsn: str, debug: bool = False) -> AsyncEngine:
-    engine_options: dict[str, Any] = dict(
+def create_engine(
+    *, dsn: str, application_name: str | None = None, debug: bool = False
+) -> AsyncEngine:
+    return create_async_engine(
+        dsn,
         echo=debug,
+        connect_args={"server_settings": {"application_name": application_name}}
+        if application_name
+        else {},
     )
-    return create_async_engine(dsn, **engine_options)
 
 
 def create_sessionmaker(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncGenerator
+from typing import Literal
 
 from fastapi import Depends, Request
 
@@ -13,14 +14,13 @@ from polar.kit.db.postgres import (
 from polar.kit.db.postgres import create_engine as _create_engine
 
 
-def create_engine() -> AsyncEngine:
+def create_engine(process_name: Literal["app", "worker", "script"]) -> AsyncEngine:
     return _create_engine(
         dsn=str(settings.postgres_dsn),
+        application_name=f"{settings.ENV.value}.{process_name}",
         debug=settings.DEBUG,
     )
 
-
-AsyncEngineLocal = create_engine()
 
 AsyncSessionMaker = async_sessionmaker[AsyncSession]
 
@@ -47,7 +47,6 @@ async def get_db_session(
 
 __all__ = [
     "AsyncSession",
-    "AsyncEngineLocal",
     "sql",
     "create_engine",
     "create_sessionmaker",

--- a/server/polar/worker.py
+++ b/server/polar/worker.py
@@ -89,7 +89,7 @@ class WorkerSettings:
             raise Exception("arq_pool already exists in startup")
         arq_pool = await create_pool()
 
-        engine = create_engine()
+        engine = create_engine("worker")
         sessionmaker = create_sessionmaker(engine)
         ctx.update({"engine": engine, "sessionmaker": sessionmaker})
 

--- a/server/scripts/anonymous_pledge_migration.py
+++ b/server/scripts/anonymous_pledge_migration.py
@@ -46,7 +46,7 @@ async def anonymous_pledge_migration(
         False, help="If `True`, changes won't be commited to the database."
     ),
 ) -> None:
-    engine = create_engine()
+    engine = create_engine("script")
     async with engine.connect() as connection:
         async with connection.begin() as transaction:
             session = AsyncSession(

--- a/server/scripts/dev_github.py
+++ b/server/scripts/dev_github.py
@@ -16,7 +16,7 @@ from polar.kit.db.postgres import create_sessionmaker
 from polar.models import Issue, Organization, Repository
 from polar.models.user_organization import UserOrganization
 from polar.organization.schemas import OrganizationCreate
-from polar.postgres import AsyncEngineLocal, AsyncSession, sql
+from polar.postgres import AsyncSession, create_engine, sql
 from polar.repository.schemas import RepositoryCreate
 from polar.user.service import user as user_service
 from polar.user_organization.service import user_organization
@@ -34,7 +34,8 @@ cli = typer.Typer()
 # Helpers
 ###############################################################################
 
-AsyncSessionLocal = create_sessionmaker(engine=AsyncEngineLocal)
+engine = create_engine("script")
+AsyncSessionLocal = create_sessionmaker(engine=engine)
 
 
 def typer_async(f):  # type: ignore

--- a/server/scripts/issues.py
+++ b/server/scripts/issues.py
@@ -11,7 +11,7 @@ from polar.integrations.github.service import (
     github_repository,
 )
 from polar.kit.db.postgres import create_sessionmaker
-from polar.postgres import AsyncEngineLocal
+from polar.postgres import create_engine
 
 #
 # This file contains scripts ready that are safe to run in production
@@ -19,8 +19,8 @@ from polar.postgres import AsyncEngineLocal
 
 cli = typer.Typer()
 
-
-AsyncSessionLocal = create_sessionmaker(engine=AsyncEngineLocal)
+engine = create_engine("script")
+AsyncSessionLocal = create_sessionmaker(engine=engine)
 
 
 def typer_async(f):  # type: ignore

--- a/server/scripts/loops_migration.py
+++ b/server/scripts/loops_migration.py
@@ -51,7 +51,7 @@ async def loops_migration(
     ),
 ) -> None:
     loops_client = LoopsClient(settings.LOOPS_API_KEY if not dry_run else None)
-    engine = create_engine()
+    engine = create_engine("script")
     sessionmaker = create_sessionmaker(engine)
     async with sessionmaker() as session:
         users_statement = (
@@ -131,7 +131,7 @@ async def personal_organization_name(
     ),
 ) -> None:
     loops_client = LoopsClient(settings.LOOPS_API_KEY if not dry_run else None)
-    engine = create_engine()
+    engine = create_engine("script")
     sessionmaker = create_sessionmaker(engine)
     async with sessionmaker() as session:
         users_statement = (

--- a/server/scripts/transfer_fix.py
+++ b/server/scripts/transfer_fix.py
@@ -60,7 +60,7 @@ async def organizations_renamed(
         False, help="If `True`, changes won't be commited to the database."
     ),
 ) -> None:
-    engine = create_engine()
+    engine = create_engine("script")
     async with engine.connect() as connection:
         async with connection.begin() as transaction:
             session = AsyncSession(
@@ -136,7 +136,7 @@ async def repositories_transferred(
         False, help="If `True`, changes won't be commited to the database."
     ),
 ) -> None:
-    engine = create_engine()
+    engine = create_engine("script")
     async with engine.connect() as connection:
         async with connection.begin() as transaction:
             session = AsyncSession(
@@ -221,7 +221,7 @@ async def issues_transferred(
         False, help="If `True`, changes won't be commited to the database."
     ),
 ) -> None:
-    engine = create_engine()
+    engine = create_engine("script")
     async with engine.connect() as connection:
         async with connection.begin() as transaction:
             session = AsyncSession(

--- a/server/tests/fixtures/database.py
+++ b/server/tests/fixtures/database.py
@@ -25,7 +25,7 @@ class TestModel(Model):
 
 @pytest_asyncio.fixture(scope="session")
 async def engine() -> AsyncIterator[AsyncEngine]:
-    engine = create_engine()
+    engine = create_engine("app")
     yield engine
     await engine.dispose()
 


### PR DESCRIPTION
This is useful when querying for `pg_stat_activity` in PostgreSQL
because it'll tell us which processes has opened connections.

Hopefully, it'll help us debug #265.