### PR TITLE
clients/Poll: override renderer when rendering for emails

### DIFF
--- a/clients/apps/web/src/app/(email)/email/article/[id]/route.tsx
+++ b/clients/apps/web/src/app/(email)/email/article/[id]/route.tsx
@@ -22,6 +22,8 @@ import Markdown from 'markdown-to-jsx'
 
 import { markdownOpts } from '@/components/Feed/Posts/markdown'
 
+import Poll from '@/components/Feed/Posts/Poll'
+
 // used by the renderer
 import 'postcss'
 
@@ -232,7 +234,17 @@ export async function GET(
                 <Column>
                   <Markdown
                     // @ts-ignore
-                    options={{ ...markdownOpts }}
+                    options={{
+                      ...markdownOpts,
+                      overrides: {
+                        ...markdownOpts.overrides,
+
+                        // custom email overrides
+                        poll: (args: any) => (
+                          <Poll {...args} renderer={EmailPoll} />
+                        ),
+                      },
+                    }}
                   >
                     {article.body}
                   </Markdown>
@@ -300,4 +312,19 @@ export async function GET(
     status: 200,
     headers: { 'Content-Type': 'text/html' },
   })
+}
+
+const EmailPoll = (props: { options: string[] }) => {
+  return (
+    <Container className="my-2 bg-green-300 p-8">
+      <table className="w-full">
+        {props.options.map((s) => (
+          <tr>
+            <td>{s}</td>
+            <td className="text-right">123 votes (10%)</td>
+          </tr>
+        ))}
+      </table>
+    </Container>
+  )
 }

--- a/clients/apps/web/src/components/Feed/Posts/Poll.tsx
+++ b/clients/apps/web/src/components/Feed/Posts/Poll.tsx
@@ -4,7 +4,10 @@ const InvalidPoll = () => (
   </div>
 )
 
-const Poll = (props: { children?: React.ReactNode }) => {
+const Poll = (props: {
+  children?: React.ReactNode
+  renderer?: typeof BrowserPoll
+}) => {
   if (!props.children || typeof props.children !== 'object') {
     return <InvalidPoll />
   }
@@ -52,9 +55,18 @@ const Poll = (props: { children?: React.ReactNode }) => {
     return <InvalidPoll />
   }
 
+  if (props.renderer) {
+    const C = props.renderer
+    return <C options={options} />
+  }
+
+  return <BrowserPoll options={options} />
+}
+
+const BrowserPoll = (props: { options: string[] }) => {
   return (
     <div className="my-2 flex flex-col space-y-2 bg-blue-300 p-8">
-      {options.map((s) => (
+      {props.options.map((s) => (
         <div className="item-center flex justify-between bg-black/20 p-2">
           <div>{s}</div>
           <div>123 votes (10%)</div>

--- a/clients/apps/web/src/components/Feed/Posts/markdown.tsx
+++ b/clients/apps/web/src/components/Feed/Posts/markdown.tsx
@@ -110,7 +110,6 @@ const strictCreateElement = (
 export const markdownOpts = {
   disableParsingRawHTML: false,
   overrides: {
-    Poll,
     poll: Poll,
     // example style overrides
     img: (args: any) => <img {...args} style={{ maxWidth: '100%' }} />,


### PR DESCRIPTION
### Email (table)

<img width="630" alt="Screenshot 2023-12-01 at 11 23 07" src="https://github.com/polarsource/polar/assets/47952/5de3015c-9a88-4722-bb0f-0781927920d9">


### Browser (flexbox!)

<img width="694" alt="Screenshot 2023-12-01 at 11 23 12" src="https://github.com/polarsource/polar/assets/47952/048b6bf4-16d2-47eb-9360-faa4b80b89eb">
