### PR TITLE
astro: ensure client doesn't throw

### DIFF
--- a/clients/packages/astro/src/upload.ts
+++ b/clients/packages/astro/src/upload.ts
@@ -316,7 +316,7 @@ export class PolarUploadBuilder<
 			| ((value: PolarUploadResult) => TResult1 | PromiseLike<TResult1>)
 			| null
 			| undefined,
-		onrejected?:
+		_onrejected?:
 			| ((reason: PolarUploadResult) => TResult2 | PromiseLike<TResult2>)
 			| null
 			| undefined
@@ -324,20 +324,20 @@ export class PolarUploadBuilder<
 		// Find organization
 		const orgResult = await this.getOrganization();
 		if (orgResult.error) {
-			if (onrejected) {
-				return onrejected(orgResult);
+			if (onfulfilled) {
+				return onfulfilled(orgResult);
 			}
-			return Promise.reject(orgResult);
+			return orgResult as TResult1;
 		}
 		const org = orgResult.data;
 
 		// Fetch articles
 		const articlesResult = await this.getArticles();
 		if (articlesResult.error) {
-			if (onrejected) {
-				return onrejected(articlesResult);
+			if (onfulfilled) {
+				return onfulfilled(articlesResult);
 			}
-			return Promise.reject(articlesResult);
+			return articlesResult as TResult1;
 		}
 		const articles = articlesResult.data;
 
@@ -385,10 +385,10 @@ export class PolarUploadBuilder<
 			}
 		}
 		if (errors.length > 0) {
-			if (onrejected) {
-				return onrejected({ data: null, error: new ErrorGroup(errors) });
+			if (onfulfilled) {
+				return onfulfilled({ data: null, error: new ErrorGroup(errors) });
 			}
-			return Promise.reject({ data: null, error: new ErrorGroup(errors) });
+			return { data: null, error: new ErrorGroup(errors) } as TResult1;
 		}
 
 		const created: Article[] = [];

--- a/clients/packages/astro/src/upload.ts
+++ b/clients/packages/astro/src/upload.ts
@@ -19,7 +19,14 @@
  * This is inspired by the [Supabase Client](https://supabase.com/docs/reference/javascript/select),
  * which uses a similar pattern for building queries.
  */
-import type { Article, ArticleCreate, ArticleUpdate, Organization, PolarAPI } from '@polar-sh/sdk';
+import {
+	ResponseError,
+	type Article,
+	type ArticleCreate,
+	type ArticleUpdate,
+	type Organization,
+	type PolarAPI,
+} from '@polar-sh/sdk';
 import { ErrorGroup, PolarUploadError, type AstroCollectionEntry, type PolarResult } from './types';
 
 /**
@@ -162,23 +169,30 @@ export class PolarUploadBuilder<
 			});
 			return { data: response, error: null };
 		} catch (error) {
+			if (error instanceof ResponseError) {
+				return {
+					data: null,
+					error: new PolarUploadError(await error.response.text(), error.response.status, {
+						cause: error,
+					}),
+				};
+			}
 			if (error instanceof Error) {
 				return {
 					data: null,
 					error: new PolarUploadError(error.message, 500, { cause: error }),
 				};
-			} else {
-				return {
-					data: null,
-					error: new PolarUploadError(
-						'An unknown error occurred while fetching the organization. Does it exist?',
-						500,
-						{
-							cause: error,
-						}
-					),
-				};
 			}
+			return {
+				data: null,
+				error: new PolarUploadError(
+					`An unknown error occurred while fetching organization: ${this.options.organizationName}`,
+					500,
+					{
+						cause: error,
+					}
+				),
+			};
 		}
 	}
 
@@ -260,19 +274,30 @@ export class PolarUploadBuilder<
 			});
 			return { data: response, error: null };
 		} catch (error) {
+			if (error instanceof ResponseError) {
+				return {
+					data: null,
+					error: new PolarUploadError(await error.response.text(), error.response.status, {
+						cause: error,
+					}),
+				};
+			}
 			if (error instanceof Error) {
 				return {
 					data: null,
 					error: new PolarUploadError(error.message, 500, { cause: error }),
 				};
-			} else {
-				return {
-					data: null,
-					error: new PolarUploadError('An unknown error occurred.', 500, {
-						cause: error,
-					}),
-				};
 			}
+			return {
+				data: null,
+				error: new PolarUploadError(
+					`An unknown error occurred while creating article with slug: ${article.slug}`,
+					500,
+					{
+						cause: error,
+					}
+				),
+			};
 		}
 	}
 
@@ -290,19 +315,30 @@ export class PolarUploadBuilder<
 			});
 			return { data: response, error: null };
 		} catch (error) {
+			if (error instanceof ResponseError) {
+				return {
+					data: null,
+					error: new PolarUploadError(await error.response.text(), error.response.status, {
+						cause: error,
+					}),
+				};
+			}
 			if (error instanceof Error) {
 				return {
 					data: null,
 					error: new PolarUploadError(error.message, 500, { cause: error }),
 				};
-			} else {
-				return {
-					data: null,
-					error: new PolarUploadError('An unknown error occurred.', 500, {
-						cause: error,
-					}),
-				};
 			}
+			return {
+				data: null,
+				error: new PolarUploadError(
+					`An unknown error occurred while updating article with ID: ${articleId}`,
+					500,
+					{
+						cause: error,
+					}
+				),
+			};
 		}
 	}
 


### PR DESCRIPTION
The `PolarUploadBuilder` class should never throw an error. This PR fixes some undesirable behaviour where it would throw an incorrectly-instantiated error.

Also use `onfulfilled` to ensure the promise always completes and doesn't throw that way.