### PR TITLE
server/onboarding: Reactivate deleted organization in case one exists

### DIFF
--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -63,6 +63,7 @@ class UserOrganizationervice:
                 UserOrganization.deleted_at.is_(None),
                 Organization.platform == platform,
                 Organization.is_personal.is_(True),
+                Organization.deleted_at.is_(None),
             )
             .options(
                 joinedload(UserOrganization.user),


### PR DESCRIPTION
By ensuring our getter for existing organizations filters out
organizations that have been deleted too.
