### PR TITLE
server: differentiate email for subscription cancelation

### DIFF
--- a/server/polar/subscription/email_templates/cancellation.html
+++ b/server/polar/subscription/email_templates/cancellation.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Your subscription has been canceled</h1>
+<p>We're sorry to see you go! Your subscription to <strong>{{ product.name }}</strong> will remain active until <strong>{{ subscription.current_period_end | date: "%B %d, %Y" }}</strong>, after which it will be canceled.</p>
+<p>If you change your mind, you can renew your subscription anytime before the end date.</p>
+
+<p>Meanwhile, you will continue to have access to the following benefits:</p>
+<ul>
+  {% for benefit in product.benefits %}
+    <li>{{ benefit.description }}</li>
+  {% endfor %}
+</ul>
+
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td align="center">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+                <tr>
+                    <td align="center">
+                        <a href="{{ url | safe }}" class="f-fallback button">Manage my subscription</a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<!-- Sub copy -->
+<table class="body-sub" role="presentation">
+    <tr>
+        <td>
+            <p class="f-fallback sub">If you're having trouble with the button above, copy and paste the URL below into your web browser:</p>
+            <p class="f-fallback sub"><a href="{{ url | safe }}">{{ url | safe }}</a></p>
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -616,7 +616,6 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
             },
         )
 
-        # Send the email to the user
         email_sender.send_to_user(
             to_email_addr=user.email,
             subject=subject,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -509,6 +509,8 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
             and not subscription.cancel_at_period_end
         ):
             await self.send_confirmation_email(session, subscription)
+        elif subscription.cancel_at_period_end:
+            await self.send_cancellation_email(session, subscription)
 
         return subscription
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -601,7 +601,6 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
         assert featured_organization is not None
         user = subscription.user
 
-        # Render the cancellation email using the updated template
         subject, body = email_renderer.render_from_template(
             "Your {{ product.name }} subscription cancellation",
             "subscription/cancellation.html",


### PR DESCRIPTION
On the existing code, Polar send the subscription created email for when the even is subscription cancelation.