### PR TITLE
docs: Remove human title of parameter names

### DIFF
--- a/clients/apps/web/src/components/Documentation/Parameters.tsx
+++ b/clients/apps/web/src/components/Documentation/Parameters.tsx
@@ -24,7 +24,7 @@ export const Parameters = ({
           <ParameterItem key={index}>
             <AnchoredElement id={['parameters', parameter.name]}>
               <div className="flex flex-row items-center gap-x-3">
-                <span className="font-mono text-sm text-blue-500 dark:text-blue-400">
+                <span className="font-mono font-medium text-black dark:text-white">
                   {parameter.name}
                 </span>
                 <span className="text-xxs rounded-md bg-blue-50 px-2 py-1 font-mono font-normal capitalize text-blue-500 dark:bg-blue-950/50 dark:text-blue-300">
@@ -37,12 +37,6 @@ export const Parameters = ({
                 {parameter.required ? <RequiredBadge /> : <OptionalBadge />}
               </div>
             </AnchoredElement>
-
-            <span className="text-lg font-medium text-black dark:text-white">
-              {parameter.schema &&
-                'title' in parameter.schema &&
-                parameter.schema?.title}
-            </span>
 
             {parameter.description && (
               <MDXContentWrapper className="text-sm">


### PR DESCRIPTION
Just causes duplication and confusion + more text to parse.
