### PR TITLE
Make Account API return only one account per user/organization

### DIFF
--- a/clients/apps/web/src/app/(backer)/feed/page.tsx
+++ b/clients/apps/web/src/app/(backer)/feed/page.tsx
@@ -12,9 +12,9 @@ import { IssueListType, IssueStatus } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { Banner } from 'polarkit/components/ui/molecules'
 import {
-  useListAccountsByUser,
   useListRewardsToUser,
   usePersonalDashboard,
+  useUserAccount,
 } from 'polarkit/hooks'
 
 export default function Page() {
@@ -47,13 +47,12 @@ export default function Page() {
   const totalCount = dashboard?.pages[0].pagination.total_count ?? undefined
 
   const rewards = useListRewardsToUser(currentUser?.id)
-  const accounts = useListAccountsByUser(currentUser?.id)
+  const { data: account } = useUserAccount(currentUser?.id)
 
   const showPendingRewardsBanner =
     rewards.data?.items &&
     rewards.data?.items.length > 0 &&
-    accounts.data?.items &&
-    accounts.data.items.length === 0
+    account === undefined
 
   return (
     <div className="mb-24 mt-2 space-y-10">

--- a/clients/apps/web/src/app/(dashboard)/finance/incoming/ClientPage.tsx
+++ b/clients/apps/web/src/app/(dashboard)/finance/incoming/ClientPage.tsx
@@ -9,7 +9,7 @@ import { Tabs, TabsList, TabsTrigger } from 'polarkit/components/ui/atoms'
 import { Separator } from 'polarkit/components/ui/separator'
 import { TabsContent } from 'polarkit/components/ui/tabs'
 import {
-  useListAccountsByOrganization,
+  useOrganizationAccount,
   usePayoutTransactions,
   useTransferTransactions,
 } from 'polarkit/hooks'
@@ -25,9 +25,9 @@ export default function ClientPage() {
     router.replace(`/finance/incoming?type=${value}`)
   }, [])
 
-  const organizationAccounts =
-    useListAccountsByOrganization(personalOrganization?.id).data?.items ?? []
-  const [organizationAccount] = organizationAccounts
+  const { data: organizationAccount } = useOrganizationAccount(
+    personalOrganization?.id,
+  )
 
   const transfers = useTransferTransactions({
     accountId: organizationAccount?.id,
@@ -45,7 +45,7 @@ export default function ClientPage() {
     <div className="flex flex-col gap-y-6">
       {personalOrganization && (
         <AccountBanner
-          accounts={organizationAccounts}
+          account={organizationAccount}
           org={personalOrganization}
         />
       )}

--- a/clients/apps/web/src/app/(dashboard)/finance/outgoing/ClientPage.tsx
+++ b/clients/apps/web/src/app/(dashboard)/finance/outgoing/ClientPage.tsx
@@ -6,7 +6,7 @@ import TransactionsList from '@/components/Transactions/TransactionsList'
 import { useAuth, usePersonalOrganization } from '@/hooks'
 import { Separator } from 'polarkit/components/ui/separator'
 import {
-  useListAccountsByOrganization,
+  useOrganizationAccount,
   useUserPaymentTransactions,
 } from 'polarkit/hooks'
 
@@ -15,8 +15,9 @@ export default function ClientPage() {
   const { currentPage, setCurrentPage } = usePagination()
   const personalOrganization = usePersonalOrganization()
 
-  const organizationAccounts =
-    useListAccountsByOrganization(personalOrganization?.id).data?.items ?? []
+  const { data: organizationAccount } = useOrganizationAccount(
+    personalOrganization?.id,
+  )
 
   const transactions = useUserPaymentTransactions({
     userId: currentUser?.id,
@@ -27,7 +28,7 @@ export default function ClientPage() {
     <div className="flex flex-col gap-y-6">
       {personalOrganization && (
         <AccountBanner
-          accounts={organizationAccounts}
+          account={organizationAccount}
           org={personalOrganization}
         />
       )}

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/ClientPage.tsx
@@ -4,9 +4,9 @@ import Finance from '@/components/Finance/Finance'
 import { useToast } from '@/components/Toast/use-toast'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
-  useListAccountsByOrganization,
   useListPledgesForOrganization,
   useListRewards,
+  useOrganizationAccount,
 } from 'polarkit/hooks'
 import { useEffect } from 'react'
 import { useCurrentOrgAndRepoFromURL } from '../../../../../hooks'
@@ -38,7 +38,7 @@ export default function ClientPage() {
 
   const pledges = useListPledgesForOrganization(org?.platform, org?.name)
   const rewards = useListRewards(org?.id)
-  const accounts = useListAccountsByOrganization(org?.id)
+  const { data: account } = useOrganizationAccount(org?.id)
 
   return (
     <>
@@ -48,7 +48,7 @@ export default function ClientPage() {
           rewards={rewards.data.items}
           org={org}
           tab="current"
-          accounts={accounts.data?.items || []}
+          account={account}
         />
       )}
     </>

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/contributors/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/contributors/ClientPage.tsx
@@ -4,9 +4,9 @@ import Finance from '@/components/Finance/Finance'
 import { useCurrentOrgAndRepoFromURL } from '@/hooks/org'
 import { useRouter } from 'next/navigation'
 import {
-  useListAccountsByOrganization,
   useListPledgesForOrganization,
   useListRewards,
+  useOrganizationAccount,
 } from 'polarkit/hooks'
 import { useEffect } from 'react'
 
@@ -23,7 +23,7 @@ export default function ClientPage() {
 
   const pledges = useListPledgesForOrganization(org?.platform, org?.name)
   const rewards = useListRewards(org?.id)
-  const accounts = useListAccountsByOrganization(org?.id)
+  const { data: account } = useOrganizationAccount(org?.id)
 
   return (
     <>
@@ -33,7 +33,7 @@ export default function ClientPage() {
           rewards={rewards.data.items}
           org={org}
           tab="contributors"
-          accounts={accounts.data?.items || []}
+          account={account}
         />
       )}
     </>

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/rewarded/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/rewarded/ClientPage.tsx
@@ -4,9 +4,9 @@ import Finance from '@/components/Finance/Finance'
 import Head from 'next/head'
 import { useRouter } from 'next/navigation'
 import {
-  useListAccountsByOrganization,
   useListPledgesForOrganization,
   useListRewards,
+  useOrganizationAccount,
 } from 'polarkit/hooks'
 import { useEffect } from 'react'
 import { useCurrentOrgAndRepoFromURL } from '../../../../../../hooks'
@@ -24,7 +24,7 @@ export default function ClientPage() {
 
   const pledges = useListPledgesForOrganization(org?.platform, org?.name)
   const rewards = useListRewards(org?.id)
-  const accounts = useListAccountsByOrganization(org?.id)
+  const { data: account } = useOrganizationAccount(org?.id)
 
   return (
     <>
@@ -37,7 +37,7 @@ export default function ClientPage() {
           rewards={rewards.data.items}
           org={org}
           tab="rewarded"
-          accounts={accounts.data?.items || []}
+          account={account}
         />
       )}
     </>

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance_new/incoming/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance_new/incoming/ClientPage.tsx
@@ -9,7 +9,7 @@ import { Tabs, TabsList, TabsTrigger } from 'polarkit/components/ui/atoms'
 import { Separator } from 'polarkit/components/ui/separator'
 import { TabsContent } from 'polarkit/components/ui/tabs'
 import {
-  useListAccountsByOrganization,
+  useOrganizationAccount,
   usePayoutTransactions,
   useTransferTransactions,
 } from 'polarkit/hooks'
@@ -30,9 +30,7 @@ export default function ClientPage() {
     [org],
   )
 
-  const organizationAccounts =
-    useListAccountsByOrganization(org?.id).data?.items ?? []
-  const [organizationAccount] = organizationAccounts
+  const { data: organizationAccount } = useOrganizationAccount(org?.id)
 
   const transfers = useTransferTransactions({
     accountId: organizationAccount?.id,
@@ -48,7 +46,7 @@ export default function ClientPage() {
 
   return (
     <div className="flex flex-col gap-y-6">
-      {org && <AccountBanner accounts={organizationAccounts} org={org} />}
+      {org && <AccountBanner account={organizationAccount} org={org} />}
       <div className="dark:bg-polar-900 dark:border-polar-800 min-h-[480px] rounded-2xl border border-gray-100 bg-white p-6 md:rounded-3xl md:p-12">
         <Tabs
           defaultValue={params.get('type') ?? 'transactions'}

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance_new/outgoing/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance_new/outgoing/ClientPage.tsx
@@ -6,7 +6,7 @@ import TransactionsList from '@/components/Transactions/TransactionsList'
 import { useCurrentOrgAndRepoFromURL } from '@/hooks'
 import { Separator } from 'polarkit/components/ui/separator'
 import {
-  useListAccountsByOrganization,
+  useOrganizationAccount,
   useOrganizationPaymentTransactions,
 } from 'polarkit/hooks'
 
@@ -14,8 +14,7 @@ export default function ClientPage() {
   const { currentPage, setCurrentPage } = usePagination()
   const { org } = useCurrentOrgAndRepoFromURL()
 
-  const organizationAccounts =
-    useListAccountsByOrganization(org?.id).data?.items ?? []
+  const { data: organizationAccount } = useOrganizationAccount(org?.id)
 
   const transactions = useOrganizationPaymentTransactions({
     organizationId: org?.id,
@@ -24,7 +23,7 @@ export default function ClientPage() {
 
   return (
     <div className="flex flex-col gap-y-6">
-      {org && <AccountBanner accounts={organizationAccounts} org={org} />}
+      {org && <AccountBanner account={organizationAccount} org={org} />}
       <div className="dark:bg-polar-900 dark:border-polar-800 min-h-[480px] rounded-2xl border border-gray-100 bg-white p-6 md:rounded-3xl md:p-12">
         <div className="flex flex-row items-center justify-between">
           <div className="flex flex-col gap-y-2">

--- a/clients/apps/web/src/components/Finance/Finance.tsx
+++ b/clients/apps/web/src/components/Finance/Finance.tsx
@@ -8,6 +8,7 @@ import {
   PledgeState,
   Reward,
   RewardState,
+  Status,
 } from '@polar-sh/sdk'
 import Link from 'next/link'
 import {
@@ -48,10 +49,10 @@ const Finance = (props: {
   org: Organization
   tab: 'current' | 'rewarded' | 'contributors'
   pledges: Pledge[]
-  accounts: Account[]
+  account: Account | undefined
   rewards: Reward[]
 }) => {
-  const { org, tab, pledges, accounts, rewards } = props
+  const { org, tab, pledges, account, rewards } = props
 
   const currentPledges =
     pledges.filter(
@@ -89,7 +90,7 @@ const Finance = (props: {
 
   return (
     <div className="flex flex-col space-y-8">
-      <AccountBanner accounts={accounts} org={org} />
+      <AccountBanner account={account} org={org} />
 
       <div className="flex space-x-8">
         <HeaderPill
@@ -244,8 +245,11 @@ const Triangle = () => (
   </svg>
 )
 
-const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
-  const { accounts } = props
+const AccountBanner = (props: {
+  org: Organization
+  account: Account | undefined
+}) => {
+  const { account } = props
 
   const goToDashboard = async (account: Account) => {
     const link = await api.accounts.dashboardLink({
@@ -267,7 +271,7 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
     setShowSetupModal(!showSetupModal)
   }
 
-  if (accounts.length === 0) {
+  if (!account) {
     return (
       <>
         <Banner
@@ -306,8 +310,8 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
     )
   }
 
-  if (accounts.length > 0 && !accounts[0].is_details_submitted) {
-    const AccountTypeIcon = ACCOUNT_TYPE_ICON[accounts[0].account_type]
+  if (account && account.status !== Status.ACTIVE) {
+    const AccountTypeIcon = ACCOUNT_TYPE_ICON[account.account_type]
     return (
       <Banner
         color="default"
@@ -316,7 +320,7 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
             size="sm"
             onClick={(e) => {
               e.preventDefault()
-              goToOnboarding(accounts[0])
+              goToOnboarding(account)
             }}
           >
             <span>Continue setup</span>
@@ -326,17 +330,15 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
         <Icon classes="bg-blue-500 p-1" icon={<AccountTypeIcon />} />
         <span className="text-sm">
           Continue the setup of your{' '}
-          <strong>
-            {ACCOUNT_TYPE_DISPLAY_NAMES[accounts[0].account_type]}
-          </strong>{' '}
+          <strong>{ACCOUNT_TYPE_DISPLAY_NAMES[account.account_type]}</strong>{' '}
           account to receive payouts
         </span>
       </Banner>
     )
   }
 
-  if (accounts.length > 0 && accounts[0].is_details_submitted) {
-    const accountType = accounts[0].account_type
+  if (account && account.status === Status.ACTIVE) {
+    const accountType = account.account_type
     const AccountTypeIcon = ACCOUNT_TYPE_ICON[accountType]
     return (
       <>
@@ -349,7 +351,7 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
                   className="whitespace-nowrap font-medium text-blue-500 dark:text-blue-400"
                   onClick={(e) => {
                     e.preventDefault()
-                    goToDashboard(accounts[0])
+                    goToDashboard(account)
                   }}
                 >
                   Go to {ACCOUNT_TYPE_DISPLAY_NAMES[accountType]}

--- a/clients/apps/web/src/components/Subscriptions/TiersPage.tsx
+++ b/clients/apps/web/src/components/Subscriptions/TiersPage.tsx
@@ -2,14 +2,11 @@
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { Add, Bolt } from '@mui/icons-material'
-import { Organization } from '@polar-sh/sdk'
+import { Organization, Status } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { Button } from 'polarkit/components/ui/atoms'
-import {
-  useOrganizationHasActiveAccount,
-  useSubscriptionTiers,
-} from 'polarkit/hooks'
-import React from 'react'
+import { useOrganizationAccount, useSubscriptionTiers } from 'polarkit/hooks'
+import React, { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 import EmptyLayout from '../Layout/EmptyLayout'
 import AccountBanner from '../Transactions/AccountBanner'
@@ -21,7 +18,11 @@ interface TiersPageProps {
 
 const TiersPage: React.FC<TiersPageProps> = ({ organization }) => {
   const { data: subscriptionTiers } = useSubscriptionTiers(organization.name)
-  const hasActiveAccount = useOrganizationHasActiveAccount(organization.id)
+  const { data: account } = useOrganizationAccount(organization.id)
+  const isAccountActive = useMemo(
+    () => account && account.status === Status.ACTIVE,
+    [account],
+  )
 
   if (!subscriptionTiers?.items?.length) {
     return (
@@ -46,8 +47,8 @@ const TiersPage: React.FC<TiersPageProps> = ({ organization }) => {
   return (
     <DashboardBody>
       <div className="flex flex-col gap-y-12 py-2">
-        {!hasActiveAccount && (
-          <AccountBanner org={organization} accounts={[]} />
+        {!isAccountActive && (
+          <AccountBanner org={organization} account={account} />
         )}
         <div className="flex flex-row justify-between">
           <div className="flex flex-col gap-y-2">
@@ -62,10 +63,10 @@ const TiersPage: React.FC<TiersPageProps> = ({ organization }) => {
                 pathname: `/maintainer/${organization.name}/subscriptions/tiers/new`,
               }}
               className={twMerge(
-                ...(!hasActiveAccount ? ['pointer-events-none'] : []),
+                ...(!isAccountActive ? ['pointer-events-none'] : []),
               )}
             >
-              <Button disabled={!hasActiveAccount}>
+              <Button disabled={!isAccountActive}>
                 <Add className="mr-2" fontSize="small" />
                 New Tier
               </Button>

--- a/clients/apps/web/src/components/Transactions/AccountBanner.tsx
+++ b/clients/apps/web/src/components/Transactions/AccountBanner.tsx
@@ -1,5 +1,5 @@
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid'
-import { Account, AccountType, Organization } from '@polar-sh/sdk'
+import { Account, AccountType, Organization, Status } from '@polar-sh/sdk'
 import { api } from 'polarkit'
 import {
   ACCOUNT_TYPE_DISPLAY_NAMES,
@@ -13,8 +13,11 @@ import SetupAccount from '../Dashboard/SetupAccount'
 import Icon from '../Icons/Icon'
 import { Modal } from '../Modal'
 
-const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
-  const { accounts } = props
+const AccountBanner = (props: {
+  org: Organization
+  account: Account | undefined
+}) => {
+  const { account } = props
 
   const goToDashboard = async (account: Account) => {
     const link = await api.accounts.dashboardLink({
@@ -36,7 +39,7 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
     setShowSetupModal(!showSetupModal)
   }
 
-  if (accounts.length === 0) {
+  if (!account) {
     return (
       <>
         <Banner
@@ -75,8 +78,8 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
     )
   }
 
-  if (accounts.length > 0 && !accounts[0].is_details_submitted) {
-    const AccountTypeIcon = ACCOUNT_TYPE_ICON[accounts[0].account_type]
+  if (account && account.status !== Status.ACTIVE) {
+    const AccountTypeIcon = ACCOUNT_TYPE_ICON[account.account_type]
     return (
       <Banner
         color="default"
@@ -85,7 +88,7 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
             size="sm"
             onClick={(e) => {
               e.preventDefault()
-              goToOnboarding(accounts[0])
+              goToOnboarding(account)
             }}
           >
             <span>Continue setup</span>
@@ -95,17 +98,15 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
         <Icon classes="bg-blue-500 p-1" icon={<AccountTypeIcon />} />
         <span className="text-sm">
           Continue the setup of your{' '}
-          <strong>
-            {ACCOUNT_TYPE_DISPLAY_NAMES[accounts[0].account_type]}
-          </strong>{' '}
+          <strong>{ACCOUNT_TYPE_DISPLAY_NAMES[account.account_type]}</strong>{' '}
           account to receive transfers
         </span>
       </Banner>
     )
   }
 
-  if (accounts.length > 0 && accounts[0].is_details_submitted) {
-    const accountType = accounts[0].account_type
+  if (account && account.status === Status.ACTIVE) {
+    const accountType = account.account_type
     const AccountTypeIcon = ACCOUNT_TYPE_ICON[accountType]
     return (
       <>
@@ -118,7 +119,7 @@ const AccountBanner = (props: { org: Organization; accounts: Account[] }) => {
                   className="whitespace-nowrap font-medium text-blue-500 dark:text-blue-400"
                   onClick={(e) => {
                     e.preventDefault()
-                    goToDashboard(accounts[0])
+                    goToDashboard(account)
                   }}
                 >
                   Go to {ACCOUNT_TYPE_DISPLAY_NAMES[accountType]}

--- a/clients/apps/web/src/stories/FinancePage.stories.tsx
+++ b/clients/apps/web/src/stories/FinancePage.stories.tsx
@@ -96,7 +96,7 @@ export const Default: Story = {
     pledges: all_pledge_states,
     org: org,
     tab: 'current',
-    accounts: [],
+    account: undefined,
     rewards: rewards,
   },
 }
@@ -136,16 +136,14 @@ export const StripeHalfSetup: Story = {
   args: {
     ...Default.args,
     tab: 'rewarded',
-    accounts: [
-      {
-        id: 'xx',
-        account_type: AccountType.STRIPE,
-        status: Status.ACTIVE,
-        country: 'SE',
-        stripe_id: '',
-        is_details_submitted: false,
-      },
-    ],
+    account: {
+      id: 'xx',
+      account_type: AccountType.STRIPE,
+      status: Status.ACTIVE,
+      country: 'SE',
+      stripe_id: '',
+      is_details_submitted: false,
+    },
   },
 }
 
@@ -154,16 +152,14 @@ export const StripeSetup: Story = {
   args: {
     ...Default.args,
     tab: 'rewarded',
-    accounts: [
-      {
-        id: 'xx',
-        account_type: AccountType.STRIPE,
-        status: Status.ACTIVE,
-        country: 'SE',
-        stripe_id: 'xxx',
-        is_details_submitted: true,
-      },
-    ],
+    account: {
+      id: 'xx',
+      account_type: AccountType.STRIPE,
+      status: Status.ACTIVE,
+      country: 'SE',
+      stripe_id: 'xxx',
+      is_details_submitted: true,
+    },
   },
 }
 
@@ -190,16 +186,14 @@ export const StripeSetupDark: Story = {
   args: {
     ...Default.args,
     tab: 'rewarded',
-    accounts: [
-      {
-        id: 'xx',
-        account_type: AccountType.STRIPE,
-        status: Status.ACTIVE,
-        country: 'SE',
-        stripe_id: 'xxx',
-        is_details_submitted: true,
-      },
-    ],
+    account: {
+      id: 'xx',
+      account_type: AccountType.STRIPE,
+      status: Status.ACTIVE,
+      country: 'SE',
+      stripe_id: 'xxx',
+      is_details_submitted: true,
+    },
   },
 
   parameters: {
@@ -212,16 +206,14 @@ export const OpenCollectiveSetup: Story = {
   args: {
     ...Default.args,
     tab: 'rewarded',
-    accounts: [
-      {
-        id: 'xx',
-        account_type: AccountType.OPEN_COLLECTIVE,
-        status: Status.ACTIVE,
-        country: 'SE',
-        open_collective_slug: 'polar',
-        is_details_submitted: true,
-      },
-    ],
+    account: {
+      id: 'xx',
+      account_type: AccountType.OPEN_COLLECTIVE,
+      status: Status.ACTIVE,
+      country: 'SE',
+      open_collective_slug: 'polar',
+      is_details_submitted: true,
+    },
   },
 }
 
@@ -230,16 +222,14 @@ export const OpenCollectiveSetupDark: Story = {
   args: {
     ...Default.args,
     tab: 'rewarded',
-    accounts: [
-      {
-        id: 'xx',
-        account_type: AccountType.OPEN_COLLECTIVE,
-        status: Status.ACTIVE,
-        country: 'SE',
-        open_collective_slug: 'polar',
-        is_details_submitted: true,
-      },
-    ],
+    account: {
+      id: 'xx',
+      account_type: AccountType.OPEN_COLLECTIVE,
+      status: Status.ACTIVE,
+      country: 'SE',
+      open_collective_slug: 'polar',
+      is_details_submitted: true,
+    },
   },
 
   parameters: {

--- a/clients/packages/polarkit/src/hooks/queries/index.ts
+++ b/clients/packages/polarkit/src/hooks/queries/index.ts
@@ -1,9 +1,4 @@
-import {
-  ListResourceRepository,
-  Platforms,
-  ResponseError,
-  Status,
-} from '@polar-sh/sdk'
+import { ListResourceRepository, Platforms, ResponseError } from '@polar-sh/sdk'
 import {
   UseMutationResult,
   UseQueryResult,
@@ -50,11 +45,11 @@ export const useSearchRepositories = (
     retry: defaultRetry,
   })
 
-export const useListAccountsByOrganization = (organization_id?: string) =>
+export const useOrganizationAccount = (organization_id?: string) =>
   useQuery({
     queryKey: ['accounts', organization_id],
     queryFn: () =>
-      api.accounts.search({
+      api.accounts.lookup({
         organizationId: organization_id,
       }),
 
@@ -62,22 +57,11 @@ export const useListAccountsByOrganization = (organization_id?: string) =>
     retry: defaultRetry,
   })
 
-export const useOrganizationHasActiveAccount = (
-  organization_id?: string,
-): boolean => {
-  const { data: accounts } = useListAccountsByOrganization(organization_id)
-  return (
-    accounts !== undefined &&
-    accounts.items !== undefined &&
-    accounts.items.some((account) => account.status === Status.ACTIVE)
-  )
-}
-
-export const useListAccountsByUser = (user_id?: string) =>
+export const useUserAccount = (user_id?: string) =>
   useQuery({
     queryKey: ['accounts', user_id],
     queryFn: () =>
-      api.accounts.search({
+      api.accounts.lookup({
         userId: user_id,
       }),
 

--- a/clients/packages/sdk/src/client/apis/AccountsApi.ts
+++ b/clients/packages/sdk/src/client/apis/AccountsApi.ts
@@ -19,7 +19,6 @@ import type {
   AccountCreate,
   AccountLink,
   HTTPValidationError,
-  ListResourceAccount,
 } from '../models/index';
 
 export interface AccountsApiCreateRequest {
@@ -34,13 +33,13 @@ export interface AccountsApiGetRequest {
     id: string;
 }
 
-export interface AccountsApiOnboardingLinkRequest {
-    id: string;
-}
-
-export interface AccountsApiSearchRequest {
+export interface AccountsApiLookupRequest {
     organizationId?: string;
     userId?: string;
+}
+
+export interface AccountsApiOnboardingLinkRequest {
+    id: string;
 }
 
 /**
@@ -166,6 +165,48 @@ export class AccountsApi extends runtime.BaseAPI {
     }
 
     /**
+     * Lookup
+     */
+    async lookupRaw(requestParameters: AccountsApiLookupRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Account>> {
+        const queryParameters: any = {};
+
+        if (requestParameters.organizationId !== undefined) {
+            queryParameters['organization_id'] = requestParameters.organizationId;
+        }
+
+        if (requestParameters.userId !== undefined) {
+            queryParameters['user_id'] = requestParameters.userId;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("HTTPBearer", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/api/v1/accounts/lookup`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response);
+    }
+
+    /**
+     * Lookup
+     */
+    async lookup(requestParameters: AccountsApiLookupRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Account> {
+        const response = await this.lookupRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
      * Onboarding Link
      */
     async onboardingLinkRaw(requestParameters: AccountsApiOnboardingLinkRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<AccountLink>> {
@@ -200,48 +241,6 @@ export class AccountsApi extends runtime.BaseAPI {
      */
     async onboardingLink(requestParameters: AccountsApiOnboardingLinkRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<AccountLink> {
         const response = await this.onboardingLinkRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * Search
-     */
-    async searchRaw(requestParameters: AccountsApiSearchRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListResourceAccount>> {
-        const queryParameters: any = {};
-
-        if (requestParameters.organizationId !== undefined) {
-            queryParameters['organization_id'] = requestParameters.organizationId;
-        }
-
-        if (requestParameters.userId !== undefined) {
-            queryParameters['user_id'] = requestParameters.userId;
-        }
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
-            const token = this.configuration.accessToken;
-            const tokenString = await token("HTTPBearer", []);
-
-            if (tokenString) {
-                headerParameters["Authorization"] = `Bearer ${tokenString}`;
-            }
-        }
-        const response = await this.request({
-            path: `/api/v1/accounts/search`,
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response);
-    }
-
-    /**
-     * Search
-     */
-    async search(requestParameters: AccountsApiSearchRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListResourceAccount> {
-        const response = await this.searchRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/clients/packages/sdk/src/client/models/index.ts
+++ b/clients/packages/sdk/src/client/models/index.ts
@@ -1618,25 +1618,6 @@ export type ListFundingSortBy = typeof ListFundingSortBy[keyof typeof ListFundin
 /**
  * 
  * @export
- * @interface ListResourceAccount
- */
-export interface ListResourceAccount {
-    /**
-     * 
-     * @type {Array<Account>}
-     * @memberof ListResourceAccount
-     */
-    items?: Array<Account>;
-    /**
-     * 
-     * @type {Pagination}
-     * @memberof ListResourceAccount
-     */
-    pagination: Pagination;
-}
-/**
- * 
- * @export
  * @interface ListResourceArticle
  */
 export interface ListResourceArticle {


### PR DESCRIPTION
We used to have a `/search` API for Account which returned a list of accounts for a given user/organization.

Since `Account` have a unique constraint on `user_id`/`organization_id`, it makes more sense to use a `/lookup` which return a single account or 404. It greatly simplifies the reasoning in the UI.

Preliminary work for #1807.