### PR TITLE
clients/posts: use current user in demo issues

### DIFF
--- a/clients/apps/web/src/app/(public)/[organization]/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/page.tsx
@@ -138,7 +138,7 @@ export default async function Page({
 
   const currentTab = searchParams.tab as string | undefined
 
-  const posts = (await getFeed(api)).filter(
+  const posts = (await getFeed(api, params.organization)).filter(
     (entry) =>
       !isRecommendation(entry) && entry.author.username === organization.name,
   ) as Post[]

--- a/clients/apps/web/src/app/(public)/[organization]/posts/[postId]/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/posts/[postId]/page.tsx
@@ -79,7 +79,7 @@ export default async function Page({
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
   const api = getServerSideAPI()
-  const post = await (await getFeed(api))
+  const post = await (await getFeed(api, params.organization))
     .filter((value): value is Post => !isRecommendation(value))
     .find((post) => post.id === params.postId)
 

--- a/clients/apps/web/src/app/maintainer/[organization]/posts/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/posts/ClientPage.tsx
@@ -72,10 +72,15 @@ const ClientPage = () => {
   const organization = useCurrentOrgAndRepoFromURL().org
 
   useEffect(() => {
-    getFeed(api).then((feed) =>
+    if (!organization) {
+      setPosts([])
+      return
+    }
+
+    getFeed(api, organization.name).then((feed) =>
       setPosts(feed.filter((entity) => !isRecommendation(entity)) as Post[]),
     )
-  }, [])
+  }, [organization])
 
   return (
     <>

--- a/clients/apps/web/src/app/maintainer/[organization]/posts/[post]/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/posts/[post]/ClientPage.tsx
@@ -15,7 +15,7 @@ const ClientPage = () => {
   const [body, setBody] = useState(post?.body || '')
 
   useEffect(() => {
-    getFeed(api).then((feed) => {
+    getFeed(api, organization as string).then((feed) => {
       const post = feed.find(
         (post) => 'id' in post && post.id === postId,
       ) as Post

--- a/clients/apps/web/src/components/Feed/Feed.tsx
+++ b/clients/apps/web/src/components/Feed/Feed.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRequireAuth } from '@/hooks'
 import { ArrowBackOutlined } from '@mui/icons-material'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -16,10 +17,11 @@ export const Feed = () => {
   const [feed, setFeed] = useState<(Recommendation | Post)[]>([])
   const params = useSearchParams()
   const router = useRouter()
+  const { currentUser } = useRequireAuth()
 
   useEffect(() => {
-    getFeed(api).then((feed) => setFeed(feed))
-  }, [])
+    getFeed(api, currentUser?.username || '').then((feed) => setFeed(feed))
+  }, [currentUser])
 
   const post = feed.find(
     (post) => 'id' in post && post.id === params.get('post'),

--- a/clients/apps/web/src/components/Feed/data.ts
+++ b/clients/apps/web/src/components/Feed/data.ts
@@ -121,6 +121,7 @@ export const isRecommendation = (
 
 export const getFeed = async (
   api: PolarAPI,
+  demoEmbedIssuesOrganizationName: string,
 ): Promise<(Post | Recommendation)[]> => [
   {
     id: '123',
@@ -301,7 +302,7 @@ The Polar maintainers`,
     issues:
       (
         await api.issues.search({
-          organizationName: 'emilwidlund',
+          organizationName: demoEmbedIssuesOrganizationName,
           platform: Platforms.GITHUB,
         })
       ).items
@@ -581,7 +582,7 @@ Learn more over at the [README](https://polar.sh).`,
     issues:
       (
         await api.issues.search({
-          organizationName: 'emilwidlund',
+          organizationName: demoEmbedIssuesOrganizationName,
           platform: Platforms.GITHUB,
         })
       ).items


### PR DESCRIPTION
Previously the page would not load if you did not have a emilwidlund org in your database. This changes the demo to use the current user or organization when generating demo data. :-)