### PR TITLE
clients/web: avoid floating point errors when converting money input to cents

### DIFF
--- a/clients/packages/polarkit/src/components/ui/atoms/MoneyInput.tsx
+++ b/clients/packages/polarkit/src/components/ui/atoms/MoneyInput.tsx
@@ -20,8 +20,8 @@ const getCents = (value: string): number => {
   if (isNaN(newAmount)) {
     newAmount = 0
   }
-  const amountInCents = newAmount * 100
-  return amountInCents
+  // Round to avoid floating point errors
+  return Math.round(newAmount * 100)
 }
 
 const MoneyInput = (props: Props) => {


### PR DESCRIPTION
Fix #3924