### PR TITLE
server/user: eager loading of oauth accounts

### DIFF
--- a/server/polar/integrations/github/client.py
+++ b/server/polar/integrations/github/client.py
@@ -21,6 +21,7 @@ from polar.integrations.github.cache import RedisCache
 from polar.models.user import User
 from polar.postgres import AsyncSession
 from polar.types import JSONAny
+from polar.user.oauth_service import oauth_account_service
 
 log = structlog.get_logger()
 
@@ -117,7 +118,9 @@ class RefreshAccessToken(rest.GitHubRestModel):
 async def get_user_client(
     session: AsyncSession, user: User
 ) -> GitHub[TokenAuthStrategy]:
-    oauth = user.get_platform_oauth_account(Platforms.github)
+    oauth = await oauth_account_service.get_by_platform_and_user_id(
+        session, Platforms.github, user.id
+    )
     if not oauth:
         raise Exception("no github oauth account found")
 

--- a/server/polar/integrations/github/service/user.py
+++ b/server/polar/integrations/github/service/user.py
@@ -11,8 +11,8 @@ from polar.models import OAuthAccount, User
 from polar.organization.service import organization
 from polar.postgres import AsyncSession
 from polar.posthog import posthog
+from polar.user.oauth_service import oauth_account_service
 from polar.user.service import UserService
-from polar.user.service import oauth_account as oauth_account_service
 
 from .. import client as github
 from ..schemas import OAuthAccessToken
@@ -325,7 +325,9 @@ class GithubUserService(UserService):
             user_id=user.id,
             installation_ids=[i.id for i in installations],
         )
-        gh_oauth = user.get_platform_oauth_account(Platforms.github)
+        gh_oauth = await oauth_account_service.get_by_platform_and_user_id(
+            session, Platforms.github, user.id
+        )
         if not gh_oauth:
             log.error("sync_github_orgs.no_platform_oauth_found", user_id=user.id)
             return org_count

--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -76,7 +76,7 @@ class User(RecordModel):
 
     @declared_attr
     def oauth_accounts(cls) -> Mapped[list[OAuthAccount]]:
-        return relationship(OAuthAccount, lazy="joined", back_populates="user")
+        return relationship(OAuthAccount, lazy="raise", back_populates="user")
 
     invite_only_approved: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -28,10 +28,16 @@ AuthUserRead = AuthenticatedWithScope(
 
 
 @router.get("/me", response_model=UserRead)
-async def get_authenticated(auth: Auth = Depends(AuthUserRead)) -> User:
+async def get_authenticated(
+    auth: Auth = Depends(AuthUserRead),
+    session: AsyncSession = Depends(get_db_session),
+) -> UserRead:
     if not auth.user:
         raise Unauthorized()
-    return auth.user
+
+    user = await user_service.get_loaded(session, auth.user.id)
+
+    return UserRead.from_orm(user)
 
 
 @router.get("/me/scopes", response_model=UserScopes)

--- a/server/polar/user/oauth_service.py
+++ b/server/polar/user/oauth_service.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+import structlog
+
+from polar.enums import Platforms
+from polar.kit.services import ResourceServiceReader
+from polar.logging import Logger
+from polar.models import OAuthAccount
+from polar.postgres import AsyncSession
+
+log: Logger = structlog.get_logger()
+
+
+class OAuthAccountService(ResourceServiceReader[OAuthAccount]):
+    async def get_by_platform_and_account_id(
+        self, session: AsyncSession, platform: Platforms, account_id: str
+    ) -> OAuthAccount | None:
+        return await self.get_by(session, platform=platform, account_id=account_id)
+
+    async def get_by_platform_and_user_id(
+        self, session: AsyncSession, platform: Platforms, user_id: UUID
+    ) -> OAuthAccount | None:
+        return await self.get_by(session, platform=platform, user_id=user_id)
+
+
+oauth_account_service = OAuthAccountService(OAuthAccount)

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -2,15 +2,16 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import func
+from sqlalchemy.orm import joinedload
 
 from polar.account.service import account as account_service
 from polar.authz.service import AccessType, Authz
-from polar.enums import Platforms, UserSignupType
+from polar.enums import UserSignupType
 from polar.exceptions import PolarError
 from polar.integrations.loops.service import loops as loops_service
-from polar.kit.services import ResourceService, ResourceServiceReader
+from polar.kit.services import ResourceService
 from polar.logging import Logger
-from polar.models import OAuthAccount, User
+from polar.models import User
 from polar.postgres import AsyncSession, sql
 from polar.posthog import posthog
 
@@ -34,20 +35,57 @@ class InvalidAccount(UserError):
 
 
 class UserService(ResourceService[User, UserCreate, UserUpdate]):
+    async def get_loaded(self, session: AsyncSession, id: UUID) -> User | None:
+        query = (
+            sql.select(User)
+            .where(
+                User.id == id,
+                User.deleted_at.is_(None),
+            )
+            .options(joinedload(User.oauth_accounts))
+        )
+        res = await session.execute(query)
+        return res.scalars().unique().one_or_none()
+
     async def get_by_email(self, session: AsyncSession, email: str) -> User | None:
-        query = sql.select(self.model).where(func.lower(User.email) == email.lower())
+        query = (
+            sql.select(User)
+            .where(
+                func.lower(User.email) == email.lower(),
+                User.deleted_at.is_(None),
+            )
+            .options(joinedload(User.oauth_accounts))
+        )
         res = await session.execute(query)
         return res.scalars().unique().one_or_none()
 
     async def get_by_username(
         self, session: AsyncSession, username: str
     ) -> User | None:
-        return await self.get_by(session, username=username)
+        query = (
+            sql.select(User)
+            .where(
+                User.username == username,
+                User.deleted_at.is_(None),
+            )
+            .options(joinedload(User.oauth_accounts))
+        )
+        res = await session.execute(query)
+        return res.scalars().unique().one_or_none()
 
     async def get_by_stripe_customer_id(
         self, session: AsyncSession, stripe_customer_id: str
     ) -> User | None:
-        return await self.get_by(session, stripe_customer_id=stripe_customer_id)
+        query = (
+            sql.select(User)
+            .where(
+                User.stripe_customer_id == stripe_customer_id,
+                User.deleted_at.is_(None),
+            )
+            .options(joinedload(User.oauth_accounts))
+        )
+        res = await session.execute(query)
+        return res.scalars().unique().one_or_none()
 
     async def get_by_email_or_signup(
         self,
@@ -115,13 +153,3 @@ class UserService(ResourceService[User, UserCreate, UserUpdate]):
 
 
 user = UserService(User)
-
-
-class OAuthAccountService(ResourceServiceReader[OAuthAccount]):
-    async def get_by_platform_and_account_id(
-        self, session: AsyncSession, platform: Platforms, account_id: str
-    ) -> OAuthAccount | None:
-        return await self.get_by(session, platform=platform, account_id=account_id)
-
-
-oauth_account = OAuthAccountService(OAuthAccount)


### PR DESCRIPTION
Lazy loading does not work well in async contexts. Removing the second-to-last lazy="joined"!