### PR TITLE
clients/subscriptions: pass all data, including tier group to TierCard when editing

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/SubscriptionTierEditPage.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionTierEditPage.tsx
@@ -221,6 +221,7 @@ const SubscriptionTierEdit = ({
           <SubscriptionTierCard
             className="w-1/4"
             subscriptionTier={{
+              ...subscriptionTier,
               ...editingSubscriptionTier,
               benefits: enabledBenefits,
             }}


### PR DESCRIPTION
This fixes a bug where the tier group icon would disappear when making changes to the tier on the edit page.