### PR TITLE
clients/editor: component buttons directly

### DIFF
--- a/clients/apps/web/src/components/Feed/Toolbar/MarkdownToolbar.tsx
+++ b/clients/apps/web/src/components/Feed/Toolbar/MarkdownToolbar.tsx
@@ -1,11 +1,4 @@
-import { ChevronDownIcon } from '@heroicons/react/24/outline'
 import { Button } from 'polarkit/components/ui/atoms'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from 'polarkit/components/ui/dropdown-menu'
 import { useMarkdownComponents } from './useMarkdownComponents'
 
 export const MarkdownToolbar = () => {
@@ -14,28 +7,15 @@ export const MarkdownToolbar = () => {
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild onMouseDown={(e) => e.stopPropagation()}>
-          <Button variant="secondary" className="px-2 text-left" size="sm">
-            <span>Components</span>
-            <ChevronDownIcon className="ml-2 h-3 w-3" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={insertPaywall} className="cursor-pointer">
-            Paywall
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={insertSubscribeNow}
-            className="cursor-pointer"
-          >
-            Subscription Upsell
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={insertAd} className="cursor-pointer">
-            Ad
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <Button onClick={insertPaywall} size={'sm'} variant={'secondary'}>
+        {'<Paywall />'}
+      </Button>
+      <Button onClick={insertSubscribeNow} size={'sm'} variant={'secondary'}>
+        {'<SubscribeNow />'}
+      </Button>
+      <Button onClick={insertAd} size={'sm'} variant={'secondary'}>
+        {'<Ad />'}
+      </Button>
     </>
   )
 }


### PR DESCRIPTION
Showing the components directly solves a problem in WebKit where focus was lost, and we where unable to move the focus back to the textarea to run document.execCommand(). There might be a better way to fix this, but this is an easy and straight forward one.

Fixes #2342 