### PR TITLE
docs: Temporarily stop docs.polar.sh redirect

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -197,17 +197,16 @@ const nextConfig = {
         permanent: false,
       },
 
-
       // Redirect /docs to docs.polar.sh
-      ...ENVIRONMENT !== 'development' ?
-        [{
-          source: '/docs/:path*',
-          destination: 'https://docs.polar.sh/:path*',
-          permanent: false,
-        }]
-        :
-        [],
-
+      // ...ENVIRONMENT !== 'development' ?
+      // [{
+      //   source: '/docs/:path*',
+      //   destination: 'https://docs.polar.sh/:path*',
+      //   permanent: false,
+      // }]
+      // :
+      // [],
+      //
       {
         source: '/dashboard',
         destination: '/login',


### PR DESCRIPTION
Not working at the moment. Uncomment and stop the redirect attempt until
real fix can be deployed.
