### PR TITLE
clients/SyntaxHighlighter: align code lines, and right align line num…

### DIFF
--- a/clients/apps/web/src/components/Feed/Markdown/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -75,6 +75,8 @@ const SyntaxHighlighter = (props: {
     Prism.tokenize(line, languageGrammar),
   )
 
+  const width = Math.log10(tokensPerLine.length) * 10
+
   return (
     <pre style={{ ...theme.base }}>
       <code>
@@ -82,10 +84,13 @@ const SyntaxHighlighter = (props: {
           <div key={lineIndex} className="m-0">
             <span
               style={{
-                paddingRight: '1.5rem',
+                marginRight: '1.5rem',
                 opacity: '.2',
                 fontSize: '.7rem',
                 userSelect: 'none',
+                textAlign: 'right',
+                display: 'inline-block',
+                width: `${width}px`,
               }}
             >
               {lineIndex + 1}


### PR DESCRIPTION
…bers

This removes the 'jump' when going from line number 9 to 10 as the line number had different widths.