### PR TITLE
server/benefits: disable revoke for old version of the github_reposit…

### DIFF
--- a/server/polar/subscription/service/benefits/github_repository.py
+++ b/server/polar/subscription/service/benefits/github_repository.py
@@ -210,6 +210,10 @@ class SubscriptionBenefitGitHubRepositoryService(
             user_id=str(user.id),
         )
 
+        if benefit.properties["repository_id"]:
+            bound_logger.info("skipping revoke for old version of this benefit type")
+            return {}
+
         client = await self._get_github_app_client(bound_logger, benefit)
 
         repository_owner = benefit.properties["repository_owner"]


### PR DESCRIPTION
…ory benefit

To allow an easier migration to the new benefit version