### PR TITLE
clients: Fix gready redirect of /purchases/subscriptions

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -194,15 +194,6 @@ const nextConfig = {
         permanent: true,
       },
 
-      // Redirect /:slug/subscriptions to /:slug
-      // Now we surface subscriptions on landing page vs. below subpage
-      {
-        source: '/:slug/subscriptions',
-        destination: '/:slug',
-        permanent: true,
-      },
-
-
       // Redirect /docs/overview/:path to /docs/:path
       {
         source: '/docs/overview/:path*',

--- a/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation'
+
+export default async function Page({
+  params,
+}: {
+  params: { organization: string; }
+}) {
+  redirect(`/organizations/${params.organization}`)
+}

--- a/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/[organization]/(sidebar)/subscriptions/page.tsx
@@ -5,5 +5,5 @@ export default async function Page({
 }: {
   params: { organization: string; }
 }) {
-  redirect(`/organizations/${params.organization}`)
+  redirect(`/${params.organization}`)
 }


### PR DESCRIPTION
Avoid overwriting a real route by moving the redirect to the storefront
/:slug/subscriptions app directory
