### PR TITLE
Post-commit era - Transactions

### DIFF
--- a/server/polar/transaction/service/balance.py
+++ b/server/polar/transaction/service/balance.py
@@ -80,7 +80,7 @@ class BalanceTransactionService(BaseTransactionService):
 
         session.add(outgoing_transaction)
         session.add(incoming_transaction)
-        await session.commit()
+        await session.flush()
 
         if destination_account is not None:
             await account_service.check_review_threshold(session, destination_account)
@@ -200,7 +200,7 @@ class BalanceTransactionService(BaseTransactionService):
 
         session.add(outgoing_reversal)
         session.add(incoming_reversal)
-        await session.commit()
+        await session.flush()
 
         return (outgoing_reversal, incoming_reversal)
 

--- a/server/polar/transaction/service/dispute.py
+++ b/server/polar/transaction/service/dispute.py
@@ -96,7 +96,7 @@ class DisputeTransactionService(BaseTransactionService):
                 amount=balance_refund_amount,
             )
 
-        await session.commit()
+        await session.flush()
 
         return dispute_transaction
 
@@ -169,7 +169,7 @@ class DisputeTransactionService(BaseTransactionService):
                 issue_reward=outgoing.issue_reward,
             )
 
-        await session.commit()
+        await session.flush()
 
         return dispute_transaction
 

--- a/server/polar/transaction/service/payment.py
+++ b/server/polar/transaction/service/payment.py
@@ -138,7 +138,7 @@ class PaymentTransactionService(BaseTransactionService):
         transaction.incurred_transactions = transaction_fees
 
         session.add(transaction)
-        await session.commit()
+        await session.flush()
 
         return transaction
 

--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -179,7 +179,7 @@ class PayoutTransactionService(BaseTransactionService):
             transaction.incurred_transactions.append(incoming)
 
         session.add(transaction)
-        await session.commit()
+        await session.flush()
 
         return transaction
 
@@ -224,7 +224,7 @@ class PayoutTransactionService(BaseTransactionService):
             payout.payout_id = stripe_payout.id
 
             session.add(payout)
-            await session.commit()
+            await session.flush()
 
     async def create_payout_from_stripe(
         self,
@@ -297,7 +297,7 @@ class PayoutTransactionService(BaseTransactionService):
                     )
 
         session.add(transaction)
-        await session.commit()
+        await session.flush()
 
         return transaction
 

--- a/server/polar/transaction/service/processor_fee.py
+++ b/server/polar/transaction/service/processor_fee.py
@@ -71,7 +71,7 @@ class ProcessorFeeTransactionService(BaseTransactionService):
             session.add(payment_fee_transaction)
             fee_transactions.append(payment_fee_transaction)
 
-        await session.commit()
+        await session.flush()
 
         return fee_transactions
 
@@ -113,7 +113,7 @@ class ProcessorFeeTransactionService(BaseTransactionService):
         session.add(refund_fee_transaction)
         fee_transactions.append(refund_fee_transaction)
 
-        await session.commit()
+        await session.flush()
 
         return fee_transactions
 
@@ -154,7 +154,7 @@ class ProcessorFeeTransactionService(BaseTransactionService):
         session.add(dispute_fee_transaction)
         fee_transactions.append(dispute_fee_transaction)
 
-        await session.commit()
+        await session.flush()
 
         return fee_transactions
 
@@ -193,7 +193,7 @@ class ProcessorFeeTransactionService(BaseTransactionService):
             session.add(transaction)
             transactions.append(transaction)
 
-        await session.commit()
+        await session.flush()
 
         return transactions
 

--- a/server/polar/transaction/service/refund.py
+++ b/server/polar/transaction/service/refund.py
@@ -110,7 +110,7 @@ class RefundTransactionService(BaseTransactionService):
                     amount=balance_refund_amount,
                 )
 
-        await session.commit()
+        await session.flush()
 
         return refund_transactions
 

--- a/server/scripts/account_payout_schedule.py
+++ b/server/scripts/account_payout_schedule.py
@@ -45,11 +45,7 @@ async def account_payout_schedule() -> None:
     async with engine.connect() as connection:
         async with connection.begin():
             session = AsyncSession(
-                bind=connection,
-                expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
-                join_transaction_mode="create_savepoint",
+                bind=connection, join_transaction_mode="create_savepoint"
             )
 
             accounts_statement = select(Account).where(

--- a/server/scripts/anonymous_pledge_migration.py
+++ b/server/scripts/anonymous_pledge_migration.py
@@ -52,8 +52,6 @@ async def anonymous_pledge_migration(
             session = AsyncSession(
                 bind=connection,
                 expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
                 join_transaction_mode="create_savepoint",
             )
 

--- a/server/scripts/platform_fees_migration.py
+++ b/server/scripts/platform_fees_migration.py
@@ -53,8 +53,6 @@ async def platform_fees_migration(
             session = AsyncSession(
                 bind=connection,
                 expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
                 join_transaction_mode="create_savepoint",
             )
 

--- a/server/scripts/pledge_invoice_payment_fix.py
+++ b/server/scripts/pledge_invoice_payment_fix.py
@@ -56,8 +56,6 @@ async def pledge_invoice_payment_fix(
             session = AsyncSession(
                 bind=connection,
                 expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
                 join_transaction_mode="create_savepoint",
             )
 

--- a/server/scripts/transfer_fix.py
+++ b/server/scripts/transfer_fix.py
@@ -66,8 +66,6 @@ async def organizations_renamed(
             session = AsyncSession(
                 bind=connection,
                 expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
                 join_transaction_mode="create_savepoint",
             )
 
@@ -142,8 +140,6 @@ async def repositories_transferred(
             session = AsyncSession(
                 bind=connection,
                 expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
                 join_transaction_mode="create_savepoint",
             )
 
@@ -227,8 +223,6 @@ async def issues_transferred(
             session = AsyncSession(
                 bind=connection,
                 expire_on_commit=False,
-                autocommit=False,
-                autoflush=False,
                 join_transaction_mode="create_savepoint",
             )
 


### PR DESCRIPTION
Remove `.commit()` for transactions logic.

The most straightforward way is to replace `.commit()` by `.flush()`.

There are probably more optimal ways (i.e. limit the number of flushes), but for code that were designed to frenetically commit, it would require to revisit each interaction.