### PR TITLE
clients/posts: publish tab on new post

### DIFF
--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/[post]/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/[post]/ClientPage.tsx
@@ -93,8 +93,11 @@ const ClientPage = () => {
       post.data.visibility === ArticleVisibilityEnum.PUBLIC,
   )
 
+  const defaultTab =
+    window && window.location.hash === '#settings' ? 'settings' : 'edit'
+
   return (
-    <Tabs className="flex h-full flex-col" defaultValue="edit">
+    <Tabs className="flex h-full flex-col" defaultValue={defaultTab}>
       <DashboardTopbar title="Edit Post" isFixed useOrgFromURL>
         <div className="flex flex-row items-center gap-x-2">
           <span className="dark:text-polar-500 px-4 text-sm text-gray-500">

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/new/ClientPage.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/posts/new/ClientPage.tsx
@@ -22,8 +22,10 @@ const ClientPage = () => {
   const router = useRouter()
   const create = useCreateArticle()
 
+  const canCreate = org && article.title.length > 0
+
   const handleContinue = async () => {
-    if (!org || article.title.length < 1) {
+    if (!canCreate) {
       return
     }
 
@@ -52,12 +54,33 @@ const ClientPage = () => {
     }
   }, [handleContinue])
 
+  const onTabChange = async (tab: string) => {
+    if (tab === 'settings') {
+      if (!canCreate) {
+        return
+      }
+
+      const created = await create.mutateAsync({
+        ...article,
+        organization_id: org.id,
+      })
+
+      router.replace(
+        `/maintainer/${created.organization.name}/posts/${created.slug}#settings`,
+      )
+    }
+  }
+
   if (!org) {
     return null
   }
 
   return (
-    <Tabs className="flex flex-col" defaultValue="edit">
+    <Tabs
+      className="flex flex-col"
+      defaultValue="edit"
+      onValueChange={onTabChange}
+    >
       <DashboardTopbar title="Create Post" isFixed useOrgFromURL>
         <Button
           onClick={handleContinue}
@@ -69,6 +92,7 @@ const ClientPage = () => {
       </DashboardTopbar>
       <PostEditor
         disabled={create.isPending}
+        canCreate={canCreate}
         title={article.title}
         body={article.body}
         onTitleChange={(title) => setArticle((a) => ({ ...a, title }))}

--- a/clients/apps/web/src/components/Feed/PostEditor.tsx
+++ b/clients/apps/web/src/components/Feed/PostEditor.tsx
@@ -49,6 +49,7 @@ interface PostEditorProps {
   onBodyChange: (body: string) => void
   previewProps: React.ComponentProps<typeof LongformPost>
   disabled?: boolean
+  canCreate?: boolean
 }
 
 export const PostEditor = ({
@@ -59,6 +60,7 @@ export const PostEditor = ({
   onBodyChange,
   previewProps,
   disabled,
+  canCreate,
 }: PostEditorProps) => {
   const [previewAs, setPreviewAs] = useState<string>('premium')
   const { org } = useCurrentOrgAndRepoFromURL()
@@ -73,6 +75,7 @@ export const PostEditor = ({
         article={article}
         previewAs={previewAs}
         onPreviewAsChange={setPreviewAs}
+        canCreate={canCreate}
       />
       <div className="dark:bg-polar-950 h-full bg-white">
         <DashboardBody className="mt-0 h-full">

--- a/clients/apps/web/src/components/Feed/Toolbar/PostToolbar.tsx
+++ b/clients/apps/web/src/components/Feed/Toolbar/PostToolbar.tsx
@@ -11,12 +11,14 @@ interface PostToolbarProps {
   article?: Article
   previewAs: string
   onPreviewAsChange: (value: string) => void
+  canCreate?: boolean
 }
 
 export const PostToolbar = ({
   article,
   previewAs,
   onPreviewAsChange,
+  canCreate,
 }: PostToolbarProps) => {
   const isPublished = Boolean(
     article &&
@@ -35,7 +37,11 @@ export const PostToolbar = ({
           <TabsTrigger value="preview" size="small">
             Preview
           </TabsTrigger>
-          <TabsTrigger value="settings" size="small">
+          <TabsTrigger
+            value="settings"
+            size="small"
+            disabled={canCreate === false}
+          >
             {isPublished ? 'Settings' : 'Publish'}
           </TabsTrigger>
         </TabsList>


### PR DESCRIPTION
Fixes #2317 

The publish tab now creates the post, and redirects to the settings tab :)

The UI flickers a bit when this happens, which is to be improved later, shipping this as is as it's still a huge improvement.