### PR TITLE
chore: add  to unsubscribe dropdowns

### DIFF
--- a/clients/apps/web/src/app/(topbar)/(backer)/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(topbar)/(backer)/subscriptions/ClientPage.tsx
@@ -185,7 +185,7 @@ const Subscription = ({
                 align="end"
                 className="dark:bg-polar-800 bg-gray-50 shadow-lg"
               >
-                <DropdownMenuItem onClick={() => setShowCancelModal(true)}>
+                <DropdownMenuItem onClick={() => setShowCancelModal(true)} className="cursor-pointer">
                   Unsubscribe
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/clients/apps/web/src/components/Feed/MySubscriptions.tsx
+++ b/clients/apps/web/src/components/Feed/MySubscriptions.tsx
@@ -89,7 +89,7 @@ const SubscriptionOrganizationItem = ({
               align="end"
               className="dark:bg-polar-800 bg-gray-50 shadow-lg"
             >
-              <DropdownMenuItem onClick={() => setShowCancelModal(true)}>
+              <DropdownMenuItem onClick={() => setShowCancelModal(true)} className="cursor-pointer">
                 Unsubscribe
               </DropdownMenuItem>
             </DropdownMenuContent>


### PR DESCRIPTION
Fixes #2511 

---

Note: I wasn't sure whether to just update the 'Unsubscribe' dropdown items, or whether all dropdown menu items should have `cursor-pointer`, so I did the former. Happy to update so that the `DropdownMenuItem` in `polarkit` uses the class by default.