### PR TITLE
server/subscription: prevent accepting empty string as tier description

### DIFF
--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -174,6 +174,13 @@ class SubscriptionTierCreate(Schema):
             )
         return values
 
+    # FIXME: in Pydantic V2, replace with an annotated type
+    @validator("description")
+    def empty_str_to_none(cls, v: str | None) -> str | None:
+        if v == "":
+            return None
+        return v
+
 
 class SubscriptionTierUpdate(Schema):
     name: str | None = Field(
@@ -185,6 +192,13 @@ class SubscriptionTierUpdate(Schema):
     is_highlighted: bool | None = None
     price_amount: int | None = Field(default=None, gt=0)
     price_currency: str | None = Field(default=None, regex="USD")
+
+    # FIXME: in Pydantic V2, replace with an annotated type
+    @validator("description")
+    def empty_str_to_none(cls, v: str | None) -> str | None:
+        if v == "":
+            return None
+        return v
 
 
 class SubscriptionTierBenefitsUpdate(Schema):

--- a/server/polar/subscription/service/subscription_tier.py
+++ b/server/polar/subscription/service/subscription_tier.py
@@ -300,7 +300,7 @@ class SubscriptionTierService(
             )
 
         return await subscription_tier.update(
-            session, **update_schema.dict(exclude_unset=True)
+            session, **update_schema.dict(exclude_unset=True, exclude_none=True)
         )
 
     async def create_free(

--- a/server/tests/subscription/conftest.py
+++ b/server/tests/subscription/conftest.py
@@ -61,6 +61,7 @@ async def create_subscription_tier(
     subscription_tier = SubscriptionTier(
         type=type,
         name=name,
+        description="Description",
         price_amount=price_amount,
         price_currency="USD",
         is_highlighted=is_highlighted,
@@ -70,7 +71,6 @@ async def create_subscription_tier(
         stripe_product_id=rstr("PRODUCT_ID"),
         stripe_price_id=rstr("PRICE_ID"),
         subscription_tier_benefits=[],
-        description="x",
     )
     session.add(subscription_tier)
     await session.commit()


### PR DESCRIPTION
Fix #2187