### PR TITLE
clients: Better error handling in GitHub installation

### DIFF
--- a/clients/apps/web/src/app/(installation)/github/installation/page.tsx
+++ b/clients/apps/web/src/app/(installation)/github/installation/page.tsx
@@ -9,7 +9,6 @@ import { api } from '@/utils/api'
 import {
   InstallationCreatePlatformEnum,
   Organization,
-  ResponseError,
   UserSignupType,
 } from '@polar-sh/sdk'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -75,9 +74,16 @@ export default function Page() {
         // redirect
         router.replace(`/maintainer/${organization.name}/initialize`)
       })
-      .catch((err: ResponseError) => {
+      .catch((err) => {
         if (signal.aborted) {
           return
+        }
+
+        if (err.name === 'FetchError') {
+          setError('Could not fetch data from GitHub. Try refreshing the page.')
+          // Since we get rare issues here sometimes. Raise so we capture in
+          // Sentry for more details.
+          throw err
         }
         if (err.response.status === 401) {
           setShowLogin(true)


### PR DESCRIPTION
Sometimes users report an error during installation. I suspect it might
be that GitHub redirects back immediately, but might not have fully
completed the installation (worker tasks). So our API seems to fail
without us capturing/handling it properly.

Informing the user to attempt to reload + throwing the error so Sentry
logs it for us to debug more closely.
