### PR TITLE
clients/article: demo with reactive component in browsers

### DIFF
--- a/clients/apps/web/src/components/Feed/LongformPost.tsx
+++ b/clients/apps/web/src/components/Feed/LongformPost.tsx
@@ -8,7 +8,7 @@ import { Avatar, Button } from 'polarkit/components/ui/atoms'
 
 // @ts-ignore
 import Markdown from 'markdown-to-jsx'
-import { markdownOpts } from './Posts/markdown'
+import { markdownBrowserOpts } from './Posts/markdownBrowser'
 
 const staggerTransition = {
   staggerChildren: 0.2,
@@ -66,7 +66,7 @@ export default function LongformPost({ post }: LongformPostProps) {
         <div className="prose dark:prose-invert dark:prose-headings:text-polar-50 prose-headings:font-normal prose-p:text-gray-600 prose-img:rounded-3xl dark:prose-p:text-polar-300 prose-a:text-blue-500 hover:prose-a:text-blue-400 dark:hover:prose-a:text-blue-300 dark:prose-a:text-blue-400 prose-a:no-underline space-y-16">
           <Markdown
             // @ts-ignore
-            options={{ ...markdownOpts }}
+            options={{ ...markdownBrowserOpts }}
           >
             {post.body}
           </Markdown>

--- a/clients/apps/web/src/components/Feed/Posts/BrowserPoll.tsx
+++ b/clients/apps/web/src/components/Feed/Posts/BrowserPoll.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BrowserPoll = (props: { options: string[] }) => {
+  const [clicked, setClicked] = useState<string>()
+
+  return (
+    <div className="my-2 flex flex-col space-y-2 bg-blue-300 p-8">
+      {props.options.map((s) => (
+        <div
+          className={twMerge(
+            'item-center flex cursor-pointer justify-between bg-black/20 p-2',
+            clicked === s ? 'bg-green-300' : '',
+          )}
+          onClick={() => setClicked(s)}
+        >
+          <div>{s}</div>
+          <div>123 votes (10%)</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default BrowserPoll

--- a/clients/apps/web/src/components/Feed/Posts/Poll.tsx
+++ b/clients/apps/web/src/components/Feed/Posts/Poll.tsx
@@ -6,7 +6,7 @@ const InvalidPoll = () => (
 
 const Poll = (props: {
   children?: React.ReactNode
-  renderer?: typeof BrowserPoll
+  renderer?: (props: { options: string[] }) => JSX.Element
 }) => {
   if (!props.children || typeof props.children !== 'object') {
     return <InvalidPoll />
@@ -60,20 +60,7 @@ const Poll = (props: {
     return <C options={options} />
   }
 
-  return <BrowserPoll options={options} />
-}
-
-const BrowserPoll = (props: { options: string[] }) => {
-  return (
-    <div className="my-2 flex flex-col space-y-2 bg-blue-300 p-8">
-      {props.options.map((s) => (
-        <div className="item-center flex justify-between bg-black/20 p-2">
-          <div>{s}</div>
-          <div>123 votes (10%)</div>
-        </div>
-      ))}
-    </div>
-  )
+  throw new Error('No Poll renderer configured')
 }
 
 export default Poll

--- a/clients/apps/web/src/components/Feed/Posts/markdownBrowser.tsx
+++ b/clients/apps/web/src/components/Feed/Posts/markdownBrowser.tsx
@@ -1,0 +1,13 @@
+import BrowserPoll from './BrowserPoll'
+import Poll from './Poll'
+import { markdownOpts } from './markdown'
+
+export const markdownBrowserOpts = {
+  ...markdownOpts,
+  overrides: {
+    ...markdownOpts.overrides,
+
+    // browser overrides
+    poll: (args: any) => <Poll {...args} renderer={BrowserPoll} />,
+  },
+} as const

--- a/clients/apps/web/src/components/Markdown/MarkdownPreview.tsx
+++ b/clients/apps/web/src/components/Markdown/MarkdownPreview.tsx
@@ -4,7 +4,7 @@ import { twMerge } from 'tailwind-merge'
 
 // @ts-ignore
 import Markdown from 'markdown-to-jsx'
-import { markdownOpts } from '../Feed/Posts/markdown'
+import { markdownBrowserOpts } from '../Feed/Posts/markdownBrowser'
 
 export const MarkdownPreview = (props: {
   body: string
@@ -14,7 +14,7 @@ export const MarkdownPreview = (props: {
     <Markdown
       className={twMerge('relative w-full leading-relaxed', props.className)}
       // @ts-ignore
-      options={{ ...markdownOpts }}
+      options={{ ...markdownBrowserOpts }}
     >
       {props.body}
     </Markdown>


### PR DESCRIPTION
Splits the dependency graph into one path for web-components and another one for email-components, so that we can use client-side reactive React. :)