### PR TITLE
feat(discord): add more detail to pledge embed

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -101,6 +101,8 @@ class Settings(BaseSettings):
 
     # Discord
     DISCORD_WEBHOOK_URL: str | None = None
+    FAVICON_URL: str = "https://raw.githubusercontent.com/polarsource/polar/2648cf7472b5128704a097cd1eb3ae5f1dd847e5/docs/docs/assets/favicon.png"
+    THUMBNAIL_URL: str = "https://raw.githubusercontent.com/polarsource/polar/4fd899222e200ca70982f437039f549b7a822ecc/clients/apps/web/public/email-logo-dark.png"
 
     # Posthog
     POSTHOG_PROJECT_API_KEY: str = ""

--- a/server/polar/receivers/pledges.py
+++ b/server/polar/receivers/pledges.py
@@ -126,23 +126,43 @@ async def pledge_created_webhook_alerts(hook: PledgeHook) -> None:
         return
 
     for wh in webhooks:
-        description = (
-            f'A ${pledge.amount/100} pledge has been made towards "{issue.title}".'
-        )
-
         if wh.integration == "discord":
-            webhook = AsyncDiscordWebhook(url=wh.url, content="New pledge")
+            webhook = AsyncDiscordWebhook(url=wh.url, content="New Pledge Received")
+            _pledge_amount = pledge.amount / 100
+            _issue_polar_url = (
+                f"https://polar.sh/{org.name}/{repo.name}/issues/{issue.number}"
+            )
+            _issue_github_url = (
+                f"https://github.com/{org.name}/{repo.name}/issues/{issue.number}"
+            )
+
+            description = (
+                f"A ${_pledge_amount} pledge has been made towards [{repo.name}#{issue.number}]({_issue_github_url}): "
+                f"\n > `{issue.title}`."
+            )
 
             embed = DiscordEmbed(
-                title="New pledge",
+                title="New pledge Received",
                 description=description,
                 color="65280",
             )
 
+            embed.set_thumbnail(url=settings.THUMBNAIL_URL)
+            embed.set_author(name="Polar.sh", icon_url=settings.FAVICON_URL)
             embed.add_embed_field(
-                name="Polar",
-                value=f"[Open](https://polar.sh/{org.name}/{repo.name}/issues/{issue.number})",
+                name="Polar.sh",
+                value=f"[View on Polar.sh]({_issue_polar_url})",
+                inline=True,
             )
+            embed.add_embed_field(
+                name="Issue",
+                value=f"[View on GitHub]({_issue_github_url})",
+                inline=True,
+            )
+            embed.add_embed_field(
+                name="Amount", value=f"${_pledge_amount}", inline=True
+            )
+            embed.set_footer(text="Powered by Polar.sh")
 
             webhook.add_embed(embed)
             await webhook.execute()


### PR DESCRIPTION
## Description

- Makes Discord embed for pledge events prettier

## Closes

- Closes #2864

## Note

- Feel free to close, just had a wild hair on lunch.
- I tested locally but I'd like to be able to test with the pulled values from the database and others, if someone can do that?

## UI

<details>
<summary>Before</summary>

<img width="514" alt="image" src="https://github.com/polarsource/polar/assets/45884264/df79085a-7273-4a05-a6da-283627160fcf">

</details>

<details>
<summary>After</summary>

<img width="401" alt="image" src="https://github.com/polarsource/polar/assets/45884264/02d49b81-ad09-4269-94bb-0508a82c5c2e">

</details>
