### PR TITLE
clients/posts: support or ads markdown directly in posts

### DIFF
--- a/clients/apps/web/src/components/Feed/Markdown/Img/ImageOverlay.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/Img/ImageOverlay.tsx
@@ -4,12 +4,28 @@ import Image from 'next/image'
 import { ComponentProps } from 'react'
 import { twMerge } from 'tailwind-merge'
 
+const numOrDefault = (
+  n: number | string | undefined,
+  _default: number,
+): number => {
+  if (typeof n === 'number') {
+    return n
+  }
+  if (typeof n === 'string' && parseInt(n) > 0) {
+    return parseInt(n)
+  }
+  return _default
+}
+
 export const ImageOverlay = (props: ComponentProps<'img'>) => {
   const { isShown, hide, show } = useModal()
 
   if (!props.src) {
     return <></>
   }
+
+  const width = numOrDefault(props.width, 672)
+  const height = numOrDefault(props.height, 100)
 
   // Optimize images if they are served from the Polar Vercel Blob Bucket
   if (
@@ -24,8 +40,8 @@ export const ImageOverlay = (props: ComponentProps<'img'>) => {
           alt={props.alt ?? ''}
           className={twMerge(props.className, 'cursor-pointer')}
           onClick={show}
-          width={672}
-          height={100}
+          width={width}
+          height={height}
           quality={90}
         />
         <Modal
@@ -51,7 +67,8 @@ export const ImageOverlay = (props: ComponentProps<'img'>) => {
         alt={props.alt ?? ''}
         className={twMerge(props.className, 'cursor-pointer')}
         onClick={show}
-        width={672}
+        width={width}
+        height={height}
       />
       <Modal
         modalContent={
@@ -59,7 +76,6 @@ export const ImageOverlay = (props: ComponentProps<'img'>) => {
             src={props.src}
             alt={props.alt ?? ''}
             className={twMerge(props.className, 'w-full max-w-screen-xl')}
-            width={672}
           />
         }
         isShown={isShown}

--- a/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
+++ b/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ads-embed 1`] = `
+<div>
+  <div>
+    <a
+      href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    >
+      <picture>
+        <img
+          alt="Click me!!!!!"
+          height="100"
+          src="https://polar.sh/embed/ad?id=63f3a3cc-54ae-45e9-987a-7174364d234e"
+          style="max-width: 100%;"
+          width="100"
+        />
+      </picture>
+    </a>
+    <a
+      href="https://polar.sh/zegl"
+    >
+      <picture>
+        <source
+          media="(prefers-color-scheme: dark)"
+          srcset="https://polar.sh/embed/ad?id=94c1676c-db08-4489-b4b4-e25beadf2542&dark=1"
+        />
+        <img
+          alt="Hello world!"
+          height="100"
+          src="https://polar.sh/embed/ad?id=94c1676c-db08-4489-b4b4-e25beadf2542"
+          style="max-width: 100%;"
+          width="100"
+        />
+      </picture>
+    </a>
+  </div>
+</div>
+`;
+
 exports[`basic 1`] = `
 <div>
   <div>
@@ -99,6 +136,7 @@ exports[`polar 1`] = `
   <div>
     <p>
       <img
+        alt="image.png"
         src="https://7vk6rcnylug0u6hg.public.blob.vercel-storage.com/image-fCQqIZt3zubCpaMQzy6ZONZAOG6QDq.png"
         style="max-width: 100%;"
       />
@@ -140,6 +178,7 @@ exports[`polar 1`] = `
     </h3>
     <p>
       <img
+        alt="Screenshot 2024-01-09 at 10.44.55.png"
         src="https://7vk6rcnylug0u6hg.public.blob.vercel-storage.com/Screenshot%202024-01-09%20at%2010.44.55-uy562dyst8J1Hk4QScE5i6DE3Aa2jA.png"
         style="max-width: 100%;"
       />
@@ -211,6 +250,7 @@ exports[`polar 1`] = `
     </h3>
     <p>
       <img
+        alt="image.png"
         src="https://7vk6rcnylug0u6hg.public.blob.vercel-storage.com/image-QKge9Wh9vpdhZRIPLnsMWFesg8SPEY.png"
         style="max-width: 100%;"
       />

--- a/clients/apps/web/src/components/Feed/Markdown/markdown.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/markdown.tsx
@@ -74,6 +74,8 @@ export const wrapStrictCreateElement = (args: {
       'hr',
       'span',
       'input',
+      'picture',
+      'source',
     ]
 
     // clean up props, only pass down a limited set of safe props
@@ -109,6 +111,7 @@ export const wrapStrictCreateElement = (args: {
         trimProps.src = props?.src
         trimProps.height = props?.height
         trimProps.width = props?.width
+        trimProps.alt = props?.alt
         children = undefined // can never have children
       }
 
@@ -185,6 +188,11 @@ export const wrapStrictCreateElement = (args: {
       trimProps.checked = props?.checked
       trimProps.disabled = 'disabled'
       children = undefined // can never have children
+    }
+
+    if (type === 'source') {
+      trimProps.media = props?.media
+      trimProps.srcSet = props?.srcSet
     }
 
     if (type === 'p' && Array.isArray(children)) {

--- a/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
@@ -219,3 +219,20 @@ test('polar', () => {
   )
   expect(container).toMatchSnapshot()
 })
+
+test('ads-embed', () => {
+  const { container } = render(
+    <TestRenderer
+      article={{
+        ...article,
+        body: `
+        
+<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"><picture><img src="https://polar.sh/embed/ad?id=63f3a3cc-54ae-45e9-987a-7174364d234e" alt="Click me!!!!!" height="100" width="100" /></picture></a>
+<a href="https://polar.sh/zegl"><picture><source media="(prefers-color-scheme: dark)" srcset="https://polar.sh/embed/ad?id=94c1676c-db08-4489-b4b4-e25beadf2542&dark=1"><img src="https://polar.sh/embed/ad?id=94c1676c-db08-4489-b4b4-e25beadf2542" alt="Hello world!" height="100" width="100" /></picture></a>
+
+        `,
+      }}
+    />,
+  )
+  expect(container).toMatchSnapshot()
+})


### PR DESCRIPTION
Adds support for the `<picture>` and `<source>` HTML elements. As well as respecting alt/height/width properties of `<img>` elements.

(you can now have custom dark-mode images in posts!)

<img width="1545" alt="Screenshot 2024-01-31 at 16 12 28" src="https://github.com/polarsource/polar/assets/47952/cfa95e14-7f49-4dcc-8faf-28936f039e17">
<img width="1545" alt="Screenshot 2024-01-31 at 16 12 20" src="https://github.com/polarsource/polar/assets/47952/a904e1c5-7b5a-4db0-a037-3aab63ba43e3">
<img width="1545" alt="Screenshot 2024-01-31 at 16 12 12" src="https://github.com/polarsource/polar/assets/47952/af4fb978-58dd-4e5b-8fa6-429911bec21d">
