### PR TITLE
clients/posts: disable reveal animations

### DIFF
--- a/clients/apps/web/src/app/(public)/[organization]/(layout)/posts/[postSlug]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/(layout)/posts/[postSlug]/ClientPage.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import LongformPost from '@/components/Feed/LongformPost'
-import { StaggerReveal } from '@/components/Shared/StaggerReveal'
 import { useAuth } from '@/hooks/auth'
 import { ArrowBackOutlined } from '@mui/icons-material'
 import { Article } from '@polar-sh/sdk'
@@ -44,7 +43,7 @@ export default function Page({ article }: { article: Article }) {
     (userSubs.data?.items && userSubs.data.items?.length > 0) ?? false
 
   return (
-    <StaggerReveal className="dark:md:bg-polar-900 dark:md:border-polar-800 relative flex w-full flex-col items-center rounded-3xl md:bg-white md:p-12 md:shadow-xl dark:md:border">
+    <div className="dark:md:bg-polar-900 dark:md:border-polar-800 relative flex w-full flex-col items-center rounded-3xl md:bg-white md:p-12 md:shadow-xl dark:md:border">
       <Link
         className="absolute left-16 top-16 hidden flex-shrink md:block"
         href={`/${article.organization.name}`}
@@ -61,7 +60,8 @@ export default function Page({ article }: { article: Article }) {
         article={article}
         isSubscriber={isSubscriber}
         showPaywalledContent={true} // Can safely be true. If the user doesn't have permissions to see the paywalled content it will already be stripped out.
+        animation={false}
       />
-    </StaggerReveal>
+    </div>
   )
 }

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/[post]/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/[post]/ClientPage.tsx
@@ -123,6 +123,7 @@ const ClientPage = () => {
           },
           isSubscriber: true,
           showPaywalledContent: true,
+          animation: false,
         }}
       />
       <AnimatePresence>

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/new/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/new/ClientPage.tsx
@@ -57,6 +57,7 @@ const ClientPage = () => {
           article: { ...article, organization: org, byline: org },
           isSubscriber: true,
           showPaywalledContent: true,
+          animation: false,
         }}
       />
     </Tabs>

--- a/clients/apps/web/src/components/Feed/LongformPost.tsx
+++ b/clients/apps/web/src/components/Feed/LongformPost.tsx
@@ -24,6 +24,7 @@ interface LongformPostProps {
   revealTransition?: typeof defaultRevealTransition
   showPaywalledContent: boolean
   isSubscriber: boolean
+  animation: boolean
 }
 
 export default function LongformPost({
@@ -32,6 +33,7 @@ export default function LongformPost({
   revealTransition,
   showPaywalledContent,
   isSubscriber,
+  animation,
 }: LongformPostProps) {
   const { currentUser } = useAuth()
   const organization = article.organization
@@ -56,6 +58,19 @@ export default function LongformPost({
   staggerTransition = staggerTransition ?? defaultStaggerTransition
   revealTransition = revealTransition ?? defaultRevealTransition
 
+  const noAnimationVariants = {
+    hidden: { opacity: 1 },
+    visible: {
+      opacity: 1,
+      transition: {
+        duration: 0,
+      },
+    },
+  }
+
+  // Use downstream defaults if animation is enabled
+  const animationVariants = animation ? {} : noAnimationVariants
+
   const publishedDate = useMemo(
     () => (article.published_at ? new Date(article.published_at) : undefined),
     [article],
@@ -79,22 +94,38 @@ export default function LongformPost({
   )
 
   return (
-    <StaggerReveal className="max-w-2xl" transition={staggerTransition}>
+    <StaggerReveal
+      className="max-w-2xl"
+      transition={staggerTransition}
+      variants={animationVariants}
+    >
       <div className="flex flex-col items-center gap-y-16 pb-16 pt-4">
-        <StaggerReveal.Child transition={revealTransition}>
+        <StaggerReveal.Child
+          transition={revealTransition}
+          variants={animationVariants}
+        >
           <LogoIcon className="text-blue-500 dark:text-blue-400" size={40} />
         </StaggerReveal.Child>
-        <StaggerReveal.Child transition={revealTransition}>
+        <StaggerReveal.Child
+          transition={revealTransition}
+          variants={animationVariants}
+        >
           <span className="dark:text-polar-500 text-gray-500">
             {publishedDateText}
           </span>
         </StaggerReveal.Child>
-        <StaggerReveal.Child transition={revealTransition}>
+        <StaggerReveal.Child
+          transition={revealTransition}
+          variants={animationVariants}
+        >
           <h1 className="text-center text-4xl font-bold leading-normal md:leading-relaxed">
             {article.title}
           </h1>
         </StaggerReveal.Child>
-        <StaggerReveal.Child transition={revealTransition}>
+        <StaggerReveal.Child
+          transition={revealTransition}
+          variants={animationVariants}
+        >
           <div className="flex flex-row items-center gap-x-3">
             <Avatar
               className="h-8 w-8"
@@ -108,7 +139,10 @@ export default function LongformPost({
         </StaggerReveal.Child>
       </div>
 
-      <StaggerReveal.Child transition={revealTransition}>
+      <StaggerReveal.Child
+        transition={revealTransition}
+        variants={animationVariants}
+      >
         <div className="prose dark:prose-pre:bg-polar-800 prose-pre:bg-gray-100 dark:prose-invert prose-pre:rounded-2xl dark:prose-headings:text-white prose-p:text-gray-700 prose-img:rounded-2xl dark:prose-p:text-polar-200 prose-a:text-blue-500 hover:prose-a:text-blue-400 dark:hover:prose-a:text-blue-300 dark:prose-a:text-blue-400 prose-a:no-underline mb-8 w-full max-w-none space-y-16">
           <BrowserRender
             article={article}
@@ -122,6 +156,7 @@ export default function LongformPost({
         <StaggerReveal.Child
           className="flex flex-col gap-y-16"
           transition={revealTransition}
+          variants={animationVariants}
         >
           <div className="dark:bg-polar-800 flex flex-col items-center gap-y-6 rounded-3xl bg-gray-100 p-8 py-12 md:px-16">
             <Avatar

--- a/clients/apps/web/src/components/Feed/PostEditor.tsx
+++ b/clients/apps/web/src/components/Feed/PostEditor.tsx
@@ -94,6 +94,7 @@ export const PostEditor = ({
                 <StaggerReveal className="dark:md:bg-polar-900 dark:md:border-polar-800 relative my-8 flex h-full min-h-screen w-full flex-col items-center rounded-[3rem] md:bg-white md:p-12 md:shadow-xl dark:md:border">
                   <LongformPost
                     {...previewProps}
+                    animation={false}
                     revealTransition={{ duration: 0 }}
                     staggerTransition={{ staggerChildren: 0 }}
                     showPaywalledContent={previewAs === 'premium'}

--- a/clients/apps/web/src/components/Shared/StaggerReveal.tsx
+++ b/clients/apps/web/src/components/Shared/StaggerReveal.tsx
@@ -34,16 +34,17 @@ export interface StaggerRevealProps extends HTMLMotionProps<'div'> {
 export const StaggerReveal = ({ transition, ...props }: StaggerRevealProps) => {
   return (
     <motion.div
-      {...props}
       variants={{
         ...revealVariants,
         visible: {
           ...revealVariants.visible,
           transition: { ...revealVariants.visible.transition, ...transition },
         },
+        ...props.variants,
       }}
       initial="hidden"
       animate="visible"
+      {...props}
     />
   )
 }
@@ -53,7 +54,6 @@ StaggerReveal.displayName = 'StaggerReveal'
 StaggerReveal.Child = ({ transition, ...props }: StaggerRevealProps) => {
   return (
     <motion.div
-      {...props}
       variants={{
         ...staggerRevealVariants,
         visible: {
@@ -62,8 +62,10 @@ StaggerReveal.Child = ({ transition, ...props }: StaggerRevealProps) => {
             ...staggerRevealVariants.visible.transition,
             ...transition,
           },
+          ...props.variants,
         },
       }}
+      {...props}
     />
   )
 }


### PR DESCRIPTION
Current thesis is that the animations have a large effect on SEO ranking. Disabling animations for posts on the public pages.

If we want, we could later re-enable animations, but ideally only on in-app navigations, such as when navigating from a list view. But not on the first page load.