### PR TITLE
server/ingress: fix FastAPI hostname detection when running behind Caddy

### DIFF
--- a/server/Caddyfile
+++ b/server/Caddyfile
@@ -1,6 +1,13 @@
-:6380 {
+servers :6380 {
 	route /api/v1/* {
-		reverse_proxy host.docker.internal:8000
+		reverse_proxy {
+			to host.docker.internal:8000
+			trusted_proxies private_ranges
+		}
 	}
-	reverse_proxy host.docker.internal:3000
+
+	reverse_proxy {
+		to host.docker.internal:3000
+		trusted_proxies private_ranges
+	}
 }


### PR DESCRIPTION
I'm running local dev behind a proxy (for testing in a more realistic environment, with HTTPS etc). Adding trusted_proxies to make FastAPIs request.url_for() work as expected