### PR TITLE
Fix #3347

### DIFF
--- a/clients/apps/web/src/components/Organization/OrganizationPublicSidebar.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationPublicSidebar.tsx
@@ -4,6 +4,7 @@ import revalidate from '@/app/actions'
 import { useAuth } from '@/hooks'
 import { useUpdateOrganization } from '@/hooks/queries'
 import { api } from '@/utils/api'
+import { CONFIG } from '@/utils/config'
 import { RssIcon } from '@heroicons/react/20/solid'
 import { LanguageOutlined, MailOutline } from '@mui/icons-material'
 import {
@@ -247,7 +248,7 @@ const RssModal = ({
   const { currentUser } = useAuth()
   const [token, setToken] = useState<string>()
   const auth = token ? `?auth=${token}` : ''
-  const url = `https://polar.sh/${organization.name}/rss${auth}`
+  const url = `${CONFIG.FRONTEND_BASE_URL}/${organization.name}/rss${auth}`
 
   useEffect(() => {
     if (!currentUser) {
@@ -260,7 +261,7 @@ const RssModal = ({
       .create({
         createPersonalAccessToken: {
           comment: `RSS for ${organization.name}`,
-          scopes: ['articles:read'],
+          scopes: ['organizations:read', 'articles:read'],
         },
       })
       .then((res: CreatePersonalAccessTokenResponse) => {

--- a/clients/packages/sdk/openapi/source.json
+++ b/clients/packages/sdk/openapi/source.json
@@ -5214,6 +5214,15 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5265,6 +5274,15 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5339,6 +5357,15 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5435,6 +5462,15 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5485,6 +5521,14 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5553,6 +5597,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5618,6 +5670,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5677,6 +5737,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5726,6 +5794,14 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5780,6 +5856,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5826,6 +5910,14 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -6265,8 +6357,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "backer:subscriptions:write",
-                            "backer:subscriptions:read"
+                            "backer:subscriptions:read",
+                            "backer:subscriptions:write"
                         ]
                     },
                     {
@@ -10966,8 +11058,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -11137,8 +11229,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -11373,8 +11465,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -16748,7 +16840,8 @@
                                     "type": "string",
                                     "enum": [
                                         "articles:read",
-                                        "user:read"
+                                        "user:read",
+                                        "organizations:read"
                                     ]
                                 },
                                 "type": "array"
@@ -20111,7 +20204,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "default": "openid profile email articles:read user:read creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
+                        "default": "openid profile email articles:read user:read organizations:read organizations:write creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
                     },
                     "client_name": {
                         "type": "string",
@@ -20272,7 +20365,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "default": "openid profile email articles:read user:read creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
+                        "default": "openid profile email articles:read user:read organizations:read organizations:write creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
                     },
                     "client_name": {
                         "type": "string",
@@ -20393,7 +20486,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "default": "openid profile email articles:read user:read creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
+                        "default": "openid profile email articles:read user:read organizations:read organizations:write creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
                     },
                     "client_name": {
                         "type": "string",
@@ -24377,6 +24470,8 @@
                     "user:read",
                     "admin",
                     "web_default",
+                    "organizations:read",
+                    "organizations:write",
                     "creator:subscriptions:read",
                     "creator:subscriptions:write",
                     "backer:subscriptions:read",

--- a/clients/packages/sdk/openapi/updated.json
+++ b/clients/packages/sdk/openapi/updated.json
@@ -5214,6 +5214,15 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5265,6 +5274,15 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5339,6 +5357,15 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5435,6 +5462,15 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write",
+                            "organizations:read"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5485,6 +5521,14 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5553,6 +5597,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5618,6 +5670,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5677,6 +5737,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5726,6 +5794,14 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -5780,6 +5856,14 @@
                     },
                     {
                         "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
+                    },
+                    {
+                        "HTTPBearer": []
                     }
                 ],
                 "parameters": [
@@ -5826,6 +5910,14 @@
                 "security": [
                     {
                         "OpenIdConnect": []
+                    },
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "OpenIdConnect": [
+                            "organizations:write"
+                        ]
                     },
                     {
                         "HTTPBearer": []
@@ -6265,8 +6357,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "backer:subscriptions:write",
-                            "backer:subscriptions:read"
+                            "backer:subscriptions:read",
+                            "backer:subscriptions:write"
                         ]
                     },
                     {
@@ -10966,8 +11058,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -11137,8 +11229,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -11373,8 +11465,8 @@
                     },
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -16180,7 +16272,8 @@
                                     "type": "string",
                                     "enum": [
                                         "articles:read",
-                                        "user:read"
+                                        "user:read",
+                                        "organizations:read"
                                     ]
                                 },
                                 "type": "array"
@@ -18999,7 +19092,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "default": "openid profile email articles:read user:read creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
+                        "default": "openid profile email articles:read user:read organizations:read organizations:write creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
                     },
                     "client_name": {
                         "type": "string",
@@ -19160,7 +19253,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "default": "openid profile email articles:read user:read creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
+                        "default": "openid profile email articles:read user:read organizations:read organizations:write creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
                     },
                     "client_name": {
                         "type": "string",
@@ -19281,7 +19374,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "default": "openid profile email articles:read user:read creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
+                        "default": "openid profile email articles:read user:read organizations:read organizations:write creator:subscriptions:read creator:subscriptions:write backer:subscriptions:read backer:subscriptions:write creator:products:read creator:products:write creator:benefits:read creator:benefits:write orders:read webhooks:read webhooks:write"
                     },
                     "client_name": {
                         "type": "string",
@@ -22549,6 +22642,8 @@
                     "user:read",
                     "admin",
                     "web_default",
+                    "organizations:read",
+                    "organizations:write",
                     "creator:subscriptions:read",
                     "creator:subscriptions:write",
                     "backer:subscriptions:read",

--- a/clients/packages/sdk/src/client/models/index.ts
+++ b/clients/packages/sdk/src/client/models/index.ts
@@ -3704,7 +3704,8 @@ export interface CreatePersonalAccessToken {
  */
 export const CreatePersonalAccessTokenScopesEnum = {
     ARTICLESREAD: 'articles:read',
-    USERREAD: 'user:read'
+    USERREAD: 'user:read',
+    ORGANIZATIONSREAD: 'organizations:read'
 } as const;
 export type CreatePersonalAccessTokenScopesEnum = typeof CreatePersonalAccessTokenScopesEnum[keyof typeof CreatePersonalAccessTokenScopesEnum];
 
@@ -9763,6 +9764,8 @@ export const Scope = {
     USERREAD: 'user:read',
     ADMIN: 'admin',
     WEB_DEFAULT: 'web_default',
+    ORGANIZATIONSREAD: 'organizations:read',
+    ORGANIZATIONSWRITE: 'organizations:write',
     CREATORSUBSCRIPTIONSREAD: 'creator:subscriptions:read',
     CREATORSUBSCRIPTIONSWRITE: 'creator:subscriptions:write',
     BACKERSUBSCRIPTIONSREAD: 'backer:subscriptions:read',

--- a/server/polar/auth/scope.py
+++ b/server/polar/auth/scope.py
@@ -15,6 +15,9 @@ class Scope(StrEnum):
     admin = "admin"  # Admin scope. For Polar staff only.
     web_default = "web_default"  # Web default scope. For users logged in on the web.
 
+    organizations_read = "organizations:read"
+    organizations_write = "organizations:write"
+
     creator_subscriptions_read = "creator:subscriptions:read"
     creator_subscriptions_write = "creator:subscriptions:write"
     backer_subscriptions_read = "backer:subscriptions:read"

--- a/server/polar/organization/auth.py
+++ b/server/polar/organization/auth.py
@@ -1,0 +1,45 @@
+from typing import Annotated
+
+from fastapi import Depends
+
+from polar.auth.dependencies import Authenticator
+from polar.auth.models import Anonymous, AuthSubject, Organization, User
+from polar.auth.scope import Scope
+
+AnonymousOrganizationsRead = Annotated[
+    AuthSubject[User | Organization],
+    Depends(
+        Authenticator(
+            required_scopes={
+                Scope.web_default,
+                Scope.organizations_read,
+                Scope.organizations_write,
+            },
+            allowed_subjects={Anonymous, User, Organization},
+        )
+    ),
+]
+
+OrganizationsRead = Annotated[
+    AuthSubject[User | Organization],
+    Depends(
+        Authenticator(
+            required_scopes={
+                Scope.web_default,
+                Scope.organizations_read,
+                Scope.organizations_write,
+            },
+            allowed_subjects={User, Organization},
+        )
+    ),
+]
+
+OrganizationsWrite = Annotated[
+    AuthSubject[User | Organization],
+    Depends(
+        Authenticator(
+            required_scopes={Scope.web_default, Scope.organizations_write},
+            allowed_subjects={User, Organization},
+        )
+    ),
+]

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -20,6 +20,7 @@ from polar.user_organization.service import (
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
 
+from .auth import OrganizationsWrite
 from .schemas import (
     OrganizationCreateFromGitHubInstallation,
     OrganizationCreateFromGitHubUser,
@@ -249,14 +250,14 @@ class OrganizationService(ResourceServiceReader[Organization]):
         session: AsyncSession,
         *,
         authz: Authz,
-        user: User,
+        auth_subject: OrganizationsWrite,
         organization: Organization,
         account_id: UUID,
     ) -> Organization:
         account = await account_service.get_by_id(session, account_id)
         if account is None:
             raise InvalidAccount(account_id)
-        if not await authz.can(user, AccessType.write, account):
+        if not await authz.can(auth_subject.subject, AccessType.write, account):
             raise InvalidAccount(account_id)
 
         first_account_set = organization.account_id is None

--- a/server/polar/personal_access_token/endpoints.py
+++ b/server/polar/personal_access_token/endpoints.py
@@ -92,6 +92,7 @@ async def create(
         mapped = {
             "articles:read": Scope.articles_read,
             "user:read": Scope.user_read,
+            "organizations:read": Scope.organizations_read,
         }
         scopes = [mapped[k] for k in payload.scopes]
     else:

--- a/server/polar/personal_access_token/schemas.py
+++ b/server/polar/personal_access_token/schemas.py
@@ -28,7 +28,9 @@ class PersonalAccessToken(Schema):
 
 class CreatePersonalAccessToken(Schema):
     comment: str
-    scopes: list[Literal["articles:read", "user:read"]] | None = None
+    scopes: list[Literal["articles:read", "user:read", "organizations:read"]] | None = (
+        None
+    )
 
 
 class CreatePersonalAccessTokenResponse(PersonalAccessToken):


### PR DESCRIPTION
This fixes #3347 

RSS worked for public reads, but with a token to read premium posts it failed due to not having permissions to read organizations. 

I've ported our organizations endpoint to receive dedicated API scopes as intended and added them to our RSS PAT request.

However, it's TBD whether we want to support RSS this way in the future. Nonetheless we're fixing it now since it's broken for the current feature and then separately we'll evaluate the future long-term.