### PR TITLE
clients/subscriptions: offer to go to /org after subscribing to org

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/SubscriptionSuccess.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionSuccess.tsx
@@ -89,8 +89,8 @@ export const SubscriptionSuccess = (props: {
             </CardContent>
             <CardFooter className="flex justify-center">
               {currentUser && (
-                <Link className="grow" href="/feed">
-                  <Button className="w-full">Back to your dashboard</Button>
+                <Link className="grow" href={`/${organizationName}`}>
+                  <Button className="w-full">Go to {organizationName}</Button>
                 </Link>
               )}
               {!currentUser && (


### PR DESCRIPTION
For already logged in users

Before/After:

<img width="1909" alt="Screenshot 2024-01-30 at 16 05 03" src="https://github.com/polarsource/polar/assets/47952/3840a538-1be1-4d74-8201-5547cfa125f1">


<img width="1545" alt="Screenshot 2024-01-30 at 16 06 33" src="https://github.com/polarsource/polar/assets/47952/e58a67ef-bd58-452d-915d-743b0eb6c439">
