### PR TITLE
server/transaction: temporarily disable setting transfer group while payout

### DIFF
--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -449,7 +449,7 @@ class PayoutTransactionService(BaseTransactionService):
                     account.stripe_id,
                     amount,
                     source_transaction=source_transaction,
-                    transfer_group=transfer_group,
+                    # transfer_group=transfer_group,
                     metadata={"payout_transaction_id": str(transaction.id)},
                 )
                 balance_transaction.transfer_id = stripe_transfer.id

--- a/server/tests/transaction/service/test_payout.py
+++ b/server/tests/transaction/service/test_payout.py
@@ -203,7 +203,7 @@ class TestCreatePayout:
                 payment_transaction_1.charge_id,
                 payment_transaction_2.charge_id,
             ]
-            assert call[1]["transfer_group"] == str(payout.id)
+            # assert call[1]["transfer_group"] == str(payout.id)
             assert call[1]["metadata"]["payout_transaction_id"] == str(payout.id)
 
         stripe_service_mock.create_payout.assert_not_called()


### PR DESCRIPTION
Because of conflicts when trying to pay out pledges