### PR TITLE
server/oauth2: fix userinfo endpoint when output doesn't include some fields due to lacking scope

### DIFF
--- a/server/polar/oauth2/endpoints/oauth2.py
+++ b/server/polar/oauth2/endpoints/oauth2.py
@@ -291,6 +291,7 @@ async def introspect(
     name="oauth2:userinfo",
     operation_id="oauth2:userinfo",
     response_model=UserInfoSchema,
+    response_model_exclude_unset=True,
     tags=[APITag.featured, APITag.documented],
     openapi_extra={"x-speakeasy-name-override": "userinfo"},
 )
@@ -305,6 +306,7 @@ async def userinfo_get(token: OAuth2Token = Depends(get_token)) -> UserInfo:
     "/userinfo",
     summary="Get User Info",
     response_model=UserInfoSchema,
+    response_model_exclude_unset=True,
     include_in_schema=False,
 )
 async def userinfo_post(token: OAuth2Token = Depends(get_token)) -> UserInfo:

--- a/server/polar/oauth2/schemas.py
+++ b/server/polar/oauth2/schemas.py
@@ -181,14 +181,14 @@ class IntrospectTokenResponse(Schema):
 
 class UserInfoUser(Schema):
     sub: str
-    name: str | None
-    email: str | None
-    email_verified: bool | None
+    name: str | None = None
+    email: str | None = None
+    email_verified: bool | None = None
 
 
 class UserInfoOrganization(Schema):
     sub: str
-    name: str | None
+    name: str | None = None
 
 
 UserInfo = UserInfoUser | UserInfoOrganization

--- a/server/tests/oauth2/endpoints/list/test_list_oauth2_clients.py
+++ b/server/tests/oauth2/endpoints/list/test_list_oauth2_clients.py
@@ -3,10 +3,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 
 from polar.kit.db.postgres import AsyncSession
-from polar.models import (
-    OAuth2Client,
-    User,
-)
+from polar.models import OAuth2Client, User
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 

--- a/server/tests/oauth2/endpoints/userinfo/conftest.py
+++ b/server/tests/oauth2/endpoints/userinfo/conftest.py
@@ -1,0 +1,9 @@
+import pytest_asyncio
+
+from polar.kit.db.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture, save_fixture_factory
+
+
+@pytest_asyncio.fixture
+def save_fixture(session: AsyncSession) -> SaveFixture:
+    return save_fixture_factory(session)

--- a/server/tests/oauth2/endpoints/userinfo/test_userinfo.py
+++ b/server/tests/oauth2/endpoints/userinfo/test_userinfo.py
@@ -1,0 +1,63 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from polar.models import OAuth2Client, User
+from tests.fixtures.database import SaveFixture
+
+from ...conftest import create_oauth2_token
+
+
+@pytest_asyncio.fixture
+async def oauth2_client(save_fixture: SaveFixture, user: User) -> OAuth2Client:
+    oauth2_client = OAuth2Client(
+        client_id="polar_ci_123",
+        client_secret="polar_cs_123",
+        registration_access_token="polar_crt_123",
+        user=user,
+    )
+    oauth2_client.set_client_metadata(
+        {
+            "client_name": "Test Client",
+            "redirect_uris": ["http://127.0.0.1:8000/docs/oauth2-redirect"],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": "openid profile email",
+        }
+    )
+    await save_fixture(oauth2_client)
+    return oauth2_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_db_asserts
+@pytest.mark.parametrize("method", ["GET", "POST"])
+class TestOAuth2UserInfo:
+    async def test_no_scope(
+        self,
+        method: str,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user: User,
+        oauth2_client: OAuth2Client,
+    ) -> None:
+        await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="ACCESS_TOKEN",
+            refresh_token="REFRESH_TOKEN",
+            scopes=[],
+            user=user,
+        )
+
+        response = await client.request(
+            method,
+            "/v1/oauth2/userinfo",
+            headers={"Authorization": "Bearer ACCESS_TOKEN"},
+        )
+
+        assert response.status_code == 200
+
+        json = response.json()
+        assert json["sub"] == str(user.id)


### PR DESCRIPTION
Fix #4075