### PR TITLE
clients: remove <Suspense> boundary on public pages

### DIFF
--- a/clients/apps/web/src/app/(public)/[organization]/(layout)/layout.tsx
+++ b/clients/apps/web/src/app/(public)/[organization]/(layout)/layout.tsx
@@ -6,7 +6,7 @@ import { getServerSideAPI } from '@/utils/api'
 import { Organization, Platforms, UserRead } from '@polar-sh/sdk'
 import { notFound } from 'next/navigation'
 import { LogoType } from 'polarkit/components/brand'
-import React, { Suspense } from 'react'
+import React from 'react'
 import LayoutTopbarAuth from './LayoutTopbarAuth'
 
 const cacheConfig = {
@@ -83,9 +83,7 @@ export default async function Layout({
                   organization={organization}
                 />
               </div>
-              <div className="flex h-full w-full flex-col">
-                <Suspense>{children}</Suspense>
-              </div>
+              <div className="flex h-full w-full flex-col">{children}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Hoping that this will lead to more of the page to get rendered serverside when it isn't cached.