### PR TITLE
server/oauth2: make sure to include scopes enum in OpenAPI schema

### DIFF
--- a/server/polar/oauth2/endpoints/oauth2.py
+++ b/server/polar/oauth2/endpoints/oauth2.py
@@ -122,7 +122,7 @@ async def delete_client(
     )
 
 
-@router.get("/authorize", include_in_schema=IN_DEVELOPMENT_ONLY)
+@router.get("/authorize")
 async def authorize(
     request: Request,
     auth_subject: WebUserOrAnonymous,

--- a/server/tests/test_openapi.py
+++ b/server/tests/test_openapi.py
@@ -1,0 +1,12 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_db_asserts
+async def test_openapi(client: AsyncClient) -> None:
+    response = await client.get("/openapi.json")
+    assert response.status_code == 200
+
+    schema = response.json()
+    assert "Scope" in schema["components"]["schemas"]


### PR DESCRIPTION
Prevent /authorize page from being broken 😅