### PR TITLE
clients: blur money input on scroll

### DIFF
--- a/clients/packages/polarkit/src/components/ui/atoms/MoneyInput.tsx
+++ b/clients/packages/polarkit/src/components/ui/atoms/MoneyInput.tsx
@@ -75,6 +75,9 @@ const MoneyInput = (props: Props) => {
       postSlot={postSlot}
       onBlur={onBlur}
       onFocus={onFocus}
+      onWheel={(e) => {
+        ;(e.target as HTMLInputElement).blur()
+      }}
     />
   )
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/5879e618-393b-42ff-b752-0bf4107fbc32

The current input scroll behavior is very error-prone, as shown in the attached video

Lemon Squeezy, Tokopedia also disable the scroll on the input[type=number].