### PR TITLE
server/users: move away from user.username

### DIFF
--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -157,7 +157,7 @@ class AccountService(ResourceService[Account, AccountCreate, AccountUpdate]):
         await session.refresh(account, {"users", "organizations"})
         associations = []
         for user in account.users:
-            associations.append(f"user/{user.username}")
+            associations.append(f"user/{user.username_or_email}")
         for organization in account.organizations:
             associations.append(f"org/{organization.name}")
         return "·".join(associations)

--- a/server/polar/article/schemas.py
+++ b/server/polar/article/schemas.py
@@ -115,7 +115,7 @@ class Article(Schema):
             )
         if i.byline == i.Byline.user:
             byline = Byline(
-                name=i.created_by_user.username,
+                name=i.created_by_user.public_name,
                 avatar_url=i.created_by_user.avatar_url,
             )
 

--- a/server/polar/article/tasks.py
+++ b/server/polar/article/tasks.py
@@ -90,7 +90,7 @@ async def articles_send_to_user(
                     "Reply-To"
                 ] = f"{from_name} <{article.organization.email}>"
         else:
-            from_name = article.created_by_user.username
+            from_name = article.created_by_user.public_name
             if article.created_by_user.email:
                 email_headers[
                     "Reply-To"

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -155,7 +155,8 @@ class Auth:
         if Scope.web_default not in scoped_subject.scopes:
             raise Unauthorized("This endpoint does not support scoped auth tokens")
 
-        if scoped_subject.subject.username not in allowed:
+        username = scoped_subject.subject.github_username
+        if not username or username not in allowed:
             raise HTTPException(
                 status_code=404,
                 detail="Not Found",

--- a/server/polar/backoffice/endpoints.py
+++ b/server/polar/backoffice/endpoints.py
@@ -210,7 +210,7 @@ async def manage_badge(
     log.info(
         "backoffice.badge",
         badge=badge.model_dump(mode="json"),
-        admin=auth.user.username,
+        admin=auth.user.email,
     )
 
     org = await organization_service.get_by_name(

--- a/server/polar/integrations/github/service/issue.py
+++ b/server/polar/integrations/github/service/issue.py
@@ -724,9 +724,11 @@ class GithubIssueService(IssueService):
         # concurrently crawl each repository
         jobs: list[Awaitable[list[Issue]]] = []
 
+        self_github_username = user.github_username
+
         for r in starred.parsed_data:
             # skip self owned repos
-            if r.owner.login == user.username:
+            if r.owner.login == self_github_username:
                 continue
             if r.private:
                 continue

--- a/server/polar/integrations/github/service/user.py
+++ b/server/polar/integrations/github/service/user.py
@@ -84,7 +84,7 @@ class GithubUserService(UserService):
             .join(OAuthAccount, User.id == OAuthAccount.user_id)
             .where(
                 OAuthAccount.platform == OAuthPlatform.github,
-                User.username == username,
+                OAuthAccount.account_username == username,
             )
         )
         res = await session.execute(stmt)

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -81,7 +81,7 @@ class StripeService:
             issue_id=pledge_issue.id,
             issue_title=pledge_issue.title,
             user_id=user.id,
-            user_username=user.username,
+            user_username=user.username_or_email,
             user_email=user.email,
         )
 
@@ -110,7 +110,7 @@ class StripeService:
             issue_id=issue.id,
             issue_title=issue.title,
             user_id=user.id,
-            user_username=user.username,
+            user_username=user.username_or_email,
             user_email=user.email,
             organization_id=organization.id,
             organization_name=organization.name,

--- a/server/polar/models/account.py
+++ b/server/polar/models/account.py
@@ -107,7 +107,7 @@ class Account(RecordModel):
     def get_associations_names(self) -> list[str]:
         associations_names: list[str] = []
         for user in self.users:
-            associations_names.append(user.username)
+            associations_names.append(user.username_or_email)
         for organization in self.organizations:
             associations_names.append(organization.name)
         return associations_names

--- a/server/polar/pledge/schemas.py
+++ b/server/polar/pledge/schemas.py
@@ -33,8 +33,8 @@ class Pledger(Schema):
 
         if p.user:
             return cls(
-                name=p.user.username,
-                github_username=p.user.username,
+                name=p.user.username_or_email,
+                github_username=p.user.github_username,
                 avatar_url=p.user.avatar_url,
             )
 
@@ -50,8 +50,8 @@ class Pledger(Schema):
     @classmethod
     def from_user(cls, user: User) -> Self:
         return cls(
-            name=user.username,
-            github_username=user.username,
+            name=user.username_or_email,
+            github_username=user.github_username,
             avatar_url=user.avatar_url,
         )
 

--- a/server/polar/pledge/service.py
+++ b/server/polar/pledge/service.py
@@ -487,7 +487,7 @@ class PledgeService(ResourceServiceReader[Pledge]):
             issue_org_name=org.name,
             issue_repo_name=repo.name,
             issue_number=issue.number,
-            team_member_name=created_by_user.username,
+            team_member_name=created_by_user.username_or_email,
             team_name=pledging_org.name,
             pledge_id=pledge.id,
         )

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -138,13 +138,16 @@ async def create_issue(
     return issue
 
 
-@pytest_asyncio.fixture(scope="function")
-async def user_github_oauth(save_fixture: SaveFixture, user: User) -> OAuthAccount:
+async def create_user_github_oauth(
+    save_fixture: SaveFixture,
+    user: User,
+) -> OAuthAccount:
     oauth_account = OAuthAccount(
         platform=Platforms.github,
         access_token="xxyyzz",
         account_id="xxyyzz",
         account_email="foo@bar.com",
+        account_username=rstr("gh_username"),
         user_id=user.id,
     )
     await save_fixture(oauth_account)
@@ -152,14 +155,24 @@ async def user_github_oauth(save_fixture: SaveFixture, user: User) -> OAuthAccou
 
 
 @pytest_asyncio.fixture(scope="function")
-async def user(save_fixture: SaveFixture) -> User:
+async def user_github_oauth(
+    save_fixture: SaveFixture,
+    user: User,
+) -> OAuthAccount:
+    return await create_user_github_oauth(save_fixture, user)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def user(
+    save_fixture: SaveFixture,
+) -> User:
     return await create_user(save_fixture)
 
 
 async def create_user(save_fixture: SaveFixture) -> User:
     user = User(
         id=uuid.uuid4(),
-        username=rstr("testuser"),
+        username=rstr("DEPRECATED_testuser"),
         email=rstr("test") + "@example.com",
         avatar_url="https://avatars.githubusercontent.com/u/47952?v=4",
     )
@@ -171,7 +184,7 @@ async def create_user(save_fixture: SaveFixture) -> User:
 async def user_second(save_fixture: SaveFixture) -> User:
     user = User(
         id=uuid.uuid4(),
-        username=rstr("testuser"),
+        username=rstr("DEPRECATED_testuser"),
         email=rstr("test") + "@example.com",
         avatar_url="https://avatars.githubusercontent.com/u/47952?v=4",
     )

--- a/server/tests/pledge/test_service.py
+++ b/server/tests/pledge/test_service.py
@@ -594,6 +594,7 @@ async def test_create_issue_rewards_associate_username(
         access_token="access_token",
         account_id="1337",
         account_email="test_gh_user@polar.sh",
+        account_username="test_gh_user",
     )
     await save_fixture(oauth)
 

--- a/server/tests/reward/test_service.py
+++ b/server/tests/reward/test_service.py
@@ -116,15 +116,13 @@ async def test_list_rewards_to_user(
     repository: Repository,
     user: User,
 ) -> None:
-    user.username = "test_gh_user"
-    await save_fixture(user)
-
     oauth = OAuthAccount(
         platform=Platforms.github,
         user_id=user.id,
         access_token="access_token",
         account_id="1337",
         account_email="test_gh_user@polar.sh",
+        account_username="test_gh_user",
     )
     await save_fixture(oauth)
 


### PR DESCRIPTION
Use user.username_or_email or user.github_username (or similar) to get this data instead

This does not change anything in the wild, as the username field can contain email adresses