### PR TITLE
chore: use semantic HTML for LongFormPost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ playground.py
 
 .DS_Store
 .pnpm-store
+
+# Secrets
+.secrets/

--- a/clients/apps/web/src/components/Feed/LongformPost.tsx
+++ b/clients/apps/web/src/components/Feed/LongformPost.tsx
@@ -74,26 +74,27 @@ export default function LongformPost({
       publishedDate
         ? new Date() > publishedDate
           ? publishedDate.toLocaleString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })
           : `Scheduled on ${publishedDate.toLocaleString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}`
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}`
         : 'Unpublished',
     [publishedDate],
   )
 
   return (
     <StaggerReveal
+      as="article"
       className="w-full max-w-2xl"
       transition={staggerTransition}
       variants={animationVariants}
     >
-      <div className="flex flex-col items-center gap-y-8 pb-16 pt-4">
+      <header className="flex flex-col items-center gap-y-8 pb-16 pt-4">
         <StaggerReveal.Child
           transition={revealTransition}
           variants={animationVariants}
@@ -104,9 +105,9 @@ export default function LongformPost({
           transition={revealTransition}
           variants={animationVariants}
         >
-          <span className="dark:text-polar-500 text-gray-500">
+          <time className="dark:text-polar-500 text-gray-500" dateTime={publishedDate?.toISOString()}>
             {publishedDateText}
-          </span>
+          </time>
         </StaggerReveal.Child>
         <StaggerReveal.Child
           transition={revealTransition}
@@ -131,7 +132,7 @@ export default function LongformPost({
             </h3>
           </div>
         </StaggerReveal.Child>
-      </div>
+      </header>
 
       <StaggerReveal.Child
         transition={revealTransition}
@@ -184,9 +185,8 @@ const UpsellNonSubscriber = ({ article }: { article: RenderArticle }) => (
       <p className="dark:text-polar-300 text-center text-gray-500">
         {article.organization?.bio
           ? article.organization?.bio
-          : `Support ${
-              article.organization.pretty_name || article.organization.name
-            } by subscribing to their work and get access to exclusive content.`}
+          : `Support ${article.organization.pretty_name || article.organization.name
+          } by subscribing to their work and get access to exclusive content.`}
       </p>
       <Link href={`/${article.organization.name}/subscriptions`}>
         <Button className="mt-4">Subscribe</Button>
@@ -214,9 +214,8 @@ const UpsellFreeSubscriberToPaid = ({
       <p className="dark:text-polar-300 text-center text-gray-500">
         {article.organization?.bio
           ? article.organization?.bio
-          : `Support ${
-              article.organization.pretty_name || article.organization.name
-            } by subscribing to their work and get access to exclusive content.`}
+          : `Support ${article.organization.pretty_name || article.organization.name
+          } by subscribing to their work and get access to exclusive content.`}
       </p>
       <Link href={`/${article.organization.name}/subscriptions`}>
         <Button className="mt-4">Upgrade</Button>

--- a/clients/apps/web/src/components/Feed/LongformPost.tsx
+++ b/clients/apps/web/src/components/Feed/LongformPost.tsx
@@ -74,15 +74,15 @@ export default function LongformPost({
       publishedDate
         ? new Date() > publishedDate
           ? publishedDate.toLocaleString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })
           : `Scheduled on ${publishedDate.toLocaleString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })}`
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}`
         : 'Unpublished',
     [publishedDate],
   )
@@ -105,7 +105,10 @@ export default function LongformPost({
           transition={revealTransition}
           variants={animationVariants}
         >
-          <time className="dark:text-polar-500 text-gray-500" dateTime={publishedDate?.toISOString()}>
+          <time
+            className="dark:text-polar-500 text-gray-500"
+            dateTime={publishedDate?.toISOString()}
+          >
             {publishedDateText}
           </time>
         </StaggerReveal.Child>
@@ -148,24 +151,26 @@ export default function LongformPost({
         </div>
       </StaggerReveal.Child>
 
-      {shouldRenderPaywall && (
-        <StaggerReveal.Child
-          transition={revealTransition}
-          variants={animationVariants}
-        >
-          <PostPaywall article={article} isSubscriber={isSubscriber} />
-        </StaggerReveal.Child>
-      )}
+      <footer>
+        {shouldRenderPaywall && (
+          <StaggerReveal.Child
+            transition={revealTransition}
+            variants={animationVariants}
+          >
+            <PostPaywall article={article} isSubscriber={isSubscriber} />
+          </StaggerReveal.Child>
+        )}
 
-      {showNonSubscriberUpsell ? (
-        <UpsellNonSubscriber article={article} />
-      ) : null}
+        {showNonSubscriberUpsell ? (
+          <UpsellNonSubscriber article={article} />
+        ) : null}
 
-      {showSubscriberUpsell ? (
-        <UpsellFreeSubscriberToPaid article={article} />
-      ) : null}
+        {showSubscriberUpsell ? (
+          <UpsellFreeSubscriberToPaid article={article} />
+        ) : null}
 
-      {showShare ? <Share className="my-8 flex" article={article} /> : null}
+        {showShare ? <Share className="my-8 flex" article={article} /> : null}
+      </footer>
     </StaggerReveal>
   )
 }
@@ -185,8 +190,9 @@ const UpsellNonSubscriber = ({ article }: { article: RenderArticle }) => (
       <p className="dark:text-polar-300 text-center text-gray-500">
         {article.organization?.bio
           ? article.organization?.bio
-          : `Support ${article.organization.pretty_name || article.organization.name
-          } by subscribing to their work and get access to exclusive content.`}
+          : `Support ${
+              article.organization.pretty_name || article.organization.name
+            } by subscribing to their work and get access to exclusive content.`}
       </p>
       <Link href={`/${article.organization.name}/subscriptions`}>
         <Button className="mt-4">Subscribe</Button>
@@ -214,8 +220,9 @@ const UpsellFreeSubscriberToPaid = ({
       <p className="dark:text-polar-300 text-center text-gray-500">
         {article.organization?.bio
           ? article.organization?.bio
-          : `Support ${article.organization.pretty_name || article.organization.name
-          } by subscribing to their work and get access to exclusive content.`}
+          : `Support ${
+              article.organization.pretty_name || article.organization.name
+            } by subscribing to their work and get access to exclusive content.`}
       </p>
       <Link href={`/${article.organization.name}/subscriptions`}>
         <Button className="mt-4">Upgrade</Button>

--- a/clients/apps/web/src/components/Shared/StaggerReveal.tsx
+++ b/clients/apps/web/src/components/Shared/StaggerReveal.tsx
@@ -27,13 +27,17 @@ const staggerRevealVariants = {
   },
 }
 
-export interface StaggerRevealProps extends HTMLMotionProps<'div'> {
+type MotionElement = 'div' | 'article'
+
+export interface StaggerRevealProps extends HTMLMotionProps<MotionElement> {
+  as?: MotionElement
   transition?: Partial<Transition>
 }
 
-export const StaggerReveal = ({ transition, ...props }: StaggerRevealProps) => {
+export const StaggerReveal = ({ transition, as, ...props }: StaggerRevealProps) => {
+  const Component = motion[as ?? 'div']
   return (
-    <motion.div
+    <Component
       variants={{
         ...revealVariants,
         visible: {
@@ -51,9 +55,10 @@ export const StaggerReveal = ({ transition, ...props }: StaggerRevealProps) => {
 
 StaggerReveal.displayName = 'StaggerReveal'
 
-StaggerReveal.Child = ({ transition, ...props }: StaggerRevealProps) => {
+StaggerReveal.Child = ({ transition, as, ...props }: StaggerRevealProps) => {
+  const Component = motion[as ?? 'div']
   return (
-    <motion.div
+    <Component
       variants={{
         ...staggerRevealVariants,
         visible: {


### PR DESCRIPTION
This is a minor change that makes the `LongFormPost` component use semantic HTML tags. There's more that could be done (e.g. using the `<footer>` tag), but it's somewhat of a start.

This should make posts easier for both screenreader users and crawlers to parse!

### Notes

I tried to make the `as` property of the `StaggerReveal` component take in any HTML element, but this caused some weird type issues that I'm not familiar enough with React/Framer Motion to fix.

It's also worth noting that I wasn't able to run a local development environment, and codespaces were giving me issues, so it's entirely possible that this is completely borked. Sorry about that 😅 