### PR TITLE
client: Link Creator Dashboard to current organization if user has th…

### DIFF
--- a/clients/apps/web/src/app/[organization]/(sidebar)/layout.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/layout.tsx
@@ -115,6 +115,7 @@ export default async function Layout({
               <PolarMenu
                 authenticatedUser={authenticatedUser}
                 userOrganizations={userOrganizations}
+                organization={organization}
               />
             </div>
           </div>

--- a/clients/apps/web/src/app/[organization]/(sidebar)/layout.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/layout.tsx
@@ -90,6 +90,7 @@ export default async function Layout({
           <PolarMenu
             authenticatedUser={authenticatedUser}
             userOrganizations={userOrganizations}
+            organization={organization}
           />
         </div>
         <div className="relative flex w-fit flex-shrink-0 flex-col justify-between py-8 md:sticky md:top-0 md:py-16">

--- a/clients/apps/web/src/app/[organization]/[repo]/layout.tsx
+++ b/clients/apps/web/src/app/[organization]/[repo]/layout.tsx
@@ -50,6 +50,7 @@ export default async function Layout({
           <PolarMenu
             authenticatedUser={authenticatedUser}
             userOrganizations={userOrganizations}
+            organization={organization}
           />
         </div>
         <div className="jusitfy-between flex w-full flex-row items-center gap-x-10">
@@ -82,6 +83,7 @@ export default async function Layout({
             <PolarMenu
               authenticatedUser={authenticatedUser}
               userOrganizations={userOrganizations}
+              organization={organization}
             />
           </div>
         </div>

--- a/clients/apps/web/src/components/Layout/PolarMenu.tsx
+++ b/clients/apps/web/src/components/Layout/PolarMenu.tsx
@@ -67,5 +67,4 @@ const PolarMenu = ({
   )
 }
 
-
 export default PolarMenu

--- a/clients/apps/web/src/components/Layout/PolarMenu.tsx
+++ b/clients/apps/web/src/components/Layout/PolarMenu.tsx
@@ -12,15 +12,23 @@ import GetStartedButton from '../Auth/GetStartedButton'
 const PolarMenu = ({
   authenticatedUser,
   userOrganizations,
+  organization,
 }: {
   authenticatedUser?: UserRead
   userOrganizations: Organization[]
+  organization: Organization
 }) => {
   const loginLink = useLoginLink()
 
   const hasOrgs = Boolean(userOrganizations && userOrganizations.length > 0)
 
-  const creatorPath = `${CONFIG.FRONTEND_BASE_URL}/dashboard/${userOrganizations?.[0]?.slug}`
+  const organizationExistsInUserOrgs = userOrganizations.some(
+    (userOrg) => userOrg.id === organization.id
+  )
+
+  const creatorPath = `${CONFIG.FRONTEND_BASE_URL}/dashboard/${
+    organizationExistsInUserOrgs ? organization?.slug : userOrganizations?.[0]?.slug
+  }`
 
   return (
     <div className="flex h-9 flex-row items-center gap-x-6">
@@ -58,5 +66,6 @@ const PolarMenu = ({
     </div>
   )
 }
+
 
 export default PolarMenu

--- a/clients/apps/web/src/components/Layout/PolarMenu.tsx
+++ b/clients/apps/web/src/components/Layout/PolarMenu.tsx
@@ -16,14 +16,14 @@ const PolarMenu = ({
 }: {
   authenticatedUser?: UserRead
   userOrganizations: Organization[]
-  organization: Organization
+  organization?: Organization
 }) => {
   const loginLink = useLoginLink()
 
   const hasOrgs = Boolean(userOrganizations && userOrganizations.length > 0)
 
   const organizationExistsInUserOrgs = userOrganizations.some(
-    (userOrg) => userOrg.id === organization.id
+    (userOrg) => userOrg.id === organization?.id
   )
 
   const creatorPath = `${CONFIG.FRONTEND_BASE_URL}/dashboard/${


### PR DESCRIPTION
client: Link Creator Dashboard to current organization if user has the organization

<img width="329" alt="image" src="https://github.com/user-attachments/assets/31dd701f-a879-45d9-8428-46eb7bbe78d7">

## Issue:

Currently, when a user visits their organization page and clicks the "Creator Dashboard" button, it always links to the first organization in their list. This is incorrect if the user owns the visited organization.

## Solution:

Identify Ownership: Determine if the current user is the owner of the visited organization.
Link to Current Organization: If the user is the owner, link the "Creator Dashboard" button directly to the current organization's dashboard page.

## Expected Behavior:

When a user who owns an organization visits their organization page and clicks the "Creator Dashboard" button, it should link to the dashboard for that specific organization.
