### PR TITLE
clients/navigation: rename Feed and Funding

### DIFF
--- a/clients/apps/web/src/app/(backer)/funding/FundingPage.tsx
+++ b/clients/apps/web/src/app/(backer)/funding/FundingPage.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import IssueList from '@/components/Dashboard/IssueList'
+import {
+  DashboardFilters,
+  DefaultFilters,
+} from '@/components/Dashboard/filters'
+import Recommended from '@/components/Feed/Recommended'
+import FundAGithubIssue from '@/components/Onboarding/FundAGithubIssue'
+import { useAuth, useGitHubAccount } from '@/hooks'
+import { IssueListType, IssueStatus } from '@polar-sh/sdk'
+import Link from 'next/link'
+import { Banner } from 'polarkit/components/ui/molecules'
+import {
+  useAccount,
+  useListRewardsToUser,
+  usePersonalDashboard,
+} from 'polarkit/hooks'
+
+const FundingPage = () => {
+  const { currentUser } = useAuth()
+  const githubAccount = useGitHubAccount()
+
+  const filters: DashboardFilters = {
+    ...DefaultFilters,
+    tab: IssueListType.DEPENDENCIES,
+    onlyPledged: true,
+  }
+
+  const dashboardQuery = usePersonalDashboard(
+    filters.tab,
+    filters.q,
+    [
+      IssueStatus.BACKLOG,
+      IssueStatus.BUILDING,
+      IssueStatus.CLOSED,
+      IssueStatus.IN_PROGRESS,
+      IssueStatus.PULL_REQUEST,
+      IssueStatus.TRIAGED,
+    ],
+    filters.sort,
+    filters.onlyPledged,
+    filters.onlyBadged,
+  )
+
+  const dashboard = dashboardQuery.data
+  const totalCount = dashboard?.pages[0].pagination.total_count ?? undefined
+
+  const rewards = useListRewardsToUser(currentUser?.id)
+  const { data: account } = useAccount(currentUser?.account_id)
+
+  const showPendingRewardsBanner =
+    rewards.data?.items &&
+    rewards.data?.items.length > 0 &&
+    account === undefined
+
+  return (
+    <div className="mb-24 mt-2 space-y-10">
+      <div className="space-y-10">
+        {showPendingRewardsBanner && (
+          <Banner color="blue">
+            <div className="flex w-full items-center justify-between">
+              <span>
+                Great news! You have pending rewards and payouts. Setup a Stripe
+                account to get paid.
+              </span>
+              <Link href="/rewards" className="whitespace-nowrap font-medium">
+                Go to Rewards
+              </Link>
+            </div>
+          </Banner>
+        )}
+
+        <FundAGithubIssue />
+
+        {totalCount !== undefined && totalCount > 0 && (
+          <div>
+            <h1 className="dark:text-polar-300 text-lg text-gray-900">
+              Funded issues
+            </h1>
+            <IssueList
+              totalCount={totalCount}
+              loading={dashboardQuery.isLoading}
+              dashboard={dashboard}
+              filters={filters}
+              onSetFilters={() => {}}
+              isInitialLoading={dashboardQuery.isInitialLoading}
+              isFetchingNextPage={dashboardQuery.isFetchingNextPage}
+              hasNextPage={dashboardQuery.hasNextPage || false}
+              fetchNextPage={dashboardQuery.fetchNextPage}
+            />
+          </div>
+        )}
+      </div>
+
+      {githubAccount && <Recommended />}
+    </div>
+  )
+}
+
+export default FundingPage

--- a/clients/apps/web/src/app/(backer)/funding/page.tsx
+++ b/clients/apps/web/src/app/(backer)/funding/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import FundingPage from '../funding/FundingPage'
+import FundingPage from './FundingPage'
 
 export default function Page() {
   return <FundingPage />

--- a/clients/apps/web/src/components/Dashboard/navigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigation.tsx
@@ -123,7 +123,7 @@ export const backerRoutes = (
           ? [
               {
                 id: 'posts',
-                title: 'Posts',
+                title: 'Feed',
                 link: `/posts`,
                 icon: (
                   <ViewDayOutlined className="h-5 w-5" fontSize="inherit" />
@@ -154,7 +154,12 @@ export const backerRoutes = (
   {
     id: 'funding',
     title: 'Funding',
-    link: isPersonal ? `/feed` : `/maintainer/${org?.name}/funding`,
+    link:
+      isPersonal && isFeatureEnabled('feed')
+        ? `/funding` // personal and new feed
+        : isPersonal
+          ? '/feed' // personal and old feed
+          : `/maintainer/${org?.name}/funding`, // orgs
     icon: <FavoriteBorderOutlined className="h-5 w-5" fontSize="inherit" />,
     postIcon: undefined,
     if: true,


### PR DESCRIPTION
With feature flags:

* Feed links to /posts (new name, same url)
* Funding links to /funding (new route)

Without feature flag:

* Funding links to /feed (same route as before, but renamed)