### PR TITLE
docs: add trailing slash redirects

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "trailingSlash": true
+}


### PR DESCRIPTION
Pages without a trailing slash will redirect to the slashed version. Eg /faq redirects to /faq/

This mimics the behaviour of `mkdocs serve` on Vercel.