### PR TITLE
clients/articles: decode html entities in the text only renderer

### DIFF
--- a/clients/apps/web/package.json
+++ b/clients/apps/web/package.json
@@ -47,6 +47,7 @@
     "class-variance-authority": "^0.6.0",
     "cmdk": "^0.2.0",
     "framer-motion": "^10.17.8",
+    "html-entities": "^2.4.0",
     "markdown-to-jsx": "^7.3.2",
     "mermaid": "^10.6.1",
     "next": "^14.0.4",

--- a/clients/apps/web/src/app/(topbar)/[organization]/(layout)/posts/[postSlug]/page.tsx
+++ b/clients/apps/web/src/app/(topbar)/[organization]/(layout)/posts/[postSlug]/page.tsx
@@ -1,4 +1,4 @@
-import PreviewText from '@/components/Feed/Markdown/preview'
+import PreviewText, { UnescapeText } from '@/components/Feed/Markdown/preview'
 import { getServerSideAPI } from '@/utils/api'
 import { firstImageUrlFromMarkdown } from '@/utils/markdown'
 import {
@@ -59,9 +59,10 @@ export async function generateMetadata(
   // This is pretty fast so it's nothing that I'm worried about.
   const ReactDOMServer = (await import('react-dom/server')).default
 
-  const preview = ReactDOMServer.renderToStaticMarkup(
-    <PreviewText article={article} />,
+  const preview = UnescapeText(
+    ReactDOMServer.renderToStaticMarkup(<PreviewText article={article} />),
   )
+
   const image = firstImageUrlFromMarkdown(article.body)
 
   return {

--- a/clients/apps/web/src/components/Feed/Markdown/preview.test.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/preview.test.tsx
@@ -1,0 +1,24 @@
+import { Article } from '@polar-sh/sdk'
+import '@testing-library/jest-dom'
+import { article } from 'polarkit/testdata'
+import ReactDOMServer from 'react-dom/server'
+import PreviewText, { UnescapeText } from './preview'
+
+const TestRenderer = (article: Article) => {
+  const preview = UnescapeText(
+    ReactDOMServer.renderToStaticMarkup(<PreviewText article={article} />),
+  )
+  return preview
+}
+
+test('entities', () => {
+  const a = {
+    ...article,
+    body: `
+**This** is a test & "preview"
+
+<img src="https://framerusercontent.com/images/O7exOgMXifmEOmoFdmbAVNBk6Y.png">
+`,
+  }
+  expect(TestRenderer(a)).toEqual('This is a test & "preview"')
+})

--- a/clients/apps/web/src/components/Feed/Markdown/preview.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/preview.tsx
@@ -1,4 +1,5 @@
 import { Article } from '@polar-sh/sdk'
+import { decode } from 'html-entities'
 import Markdown from 'markdown-to-jsx'
 import { markdownOpts, wrapStrictCreateElement } from './markdown'
 
@@ -15,6 +16,7 @@ export const previewOpts = {
   },
 } as const
 
+// Text only renderer. Used to generate contents for og:description and similar
 export default function PreviewText(props: { article: Article }) {
   return (
     <Markdown
@@ -38,12 +40,11 @@ export default function PreviewText(props: { article: Article }) {
         wrapper: (args: any) => <>{args.children}</>,
       }}
     >
-      {props.article.body
-        .substring(0, 500)
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .trim()}
+      {props.article.body.substring(0, 500)}
     </Markdown>
   )
+}
+
+export function UnescapeText(str: string): string {
+  return decode(str, { scope: 'strict' }).trim()
 }

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       framer-motion:
         specifier: ^10.17.8
         version: 10.17.8(react-dom@18.2.0)(react@18.2.0)
+      html-entities:
+        specifier: ^2.4.0
+        version: 2.4.0
       markdown-to-jsx:
         specifier: ^7.3.2
         version: 7.3.2(react@18.2.0)
@@ -3887,7 +3890,7 @@ packages:
       core-js-pure: 3.30.1
       error-stack-parser: 2.1.4
       find-up: 5.0.0
-      html-entities: 2.3.3
+      html-entities: 2.4.0
       loader-utils: 2.0.4
       react-refresh: 0.14.0
       schema-utils: 3.3.0
@@ -13514,9 +13517,8 @@ packages:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  /html-entities@2.3.3:
-    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
-    dev: true
+  /html-entities@2.4.0:
+    resolution: {integrity: sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==}
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -20285,7 +20287,7 @@ packages:
     resolution: {integrity: sha512-IK/0WAHs7MTu1tzLTjio73LjS3Ov+VvBKQmE8WPlJutgG5zT6Urgq/BbAdRrHTRpyzK0dvAvFh1Qg98akxgZpA==}
     dependencies:
       ansi-html-community: 0.0.8
-      html-entities: 2.3.3
+      html-entities: 2.4.0
       strip-ansi: 6.0.1
     dev: true
 


### PR DESCRIPTION
Fixes incorrect html entities in og:description and similar