### PR TITLE
Post-commit era - Stage 1 - Remove from tests

### DIFF
--- a/server/polar/kit/db/models/base.py
+++ b/server/polar/kit/db/models/base.py
@@ -46,3 +46,9 @@ class RecordModel(TimestampedModel):
     id: MappedColumn[UUID] = mapped_column(
         PostgresUUID, primary_key=True, default=generate_uuid
     )
+
+    def __eq__(self, __value: object) -> bool:
+        return isinstance(__value, self.__class__) and self.id == __value.id
+
+    def __hash__(self) -> int:
+        return self.id.int

--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -21,13 +21,7 @@ def create_engine(
 
 
 def create_sessionmaker(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
-    return async_sessionmaker(
-        engine,
-        autocommit=False,
-        autoflush=False,
-        expire_on_commit=False,
-        class_=AsyncSession,
-    )
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 
 __all__ = [

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -40,11 +40,11 @@ async def get_db_session(
     async with sessionmaker() as session:
         try:
             yield session
-        except Exception as e:
+        except:
             await session.rollback()
-            raise e
-        finally:
-            await session.close()
+            raise
+        else:
+            await session.commit()
 
 
 __all__ = [

--- a/server/polar/worker.py
+++ b/server/polar/worker.py
@@ -271,7 +271,13 @@ def interval(
 async def AsyncSessionMaker(ctx: JobContext) -> AsyncIterator[AsyncSession]:
     """Helper to open an AsyncSession context manager from the job context."""
     async with ctx["sessionmaker"]() as session:
-        yield session
+        try:
+            yield session
+        except:
+            await session.rollback()
+            raise
+        else:
+            await session.commit()
 
 
 __all__ = [

--- a/server/tests/account/conftest.py
+++ b/server/tests/account/conftest.py
@@ -1,10 +1,10 @@
 from polar.enums import AccountType
 from polar.models import Account, User
-from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 
 
 async def create_account(
-    session: AsyncSession, *, admin: User, status: Account.Status
+    save_fixture: SaveFixture, *, admin: User, status: Account.Status
 ) -> Account:
     account = Account(
         account_type=AccountType.stripe,
@@ -16,7 +16,5 @@ async def create_account(
         is_charges_enabled=True,
         is_payouts_enabled=True,
     )
-    session.add(account)
-    await session.commit()
-    session.expunge_all()
+    await save_fixture(account)
     return account

--- a/server/tests/account/test_tasks.py
+++ b/server/tests/account/test_tasks.py
@@ -16,6 +16,7 @@ from polar.notifications.service import NotificationsService
 from polar.notifications.service import notifications as notification_service
 from polar.worker import JobContext, PolarWorkerContext
 from tests.account.conftest import create_account
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -38,10 +39,11 @@ class TestAccountUnderReview:
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
     ) -> None:
         account = await create_account(
-            session, admin=user, status=Account.Status.UNDER_REVIEW
+            save_fixture, admin=user, status=Account.Status.UNDER_REVIEW
         )
 
         # then
@@ -82,10 +84,11 @@ class TestAccountReviewed:
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
     ) -> None:
         account = await create_account(
-            session, admin=user, status=Account.Status.ACTIVE
+            save_fixture, admin=user, status=Account.Status.ACTIVE
         )
 
         release_account_mock = mocker.patch.object(

--- a/server/tests/advertisements/conftest.py
+++ b/server/tests/advertisements/conftest.py
@@ -1,16 +1,16 @@
 import pytest_asyncio
 
-from polar.kit.db.postgres import AsyncSession
 from polar.models import (
     Subscription,
     SubscriptionBenefit,
 )
 from polar.models.advertisement_campaign import AdvertisementCampaign
+from tests.fixtures.database import SaveFixture
 
 
 @pytest_asyncio.fixture
 async def advertisement_campaign(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     subscription: Subscription,
     subscription_benefit_organization: SubscriptionBenefit,
 ) -> AdvertisementCampaign:
@@ -21,6 +21,5 @@ async def advertisement_campaign(
         text="",
         link_url="https://example.com",
     )
-    session.add(ad)
-    await session.commit()
+    await save_fixture(ad)
     return ad

--- a/server/tests/advertisements/test_endpoints.py
+++ b/server/tests/advertisements/test_endpoints.py
@@ -9,6 +9,7 @@ from polar.models.subscription import Subscription
 from polar.models.subscription_benefit import SubscriptionBenefit
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_subscription_benefit_grant
 
 
@@ -22,10 +23,10 @@ class TestAdvertisementCampaign:
         user: User,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
     ) -> None:
         await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
@@ -76,10 +77,10 @@ class TestAdvertisementCampaign:
         user: User,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
     ) -> None:
         await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
@@ -119,10 +120,10 @@ class TestAdvertisementCampaign:
         user: User,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
     ) -> None:
         await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
@@ -165,11 +166,11 @@ class TestAdvertisementCampaign:
         user: User,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
         advertisement_campaign: AdvertisementCampaign,
     ) -> None:
         await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
@@ -194,11 +195,11 @@ class TestAdvertisementCampaign:
         user_second_auth_jwt: str,
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
         advertisement_campaign: AdvertisementCampaign,
     ) -> None:
         await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
@@ -224,14 +225,14 @@ class TestAdvertisementCampaign:
         user_organization: UserOrganization,  # member
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
         advertisement_campaign: AdvertisementCampaign,
     ) -> None:
         user_organization.is_admin = True
-        await session.commit()
+        await save_fixture(user_organization)
 
         await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
@@ -256,20 +257,20 @@ class TestAdvertisementCampaign:
         user_organization: UserOrganization,  # member
         subscription: Subscription,
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
         advertisement_campaign: AdvertisementCampaign,
     ) -> None:
         user_organization.is_admin = True
-        await session.commit()
+        await save_fixture(user_organization)
 
         grant = await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
         )
         grant.revoked_at = utc_now()
-        await session.commit()
+        await save_fixture(grant)
 
         # appears in search
         searched = await client.get(
@@ -331,20 +332,19 @@ class TestAdvertisementCampaign:
         subscription: Subscription,
         user_organization: UserOrganization,  # member
         subscription_benefit_organization: SubscriptionBenefit,
-        session: AsyncSession,
         advertisement_campaign: AdvertisementCampaign,
         auth_jwt: str,
+        save_fixture: SaveFixture,
     ) -> None:
         user_organization.is_admin = True
-        await session.commit()
+        await save_fixture(user_organization)
 
         grant = await create_subscription_benefit_grant(
-            session,
+            save_fixture,
             user,
             subscription,
             subscription_benefit_organization,
         )
-        await session.commit()
 
         track = await client.post(
             f"/api/v1/advertisements/campaigns/{advertisement_campaign.id}/track_view"

--- a/server/tests/article/test_endpoints.py
+++ b/server/tests/article/test_endpoints.py
@@ -7,6 +7,7 @@ from polar.models.organization import Organization
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_user
 
 
@@ -18,10 +19,10 @@ async def test_create(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.post(
         "/api/v1/articles",
@@ -47,10 +48,10 @@ async def test_create_with_slug(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.post(
         "/api/v1/articles",
@@ -77,10 +78,10 @@ async def test_create_with_slug_slugify(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.post(
         "/api/v1/articles",
@@ -102,11 +103,7 @@ async def test_create_with_slug_slugify(
 @pytest.mark.asyncio
 @pytest.mark.http_auto_expunge
 async def test_create_non_member(
-    user: User,
-    organization: Organization,
-    auth_jwt: str,
-    client: AsyncClient,
-    session: AsyncSession,
+    user: User, organization: Organization, auth_jwt: str, client: AsyncClient
 ) -> None:
     response = await client.post(
         "/api/v1/articles",
@@ -129,7 +126,6 @@ async def test_create_non_admin(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
 ) -> None:
     response = await client.post(
         "/api/v1/articles",
@@ -152,9 +148,10 @@ async def test_get_public(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -204,9 +201,10 @@ async def test_get_hidden(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -246,9 +244,10 @@ async def test_get_private(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -308,9 +307,10 @@ async def test_byline_default(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -338,9 +338,10 @@ async def test_byline_user(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -369,9 +370,10 @@ async def test_byline_org(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -400,9 +402,10 @@ async def test_list(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -511,19 +514,17 @@ async def test_list(
         organization_id=organization.id,
         paid_subscriber=False,
     )
-    session.add(sub)
+    await save_fixture(sub)
 
     # create other subscribers
     for _ in range(5):
-        u = await create_user(session)
+        u = await create_user(save_fixture)
         s2 = ArticlesSubscription(
             user_id=u.id,
             organization_id=organization.id,
             paid_subscriber=False,
         )
-        session.add(s2)
-
-    await session.commit()
+        await save_fixture(s2)
 
     # authed and is subscribed
     get_show_unpublished = await client.get(
@@ -547,7 +548,6 @@ async def test_list(
 
     # authed and is premium subscribed and want to see unpublished
     sub.paid_subscriber = True
-    await session.commit()
 
     get_show_unpublished = await client.get(
         f"/api/v1/articles/search?platform=github&organization_name={organization.name}&show_unpublished=true",
@@ -567,9 +567,10 @@ async def test_slug_collision(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -622,9 +623,10 @@ async def test_update(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -671,9 +673,10 @@ async def test_view_counter(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -721,10 +724,10 @@ async def test_pinned(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response_pinned = await client.post(
         "/api/v1/articles",
@@ -818,10 +821,10 @@ async def test_og_image_url(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.post(
         "/api/v1/articles",
@@ -886,10 +889,10 @@ async def test_og_description(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.post(
         "/api/v1/articles",

--- a/server/tests/dashboard/test_endpoints.py
+++ b/server/tests/dashboard/test_endpoints.py
@@ -10,7 +10,7 @@ from polar.models.pledge import Pledge, PledgeState
 from polar.models.repository import Repository
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
-from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -141,12 +141,12 @@ async def test_get_with_pledge_initiated(
     pledge: Pledge,
     issue: Issue,
     auth_jwt: str,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     client: AsyncClient,
 ) -> None:
     # assert that initiated pledges does not appear in the result
     pledge.state = PledgeState.initiated
-    await pledge.save(session)
+    await save_fixture(pledge)
 
     response = await client.get(
         f"/api/v1/dashboard/github/{organization.name}",
@@ -252,11 +252,11 @@ async def test_get_only_badged_is_badged(
     # pledge: Pledge,
     issue: Issue,
     auth_jwt: str,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     client: AsyncClient,
 ) -> None:
     issue.pledge_badge_embedded_at = datetime.now(UTC)
-    await issue.save(session)
+    await save_fixture(issue)
 
     response = await client.get(
         f"/api/v1/dashboard/github/{organization.name}?only_badged=True",

--- a/server/tests/fixtures/predictable_objects.py
+++ b/server/tests/fixtures/predictable_objects.py
@@ -5,24 +5,18 @@ from datetime import datetime
 import pytest_asyncio
 
 from polar.enums import Platforms
-from polar.integrations.github.service import (
-    github_organization,
-    github_repository,
-)
 from polar.models.issue import Issue
 from polar.models.organization import Organization
 from polar.models.pledge import Pledge, PledgeState
 from polar.models.pull_request import PullRequest
 from polar.models.repository import Repository
 from polar.models.user import User
-from polar.organization.schemas import OrganizationCreate
-from polar.postgres import AsyncSession
-from polar.repository.schemas import RepositoryCreate
+from tests.fixtures.database import SaveFixture
 
 
 @pytest_asyncio.fixture
-async def predictable_organization(session: AsyncSession) -> Organization:
-    create_schema = OrganizationCreate(
+async def predictable_organization(save_fixture: SaveFixture) -> Organization:
+    organization = Organization(
         platform=Platforms.github,
         name="testorg",
         external_id=random.randrange(5000),
@@ -33,16 +27,13 @@ async def predictable_organization(session: AsyncSession) -> Organization:
         installation_updated_at=datetime.now(),
         installation_suspended_at=None,
     )
-
-    org = await github_organization.create(session, create_schema)
-    session.add(org)
-    await session.commit()
-    return org
+    await save_fixture(organization)
+    return organization
 
 
 @pytest_asyncio.fixture
-async def predictable_pledging_organization(session: AsyncSession) -> Organization:
-    create_schema = OrganizationCreate(
+async def predictable_pledging_organization(save_fixture: SaveFixture) -> Organization:
+    organization = Organization(
         platform=Platforms.github,
         name="pledging_org",
         external_id=random.randrange(5000),
@@ -53,37 +44,32 @@ async def predictable_pledging_organization(session: AsyncSession) -> Organizati
         installation_updated_at=datetime.now(),
         installation_suspended_at=None,
     )
-
-    org = await github_organization.create(session, create_schema)
-    session.add(org)
-    await session.commit()
-    return org
+    await save_fixture(organization)
+    return organization
 
 
 @pytest_asyncio.fixture
 async def predictable_repository(
-    session: AsyncSession, predictable_organization: Organization
+    save_fixture: SaveFixture, predictable_organization: Organization
 ) -> Repository:
-    create_schema = RepositoryCreate(
+    repository = Repository(
         platform=Platforms.github,
         name="testrepo",
         organization_id=predictable_organization.id,
         external_id=random.randrange(5000),
         is_private=True,
     )
-    repo = await github_repository.create(session, create_schema)
-    session.add(repo)
-    await session.commit()
-    return repo
+    await save_fixture(repository)
+    return repository
 
 
 @pytest_asyncio.fixture
 async def predictable_issue(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     predictable_organization: Organization,
     predictable_repository: Repository,
 ) -> Issue:
-    issue = await Issue(
+    issue = Issue(
         id=uuid.uuid4(),
         organization_id=predictable_organization.id,
         repository_id=predictable_repository.id,
@@ -97,39 +83,31 @@ async def predictable_issue(
         external_lookup_key=str(uuid.uuid4()),  # not realistic
         issue_has_in_progress_relationship=False,
         issue_has_pull_request_relationship=False,
-    ).save(
-        session=session,
     )
-
-    await session.commit()
+    await save_fixture(issue)
     return issue
 
 
 @pytest_asyncio.fixture
-async def predictable_user(
-    session: AsyncSession,
-) -> User:
-    user = await User(
+async def predictable_user(save_fixture: SaveFixture) -> User:
+    user = User(
         id=uuid.uuid4(),
         username="foobar",
         email="test@example.com",
-    ).save(
-        session=session,
     )
-
-    await session.commit()
+    await save_fixture(user)
     return user
 
 
 @pytest_asyncio.fixture
 async def predictable_pledge(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     predictable_organization: Organization,
     predictable_repository: Repository,
     predictable_issue: Issue,
     predictable_pledging_organization: Organization,
 ) -> Pledge:
-    pledge = await Pledge(
+    pledge = Pledge(
         id=uuid.uuid4(),
         by_organization_id=predictable_pledging_organization.id,
         issue_id=predictable_issue.id,
@@ -138,21 +116,18 @@ async def predictable_pledge(
         amount=12345,
         fee=123,
         state=PledgeState.created,
-    ).save(
-        session=session,
     )
-
-    await session.commit()
+    await save_fixture(pledge)
     return pledge
 
 
 @pytest_asyncio.fixture
 async def predictable_pull_request(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     predictable_organization: Organization,
     predictable_repository: Repository,
 ) -> PullRequest:
-    pr = await PullRequest(
+    pr = PullRequest(
         id=uuid.uuid4(),
         repository_id=predictable_repository.id,
         organization_id=predictable_organization.id,
@@ -177,9 +152,6 @@ async def predictable_pull_request(
         merged_at=None,
         merge_commit_sha=None,
         body="x",
-    ).save(
-        session=session,
     )
-
-    await session.commit()
+    await save_fixture(pr)
     return pr

--- a/server/tests/funding/conftest.py
+++ b/server/tests/funding/conftest.py
@@ -2,19 +2,19 @@ import pytest_asyncio
 
 from polar.models import Issue, Organization, Pledge, Repository
 from polar.models.pledge import PledgeState, PledgeType
-from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_issue, create_pledge
 
 IssuesPledgesFixture = list[tuple[Issue, list[Pledge]]]
 
 
 async def create_issues_pledges(
-    session: AsyncSession, organization: Organization, repository: Repository
+    save_fixture: SaveFixture, organization: Organization, repository: Repository
 ) -> IssuesPledgesFixture:
-    issue_1 = await create_issue(session, organization, repository)
+    issue_1 = await create_issue(save_fixture, organization, repository)
     issue_1_pledges = [
         await create_pledge(
-            session,
+            save_fixture,
             organization,
             repository,
             issue_1,
@@ -22,7 +22,7 @@ async def create_issues_pledges(
             type=PledgeType.pay_upfront,
         ),
         await create_pledge(
-            session,
+            save_fixture,
             organization,
             repository,
             issue_1,
@@ -30,7 +30,7 @@ async def create_issues_pledges(
             type=PledgeType.pay_upfront,
         ),
         await create_pledge(
-            session,
+            save_fixture,
             organization,
             repository,
             issue_1,
@@ -39,13 +39,13 @@ async def create_issues_pledges(
         ),
     ]
 
-    issue_2 = await create_issue(session, organization, repository)
+    issue_2 = await create_issue(save_fixture, organization, repository)
     issue_2_pledges: list[Pledge] = []
 
-    issue_3 = await create_issue(session, organization, repository)
+    issue_3 = await create_issue(save_fixture, organization, repository)
     issue_3_pledges: list[Pledge] = [
         await create_pledge(
-            session,
+            save_fixture,
             organization,
             repository,
             issue_3,
@@ -64,6 +64,6 @@ async def create_issues_pledges(
 
 @pytest_asyncio.fixture
 async def issues_pledges(
-    session: AsyncSession, organization: Organization, public_repository: Repository
+    save_fixture: SaveFixture, organization: Organization, public_repository: Repository
 ) -> IssuesPledgesFixture:
-    return await create_issues_pledges(session, organization, public_repository)
+    return await create_issues_pledges(save_fixture, organization, public_repository)

--- a/server/tests/funding/test_endpoints.py
+++ b/server/tests/funding/test_endpoints.py
@@ -6,6 +6,7 @@ from polar.models import Organization
 from polar.models.repository import Repository
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_repository
 
 from .conftest import IssuesPledgesFixture, create_issues_pledges
@@ -49,10 +50,10 @@ class TestSearch:
         client: AsyncClient,
         organization: Organization,
         repository: Repository,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
     ) -> None:
         repository.is_private = False
-        await repository.save(session)
+        await save_fixture(repository)
 
         response = await client.get(
             "/api/v1/funding/search",
@@ -73,10 +74,10 @@ class TestSearch:
         client: AsyncClient,
         organization: Organization,
         repository: Repository,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
     ) -> None:
         repository.is_private = False
-        await repository.save(session)
+        await save_fixture(repository)
 
         response = await client.get(
             "/api/v1/funding/search",
@@ -97,14 +98,15 @@ class TestSearch:
         client: AsyncClient,
         organization: Organization,
         user_organization: UserOrganization,  # makes User a member of Organization
+        save_fixture: SaveFixture,
         session: AsyncSession,
         auth_jwt: str,
     ) -> None:
         private_repository = await create_repository(
-            session, organization, is_private=True
+            save_fixture, organization, is_private=True
         )
         issues_pledges = await create_issues_pledges(
-            session, organization, private_repository
+            save_fixture, organization, private_repository
         )
 
         # then

--- a/server/tests/integrations/github/service/test_reference.py
+++ b/server/tests/integrations/github/service/test_reference.py
@@ -13,6 +13,7 @@ from polar.models.organization import Organization
 from polar.models.pull_request import PullRequest
 from polar.models.repository import Repository
 from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.vcr import read_cassette
 
 
@@ -27,6 +28,7 @@ async def test_parse_repository_issues() -> None:
 @pytest.mark.asyncio
 async def test_parse_issue_timeline(
     session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
     repository: Repository,
     issue: Issue,
@@ -38,17 +40,15 @@ async def test_parse_issue_timeline(
     # Create Org/Repo/Issue (setup to match names and ids in issue_timeline.json)
     organization.name = "zegloforko"
     organization.external_id = 456
-    await organization.save(session)
+    await save_fixture(organization)
 
     repository.name = "polarforkotest"
     repository.external_id = 617059064
-    await repository.save(session)
+    await save_fixture(repository)
 
     pull_request.number = 1
     pull_request.external_id = 1234
-    await pull_request.save(session)
-    await session.commit()
-    await session.flush()
+    await save_fixture(pull_request)
 
     client = github.get_client("fake")
 
@@ -95,6 +95,7 @@ async def test_parse_issue_timeline(
 @pytest.mark.asyncio
 async def test_parse_issue_timeline_rclone(
     session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
     repository: Repository,
     issue: Issue,
@@ -105,17 +106,15 @@ async def test_parse_issue_timeline_rclone(
 
     organization.name = "zegloforko"
     organization.external_id = 456
-    await organization.save(session)
+    await save_fixture(organization)
 
     repository.name = "polarforkotest"
     repository.external_id = 617059064
-    await repository.save(session)
+    await save_fixture(repository)
 
     pull_request.number = 1
     pull_request.external_id = 1234
-    await pull_request.save(session)
-    await session.commit()
-    await session.flush()
+    await save_fixture(pull_request)
 
     client = github.get_client("fake")
 

--- a/server/tests/integrations/github/service/test_repository.py
+++ b/server/tests/integrations/github/service/test_repository.py
@@ -4,6 +4,7 @@ from polar.integrations.github.service.repository import github_repository
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.utils import utc_now
 from polar.models.organization import Organization
+from tests.fixtures.database import SaveFixture
 from tests.integrations.github.repository import create_github_repository
 
 
@@ -34,6 +35,7 @@ async def test_create_or_update_from_github(
 @pytest.mark.asyncio
 async def test_create_or_update_from_github_deleted_repo(
     session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
 ) -> None:
     # then
@@ -47,7 +49,7 @@ async def test_create_or_update_from_github_deleted_repo(
 
     # repo is deleted
     first_repo.deleted_at = utc_now()
-    await first_repo.save(session)
+    await save_fixture(first_repo)
 
     # a new repo with the same name, but different id is created
 

--- a/server/tests/kit/db/models/mixins/test_serialize.py
+++ b/server/tests/kit/db/models/mixins/test_serialize.py
@@ -1,8 +1,7 @@
 import pytest
 
 from polar.kit.db.models.mixins import SerializeMixin
-from polar.postgres import AsyncSession
-from tests.fixtures.database import TestModel
+from tests.fixtures.database import SaveFixture, TestModel
 
 
 class SerializeModel(TestModel, SerializeMixin):
@@ -11,10 +10,9 @@ class SerializeModel(TestModel, SerializeMixin):
 
 @pytest.mark.asyncio
 @pytest.mark.skip_db_asserts
-async def test_to_dict(session: AsyncSession) -> None:
+async def test_to_dict(save_fixture: SaveFixture) -> None:
     created = SerializeModel(int_column=1, str_column="Dict")
-    session.add(created)
-    await session.commit()
+    await save_fixture(created)
 
     assert created.id is not None
     as_dict = created.to_dict()

--- a/server/tests/models/test_pledge.py
+++ b/server/tests/models/test_pledge.py
@@ -6,6 +6,7 @@ from polar.models.pledge import Pledge
 from polar.models.repository import Repository
 from polar.pledge.service import pledge
 from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,7 @@ from polar.postgres import AsyncSession
 )
 async def test_pledge(
     session: AsyncSession,
+    save_fixture: SaveFixture,
     test_amount: str,
     organization: Organization,
     repository: Repository,
@@ -23,21 +25,17 @@ async def test_pledge(
 ) -> None:
     email = "alice@polar.sh"
 
-    created = await Pledge(
+    created = Pledge(
         issue_id=issue.id,
         repository_id=repository.id,
         organization_id=organization.id,
         email=email,
         amount=int(test_amount),
         fee=0,
-    ).save(
-        session,
     )
+    await save_fixture(created)
 
     assert created.id is not None
-
-    await session.commit()
-    await session.refresh(created)
 
     got = await pledge.get(session, created.id)
     assert got is not None

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -10,6 +10,7 @@ from polar.models.user_organization import UserOrganization
 from polar.organization.schemas import Organization as OrganizationSchema
 from polar.postgres import AsyncSession
 from polar.user_organization.schemas import OrganizationMember
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -32,13 +33,13 @@ async def test_get_organization(
 @pytest.mark.asyncio
 @pytest.mark.http_auto_expunge
 async def test_get_organization_member_only_fields_no_member(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
     auth_jwt: str,
     client: AsyncClient,
 ) -> None:
     organization.billing_email = "billing@polar.sh"
-    await organization.save(session)
+    await save_fixture(organization)
 
     response = await client.get(
         f"/api/v1/organizations/{organization.id}",
@@ -56,14 +57,14 @@ async def test_get_organization_member_only_fields_no_member(
 @pytest.mark.asyncio
 @pytest.mark.http_auto_expunge
 async def test_get_organization_member_only_fields_is_member(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
     auth_jwt: str,
     client: AsyncClient,
     user_organization: UserOrganization,  # makes User a member of Organization
 ) -> None:
     organization.billing_email = "billing@polar.sh"
-    await organization.save(session)
+    await save_fixture(organization)
 
     response = await client.get(
         f"/api/v1/organizations/{organization.id}",
@@ -81,13 +82,14 @@ async def test_get_organization_member_only_fields_is_member(
 @pytest.mark.asyncio
 async def test_update_organization_billing_email(
     session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
     auth_jwt: str,
     client: AsyncClient,
     user_organization: UserOrganization,  # makes User a member of Organization
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()
@@ -170,9 +172,10 @@ async def test_list_organization_member_admin(
     auth_jwt: str,
     client: AsyncClient,
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.get(
         "/api/v1/organizations",
@@ -241,7 +244,7 @@ async def test_organization_search_no_matches(
 @pytest.mark.asyncio
 @pytest.mark.http_auto_expunge
 async def test_get_organization_deleted(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     organization: Organization,
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
@@ -249,7 +252,7 @@ async def test_get_organization_deleted(
 ) -> None:
     # soft-delete the organization
     organization.deleted_at = utc_now()
-    await organization.save(session)
+    await save_fixture(organization)
 
     response = await client.get(
         f"/api/v1/organizations/{organization.id}",
@@ -285,9 +288,10 @@ async def test_update_organization(
     client: AsyncClient,
     user_organization: UserOrganization,  # makes User a member of Organization
     session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     # then
     session.expunge_all()

--- a/server/tests/repository/test_endpoints.py
+++ b/server/tests/repository/test_endpoints.py
@@ -5,7 +5,7 @@ from polar.config import settings
 from polar.models.organization import Organization
 from polar.models.repository import Repository
 from polar.models.user_organization import UserOrganization
-from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -103,10 +103,10 @@ async def test_list_repositories_admin(
     user_organization: UserOrganization,  # makes User a member of Organization
     auth_jwt: str,
     client: AsyncClient,
-    session: AsyncSession,
+    save_fixture: SaveFixture,
 ) -> None:
     user_organization.is_admin = True
-    await user_organization.save(session)
+    await save_fixture(user_organization)
 
     response = await client.get(
         "/api/v1/repositories",

--- a/server/tests/subscription/service/benefits/test_articles.py
+++ b/server/tests/subscription/service/benefits/test_articles.py
@@ -17,6 +17,7 @@ from polar.subscription.service.benefits.articles import (
 from polar.subscription.service.subscription_benefit import (
     subscription_benefit as subscription_benefit_service,
 )
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_subscription,
     create_subscription_benefit,
@@ -29,34 +30,35 @@ from tests.fixtures.random_objects import (
 async def test_concurrent_subscription_upgrade(
     repeat: int,
     session: AsyncSession,
+    save_fixture: SaveFixture,
     user: User,
     organization: Organization,
     subscription_tier_organization: SubscriptionTier,
 ) -> None:
     previous_subscription = await create_subscription(
-        session,
+        save_fixture,
         subscription_tier=subscription_tier_organization,
         user=user,
         status=SubscriptionStatus.canceled,
     )
     previous_benefit = await create_subscription_benefit(
-        session,
+        save_fixture,
         type=SubscriptionBenefitType.articles,
         organization=organization,
         properties={"paid_articles": False},
     )
     await create_subscription_benefit_grant(
-        session, user, previous_subscription, previous_benefit
+        save_fixture, user, previous_subscription, previous_benefit
     )
 
     new_subscription = await create_subscription(
-        session,
+        save_fixture,
         subscription_tier=subscription_tier_organization,
         user=user,
         status=SubscriptionStatus.active,
     )
     new_benefit = await create_subscription_benefit(
-        session,
+        save_fixture,
         type=SubscriptionBenefitType.articles,
         organization=organization,
         properties={"paid_articles": True},

--- a/server/tests/subscription/service/test_subscription_benefit.py
+++ b/server/tests/subscription/service/test_subscription_benefit.py
@@ -37,6 +37,7 @@ from polar.subscription.service.subscription_benefit import (
 from polar.subscription.service.subscription_benefit_grant import (
     SubscriptionBenefitGrantService,
 )
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_subscription_benefit
 
 
@@ -83,12 +84,13 @@ class TestSearch:
     async def test_filter_type(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
         plain_subscription_benefit = await create_subscription_benefit(
-            session, type=SubscriptionBenefitType.custom, organization=organization
+            save_fixture, type=SubscriptionBenefitType.custom, organization=organization
         )
 
         # then
@@ -516,13 +518,14 @@ class TestUserDelete:
     async def test_not_deletable_subscription_benefit(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         authz: Authz,
         user: User,
         organization: Organization,
         user_organization_admin: UserOrganization,
     ) -> None:
         subscription_benefit = await create_subscription_benefit(
-            session,
+            save_fixture,
             type=SubscriptionBenefitType.articles,
             is_tax_applicable=True,
             organization=organization,

--- a/server/tests/subscription/service/test_subscription_tier.py
+++ b/server/tests/subscription/service/test_subscription_tier.py
@@ -31,6 +31,7 @@ from polar.subscription.service.subscription_tier import (
 from polar.subscription.service.subscription_tier import (
     subscription_tier as subscription_tier_service,
 )
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     add_subscription_benefits,
     create_subscription_benefit,
@@ -105,14 +106,17 @@ class TestSearch:
     async def test_filter_type(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
         organization: Organization,
     ) -> None:
         individual_subscription_tier = await create_subscription_tier(
-            session, type=SubscriptionTierType.individual, organization=organization
+            save_fixture,
+            type=SubscriptionTierType.individual,
+            organization=organization,
         )
         await create_subscription_tier(
-            session, type=SubscriptionTierType.business, organization=organization
+            save_fixture, type=SubscriptionTierType.business, organization=organization
         )
 
         # then
@@ -197,12 +201,13 @@ class TestSearch:
     async def test_filter_include_archived(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
         archived_subscription_tier = await create_subscription_tier(
-            session, organization=organization, is_archived=True
+            save_fixture, organization=organization, is_archived=True
         )
 
         # then
@@ -518,6 +523,7 @@ class TestUserCreate:
     async def test_valid_highlighted(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         authz: Authz,
         user: User,
         organization: Organization,
@@ -525,10 +531,10 @@ class TestUserCreate:
         stripe_service_mock: MagicMock,
     ) -> None:
         highlighted_subscription_tier = await create_subscription_tier(
-            session, organization=organization, is_highlighted=True
+            save_fixture, organization=organization, is_highlighted=True
         )
         await create_subscription_tier(
-            session, organization=organization, is_highlighted=False
+            save_fixture, organization=organization, is_highlighted=False
         )
         create_product_with_price_mock: (
             MagicMock
@@ -756,6 +762,7 @@ class TestUserUpdate:
     async def test_valid_highlighted(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         authz: Authz,
         user: User,
         organization: Organization,
@@ -764,7 +771,7 @@ class TestUserUpdate:
         stripe_service_mock: MagicMock,
     ) -> None:
         highlighted_subscription_tier = await create_subscription_tier(
-            session, organization=organization, is_highlighted=True
+            save_fixture, organization=organization, is_highlighted=True
         )
 
         create_price_for_product_mock: (
@@ -875,6 +882,7 @@ class TestUpdateBenefits:
     async def test_not_existing_benefit(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         authz: Authz,
         user: User,
         user_organization_admin: UserOrganization,
@@ -882,7 +890,7 @@ class TestUpdateBenefits:
         subscription_benefits: list[SubscriptionBenefit],
     ) -> None:
         subscription_tier_organization = await add_subscription_benefits(
-            session,
+            save_fixture,
             subscription_tier=subscription_tier_organization,
             subscription_benefits=subscription_benefits,
         )
@@ -1018,6 +1026,7 @@ class TestUpdateBenefits:
     async def test_deleted(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         enqueue_job_mock: AsyncMock,
         authz: Authz,
         user: User,
@@ -1026,7 +1035,7 @@ class TestUpdateBenefits:
         subscription_benefits: list[SubscriptionBenefit],
     ) -> None:
         subscription_tier_organization = await add_subscription_benefits(
-            session,
+            save_fixture,
             subscription_tier=subscription_tier_organization,
             subscription_benefits=subscription_benefits,
         )
@@ -1060,6 +1069,7 @@ class TestUpdateBenefits:
     async def test_reordering(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         enqueue_job_mock: AsyncMock,
         authz: Authz,
         user: User,
@@ -1068,7 +1078,7 @@ class TestUpdateBenefits:
         subscription_benefits: list[SubscriptionBenefit],
     ) -> None:
         subscription_tier_organization = await add_subscription_benefits(
-            session,
+            save_fixture,
             subscription_tier=subscription_tier_organization,
             subscription_benefits=subscription_benefits,
         )
@@ -1118,6 +1128,7 @@ class TestUpdateBenefits:
     async def test_add_not_selectable(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         authz: Authz,
         user: User,
         user_organization_admin: UserOrganization,
@@ -1125,7 +1136,7 @@ class TestUpdateBenefits:
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
         not_selectable_benefit = await create_subscription_benefit(
-            session,
+            save_fixture,
             type=SubscriptionBenefitType.articles,
             is_tax_applicable=True,
             organization=organization,
@@ -1153,6 +1164,7 @@ class TestUpdateBenefits:
     async def test_remove_not_selectable(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         authz: Authz,
         user: User,
         user_organization_admin: UserOrganization,
@@ -1160,7 +1172,7 @@ class TestUpdateBenefits:
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
         not_selectable_benefit = await create_subscription_benefit(
-            session,
+            save_fixture,
             type=SubscriptionBenefitType.articles,
             is_tax_applicable=True,
             organization=organization,
@@ -1168,7 +1180,7 @@ class TestUpdateBenefits:
         )
 
         subscription_tier_organization = await add_subscription_benefits(
-            session,
+            save_fixture,
             subscription_tier=subscription_tier_organization,
             subscription_benefits=[not_selectable_benefit],
         )
@@ -1194,6 +1206,7 @@ class TestUpdateBenefits:
     async def test_add_with_existing_not_selectable(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         enqueue_job_mock: AsyncMock,
         authz: Authz,
         user: User,
@@ -1202,21 +1215,21 @@ class TestUpdateBenefits:
         subscription_tier_organization: SubscriptionTier,
     ) -> None:
         not_selectable_benefit = await create_subscription_benefit(
-            session,
+            save_fixture,
             type=SubscriptionBenefitType.articles,
             is_tax_applicable=True,
             organization=organization,
             selectable=False,
         )
         selectable_benefit = await create_subscription_benefit(
-            session,
+            save_fixture,
             type=SubscriptionBenefitType.custom,
             is_tax_applicable=True,
             organization=organization,
             description="SELECTABLE",
         )
         subscription_tier_organization = await add_subscription_benefits(
-            session,
+            save_fixture,
             subscription_tier=subscription_tier_organization,
             subscription_benefits=[not_selectable_benefit],
         )

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -35,6 +35,7 @@ from polar.subscription.tasks import (  # type: ignore[attr-defined]
     subscription_update_subscription_tier_benefits_grants,
 )
 from polar.worker import JobContext, PolarWorkerContext
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -379,6 +380,7 @@ class TestSubscriptionBenefitUpdate:
     async def test_existing_grant(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         mocker: MockerFixture,
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
@@ -392,8 +394,7 @@ class TestSubscriptionBenefitUpdate:
             subscription_benefit=subscription_benefit_organization,
         )
         grant.set_granted()
-        session.add(grant)
-        await session.commit()
+        await save_fixture(grant)
 
         update_benefit_grant_mock = mocker.patch.object(
             subscription_benefit_grant_service,
@@ -411,6 +412,7 @@ class TestSubscriptionBenefitUpdate:
     async def test_retry(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         mocker: MockerFixture,
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
@@ -424,8 +426,7 @@ class TestSubscriptionBenefitUpdate:
             subscription_benefit=subscription_benefit_organization,
         )
         grant.set_granted()
-        session.add(grant)
-        await session.commit()
+        await save_fixture(grant)
 
         update_benefit_grant_mock = mocker.patch.object(
             subscription_benefit_grant_service,
@@ -463,6 +464,7 @@ class TestSubscriptionBenefitDelete:
     async def test_existing_grant(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         mocker: MockerFixture,
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
@@ -476,8 +478,7 @@ class TestSubscriptionBenefitDelete:
             subscription_benefit=subscription_benefit_organization,
         )
         grant.set_granted()
-        session.add(grant)
-        await session.commit()
+        await save_fixture(grant)
 
         delete_benefit_grant_mock = mocker.patch.object(
             subscription_benefit_grant_service,
@@ -495,6 +496,7 @@ class TestSubscriptionBenefitDelete:
     async def test_retry(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         mocker: MockerFixture,
         job_context: JobContext,
         polar_worker_context: PolarWorkerContext,
@@ -508,8 +510,7 @@ class TestSubscriptionBenefitDelete:
             subscription_benefit=subscription_benefit_organization,
         )
         grant.set_granted()
-        session.add(grant)
-        await session.commit()
+        await save_fixture(grant)
 
         delete_benefit_grant_mock = mocker.patch.object(
             subscription_benefit_grant_service,

--- a/server/tests/transaction/service/test_dispute.py
+++ b/server/tests/transaction/service/test_dispute.py
@@ -17,6 +17,7 @@ from polar.transaction.service.dispute import (
     dispute_transaction as dispute_transaction_service,
 )
 from polar.transaction.service.processor_fee import ProcessorFeeTransactionService
+from tests.fixtures.database import SaveFixture
 
 
 def build_stripe_balance_transaction(
@@ -108,6 +109,7 @@ class TestCreateDispute:
     async def test_valid(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
         pledge: Pledge,
         balance_transaction_service_mock: MagicMock,
@@ -131,7 +133,7 @@ class TestCreateDispute:
             is_payouts_enabled=True,
             stripe_id="STRIPE_ACCOUNT_ID",
         )
-        session.add(account)
+        await save_fixture(account)
 
         payment_transaction = Transaction(
             type=TransactionType.payment,
@@ -144,7 +146,7 @@ class TestCreateDispute:
             charge_id=charge.id,
             pledge=pledge,
         )
-        session.add(payment_transaction)
+        await save_fixture(payment_transaction)
 
         outgoing_balance_1 = Transaction(
             type=TransactionType.balance,
@@ -173,8 +175,8 @@ class TestCreateDispute:
             transfer_id="STRIPE_TRANSFER_ID",
             balance_correlation_key="BALANCE_1",
         )
-        session.add(outgoing_balance_1)
-        session.add(incoming_balance_1)
+        await save_fixture(outgoing_balance_1)
+        await save_fixture(incoming_balance_1)
 
         outgoing_balance_2 = Transaction(
             type=TransactionType.balance,
@@ -203,10 +205,8 @@ class TestCreateDispute:
             transfer_id="STRIPE_TRANSFER_ID",
             balance_correlation_key="BALANCE_2",
         )
-        session.add(outgoing_balance_2)
-        session.add(incoming_balance_2)
-
-        await session.commit()
+        await save_fixture(outgoing_balance_2)
+        await save_fixture(incoming_balance_2)
 
         # then
         session.expunge_all()
@@ -260,6 +260,7 @@ class TestCreateDisputeReversal:
     async def test_valid(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         user: User,
         pledge: Pledge,
         balance_transaction_service_mock: MagicMock,
@@ -288,7 +289,7 @@ class TestCreateDisputeReversal:
             is_payouts_enabled=True,
             stripe_id="STRIPE_ACCOUNT_ID",
         )
-        session.add(account)
+        await save_fixture(account)
 
         payment_transaction = Transaction(
             type=TransactionType.payment,
@@ -301,7 +302,7 @@ class TestCreateDisputeReversal:
             charge_id=charge.id,
             pledge=pledge,
         )
-        session.add(payment_transaction)
+        await save_fixture(payment_transaction)
 
         dispute_transaction = Transaction(
             type=TransactionType.dispute,
@@ -314,7 +315,7 @@ class TestCreateDisputeReversal:
             charge_id=charge.id,
             pledge=pledge,
         )
-        session.add(dispute_transaction)
+        await save_fixture(dispute_transaction)
 
         # First balance
         outgoing_balance_1 = Transaction(
@@ -344,8 +345,8 @@ class TestCreateDisputeReversal:
             transfer_id="STRIPE_TRANSFER_ID",
             balance_correlation_key="BALANCE_1",
         )
-        session.add(outgoing_balance_1)
-        session.add(incoming_balance_1)
+        await save_fixture(outgoing_balance_1)
+        await save_fixture(incoming_balance_1)
 
         # First balance reversal
         outgoing_reversal_balance_1 = Transaction(
@@ -376,8 +377,8 @@ class TestCreateDisputeReversal:
             balance_correlation_key="BALANCE_REVERSAL_1",
             balance_reversal_transaction=outgoing_balance_1,
         )
-        session.add(outgoing_reversal_balance_1)
-        session.add(incoming_reversal_balance_1)
+        await save_fixture(outgoing_reversal_balance_1)
+        await save_fixture(incoming_reversal_balance_1)
 
         # Second balance
         outgoing_balance_2 = Transaction(
@@ -407,8 +408,8 @@ class TestCreateDisputeReversal:
             transfer_id="STRIPE_TRANSFER_ID",
             balance_correlation_key="BALANCE_2",
         )
-        session.add(outgoing_balance_2)
-        session.add(incoming_balance_2)
+        await save_fixture(outgoing_balance_2)
+        await save_fixture(incoming_balance_2)
 
         # Second balance reversal
         outgoing_reversal_balance_2 = Transaction(
@@ -439,10 +440,8 @@ class TestCreateDisputeReversal:
             balance_correlation_key="BALANCE_REVERSAL_2",
             balance_reversal_transaction=outgoing_balance_2,
         )
-        session.add(outgoing_reversal_balance_2)
-        session.add(incoming_reversal_balance_2)
-
-        await session.commit()
+        await save_fixture(outgoing_reversal_balance_2)
+        await save_fixture(incoming_reversal_balance_2)
 
         # then
         session.expunge_all()

--- a/server/tests/transaction/service/test_platform_fee.py
+++ b/server/tests/transaction/service/test_platform_fee.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
+from sqlalchemy.orm import joinedload
 
 from polar.enums import AccountType
 from polar.models import (
@@ -22,11 +23,12 @@ from polar.transaction.service.platform_fee import (
 from polar.transaction.service.platform_fee import (
     platform_fee_transaction as platform_fee_transaction_service,
 )
+from tests.fixtures.database import SaveFixture
 from tests.transaction.conftest import create_account
 
 
 async def create_balance_transactions(
-    session: AsyncSession,
+    save_fixture: SaveFixture,
     *,
     account: Account,
     pledge: Pledge | None = None,
@@ -45,7 +47,7 @@ async def create_balance_transactions(
         issue_reward=issue_reward,
         subscription=subscription,
     )
-    session.add(payment_transaction)
+    await save_fixture(payment_transaction)
 
     payment_transaction_fee = Transaction(
         type=TransactionType.processor_fee,
@@ -57,7 +59,7 @@ async def create_balance_transactions(
         tax_amount=0,
         incurred_by_transaction=payment_transaction,
     )
-    session.add(payment_transaction_fee)
+    await save_fixture(payment_transaction_fee)
 
     outgoing = Transaction(
         type=TransactionType.balance,
@@ -88,31 +90,61 @@ async def create_balance_transactions(
         balance_correlation_key="BALANCE_1",
         payment_transaction=payment_transaction,
     )
-    session.add(outgoing)
-    session.add(incoming)
-    await session.commit()
+
+    await save_fixture(outgoing)
+    await save_fixture(incoming)
+
     return outgoing, incoming
+
+
+async def load_balance_transactions(
+    session: AsyncSession,
+    balance_transactions: tuple[Transaction, Transaction],
+) -> tuple[Transaction, Transaction]:
+    outgoing, incoming = balance_transactions
+
+    load_options = (
+        joinedload(Transaction.account),
+        joinedload(Transaction.pledge),
+        joinedload(Transaction.issue_reward),
+        joinedload(Transaction.subscription),
+    )
+
+    loaded_outgoing = await session.get(Transaction, outgoing.id, options=load_options)
+    loaded_incoming = await session.get(Transaction, incoming.id, options=load_options)
+
+    assert loaded_outgoing is not None
+    assert loaded_incoming is not None
+
+    return loaded_outgoing, loaded_incoming
 
 
 @pytest_asyncio.fixture
 async def account_processor_fees(
-    session: AsyncSession, organization: Organization, user: User
+    save_fixture: SaveFixture, organization: Organization, user: User
 ) -> Account:
     return await create_account(
-        session, organization, user, processor_fees_applicable=True
+        save_fixture, organization, user, processor_fees_applicable=True
     )
 
 
 @pytest.mark.asyncio
 class TestCreateFeesReversalBalances:
     async def test_dangling_balance_transactions(
-        self, session: AsyncSession, account_processor_fees: Account
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account_processor_fees: Account,
     ) -> None:
+        balance_transactions = await create_balance_transactions(
+            save_fixture, account=account_processor_fees
+        )
+
         # then
         session.expunge_all()
 
-        balance_transactions = await create_balance_transactions(
-            session, account=account_processor_fees
+        balance_transactions = await load_balance_transactions(
+            session, balance_transactions
         )
 
         with pytest.raises(DanglingBalanceTransactions):
@@ -123,18 +155,23 @@ class TestCreateFeesReversalBalances:
     async def test_pledge(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         account_processor_fees: Account,
         transaction_pledge: Pledge,
         transaction_issue_reward: IssueReward,
     ) -> None:
-        # then
-        session.expunge_all()
-
         balance_transactions = await create_balance_transactions(
-            session,
+            save_fixture,
             account=account_processor_fees,
             pledge=transaction_pledge,
             issue_reward=transaction_issue_reward,
+        )
+
+        # then
+        session.expunge_all()
+
+        balance_transactions = await load_balance_transactions(
+            session, balance_transactions
         )
         outgoing, incoming = balance_transactions
 
@@ -150,12 +187,12 @@ class TestCreateFeesReversalBalances:
         reversal_outgoing, reversal_incoming = fees_reversal_balances[0]
 
         assert reversal_outgoing.amount == -500
-        assert reversal_outgoing.account_id == incoming.account_id
+        assert reversal_outgoing.account == incoming.account
         assert reversal_outgoing.platform_fee_type == PlatformFeeType.platform
         assert reversal_outgoing.incurred_by_transaction == incoming
 
         assert reversal_incoming.amount == 500
-        assert reversal_incoming.account_id is None
+        assert reversal_incoming.account is None
         assert reversal_incoming.platform_fee_type == PlatformFeeType.platform
         assert reversal_incoming.incurred_by_transaction == outgoing
 
@@ -163,12 +200,12 @@ class TestCreateFeesReversalBalances:
         reversal_outgoing, reversal_incoming = fees_reversal_balances[1]
 
         assert reversal_outgoing.amount == -500
-        assert reversal_outgoing.account_id == incoming.account_id
+        assert reversal_outgoing.account == incoming.account
         assert reversal_outgoing.platform_fee_type == PlatformFeeType.payment
         assert reversal_outgoing.incurred_by_transaction == incoming
 
         assert reversal_incoming.amount == 500
-        assert reversal_incoming.account_id is None
+        assert reversal_incoming.account is None
         assert reversal_incoming.platform_fee_type == PlatformFeeType.payment
         assert reversal_incoming.incurred_by_transaction == outgoing
 
@@ -176,28 +213,33 @@ class TestCreateFeesReversalBalances:
         reversal_outgoing, reversal_incoming = fees_reversal_balances[2]
 
         assert reversal_outgoing.amount == -50
-        assert reversal_outgoing.account_id == incoming.account_id
+        assert reversal_outgoing.account == incoming.account
         assert reversal_outgoing.platform_fee_type == PlatformFeeType.invoice
         assert reversal_outgoing.incurred_by_transaction == incoming
 
         assert reversal_incoming.amount == 50
-        assert reversal_incoming.account_id is None
+        assert reversal_incoming.account is None
         assert reversal_incoming.platform_fee_type == PlatformFeeType.invoice
         assert reversal_incoming.incurred_by_transaction == outgoing
 
     async def test_subscription(
         self,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         account_processor_fees: Account,
         transaction_subscription: Subscription,
     ) -> None:
+        balance_transactions = await create_balance_transactions(
+            save_fixture,
+            account=account_processor_fees,
+            subscription=transaction_subscription,
+        )
+
         # then
         session.expunge_all()
 
-        balance_transactions = await create_balance_transactions(
-            session,
-            account=account_processor_fees,
-            subscription=transaction_subscription,
+        balance_transactions = await load_balance_transactions(
+            session, balance_transactions
         )
         outgoing, incoming = balance_transactions
 
@@ -212,12 +254,12 @@ class TestCreateFeesReversalBalances:
         reversal_outgoing, reversal_incoming = fees_reversal_balances[0]
 
         assert reversal_outgoing.amount == -500
-        assert reversal_outgoing.account_id == incoming.account_id
+        assert reversal_outgoing.account == incoming.account
         assert reversal_outgoing.platform_fee_type == PlatformFeeType.platform
         assert reversal_outgoing.incurred_by_transaction == incoming
 
         assert reversal_incoming.amount == 500
-        assert reversal_incoming.account_id is None
+        assert reversal_incoming.account is None
         assert reversal_incoming.platform_fee_type == PlatformFeeType.platform
         assert reversal_incoming.incurred_by_transaction == outgoing
 
@@ -225,12 +267,12 @@ class TestCreateFeesReversalBalances:
         reversal_outgoing, reversal_incoming = fees_reversal_balances[1]
 
         assert reversal_outgoing.amount == -500
-        assert reversal_outgoing.account_id == incoming.account_id
+        assert reversal_outgoing.account == incoming.account
         assert reversal_outgoing.platform_fee_type == PlatformFeeType.payment
         assert reversal_outgoing.incurred_by_transaction == incoming
 
         assert reversal_incoming.amount == 500
-        assert reversal_incoming.account_id is None
+        assert reversal_incoming.account is None
         assert reversal_incoming.platform_fee_type == PlatformFeeType.payment
         assert reversal_incoming.incurred_by_transaction == outgoing
 
@@ -238,12 +280,12 @@ class TestCreateFeesReversalBalances:
         reversal_outgoing, reversal_incoming = fees_reversal_balances[2]
 
         assert reversal_outgoing.amount == -50
-        assert reversal_outgoing.account_id == incoming.account_id
+        assert reversal_outgoing.account == incoming.account
         assert reversal_outgoing.platform_fee_type == PlatformFeeType.subscription
         assert reversal_outgoing.incurred_by_transaction == incoming
 
         assert reversal_incoming.amount == 50
-        assert reversal_incoming.account_id is None
+        assert reversal_incoming.account is None
         assert reversal_incoming.platform_fee_type == PlatformFeeType.subscription
         assert reversal_incoming.incurred_by_transaction == outgoing
 
@@ -267,10 +309,14 @@ class TestCreatePayoutFeesBalances:
         assert payout_fees_balances == []
 
     async def test_not_stripe(
-        self, session: AsyncSession, organization: Organization, user: User
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
     ) -> None:
         account = await create_account(
-            session,
+            save_fixture,
             organization=organization,
             user=user,
             account_type=AccountType.open_collective,
@@ -307,6 +353,7 @@ class TestCreatePayoutFeesBalances:
         self,
         payout_created_at: datetime | None,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         account_processor_fees: Account,
     ) -> None:
         if payout_created_at is not None:
@@ -321,8 +368,7 @@ class TestCreatePayoutFeesBalances:
                 account=account_processor_fees,
                 tax_amount=0,
             )
-            session.add(payout_transaction)
-            await session.commit()
+            await save_fixture(payout_transaction)
 
         # then
         session.expunge_all()
@@ -338,11 +384,11 @@ class TestCreatePayoutFeesBalances:
 
         account_fee_outgoing = payout_fees_balances[0][0]
         assert account_fee_outgoing.platform_fee_type == PlatformFeeType.account
-        assert account_fee_outgoing.account_id == account_processor_fees.id
+        assert account_fee_outgoing.account == account_processor_fees
 
         payout_fee_outgoing = payout_fees_balances[1][0]
         assert payout_fee_outgoing.platform_fee_type == PlatformFeeType.payout
-        assert payout_fee_outgoing.account_id == account_processor_fees.id
+        assert payout_fee_outgoing.account == account_processor_fees
 
         assert (
             balance_amount
@@ -350,7 +396,10 @@ class TestCreatePayoutFeesBalances:
         )
 
     async def test_stripe_last_payout(
-        self, session: AsyncSession, account_processor_fees: Account
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account_processor_fees: Account,
     ) -> None:
         payout_transaction = Transaction(
             created_at=datetime.now(UTC) - timedelta(days=7),
@@ -363,8 +412,7 @@ class TestCreatePayoutFeesBalances:
             account=account_processor_fees,
             tax_amount=0,
         )
-        session.add(payout_transaction)
-        await session.commit()
+        await save_fixture(payout_transaction)
 
         # then
         session.expunge_all()
@@ -380,15 +428,19 @@ class TestCreatePayoutFeesBalances:
 
         payout_fee_outgoing = payout_fees_balances[0][0]
         assert payout_fee_outgoing.platform_fee_type == PlatformFeeType.payout
-        assert payout_fee_outgoing.account_id == account_processor_fees.id
+        assert payout_fee_outgoing.account == account_processor_fees
 
         assert balance_amount == 10000 + payout_fee_outgoing.amount
 
     async def test_stripe_cross_border(
-        self, session: AsyncSession, organization: Organization, user: User
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
     ) -> None:
         account = await create_account(
-            session,
+            save_fixture,
             organization,
             user,
             country="FR",
@@ -410,18 +462,18 @@ class TestCreatePayoutFeesBalances:
 
         account_fee_outgoing = payout_fees_balances[0][0]
         assert account_fee_outgoing.platform_fee_type == PlatformFeeType.account
-        assert account_fee_outgoing.account_id == account.id
+        assert account_fee_outgoing.account == account
 
         cross_border_fee_outgoing = payout_fees_balances[1][0]
         assert (
             cross_border_fee_outgoing.platform_fee_type
             == PlatformFeeType.cross_border_transfer
         )
-        assert cross_border_fee_outgoing.account_id == account.id
+        assert cross_border_fee_outgoing.account == account
 
         payout_fee_outgoing = payout_fees_balances[2][0]
         assert payout_fee_outgoing.platform_fee_type == PlatformFeeType.payout
-        assert payout_fee_outgoing.account_id == account.id
+        assert payout_fee_outgoing.account == account
 
         assert (
             balance_amount


### PR DESCRIPTION
Massive effort to get rid of overuse of `commit()` in the code base.

# Stage 1: remove it from unit tests.

It implies to stop using `commit()`, `Model.create()` and `Model.save()`.

We now have a `save_fixture` fixture taking care of creating databse objects in tests (flushing, but *not* commiting and expunge).

---

Tests will also emit a warning whenever `commit` is called.