### PR TITLE
Polar Page: Customize Free Subscription Promotion & Counting

### DIFF
--- a/clients/apps/web/src/app/[organization]/(sidebar)/layout.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/layout.tsx
@@ -43,7 +43,12 @@ export default async function Layout({
         platform: Platforms.GITHUB,
         organizationName: params.organization,
       },
-      cacheConfig,
+      {
+        next: {
+          revalidate: 30,
+          tags: [`organization:${params.organization}`]
+        }
+      },
     )
     if (!organization) {
       notFound()

--- a/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/ClientPage.tsx
@@ -32,6 +32,7 @@ const ClientPage: React.FC<OrganizationSubscriptionsPublicPageProps> = ({
     () => !orgs.data?.items?.map((o) => o.id).includes(organization.id),
     [organization, orgs],
   )
+  const showFreeTier = organization.profile_settings?.subscribe?.promote ?? true
 
   if (!organization.feature_settings?.subscriptions_enabled) {
     return redirect(organizationPageLink(organization))
@@ -56,7 +57,7 @@ const ClientPage: React.FC<OrganizationSubscriptionsPublicPageProps> = ({
       )}
       <div className="flex flex-row flex-wrap gap-8">
         {products
-          .filter(hasRecurringInterval(recurringInterval))
+          .filter(hasRecurringInterval(recurringInterval, !showFreeTier))
           .map((tier) => (
             <SubscriptionTierCard
               className="w-full self-stretch md:max-w-[290px]"

--- a/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
@@ -90,13 +90,20 @@ export default async function Page({
   let organization: Organization | undefined
   let products: ListResourceProduct | undefined
 
+  const pageCache = {
+    next: {
+      ...cacheConfig.next,
+      tags: [`organization:${params.organization}`],
+    }
+  }
+
   try {
     organization = await api.organizations.lookup(
       {
         platform: Platforms.GITHUB,
         organizationName: params.organization,
       },
-      cacheConfig,
+      pageCache,
     )
     products = await api.products.list(
       {
@@ -105,7 +112,7 @@ export default async function Page({
         isRecurring: true,
         limit: 100,
       },
-      cacheConfig,
+      pageCache,
     )
   } catch (e) {
     notFound()

--- a/clients/apps/web/src/components/Organization/OrganizationPublicSidebar.tsx
+++ b/clients/apps/web/src/components/Organization/OrganizationPublicSidebar.tsx
@@ -12,7 +12,6 @@ import {
   Organization,
   OrganizationProfileSettings,
   Product,
-  SubscriptionTierType,
 } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { useSelectedLayoutSegment } from 'next/navigation'
@@ -28,11 +27,11 @@ import { Modal, ModalHeader } from '../Modal'
 import { useModal } from '../Modal/useModal'
 import { DescriptionEditor } from '../Profile/DescriptionEditor/DescriptionEditor'
 import Spinner from '../Shared/Spinner'
-import { FreeTierSubscribe } from './FreeTierSubscribe'
+import { SubscribeEditor } from '../Profile/SubscribeEditor/SubscribeEditor'
 
 interface OrganizationPublicSidebarProps {
   organization: Organization
-  organizationCustomers: ListResourceOrganizationCustomer
+  organizationCustomers: ListResourceOrganizationCustomer | undefined
   userAdminOrganizations: Organization[]
   products: Product[]
 }
@@ -51,14 +50,7 @@ export const OrganizationPublicSidebar = ({
     show: showRssModal,
   } = useModal()
 
-  const freeSubscriptionTier = products.find(
-    (tier) => tier.type === SubscriptionTierType.FREE,
-  )
-
   const isAdmin = userAdminOrganizations.some((o) => o.id === organization.id)
-
-  const shouldRenderSubscriberCount =
-    (organizationCustomers.items?.length ?? 0) > 0
 
   const updateOrganizationMutation = useUpdateOrganization()
 
@@ -166,48 +158,7 @@ export const OrganizationPublicSidebar = ({
             </Button>
           </div>
         </div>
-        {(organization.feature_settings?.subscriptions_enabled ||
-          organization.feature_settings?.articles_enabled) && (
-          <div className="flex w-full flex-col gap-y-6">
-            {freeSubscriptionTier && !isAdmin ? (
-              <>
-                <FreeTierSubscribe
-                  product={freeSubscriptionTier}
-                  organization={organization}
-                  upsellSubscriptions
-                />
-              </>
-            ) : null}
-            {shouldRenderSubscriberCount && (
-              <div className="flex flex-row items-center gap-x-4">
-                <div className="flex w-fit flex-shrink-0 flex-row items-center md:hidden lg:flex">
-                  {organizationCustomers.items?.map((user, i, array) => (
-                    <Avatar
-                      className={twMerge(
-                        'h-10 w-10',
-                        i !== array.length - 1 && '-mr-3',
-                      )}
-                      key={i}
-                      name={user.public_name ?? ''}
-                      avatar_url={user.avatar_url}
-                      height={40}
-                      width={40}
-                    />
-                  ))}
-                </div>
-                <span className="text-sm">
-                  {Intl.NumberFormat('en-US', {
-                    notation: 'compact',
-                    compactDisplay: 'short',
-                  }).format(organizationCustomers.pagination.total_count)}{' '}
-                  {organizationCustomers.pagination.total_count === 1
-                    ? 'Subscriber'
-                    : 'Subscribers'}
-                </span>
-              </div>
-            )}
-          </div>
-        )}
+        <SubscribeEditor organization={organization} customerList={organizationCustomers} products={products} isAdmin={isAdmin} />
 
         {organization.donations_enabled && !isDonatePage ? (
           <DonateWidget organization={organization} />

--- a/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
+++ b/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
@@ -135,7 +135,6 @@ const SubscribeAdminSettings = ({
         hide={hideModal}
         modalContent={
           <SubscribeSettingsModal
-            organization={organization}
             settings={settings}
             setSettings={setSettings}
             saveSettings={updateSettings}
@@ -148,13 +147,11 @@ const SubscribeAdminSettings = ({
 }
 
 const SubscribeSettingsModal = ({
-  organization,
   settings,
   setSettings,
   saveSettings,
   hideModal,
 }: {
-  organization: Organization
   settings: OrganizationSubscribePromoteSettings
   setSettings: (settings: OrganizationSubscribePromoteSettings) => void
   saveSettings: () => void

--- a/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
+++ b/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
@@ -1,0 +1,247 @@
+import revalidate from '@/app/actions'
+import { Modal } from '@/components/Modal'
+import { twMerge } from 'tailwind-merge'
+import { useModal } from '@/components/Modal/useModal'
+import { useUpdateOrganization } from '@/hooks/queries'
+import { SettingsOutlined } from '@mui/icons-material'
+import { useState } from 'react'
+import {
+  Organization,
+  ListResourceOrganizationCustomer,
+  OrganizationSubscribePromoteSettings,
+  Product,
+  SubscriptionTierType,
+} from '@polar-sh/sdk'
+import Avatar from 'polarkit/components/ui/atoms/avatar'
+import { Switch } from 'polarkit/components/ui/atoms'
+import { FreeTierSubscribe } from '../../Organization/FreeTierSubscribe'
+import { CloseOutlined } from '@mui/icons-material'
+import Button from 'polarkit/components/ui/atoms/button'
+
+const getDefaultSettings = (organization: Organization): OrganizationSubscribePromoteSettings => {
+  return organization.profile_settings?.subscribe ?? {
+    promote: true,
+    show_count: true,
+    count_free: true,
+  }
+}
+
+export interface SubscribeEditorProps {
+  organization: Organization
+  customerList: ListResourceOrganizationCustomer | undefined
+  products: Product[]
+  isAdmin: boolean
+}
+
+export const SubscribeEditor = ({
+  organization,
+  customerList,
+  products,
+  isAdmin,
+}: SubscribeEditorProps) => {
+  const isSubscriptionsEnabled = organization.feature_settings?.subscriptions_enabled
+  if (!isSubscriptionsEnabled) {
+    return null
+  }
+
+  const settings = getDefaultSettings(organization)
+  const freeSubscriptionTier = products.find(
+    (tier) => tier.type === SubscriptionTierType.FREE,
+  )
+  const customerCount = customerList?.items?.length ?? 0
+  const showCount = customerList && customerCount && settings.show_count
+
+  return (
+    <div className="flex w-full flex-col gap-y-6">
+      {settings.promote && freeSubscriptionTier && !isAdmin ? (
+        <FreeTierSubscribe
+          product={freeSubscriptionTier}
+          organization={organization}
+          upsellSubscriptions
+        />
+      ) : null}
+      <div className="flex flex-row items-center gap-x-4">
+      {showCount && (
+        <>
+          <div className="flex w-fit flex-shrink-0 flex-row items-center md:hidden lg:flex">
+            {customerList.items?.map((user, i, array) => (
+              <Avatar
+                className={twMerge(
+                  'h-10 w-10',
+                  i !== array.length - 1 && '-mr-3',
+                )}
+                key={i}
+                name={user.public_name ?? ''}
+                avatar_url={user.avatar_url}
+                height={30}
+                width={30}
+              />
+            ))}
+          </div>
+          <p className="text-sm font-medium">
+            {Intl.NumberFormat('en-US', {
+              notation: 'compact',
+              compactDisplay: 'short',
+            }).format(customerList.pagination.total_count)}{' '}
+            <span className="font-light">
+            {customerList.pagination.total_count === 1
+              ? 'Subscriber'
+              : 'Subscribers'}
+            </span>
+          </p>
+        </>
+      )}
+      {isAdmin && <SubscribeAdminSettings organization={organization} showTip={!customerCount} />}
+      </div>
+    </div>
+  )
+}
+
+const SubscribeAdminSettings = ({
+  organization,
+  showTip
+}: {
+  organization: Organization
+  showTip: boolean
+}) => {
+  const updateOrganizationMutation = useUpdateOrganization()
+  const { isShown: isModalShown, hide: hideModal, show: showModal } = useModal()
+
+  const [settings, setSettings] = useState<OrganizationSubscribePromoteSettings>(
+    getDefaultSettings(organization)
+  )
+  const updateSettings = async () => {
+    await updateOrganizationMutation
+      .mutateAsync({
+        id: organization.id,
+        settings: {
+          profile_settings: {
+            subscribe: settings
+          },
+        },
+      })
+      .then(() => revalidate(`organization:${organization.name}`))
+  }
+
+  return (
+    <>
+      <a className="text-sm flex flex-row cursor-pointer items-center gap-x-2 text-gray-600 dark:text-gray-400" onClick={showModal}>
+        <SettingsOutlined fontSize="small" className="mr-2" />
+        {showTip && <span>Subscription promotion</span>}
+      </a>
+      <Modal
+        className="lg:max-w-md"
+        isShown={isModalShown}
+        hide={hideModal}
+        modalContent={
+          <SubscribeSettingsModal
+            organization={organization}
+            settings={settings}
+            setSettings={setSettings}
+            saveSettings={updateSettings}
+            hideModal={hideModal}
+          />
+        }
+      />
+    </>
+  )
+}
+
+const SubscribeSettingsModal = ({
+  organization,
+  settings,
+  setSettings,
+  saveSettings,
+  hideModal,
+}: {
+  organization: Organization
+  settings: OrganizationSubscribePromoteSettings
+  setSettings: (settings: OrganizationSubscribePromoteSettings) => void
+  saveSettings: () => void
+  hideModal: () => void
+}) => {
+  return (
+    <div className="relative flex flex-col gap-y-8 p-10">
+      <div className="absolute right-6 top-6">
+        <Button
+          className="focus-visible:ring-0"
+          onClick={hideModal}
+          size="icon"
+          variant="ghost"
+        >
+          <CloseOutlined
+            className="dark:text-polar-200 text-gray-700"
+            fontSize="small"
+          />
+        </Button>
+      </div>
+      <div className="flex flex-col gap-y-2">
+        <h3>Subscription Promotion</h3>
+        <p className="dark:text-polar-500 text-sm text-gray-500">
+          Customize how you want to attract more subscribers.
+        </p>
+      </div>
+      <div className="flex w-full flex-col gap-y-8">
+        <div className="flex max-h-[420px] w-full flex-col gap-y-6 overflow-y-auto">
+          <SettingsRow
+            settings={settings}
+            setSettings={setSettings}
+            settingKey="promote"
+            title='Show "Subscribe with Email"'
+            description="Increasing conversion of visitors to subscribers" />
+
+          <SettingsRow
+            settings={settings}
+            setSettings={setSettings}
+            settingKey="show_count"
+            title='Show subscriber count'
+            description="Increasing social proof for others to follow"
+            />
+
+          <SettingsRow
+            settings={settings}
+            setSettings={setSettings}
+            settingKey="count_free"
+            title='Count free subscriptions'
+            description="Include free subscriptions in public count" />
+        </div>
+
+        <Button onClick={saveSettings}>Save</Button>
+      </div>
+    </div>
+  )
+}
+
+const SettingsRow = ({
+  settings,
+  setSettings,
+  settingKey,
+  title,
+  description
+}: {
+  settings: OrganizationSubscribePromoteSettings
+  setSettings: (settings: OrganizationSubscribePromoteSettings) => void
+  settingKey: 'promote' | 'show_count' | 'count_free'
+  title: string
+  description: string
+}) => {
+  const checked = settings[settingKey]
+  const onChange = (checked: boolean) => {
+    setSettings({
+      ...settings,
+      [settingKey]: checked
+    })
+  }
+
+  return (
+    <div className="flex flex-row items-center">
+      <label htmlFor={`subscribe-${settingKey}`} className="text-sm grow font-medium flex flex-col">
+        {title}
+        {description && (
+          <span className="font-normal text-gray-500">{description}</span>
+        )}
+      </label>
+      <Switch id={`subscribe-${settingKey}`} checked={checked} onCheckedChange={onChange} />
+    </div>
+  )
+}

--- a/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
+++ b/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
@@ -110,6 +110,7 @@ const SubscribeAdminSettings = ({
   const [settings, setSettings] = useState<OrganizationSubscribePromoteSettings>(
     getDefaultSettings(organization)
   )
+
   const updateSettings = (onSuccess: () => void) => {
     updateOrganizationMutation
       .mutateAsync({
@@ -120,7 +121,10 @@ const SubscribeAdminSettings = ({
           },
         },
       }, {
-        onSuccess
+        onSuccess: (updated: Organization) => {
+          setSettings(getDefaultSettings(updated))
+          onSuccess()
+        }
       })
       .then(() => revalidate(`organization:${organization.name}`))
   }

--- a/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
+++ b/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
@@ -187,15 +187,15 @@ const SubscribeSettingsModal = ({
             settings={settings}
             setSettings={setSettings}
             settingKey="promote"
-            title='Show "Subscribe with Email"'
-            description="Increasing conversion of visitors to subscribers" />
+            title='Promote Free Email Subscription'
+            description="Increase conversion of visitors to subscribers" />
 
           <SettingsRow
             settings={settings}
             setSettings={setSettings}
             settingKey="show_count"
             title='Show subscriber count'
-            description="Increasing social proof for others to follow"
+            description="Add social proof for others to follow"
             />
 
           <SettingsRow

--- a/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
+++ b/clients/apps/web/src/components/Profile/SubscribeEditor/SubscribeEditor.tsx
@@ -110,8 +110,8 @@ const SubscribeAdminSettings = ({
   const [settings, setSettings] = useState<OrganizationSubscribePromoteSettings>(
     getDefaultSettings(organization)
   )
-  const updateSettings = async () => {
-    await updateOrganizationMutation
+  const updateSettings = (onSuccess: () => void) => {
+    updateOrganizationMutation
       .mutateAsync({
         id: organization.id,
         settings: {
@@ -119,6 +119,8 @@ const SubscribeAdminSettings = ({
             subscribe: settings
           },
         },
+      }, {
+        onSuccess
       })
       .then(() => revalidate(`organization:${organization.name}`))
   }
@@ -154,9 +156,18 @@ const SubscribeSettingsModal = ({
 }: {
   settings: OrganizationSubscribePromoteSettings
   setSettings: (settings: OrganizationSubscribePromoteSettings) => void
-  saveSettings: () => void
+  saveSettings: (onSuccess: () => void) => void
   hideModal: () => void
 }) => {
+  const [isSaving, setIsSaving] = useState(false)
+  const onSubmit = async () => {
+    setIsSaving(true)
+    saveSettings(() => {
+      setIsSaving(false)
+    })
+  }
+
+
   return (
     <div className="relative flex flex-col gap-y-8 p-10">
       <div className="absolute right-6 top-6">
@@ -203,7 +214,7 @@ const SubscribeSettingsModal = ({
             description="Include free subscriptions in public count" />
         </div>
 
-        <Button onClick={saveSettings}>Save</Button>
+        <Button onClick={onSubmit} loading={isSaving}>Save</Button>
       </div>
     </div>
   )

--- a/clients/packages/sdk/openapi/source.json
+++ b/clients/packages/sdk/openapi/source.json
@@ -89,7 +89,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -1209,8 +1209,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -2604,7 +2604,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -2983,6 +2983,15 @@
                 ],
                 "parameters": [
                     {
+                        "name": "state",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "State"
+                        }
+                    },
+                    {
                         "name": "code",
                         "in": "query",
                         "required": false,
@@ -3012,22 +3021,6 @@
                                 }
                             ],
                             "title": "Code Verifier"
-                        }
-                    },
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "State"
                         }
                     },
                     {
@@ -3147,6 +3140,15 @@
                 ],
                 "parameters": [
                     {
+                        "name": "state",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "State"
+                        }
+                    },
+                    {
                         "name": "code",
                         "in": "query",
                         "required": false,
@@ -3176,22 +3178,6 @@
                                 }
                             ],
                             "title": "Code Verifier"
-                        }
-                    },
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "State"
                         }
                     },
                     {
@@ -4219,8 +4205,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4274,8 +4260,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4381,8 +4367,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4578,8 +4564,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4653,8 +4639,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4712,8 +4698,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "patch": {
@@ -4936,8 +4922,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5257,8 +5243,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5702,8 +5688,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5768,8 +5754,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5821,8 +5807,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5909,8 +5895,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "post": {
@@ -6436,8 +6422,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6492,8 +6478,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6658,8 +6644,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6831,8 +6817,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6895,8 +6881,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -7182,7 +7168,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -7244,7 +7230,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -7313,7 +7299,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -7386,9 +7372,10 @@
                             },
                             "description": "Filter by the type of purchase the customer made.",
                             "default": [
-                                "order",
-                                "subscription",
-                                "donation"
+                                "paid_subscription",
+                                "donation",
+                                "free_subscription",
+                                "order"
                             ],
                             "title": "Customer Types"
                         },
@@ -7505,7 +7492,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -7811,7 +7798,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Organization"
+                                    "$ref": "#/components/schemas/Organization-Output"
                                 }
                             }
                         }
@@ -8455,8 +8442,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "post": {
@@ -8588,8 +8575,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "patch": {
@@ -10461,8 +10448,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -10525,8 +10512,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -10914,8 +10901,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "put": {
@@ -10976,8 +10963,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "delete": {
@@ -11028,8 +11015,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -11077,8 +11064,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -11477,8 +11464,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "benefits:read",
-                            "benefits:write"
+                            "benefits:write",
+                            "benefits:read"
                         ]
                     },
                     {
@@ -11717,8 +11704,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "benefits:read",
-                            "benefits:write"
+                            "benefits:write",
+                            "benefits:read"
                         ]
                     },
                     {
@@ -12022,8 +12009,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "benefits:read",
-                            "benefits:write"
+                            "benefits:write",
+                            "benefits:read"
                         ]
                     },
                     {
@@ -12178,8 +12165,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -12351,8 +12338,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -12581,8 +12568,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -12745,8 +12732,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "products:read",
-                            "products:write"
+                            "products:write",
+                            "products:read"
                         ]
                     },
                     {
@@ -12941,8 +12928,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "post": {
@@ -13023,8 +13010,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "products:read",
-                            "products:write"
+                            "products:write",
+                            "products:read"
                         ]
                     },
                     {
@@ -13083,8 +13070,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "patch": {
@@ -13709,8 +13696,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -14854,7 +14841,7 @@
                     },
                     "organizations": {
                         "items": {
-                            "$ref": "#/components/schemas/Organization"
+                            "$ref": "#/components/schemas/Organization-Output"
                         },
                         "type": "array",
                         "title": "Organizations"
@@ -15516,7 +15503,7 @@
                         "title": "Organization Id"
                     },
                     "organization": {
-                        "$ref": "#/components/schemas/Organization"
+                        "$ref": "#/components/schemas/Organization-Output"
                     },
                     "published_at": {
                         "anyOf": [
@@ -16556,7 +16543,7 @@
                     "organization": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/Organization"
+                                "$ref": "#/components/schemas/Organization-Output"
                             },
                             {
                                 "type": "null"
@@ -21630,7 +21617,7 @@
                 "properties": {
                     "items": {
                         "items": {
-                            "$ref": "#/components/schemas/Organization"
+                            "$ref": "#/components/schemas/Organization-Output"
                         },
                         "type": "array",
                         "title": "Items",
@@ -24222,7 +24209,247 @@
                 ],
                 "title": "OrderUser"
             },
-            "Organization": {
+            "Organization-Input": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "platform": {
+                        "$ref": "#/components/schemas/Platforms"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "avatar_url": {
+                        "type": "string",
+                        "title": "Avatar Url"
+                    },
+                    "is_personal": {
+                        "type": "boolean",
+                        "title": "Is Personal"
+                    },
+                    "bio": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bio",
+                        "description": "Public field from GitHub"
+                    },
+                    "pretty_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pretty Name",
+                        "description": "Public field from GitHub"
+                    },
+                    "company": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Company",
+                        "description": "Public field from GitHub"
+                    },
+                    "blog": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Blog",
+                        "description": "Public field from GitHub"
+                    },
+                    "location": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Location",
+                        "description": "Public field from GitHub"
+                    },
+                    "email": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Email",
+                        "description": "Public field from GitHub"
+                    },
+                    "twitter_username": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Twitter Username",
+                        "description": "Public field from GitHub"
+                    },
+                    "pledge_minimum_amount": {
+                        "type": "integer",
+                        "title": "Pledge Minimum Amount"
+                    },
+                    "pledge_badge_show_amount": {
+                        "type": "boolean",
+                        "title": "Pledge Badge Show Amount"
+                    },
+                    "default_upfront_split_to_contributors": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Default Upfront Split To Contributors"
+                    },
+                    "account_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Account Id"
+                    },
+                    "has_app_installed": {
+                        "type": "boolean",
+                        "title": "Has App Installed",
+                        "description": "Whether the organization has the Polar GitHub App installed for repositories or not."
+                    },
+                    "public_page_enabled": {
+                        "type": "boolean",
+                        "title": "Public Page Enabled",
+                        "description": "If this organization has a public Polar page"
+                    },
+                    "donations_enabled": {
+                        "type": "boolean",
+                        "title": "Donations Enabled",
+                        "description": "If this organizations accepts donations"
+                    },
+                    "public_donation_timestamps": {
+                        "type": "boolean",
+                        "title": "Public Donation Timestamps",
+                        "description": "If this organization should make donation timestamps publicly available"
+                    },
+                    "profile_settings": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationProfileSettings"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Settings for the organization profile"
+                    },
+                    "feature_settings": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationFeatureSettings"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Settings for the organization features"
+                    },
+                    "billing_email": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Billing Email",
+                        "description": "Where to send emails about payments for pledegs that this organization/team has made. Only visible for members of the organization"
+                    },
+                    "total_monthly_spending_limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Monthly Spending Limit",
+                        "description": "Overall team monthly spending limit, per calendar month. Only visible for members of the organization"
+                    },
+                    "per_user_monthly_spending_limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Per User Monthly Spending Limit",
+                        "description": "Team members monthly spending limit, per calendar month. Only visible for members of the organization"
+                    },
+                    "is_teams_enabled": {
+                        "type": "boolean",
+                        "title": "Is Teams Enabled",
+                        "description": "Feature flag for if this organization is a team."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "platform",
+                    "name",
+                    "avatar_url",
+                    "is_personal",
+                    "pledge_minimum_amount",
+                    "pledge_badge_show_amount",
+                    "has_app_installed",
+                    "public_page_enabled",
+                    "donations_enabled",
+                    "public_donation_timestamps",
+                    "profile_settings",
+                    "feature_settings",
+                    "is_teams_enabled"
+                ],
+                "title": "Organization"
+            },
+            "Organization-Output": {
                 "properties": {
                     "id": {
                         "type": "string",
@@ -24604,7 +24831,8 @@
             "OrganizationCustomerType": {
                 "type": "string",
                 "enum": [
-                    "subscription",
+                    "free_subscription",
+                    "paid_subscription",
                     "order",
                     "donation"
                 ],
@@ -24738,6 +24966,22 @@
                         ],
                         "title": "Links",
                         "description": "A list of links associated with the organization"
+                    },
+                    "subscribe": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationSubscribePromoteSettings"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Subscription promotion settings",
+                        "default": {
+                            "promote": true,
+                            "show_count": true,
+                            "count_free": true
+                        }
                     }
                 },
                 "type": "object",
@@ -24769,6 +25013,30 @@
                     "url"
                 ],
                 "title": "OrganizationStripePortalSession"
+            },
+            "OrganizationSubscribePromoteSettings": {
+                "properties": {
+                    "promote": {
+                        "type": "boolean",
+                        "title": "Promote",
+                        "description": "Promote email subscription (free)",
+                        "default": true
+                    },
+                    "show_count": {
+                        "type": "boolean",
+                        "title": "Show Count",
+                        "description": "Show subscription count publicly",
+                        "default": true
+                    },
+                    "count_free": {
+                        "type": "boolean",
+                        "title": "Count Free",
+                        "description": "Include free subscribers in total count",
+                        "default": true
+                    }
+                },
+                "type": "object",
+                "title": "OrganizationSubscribePromoteSettings"
             },
             "OrganizationUpdate": {
                 "properties": {
@@ -27302,7 +27570,7 @@
                         "description": "Settings for the repository profile"
                     },
                     "organization": {
-                        "$ref": "#/components/schemas/Organization"
+                        "$ref": "#/components/schemas/Organization-Input"
                     }
                 },
                 "type": "object",
@@ -27395,7 +27663,7 @@
                         "description": "Settings for the repository profile"
                     },
                     "organization": {
-                        "$ref": "#/components/schemas/Organization"
+                        "$ref": "#/components/schemas/Organization-Output"
                     }
                 },
                 "type": "object",
@@ -27755,7 +28023,7 @@
                     "organization": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/Organization"
+                                "$ref": "#/components/schemas/Organization-Output"
                             },
                             {
                                 "type": "null"
@@ -31764,7 +32032,7 @@
                         "title": "Type"
                     },
                     "data": {
-                        "$ref": "#/components/schemas/Organization"
+                        "$ref": "#/components/schemas/Organization-Input"
                     }
                 },
                 "type": "object",

--- a/clients/packages/sdk/openapi/updated.json
+++ b/clients/packages/sdk/openapi/updated.json
@@ -1209,8 +1209,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -2983,6 +2983,15 @@
                 ],
                 "parameters": [
                     {
+                        "name": "state",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "State"
+                        }
+                    },
+                    {
                         "name": "code",
                         "in": "query",
                         "required": false,
@@ -3012,22 +3021,6 @@
                                 }
                             ],
                             "title": "Code Verifier"
-                        }
-                    },
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "State"
                         }
                     },
                     {
@@ -3147,6 +3140,15 @@
                 ],
                 "parameters": [
                     {
+                        "name": "state",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "State"
+                        }
+                    },
+                    {
                         "name": "code",
                         "in": "query",
                         "required": false,
@@ -3176,22 +3178,6 @@
                                 }
                             ],
                             "title": "Code Verifier"
-                        }
-                    },
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "State"
                         }
                     },
                     {
@@ -4219,8 +4205,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4274,8 +4260,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4381,8 +4367,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4578,8 +4564,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4653,8 +4639,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -4712,8 +4698,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "patch": {
@@ -4936,8 +4922,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5257,8 +5243,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5702,8 +5688,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5768,8 +5754,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5821,8 +5807,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -5909,8 +5895,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "post": {
@@ -6436,8 +6422,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6492,8 +6478,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6658,8 +6644,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6831,8 +6817,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -6895,8 +6881,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -7386,9 +7372,10 @@
                             },
                             "description": "Filter by the type of purchase the customer made.",
                             "default": [
-                                "order",
-                                "subscription",
-                                "donation"
+                                "paid_subscription",
+                                "donation",
+                                "free_subscription",
+                                "order"
                             ],
                             "title": "Customer Types"
                         },
@@ -8455,8 +8442,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "post": {
@@ -8588,8 +8575,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "patch": {
@@ -10461,8 +10448,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -10525,8 +10512,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -10914,8 +10901,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "put": {
@@ -10976,8 +10963,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "delete": {
@@ -11028,8 +11015,8 @@
                     }
                 },
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -11077,8 +11064,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -11477,8 +11464,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "benefits:read",
-                            "benefits:write"
+                            "benefits:write",
+                            "benefits:read"
                         ]
                     },
                     {
@@ -11717,8 +11704,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "benefits:read",
-                            "benefits:write"
+                            "benefits:write",
+                            "benefits:read"
                         ]
                     },
                     {
@@ -12022,8 +12009,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "benefits:read",
-                            "benefits:write"
+                            "benefits:write",
+                            "benefits:read"
                         ]
                     },
                     {
@@ -12178,8 +12165,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -12351,8 +12338,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -12581,8 +12568,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "webhooks:read",
-                            "webhooks:write"
+                            "webhooks:write",
+                            "webhooks:read"
                         ]
                     },
                     {
@@ -12745,8 +12732,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "products:read",
-                            "products:write"
+                            "products:write",
+                            "products:read"
                         ]
                     },
                     {
@@ -12941,8 +12928,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "post": {
@@ -13023,8 +13010,8 @@
                 "security": [
                     {
                         "OpenIdConnect": [
-                            "products:read",
-                            "products:write"
+                            "products:write",
+                            "products:read"
                         ]
                     },
                     {
@@ -13083,8 +13070,8 @@
                 },
                 "x-polar-allowed-subjects": [
                     "Organization",
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             },
             "patch": {
@@ -13709,8 +13696,8 @@
                     }
                 ],
                 "x-polar-allowed-subjects": [
-                    "Anonymous",
-                    "User"
+                    "User",
+                    "Anonymous"
                 ]
             }
         },
@@ -23110,246 +23097,6 @@
                 ],
                 "title": "OrderUser"
             },
-            "Organization": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "platform": {
-                        "$ref": "#/components/schemas/Platforms"
-                    },
-                    "name": {
-                        "type": "string",
-                        "title": "Name"
-                    },
-                    "avatar_url": {
-                        "type": "string",
-                        "title": "Avatar Url"
-                    },
-                    "is_personal": {
-                        "type": "boolean",
-                        "title": "Is Personal"
-                    },
-                    "bio": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Bio",
-                        "description": "Public field from GitHub"
-                    },
-                    "pretty_name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pretty Name",
-                        "description": "Public field from GitHub"
-                    },
-                    "company": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Company",
-                        "description": "Public field from GitHub"
-                    },
-                    "blog": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Blog",
-                        "description": "Public field from GitHub"
-                    },
-                    "location": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Location",
-                        "description": "Public field from GitHub"
-                    },
-                    "email": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Email",
-                        "description": "Public field from GitHub"
-                    },
-                    "twitter_username": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Twitter Username",
-                        "description": "Public field from GitHub"
-                    },
-                    "pledge_minimum_amount": {
-                        "type": "integer",
-                        "title": "Pledge Minimum Amount"
-                    },
-                    "pledge_badge_show_amount": {
-                        "type": "boolean",
-                        "title": "Pledge Badge Show Amount"
-                    },
-                    "default_upfront_split_to_contributors": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Default Upfront Split To Contributors"
-                    },
-                    "account_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid4"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Account Id"
-                    },
-                    "has_app_installed": {
-                        "type": "boolean",
-                        "title": "Has App Installed",
-                        "description": "Whether the organization has the Polar GitHub App installed for repositories or not."
-                    },
-                    "public_page_enabled": {
-                        "type": "boolean",
-                        "title": "Public Page Enabled",
-                        "description": "If this organization has a public Polar page"
-                    },
-                    "donations_enabled": {
-                        "type": "boolean",
-                        "title": "Donations Enabled",
-                        "description": "If this organizations accepts donations"
-                    },
-                    "public_donation_timestamps": {
-                        "type": "boolean",
-                        "title": "Public Donation Timestamps",
-                        "description": "If this organization should make donation timestamps publicly available"
-                    },
-                    "profile_settings": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/OrganizationProfileSettings"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Settings for the organization profile"
-                    },
-                    "feature_settings": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/OrganizationFeatureSettings"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "Settings for the organization features"
-                    },
-                    "billing_email": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Billing Email",
-                        "description": "Where to send emails about payments for pledegs that this organization/team has made. Only visible for members of the organization"
-                    },
-                    "total_monthly_spending_limit": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Total Monthly Spending Limit",
-                        "description": "Overall team monthly spending limit, per calendar month. Only visible for members of the organization"
-                    },
-                    "per_user_monthly_spending_limit": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Per User Monthly Spending Limit",
-                        "description": "Team members monthly spending limit, per calendar month. Only visible for members of the organization"
-                    },
-                    "is_teams_enabled": {
-                        "type": "boolean",
-                        "title": "Is Teams Enabled",
-                        "description": "Feature flag for if this organization is a team."
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "platform",
-                    "name",
-                    "avatar_url",
-                    "is_personal",
-                    "pledge_minimum_amount",
-                    "pledge_badge_show_amount",
-                    "has_app_installed",
-                    "public_page_enabled",
-                    "donations_enabled",
-                    "public_donation_timestamps",
-                    "profile_settings",
-                    "feature_settings",
-                    "is_teams_enabled"
-                ],
-                "title": "Organization"
-            },
             "OrganizationBadgeSettingsRead": {
                 "properties": {
                     "show_amount": {
@@ -23492,7 +23239,8 @@
             "OrganizationCustomerType": {
                 "type": "string",
                 "enum": [
-                    "subscription",
+                    "free_subscription",
+                    "paid_subscription",
                     "order",
                     "donation"
                 ],
@@ -23626,6 +23374,22 @@
                         ],
                         "title": "Links",
                         "description": "A list of links associated with the organization"
+                    },
+                    "subscribe": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationSubscribePromoteSettings"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Subscription promotion settings",
+                        "default": {
+                            "promote": true,
+                            "show_count": true,
+                            "count_free": true
+                        }
                     }
                 },
                 "type": "object",
@@ -23657,6 +23421,30 @@
                     "url"
                 ],
                 "title": "OrganizationStripePortalSession"
+            },
+            "OrganizationSubscribePromoteSettings": {
+                "properties": {
+                    "promote": {
+                        "type": "boolean",
+                        "title": "Promote",
+                        "description": "Promote email subscription (free)",
+                        "default": true
+                    },
+                    "show_count": {
+                        "type": "boolean",
+                        "title": "Show Count",
+                        "description": "Show subscription count publicly",
+                        "default": true
+                    },
+                    "count_free": {
+                        "type": "boolean",
+                        "title": "Count Free",
+                        "description": "Include free subscribers in total count",
+                        "default": true
+                    }
+                },
+                "type": "object",
+                "title": "OrganizationSubscribePromoteSettings"
             },
             "OrganizationUpdate": {
                 "properties": {
@@ -29909,6 +29697,246 @@
                     "pledge_badge_currently_embedded"
                 ],
                 "title": "Issue"
+            },
+            "Organization": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "platform": {
+                        "$ref": "#/components/schemas/Platforms"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "avatar_url": {
+                        "type": "string",
+                        "title": "Avatar Url"
+                    },
+                    "is_personal": {
+                        "type": "boolean",
+                        "title": "Is Personal"
+                    },
+                    "bio": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bio",
+                        "description": "Public field from GitHub"
+                    },
+                    "pretty_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pretty Name",
+                        "description": "Public field from GitHub"
+                    },
+                    "company": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Company",
+                        "description": "Public field from GitHub"
+                    },
+                    "blog": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Blog",
+                        "description": "Public field from GitHub"
+                    },
+                    "location": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Location",
+                        "description": "Public field from GitHub"
+                    },
+                    "email": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Email",
+                        "description": "Public field from GitHub"
+                    },
+                    "twitter_username": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Twitter Username",
+                        "description": "Public field from GitHub"
+                    },
+                    "pledge_minimum_amount": {
+                        "type": "integer",
+                        "title": "Pledge Minimum Amount"
+                    },
+                    "pledge_badge_show_amount": {
+                        "type": "boolean",
+                        "title": "Pledge Badge Show Amount"
+                    },
+                    "default_upfront_split_to_contributors": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Default Upfront Split To Contributors"
+                    },
+                    "account_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Account Id"
+                    },
+                    "has_app_installed": {
+                        "type": "boolean",
+                        "title": "Has App Installed",
+                        "description": "Whether the organization has the Polar GitHub App installed for repositories or not."
+                    },
+                    "public_page_enabled": {
+                        "type": "boolean",
+                        "title": "Public Page Enabled",
+                        "description": "If this organization has a public Polar page"
+                    },
+                    "donations_enabled": {
+                        "type": "boolean",
+                        "title": "Donations Enabled",
+                        "description": "If this organizations accepts donations"
+                    },
+                    "public_donation_timestamps": {
+                        "type": "boolean",
+                        "title": "Public Donation Timestamps",
+                        "description": "If this organization should make donation timestamps publicly available"
+                    },
+                    "profile_settings": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationProfileSettings"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Settings for the organization profile"
+                    },
+                    "feature_settings": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationFeatureSettings"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Settings for the organization features"
+                    },
+                    "billing_email": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Billing Email",
+                        "description": "Where to send emails about payments for pledegs that this organization/team has made. Only visible for members of the organization"
+                    },
+                    "total_monthly_spending_limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Monthly Spending Limit",
+                        "description": "Overall team monthly spending limit, per calendar month. Only visible for members of the organization"
+                    },
+                    "per_user_monthly_spending_limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Per User Monthly Spending Limit",
+                        "description": "Team members monthly spending limit, per calendar month. Only visible for members of the organization"
+                    },
+                    "is_teams_enabled": {
+                        "type": "boolean",
+                        "title": "Is Teams Enabled",
+                        "description": "Feature flag for if this organization is a team."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "platform",
+                    "name",
+                    "avatar_url",
+                    "is_personal",
+                    "pledge_minimum_amount",
+                    "pledge_badge_show_amount",
+                    "has_app_installed",
+                    "public_page_enabled",
+                    "donations_enabled",
+                    "public_donation_timestamps",
+                    "profile_settings",
+                    "feature_settings",
+                    "is_teams_enabled"
+                ],
+                "title": "Organization"
             },
             "Pledge": {
                 "properties": {

--- a/clients/packages/sdk/src/client/apis/IntegrationsDiscordApi.ts
+++ b/clients/packages/sdk/src/client/apis/IntegrationsDiscordApi.ts
@@ -28,9 +28,9 @@ export interface IntegrationsDiscordApiIntegrationsDiscordBotAuthorizeRequest {
 }
 
 export interface IntegrationsDiscordApiIntegrationsDiscordBotCallbackRequest {
+    state: string;
     code?: string;
     codeVerifier?: string;
-    state?: string;
     error?: string;
 }
 
@@ -39,9 +39,9 @@ export interface IntegrationsDiscordApiIntegrationsDiscordUserAuthorizeRequest {
 }
 
 export interface IntegrationsDiscordApiIntegrationsDiscordUserCallbackRequest {
+    state: string;
     code?: string;
     codeVerifier?: string;
-    state?: string;
     error?: string;
 }
 
@@ -141,7 +141,18 @@ export class IntegrationsDiscordApi extends runtime.BaseAPI {
      * Integrations.Discord.Bot Callback
      */
     async integrationsDiscordBotCallbackRaw(requestParameters: IntegrationsDiscordApiIntegrationsDiscordBotCallbackRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<any>> {
+        if (requestParameters['state'] == null) {
+            throw new runtime.RequiredError(
+                'state',
+                'Required parameter "state" was null or undefined when calling integrationsDiscordBotCallback().'
+            );
+        }
+
         const queryParameters: any = {};
+
+        if (requestParameters['state'] != null) {
+            queryParameters['state'] = requestParameters['state'];
+        }
 
         if (requestParameters['code'] != null) {
             queryParameters['code'] = requestParameters['code'];
@@ -149,10 +160,6 @@ export class IntegrationsDiscordApi extends runtime.BaseAPI {
 
         if (requestParameters['codeVerifier'] != null) {
             queryParameters['code_verifier'] = requestParameters['codeVerifier'];
-        }
-
-        if (requestParameters['state'] != null) {
-            queryParameters['state'] = requestParameters['state'];
         }
 
         if (requestParameters['error'] != null) {
@@ -186,7 +193,7 @@ export class IntegrationsDiscordApi extends runtime.BaseAPI {
     /**
      * Integrations.Discord.Bot Callback
      */
-    async integrationsDiscordBotCallback(requestParameters: IntegrationsDiscordApiIntegrationsDiscordBotCallbackRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<any> {
+    async integrationsDiscordBotCallback(requestParameters: IntegrationsDiscordApiIntegrationsDiscordBotCallbackRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<any> {
         const response = await this.integrationsDiscordBotCallbackRaw(requestParameters, initOverrides);
         return await response.value();
     }
@@ -237,7 +244,18 @@ export class IntegrationsDiscordApi extends runtime.BaseAPI {
      * Integrations.Discord.User Callback
      */
     async integrationsDiscordUserCallbackRaw(requestParameters: IntegrationsDiscordApiIntegrationsDiscordUserCallbackRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<any>> {
+        if (requestParameters['state'] == null) {
+            throw new runtime.RequiredError(
+                'state',
+                'Required parameter "state" was null or undefined when calling integrationsDiscordUserCallback().'
+            );
+        }
+
         const queryParameters: any = {};
+
+        if (requestParameters['state'] != null) {
+            queryParameters['state'] = requestParameters['state'];
+        }
 
         if (requestParameters['code'] != null) {
             queryParameters['code'] = requestParameters['code'];
@@ -245,10 +263,6 @@ export class IntegrationsDiscordApi extends runtime.BaseAPI {
 
         if (requestParameters['codeVerifier'] != null) {
             queryParameters['code_verifier'] = requestParameters['codeVerifier'];
-        }
-
-        if (requestParameters['state'] != null) {
-            queryParameters['state'] = requestParameters['state'];
         }
 
         if (requestParameters['error'] != null) {
@@ -282,7 +296,7 @@ export class IntegrationsDiscordApi extends runtime.BaseAPI {
     /**
      * Integrations.Discord.User Callback
      */
-    async integrationsDiscordUserCallback(requestParameters: IntegrationsDiscordApiIntegrationsDiscordUserCallbackRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<any> {
+    async integrationsDiscordUserCallback(requestParameters: IntegrationsDiscordApiIntegrationsDiscordUserCallbackRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<any> {
         const response = await this.integrationsDiscordUserCallbackRaw(requestParameters, initOverrides);
         return await response.value();
     }

--- a/clients/packages/sdk/src/client/models/index.ts
+++ b/clients/packages/sdk/src/client/models/index.ts
@@ -8617,7 +8617,8 @@ export interface OrganizationCustomer {
  * @export
  */
 export const OrganizationCustomerType = {
-    SUBSCRIPTION: 'subscription',
+    FREE_SUBSCRIPTION: 'free_subscription',
+    PAID_SUBSCRIPTION: 'paid_subscription',
     ORDER: 'order',
     DONATION: 'donation'
 } as const;
@@ -8723,6 +8724,12 @@ export interface OrganizationProfileSettings {
      * @memberof OrganizationProfileSettings
      */
     links?: Array<string>;
+    /**
+     * 
+     * @type {OrganizationSubscribePromoteSettings}
+     * @memberof OrganizationProfileSettings
+     */
+    subscribe?: OrganizationSubscribePromoteSettings;
 }
 /**
  * 
@@ -8749,6 +8756,31 @@ export interface OrganizationStripePortalSession {
      * @memberof OrganizationStripePortalSession
      */
     url: string;
+}
+/**
+ * 
+ * @export
+ * @interface OrganizationSubscribePromoteSettings
+ */
+export interface OrganizationSubscribePromoteSettings {
+    /**
+     * Promote email subscription (free)
+     * @type {boolean}
+     * @memberof OrganizationSubscribePromoteSettings
+     */
+    promote?: boolean;
+    /**
+     * Show subscription count publicly
+     * @type {boolean}
+     * @memberof OrganizationSubscribePromoteSettings
+     */
+    show_count?: boolean;
+    /**
+     * Include free subscribers in total count
+     * @type {boolean}
+     * @memberof OrganizationSubscribePromoteSettings
+     */
+    count_free?: boolean;
 }
 /**
  * 

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -196,7 +196,8 @@ async def list_organization_customers(
     pagination: PaginationParamsQuery,
     customer_types: set[OrganizationCustomerType] = Query(
         {
-            OrganizationCustomerType.subscription,
+            OrganizationCustomerType.free_subscription,
+            OrganizationCustomerType.paid_subscription,
             OrganizationCustomerType.order,
             OrganizationCustomerType.donation,
         },

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -37,6 +37,14 @@ class OrganizationFeatureSettings(Schema):
     )
 
 
+class OrganizationSubscribePromoteSettings(Schema):
+    promote: bool = Field(True, description="Promote email subscription (free)")
+    show_count: bool = Field(True, description="Show subscription count publicly")
+    count_free: bool = Field(
+        True, description="Include free subscribers in total count"
+    )
+
+
 class OrganizationProfileSettings(Schema):
     description: Annotated[
         str | None,
@@ -51,6 +59,14 @@ class OrganizationProfileSettings(Schema):
     )
     links: list[HttpUrl] | None = Field(
         None, description="A list of links associated with the organization"
+    )
+    subscribe: OrganizationSubscribePromoteSettings | None = Field(
+        OrganizationSubscribePromoteSettings(
+            promote=True,
+            show_count=True,
+            count_free=True,
+        ),
+        description="Subscription promotion settings",
     )
 
 
@@ -163,13 +179,13 @@ class Organization(Schema):
             #
             billing_email=o.billing_email if include_member_fields else None,
             #
-            total_monthly_spending_limit=o.total_monthly_spending_limit
-            if include_member_fields
-            else None,
+            total_monthly_spending_limit=(
+                o.total_monthly_spending_limit if include_member_fields else None
+            ),
             #
-            per_user_monthly_spending_limit=o.per_user_monthly_spending_limit
-            if include_member_fields
-            else None,
+            per_user_monthly_spending_limit=(
+                o.per_user_monthly_spending_limit if include_member_fields else None
+            ),
             is_teams_enabled=o.is_teams_enabled,
         )
 
@@ -212,7 +228,8 @@ class CreditBalance(Schema):
 
 
 class OrganizationCustomerType(StrEnum):
-    subscription = "subscription"
+    free_subscription = "free_subscription"
+    paid_subscription = "paid_subscription"
     order = "order"
     donation = "donation"
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -488,6 +488,11 @@ async def test_update_organization_profile_settings(
         "featured_organizations": None,
         "description": None,
         "links": None,
+        "subscribe": {
+            "promote": True,
+            "show_count": True,
+            "count_free": True,
+        },
     }
 
     # set featured_projects


### PR DESCRIPTION
https://github.com/user-attachments/assets/8e35a381-7931-4500-8dec-be319170e829

Give creators more control over how to promote subscriptions on their Polar page.
- Show/hide `Subscribe with Email` and subsequently the `Free` tier on the `Subscriptions` page
- Show/hide the public count/display of active subscribers
- Include/exclude free subscribers in the total count of active subscribers

- [x] Fixes #2818

Leverage the same `profile_settings` in the `Subscribe` embed badge to reflect the same count.

- [x] Fixes #3659 