### PR TITLE
server/transaction: fix payout computation

### DIFF
--- a/server/polar/models/transaction.py
+++ b/server/polar/models/transaction.py
@@ -488,3 +488,13 @@ class Transaction(RecordModel):
     def net_amount(self) -> int:
         inclusive = 1 if self.type == TransactionType.balance else -1
         return self.gross_amount + inclusive * self.incurred_amount
+
+    @property
+    def reversed_amount(self) -> int:
+        return sum(
+            transaction.amount for transaction in self.balance_reversal_transactions
+        )
+
+    @property
+    def transferable_amount(self) -> int:
+        return self.amount + self.reversed_amount

--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -434,12 +434,14 @@ class PayoutTransactionService(BaseTransactionService):
                 and balance_transaction.payment_transaction.charge_id is not None
             ):
                 source_transaction = balance_transaction.payment_transaction.charge_id
-                transfer_amount = max(balance_transaction.net_amount - payout_fees, 0)
+                transfer_amount = max(
+                    balance_transaction.transferable_amount - payout_fees, 0
+                )
                 if transfer_amount > 0:
                     transfers.append(
                         (source_transaction, transfer_amount, balance_transaction)
                     )
-                payout_fees -= balance_transaction.net_amount - transfer_amount
+                payout_fees -= balance_transaction.transferable_amount - transfer_amount
 
         transfers_sum = sum(amount for _, amount, _ in transfers)
         if transfers_sum != -transaction.amount:
@@ -520,7 +522,7 @@ class PayoutTransactionService(BaseTransactionService):
                 Transaction.payout_transaction_id.is_(None),
             )
             .options(
-                selectinload(Transaction.account_incurred_transactions),
+                selectinload(Transaction.balance_reversal_transactions),
                 selectinload(Transaction.payment_transaction),
             )
         )


### PR DESCRIPTION
We were not considering all the balance reversal when computing the transfer of a balance. This caused a mismatch when some balance were refunded.