### PR TITLE
server/organization: require either `slug` or `is_member` on list API

### DIFF
--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -9,6 +9,7 @@ from polar.authz.service import AccessType, Authz
 from polar.exceptions import (
     InternalServerError,
     NotPermitted,
+    PolarRequestValidationError,
     ResourceNotFound,
     Unauthorized,
 )
@@ -75,6 +76,18 @@ async def list(
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[OrganizationSchema]:
     """List organizations."""
+    if slug is None and is_member is None:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "loc": ("query",),
+                    "msg": "At least one of 'slug' or 'is_member' must be provided.",
+                    "type": "missing",
+                    "input": None,
+                }
+            ]
+        )
+
     results, count = await organization_service.list(
         session,
         auth_subject,

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -19,25 +19,9 @@ class TestListOrganizations:
     @pytest.mark.auth(
         AuthSubjectFixture(subject="anonymous"),
         AuthSubjectFixture(subject="user"),
-    )
-    async def test_anonymous_user(
-        self,
-        client: AsyncClient,
-        organization: Organization,
-        organization_second: Organization,
-        organization_blocked: Organization,
-    ) -> None:
-        response = await client.get("/v1/organizations/")
-
-        assert response.status_code == 200
-
-        json = response.json()
-        assert json["pagination"]["total_count"] == 2
-
-    @pytest.mark.auth(
         AuthSubjectFixture(subject="organization"),
     )
-    async def test_organization(
+    async def test_no_filter(
         self,
         client: AsyncClient,
         organization: Organization,
@@ -46,11 +30,7 @@ class TestListOrganizations:
     ) -> None:
         response = await client.get("/v1/organizations/")
 
-        assert response.status_code == 200
-
-        json = response.json()
-        assert json["pagination"]["total_count"] == 1
-        assert json["items"][0]["id"] == str(organization.id)
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_filter_slug(


### PR DESCRIPTION
Prevent users from enumerating organizations.