### PR TITLE
Add support for importing subscribers from mailchimp

### DIFF
--- a/server/polar/kit/csv.py
+++ b/server/polar/kit/csv.py
@@ -11,6 +11,8 @@ def get_emails_from_csv(contents: str) -> list[str]:
             row.get("email", None)
             or row.get("EMAIL", None)
             or row.get("Email", None)
+            # Mailchimp uses "Email Address"
+            or row.get("Email Address", None)
             or None
             for row in reader
         ]


### PR DESCRIPTION
Mailchimp uses "Email Address" as the column name:

<img width="404" alt="image" src="https://github.com/polarsource/polar/assets/667029/e699a094-8b99-4694-84c1-a3c6da81a90f">

Let me know if you want me to add a test :)