### PR TITLE
server: remove XForwardedHostMiddleware

### DIFF
--- a/.devcontainer/Caddyfile
+++ b/.devcontainer/Caddyfile
@@ -2,6 +2,7 @@
 	route /v1/* {
 		reverse_proxy 127.0.0.1:8000 {
 			trusted_proxies private_ranges
+      header_up Host {http.request.header.X-Forwarded-Host}
 		}
 	}
 	route * {

--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -1,6 +1,5 @@
 import contextlib
 from collections.abc import AsyncIterator
-from os import environ
 from typing import TypedDict
 
 import structlog
@@ -34,7 +33,6 @@ from polar.middlewares import (
     LogCorrelationIdMiddleware,
     PathRewriteMiddleware,
     SandboxResponseHeaderMiddleware,
-    XForwardedHostMiddleware,
 )
 from polar.oauth2.endpoints.well_known import router as well_known_router
 from polar.oauth2.exception_handlers import OAuth2Error, oauth2_error_exception_handler
@@ -132,10 +130,6 @@ def create_app() -> FastAPI:
 
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")
     app.add_middleware(FlushEnqueuedWorkerJobsMiddleware)
-    app.add_middleware(
-        XForwardedHostMiddleware,
-        trusted_hosts=environ.get("FORWARDED_ALLOW_IPS", "127.0.0.1"),
-    )
     app.add_middleware(LogCorrelationIdMiddleware)
     if settings.is_sandbox():
         app.add_middleware(SandboxResponseHeaderMiddleware)

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -29,39 +29,6 @@ class LogCorrelationIdMiddleware:
         structlog.contextvars.unbind_contextvars("correlation_id", "method", "path")
 
 
-class XForwardedHostMiddleware:
-    """
-    Ensures the app respects the `X-Forwarded-Host` if correctly trusted.
-
-    Necessary to make `.url_for` correctly working behind a proxy.
-
-    Should not be necessary anymore when Uvicorn releases this:
-    https://github.com/encode/uvicorn/pull/2231
-    """
-
-    def __init__(self, app: ASGIApp, trusted_hosts: str | list[str] = "127.0.0.1"):
-        self.app = app
-        if isinstance(trusted_hosts, str):
-            self.trusted_hosts = {item.strip() for item in trusted_hosts.split(",")}
-        else:
-            self.trusted_hosts = set(trusted_hosts)
-        self.always_trust = "*" in self.trusted_hosts
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] in ("http", "websocket"):
-            client_addr: tuple[str, int] | None = scope.get("client")
-            client_host = client_addr[0] if client_addr else None
-
-            if self.always_trust or client_host in self.trusted_hosts:
-                headers = MutableHeaders(scope=scope)
-
-                if "x-forwarded-host" in headers:
-                    headers.update({"host": headers["x-forwarded-host"]})
-                    scope["headers"] = headers.raw
-
-        return await self.app(scope, receive, send)
-
-
 class FlushEnqueuedWorkerJobsMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app


### PR DESCRIPTION
Unnecessary to make things work on Render: it was made for GitHub Codespaces.

Removing it because it probably exposes us to security issues (Render doesn't sanitate it), and found a better way to handle it for GH Codespace