### PR TITLE
server/dx: tweak Alembic migrations filename

### DIFF
--- a/server/alembic.ini
+++ b/server/alembic.ini
@@ -8,8 +8,7 @@ script_location = migrations
 # Uncomment the line below if you want the files to be prepended with date and time
 # see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
 # for all available tokens
-# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
-file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(slug)s
+file_template = %%(year)d-%%(month).2d-%%(day).2d-%%(hour).2d%%(minute).2d_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.


### PR DESCRIPTION
Add hours and minutes to ease sorting when several migrations are issued on the same day