### PR TITLE
Auth scopes

### DIFF
--- a/server/polar/article/endpoints.py
+++ b/server/polar/article/endpoints.py
@@ -34,7 +34,7 @@ from .service import article_service
 router = APIRouter(tags=["articles"])
 
 OptionalUserArticleRead = AuthenticatedWithScope(
-    required_scopes=[Scope.admin, Scope.articles_read],
+    required_scopes=[Scope.web_default, Scope.articles_read],
     allow_anonymous=True,
     fallback_to_anonymous=True,
 )

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -37,7 +37,7 @@ async def _current_user_optional(
         user = await AuthService.get_user_from_cookie(session, cookie=cookie_token)
         if user:
             return (
-                ScopedSubject(subject=user, scopes=[Scope.admin]),
+                ScopedSubject(subject=user, scopes=[Scope.web_default]),
                 AuthMethod.COOKIE,
             )
 
@@ -107,9 +107,9 @@ class Auth:
     ) -> Self:
         scoped_subject, auth_method = user_auth_method
 
-        # This authentication mechanism is not aware of scopes. Require the admin scope to auth as user.
-        if Scope.admin not in scoped_subject.scopes:
-            raise Unauthorized("This endpoint does not support scoped auth tokens 1 ")
+        # This authentication mechanism is not aware of scopes. Require the web_default scope to auth as user.
+        if Scope.web_default not in scoped_subject.scopes:
+            raise Unauthorized("This endpoint does not support scoped auth tokens")
 
         return cls(scoped_subject=scoped_subject, auth_method=auth_method)
 
@@ -124,10 +124,8 @@ class Auth:
 
         if scoped_subject:
             # This authentication mechanism is not aware of scopes. Require the admin scope to auth as user.
-            if Scope.admin not in scoped_subject.scopes:
-                raise Unauthorized(
-                    "This endpoint does not support scoped auth tokens2 "
-                )
+            if Scope.web_default not in scoped_subject.scopes:
+                raise Unauthorized("This endpoint does not support scoped auth tokens")
 
             return cls(scoped_subject=scoped_subject, auth_method=auth_method)
         else:
@@ -154,8 +152,8 @@ class Auth:
             )
 
         # must have admin scope
-        if Scope.admin not in scoped_subject.scopes:
-            raise Unauthorized("This endpoint does not support scoped auth tokens3")
+        if Scope.web_default not in scoped_subject.scopes:
+            raise Unauthorized("This endpoint does not support scoped auth tokens")
 
         if scoped_subject.subject.username not in allowed:
             raise HTTPException(

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -122,7 +122,9 @@ class AuthService:
                 if user:
                     return ScopedSubject(
                         subject=user,
-                        scopes=[Scope.admin],  # cookie based auth, has full admin scope
+                        scopes=[
+                            Scope.web_default
+                        ],  # cookie based auth, has full admin scope
                     )
 
             # Personal Access Token in the Authorization header.
@@ -136,7 +138,7 @@ class AuthService:
                 if "scopes" in decoded:
                     scopes = [Scope(x) for x in decoded["scopes"].split(",")]
                 else:
-                    scopes = [Scope.admin]
+                    scopes = [Scope.web_default]
 
                 await personal_access_token_service.record_usage(session, id=pat.id)
 

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -1,4 +1,3 @@
-from ast import Tuple
 from datetime import datetime
 from uuid import UUID
 
@@ -6,7 +5,7 @@ import structlog
 from fastapi import Request, Response
 from fastapi.responses import RedirectResponse
 
-from polar.authz.service import Scope, ScopedSubject, Subject
+from polar.authz.service import Scope, ScopedSubject
 from polar.config import settings
 from polar.kit import jwt
 from polar.kit.http import get_safe_return_url

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -65,7 +65,7 @@ class AuthService:
 
     @classmethod
     def generate_pat_token(
-        cls, pat_id: UUID, expires_at: datetime, scopes: list[Scope] = [Scope.admin]
+        cls, pat_id: UUID, expires_at: datetime, scopes: list[Scope]
     ) -> str:
         return jwt.encode(
             data={
@@ -135,7 +135,7 @@ class AuthService:
                     return None
 
                 if "scopes" in decoded:
-                    scopes = decoded["scopes"]
+                    scopes = [Scope(x) for x in decoded["scopes"].split(",")]
                 else:
                     scopes = [Scope.admin]
 

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -50,6 +50,20 @@ Object = (
 )
 
 
+class Scope(str, Enum):
+    admin = "admin"  # default web scope, the token can do anything
+    articles_read = "articles:read"  # article read only scope (used by RSS auth)
+
+
+class ScopedSubject:
+    subject: Subject
+    scopes: list[Scope]
+
+    def __init__(self, *, subject: Subject, scopes: list[Scope] = []):
+        self.subject = subject
+        self.scopes = scopes
+
+
 class Authz:
     session: AsyncSession
 

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -51,7 +51,7 @@ Object = (
 
 
 class Scope(str, Enum):
-    admin = "admin"  # default web scope, the token can do anything
+    web_default = "web_default"  # Web default scope. For users logged in on the web.
     articles_read = "articles:read"  # article read only scope (used by RSS auth)
     user_read = "user:read"
 

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -53,6 +53,7 @@ Object = (
 class Scope(str, Enum):
     admin = "admin"  # default web scope, the token can do anything
     articles_read = "articles:read"  # article read only scope (used by RSS auth)
+    user_read = "user:read"
 
 
 class ScopedSubject:

--- a/server/polar/personal_access_token/endpoints.py
+++ b/server/polar/personal_access_token/endpoints.py
@@ -93,7 +93,7 @@ async def create(
         }
         scopes = [mapped[k] for k in payload.scopes]
     else:
-        scopes = [Scope.admin]
+        scopes = [Scope.web_default]
 
     return CreatePersonalAccessTokenResponse(
         id=pat.id,

--- a/server/polar/personal_access_token/endpoints.py
+++ b/server/polar/personal_access_token/endpoints.py
@@ -89,6 +89,7 @@ async def create(
     if payload.scopes:
         mapped = {
             "articles:read": Scope.articles_read,
+            "user:read": Scope.user_read,
         }
         scopes = [mapped[k] for k in payload.scopes]
     else:

--- a/server/polar/personal_access_token/schemas.py
+++ b/server/polar/personal_access_token/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Self
+from typing import Literal, Self
 from uuid import UUID
 
 from polar.kit.schemas import Schema
@@ -28,6 +28,7 @@ class PersonalAccessToken(Schema):
 
 class CreatePersonalAccessToken(Schema):
     comment: str
+    scopes: list[Literal["articles:read"]] | None = None
 
 
 class CreatePersonalAccessTokenResponse(PersonalAccessToken):

--- a/server/polar/personal_access_token/schemas.py
+++ b/server/polar/personal_access_token/schemas.py
@@ -28,7 +28,7 @@ class PersonalAccessToken(Schema):
 
 class CreatePersonalAccessToken(Schema):
     comment: str
-    scopes: list[Literal["articles:read"]] | None = None
+    scopes: list[Literal["articles:read", "user:read"]] | None = None
 
 
 class CreatePersonalAccessTokenResponse(PersonalAccessToken):

--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -11,7 +11,7 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import Dsn
 
-from polar.auth.dependencies import Auth
+from polar.auth.dependencies import Auth, AuthenticatedWithScope
 from polar.config import settings
 from polar.posthog import posthog
 
@@ -125,7 +125,14 @@ def configure_sentry() -> None:
     )
 
 
-async def set_sentry_user(auth: Auth = Depends(Auth.optional_user)) -> None:
+async def set_sentry_user(
+    auth: Auth = Depends(
+        AuthenticatedWithScope(
+            allow_anonymous=True,
+            fallback_to_anonymous=True,
+        )
+    ),
+) -> None:
     if auth.user is not None:
         sentry_sdk.set_user(
             {

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -35,8 +35,16 @@ async def get_authenticated(auth: Auth = Depends(AuthUserRead)) -> User:
 
 
 @router.get("/me/scopes", response_model=UserScopes)
-async def scopes(auth: UserRequiredAuth) -> UserScopes:
-    return UserScopes(scopes=[str(s) for s in auth.scoped_subject.scopes])
+async def scopes(
+    auth: Auth = Depends(
+        AuthenticatedWithScope(
+            # require auth, but don't check scopes
+            fallback_to_anonymous=False,
+            allow_anonymous=False,
+        )
+    ),
+) -> UserScopes:
+    return UserScopes(scopes=[s.value for s in auth.scoped_subject.scopes])
 
 
 @router.post("/me/token")

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 
 AuthUserRead = AuthenticatedWithScope(
-    required_scopes=[Scope.admin, Scope.user_read],
+    required_scopes=[Scope.web_default, Scope.user_read],
     allow_anonymous=False,
     fallback_to_anonymous=False,
 )

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -11,6 +11,7 @@ from polar.user.service import user as user_service
 
 from .schemas import (
     UserRead,
+    UserScopes,
     UserSetAccount,
     UserStripePortalSession,
     UserUpdateSettings,
@@ -22,6 +23,11 @@ router = APIRouter(prefix="/users", tags=["users"])
 @router.get("/me", response_model=UserRead)
 async def get_authenticated(auth: UserRequiredAuth) -> User:
     return auth.user
+
+
+@router.get("/me/scopes", response_model=UserScopes)
+async def scopes(auth: UserRequiredAuth) -> UserScopes:
+    return UserScopes(scopes=[str(s) for s in auth.scoped_subject.scopes])
 
 
 @router.post("/me/token")

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -72,3 +72,7 @@ class UserSetAccount(Schema):
 
 class UserStripePortalSession(Schema):
     url: str
+
+
+class UserScopes(Schema):
+    scopes: list[str]

--- a/server/tests/personal_access_token/test_endpoints.py
+++ b/server/tests/personal_access_token/test_endpoints.py
@@ -136,7 +136,7 @@ async def test_incorrect_scope(auth_jwt: str, client: AsyncClient) -> None:
 
     assert (
         response.text
-        == '{"detail":"Missing required scope: have=articles:read requires=admin,user:read"}'
+        == '{"detail":"Missing required scope: have=articles:read requires=web_default,user:read"}'
     )
     assert response.status_code == 401
 

--- a/server/tests/personal_access_token/test_endpoints.py
+++ b/server/tests/personal_access_token/test_endpoints.py
@@ -1,7 +1,6 @@
 import pytest
 from httpx import AsyncClient
 
-from polar.authz.service import Scope
 from polar.config import settings
 
 
@@ -114,7 +113,7 @@ async def test_create_scoped(auth_jwt: str, client: AsyncClient) -> None:
         headers={"Authorization": "Bearer " + response.json()["token"]},
     )
 
-    assert response.json() == {"scopes": [Scope.articles_read]}
+    assert response.json() == {"scopes": ["articles:read"]}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
In before: posts-only access tokens for RSS feeds

Adding a `ScopedSubject` that tracks a subject (still `User | Anonymous`) and a list of scopes. By default this scope is "admin" which is the default web scope, and is only used internally.

The goal is to be able to create PATs with a `articles:read` scope that only allows read access to articles endpoints.

- [x] parse cookies and PATs
- [x] create scope check mechanism 