### PR TITLE
server/subscriptions: add missing join in subscribed search

### DIFF
--- a/server/polar/subscription/service/subscription.py
+++ b/server/polar/subscription/service/subscription.py
@@ -1108,6 +1108,11 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
                     UserOrganization.user_id == user.id,
                 ),
             )
+            .join(
+                SubscriptionTier,
+                isouter=True,
+                onclause=Subscription.subscription_tier_id == SubscriptionTier.id,
+            )
             .where(
                 Subscription.deleted_at.is_(None),
                 or_(


### PR DESCRIPTION
Previously the query looked like this:

    FROM
    subscriptions
    LEFT OUTER JOIN user_organizations ON user_organizations.organization_id = subscriptions.organization_id
    AND user_organizations.user_id = 7
    LEFT OUTER JOIN organizations AS organizations_1 ON organizations_1.id = subscriptions.organization_id
    LEFT OUTER JOIN subscription_tiers AS subscription_tiers_1 ON subscription_tiers_1.id = subscriptions.subscription_tier_id,
    subscription_tiers

Adding the missing join :)