### PR TITLE
client: Don't link issue to funding in dashboard, but show funding button

### DIFF
--- a/clients/apps/web/src/components/Issues/IssueListItem.tsx
+++ b/clients/apps/web/src/components/Issues/IssueListItem.tsx
@@ -93,6 +93,7 @@ const IssueListItem = (props: {
               {props.right}
             </>
           }
+          linkToFunding={!props.canAddRemovePolarLabel}
         />
         {havePledgeOrReference && (
           <IssueActivityBox>

--- a/clients/apps/web/src/components/Issues/IssueSummary.tsx
+++ b/clients/apps/web/src/components/Issues/IssueSummary.tsx
@@ -2,8 +2,11 @@
 
 import { organizationPageLink } from '@/utils/nav'
 import { CheckCircleIcon } from '@heroicons/react/24/outline'
+import { FavoriteBorderOutlined } from '@mui/icons-material'
 import { Issue, IssueStateEnum, Label } from '@polar-sh/sdk'
+import Link from 'next/link'
 import { PolarTimeAgo } from 'polarkit/components/ui/atoms'
+import Button from 'polarkit/components/ui/atoms/button'
 import { twMerge } from 'tailwind-merge'
 import IconCounter from './IconCounter'
 import IssueLabel from './IssueLabel'
@@ -14,6 +17,7 @@ interface IssueSummaryProps {
   showLogo?: boolean
   showStatus?: boolean
   right?: React.ReactElement
+  linkToFunding?: boolean
 }
 
 const IssueSummary: React.FC<IssueSummaryProps> = ({
@@ -21,6 +25,7 @@ const IssueSummary: React.FC<IssueSummaryProps> = ({
   showLogo,
   showStatus,
   right,
+  linkToFunding,
 }) => {
   const {
     title,
@@ -51,6 +56,12 @@ const IssueSummary: React.FC<IssueSummaryProps> = ({
 
   const markdownTitle = generateMarkdownTitle(title)
 
+  const fundingLink = organizationPageLink(
+    organization,
+    `${repository.name}/issues/${number}`,
+  )
+  linkToFunding = linkToFunding !== undefined ? linkToFunding : true
+
   return (
     <div className="dark:md:hover:bg-polar-800 duration-50 dark:text-polar-50 md:hover:bg-gray-75 group flex flex-col items-start justify-between gap-4 overflow-hidden px-6 py-4 pb-5 md:flex-row md:items-center md:rounded-2xl">
       <div className="flex flex-row items-center">
@@ -69,15 +80,18 @@ const IssueSummary: React.FC<IssueSummaryProps> = ({
 
         <div className="flex flex-col gap-2">
           <div className="flex flex-wrap items-start gap-x-4 gap-y-2">
-            <a
-              className="text-md dark:text-polar-50 text-nowrap font-medium"
-              href={organizationPageLink(
-                organization,
-                `${repository.name}/issues/${number}`,
-              )}
-            >
-              {markdownTitle}
-            </a>
+            {linkToFunding ? (
+              <Link
+                className="text-md dark:text-polar-50 text-nowrap font-medium"
+                href={fundingLink}
+              >
+                {markdownTitle}
+              </Link>
+            ) : (
+              <span className="text-md dark:text-polar-50 text-nowrap font-medium">
+                {markdownTitle}
+              </span>
+            )}
 
             {issue.labels &&
               issue.labels.map((label: Label) => {
@@ -86,7 +100,13 @@ const IssueSummary: React.FC<IssueSummaryProps> = ({
           </div>
           <div className="dark:text-polar-400 text-xs text-gray-500">
             <p>
-              #{number}{' '}
+              <a
+                href={`https://github.com/${organization.name}/${repository.name}/issues/${number}`}
+                className="text-gray-700"
+                rel="nofollow"
+              >
+                #{number}
+              </a>{' '}
               {isOpen ? (
                 <>
                   opened <PolarTimeAgo date={createdAt} />
@@ -132,6 +152,12 @@ const IssueSummary: React.FC<IssueSummaryProps> = ({
           )}
         </div>
 
+        <Link href={fundingLink} className="font-medium text-blue-500">
+          <Button size="sm" variant="secondary" asChild>
+            <FavoriteBorderOutlined fontSize="inherit" />
+            <span className="ml-1.5">Fund</span>
+          </Button>
+        </Link>
         {right}
       </div>
     </div>

--- a/clients/apps/web/src/components/Organization/IssuesLookingForFunding.tsx
+++ b/clients/apps/web/src/components/Organization/IssuesLookingForFunding.tsx
@@ -1,9 +1,7 @@
 'use client'
 
 import { useSearchFunding } from '@/hooks/queries'
-import { organizationPageLink } from '@/utils/nav'
 import {
-  FavoriteBorderOutlined,
   FilterList,
   HowToVoteOutlined,
   SearchOutlined,
@@ -15,7 +13,6 @@ import {
   Organization,
   Repository,
 } from '@polar-sh/sdk'
-import Link from 'next/link'
 import {
   ReadonlyURLSearchParams,
   useRouter,
@@ -104,23 +101,7 @@ const IssuesLookingForFunding = ({
           <div className="dark:divider-polar-700 -mx-6 flex flex-col divide-y md:divide-y-0">
             {listIssues.map((i) => (
               <Fragment key={i.issue.id}>
-                <IssueSummary
-                  issue={i.issue}
-                  right={
-                    <Link
-                      href={organizationPageLink(
-                        i.issue.repository.organization,
-                        `${i.issue.repository.name}/issues/${i.issue.number}`,
-                      )}
-                      className="font-medium text-blue-500"
-                    >
-                      <Button size="sm" variant="secondary" asChild>
-                        <FavoriteBorderOutlined fontSize="inherit" />
-                        <span className="ml-1.5">Fund</span>
-                      </Button>
-                    </Link>
-                  }
-                />
+                <IssueSummary issue={i.issue} />
                 {(i.total.amount > 0 ||
                   !!i.funding_goal ||
                   !!i.issue.upfront_split_to_contributors) && (

--- a/clients/apps/web/src/components/Organization/OrganizationIssueSummaryList.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationIssueSummaryList.tsx
@@ -1,8 +1,6 @@
 import { organizationPageLink } from '@/utils/nav'
-import { FavoriteBorderOutlined } from '@mui/icons-material'
 import { IssueFunding, Organization } from '@polar-sh/sdk'
 import Link from 'next/link'
-import Button from 'polarkit/components/ui/atoms/button'
 import { ShadowBoxOnMd } from 'polarkit/components/ui/atoms/shadowbox'
 import { Fragment } from 'react'
 import IssueActivityBox from '../Issues/IssueActivityBox'
@@ -37,23 +35,7 @@ export const OrganizationIssueSummaryList = ({
         <div className="-mx-4 flex flex-col divide-y md:divide-y-0">
           {issues.map((i) => (
             <Fragment key={i.issue.id}>
-              <IssueSummary
-                issue={i.issue}
-                right={
-                  <Link
-                    href={organizationPageLink(
-                      organization,
-                      `${i.issue.repository.name}/issues/${i.issue.number}`,
-                    )}
-                    className="font-medium text-blue-500"
-                  >
-                    <Button size="sm" variant="secondary" asChild>
-                      <FavoriteBorderOutlined fontSize="inherit" />
-                      <span className="ml-1.5">Fund</span>
-                    </Button>
-                  </Link>
-                }
-              />
+              <IssueSummary issue={i.issue} />
               {i.total.amount > 0 ||
               !!i.funding_goal ||
               !!i.issue.upfront_split_to_contributors ? (


### PR DESCRIPTION
Confusing UX that the entire issue linked to funding in the dashboard
when the main mode is badging. Solving this by removing linking the
headline in the dashboard. But adding the funding button everywhere to
still have it accessible, i.e maintainers funding it themselves for
rewards.
