### PR TITLE
server/github: handle deleted repo with same name

### DIFF
--- a/server/polar/integrations/github/tasks/webhook.py
+++ b/server/polar/integrations/github/tasks/webhook.py
@@ -480,6 +480,12 @@ async def repository_transferred(
                 repository.id, new_organization_id
             )
 
+        await service.github_repository.rename_deleted_repository_with_same_name(
+            session,
+            new_organization,
+            event.repository,
+        )
+
         repository.organization = new_organization
         # GitHub triggers the `installation_repositories.removed` event
         # from the source installation, so make sure it's not deleted


### PR DESCRIPTION
On a new installation of a repository, and on transferred repositories:

If there alredy exists a (deleted) repository with the same name as the new repository, rename the old repository so that the new one can use it's name.