### PR TITLE
clients/repository: error handling for repository description

### DIFF
--- a/clients/apps/web/src/app/[organization]/[repo]/ClientPage.tsx
+++ b/clients/apps/web/src/app/[organization]/[repo]/ClientPage.tsx
@@ -33,7 +33,7 @@ import { ShadowBoxOnMd } from 'polarkit/components/ui/atoms/shadowbox'
 import { useUpdateProject } from 'polarkit/hooks'
 import { formatStarsNumber } from 'polarkit/utils'
 import { organizationPageLink } from 'polarkit/utils/nav'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 const ClientPage = ({
   organization,
@@ -54,7 +54,6 @@ const ClientPage = ({
   links: { opengraph: OgObject; url: string }[]
   posts: Article[]
 }) => {
-  const [descriptionIsLoading, setDescriptionIsLoading] = useState(false)
   const isAdmin = useMemo(
     () => adminOrganizations?.some((org) => org.id === organization.id),
     [organization, adminOrganizations],
@@ -89,15 +88,10 @@ const ClientPage = ({
 
   const updateDescription = useDebouncedCallback(
     async (description: string | undefined) => {
-      setDescriptionIsLoading(true)
-      try {
-        await updateProfile({ set_description: true, description })
-      } finally {
-        setDescriptionIsLoading(false)
-      }
+      await updateProfile({ set_description: true, description })
     },
     500,
-    [updateProfile, setDescriptionIsLoading],
+    [updateProfile],
   )
 
   const updateLinks = (links: LinkItem[]) => {
@@ -113,18 +107,19 @@ const ClientPage = ({
       <div className="flex w-full flex-col gap-16">
         <div className="flex flex-col gap-16 md:flex-row">
           <div className="flex w-full min-w-0 flex-shrink flex-col gap-y-16">
-            {repository.description && (
-              <DescriptionEditor
-                description={
-                  repository.profile_settings.description ??
-                  repository.description ??
-                  ''
-                }
-                onChange={updateDescription}
-                disabled={!isAdmin}
-                loading={descriptionIsLoading}
-              />
-            )}
+            <DescriptionEditor
+              description={
+                repository.profile_settings.description ??
+                repository.description ??
+                ''
+              }
+              onChange={updateDescription}
+              disabled={!isAdmin}
+              loading={updateProjectMutation.isPending}
+              failed={updateProjectMutation.isError}
+              maxLength={240}
+            />
+
             <CoverEditor
               organization={organization}
               onChange={updateCoverImage}

--- a/clients/apps/web/src/components/Organization/OrganizationPublicSidebar.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationPublicSidebar.tsx
@@ -126,6 +126,7 @@ export const OrganizationPublicSidebar = ({
             size="small"
             loading={updateOrganizationMutation.isPending}
             failed={updateOrganizationMutation.isError}
+            maxLength={160}
           />
           <div className="flex flex-row flex-wrap items-center gap-2.5 text-lg">
             <SocialLink href={`https://github.com/${organization.name}`}>

--- a/clients/apps/web/src/components/Profile/DescriptionEditor/DescriptionEditor.tsx
+++ b/clients/apps/web/src/components/Profile/DescriptionEditor/DescriptionEditor.tsx
@@ -10,6 +10,7 @@ export interface DescriptionEditorProps {
   failed?: boolean
   className?: string
   size?: 'default' | 'small'
+  maxLength: number
 }
 
 export const DescriptionEditor = ({
@@ -20,6 +21,7 @@ export const DescriptionEditor = ({
   failed,
   className,
   size = 'default',
+  maxLength,
 }: DescriptionEditorProps) => {
   const paragraphRef = useRef<HTMLParagraphElement>(null)
 
@@ -42,7 +44,7 @@ export const DescriptionEditor = ({
     setContentLength(content.length)
   }
 
-  const showLength = isDirty || contentLength > 160
+  const showLength = isDirty || contentLength > maxLength
 
   return (
     <div
@@ -79,10 +81,10 @@ export const DescriptionEditor = ({
         <div
           className={twMerge(
             'text-gray absolute bottom-2 right-2 text-xs',
-            contentLength > 160 ? 'text-red-500' : 'text-gray-500',
+            contentLength > maxLength ? 'text-red-500' : 'text-gray-500',
           )}
         >
-          {contentLength}/160
+          {contentLength}/{maxLength}
         </div>
       ) : null}
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -134,7 +134,10 @@ class Organization(Schema):
 
 class OrganizationProfileSettingsUpdate(Schema):
     set_description: bool | None = None
-    description: str | None = None
+    description: str | None = Field(
+        None,
+        max_length=160,
+    )
 
     featured_projects: list[UUID4] | None = None
     featured_organizations: list[UUID4] | None = None

--- a/server/polar/repository/schemas.py
+++ b/server/polar/repository/schemas.py
@@ -78,7 +78,10 @@ class Repository(Schema):
 
 class RepositoryProfileSettingsUpdate(Schema):
     set_description: bool | None = None
-    description: str | None = None
+    description: str | None = Field(
+        None,
+        max_length=REPOSITORY_PROFILE_DESCRIPTION_MAX_LENGTH,
+    )
 
     set_cover_image_url: bool | None = None
     cover_image_url: str | None = None

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 from httpx import AsyncClient
-from pydantic import ValidationError
 
 from polar.config import settings
 from polar.kit.utils import utc_now
@@ -615,17 +614,19 @@ async def test_update_organization_profile_settings_description(
     assert response.json()["id"] == str(organization.id)
     assert response.json()["profile_settings"]["description"] == "Hello whitespace!"
 
-    # setting a description which exceeds the maximum length should throw a validation error
-    with pytest.raises(ValidationError):
-        response = await client.patch(
-            f"/api/v1/organizations/{organization.id}",
-            json={
-                "profile_settings": {
-                    "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium.",
-                    "set_description": True,
-                }
-            },
-        )
+    # setting a description which exceeds the maximum length
+    response = await client.patch(
+        f"/api/v1/organizations/{organization.id}",
+        json={
+            "profile_settings": {
+                "description": "a" * 161,
+                "set_description": True,
+            }
+        },
+    )
+
+    assert 422 == response.status_code
+    assert response.json()["detail"][0]["type"] == "string_too_long"
 
 
 @pytest.mark.asyncio

--- a/server/tests/repository/test_endpoints.py
+++ b/server/tests/repository/test_endpoints.py
@@ -469,17 +469,18 @@ async def test_update_repository_profile_settings_description(
     assert response.json()["id"] == str(repository.id)
     assert response.json()["profile_settings"]["description"] == "Hello whitespace!"
 
-    # setting a description which exceeds the maximum length should throw a validation error
-    with pytest.raises(ValidationError):
-        response = await client.patch(
-            f"/api/v1/repositories/{repository.id}",
-            json={
-                "profile_settings": {
-                    "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium.",
-                    "set_description": True,
-                }
-            },
-        )
+    # setting a description which exceeds the maximum length
+    response = await client.patch(
+        f"/api/v1/repositories/{repository.id}",
+        json={
+            "profile_settings": {
+                "description": "a" * 270,
+                "set_description": True,
+            }
+        },
+    )
+    assert 422 == response.status_code
+    assert response.json()["detail"][0]["type"] == "string_too_long"
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/service/test_subscription_tier.py
+++ b/server/tests/subscription/service/test_subscription_tier.py
@@ -375,7 +375,7 @@ class TestSearch:
         user_organization_second: UserOrganization,  # joined data, make sure that it doesn't affect anything...
     ) -> None:
         repository.is_private = True
-        assert save_fixture(repository)
+        await save_fixture(repository)
 
         benefits = []
         for _ in range(10):


### PR DESCRIPTION
Same as what I previously added for org descriptions.