### PR TITLE
api: Require `organization_id` in /products

### DIFF
--- a/server/polar/product/endpoints.py
+++ b/server/polar/product/endpoints.py
@@ -31,8 +31,8 @@ ProductNotFound = {
 async def list(
     pagination: PaginationParamsQuery,
     auth_subject: auth.CreatorProductsReadOrAnonymous,
-    organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
-        None, title="OrganizationID Filter", description="Filter by organization ID."
+    organization_id: MultipleQueryFilter[OrganizationID] = Query(
+        title="OrganizationID Filter", description="Filter by organization ID."
     ),
     is_archived: bool | None = Query(None, description="Filter on archived products."),
     is_recurring: bool | None = Query(

--- a/server/tests/product/service/test_product.py
+++ b/server/tests/product/service/test_product.py
@@ -66,8 +66,16 @@ class TestList:
         # then
         session.expunge_all()
 
+        with pytest.raises(NotPermitted):
+            results, count = await product_service.list(
+                session, auth_subject, pagination=PaginationParams(1, 10)
+            )
+
         results, count = await product_service.list(
-            session, auth_subject, pagination=PaginationParams(1, 10)
+            session,
+            auth_subject,
+            organization_id=[p.organization_id for p in products],
+            pagination=PaginationParams(1, 10),
         )
 
         assert count == 4
@@ -260,6 +268,7 @@ class TestList:
             session,
             get_auth_subject(Anonymous()),
             is_archived=False,
+            organization_id=[organization.id],
             pagination=PaginationParams(1, 10),
         )
         assert count == 0
@@ -267,6 +276,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             get_auth_subject(Anonymous()),
+            organization_id=[organization.id],
             pagination=PaginationParams(1, 10),
         )
         assert count == 0
@@ -406,6 +416,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             get_auth_subject(Anonymous()),
+            organization_id=[organization.id],
             pagination=PaginationParams(1, 8),  # page 1, limit 8
         )
         assert 10 == count
@@ -413,6 +424,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             get_auth_subject(Anonymous()),
+            organization_id=[organization.id],
             pagination=PaginationParams(2, 8),  # page 2, limit 8
         )
         assert 10 == count

--- a/server/tests/product/service/test_product.py
+++ b/server/tests/product/service/test_product.py
@@ -66,11 +66,6 @@ class TestList:
         # then
         session.expunge_all()
 
-        with pytest.raises(NotPermitted):
-            results, count = await product_service.list(
-                session, auth_subject, pagination=PaginationParams(1, 10)
-            )
-
         results, count = await product_service.list(
             session,
             auth_subject,
@@ -98,7 +93,10 @@ class TestList:
         session.expunge_all()
 
         results, count = await product_service.list(
-            session, auth_subject, pagination=PaginationParams(1, 10)
+            session,
+            auth_subject,
+            organization_id=[p.organization_id for p in products],
+            pagination=PaginationParams(1, 10),
         )
 
         assert count == 4
@@ -120,7 +118,10 @@ class TestList:
         session.expunge_all()
 
         results, count = await product_service.list(
-            session, auth_subject, pagination=PaginationParams(1, 10)
+            session,
+            auth_subject,
+            organization_id=[p.organization_id for p in products],
+            pagination=PaginationParams(1, 10),
         )
 
         assert count == 4
@@ -137,7 +138,10 @@ class TestList:
         session.expunge_all()
 
         results, count = await product_service.list(
-            session, auth_subject, pagination=PaginationParams(1, 10)
+            session,
+            auth_subject,
+            organization_id=[p.organization_id for p in products],
+            pagination=PaginationParams(1, 10),
         )
 
         assert count == 3
@@ -171,6 +175,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[organization.id],
             is_recurring=True,
             pagination=PaginationParams(1, 10),
         )
@@ -182,6 +187,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[organization.id],
             is_recurring=False,
             pagination=PaginationParams(1, 10),
         )
@@ -213,6 +219,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[organization.id],
             type=[SubscriptionTierType.individual],
             pagination=PaginationParams(1, 10),
         )
@@ -287,6 +294,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[user_organization.organization_id],
             is_archived=False,
             pagination=PaginationParams(1, 10),
         )
@@ -295,6 +303,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[user_organization.organization_id],
             pagination=PaginationParams(1, 10),
         )
         assert count == 1
@@ -320,6 +329,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[organization.id],
             is_archived=False,
             pagination=PaginationParams(1, 10),
         )
@@ -328,6 +338,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[organization.id],
             pagination=PaginationParams(1, 10),
         )
         assert count == 0
@@ -435,6 +446,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[user_organization.organization_id],
             pagination=PaginationParams(1, 8),  # page 1, limit 8
         )
         assert 20 == count
@@ -442,6 +454,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[user_organization.organization_id],
             pagination=PaginationParams(2, 8),  # page 2, limit 8
         )
         assert 20 == count
@@ -449,6 +462,7 @@ class TestList:
         results, count = await product_service.list(
             session,
             auth_subject,
+            organization_id=[user_organization.organization_id],
             pagination=PaginationParams(3, 8),  # page 3, limit 8
         )
         assert 20 == count

--- a/server/tests/product/test_endpoints.py
+++ b/server/tests/product/test_endpoints.py
@@ -38,7 +38,7 @@ class TestListProducts:
         json = response.json()
         assert json["pagination"]["total_count"] == 3
 
-    async def test_anonymous_without_filter_403(
+    async def test_anonymous_without_organization_filter(
         self,
         client: AsyncClient,
         organization: Organization,
@@ -48,12 +48,7 @@ class TestListProducts:
             "/v1/products/",
         )
 
-        assert response.status_code == 403
-        response = await client.get(
-            "/v1/products/",
-            params={"organization_id": str(organization.id)},
-        )
-        assert response.status_code == 200
+        assert response.status_code == 422
 
     async def test_with_benefits(
         self,

--- a/server/tests/product/test_endpoints.py
+++ b/server/tests/product/test_endpoints.py
@@ -38,6 +38,23 @@ class TestListProducts:
         json = response.json()
         assert json["pagination"]["total_count"] == 3
 
+    async def test_anonymous_without_filter_403(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        products: list[Product],
+    ) -> None:
+        response = await client.get(
+            "/v1/products/",
+        )
+
+        assert response.status_code == 403
+        response = await client.get(
+            "/v1/products/",
+            params={"organization_id": str(organization.id)},
+        )
+        assert response.status_code == 200
+
     async def test_with_benefits(
         self,
         session: AsyncSession,


### PR DESCRIPTION
Currently, we allow discovery on all public products.

We no longer desire that to be the case and that our API should always only be
focused on the creators scope or in case of public data, narrowly defined such.
