### PR TITLE
clients/web: fix root redirection for authenticated users

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -165,7 +165,7 @@ const nextConfig = {
 
       {
         source:
-          '/:rootPath(dashboard|feed|for-you|posts|purchases|funding|rewards|settings|backoffice|maintainer|finance):subPath(/?.*)',
+          '/:rootPath(start|dashboard|feed|for-you|posts|purchases|funding|rewards|settings|backoffice|maintainer|finance):subPath(/?.*)',
         destination: '/login?return_to=/:rootPath:subPath',
         missing: [
           {
@@ -189,7 +189,7 @@ const nextConfig = {
       // Logged-in user redirections
       {
         source: '/',
-        destination: '/dashboard',
+        destination: '/start',
         has: [
           {
             type: 'cookie',

--- a/clients/apps/web/src/app/start/page.tsx
+++ b/clients/apps/web/src/app/start/page.tsx
@@ -1,0 +1,23 @@
+import { getServerSideAPI } from '@/utils/api/serverside'
+import { getUserOrganizations } from '@/utils/user'
+import { redirect } from 'next/navigation'
+
+/**
+ * An authenticated user is automatically redirected to this page when accessing `/` instead of seeing the landing page.
+ * This is done in [`next.config.mjs`](../../../next.config.mjs).
+ *
+ * This page aims at determining where to redirect an authenticated user.
+ *
+ * - If the user has no organization, redirect them to their purchases page.
+ * - If the user has at least one organization, redirect them to the first organization's dashboard.
+ */
+export default async function Page() {
+  const api = getServerSideAPI()
+  const userOrganizations = await getUserOrganizations(api)
+
+  if (userOrganizations.length === 0) {
+    redirect('/purchases')
+  }
+
+  redirect(`/dashboard/${userOrganizations[0].slug}`)
+}


### PR DESCRIPTION
* If the user has no organization, redirect them to their purchases page.
 * If the user has at least one organization, redirect them to the first organization's dashboard.