### PR TITLE
clients/markdown: support references in abbreviated renderer

### DIFF
--- a/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
+++ b/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
@@ -627,6 +627,25 @@ exports[`polar 1`] = `
 </div>
 `;
 
+exports[`references 1`] = `
+<div>
+  <div>
+    <p>
+      In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the ends
+of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down on or to
+eat: it was a 
+      <a
+        href="https://en.wikipedia.org/wiki/Hobbit#Lifestyle"
+      >
+        hobbit-hole
+      </a>
+      , and that means comfort.
+    </p>
+    <p />
+  </div>
+</div>
+`;
+
 exports[`table 1`] = `
 <div>
   <div>

--- a/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
+++ b/clients/apps/web/src/components/Feed/Markdown/__snapshots__/render.test.tsx.snap
@@ -251,6 +251,54 @@ exports[`double-whitespace 1`] = `
 </div>
 `;
 
+exports[`footnote 1`] = `
+<div>
+  <div>
+    <p>
+      Here's a simple footnote,
+      <a
+        href="#1"
+      >
+        <sup>
+          1
+        </sup>
+      </a>
+       and here's another one
+      <a
+        href="#ref-abc"
+      >
+        <sup>
+          ref-abc
+        </sup>
+      </a>
+      .
+    </p>
+    <footer>
+      <div
+        id="1"
+      >
+        1
+        : This is the 
+        <strong>
+          first
+        </strong>
+         footnote.
+      </div>
+      <div
+        id="ref-abc"
+      >
+        ref-abc
+        : This is 
+        <code>
+          another
+        </code>
+         note!
+      </div>
+    </footer>
+  </div>
+</div>
+`;
+
 exports[`paywall 1`] = `
 <div>
   <div>

--- a/clients/apps/web/src/components/Feed/Markdown/abbreviatedContent.test.ts
+++ b/clients/apps/web/src/components/Feed/Markdown/abbreviatedContent.test.ts
@@ -1,4 +1,4 @@
-import { abbreviatedContent } from './BrowserRender'
+import { abbreviatedContent, getReferences } from './BrowserRender'
 
 describe('abbreviatedContent', () => {
   test('short', () => {
@@ -121,5 +121,56 @@ Aliquam mollis hendrerit sapien id viverra.`
 ---
 `,
     )
+  })
+
+  test('references', () => {
+    const t = `
+It was a [hobbit-hole][1], and that means comfort.
+
+---
+
+Below the boundary!
+
+[1]: <https://en.wikipedia.org/wiki/Hobbit#Lifestyle> "Hobbit lifestyles"
+    `
+
+    expect(
+      abbreviatedContent({
+        body: t,
+        includeBoundaryInBody: false,
+        includeRefs: true,
+      }).body,
+    ).toStrictEqual(`
+It was a [hobbit-hole][1], and that means comfort.
+
+[1]: <https://en.wikipedia.org/wiki/Hobbit#Lifestyle> "Hobbit lifestyles"`)
+  })
+})
+
+describe('getReferences', () => {
+  test('ref', () => {
+    const t = `
+It was a [hobbit-hole][1], and that means comfort.
+
+[1]: <https://en.wikipedia.org/wiki/Hobbit#Lifestyle> "Hobbit lifestyles"
+
+content
+
+[named-ref]: hello!!
+
+[^named-footnote]: footnote :-)
+
+more content
+`
+    expect(getReferences(t)).toStrictEqual([
+      `[1]: <https://en.wikipedia.org/wiki/Hobbit#Lifestyle> "Hobbit lifestyles"`,
+      '[named-ref]: hello!!',
+    ])
+  })
+
+  test('none', () => {
+    const t = `
+It was a [hobbit-hole][1], and that means comfort.`
+    expect(getReferences(t)).toStrictEqual([])
   })
 })

--- a/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
@@ -296,3 +296,21 @@ Here's a simple footnote,[^1] and here's another one[^ref-abc].
   )
   expect(container).toMatchSnapshot()
 })
+
+test('references', () => {
+  const { container } = render(
+    <TestRenderer
+      article={{
+        ...article,
+        body: `
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the ends
+of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down on or to
+eat: it was a [hobbit-hole][1], and that means comfort.
+
+[1]: <https://en.wikipedia.org/wiki/Hobbit#Lifestyle> "Hobbit lifestyles"
+`,
+      }}
+    />,
+  )
+  expect(container).toMatchSnapshot()
+})

--- a/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
+++ b/clients/apps/web/src/components/Feed/Markdown/render.test.tsx
@@ -278,3 +278,21 @@ block
   )
   expect(container).toMatchSnapshot()
 })
+
+test('footnote', () => {
+  const { container } = render(
+    <TestRenderer
+      article={{
+        ...article,
+        body: `
+Here's a simple footnote,[^1] and here's another one[^ref-abc].
+
+[^1]: This is the **first** footnote.
+[^ref-abc]: This is \`another\` note!
+
+`,
+      }}
+    />,
+  )
+  expect(container).toMatchSnapshot()
+})


### PR DESCRIPTION
Lifts up content from below the boundary.

This adds support for rendering the abbreviation of the following:

```markdown
Hello [World][world].

---

[world]: https://polar.sh

```