### PR TITLE
clients: Remove product creation upsell in sidebar

### DIFF
--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -26,25 +26,6 @@ import MaintainerRepoSelection from '../Dashboard/MaintainerRepoSelection'
 import DashboardProfileDropdown from '../Navigation/DashboardProfileDropdown'
 import { BrandingMenu } from './Public/BrandingMenu'
 
-const ProductsUpsell = ({ organization }: { organization: Organization }) => {
-  return (
-    <div className="dark:from-polar-800 dark:to-polar-800 mx-6 flex flex-row gap-y-8 rounded-3xl bg-gradient-to-r from-blue-200 to-blue-400 p-6 text-white">
-      <div className="flex w-full flex-col gap-y-6">
-        <h3 className="leading-normal [text-wrap:balance]">
-          Kickstart your business by selling products
-        </h3>
-        <Link href={`/dashboard/${organization.slug}/products/new`}>
-          <Button className="self-start" size="sm">
-            <div className="flex flex-row items-center gap-2">
-              <span>Create a product</span>
-            </div>
-          </Button>
-        </Link>
-      </div>
-    </div>
-  )
-}
-
 const DashboardSidebar = () => {
   const [scrollTop, setScrollTop] = useState(0)
   const { currentUser } = useAuth()
@@ -94,9 +75,6 @@ const DashboardSidebar = () => {
         >
           <div className="flex flex-col gap-y-12">
             <MaintainerNavigation />
-            {currentOrg && (nonFreeProducts?.length ?? 0) < 1 && (
-              <ProductsUpsell organization={currentOrg} />
-            )}
           </div>
           <div className="flex flex-col">
             <div className="flex px-8">

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -2,13 +2,10 @@
 
 import LogoIcon from '@/components/Brand/LogoIcon'
 import { useAuth } from '@/hooks/auth'
-import { useProducts } from '@/hooks/queries'
 import { MaintainerOrganizationContext } from '@/providers/maintainerOrganization'
 import { CloseOutlined, ShortTextOutlined } from '@mui/icons-material'
-import { Organization, Repository } from '@polar-sh/sdk'
-import Link from 'next/link'
+import { Repository } from '@polar-sh/sdk'
 import { usePathname } from 'next/navigation'
-import Button from 'polarkit/components/ui/atoms/button'
 import {
   PropsWithChildren,
   UIEventHandler,
@@ -30,8 +27,6 @@ const DashboardSidebar = () => {
   const [scrollTop, setScrollTop] = useState(0)
   const { currentUser } = useAuth()
 
-  const orgContext = useContext(MaintainerOrganizationContext)
-  const currentOrg = orgContext.organization
   const { showCommandPalette } = useDashboard()
 
   const handleScroll: UIEventHandler<HTMLDivElement> = useCallback((e) => {
@@ -43,11 +38,6 @@ const DashboardSidebar = () => {
   const upperScrollClassName = shouldRenderUpperBorder
     ? 'border-b dark:border-b-polar-700 border-b-gray-200'
     : ''
-
-  const products = useProducts(currentOrg.id)
-  const nonFreeProducts = products.data?.items.filter(
-    (product) => product.type !== 'free',
-  )
 
   if (!currentUser) {
     return <></>


### PR DESCRIPTION
We now have `Onboarding` instead with setup steps. Just an unnecessary &
bloated upsell + causes FOC on hard refreshes.
