### PR TITLE
clients/readme: Note about adding new API classes

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -39,6 +39,9 @@ pnpm dev-web
 pnpm generate
 ```
 
+**Adding a new API class?**
+You might need to manually add the generated model to `src/client/PolarAPI.ts` in the SDK package.
+
 ### Designing with Storybook
 
 Polar uses [Storybook](https://storybook.js.org) to easier work with web components and their design.


### PR DESCRIPTION
Ran into this issue last night and was convinced this file was supposed to always be auto-generated, but it seems we need to manually edit it to register new API classes. So adding a friendly note about it.