### PR TITLE
server/stripe: set account names

### DIFF
--- a/server/polar/account/endpoints.py
+++ b/server/polar/account/endpoints.py
@@ -130,6 +130,9 @@ async def dashboard_link(
             detail="Unauthorized",
         )
 
+    # update stripe account details
+    await account_service.sync_to_upstream(session, acc)
+
     link = await account_service.dashboard_link(acc)
     if not link:
         raise HTTPException(status_code=500, detail="Failed to create link")

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -146,15 +146,27 @@ class StripeService:
     def retrieve_intent(self, id: str) -> stripe_lib.PaymentIntent:
         return stripe_lib.PaymentIntent.retrieve(id)
 
-    def create_account(self, account: AccountCreate) -> stripe_lib.Account:
+    def create_account(
+        self, account: AccountCreate, name: str | None
+    ) -> stripe_lib.Account:
         create_params: stripe_lib.Account.CreateParams = {
             "country": account.country,
             "type": "express",
             "capabilities": {"transfers": {"requested": True}},
         }
+
+        if name:
+            create_params["business_profile"] = {"name": name}
+
         if account.country != "US":
             create_params["tos_acceptance"] = {"service_agreement": "recipient"}
         return stripe_lib.Account.create(**create_params)
+
+    def update_account(self, id: str, name: str | None) -> None:
+        obj = {}
+        if name:
+            obj["business_profile"] = {"name": name}
+        stripe_lib.Account.modify(id, **obj)
 
     def retrieve_account(self, id: str) -> stripe_lib.Account:
         return stripe_lib.Account.retrieve(id)


### PR DESCRIPTION
Set names of Stripe Accounts. Useful for us (Polar) to keep track of accounts. This was triggered by #1729 but does not solve it. This name is not visible in Stripe Express.