### PR TITLE
fix: update url in top bar nav to point to sdk

### DIFF
--- a/clients/apps/web/src/components/Landing/TopbarNavigation.tsx
+++ b/clients/apps/web/src/components/Landing/TopbarNavigation.tsx
@@ -191,7 +191,7 @@ const DocumentationPopover = () => {
               <PopoverLinkItem
                 title="Polar SDK"
                 description="Our very own TypeScript SDK"
-                link="/docs/api/polar-sdk"
+                link="/docs/api/sdk"
               />
               <PopoverLinkItem
                 title="GitHub Actions"


### PR DESCRIPTION
The navigation pointed to "https://docs.polar.sh/api/polar-sdk" though this path leads to 404