### PR TITLE
server/magic_link: add an interstitial HTML page when opening the magic link

### DIFF
--- a/server/tests/magic_link/test_endpoints.py
+++ b/server/tests/magic_link/test_endpoints.py
@@ -43,31 +43,9 @@ async def test_request(client: AsyncClient, mocker: MockerFixture) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
-async def test_authenticate_invalid_token(
-    client: AsyncClient, mocker: MockerFixture
-) -> None:
-    magic_link_service_mock = mocker.patch.object(
-        magic_link_service, "authenticate", side_effect=InvalidMagicLink()
-    )
-
-    response = await client.get(
-        "/v1/magic_link/authenticate", params={"token": "TOKEN"}
-    )
-
-    assert response.status_code == 303
-    assert response.headers["Location"].startswith(
-        f"{settings.FRONTEND_BASE_URL}/error"
-    )
-
-    assert magic_link_service_mock.called
-    assert magic_link_service_mock.call_args[0][1] == "TOKEN"
-
-
-@pytest.mark.asyncio
 @pytest.mark.auth
 @pytest.mark.http_auto_expunge
-async def test_authenticate_already_authenticated(
+async def test_authenticate_get_already_authenticated(
     client: AsyncClient, user: User, mocker: MockerFixture
 ) -> None:
     magic_link_service_mock = mocker.patch.object(
@@ -86,7 +64,7 @@ async def test_authenticate_already_authenticated(
 
 @pytest.mark.asyncio
 @pytest.mark.http_auto_expunge
-async def test_authenticate_valid_token(
+async def test_authenticate_get(
     client: AsyncClient, user: User, mocker: MockerFixture
 ) -> None:
     magic_link_service_mock = mocker.patch.object(
@@ -96,6 +74,61 @@ async def test_authenticate_valid_token(
     response = await client.get(
         "/v1/magic_link/authenticate", params={"token": "TOKEN"}
     )
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
+
+    magic_link_service_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.auth
+@pytest.mark.http_auto_expunge
+async def test_authenticate_post_already_authenticated(
+    client: AsyncClient, user: User, mocker: MockerFixture
+) -> None:
+    magic_link_service_mock = mocker.patch.object(
+        magic_link_service, "authenticate", new=AsyncMock(return_value=user)
+    )
+
+    response = await client.post("/v1/magic_link/authenticate", data={"token": "TOKEN"})
+
+    assert response.status_code == 303
+    assert response.headers["Location"].startswith(f"{settings.FRONTEND_BASE_URL}/")
+
+    magic_link_service_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.http_auto_expunge
+async def test_authenticate_post_invalid_token(
+    client: AsyncClient, mocker: MockerFixture
+) -> None:
+    magic_link_service_mock = mocker.patch.object(
+        magic_link_service, "authenticate", side_effect=InvalidMagicLink()
+    )
+
+    response = await client.post("/v1/magic_link/authenticate", data={"token": "TOKEN"})
+
+    assert response.status_code == 303
+    assert response.headers["Location"].startswith(
+        f"{settings.FRONTEND_BASE_URL}/error"
+    )
+
+    assert magic_link_service_mock.called
+    assert magic_link_service_mock.call_args[0][1] == "TOKEN"
+
+
+@pytest.mark.asyncio
+@pytest.mark.http_auto_expunge
+async def test_authenticate_post_valid_token(
+    client: AsyncClient, user: User, mocker: MockerFixture
+) -> None:
+    magic_link_service_mock = mocker.patch.object(
+        magic_link_service, "authenticate", new=AsyncMock(return_value=user)
+    )
+
+    response = await client.post("/v1/magic_link/authenticate", data={"token": "TOKEN"})
 
     assert response.status_code == 303
     assert response.headers["Location"].startswith(f"{settings.FRONTEND_BASE_URL}/")


### PR DESCRIPTION
Prevent magic link code from being consumed when email scanning systems automatically open links