### PR TITLE
server/worker: run github crawl jobs on a separate worker

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -61,7 +61,7 @@ services:
 
   # Worker
   - type: worker
-    name: worker-image
+    name: worker-default
     env: image
     image:
       url: ghcr.io/polarsource/polar:latest
@@ -69,6 +69,58 @@ services:
         fromRegistryCreds:
           name: polarsource
     dockerCommand: "poetry run arq run_worker.WorkerSettings --custom-log-dict run_worker.silent_logger_config_dict"
+    region: ohio
+    plan: standard
+    numInstances: 1
+    autoDeploy: false # deploys are triggered by github actions
+    envVars:
+      # PostgreSQL
+      - key: POLAR_POSTGRES_USER
+        fromDatabase:
+          name: polar
+          property: user
+      - key: POLAR_POSTGRES_PWD
+        fromDatabase:
+          name: polar
+          property: password
+      - key: POLAR_POSTGRES_DATABASE
+        fromDatabase:
+          name: polar
+          property: database
+      - key: POLAR_POSTGRES_PORT
+        fromDatabase:
+          name: polar
+          property: port
+      - key: POLAR_POSTGRES_HOST
+        fromDatabase:
+          name: polar
+          property: host
+
+      # Redis
+      - key: POLAR_REDIS_HOST
+        fromService:
+          type: redis
+          name: polar-tasks
+          property: host
+      - key: POLAR_REDIS_PORT
+        fromService:
+          type: redis
+          name: polar-tasks
+          property: port
+
+      - fromGroup: github-production
+      - fromGroup: server-common
+      - fromGroup: server-stripe
+
+  - type: worker
+    name: worker-github
+    env: image
+    image:
+      url: ghcr.io/polarsource/polar:latest
+      creds:
+        fromRegistryCreds:
+          name: polarsource
+    dockerCommand: "poetry run arq run_worker.WorkerSettingsGitHubCrawl --custom-log-dict run_worker.silent_logger_config_dict"
     region: ohio
     plan: standard
     numInstances: 1
@@ -129,51 +181,50 @@ databases:
         description: mason_app_2
     plan: standard
 
-
 envVarGroups:
-- name: github-production
-  envVars:
-    - key: POLAR_GITHUB_APP_IDENTIFIER
-      sync: false
-    - key: POLAR_GITHUB_APP_PRIVATE_KEY
-      sync: false
-    - key: POLAR_GITHUB_APP_WEBHOOK_SECRET
-      sync: false
-    - key: POLAR_GITHUB_CLIENT_ID
-      sync: false
-    - key: POLAR_GITHUB_CLIENT_SECRET
-      sync: false
+  - name: github-production
+    envVars:
+      - key: POLAR_GITHUB_APP_IDENTIFIER
+        sync: false
+      - key: POLAR_GITHUB_APP_PRIVATE_KEY
+        sync: false
+      - key: POLAR_GITHUB_APP_WEBHOOK_SECRET
+        sync: false
+      - key: POLAR_GITHUB_CLIENT_ID
+        sync: false
+      - key: POLAR_GITHUB_CLIENT_SECRET
+        sync: false
 
-- name: server-common
-  envVars:
-  - key: POLAR_GITHUB_BADGE_EMBED
-    value: 1
-  - key: POLAR_ENV
-    value: production
-  - key: POLAR_LOG_LEVEL
-    value: INFO
-  - key: POLAR_TESTING
-    value: 0
-  - key: POLAR_DEBUG
-    value: 0
-  - key: POLAR_FRONTEND_BASE_URL
-    value: "https://polar.sh"
-  - key: POLAR_SENTRY_DSN
-    sync: false
-  - key: POLAR_EMAIL_SENDER
-    value: "sendgrid"
-  - key: POLAR_SENDGRID_API_KEY
-    sync: false
-  - key: POLAR_BASE_URL
-    value: "https://api.polar.sh/api/v1"
-  - key: POLAR_DISCORD_WEBHOOK_URL
-    sync: false
-  - key: POLAR_POSTHOG_PROJECT_API_KEY
-    sync: false
+  - name: server-common
+    envVars:
+      - key: POLAR_GITHUB_BADGE_EMBED
+        value: 1
+      - key: POLAR_ENV
+        value: production
+      - key: POLAR_LOG_LEVEL
+        value: INFO
+      - key: POLAR_TESTING
+        value: 0
+      - key: POLAR_DEBUG
+        value: 0
+      - key: POLAR_FRONTEND_BASE_URL
+        value: "https://polar.sh"
+      - key: POLAR_SENTRY_DSN
+        sync: false
+      - key: POLAR_EMAIL_SENDER
+        value: "sendgrid"
+      - key: POLAR_SENDGRID_API_KEY
+        sync: false
+      - key: POLAR_BASE_URL
+        value: "https://api.polar.sh/api/v1"
+      - key: POLAR_DISCORD_WEBHOOK_URL
+        sync: false
+      - key: POLAR_POSTHOG_PROJECT_API_KEY
+        sync: false
 
-- name: server-stripe
-  envVars:
-  - key: POLAR_STRIPE_SECRET_KEY
-    sync: false
-  - key: POLAR_STRIPE_WEBHOOK_SECRET
-    sync: false
+  - name: server-stripe
+    envVars:
+      - key: POLAR_STRIPE_SECRET_KEY
+        sync: false
+      - key: POLAR_STRIPE_WEBHOOK_SECRET
+        sync: false

--- a/server/polar/integrations/github/receivers.py
+++ b/server/polar/integrations/github/receivers.py
@@ -3,7 +3,7 @@ import structlog
 from polar.issue.hooks import IssueHook, issue_upserted
 from polar.organization.service import organization as organization_service
 from polar.repository.service import repository as repository_service
-from polar.worker import enqueue_job
+from polar.worker import QueueName, enqueue_job
 
 from .badge import GithubBadge
 
@@ -36,8 +36,16 @@ async def schedule_embed_badge_task(
 async def schedule_fetch_references_and_dependencies(
     hook: IssueHook,
 ) -> None:
-    enqueue_job("github.issue.sync.issue_references", hook.issue.id)
-    enqueue_job("github.issue.sync.issue_dependencies", hook.issue.id)
+    enqueue_job(
+        "github.issue.sync.issue_references",
+        hook.issue.id,
+        queue_name=QueueName.github_crawl,
+    )
+    enqueue_job(
+        "github.issue.sync.issue_dependencies",
+        hook.issue.id,
+        queue_name=QueueName.github_crawl,
+    )
 
 
 issue_upserted.add(schedule_fetch_references_and_dependencies)

--- a/server/polar/receivers/pull_request.py
+++ b/server/polar/receivers/pull_request.py
@@ -4,7 +4,7 @@ from polar.issue.service import issue as issue_service
 from polar.organization.service import organization as organization_service
 from polar.pull_request.hooks import PullRequestHook, pull_request_upserted
 from polar.repository.service import repository as repository_service
-from polar.worker import enqueue_job
+from polar.worker import QueueName, enqueue_job
 
 
 async def pull_request_find_reverse_references(
@@ -53,7 +53,11 @@ async def pull_request_find_reverse_references(
             continue
 
         # Schedule sync for this issue
-        enqueue_job("github.issue.sync.issue_references", linked_issue.id)
+        enqueue_job(
+            "github.issue.sync.issue_references",
+            linked_issue.id,
+            queue_name=QueueName.github_crawl,
+        )
 
 
 pull_request_upserted.add(pull_request_find_reverse_references)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -79,6 +79,7 @@ types-requests = "^2.31.0.10"
 [tool.taskipy.tasks]
 api = { cmd = "task verify_github_app && env AUTHLIB_INSECURE_TRANSPORT=true  uvicorn polar.app:app --reload --workers 1 --host 127.0.0.1 --port 8000", help = "run api service" }
 worker = { cmd = "arq run_worker.WorkerSettings --watch polar --custom-log-dict run_worker.silent_logger_config_dict", help = "run arq worker" }
+worker_github_crawl = { cmd = "arq run_worker.WorkerSettingsGitHubCrawl --watch polar --custom-log-dict run_worker.silent_logger_config_dict", help = "run arq worker" }
 test = { cmd = "POLAR_ENV=testing coverage run --source polar -m pytest && coverage report -m", help = "run all tests" }
 lint = { cmd = "ruff format . && ruff check --fix .", help = "run linters with autofix" }
 lint_check = { cmd = "ruff format --check . && ruff check .", help = "run ruff linter" }

--- a/server/run_worker.py
+++ b/server/run_worker.py
@@ -12,4 +12,4 @@ configure_logging(logfire=True)
 
 from polar.receivers import *  # noqa
 from polar.tasks import *  # noqa
-from polar.worker import WorkerSettings  # noqa
+from polar.worker import WorkerSettings, WorkerSettingsGitHubCrawl  # noqa


### PR DESCRIPTION
When using outgoing webhooks in production the queue delays have become more noticeable, when developing a 30s delay in hook delivery is not a pleasant experience.

This PR creates a new arq job queue for GitHub sync/crawling, and runs the other jobs on the "default" queue.

All cronjobs still run on the "default" worker.