### PR TITLE
server/badge: remove onboarded_at check

### DIFF
--- a/server/polar/integrations/github/badge.py
+++ b/server/polar/integrations/github/badge.py
@@ -37,8 +37,8 @@ class GithubBadge:
         if not settings.GITHUB_BADGE_EMBED:
             return (False, "app_badge_not_enabled")
 
-        if organization.onboarded_at is None:
-            return (False, "org_not_onboarded")
+        if organization.installation_id is None:
+            return (False, "org_not_installed")
 
         # Triggered by label
         if triggered_from_label:
@@ -64,8 +64,8 @@ class GithubBadge:
         if not settings.GITHUB_BADGE_EMBED:
             return (False, "app_badge_not_enabled")
 
-        if organization.onboarded_at is None:
-            return (False, "org_not_onboarded")
+        if organization.installation_id is None:
+            return (False, "org_not_installed")
 
         if triggered_from_label:
             return (True, "triggered_from_label")

--- a/server/tests/integrations/github/test_badge.py
+++ b/server/tests/integrations/github/test_badge.py
@@ -206,7 +206,7 @@ async def test_should_add_badge_app_config_disabled(
 
 @pytest.mark.asyncio
 @patch("polar.config.settings.GITHUB_BADGE_EMBED", True)
-async def test_should_add_badge_org_not_onboarded(
+async def test_should_add_badge_org_not_installed(
     session: AsyncSession,
     organization: Organization,
     repository: Repository,
@@ -215,6 +215,9 @@ async def test_should_add_badge_org_not_onboarded(
     repository.pledge_badge_auto_embed = True
     await repository.save(session)
 
+    organization.installation_id = None
+    await organization.save(session)
+
     res = GithubBadge.should_add_badge(
         organization=organization,
         repository=repository,
@@ -222,7 +225,7 @@ async def test_should_add_badge_org_not_onboarded(
         triggered_from_label=False,
     )
 
-    assert res == (False, "org_not_onboarded")
+    assert res == (False, "org_not_installed")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The onboarded_at check was effectively also an installation_id check. Adding one to check that the GitHub App is installed in it's place.