### PR TITLE
server/benefit: make sure the default BenefitGrant.properties is `{}`

### DIFF
--- a/server/polar/benefit/service/benefit_grant.py
+++ b/server/polar/benefit/service/benefit_grant.py
@@ -99,7 +99,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         grant = await self.get_by_benefit_and_scope(session, user, benefit, **scope)
 
         if grant is None:
-            grant = BenefitGrant(user=user, benefit=benefit, **scope)
+            grant = BenefitGrant(user=user, benefit=benefit, properties={}, **scope)
             session.add(grant)
         elif grant.is_granted:
             return grant
@@ -151,7 +151,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         grant = await self.get_by_benefit_and_scope(session, user, benefit, **scope)
 
         if grant is None:
-            grant = BenefitGrant(user=user, benefit=benefit, **scope)
+            grant = BenefitGrant(user=user, benefit=benefit, properties={}, **scope)
             session.add(grant)
         elif grant.is_revoked:
             return grant

--- a/server/tests/benefit/benefits/test_ads.py
+++ b/server/tests/benefit/benefits/test_ads.py
@@ -1,0 +1,38 @@
+from typing import cast
+
+import pytest
+
+from polar.benefit.benefits.ads import BenefitAdsService
+from polar.models import BenefitGrant, Organization, User
+from polar.models.benefit import (
+    BenefitAds,
+    BenefitType,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_db_asserts
+async def test_grant(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    user: User,
+    organization: Organization,
+) -> None:
+    benefit = cast(
+        BenefitAds,
+        await create_benefit(
+            save_fixture,
+            type=BenefitType.ads,
+            organization=organization,
+            properties={"image_height": 100, "image_width": 100},
+        ),
+    )
+    grant = BenefitGrant(user=user, benefit=benefit, properties={})
+
+    benefit_ads_service = BenefitAdsService(session)
+    grant_properties = await benefit_ads_service.grant(benefit, user, grant.properties)
+
+    assert grant_properties == {}

--- a/server/tests/benefit/service/test_benefit_grant.py
+++ b/server/tests/benefit/service/test_benefit_grant.py
@@ -143,6 +143,27 @@ class TestGrantBenefit:
 
         assert not grant.is_granted
 
+    async def test_default_properties_value(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        user: User,
+        benefit_organization: Benefit,
+        benefit_service_mock: MagicMock,
+    ) -> None:
+        benefit_service_mock.grant.side_effect = (
+            lambda user, benefit, properties, **kwargs: properties
+        )
+
+        # then
+        session.expunge_all()
+
+        grant = await benefit_grant_service.grant_benefit(
+            session, user, benefit_organization, subscription=subscription
+        )
+
+        assert grant.properties == {}
+
 
 @pytest.mark.asyncio
 class TestRevokeBenefit:

--- a/server/tests/user/endpoints/test_benefits.py
+++ b/server/tests/user/endpoints/test_benefits.py
@@ -1,0 +1,43 @@
+import pytest
+from httpx import AsyncClient
+
+from polar.models import Benefit, Subscription, User
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit_grant
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_db_asserts
+class TestListBenefits:
+    @pytest.mark.auth
+    async def test_user(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        benefit_organization: Benefit,
+        benefit_organization_second: Benefit,
+        user: User,
+    ) -> None:
+        await create_benefit_grant(
+            save_fixture,
+            user,
+            benefit_organization,
+            granted=True,
+            subscription=subscription,
+        )
+
+        await create_benefit_grant(
+            save_fixture,
+            user,
+            benefit_organization_second,
+            granted=False,
+            subscription=subscription,
+        )
+
+        response = await client.get("/api/v1/users/benefits/")
+
+        assert response.status_code == 200
+        json = response.json()
+
+        assert json["pagination"]["total_count"] == 1


### PR DESCRIPTION
Fix #3476