### PR TITLE
server/funding: override oauth account loading

### DIFF
--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -16,6 +16,7 @@ from .account import Account
 
 
 class OAuthPlatform(StrEnum):
+    # maximum allowed length is 32 chars
     github = "github"
     github_repository_benefit = "github_repository_benefit"
     discord = "discord"
@@ -30,7 +31,7 @@ class OAuthAccount(RecordModel):
         ),
     )
 
-    platform: Mapped[OAuthPlatform] = mapped_column(String(24), nullable=False)
+    platform: Mapped[OAuthPlatform] = mapped_column(String(32), nullable=False)
     access_token: Mapped[str] = mapped_column(String(1024), nullable=False)
     expires_at: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     refresh_token: Mapped[str | None] = mapped_column(

--- a/server/tests/funding/test_service.py
+++ b/server/tests/funding/test_service.py
@@ -212,6 +212,15 @@ class TestListBy:
             is_private=False,
         )
 
+        pledging_user = await create_user(save_fixture)
+
+        # create multiple identities for pledging user
+        await create_oauth_account(save_fixture, pledging_user, OAuthPlatform.discord)
+        await create_oauth_account(save_fixture, pledging_user, OAuthPlatform.github)
+        await create_oauth_account(
+            save_fixture, pledging_user, OAuthPlatform.github_repository_benefit
+        )
+
         issues = []
 
         # create 20 issues
@@ -231,12 +240,12 @@ class TestListBy:
             )
 
         for n in range(3):
-            await create_pledge(
+            await create_user_pledge(
                 save_fixture,
                 organization,
                 repository,
                 issues[4],
-                pledging_organization=organization,
+                pledging_user=pledging_user,
                 type=PledgeType.pay_upfront,
             )
 


### PR DESCRIPTION
Load at most one oauth account. This fixes a bug where pledges where double-counted in the funding API if the pledging user had multiple oauth accounts connected.