### PR TITLE
Rewards percentage using decimal.Decimal

### DIFF
--- a/server/polar/models/issue_reward.py
+++ b/server/polar/models/issue_reward.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -53,8 +54,13 @@ class IssueReward(RecordModel):
     def user(cls) -> Mapped[User]:
         return relationship(User, lazy="raise")
 
+    @property
+    def pct(self) -> Decimal:
+        # Use decimal to avoid binary floating point issues
+        return Decimal(self.share_thousands) / 1000
+
     def get_share_amount(self, pledge: "Pledge") -> int:
-        return round(pledge.amount * self.share_thousands / 1000)
+        return round(pledge.amount * self.pct)
 
     def get_rewarded(self) -> "Organization | User | None":
         if self.organization is not None:

--- a/server/tests/reward/test_service.py
+++ b/server/tests/reward/test_service.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import timedelta
+from decimal import Decimal
 
 import pytest
 from pytest_mock import MockerFixture
@@ -109,7 +110,10 @@ async def test_list_rewards(
     assert org_tuple[1].github_username is None
     assert org_tuple[1].organization_id is organization.id
     assert org_tuple[1].share_thousands == 700
-    assert org_tuple[2].amount == round(pledge.amount * 0.7)
+
+    pct = org_tuple[1].pct
+    assert pct == Decimal("0.7")
+    assert org_tuple[2].amount == round(pledge.amount * pct)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Ensuring we always get a percentage point that uses decimal arithmetic
vs. binary floating point arithemtic in Python which is not what we
want.
