### PR TITLE
server/subscriptions: set Content-Disposition type to attachment

### DIFF
--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -684,7 +684,7 @@ async def subscriptions_export(
             yield ",".join(fields) + "\n"
 
     name = f"{organization.name}_subscribers.csv"
-    headers = {"Content-Disposition": f'inline; filename="{name}"'}
+    headers = {"Content-Disposition": f'attachment; filename="{name}"'}
     return StreamingResponse(create_csv(), headers=headers, media_type="text/csv")
 
 


### PR DESCRIPTION
This is the correct type to use to get the file to be downloaded and saved to disk in all browsers