### PR TITLE
Call `session.expunge_all()` between test setup and execution

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -85,7 +85,7 @@ verify_github_app = { cmd = "python -m polar.verify_github_app", help = "verify 
 pre_deploy = { cmd = "task db_migrate", help = "Pre-deploy command run by Render"}
 
 [tool.pytest.ini_options]
-markers = ["authenticated"]
+markers = ["authenticated", "http_auto_expunge"]
 asyncio_mode = "strict"
 
 [tool.coverage.run]

--- a/server/tests/subscription/conftest.py
+++ b/server/tests/subscription/conftest.py
@@ -1,6 +1,6 @@
 import random
 import string
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock
@@ -12,6 +12,7 @@ from pytest_mock import MockerFixture
 from polar.app import app
 from polar.enums import AccountType
 from polar.integrations.stripe.service import StripeService
+from polar.kit.db.postgres import AsyncEngine, AsyncSession
 from polar.kit.utils import utc_now
 from polar.models import (
     Account,
@@ -27,13 +28,43 @@ from polar.models import (
 from polar.models.subscription import SubscriptionStatus
 from polar.models.subscription_benefit import SubscriptionBenefitType
 from polar.models.subscription_tier import SubscriptionTierType
-from polar.postgres import AsyncSession
 from polar.subscription.endpoints import is_feature_flag_enabled
 from tests.fixtures.random_objects import create_organization, create_user
 
 
 def rstr(prefix: str) -> str:
     return f"{prefix}.{''.join(random.choices(string.ascii_uppercase + string.digits, k=6))}"
+
+
+@pytest_asyncio.fixture
+async def session(
+    engine: AsyncEngine, mocker: MockerFixture
+) -> AsyncIterator[AsyncSession]:
+    connection = await engine.connect()
+    transaction = await connection.begin()
+
+    session = AsyncSession(
+        bind=connection,
+        expire_on_commit=False,
+        autocommit=False,
+        autoflush=False,
+    )
+
+    expunge_spy = mocker.spy(session, "expunge_all")
+
+    yield session
+
+    await transaction.rollback()
+    await connection.close()
+
+    # Assert that session.expunge_all() was called.
+    #
+    # expunge_all() should be called after the test has been setup, and before
+    # the test calls out to the implementation.
+    #
+    # This is to ensure that we don't rely on the existing state in the Session
+    # from creating the tests.
+    expunge_spy.assert_called_once()
 
 
 @pytest.fixture(autouse=True)

--- a/server/tests/subscription/service/test_subscribe_session.py
+++ b/server/tests/subscription/service/test_subscribe_session.py
@@ -24,6 +24,9 @@ from polar.subscription.service.subscribe_session import (
 from polar.subscription.service.subscribe_session import (
     subscribe_session as subscribe_session_service,
 )
+from polar.subscription.service.subscription_tier import (
+    subscription_tier as subscription_tier_service,
+)
 
 from ..conftest import (
     add_subscription_benefits,
@@ -45,10 +48,22 @@ class TestCreateSubscribeSession:
         authz: Authz,
         subscription_tier_organization_free: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # create_subscribe_session calls .refresh() which requires the objects to be from the same session
+        # re-load the tier without any relationships
+        subscription_tier_organization_free_loaded = (
+            await subscription_tier_service.get(
+                session, subscription_tier_organization_free.id
+            )
+        )
+        assert subscription_tier_organization_free_loaded
+
         with pytest.raises(FreeSubscriptionTier):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization_free,
+                subscription_tier_organization_free_loaded,
                 "SUCCESS_URL",
                 Anonymous(),
                 None,
@@ -62,11 +77,21 @@ class TestCreateSubscribeSession:
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
         subscription_tier_organization.is_archived = True
+        await session.commit()
+
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
 
         with pytest.raises(ArchivedSubscriptionTier):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 "SUCCESS_URL",
                 Anonymous(),
                 None,
@@ -81,11 +106,21 @@ class TestCreateSubscribeSession:
     ) -> None:
         subscription_tier_organization.stripe_product_id = None
         subscription_tier_organization.stripe_price_id = None
+        await session.commit()
+
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
 
         with pytest.raises(NotAddedToStripeSubscriptionTier):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 "SUCCESS_URL",
                 Anonymous(),
                 None,
@@ -98,10 +133,19 @@ class TestCreateSubscribeSession:
         authz: Authz,
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(NoAssociatedPayoutAccount):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 "SUCCESS_URL",
                 Anonymous(),
                 None,
@@ -120,10 +164,19 @@ class TestCreateSubscribeSession:
             session, subscription_tier=subscription_tier_organization, user=user
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(AlreadySubscribed):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 "SUCCESS_URL",
                 user,
                 AuthMethod.COOKIE,
@@ -149,9 +202,18 @@ class TestCreateSubscribeSession:
             metadata={},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             Anonymous(),
             None,
@@ -198,9 +260,18 @@ class TestCreateSubscribeSession:
             metadata={},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             user,
             AuthMethod.COOKIE,
@@ -252,9 +323,18 @@ class TestCreateSubscribeSession:
             metadata={},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             user,
             AuthMethod.PERSONAL_ACCESS_TOKEN,
@@ -301,9 +381,18 @@ class TestCreateSubscribeSession:
             metadata={},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             user,
             AuthMethod.PERSONAL_ACCESS_TOKEN,
@@ -360,9 +449,18 @@ class TestCreateSubscribeSession:
             metadata={},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             Anonymous(),
             None,
@@ -414,9 +512,18 @@ class TestCreateSubscribeSession:
             metadata={},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             user,
             AuthMethod.COOKIE,
@@ -449,10 +556,19 @@ class TestCreateSubscribeSession:
         organization_subscriber: Organization,
         organization_account: Account,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(Unauthorized):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 "SUCCESS_URL",
                 Anonymous(),
                 None,
@@ -470,10 +586,19 @@ class TestCreateSubscribeSession:
         user: User,
         organization_account: Account,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(NotPermitted):
             await subscribe_session_service.create_subscribe_session(
                 session,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 "SUCCESS_URL",
                 user,
                 AuthMethod.COOKIE,
@@ -493,6 +618,7 @@ class TestCreateSubscribeSession:
     ) -> None:
         organization_subscriber.stripe_customer_id = "ORGANIZATION_STRIPE_CUSTOMER_ID"
         organization_subscriber_admin.stripe_customer_id = "STRIPE_CUSTOMER_ID"
+        await session.commit()
 
         create_subscription_checkout_session_mock: (
             MagicMock
@@ -505,9 +631,19 @@ class TestCreateSubscribeSession:
             metadata={"organization_subscriber_id": str(organization_subscriber.id)},
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+        subscription_tier_organization = subscription_tier_organization_loaded
+
         subscribe_session = await subscribe_session_service.create_subscribe_session(
             session,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             "SUCCESS_URL",
             organization_subscriber_admin,
             AuthMethod.COOKIE,
@@ -561,6 +697,9 @@ class TestGetSubscribeSession:
             metadata=metadata,
         )
 
+        # then
+        session.expunge_all()
+
         with pytest.raises(ResourceNotFound):
             await subscribe_session_service.get_subscribe_session(session, "SESSION_ID")
 
@@ -578,6 +717,9 @@ class TestGetSubscribeSession:
             customer_details={"name": "John", "email": "backer@example.com"},
             metadata={"subscription_tier_id": str(subscription_tier_organization.id)},
         )
+
+        # then
+        session.expunge_all()
 
         subscribe_session = await subscribe_session_service.get_subscribe_session(
             session, "SESSION_ID"

--- a/server/tests/subscription/service/test_subscription_benefit.py
+++ b/server/tests/subscription/service/test_subscription_benefit.py
@@ -47,6 +47,9 @@ class TestSearch:
         subscription_benefits: list[SubscriptionBenefit],
         user: User,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_benefit_service.search(
             session, user, pagination=PaginationParams(1, 10)
         )
@@ -61,6 +64,9 @@ class TestSearch:
         subscription_benefits: list[SubscriptionBenefit],
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_benefit_service.search(
             session, user, pagination=PaginationParams(1, 10)
         )
@@ -78,6 +84,10 @@ class TestSearch:
         plain_subscription_benefit = await create_subscription_benefit(
             session, type=SubscriptionBenefitType.custom, organization=organization
         )
+
+        # then
+        session.expunge_all()
+
         results, count = await subscription_benefit_service.search(
             session,
             user,
@@ -98,6 +108,9 @@ class TestSearch:
         subscription_benefit_organization: SubscriptionBenefit,
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_benefit_service.search(
             session, user, organization=organization, pagination=PaginationParams(1, 10)
         )
@@ -114,6 +127,9 @@ class TestSearch:
         subscription_benefits: list[SubscriptionBenefit],
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_benefit_service.search(
             session,
             user,
@@ -134,6 +150,9 @@ class TestSearch:
         subscription_benefit_private_repository: SubscriptionBenefit,
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_benefit_service.search(
             session, user, repository=repository, pagination=PaginationParams(1, 10)
         )
@@ -152,6 +171,9 @@ class TestGetById:
         subscription_benefit_organization: SubscriptionBenefit,
         user: User,
     ) -> None:
+        # then
+        session.expunge_all()
+
         not_existing_subscription_benefit = (
             await subscription_benefit_service.get_by_id(session, user, uuid.uuid4())
         )
@@ -177,6 +199,9 @@ class TestGetById:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         not_existing_subscription_benefit = (
             await subscription_benefit_service.get_by_id(session, user, uuid.uuid4())
         )
@@ -214,6 +239,10 @@ class TestUserCreate:
             properties={},
             organization_id=uuid.uuid4(),
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(OrganizationDoesNotExist):
             await subscription_benefit_service.user_create(
                 session, authz, create_schema, user
@@ -233,6 +262,10 @@ class TestUserCreate:
             properties={},
             organization_id=organization.id,
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(OrganizationDoesNotExist):
             await subscription_benefit_service.user_create(
                 session, authz, create_schema, user
@@ -253,6 +286,10 @@ class TestUserCreate:
             properties={},
             organization_id=organization.id,
         )
+
+        # then
+        session.expunge_all()
+
         subscription_benefit = await subscription_benefit_service.user_create(
             session, authz, create_schema, user
         )
@@ -268,6 +305,10 @@ class TestUserCreate:
             properties={},
             repository_id=uuid.uuid4(),
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(RepositoryDoesNotExist):
             await subscription_benefit_service.user_create(
                 session, authz, create_schema, user
@@ -287,6 +328,10 @@ class TestUserCreate:
             properties={},
             repository_id=repository.id,
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(RepositoryDoesNotExist):
             await subscription_benefit_service.user_create(
                 session, authz, create_schema, user
@@ -307,6 +352,10 @@ class TestUserCreate:
             properties={},
             repository_id=repository.id,
         )
+
+        # then
+        session.expunge_all()
+
         subscription_benefit = await subscription_benefit_service.user_create(
             session, authz, create_schema, user
         )
@@ -325,9 +374,25 @@ class TestUserUpdate:
         update_schema = SubscriptionBenefitCustomUpdate(
             description="Subscription Benefit Update"
         )
+
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_benefit_organization_loaded = (
+            await subscription_benefit_service.get(
+                session, subscription_benefit_organization.id
+            )
+        )
+        assert subscription_benefit_organization_loaded
+
         with pytest.raises(NotPermitted):
             await subscription_benefit_service.user_update(
-                session, authz, subscription_benefit_organization, update_schema, user
+                session,
+                authz,
+                subscription_benefit_organization_loaded,
+                update_schema,
+                user,
             )
 
     async def test_valid_description_change(
@@ -348,8 +413,24 @@ class TestUserUpdate:
         update_schema = SubscriptionBenefitCustomUpdate(
             description="Description update"
         )
+
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_benefit_organization_loaded = (
+            await subscription_benefit_service.get(
+                session, subscription_benefit_organization.id
+            )
+        )
+        assert subscription_benefit_organization_loaded
+
         updated_subscription_benefit = await subscription_benefit_service.user_update(
-            session, authz, subscription_benefit_organization, update_schema, user
+            session,
+            authz,
+            subscription_benefit_organization_loaded,
+            update_schema,
+            user,
         )
         assert updated_subscription_benefit.description == "Description update"
 
@@ -365,9 +446,20 @@ class TestUserDelete:
         user: User,
         subscription_benefit_organization: SubscriptionBenefit,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_benefit_organization_loaded = (
+            await subscription_benefit_service.get(
+                session, subscription_benefit_organization.id
+            )
+        )
+        assert subscription_benefit_organization_loaded
+
         with pytest.raises(NotPermitted):
             await subscription_benefit_service.user_delete(
-                session, authz, subscription_benefit_organization, user
+                session, authz, subscription_benefit_organization_loaded, user
             )
 
     async def test_not_deletable_subscription_benefit(
@@ -385,9 +477,19 @@ class TestUserDelete:
             organization=organization,
             deletable=False,
         )
+
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_benefit_loaded = await subscription_benefit_service.get(
+            session, subscription_benefit.id
+        )
+        assert subscription_benefit_loaded
+
         with pytest.raises(NotPermitted):
             await subscription_benefit_service.user_delete(
-                session, authz, subscription_benefit, user
+                session, authz, subscription_benefit_loaded, user
             )
 
     async def test_valid(
@@ -405,8 +507,19 @@ class TestUserDelete:
             spec=SubscriptionBenefitGrantService.enqueue_benefit_grant_updates,
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_benefit_organization_loaded = (
+            await subscription_benefit_service.get(
+                session, subscription_benefit_organization.id
+            )
+        )
+        assert subscription_benefit_organization_loaded
+
         updated_subscription_benefit = await subscription_benefit_service.user_delete(
-            session, authz, subscription_benefit_organization, user
+            session, authz, subscription_benefit_organization_loaded, user
         )
 
         assert updated_subscription_benefit.deleted_at is not None

--- a/server/tests/subscription/service/test_subscription_tier.py
+++ b/server/tests/subscription/service/test_subscription_tier.py
@@ -56,6 +56,9 @@ class TestSearch:
     async def test_anonymous(
         self, session: AsyncSession, subscription_tiers: list[SubscriptionTier]
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session, Anonymous(), pagination=PaginationParams(1, 10)
         )
@@ -72,6 +75,9 @@ class TestSearch:
         subscription_tiers: list[SubscriptionTier],
         user: User,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session, user, pagination=PaginationParams(1, 10)
         )
@@ -89,6 +95,9 @@ class TestSearch:
         subscription_tiers: list[SubscriptionTier],
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session, user, pagination=PaginationParams(1, 10)
         )
@@ -108,6 +117,10 @@ class TestSearch:
         await create_subscription_tier(
             session, type=SubscriptionTierType.pro, organization=organization
         )
+
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session,
             user,
@@ -129,6 +142,9 @@ class TestSearch:
         subscription_tier_organization: SubscriptionTier,
         subscription_tier_organization_second: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session, user, organization=organization, pagination=PaginationParams(1, 10)
         )
@@ -147,6 +163,9 @@ class TestSearch:
         subscription_tiers: list[SubscriptionTier],
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session,
             user,
@@ -167,6 +186,9 @@ class TestSearch:
         subscription_tier_private_repository: SubscriptionTier,
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         results, count = await subscription_tier_service.search(
             session, user, repository=repository, pagination=PaginationParams(1, 10)
         )
@@ -185,6 +207,9 @@ class TestSearch:
         archived_subscription_tier = await create_subscription_tier(
             session, organization=organization, is_archived=True
         )
+
+        # then
+        session.expunge_all()
 
         # Anonymous
         results, count = await subscription_tier_service.search(
@@ -226,6 +251,9 @@ class TestGetById:
         subscription_tier_private_repository: SubscriptionTier,
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
         not_existing_subscription_tier = await subscription_tier_service.get_by_id(
             session, Anonymous(), uuid.uuid4()
         )
@@ -249,6 +277,9 @@ class TestGetById:
         subscription_tier_organization: SubscriptionTier,
         user: User,
     ) -> None:
+        # then
+        session.expunge_all()
+
         not_existing_subscription_tier = await subscription_tier_service.get_by_id(
             session, user, uuid.uuid4()
         )
@@ -273,6 +304,9 @@ class TestGetById:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         not_existing_subscription_tier = await subscription_tier_service.get_by_id(
             session, user, uuid.uuid4()
         )
@@ -303,6 +337,10 @@ class TestUserCreate:
             price_currency="USD",
             organization_id=uuid.uuid4(),
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(OrganizationDoesNotExist):
             await subscription_tier_service.user_create(
                 session, authz, create_schema, user
@@ -322,6 +360,10 @@ class TestUserCreate:
             price_currency="USD",
             organization_id=organization.id,
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(OrganizationDoesNotExist):
             await subscription_tier_service.user_create(
                 session, authz, create_schema, user
@@ -342,6 +384,10 @@ class TestUserCreate:
             price_currency="USD",
             organization_id=organization.id,
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(NoAssociatedPayoutAccount):
             await subscription_tier_service.user_create(
                 session, authz, create_schema, user
@@ -371,6 +417,10 @@ class TestUserCreate:
             price_currency="USD",
             organization_id=organization.id,
         )
+
+        # then
+        session.expunge_all()
+
         subscription_tier = await subscription_tier_service.user_create(
             session, authz, create_schema, user
         )
@@ -390,6 +440,10 @@ class TestUserCreate:
             price_currency="USD",
             repository_id=uuid.uuid4(),
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(RepositoryDoesNotExist):
             await subscription_tier_service.user_create(
                 session, authz, create_schema, user
@@ -409,6 +463,10 @@ class TestUserCreate:
             price_currency="USD",
             repository_id=repository.id,
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(RepositoryDoesNotExist):
             await subscription_tier_service.user_create(
                 session, authz, create_schema, user
@@ -429,6 +487,10 @@ class TestUserCreate:
             price_currency="USD",
             repository_id=repository.id,
         )
+
+        # then
+        session.expunge_all()
+
         with pytest.raises(NoAssociatedPayoutAccount):
             await subscription_tier_service.user_create(
                 session, authz, create_schema, user
@@ -458,6 +520,10 @@ class TestUserCreate:
             price_currency="USD",
             repository_id=repository.id,
         )
+
+        # then
+        session.expunge_all()
+
         subscription_tier = await subscription_tier_service.user_create(
             session, authz, create_schema, user
         )
@@ -489,6 +555,9 @@ class TestUserCreate:
             price_currency="USD",
             organization_id=organization.id,
         )
+
+        # then
+        session.expunge_all()
 
         with pytest.raises(StripeError):
             await subscription_tier_service.user_create(
@@ -535,6 +604,9 @@ class TestUserCreate:
             is_highlighted=True,
         )
 
+        # then
+        session.expunge_all()
+
         subscription_tier = await subscription_tier_service.user_create(
             session, authz, create_schema, user
         )
@@ -556,10 +628,23 @@ class TestUserUpdate:
         user: User,
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         update_schema = SubscriptionTierUpdate(name="Subscription Tier Update")
         with pytest.raises(NotPermitted):
             await subscription_tier_service.user_update(
-                session, authz, subscription_tier_organization, update_schema, user
+                session,
+                authz,
+                subscription_tier_organization_loaded,
+                update_schema,
+                user,
             )
 
     async def test_valid_name_change(
@@ -574,9 +659,18 @@ class TestUserUpdate:
     ) -> None:
         update_product_mock: MagicMock = stripe_service_mock.update_product
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         update_schema = SubscriptionTierUpdate(name="Subscription Tier Update")
         updated_subscription_tier = await subscription_tier_service.user_update(
-            session, authz, subscription_tier_organization, update_schema, user
+            session, authz, subscription_tier_organization_loaded, update_schema, user
         )
         assert updated_subscription_tier.name == "Subscription Tier Update"
 
@@ -596,9 +690,18 @@ class TestUserUpdate:
     ) -> None:
         update_product_mock: MagicMock = stripe_service_mock.update_product
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         update_schema = SubscriptionTierUpdate(description="Description update")
         updated_subscription_tier = await subscription_tier_service.user_update(
-            session, authz, subscription_tier_organization, update_schema, user
+            session, authz, subscription_tier_organization_loaded, update_schema, user
         )
         assert updated_subscription_tier.description == "Description update"
 
@@ -624,9 +727,18 @@ class TestUserUpdate:
 
         old_price_id = subscription_tier_organization.stripe_price_id
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         update_schema = SubscriptionTierUpdate(price_amount=1500)
         updated_subscription_tier = await subscription_tier_service.user_update(
-            session, authz, subscription_tier_organization, update_schema, user
+            session, authz, subscription_tier_organization_loaded, update_schema, user
         )
 
         create_price_for_product_mock.assert_called_once()
@@ -654,9 +766,18 @@ class TestUserUpdate:
         ) = stripe_service_mock.create_price_for_product
         create_price_for_product_mock.return_value = SimpleNamespace(id="NEW_PRICE_ID")
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         update_schema = SubscriptionTierUpdate(is_highlighted=True)
         updated_subscription_tier = await subscription_tier_service.user_update(
-            session, authz, subscription_tier_organization, update_schema, user
+            session, authz, subscription_tier_organization_loaded, update_schema, user
         )
 
         assert updated_subscription_tier.is_highlighted
@@ -677,6 +798,9 @@ class TestCreateFree:
         organization: Organization,
         subscription_tier_organization_free: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
         subscription_tier = await subscription_tier_service.create_free(
             session, benefits=[], organization=organization
         )
@@ -695,6 +819,9 @@ class TestCreateFree:
         subscription_benefit_organization: SubscriptionBenefit,
         organization: Organization,
     ) -> None:
+        # then
+        session.expunge_all()
+
         free_subscription_tier = await subscription_tier_service.create_free(
             session,
             benefits=[subscription_benefit_organization],
@@ -725,9 +852,18 @@ class TestUpdateBenefits:
         user: User,
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(NotPermitted):
             await subscription_tier_service.update_benefits(
-                session, authz, subscription_tier_organization, [], user
+                session, authz, subscription_tier_organization_loaded, [], user
             )
 
     async def test_not_existing_benefit(
@@ -745,15 +881,29 @@ class TestUpdateBenefits:
             subscription_benefits=subscription_benefits,
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(SubscriptionBenefitDoesNotExist):
             await subscription_tier_service.update_benefits(
-                session, authz, subscription_tier_organization, [uuid.uuid4()], user
+                session,
+                authz,
+                subscription_tier_organization_loaded,
+                [uuid.uuid4()],
+                user,
             )
 
-        await session.refresh(subscription_tier_organization)
-        assert len(subscription_tier_organization.subscription_tier_benefits) == len(
-            subscription_benefits
-        )
+        await session.refresh(subscription_tier_organization_loaded)
+
+        assert len(
+            subscription_tier_organization_loaded.subscription_tier_benefits
+        ) == len(subscription_benefits)
 
     async def test_added_benefits(
         self,
@@ -765,6 +915,15 @@ class TestUpdateBenefits:
         subscription_tier_organization: SubscriptionTier,
         subscription_benefits: list[SubscriptionBenefit],
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         (
             subscription_tier,
             added,
@@ -772,7 +931,7 @@ class TestUpdateBenefits:
         ) = await subscription_tier_service.update_benefits(
             session,
             authz,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             [benefit.id for benefit in subscription_benefits],
             user,
         )
@@ -808,6 +967,15 @@ class TestUpdateBenefits:
         subscription_tier_organization: SubscriptionTier,
         subscription_benefits: list[SubscriptionBenefit],
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         (
             subscription_tier,
             added,
@@ -815,7 +983,7 @@ class TestUpdateBenefits:
         ) = await subscription_tier_service.update_benefits(
             session,
             authz,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             [benefit.id for benefit in subscription_benefits[::-1]],
             user,
         )
@@ -857,12 +1025,21 @@ class TestUpdateBenefits:
             subscription_benefits=subscription_benefits,
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         (
             subscription_tier,
             added,
             deleted,
         ) = await subscription_tier_service.update_benefits(
-            session, authz, subscription_tier_organization, [], user
+            session, authz, subscription_tier_organization_loaded, [], user
         )
 
         assert len(subscription_tier.subscription_tier_benefits) == 0
@@ -890,6 +1067,15 @@ class TestUpdateBenefits:
             subscription_benefits=subscription_benefits,
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         (
             subscription_tier,
             added,
@@ -897,7 +1083,7 @@ class TestUpdateBenefits:
         ) = await subscription_tier_service.update_benefits(
             session,
             authz,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             [benefit.id for benefit in subscription_benefits[::-1]],
             user,
         )
@@ -940,11 +1126,20 @@ class TestUpdateBenefits:
             selectable=False,
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(SubscriptionBenefitIsNotSelectable):
             await subscription_tier_service.update_benefits(
                 session,
                 authz,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 [not_selectable_benefit.id],
                 user,
             )
@@ -972,11 +1167,20 @@ class TestUpdateBenefits:
             subscription_benefits=[not_selectable_benefit],
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(SubscriptionBenefitIsNotSelectable):
             await subscription_tier_service.update_benefits(
                 session,
                 authz,
-                subscription_tier_organization,
+                subscription_tier_organization_loaded,
                 [],
                 user,
             )
@@ -1011,6 +1215,15 @@ class TestUpdateBenefits:
             subscription_benefits=[not_selectable_benefit],
         )
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         (
             _,
             added,
@@ -1018,12 +1231,12 @@ class TestUpdateBenefits:
         ) = await subscription_tier_service.update_benefits(
             session,
             authz,
-            subscription_tier_organization,
+            subscription_tier_organization_loaded,
             [not_selectable_benefit.id, selectable_benefit.id],
             user,
         )
         assert len(added) == 1
-        assert selectable_benefit in added
+        assert selectable_benefit.id in [a.id for a in added]
         assert len(deleted) == 0
 
         enqueue_job_mock.assert_awaited_once_with(
@@ -1041,9 +1254,18 @@ class TestArchive:
         user: User,
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         with pytest.raises(NotPermitted):
             await subscription_tier_service.archive(
-                session, authz, subscription_tier_organization, user
+                session, authz, subscription_tier_organization_loaded, user
             )
 
     async def test_free_tier(
@@ -1054,9 +1276,20 @@ class TestArchive:
         subscription_tier_organization_free: SubscriptionTier,
         user_organization_admin: UserOrganization,
     ) -> None:
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_free_loaded = (
+            await subscription_tier_service.get(
+                session, subscription_tier_organization_free.id
+            )
+        )
+        assert subscription_tier_organization_free_loaded
+
         with pytest.raises(FreeTierIsNotArchivable):
             await subscription_tier_service.archive(
-                session, authz, subscription_tier_organization_free, user
+                session, authz, subscription_tier_organization_free_loaded, user
             )
 
     async def test_valid(
@@ -1070,8 +1303,17 @@ class TestArchive:
     ) -> None:
         archive_product_mock: MagicMock = stripe_service_mock.archive_product
 
+        # then
+        session.expunge_all()
+
+        # load
+        subscription_tier_organization_loaded = await subscription_tier_service.get(
+            session, subscription_tier_organization.id
+        )
+        assert subscription_tier_organization_loaded
+
         updated_subscription_tier = await subscription_tier_service.archive(
-            session, authz, subscription_tier_organization, user
+            session, authz, subscription_tier_organization_loaded, user
         )
 
         archive_product_mock.assert_called_once_with(

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -38,8 +38,14 @@ from polar.worker import JobContext, PolarWorkerContext
 @pytest.mark.asyncio
 class TestSubscriptionEnqueueBenefitsGrants:
     async def test_not_existing_subscription(
-        self, job_context: JobContext, polar_worker_context: PolarWorkerContext
+        self,
+        job_context: JobContext,
+        polar_worker_context: PolarWorkerContext,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionDoesNotExist):
             await subscription_enqueue_benefits_grants(
                 job_context, uuid.uuid4(), polar_worker_context
@@ -51,12 +57,16 @@ class TestSubscriptionEnqueueBenefitsGrants:
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
         subscription: Subscription,
+        session: AsyncSession,
     ) -> None:
         enqueue_benefits_grants_mock = mocker.patch.object(
             subscription_service,
             "enqueue_benefits_grants",
             spec=SubscriptionService.enqueue_benefits_grants,
         )
+
+        # then
+        session.expunge_all()
 
         await subscription_enqueue_benefits_grants(
             job_context, subscription.id, polar_worker_context
@@ -68,8 +78,14 @@ class TestSubscriptionEnqueueBenefitsGrants:
 @pytest.mark.asyncio
 class TestSubscriptionUpdateSubscriptionTierBenefitsGrants:
     async def test_not_existing_subscription_tier(
-        self, job_context: JobContext, polar_worker_context: PolarWorkerContext
+        self,
+        job_context: JobContext,
+        polar_worker_context: PolarWorkerContext,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionTierDoesNotExist):
             await subscription_update_subscription_tier_benefits_grants(
                 job_context, uuid.uuid4(), polar_worker_context
@@ -81,12 +97,16 @@ class TestSubscriptionUpdateSubscriptionTierBenefitsGrants:
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
         subscription_tier_organization: SubscriptionTier,
+        session: AsyncSession,
     ) -> None:
         update_subscription_tier_benefits_grants_mock = mocker.patch.object(
             subscription_service,
             "update_subscription_tier_benefits_grants",
             spec=SubscriptionService.update_subscription_tier_benefits_grants,
         )
+
+        # then
+        session.expunge_all()
 
         await subscription_update_subscription_tier_benefits_grants(
             job_context, subscription_tier_organization.id, polar_worker_context
@@ -103,7 +123,11 @@ class TestSubscriptionBenefitGrant:
         polar_worker_context: PolarWorkerContext,
         subscription_benefit_organization: SubscriptionBenefit,
         user: User,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionDoesNotExist):
             await subscription_benefit_grant(
                 job_context,
@@ -119,7 +143,11 @@ class TestSubscriptionBenefitGrant:
         polar_worker_context: PolarWorkerContext,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(UserDoesNotExist):
             await subscription_benefit_grant(
                 job_context,
@@ -135,7 +163,11 @@ class TestSubscriptionBenefitGrant:
         polar_worker_context: PolarWorkerContext,
         subscription: Subscription,
         user: User,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionBenefitDoesNotExist):
             await subscription_benefit_grant(
                 job_context,
@@ -153,12 +185,16 @@ class TestSubscriptionBenefitGrant:
         subscription: Subscription,
         user: User,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
         grant_benefit_mock = mocker.patch.object(
             subscription_benefit_grant_service,
             "grant_benefit",
             spec=SubscriptionBenefitGrantService.grant_benefit,
         )
+
+        # then
+        session.expunge_all()
 
         await subscription_benefit_grant(
             job_context,
@@ -178,6 +214,7 @@ class TestSubscriptionBenefitGrant:
         subscription: Subscription,
         user: User,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
         grant_benefit_mock = mocker.patch.object(
             subscription_benefit_grant_service,
@@ -185,6 +222,9 @@ class TestSubscriptionBenefitGrant:
             spec=SubscriptionBenefitGrantService.grant_benefit,
         )
         grant_benefit_mock.side_effect = SubscriptionBenefitRetriableError(10)
+
+        # then
+        session.expunge_all()
 
         with pytest.raises(Retry):
             await subscription_benefit_grant(
@@ -204,7 +244,11 @@ class TestSubscriptionBenefitRevoke:
         polar_worker_context: PolarWorkerContext,
         subscription_benefit_organization: SubscriptionBenefit,
         user: User,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionDoesNotExist):
             await subscription_benefit_revoke(
                 job_context,
@@ -220,7 +264,11 @@ class TestSubscriptionBenefitRevoke:
         polar_worker_context: PolarWorkerContext,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(UserDoesNotExist):
             await subscription_benefit_revoke(
                 job_context,
@@ -236,7 +284,11 @@ class TestSubscriptionBenefitRevoke:
         polar_worker_context: PolarWorkerContext,
         subscription: Subscription,
         user: User,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionBenefitDoesNotExist):
             await subscription_benefit_revoke(
                 job_context,
@@ -254,12 +306,16 @@ class TestSubscriptionBenefitRevoke:
         subscription: Subscription,
         user: User,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
         revoke_benefit_mock = mocker.patch.object(
             subscription_benefit_grant_service,
             "revoke_benefit",
             spec=SubscriptionBenefitGrantService.revoke_benefit,
         )
+
+        # then
+        session.expunge_all()
 
         await subscription_benefit_revoke(
             job_context,
@@ -279,6 +335,7 @@ class TestSubscriptionBenefitRevoke:
         subscription: Subscription,
         user: User,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
         revoke_benefit_mock = mocker.patch.object(
             subscription_benefit_grant_service,
@@ -286,6 +343,9 @@ class TestSubscriptionBenefitRevoke:
             spec=SubscriptionBenefitGrantService.revoke_benefit,
         )
         revoke_benefit_mock.side_effect = SubscriptionBenefitRetriableError(10)
+
+        # then
+        session.expunge_all()
 
         with pytest.raises(Retry):
             await subscription_benefit_revoke(
@@ -304,7 +364,11 @@ class TestSubscriptionBenefitUpdate:
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionBenefitGrantDoesNotExist):
             await subscription_benefit_update(
                 job_context, uuid.uuid4(), polar_worker_context
@@ -334,6 +398,9 @@ class TestSubscriptionBenefitUpdate:
             "update_benefit_grant",
             spec=SubscriptionBenefitGrantService.update_benefit_grant,
         )
+
+        # then
+        session.expunge_all()
 
         await subscription_benefit_update(job_context, grant.id, polar_worker_context)
 
@@ -365,6 +432,9 @@ class TestSubscriptionBenefitUpdate:
         )
         update_benefit_grant_mock.side_effect = SubscriptionBenefitRetriableError(10)
 
+        # then
+        session.expunge_all()
+
         with pytest.raises(Retry):
             await subscription_benefit_update(
                 job_context, grant.id, polar_worker_context
@@ -378,7 +448,11 @@ class TestSubscriptionBenefitDelete:
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
         subscription_benefit_organization: SubscriptionBenefit,
+        session: AsyncSession,
     ) -> None:
+        # then
+        session.expunge_all()
+
         with pytest.raises(SubscriptionBenefitGrantDoesNotExist):
             await subscription_benefit_delete(
                 job_context, uuid.uuid4(), polar_worker_context
@@ -409,6 +483,9 @@ class TestSubscriptionBenefitDelete:
             spec=SubscriptionBenefitGrantService.delete_benefit_grant,
         )
 
+        # then
+        session.expunge_all()
+
         await subscription_benefit_delete(job_context, grant.id, polar_worker_context)
 
         delete_benefit_grant_mock.assert_called_once()
@@ -438,6 +515,9 @@ class TestSubscriptionBenefitDelete:
             spec=SubscriptionBenefitGrantService.delete_benefit_grant,
         )
         delete_benefit_grant_mock.side_effect = SubscriptionBenefitRetriableError(10)
+
+        # then
+        session.expunge_all()
 
         with pytest.raises(Retry):
             await subscription_benefit_delete(


### PR DESCRIPTION
Attempt to enforce calling `session.expunge_all()` between test setup and test execution.

Adding it for all subscriptions related tests to start with.

Updates #2059