### PR TITLE
clients/topbar: 'Create with Polar' and 'Login' as actions

### DIFF
--- a/clients/apps/web/src/components/Layout/Public/Topbar.tsx
+++ b/clients/apps/web/src/components/Layout/Public/Topbar.tsx
@@ -111,7 +111,7 @@ const Topbar = ({
 
   return (
     <div className="dark:border-b-polar-800 dark:bg-polar-950 sticky top-0 z-50 flex w-full flex-col items-center justify-start border-b border-b-gray-100 bg-white py-4">
-      <div className="flex w-full max-w-7xl flex-col items-stretch justify-between gap-y-4 px-2 md:flex-row md:items-center">
+      <div className="flex w-full max-w-7xl flex-row items-stretch justify-between gap-y-4 px-2 ">
         <div className="flex flex-row items-center gap-x-4 md:gap-x-12">
           {/* Do not make this a Link, it breaks the Framer site proxy */}
           <a href="/">
@@ -125,7 +125,7 @@ const Topbar = ({
           </div>
         </div>
         {!hideProfile ? (
-          <div className="relative flex flex-row items-center justify-between gap-x-6">
+          <div className="relative flex flex-row items-center justify-end gap-x-6">
             {upsell}
             <TopbarRight authenticatedUser={authenticatedUser} />
           </div>

--- a/clients/apps/web/src/components/Layout/Public/TopbarRight.tsx
+++ b/clients/apps/web/src/components/Layout/Public/TopbarRight.tsx
@@ -4,6 +4,7 @@ import Popover from '@/components/Notifications/Popover'
 import GithubLoginButton from '@/components/Shared/GithubLoginButton'
 import { ProfileMenu } from '@/components/Shared/ProfileSelection'
 import { UserRead } from '@polar-sh/sdk'
+import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 const TopbarRight = ({
@@ -22,7 +23,20 @@ const TopbarRight = ({
           <ProfileMenu authenticatedUser={authenticatedUser} />
         </div>
       ) : (
-        <GithubLoginButton text="Continue with GitHub" returnTo={returnTo} />
+        <>
+          <GithubLoginButton
+            text="Create with Polar"
+            returnTo={returnTo}
+            className="hidden md:flex"
+          />
+
+          <Link
+            href={`/login?return_to=${returnTo}`}
+            className="font-medium text-blue-500 hover:text-blue-600"
+          >
+            Login
+          </Link>
+        </>
       )}
     </>
   )


### PR DESCRIPTION
Also making the topbar smaller on mobile devices, by hiding the GH login button (oauth login is also available from the /login page)


## Before


<img width="773" alt="Screenshot 2024-02-05 at 16 38 35" src="https://github.com/polarsource/polar/assets/47952/db45fff6-f45f-474b-bc35-b2d0482ba348">
<img width="1611" alt="Screenshot 2024-02-05 at 16 38 56" src="https://github.com/polarsource/polar/assets/47952/b0a63db5-9ceb-4fe0-bf99-2dc7a006fb1f">

## After

<img width="753" alt="Screenshot 2024-02-05 at 16 38 33" src="https://github.com/polarsource/polar/assets/47952/b2165754-6696-4a45-aaae-5fb157002391">
<img width="1360" alt="Screenshot 2024-02-05 at 16 38 55" src="https://github.com/polarsource/polar/assets/47952/66111e36-52d4-46db-a991-3af2de7e7168">

