### PR TITLE
clients/auth: use a react context instead of zustand

### DIFF
--- a/clients/apps/web/src/app/maintainer/new/page.tsx
+++ b/clients/apps/web/src/app/maintainer/new/page.tsx
@@ -12,15 +12,15 @@ import { Button } from 'polarkit/components/ui/atoms'
 import { useCallback, useEffect } from 'react'
 
 export default function Page() {
-  const { authenticated, hasChecked } = useAuth()
+  const { authenticated } = useAuth()
   const router = useRouter()
 
   useEffect(() => {
-    if (!authenticated && hasChecked) {
+    if (!authenticated) {
       router.push(`/signup/maintainer`)
       return
     }
-  }, [router, authenticated, hasChecked])
+  }, [router, authenticated])
 
   const steps = [
     {

--- a/clients/apps/web/src/app/maintainer/page.tsx
+++ b/clients/apps/web/src/app/maintainer/page.tsx
@@ -13,7 +13,7 @@ import { useListAdminOrganizations } from 'polarkit/hooks'
 import { useCallback, useEffect } from 'react'
 
 export default function Page() {
-  const { authenticated, hasChecked, currentUser, reloadUser } = useAuth()
+  const { authenticated, currentUser, reloadUser } = useAuth()
   const listOrganizationsQuery = useListAdminOrganizations()
   const personalOrg = usePersonalOrganization()
 
@@ -30,7 +30,7 @@ export default function Page() {
   }, [])
 
   useEffect(() => {
-    if (!authenticated && hasChecked) {
+    if (!authenticated) {
       router.push(`/signup/maintainer`)
       return
     }
@@ -40,7 +40,7 @@ export default function Page() {
     )
 
     // If user does not have github account connected
-    if (hasChecked && authenticated && !gitHubAccount) {
+    if (authenticated && !gitHubAccount) {
       router.push('/feed')
       return
     }
@@ -52,14 +52,7 @@ export default function Page() {
       router.push(`/maintainer/${personalOrg.name}/overview`)
       return
     }
-  }, [
-    listOrganizationsQuery,
-    orgs,
-    router,
-    authenticated,
-    hasChecked,
-    currentUser,
-  ])
+  }, [listOrganizationsQuery, orgs, router, authenticated, currentUser])
 
   const steps = [
     {

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -105,13 +105,7 @@ const DashboardSidebar = () => {
 }
 
 const DashboardLayout = (props: PropsWithChildren<{ className?: string }>) => {
-  const { hydrated } = useAuth()
-
   const layoutContext = useDashboardLayoutContext()
-
-  if (!hydrated) {
-    return <></>
-  }
 
   const marginTop = layoutContext.isMD ? layoutContext.topbarHeight || 80 : 0
 

--- a/clients/apps/web/src/components/Navigation/DashboardTopbar.tsx
+++ b/clients/apps/web/src/components/Navigation/DashboardTopbar.tsx
@@ -80,7 +80,6 @@ const DashboardTopbar = ({
   const { org: currentOrgFromURL } = useCurrentOrgAndRepoFromURL()
   const personalOrg = usePersonalOrganization()
 
-  const { hydrated } = useAuth()
   const isOrgAdmin = useIsOrganizationAdmin(currentOrgFromURL)
   const isPersonal = currentOrgFromURL?.name === personalOrg?.name
 
@@ -146,10 +145,6 @@ const DashboardTopbar = ({
     setDomNode(target)
     propagateHeight(target)
   }, [])
-
-  if (!hydrated) {
-    return <></>
-  }
 
   return (
     <>

--- a/clients/apps/web/src/hooks/team.ts
+++ b/clients/apps/web/src/hooks/team.ts
@@ -4,17 +4,12 @@ import { useEffect, useState } from 'react'
 import { useAuth } from './auth'
 
 export const useListTeams = () => {
-  const { currentUser, hydrated } = useAuth()
+  const { currentUser } = useAuth()
   const allOrganizations = useListAllOrganizations()
 
   const [teams, setTeams] = useState<Organization[]>([])
 
   useEffect(() => {
-    if (!hydrated) {
-      setTeams([])
-      return
-    }
-
     // Kind of a hack.
     // Filter out the users own organization if it exists.
     // This organiztaion can not have extra members, and can not be a "Team".
@@ -23,7 +18,7 @@ export const useListTeams = () => {
       .filter((o) => o.is_teams_enabled)
 
     setTeams(allTeams)
-  }, [allOrganizations.data, currentUser, hydrated])
+  }, [allOrganizations.data, currentUser])
 
   return teams
 }

--- a/clients/apps/web/src/providers/auth.tsx
+++ b/clients/apps/web/src/providers/auth.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { UserRead } from '@polar-sh/sdk'
+import React from 'react'
+
+export type AuthContextValue = {
+  user?: UserRead
+}
+
+export const AuthContext = React.createContext<AuthContextValue | undefined>(
+  undefined,
+)
+
+export const UserContextProvider = ({
+  user,
+  children,
+}: {
+  user: AuthContextValue
+  children: React.ReactNode
+}) => {
+  return <AuthContext.Provider value={user}>{children}</AuthContext.Provider>
+}

--- a/clients/packages/polarkit/src/store/index.ts
+++ b/clients/packages/polarkit/src/store/index.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 import { CONFIG } from '../config'
 import { FormDraftSlice, createFormDraftSlice } from './formDraftSlice'
-import { UserSlice, UserState, createUserSlice } from './userContext'
+import { UserSlice, createUserSlice } from './userContext'
 
 // https://docs.pmnd.rs/zustand/guides/typescript#slices-pattern
 const useStore = create<UserSlice & FormDraftSlice>()(
@@ -17,8 +17,6 @@ const useStore = create<UserSlice & FormDraftSlice>()(
         version: CONFIG.LOCALSTORAGE_PERSIST_VERSION,
         partialize: (state) => ({
           // From UserSlice
-          authenticated: state.authenticated,
-          currentUser: state.currentUser,
           onboardingDashboardSkip: state.onboardingDashboardSkip,
           onboardingDashboardInstallChromeExtensionSkip:
             state.onboardingDashboardInstallChromeExtensionSkip,
@@ -32,4 +30,4 @@ const useStore = create<UserSlice & FormDraftSlice>()(
 )
 
 export { useStore }
-export type { UserSlice, UserState }
+export type { UserSlice }

--- a/clients/packages/polarkit/src/store/userContext.ts
+++ b/clients/packages/polarkit/src/store/userContext.ts
@@ -1,16 +1,5 @@
-import { Pledge, ResponseError, type UserRead } from '@polar-sh/sdk'
+import { Pledge } from '@polar-sh/sdk'
 import { StateCreator } from 'zustand'
-import { api } from '../api'
-
-export interface UserState {
-  authenticated: boolean
-  currentUser: UserRead | undefined
-  login: (callback?: (authenticated: boolean) => void) => {
-    request: Promise<UserRead>
-    controller: AbortController
-  }
-  logout: () => Promise<any>
-}
 
 export interface OnboardingState {
   onboardingDashboardSkip: boolean
@@ -35,7 +24,7 @@ export interface LastPledgeState {
   setLatestPledgeShown: (shown: boolean) => void
 }
 
-export interface UserSlice extends UserState, OnboardingState, LastPledgeState {
+export interface UserSlice extends OnboardingState, LastPledgeState {
   resetState: () => void
 }
 
@@ -51,38 +40,6 @@ const emptyState = {
 
 export const createUserSlice: StateCreator<UserSlice> = (set, get) => ({
   ...emptyState,
-  login: (
-    callback?: (authenticated: boolean) => void,
-  ): { request: Promise<UserRead>; controller: AbortController } => {
-    const controller = new AbortController()
-    const request = api.users.getAuthenticated({ signal: controller.signal })
-    request
-      .then((user) => {
-        set({ authenticated: true, currentUser: user })
-        if (callback) {
-          callback(true)
-        }
-      })
-      .catch((err) => {
-        if (err instanceof ResponseError) {
-          if (err.response.status === 401) {
-            set({ authenticated: false, currentUser: undefined })
-            if (callback) {
-              callback(false)
-            }
-          }
-        }
-      })
-
-    return { request, controller }
-  },
-  logout: (): Promise<any> => {
-    const request = api.users.logout()
-    request.finally(() => {
-      get().resetState()
-    })
-    return request
-  },
   setOnboardingDashboardSkip: (skip: boolean) => {
     set({
       onboardingDashboardSkip: skip,


### PR DESCRIPTION
Makes the cookie the only source of truth, and removes clientside flashes as the client was loading user data