### PR TITLE
clients/public: redirect public pages to the canonical spelling of org names

### DIFF
--- a/clients/apps/web/src/app/[organization]/(sidebar)/issues/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/issues/page.tsx
@@ -4,7 +4,7 @@ import {
   urlSearchFromObj,
 } from '@/components/Organization/filters'
 import { getServerSideAPI } from '@/utils/api'
-import { redirectToCustomDomain } from '@/utils/nav'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { headers } from 'next/headers'
@@ -116,7 +116,12 @@ export default async function Page({
     notFound()
   }
 
-  redirectToCustomDomain(organization, headers(), `/issues`)
+  redirectToCanonicalDomain({
+    organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+    subPath: `/issues`,
+  })
 
   return <ClientPage organization={organization} issues={issues} />
 }

--- a/clients/apps/web/src/app/[organization]/(sidebar)/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/page.tsx
@@ -1,5 +1,5 @@
 import { getServerSideAPI } from '@/utils/api'
-import { redirectToCustomDomain } from '@/utils/nav'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import {
   ListResourceArticle,
   ListResourceIssueFunding,
@@ -213,7 +213,11 @@ export default async function Page({
     notFound()
   }
 
-  redirectToCustomDomain(organization, headers())
+  redirectToCanonicalDomain({
+    organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+  })
 
   const posts = [
     ...(pinnedArticles.items ?? []),

--- a/clients/apps/web/src/app/[organization]/(sidebar)/posts/[postSlug]/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/posts/[postSlug]/page.tsx
@@ -1,7 +1,7 @@
 import PreviewText, { UnescapeText } from '@/components/Feed/Markdown/preview'
 import { getServerSideAPI } from '@/utils/api'
 import { firstImageUrlFromMarkdown } from '@/utils/markdown'
-import { redirectToCustomDomain } from '@/utils/nav'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import {
   Article,
   ListResourceSubscriptionTier,
@@ -168,11 +168,12 @@ export default async function Page({
     notFound()
   }
 
-  redirectToCustomDomain(
-    article.organization,
-    headers(),
-    `/posts/${article.slug}`,
-  )
+  redirectToCanonicalDomain({
+    organization: article.organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+    subPath: `/posts/${article.slug}`,
+  })
 
   return (
     <ClientPage

--- a/clients/apps/web/src/app/[organization]/(sidebar)/posts/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/posts/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSideAPI } from '@/utils/api'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import {
   ListResourceArticle,
   Organization,
@@ -6,6 +7,7 @@ import {
   ResponseError,
 } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import ClientPage from './ClientPage'
 
@@ -133,6 +135,13 @@ export default async function Page({
   } catch (e) {
     notFound()
   }
+
+  redirectToCanonicalDomain({
+    organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+    subPath: '/posts',
+  })
 
   return (
     <ClientPage

--- a/clients/apps/web/src/app/[organization]/(sidebar)/repositories/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/repositories/page.tsx
@@ -1,6 +1,8 @@
 import { getServerSideAPI } from '@/utils/api'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import { ClientPage } from './ClientPage'
 
@@ -107,6 +109,13 @@ export default async function Page({
   if (!organization) {
     notFound()
   }
+
+  redirectToCanonicalDomain({
+    organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+    subPath: '/repositories',
+  })
 
   return (
     <ClientPage

--- a/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
@@ -1,5 +1,5 @@
 import { getServerSideAPI } from '@/utils/api'
-import { redirectToCustomDomain } from '@/utils/nav'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import { Organization, Platforms, ResponseError } from '@polar-sh/sdk'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { headers } from 'next/headers'
@@ -106,7 +106,12 @@ export default async function Page({
     notFound()
   }
 
-  redirectToCustomDomain(organization, headers(), `/organization`)
+  redirectToCanonicalDomain({
+    organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+    subPath: '/subscriptions',
+  })
 
   return (
     <ClientPage

--- a/clients/apps/web/src/app/[organization]/[repo]/ClientPage.tsx
+++ b/clients/apps/web/src/app/[organization]/[repo]/ClientPage.tsx
@@ -4,7 +4,6 @@ import IssuesLookingForFunding from '@/components/Organization/IssuesLookingForF
 import { useTrafficRecordPageView } from '@/utils/traffic'
 import { ArrowUpRightIcon } from '@heroicons/react/20/solid'
 import {
-  ListResourceArticle,
   ListResourceIssueFunding,
   Organization,
   Repository,
@@ -23,8 +22,6 @@ const ClientPage = ({
   organization: Organization
   repository: Repository
   issuesFunding: ListResourceIssueFunding
-  articles: ListResourceArticle
-  pinnedArticles: ListResourceArticle
 }) => {
   useTrafficRecordPageView({ organization })
 

--- a/clients/apps/web/src/app/[organization]/subscribe/page.tsx
+++ b/clients/apps/web/src/app/[organization]/subscribe/page.tsx
@@ -1,5 +1,5 @@
 import { getServerSideAPI } from '@/utils/api'
-import { redirectToCustomDomain } from '@/utils/nav'
+import { redirectToCanonicalDomain } from '@/utils/nav'
 import {
   ListResourceSubscriptionTier,
   Organization,
@@ -126,7 +126,12 @@ export default async function Page({
     notFound()
   }
 
-  redirectToCustomDomain(organization, headers())
+  redirectToCanonicalDomain({
+    organization,
+    paramOrganizationName: params.organization,
+    headers: headers(),
+    subPath: `/subscribe`,
+  })
 
   return (
     <ClientPage

--- a/clients/apps/web/src/middleware.ts
+++ b/clients/apps/web/src/middleware.ts
@@ -11,6 +11,9 @@ export async function middleware(request: NextRequest) {
   if (url.pathname.startsWith('/_next/')) {
     return
   }
+  if (url.pathname.startsWith('/favicon.ico')) {
+    return
+  }
 
   // Proxy API requests to the Python API
   // Used on custom domains

--- a/clients/apps/web/src/utils/nav.ts
+++ b/clients/apps/web/src/utils/nav.ts
@@ -4,22 +4,32 @@ import { redirect } from 'next/navigation'
 import { NextRequest } from 'next/server'
 import { organizationPageLink } from 'polarkit/utils/nav'
 
-export const redirectToCustomDomain = (
-  org: Organization,
-  headers: ReadonlyHeaders,
-  path?: string,
-) => {
-  if (!org.custom_domain) {
-    return
+export const redirectToCanonicalDomain = ({
+  organization,
+  paramOrganizationName,
+  headers,
+  subPath,
+}: {
+  organization: Organization
+  paramOrganizationName: string
+  headers: ReadonlyHeaders
+  subPath?: string
+}) => {
+  // Redirect to custom domain.
+  // Example: polar.sh/zegl -> zegl.se
+  if (organization.custom_domain) {
+    const requestHost = headers.get('host')
+    if (!requestHost) {
+      return
+    }
+    if (requestHost !== organization.custom_domain) {
+      redirect(organizationPageLink(organization, subPath))
+    }
   }
 
-  const requestHost = headers.get('host')
-  if (!requestHost) {
-    return
-  }
-
-  if (requestHost !== org.custom_domain) {
-    redirect(organizationPageLink(org, path))
+  // Redirect to canonical spelling of org name
+  if (paramOrganizationName !== organization.name) {
+    redirect(`/${organization.name}${subPath ?? ''}`)
   }
 }
 


### PR DESCRIPTION
Org lookups are case-insensitive, redirect to the correct spelling if there's a difference