### PR TITLE
clients/markdown: downgrade renderer to v7.3

### DIFF
--- a/clients/apps/web/package.json
+++ b/clients/apps/web/package.json
@@ -48,7 +48,7 @@
     "cmdk": "^0.2.0",
     "framer-motion": "^10.17.8",
     "html-entities": "^2.4.0",
-    "markdown-to-jsx": "^7.4.1",
+    "markdown-to-jsx": "7.3.2",
     "mermaid": "^10.6.1",
     "next": "^14.0.4",
     "next-themes": "^0.2.1",

--- a/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render-browser.test.tsx.snap
+++ b/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render-browser.test.tsx.snap
@@ -50,8 +50,12 @@ exports[`basic 1`] = `
 <DocumentFragment>
   <div>
      
-# h1
 
+    <h1
+      id="h1"
+    >
+      h1
+    </h1>
     <h2
       id="h2"
     >
@@ -117,6 +121,33 @@ And here it continues in the same block.
       <p>
         This is a quoute!
       </p>
+    </blockquote>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`blockquote 1`] = `
+<DocumentFragment>
+  <div>
+    <p>
+      And code blocks:
+    </p>
+    <blockquote>
+      i am a block
+
+    </blockquote>
+    <blockquote>
+      <p>
+        multi
+      </p>
+      <p>
+        line
+      </p>
+      <p>
+        block
+      </p>
+      
+
     </blockquote>
   </div>
 </DocumentFragment>

--- a/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
+++ b/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
@@ -191,6 +191,35 @@ exports[`basic 1`] = `
 </div>
 `;
 
+exports[`blockquote 1`] = `
+<div>
+  <div>
+     
+
+    <p>
+      And code blocks:
+    </p>
+    <blockquote>
+      i am a block
+
+    </blockquote>
+    <blockquote>
+      <p>
+        multi
+      </p>
+      <p>
+        line
+      </p>
+      <p>
+        block
+      </p>
+      
+
+    </blockquote>
+  </div>
+</div>
+`;
+
 exports[`code 1`] = `
 <div>
   <div>

--- a/clients/apps/web/src/components/Feed/Markdown/render-browser.test.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/render-browser.test.tsx
@@ -182,3 +182,38 @@ pie title Pets adopted by volunteers
   // @ts-ignore
   expect(asFragment()).toMatchSnapshot()
 })
+
+test('blockquote', async () => {
+  let asFragment
+
+  await act(() => {
+    const component = render(
+      <TestRenderer
+        article={{
+          ...article,
+          body: `
+
+And code blocks:
+
+<blockquote>
+i am a block
+</blockquote>
+
+<blockquote>
+multi
+
+line
+
+block
+</blockquote>
+
+`,
+        }}
+      />,
+    )
+    asFragment = component.asFragment
+  })
+
+  // @ts-ignore
+  expect(asFragment()).toMatchSnapshot()
+})

--- a/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
@@ -249,3 +249,32 @@ func main() {
   )
   expect(container).toMatchSnapshot()
 })
+
+test('blockquote', () => {
+  const { container } = render(
+    <TestRenderer
+      article={{
+        ...article,
+        body: `
+ 
+
+And code blocks:
+
+<blockquote>
+i am a block
+</blockquote>
+
+<blockquote>
+multi
+
+line
+
+block
+</blockquote>
+
+`,
+      }}
+    />,
+  )
+  expect(container).toMatchSnapshot()
+})

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0
       markdown-to-jsx:
-        specifier: ^7.4.1
-        version: 7.4.1(react@18.2.0)
+        specifier: 7.3.2
+        version: 7.3.2(react@18.2.0)
       mermaid:
         specifier: ^10.6.1
         version: 10.6.1
@@ -7206,7 +7206,7 @@ packages:
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
-      markdown-to-jsx: 7.4.1(react@18.2.0)
+      markdown-to-jsx: 7.3.2(react@18.2.0)
       memoizerific: 1.11.3
       polished: 4.2.2
       react: 18.2.0
@@ -15329,8 +15329,8 @@ packages:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
     dev: true
 
-  /markdown-to-jsx@7.4.1(react@18.2.0):
-    resolution: {integrity: sha512-GbrbkTnHp9u6+HqbPRFJbObi369AgJNXi/sGqq5HRsoZW063xR1XDCaConqq+whfEIAlzB1YPnOgsPc7B7bc/A==}
+  /markdown-to-jsx@7.3.2(react@18.2.0):
+    resolution: {integrity: sha512-B+28F5ucp83aQm+OxNrPkS8z0tMKaeHiy0lHJs3LqCyDQFtWuenaIrkaVTgAm1pf1AU85LXltva86hlaT17i8Q==}
     engines: {node: '>= 10'}
     peerDependencies:
       react: '>= 0.14.0'


### PR DESCRIPTION
Downgrade markdown-to-jsx as a workaround for issues with `<blockquote>` in Firefox.

The issue has been reported upstream https://github.com/quantizor/markdown-to-jsx/issues/542