### PR TITLE
clients/posts: show <SubscribeNow> for subscribed users

### DIFF
--- a/clients/apps/web/src/components/Feed/Markdown/SubscribeNow/SubscribeNow.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/SubscribeNow/SubscribeNow.tsx
@@ -1,3 +1,4 @@
+import { CheckIcon } from '@heroicons/react/24/outline'
 import { Article } from '@polar-sh/sdk'
 import { useRouter } from 'next/navigation'
 import { Button } from 'polarkit/components/ui/atoms'
@@ -5,9 +6,14 @@ import { Button } from 'polarkit/components/ui/atoms'
 const SubscribeNow = (props: { article: Article; isSubscriber: boolean }) => {
   const router = useRouter()
 
-  // User is already subscribed, hide button.
   if (props.isSubscriber) {
-    return <></>
+    return (
+      <div className="flex flex-col items-center py-1">
+        <Button disabled={true}>
+          <CheckIcon className="-ml-1 mr-2 h-4 w-4" /> Subscribed
+        </Button>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
Fixes #2432

<img width="732" alt="Screenshot 2024-02-06 at 09 44 00" src="https://github.com/polarsource/polar/assets/47952/e4cfdf97-db44-456f-8ba3-21cc69d10c42">
<img width="827" alt="Screenshot 2024-02-06 at 09 43 56" src="https://github.com/polarsource/polar/assets/47952/961ccbe0-7b96-4ffb-84ff-06794b9d3a12">
