### PR TITLE
clients/repositories: notice on private repos

### DIFF
--- a/clients/apps/web/src/app/(topbar)/[organization]/(layout)/[repo]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(topbar)/[organization]/(layout)/[repo]/ClientPage.tsx
@@ -5,7 +5,9 @@ import {
   ListResourceIssueFunding,
   Organization,
   Repository,
+  Visibility,
 } from '@polar-sh/sdk'
+import { Banner } from 'polarkit/components/ui/molecules'
 import { formatStarsNumber } from 'polarkit/utils'
 
 const ClientPage = ({
@@ -21,6 +23,13 @@ const ClientPage = ({
 }) => {
   return (
     <>
+      {repository.visibility === Visibility.PRIVATE && (
+        <Banner color="muted">
+          This is a private repository. Only logged in users that are members of{' '}
+          {repository.organization.name} can see it.
+        </Banner>
+      )}
+
       <h1 className="dark:text-polar-100 text-center text-3xl font-normal text-gray-800 md:text-3xl">
         {organization.name}/{repository.name} has{' '}
         {totalIssueCount > 0 ? totalIssueCount : 'no'}{' '}

--- a/clients/apps/web/src/components/Organization/RepositoriesOverview.tsx
+++ b/clients/apps/web/src/components/Organization/RepositoriesOverview.tsx
@@ -1,6 +1,6 @@
 import { StarIcon } from '@heroicons/react/24/solid'
 import { HiveOutlined } from '@mui/icons-material'
-import { Organization, Repository } from '@polar-sh/sdk'
+import { Organization, Repository, Visibility } from '@polar-sh/sdk'
 import Link from 'next/link'
 import {
   Card,
@@ -61,6 +61,11 @@ export const RepositoriesOverivew = ({
                         Unlicensed
                       </Pill>
                     )}
+                    {repository.visibility === Visibility.PRIVATE ? (
+                      <Pill className="grow-0 px-3" color="gray">
+                        Private
+                      </Pill>
+                    ) : null}
                     <span className="flex flex-row items-center gap-x-1 text-sm">
                       <StarIcon className="h-4 w-4" />
                       <span className="pt-.5">{repository.stars}</span>
@@ -90,6 +95,11 @@ export const RepositoriesOverivew = ({
                           Unlicensed
                         </Pill>
                       )}
+                      {repository.visibility === Visibility.PRIVATE ? (
+                        <Pill className="grow-0 px-3" color="gray">
+                          Private
+                        </Pill>
+                      ) : null}
                     </span>
                     {repository.description && (
                       <p className="dark:text-polar-500 text-sm text-gray-400">


### PR DESCRIPTION
<img width="1367" alt="Screenshot 2024-01-31 at 14 38 29" src="https://github.com/polarsource/polar/assets/47952/30e198b7-743a-49e7-b519-a2afed99e73e">
<img width="1367" alt="Screenshot 2024-01-31 at 14 38 35" src="https://github.com/polarsource/polar/assets/47952/09e6111d-90f6-405f-97b8-2becd9a3b9ee">
<img width="1367" alt="Screenshot 2024-01-31 at 14 40 30" src="https://github.com/polarsource/polar/assets/47952/be24f469-4d9a-41cc-9f28-1d6ad4f5ee73">
