### PR TITLE
clients/org: implement automatic tier creation from suggested tier

### DIFF
--- a/clients/apps/web/src/app/[organization]/(sidebar)/ClientPage.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/ClientPage.tsx
@@ -3,7 +3,7 @@
 import revalidate from '@/app/actions'
 import { Post as PostComponent } from '@/components/Feed/Posts/Post'
 import { PublicPagePostWizard } from '@/components/Onboarding/Creator/PostWizard'
-import { FreeTierSubscribe } from '@/components/Organization/FreeTierSubscribe'
+import { OrganizationHighlightedTiers } from '@/components/Organization/OrganizationHighlightedTiers'
 import { OrganizationIssueSummaryList } from '@/components/Organization/OrganizationIssueSummaryList'
 import { CreatorsEditor } from '@/components/Profile/CreatorEditor/CreatorsEditor'
 import {
@@ -11,8 +11,6 @@ import {
   LinksEditor,
 } from '@/components/Profile/LinksEditor/LinksEditor'
 import { ProjectsEditor } from '@/components/Profile/ProjectEditor/ProjectsEditor'
-import SubscriptionTierCard from '@/components/Subscriptions/SubscriptionTierCard'
-import SubscriptionTierSubscribeButton from '@/components/Subscriptions/SubscriptionTierSubscribeButton'
 import { useTrafficRecordPageView } from '@/utils/traffic'
 import { ViewDayOutlined } from '@mui/icons-material'
 import {
@@ -57,16 +55,6 @@ const ClientPage = ({
     [organization, adminOrganizations],
   )
 
-  const shouldRenderSubscribeButton = !isAdmin
-
-  const highlightedTiers = useMemo(
-    () =>
-      subscriptionTiers.items?.filter(
-        ({ type, is_highlighted }) => is_highlighted,
-      ) ?? [],
-    [subscriptionTiers.items],
-  )
-
   const updateOrganizationMutation = useUpdateOrganization()
 
   const updateOrganization = (
@@ -92,57 +80,6 @@ const ClientPage = ({
     updateOrganization({
       links: links.map((l) => l.url),
     })
-  }
-
-  const HighlightedTiersModule = () => {
-    return (
-      highlightedTiers.length > 0 && (
-        <div className="flex w-full flex-col gap-y-8">
-          <div className="flex flex-col gap-y-4">
-            <div className="flex flex-row items-center justify-between">
-              <h2>Subscriptions</h2>
-              <Link
-                className="text-sm text-blue-500 dark:text-blue-400"
-                href={organizationPageLink(organization, 'subscriptions')}
-              >
-                <span>View all</span>
-              </Link>
-            </div>
-            <p className="dark:text-polar-500 text-sm text-gray-500">
-              Support {organization.name} with a subscription & receive unique
-              benefits in return
-            </p>
-          </div>
-          <div className="flex w-full flex-col gap-4">
-            {highlightedTiers.map((tier) => (
-              <SubscriptionTierCard
-                className="min-h-0 w-full"
-                key={tier.id}
-                subscriptionTier={tier}
-                variant="small"
-              >
-                {shouldRenderSubscribeButton ? (
-                  <>
-                    {tier.type === 'free' ? (
-                      <FreeTierSubscribe
-                        subscriptionTier={tier}
-                        organization={organization}
-                      />
-                    ) : (
-                      <SubscriptionTierSubscribeButton
-                        organization={organization}
-                        subscriptionTier={tier}
-                        subscribePath="/api/subscribe"
-                      />
-                    )}
-                  </>
-                ) : null}
-              </SubscriptionTierCard>
-            ))}
-          </div>
-        </div>
-      )
-    )
   }
 
   return (
@@ -189,11 +126,13 @@ const ClientPage = ({
             )}
           </div>
 
-          {highlightedTiers.length > 0 && (
-            <div className="flex w-full flex-col lg:hidden">
-              <HighlightedTiersModule />
-            </div>
-          )}
+          <div className="flex w-full flex-col lg:hidden">
+            <OrganizationHighlightedTiers
+              organization={organization}
+              adminOrganizations={adminOrganizations}
+              subscriptionTiers={subscriptionTiers.items ?? []}
+            />
+          </div>
 
           {repositories.length > 0 && (
             <ProjectsEditor
@@ -233,7 +172,11 @@ const ClientPage = ({
         </div>
 
         <div className="hidden w-full flex-col gap-y-16 md:max-w-52 lg:flex lg:max-w-72">
-          <HighlightedTiersModule />
+          <OrganizationHighlightedTiers
+            organization={organization}
+            adminOrganizations={adminOrganizations}
+            subscriptionTiers={subscriptionTiers.items ?? []}
+          />
 
           <LinksEditor
             organization={organization}

--- a/clients/apps/web/src/app/[organization]/(sidebar)/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/page.tsx
@@ -168,7 +168,13 @@ export default async function Page({
           platform: Platforms.GITHUB,
           organizationName: params.organization,
         },
-        cacheConfig,
+        {
+          ...cacheConfig,
+          next: {
+            ...cacheConfig.next,
+            tags: [`subscriptionTiers:${params.organization}`],
+          },
+        },
       ),
       api.repositories.search(
         {

--- a/clients/apps/web/src/components/Organization/OrganizationHighlightedTiers.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationHighlightedTiers.tsx
@@ -1,0 +1,271 @@
+import revalidate from '@/app/actions'
+import SubscriptionTierCard from '@/components/Subscriptions/SubscriptionTierCard'
+import { ArrowForward } from '@mui/icons-material'
+import {
+  Organization,
+  SubscriptionTier,
+  SubscriptionTierType,
+} from '@polar-sh/sdk'
+import Link from 'next/link'
+import Button from 'polarkit/components/ui/atoms/button'
+import {
+  useCreateSubscriptionTier,
+  useSubscriptionBenefits,
+  useUpdateSubscriptionTierBenefits,
+} from 'polarkit/hooks'
+import { organizationPageLink } from 'polarkit/utils/nav'
+import { useCallback, useMemo, useState } from 'react'
+import SubscriptionTierSubscribeButton from '../Subscriptions/SubscriptionTierSubscribeButton'
+import { isPremiumArticlesBenefit } from '../Subscriptions/utils'
+import { FreeTierSubscribe } from './FreeTierSubscribe'
+
+export interface OrganizationHighlightedTiersProps {
+  organization: Organization
+  adminOrganizations: Organization[]
+  subscriptionTiers: SubscriptionTier[]
+}
+
+export const OrganizationHighlightedTiers = ({
+  organization,
+  adminOrganizations,
+  subscriptionTiers,
+}: OrganizationHighlightedTiersProps) => {
+  const isAdmin = useMemo(
+    () => adminOrganizations?.some((org) => org.id === organization.id),
+    [organization, adminOrganizations],
+  )
+
+  const shouldRenderSubscribeButton = !isAdmin
+
+  const highlightedTiers = useMemo(
+    () =>
+      subscriptionTiers?.filter(({ type, is_highlighted }) => is_highlighted) ??
+      [],
+    [subscriptionTiers],
+  )
+
+  const paidSubscriptionTiers = useMemo(
+    () =>
+      subscriptionTiers?.filter(
+        ({ type }) =>
+          type === SubscriptionTierType.INDIVIDUAL ||
+          type === SubscriptionTierType.BUSINESS,
+      ) ?? [],
+    [subscriptionTiers],
+  )
+
+  if (!isAdmin && highlightedTiers.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-y-8">
+      {isAdmin ? (
+        <div className="flex flex-col gap-y-4">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <h2 className="text-lg">Subscriptions</h2>
+            <Link
+              className="flex flex-row items-center gap-2 text-sm text-blue-500 dark:text-blue-400"
+              href={`/maintainer/${organization.name}/subscriptions/tiers`}
+            >
+              <span>Configure</span>
+            </Link>
+          </div>
+          <p className="dark:text-polar-500 text-sm text-gray-500">
+            Highlight subscription tiers to feature them on your profile
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-4">
+          <div className="flex flex-row items-center justify-between">
+            <h2>Subscriptions</h2>
+            <Link
+              className="text-sm text-blue-500 dark:text-blue-400"
+              href={organizationPageLink(organization, 'subscriptions')}
+            >
+              <span>View all</span>
+            </Link>
+          </div>
+          <p className="dark:text-polar-500 text-sm text-gray-500">
+            Support {organization.name} with a subscription & receive unique
+            benefits in return
+          </p>
+        </div>
+      )}
+
+      <div className="flex w-full flex-col gap-4">
+        {highlightedTiers.length > 0 ? (
+          highlightedTiers.map((tier) => (
+            <SubscriptionTierCard
+              className="min-h-0 w-full"
+              key={tier.id}
+              subscriptionTier={tier}
+              variant="small"
+            >
+              {shouldRenderSubscribeButton ? (
+                <>
+                  {tier.type === 'free' ? (
+                    <FreeTierSubscribe
+                      subscriptionTier={tier}
+                      organization={organization}
+                    />
+                  ) : (
+                    <SubscriptionTierSubscribeButton
+                      organization={organization}
+                      subscriptionTier={tier}
+                      subscribePath="/api/subscribe"
+                    />
+                  )}
+                </>
+              ) : null}
+            </SubscriptionTierCard>
+          ))
+        ) : isAdmin && paidSubscriptionTiers.length === 0 ? (
+          <OrganizationHighlightedTiersAuthenticatedEmptyState
+            organization={organization}
+          />
+        ) : isAdmin && paidSubscriptionTiers.length > 0 ? (
+          <Link href={`/maintainer/${organization.name}/subscriptions/tiers`}>
+            <Button size="sm">
+              <div className="flex flex-row items-center gap-2">
+                <span>Highlight a tier</span>
+                <ArrowForward fontSize="inherit" />
+              </div>
+            </Button>
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+interface OrganizationHighlightedTiersAuthenticatedEmptyStateProps {
+  organization: Organization
+}
+
+const OrganizationHighlightedTiersAuthenticatedEmptyState = ({
+  organization,
+}: OrganizationHighlightedTiersAuthenticatedEmptyStateProps) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const { subscriptionTier, create } = useCreateBaselineTier(organization)
+
+  const handleCreate = useCallback(async () => {
+    setIsLoading(true)
+
+    try {
+      await create()
+    } catch (e) {
+      // Only reset loading state if there was an error
+      // If successful, the component will unmount and the loading state will be irrelevant
+      // This will eliminate the flashing loading state
+      setIsLoading(false)
+    }
+  }, [create, setIsLoading])
+
+  return (
+    <div className="flex w-full flex-col gap-y-8">
+      <div className="flex w-full flex-col gap-4">
+        <SubscriptionTierCard
+          className="min-h-0 w-full"
+          subscriptionTier={subscriptionTier}
+          variant="small"
+        >
+          <div className="flex w-full flex-col gap-2">
+            <Button onClick={handleCreate} loading={isLoading} fullWidth>
+              Create Suggested Tier
+            </Button>
+            <Link
+              href={`/maintainer/${organization.name}/subscriptions/tiers/new`}
+            >
+              <Button variant="ghost" fullWidth>
+                Edit
+              </Button>
+            </Link>
+          </div>
+        </SubscriptionTierCard>
+      </div>
+    </div>
+  )
+}
+
+interface MockedBaselineTier {
+  subscriptionTier: SubscriptionTier
+  create: () => Promise<void>
+}
+
+const useCreateBaselineTier = (
+  organization: Organization,
+): MockedBaselineTier => {
+  const mockedBaselineTier: SubscriptionTier = useMemo(() => {
+    return {
+      id: '123',
+      name: 'Supporter',
+      description:
+        'Support my work and get access to premium posts and content in the future.',
+      type: 'individual',
+      price_amount: 500,
+      price_currency: 'USD',
+      benefits: [
+        {
+          id: '1',
+          name: 'Premium posts',
+          description: 'Premium posts',
+          created_at: new Date().toISOString(),
+          deletable: false,
+          selectable: true,
+          type: 'articles',
+        },
+      ],
+      created_at: new Date().toISOString(),
+      is_highlighted: false,
+      is_archived: false,
+    }
+  }, [])
+
+  const organizationBenefits = useSubscriptionBenefits(organization.name, 99)
+  const premiumArticlesBenefit = organizationBenefits.data?.items?.filter(
+    isPremiumArticlesBenefit,
+  )[0]
+
+  const updateTierBenefits = useUpdateSubscriptionTierBenefits(
+    organization.name,
+  )
+
+  const createTierMutation = useCreateSubscriptionTier(organization.name)
+
+  const createBaselineTier = useCallback(async () => {
+    if (!premiumArticlesBenefit) {
+      return
+    }
+
+    const tier = await createTierMutation.mutateAsync({
+      name: mockedBaselineTier.name,
+      description: mockedBaselineTier.description,
+      type: SubscriptionTierType.INDIVIDUAL,
+      price_amount: mockedBaselineTier.price_amount,
+      price_currency: mockedBaselineTier.price_currency,
+      is_highlighted: true,
+      organization_id: organization.id,
+    })
+
+    await updateTierBenefits.mutateAsync({
+      id: tier.id,
+      subscriptionTierBenefitsUpdate: {
+        benefits: [premiumArticlesBenefit.id],
+      },
+    })
+
+    await revalidate(`subscriptionTiers:${organization.name}`)
+  }, [
+    organization,
+    createTierMutation,
+    mockedBaselineTier,
+    premiumArticlesBenefit,
+    updateTierBenefits,
+  ])
+
+  return {
+    subscriptionTier: mockedBaselineTier,
+    create: createBaselineTier,
+  }
+}

--- a/clients/apps/web/src/components/Organization/OrganizationHighlightedTiers.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationHighlightedTiers.tsx
@@ -172,13 +172,13 @@ const OrganizationHighlightedTiersAuthenticatedEmptyState = ({
         >
           <div className="flex w-full flex-col gap-2">
             <Button onClick={handleCreate} loading={isLoading} fullWidth>
-              Create Suggested Tier
+              Setup Suggested Tier
             </Button>
             <Link
               href={`/maintainer/${organization.name}/subscriptions/tiers/new`}
             >
               <Button variant="ghost" fullWidth>
-                Edit
+                Create Custom
               </Button>
             </Link>
           </div>

--- a/clients/apps/web/src/components/Profile/CreatorEditor/CreatorsEditor.tsx
+++ b/clients/apps/web/src/components/Profile/CreatorEditor/CreatorsEditor.tsx
@@ -1,6 +1,6 @@
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core'
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
-import { FaceOutlined, TuneOutlined } from '@mui/icons-material'
+import { FaceOutlined } from '@mui/icons-material'
 import { Organization } from '@polar-sh/sdk'
 import { Modal } from '../../Modal'
 import { useModal } from '../../Modal/useModal'
@@ -87,7 +87,6 @@ export const CreatorsEditor = ({
                 className="flex cursor-pointer flex-row items-center gap-x-2 text-sm text-blue-500 dark:text-blue-400"
                 onClick={show}
               >
-                <TuneOutlined fontSize="small" />
                 <span>Configure</span>
               </div>
             )}

--- a/clients/apps/web/src/components/Profile/LinksEditor/LinksEditor.tsx
+++ b/clients/apps/web/src/components/Profile/LinksEditor/LinksEditor.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@/components/Modal'
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core'
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
-import { LanguageOutlined, TuneOutlined } from '@mui/icons-material'
+import { LanguageOutlined } from '@mui/icons-material'
 import { Organization } from '@polar-sh/sdk'
 import { OgObject } from 'open-graph-scraper-lite/dist/lib/types'
 import { twMerge } from 'tailwind-merge'
@@ -103,7 +103,6 @@ export const LinksEditor = ({
                 className="flex cursor-pointer flex-row items-center gap-x-2 text-sm text-blue-500 dark:text-blue-400"
                 onClick={show}
               >
-                <TuneOutlined fontSize="small" />
                 <span>Configure</span>
               </div>
             )}

--- a/clients/apps/web/src/components/Profile/ProjectEditor/ProjectsEditor.tsx
+++ b/clients/apps/web/src/components/Profile/ProjectEditor/ProjectsEditor.tsx
@@ -1,11 +1,7 @@
 import revalidate from '@/app/actions'
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core'
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
-import {
-  ArrowForwardOutlined,
-  HiveOutlined,
-  TuneOutlined,
-} from '@mui/icons-material'
+import { ArrowForwardOutlined, HiveOutlined } from '@mui/icons-material'
 import { Organization, Repository } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { useUpdateOrganization } from 'polarkit/hooks'
@@ -121,7 +117,6 @@ export const ProjectsEditor = ({
                 className="flex cursor-pointer flex-row items-center gap-x-2 text-sm text-blue-500 dark:text-blue-400"
                 onClick={show}
               >
-                <TuneOutlined fontSize="small" />
                 <span>Configure</span>
               </div>
             )}

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionTierCard.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionTierCard.tsx
@@ -18,7 +18,7 @@ import { twMerge } from 'tailwind-merge'
 import SubscriptionGroupIcon from './SubscriptionGroupIcon'
 import { getSubscriptionColorByType, resolveBenefitIcon } from './utils'
 
-interface SubscriptionTierCardProps {
+export interface SubscriptionTierCardProps {
   subscriptionTier: Partial<SubscriptionTier>
   children?: React.ReactNode
   className?: string

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionTierCreatePage.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionTierCreatePage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import revalidate from '@/app/actions'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import {
   Organization,
@@ -113,7 +114,11 @@ const SubscriptionTierCreate: React.FC<SubscriptionTierCreateProps> = ({
             benefits: enabledBenefitIds,
           },
         })
+
         clearDraft('SubscriptionTierCreate')
+
+        revalidate(`subscriptionTiers:${organization.name}`)
+
         router.push(`/maintainer/${organization.name}/subscriptions/tiers`)
         router.refresh()
       } catch (e) {

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionTierEditPage.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionTierEditPage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import revalidate from '@/app/actions'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import {
   Organization,
@@ -121,6 +122,9 @@ const SubscriptionTierEdit = ({
             benefits: enabledBenefitIds,
           },
         })
+
+        revalidate(`subscriptionTiers:${organization.name}`)
+
         router.push(`/maintainer/${organization.name}/subscriptions/tiers`)
         router.refresh()
       } catch (e) {
@@ -164,6 +168,8 @@ const SubscriptionTierEdit = ({
 
   const handleArchiveSubscriptionTier = useCallback(async () => {
     await archiveSubscriptionTier.mutateAsync({ id: subscriptionTier.id })
+
+    revalidate(`subscriptionTiers:${organization.name}`)
 
     router.push(`/maintainer/${organization.name}/subscriptions/tiers`)
     router.refresh()


### PR DESCRIPTION
Implements an empty state for creators on the Org profile, where you can setup a simple $5 tier with a single click.

<img width="1327" alt="image" src="https://github.com/polarsource/polar/assets/10053249/c5d0f612-8bcd-4d5c-aa7a-81409213a643">
