### PR TITLE
clients/navigation: replace repeated navigation logic with re-usable …

### DIFF
--- a/clients/apps/web/src/app/(topbar)/(backer)/finance/layout.tsx
+++ b/clients/apps/web/src/app/(topbar)/(backer)/finance/layout.tsx
@@ -1,25 +1,14 @@
 'use client'
 
-import { personalFinanceSubRoutes } from '@/components/Dashboard/navigation'
+import { usePersonalFinanceSubRoutes } from '@/components/Dashboard/navigation'
 import { SubNav } from '@/components/Navigation/DashboardTopbar'
-import { usePathname } from 'next/navigation'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname()
-
-  const subRoutes = personalFinanceSubRoutes()
+  const subRoutes = usePersonalFinanceSubRoutes()
 
   return (
     <div className="flex flex-col gap-y-8">
-      <SubNav
-        items={
-          subRoutes.map((sub) => ({
-            ...sub,
-            active: sub.link === pathname,
-          })) ?? []
-        }
-      />
-
+      <SubNav items={subRoutes} />
       {children}
     </div>
   )

--- a/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/layout.tsx
+++ b/clients/apps/web/src/app/maintainer/[organization]/(topbar)/finance/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { dashboardRoutes } from '@/components/Dashboard/navigation'
+import { useDashboardRoutes } from '@/components/Dashboard/navigation'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { SubNav } from '@/components/Navigation/DashboardTopbar'
 import {
@@ -8,26 +8,20 @@ import {
   useIsOrganizationAdmin,
   usePersonalOrganization,
 } from '@/hooks'
-import { usePathname } from 'next/navigation'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { org: currentOrgFromURL } = useCurrentOrgAndRepoFromURL()
   const personalOrg = usePersonalOrganization()
-  const pathname = usePathname()
   const isOrgAdmin = useIsOrganizationAdmin(currentOrgFromURL)
   const isPersonal = currentOrgFromURL?.name === personalOrg?.name
 
-  const routes = currentOrgFromURL
-    ? dashboardRoutes(
-        currentOrgFromURL,
-        currentOrgFromURL ? isPersonal : true,
-        isOrgAdmin ?? false,
-      )
-    : []
-
-  const [currentRoute] = routes.filter((route) =>
-    pathname?.startsWith(route.link),
+  const routes = useDashboardRoutes(
+    currentOrgFromURL,
+    currentOrgFromURL ? isPersonal : true,
+    isOrgAdmin ?? false,
   )
+
+  const currentRoute = routes.find((r) => r.isActive)
 
   return (
     <>
@@ -36,14 +30,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           currentRoute &&
           'subs' in currentRoute &&
           (currentRoute.subs?.length ?? 0) > 0 && (
-            <SubNav
-              items={
-                currentRoute.subs?.map((sub) => ({
-                  ...sub,
-                  active: sub.link === pathname,
-                })) ?? []
-              }
-            />
+            <SubNav items={currentRoute.subs ?? []} />
           )}
         {children}
       </DashboardBody>

--- a/clients/apps/web/src/components/Dashboard/DashboardNavigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/DashboardNavigation.tsx
@@ -1,38 +1,21 @@
 import { MaintainerOrganizationContext } from '@/providers/maintainerOrganization'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 import { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { dashboardRoutes } from './navigation'
+import { useDashboardRoutes } from './navigation'
 
 const DashboardNavigation = () => {
-  const path = usePathname()
-
   const orgContext = useContext(MaintainerOrganizationContext)
   const org = orgContext?.organization
   const adminOrgs = orgContext?.adminOrganizations ?? []
   const personalOrg = orgContext?.personalOrganization
+  const isOrgAdmin = adminOrgs.some((o) => org && o.id === org.id)
+  const isPersonal = Boolean(org && personalOrg && org.id === personalOrg.id)
+  const navs = useDashboardRoutes(org, isPersonal, isOrgAdmin ?? false)
 
   if (!org) {
     return <></>
   }
-
-  const isOrgAdmin = adminOrgs.some((o) => o.id === org.id)
-  const isPersonal = org?.id === personalOrg?.id
-
-  // All routes and conditions
-  const navs = org ? dashboardRoutes(org, isPersonal, isOrgAdmin ?? false) : []
-
-  // Filter routes, set isActive, and if subs should be expanded
-  const filteredNavs = navs
-    .filter((n) => n.if)
-    .map((n) => {
-      const isActive = path && path.startsWith(n.link)
-      return {
-        ...n,
-        isActive,
-      }
-    })
 
   return (
     <>
@@ -42,7 +25,7 @@ const DashboardNavigation = () => {
         </div>
       </div>
       <div className="flex flex-col gap-2 px-4 py-3">
-        {filteredNavs.map((n) => (
+        {navs.map((n) => (
           <div key={n.link} className="flex flex-col gap-4">
             <Link
               className={twMerge(

--- a/clients/apps/web/src/components/Dashboard/MaintainerNavigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/MaintainerNavigation.tsx
@@ -2,54 +2,20 @@
 
 import { MaintainerOrganizationContext } from '@/providers/maintainerOrganization'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 import { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { maintainerRoutes } from './navigation'
+import { useMaintainerRoutes } from './navigation'
 
 const MaintainerNavigation = () => {
-  const pathname = usePathname()
-
   const orgContext = useContext(MaintainerOrganizationContext)
   const org = orgContext?.organization
   const personalOrg = orgContext?.personalOrganization
 
+  const navs = useMaintainerRoutes(org ?? personalOrg ?? undefined)
+
   if (!org) {
     return <></>
   }
-
-  // All routes and conditions
-  const navs = org
-    ? maintainerRoutes(org)
-    : personalOrg
-      ? maintainerRoutes(personalOrg)
-      : []
-
-  // Filter routes, set isActive, and if subs should be expanded
-  const filteredNavs = navs
-    .filter((n) => ('if' in n ? n.if : true))
-    .map((n) => {
-      const isActive = pathname && pathname.startsWith(n.link)
-
-      const subs =
-        ('subs' in n &&
-          n.subs?.map((s) => {
-            return {
-              ...s,
-              isActive: pathname && pathname.startsWith(s.link),
-            }
-          })) ||
-        []
-
-      const anySubIsActive = subs.find((s) => s.isActive)
-
-      return {
-        ...n,
-        isActive,
-        expandSubs: isActive || anySubIsActive,
-        subs,
-      }
-    })
 
   return (
     <>
@@ -59,7 +25,7 @@ const MaintainerNavigation = () => {
         </div>
       </div>
       <div className="flex flex-col gap-2 px-4 py-3">
-        {filteredNavs.map((n) => (
+        {navs.map((n) => (
           <div key={n.link} className="flex flex-col gap-4">
             <Link
               className={twMerge(

--- a/clients/apps/web/src/components/Layout/Public/Topbar.tsx
+++ b/clients/apps/web/src/components/Layout/Public/Topbar.tsx
@@ -16,8 +16,8 @@ import Button from 'polarkit/components/ui/atoms/button'
 import { useCallback } from 'react'
 
 import {
-  backerRoutes,
   unauthenticatedRoutes,
+  useBackerRoutes,
 } from '@/components/Dashboard/navigation'
 import { useMaintainerUpgrade } from 'polarkit/hooks'
 import TopbarNavigation from './TopbarNavigation'
@@ -109,7 +109,9 @@ const Topbar = ({
 
   const upsell = upsellOrDashboard()
 
-  const routes = authenticatedUser ? backerRoutes() : unauthenticatedRoutes
+  const backerRoutes = useBackerRoutes()
+
+  const routes = authenticatedUser ? backerRoutes : unauthenticatedRoutes
 
   return (
     <div className="dark:border-b-polar-800 dark:bg-polar-950 sticky top-0 z-50 flex w-full  flex-col items-center border-b border-b-gray-100 bg-white py-4">

--- a/clients/apps/web/src/components/Navigation/PublicProfileDropdown.tsx
+++ b/clients/apps/web/src/components/Navigation/PublicProfileDropdown.tsx
@@ -13,7 +13,7 @@ import { organizationPageLink } from 'polarkit/utils/nav'
 import { useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { usePersonalOrganization } from '../../hooks'
-import { backerRoutes, dashboardRoutes } from '../Dashboard/navigation'
+import { useBackerRoutes, useDashboardRoutes } from '../Dashboard/navigation'
 import { LinkItem, ListItem, Profile, TextItem } from './Navigation'
 
 const PublicProfileDropdown = ({
@@ -43,15 +43,9 @@ const PublicProfileDropdown = ({
 
   const loggedUser = authenticatedUser
 
-  const allBackerRoutes = backerRoutes()
-  const filteredBackerRoutes = showAllBackerRoutes
-    ? allBackerRoutes.filter((r) => r.if)
-    : []
-
-  const allPersonalRoutes = personalOrg
-    ? dashboardRoutes(personalOrg, true, true)
-    : []
-  const personalRoutes = allPersonalRoutes.filter((r) => r.if)
+  const backerRoutes = useBackerRoutes()
+  const filteredBackerRoutes = showAllBackerRoutes ? backerRoutes : []
+  const personalRoutes = useDashboardRoutes(personalOrg, true, true)
 
   if (!loggedUser) {
     return <></>


### PR DESCRIPTION
…hooks

Also adding the ability to customise the `isActive` calculation, so that we can have links in the navigation to `/overview`-pages directly, skipping the redirects.