### PR TITLE
clients/public: use getServerSideAPI()

### DIFF
--- a/clients/apps/web/src/app/(public)/[organization]/(layout)/issues/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/(layout)/issues/page.tsx
@@ -3,7 +3,6 @@ import { getServerSideAPI } from '@/utils/api'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
-import { api } from 'polarkit/api'
 import ClientPage from './ClientPage'
 
 const cacheConfig = {
@@ -21,6 +20,8 @@ export async function generateMetadata(
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
   let organization: Organization | undefined
+
+  const api = getServerSideAPI()
 
   try {
     organization = await api.organizations.lookup(

--- a/clients/apps/web/src/app/(public)/[organization]/(layout)/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/(layout)/page.tsx
@@ -3,7 +3,6 @@ import { getServerSideAPI } from '@/utils/api'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
-import { api } from 'polarkit/api'
 import ClientPage from './ClientPage'
 
 const cacheConfig = {
@@ -21,6 +20,7 @@ export async function generateMetadata(
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
   let organization: Organization | undefined
+  const api = getServerSideAPI()
 
   try {
     organization = await api.organizations.lookup(

--- a/clients/apps/web/src/app/(public)/[organization]/(layout)/repositories/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/(layout)/repositories/page.tsx
@@ -3,7 +3,6 @@ import { getServerSideAPI } from '@/utils/api'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
-import { api } from 'polarkit/api'
 import ClientPage from './ClientPage'
 
 const cacheConfig = {
@@ -21,6 +20,7 @@ export async function generateMetadata(
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
   let organization: Organization | undefined
+  const api = getServerSideAPI()
 
   try {
     organization = await api.organizations.lookup(

--- a/clients/apps/web/src/app/(public)/[organization]/(layout)/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/(layout)/subscriptions/page.tsx
@@ -3,7 +3,6 @@ import { getServerSideAPI } from '@/utils/api'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
-import { api } from 'polarkit/api'
 import ClientPage from './ClientPage'
 
 const cacheConfig = {
@@ -21,6 +20,8 @@ export async function generateMetadata(
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
   let organization: Organization | undefined
+
+  const api = getServerSideAPI()
 
   try {
     organization = await api.organizations.lookup(

--- a/clients/apps/web/src/app/(public)/[organization]/[repo]/page.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/[repo]/page.tsx
@@ -1,5 +1,6 @@
 import RepositoryPublicPage from '@/components/Organization/RepositoryPublicPage'
 import PageNotFound from '@/components/Shared/PageNotFound'
+import { getServerSideAPI } from '@/utils/api'
 import {
   ListFundingSortBy,
   ListResourceRepository,
@@ -9,7 +10,6 @@ import {
 } from '@polar-sh/sdk'
 import { Metadata, ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
-import { api } from 'polarkit'
 
 const cacheConfig = {
   next: {
@@ -27,6 +27,8 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   let organization: Organization | undefined
   let repositories: ListResourceRepository | undefined
+
+  const api = getServerSideAPI()
 
   try {
     organization = await api.organizations.lookup(
@@ -94,6 +96,8 @@ export default async function Page({
 }: {
   params: { organization: string; repo: string }
 }) {
+  const api = getServerSideAPI()
+
   const organization = await api.organizations.lookup(
     {
       platform: Platforms.GITHUB,

--- a/clients/apps/web/src/app/(public)/subscribe/route.ts
+++ b/clients/apps/web/src/app/(public)/subscribe/route.ts
@@ -1,21 +1,11 @@
-import { Configuration, PolarAPI, ResponseError } from '@polar-sh/sdk'
-import { cookies } from 'next/headers'
+import { getServerSideAPI } from '@/utils/api'
+import { ResponseError } from '@polar-sh/sdk'
 import { NextRequest } from 'next/server'
-import { getServerURL } from 'polarkit/api'
 
 export const runtime = 'edge'
 
 export async function GET(request: NextRequest) {
-  const cookieStore = cookies()
-  const api = new PolarAPI(
-    new Configuration({
-      basePath: getServerURL(),
-      credentials: 'include',
-      headers: {
-        Cookie: cookieStore.toString(),
-      },
-    }),
-  )
+  const api = getServerSideAPI()
 
   const searchParams = request.nextUrl.searchParams
   const subscriptionTierId = searchParams.get('tier') as string


### PR DESCRIPTION
This fixes some issues with broken links to private repositories etc