### PR TITLE
clients/web/checkout: fix Stripe complaining email is missing on confirm

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutForm.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutForm.tsx
@@ -156,29 +156,28 @@ const BaseCheckoutForm = ({
             className="flex flex-col gap-y-12"
           >
             <div className="flex flex-col gap-y-6">
-              {!checkout.customer_id && (
-                <FormField
-                  control={control}
-                  name="customer_email"
-                  rules={{
-                    required: 'This field is required',
-                  }}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="email"
-                          autoComplete="email"
-                          {...field}
-                          value={field.value || ''}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              )}
+              <FormField
+                control={control}
+                name="customer_email"
+                rules={{
+                  required: 'This field is required',
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        autoComplete="email"
+                        {...field}
+                        value={field.value || ''}
+                        disabled={checkout.customer_id !== null}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
               {children}
 


### PR DESCRIPTION
The email field was hidden when customer was set, so it was not part of the submit data payload.

Display it as disabled field to solve that.