### PR TITLE
clients/SyntaxHighlighter: make line numbers non-selectable

### DIFF
--- a/clients/apps/web/src/components/Feed/Markdown/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -85,6 +85,7 @@ const SyntaxHighlighter = (props: {
                 paddingRight: '1.5rem',
                 opacity: '.2',
                 fontSize: '.7rem',
+                userSelect: 'none',
               }}
             >
               {lineIndex + 1}


### PR DESCRIPTION
Fixes #2482