### PR TITLE
Custom domains

### DIFF
--- a/clients/apps/web/next.config.js
+++ b/clients/apps/web/next.config.js
@@ -1,5 +1,9 @@
 const POLAR_AUTH_COOKIE_KEY = 'polar_session'
 
+const defaultHostname = process.env.NEXT_PUBLIC_API_URL
+  ? new URL(process.env.NEXT_PUBLIC_API_URL).hostname
+  : 'polar.sh'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -135,6 +139,12 @@ const nextConfig = {
             value: 'polar.new',
           },
         ],
+        has: [
+          {
+            type: 'host',
+            value: 'polar.sh',
+          },
+        ],
         permanent: false,
       },
 
@@ -268,6 +278,12 @@ const nextConfig = {
         source: '/posts',
         destination: '/feed',
         permanent: false,
+        has: [
+          {
+            type: 'host',
+            value: 'polar.sh',
+          },
+        ],
       },
 
       // Access tokens redirect

--- a/clients/apps/web/next.config.js
+++ b/clients/apps/web/next.config.js
@@ -142,7 +142,7 @@ const nextConfig = {
         has: [
           {
             type: 'host',
-            value: 'polar.sh',
+            value: defaultHostname,
           },
         ],
         permanent: false,
@@ -281,7 +281,7 @@ const nextConfig = {
         has: [
           {
             type: 'host',
-            value: 'polar.sh',
+            value: defaultHostname,
           },
         ],
       },

--- a/clients/apps/web/src/app/(topbar)/[organization]/(layout)/issues/page.tsx
+++ b/clients/apps/web/src/app/(topbar)/[organization]/(layout)/issues/page.tsx
@@ -4,8 +4,10 @@ import {
   urlSearchFromObj,
 } from '@/components/Organization/filters'
 import { getServerSideAPI } from '@/utils/api'
+import { redirectToCustomDomain } from '@/utils/nav'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import ClientPage from './ClientPage'
 
@@ -113,6 +115,8 @@ export default async function Page({
   if (!organization) {
     notFound()
   }
+
+  redirectToCustomDomain(organization, headers(), `/issues`)
 
   return <ClientPage organization={organization} issues={issues} />
 }

--- a/clients/apps/web/src/app/(topbar)/[organization]/(layout)/page.tsx
+++ b/clients/apps/web/src/app/(topbar)/[organization]/(layout)/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSideAPI } from '@/utils/api'
+import { redirectToCustomDomain } from '@/utils/nav'
 import {
   ListResourceArticle,
   ListResourceRepository,
@@ -8,6 +9,7 @@ import {
   ResponseError,
 } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import ClientPage from './ClientPage'
 
@@ -160,6 +162,8 @@ export default async function Page({
   } catch (e) {
     notFound()
   }
+
+  redirectToCustomDomain(organization, headers())
 
   const posts = [
     ...(pinnedArticles.items ?? []),

--- a/clients/apps/web/src/app/(topbar)/[organization]/(layout)/posts/[postSlug]/page.tsx
+++ b/clients/apps/web/src/app/(topbar)/[organization]/(layout)/posts/[postSlug]/page.tsx
@@ -1,6 +1,7 @@
 import PreviewText, { UnescapeText } from '@/components/Feed/Markdown/preview'
 import { getServerSideAPI } from '@/utils/api'
 import { firstImageUrlFromMarkdown } from '@/utils/markdown'
+import { redirectToCustomDomain } from '@/utils/nav'
 import {
   Article,
   ListResourceSubscriptionTier,
@@ -8,6 +9,7 @@ import {
   ResponseError,
 } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import ClientPage from './ClientPage'
 
@@ -165,6 +167,12 @@ export default async function Page({
   if (!article) {
     notFound()
   }
+
+  redirectToCustomDomain(
+    article.organization,
+    headers(),
+    `/posts/${article.slug}`,
+  )
 
   return (
     <ClientPage

--- a/clients/apps/web/src/app/(topbar)/[organization]/(layout)/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(topbar)/[organization]/(layout)/subscriptions/page.tsx
@@ -1,6 +1,8 @@
 import { getServerSideAPI } from '@/utils/api'
+import { redirectToCustomDomain } from '@/utils/nav'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import ClientPage from './ClientPage'
 
@@ -103,6 +105,8 @@ export default async function Page({
   if (!organization) {
     notFound()
   }
+
+  redirectToCustomDomain(organization, headers(), `/organization`)
 
   return (
     <ClientPage

--- a/clients/apps/web/src/components/Feed/Posts/Post.tsx
+++ b/clients/apps/web/src/components/Feed/Posts/Post.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { organizationPageLink } from '@/utils/nav'
 import { ArrowForward } from '@mui/icons-material'
 import { Article } from '@polar-sh/sdk'
 import { motion, useSpring, useTransform } from 'framer-motion'
@@ -18,7 +19,7 @@ type FeedPost = {
 }
 
 const articleHref = (art: Article): string => {
-  return `/${art.organization.name}/posts/${art.slug}`
+  return organizationPageLink(art.organization, `posts/${art.slug}`)
 }
 
 export const Post = (props: FeedPost) => {

--- a/clients/apps/web/src/components/Organization/OrganizationPublicPageNav.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationPublicPageNav.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { organizationPageLink } from '@/utils/nav'
 import { ArrowBackOutlined } from '@mui/icons-material'
 import { Organization } from '@polar-sh/sdk'
 import Link from 'next/link'
@@ -109,7 +110,7 @@ export const OrganizationPublicPageNav = ({
           className,
         )}
       >
-        <Link href={`/${organization.name}`}>
+        <Link href={organizationPageLink(organization)}>
           <TabsTrigger
             className={tabsTriggerClassName}
             value="overview"
@@ -119,7 +120,7 @@ export const OrganizationPublicPageNav = ({
           </TabsTrigger>
         </Link>
 
-        <Link href={`/${organization.name}/posts`}>
+        <Link href={organizationPageLink(organization, 'posts')}>
           <TabsTrigger
             className={tabsTriggerClassName}
             value="posts"
@@ -129,7 +130,7 @@ export const OrganizationPublicPageNav = ({
           </TabsTrigger>
         </Link>
 
-        <Link href={`/${organization.name}/subscriptions`}>
+        <Link href={organizationPageLink(organization, 'subscriptions')}>
           <TabsTrigger
             className={tabsTriggerClassName}
             value="subscriptions"
@@ -139,7 +140,7 @@ export const OrganizationPublicPageNav = ({
           </TabsTrigger>
         </Link>
 
-        <Link href={`/${organization.name}/issues`}>
+        <Link href={organizationPageLink(organization, 'issues')}>
           <TabsTrigger
             className={tabsTriggerClassName}
             value="issues"
@@ -149,7 +150,7 @@ export const OrganizationPublicPageNav = ({
           </TabsTrigger>
         </Link>
 
-        <Link href={`/${organization.name}/repositories`}>
+        <Link href={organizationPageLink(organization, 'repositories')}>
           <TabsTrigger
             className={tabsTriggerClassName}
             value="repositories"

--- a/clients/apps/web/src/middleware.ts
+++ b/clients/apps/web/src/middleware.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Custom domain name handlings
+export function middleware(request: NextRequest) {
+  let url = new URL(request.url)
+
+  // Unaffected by middleware
+  if (url.pathname.startsWith('/_next/')) {
+    return
+  }
+  if (url.pathname.startsWith('/api/')) {
+    return
+  }
+
+  // Get hostname from request or x-forwarded-host header
+  let hostname = url.hostname
+  const forwardedHost = request.headers.get('x-forwarded-host')
+  if (forwardedHost) {
+    hostname = forwardedHost.split(':')[0]
+  }
+
+  // Test custom domains
+  // TODO: move this to a API lookup
+  const mapping: Record<string, string> = {
+    'dev.forfunc.com': 'zegl',
+    'zegl.forfunc.com': 'zegl',
+  }
+
+  if (!mapping[hostname]) {
+    return
+  }
+
+  const orgname = mapping[hostname]
+
+  const strictMatches = ['/']
+
+  const allowedPrefixes = [
+    '/posts',
+    '/subscriptions',
+    '/issues',
+    '/repositories',
+  ]
+
+  // Rewrite strict matches
+  if (strictMatches.includes(url.pathname)) {
+    return NextResponse.rewrite(
+      new URL(`/${orgname}${url.pathname}`, request.url),
+    )
+  }
+
+  // Rewrite prefix matches
+  for (const prefix of allowedPrefixes) {
+    if (url.pathname.startsWith(prefix)) {
+      return NextResponse.rewrite(
+        new URL(`/${orgname}${url.pathname}`, request.url),
+      )
+    }
+  }
+
+  // This page falls outside of the scope of this custom domain.
+  // For example if trying to access /faq or /ORGNAME
+  // Redirect to the polar.sh version
+  return NextResponse.redirect(new URL(url.pathname, 'https://polar.sh/'))
+}

--- a/clients/apps/web/src/middleware.ts
+++ b/clients/apps/web/src/middleware.ts
@@ -60,5 +60,10 @@ export function middleware(request: NextRequest) {
   // This page falls outside of the scope of this custom domain.
   // For example if trying to access /faq or /ORGNAME
   // Redirect to the polar.sh version
-  return NextResponse.redirect(new URL(url.pathname, 'https://polar.sh/'))
+  return NextResponse.redirect(
+    new URL(
+      url.pathname,
+      process.env.NEXT_PUBLIC_FRONTEND_BASE_URL ?? 'https://polar.sh',
+    ),
+  )
 }

--- a/clients/apps/web/src/utils/nav.ts
+++ b/clients/apps/web/src/utils/nav.ts
@@ -1,0 +1,37 @@
+import { Organization } from '@polar-sh/sdk'
+import { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers'
+import { redirect } from 'next/navigation'
+import { CONFIG } from 'polarkit/config'
+
+export const organizationPageLink = (
+  org: Organization,
+  path?: string,
+): string => {
+  if (org.custom_domain) {
+    if (process.env.NODE_ENV === 'production') {
+      return `https://${org.custom_domain}/${path ?? ''}`
+    }
+    return `http://${org.custom_domain}/${path ?? ''}`
+  }
+
+  return `${CONFIG.FRONTEND_BASE_URL}/${org.name}/${path ?? ''}`
+}
+
+export const redirectToCustomDomain = (
+  org: Organization,
+  headers: ReadonlyHeaders,
+  path?: string,
+) => {
+  if (!org.custom_domain) {
+    return
+  }
+
+  const requestHost = headers.get('host')
+  if (!requestHost) {
+    return
+  }
+
+  if (requestHost !== org.custom_domain) {
+    redirect(organizationPageLink(org, path))
+  }
+}

--- a/clients/packages/sdk/src/client/apis/OrganizationsApi.ts
+++ b/clients/packages/sdk/src/client/apis/OrganizationsApi.ts
@@ -55,6 +55,7 @@ export interface OrganizationsApiListMembersRequest {
 export interface OrganizationsApiLookupRequest {
     platform?: Platforms;
     organizationName?: string;
+    customDomain?: string;
 }
 
 export interface OrganizationsApiSearchRequest {
@@ -329,6 +330,10 @@ export class OrganizationsApi extends runtime.BaseAPI {
 
         if (requestParameters.organizationName !== undefined) {
             queryParameters['organization_name'] = requestParameters.organizationName;
+        }
+
+        if (requestParameters.customDomain !== undefined) {
+            queryParameters['custom_domain'] = requestParameters.customDomain;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/clients/packages/sdk/src/client/models/index.ts
+++ b/clients/packages/sdk/src/client/models/index.ts
@@ -4280,6 +4280,12 @@ export interface Organization {
      */
     has_app_installed: boolean;
     /**
+     * 
+     * @type {string}
+     * @memberof Organization
+     */
+    custom_domain?: string;
+    /**
      * Where to send emails about payments for pledegs that this organization/team has made. Only visible for members of the organization
      * @type {string}
      * @memberof Organization

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -1,32 +1,25 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": [
-    "**/.env.*local"
-  ],
+  "globalDependencies": ["**/.env.*local"],
   "globalEnv": [
+    "NODE_ENV",
     "NEXT_PUBLIC_API_URL",
     "NEXT_PUBLIC_STRIPE_KEY",
     "NEXT_PUBLIC_CODESPACE_NAME",
+    "NEXT_PUBLIC_FRONTEND_BASE_URL",
     "NEXT_PUBLIC_GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN",
     "NEXT_PUBLIC_CODESPACE_NAME",
     "NEXT_PUBLIC_GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"
   ],
   "pipeline": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        ".next/**",
-        "dist/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "dist/**"]
     },
     "lint": {},
     "test": {},
     "dev": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
Support much of the read-only experience with custom domains.

Organization pages with posts, subscriptions, and issues is browsable.

Client-side fetching of data does not work yet (pending CORS improvements on the server).

The repository pages are not yet routable.

Updates #2632