### PR TITLE
Signup Attribution & Intent

### DIFF
--- a/clients/apps/web/src/app/(installation)/github/installation/page.tsx
+++ b/clients/apps/web/src/app/(installation)/github/installation/page.tsx
@@ -12,7 +12,6 @@ import {
   FetchError,
   Organization,
   ResponseError,
-  UserSignupType,
   ValidationError,
 } from '@polar-sh/sdk'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -181,7 +180,6 @@ export default function Page() {
           {pathname && (
             <GithubLoginButton
               returnTo={pathname}
-              userSignupType={UserSignupType.MAINTAINER}
               posthogProps={{
                 view: 'Github Installation Page',
               }}

--- a/clients/apps/web/src/app/login/page.tsx
+++ b/clients/apps/web/src/app/login/page.tsx
@@ -12,10 +12,6 @@ export default async function Page({
     return_to?: string
   }
 }) {
-  const restParams = new URLSearchParams(rest)
-  const returnTo = return_to
-    ? `${return_to || ''}?${restParams.toString()}`
-    : undefined
   return (
     <div className="flex h-screen w-full grow items-center justify-center">
       <div className="flex w-full max-w-md flex-col justify-between gap-8 p-16">
@@ -29,7 +25,7 @@ export default async function Page({
             </h2>
           </div>
         </div>
-        <Login returnTo={returnTo} />
+        <Login returnTo={return_to} returnParams={rest} />
       </div>
     </div>
   )

--- a/clients/apps/web/src/app/signup/page.tsx
+++ b/clients/apps/web/src/app/signup/page.tsx
@@ -11,11 +11,6 @@ export default async function Page({
     return_to?: string
   }
 }) {
-  const restParams = new URLSearchParams(rest)
-  const returnTo = return_to
-    ? `${return_to || ''}?${restParams.toString()}`
-    : undefined
-
   const api = getServerSideAPI()
   const userOrganizations = await getUserOrganizations(api)
 
@@ -47,7 +42,9 @@ export default async function Page({
               </label>
               <Input name="org-name" autoFocus />
             </div> */}
-            <Login returnTo={returnTo} />
+            <Login returnTo={return_to} returnParams={rest} signup={{
+              intent: 'creator',
+            }}/>
           </div>
         </div>
         <div className="dark:bg-polar-950 dark:border-polar-700 rounded-4xl col-span-2 hidden overflow-hidden rounded-r-none border border-r-0 border-gray-200 bg-gray-100 md:flex">

--- a/clients/apps/web/src/components/Auth/AuthModal.tsx
+++ b/clients/apps/web/src/components/Auth/AuthModal.tsx
@@ -1,27 +1,24 @@
 import ShadowBox from 'polarkit/components/ui/atoms/shadowbox'
 import LogoIcon from '../Brand/LogoIcon'
+import { UserSignupAttribution } from '@polar-sh/sdk'
 import Login from './Login'
 
 interface AuthModalProps {
-  return_to?: string
-  params?: Record<string, string>
-  type?: 'signup' | 'login'
+  returnTo?: string
+  returnParams?: Record<string, string>
+  signup?: UserSignupAttribution
 }
 
 export const AuthModal = ({
-  return_to,
-  params,
-  type = 'login',
+  returnTo,
+  returnParams,
+  signup,
 }: AuthModalProps) => {
-  const restParams = new URLSearchParams(params)
-  const returnTo = return_to
-    ? `${return_to || ''}?${restParams.toString()}`
-    : undefined
-
-  const title = type === 'signup' ? 'Sign Up' : 'Sign In'
+  const isSignup = signup !== undefined
+  const title = isSignup ? 'Sign Up' : 'Sign In'
 
   const copy =
-    type === 'signup' ? (
+    isSignup ? (
       <p className="dark:text-polar-500 text-xl text-gray-500">
         Join thousands of developers getting paid to code on their passions
       </p>
@@ -38,7 +35,7 @@ export const AuthModal = ({
         </div>
 
         <div className="flex flex-col gap-y-12">
-          <Login returnTo={returnTo} />
+          <Login returnTo={returnTo} returnParams={returnParams} signup={signup} />
         </div>
       </div>
     </ShadowBox>

--- a/clients/apps/web/src/components/Auth/GetStartedButton.tsx
+++ b/clients/apps/web/src/components/Auth/GetStartedButton.tsx
@@ -46,9 +46,10 @@ const GetStartedButton: React.FC<GetStartedButtonProps> = ({
         hide={hideModal}
         modalContent={
           <AuthModal
-            return_to={`/dashboard/create`}
-            params={slug ? { slug, auto: 'true' } : {}}
-            type="signup"
+            returnParams={slug ? { slug, auto: 'true' } : {}}
+            signup={{
+              intent: 'creator'
+            }}
           />
         }
         className="lg:w-full lg:max-w-[480px]"

--- a/clients/apps/web/src/components/Auth/GithubLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/GithubLoginButton.tsx
@@ -1,26 +1,28 @@
 'use client'
 
 import { getGitHubAuthorizeURL } from '@/utils/auth'
-import { UserSignupType } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import Button from 'polarkit/components/ui/atoms/button'
 import { twMerge } from 'tailwind-merge'
+import { UserSignupAttribution } from '@polar-sh/sdk'
 
 const GithubLoginButton = (props: {
   className?: string
   returnTo?: string
-  userSignupType?: UserSignupType
+  signup?: UserSignupAttribution,
   size?: 'large' | 'small'
   fullWidth?: boolean
   posthogProps?: object
   text: string
 }) => {
   const search = useSearchParams()
+  const signup = props.signup
+
   const authorizeURL = getGitHubAuthorizeURL({
     paymentIntentId: search?.get('payment_intent_id') ?? undefined,
     returnTo: props.returnTo,
-    userSignupType: props.userSignupType,
+    attribution: JSON.stringify(signup),
   })
 
   const largeStyle = 'p-2.5 px-5 text-md space-x-3'

--- a/clients/apps/web/src/components/Auth/GoogleLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/GoogleLoginButton.tsx
@@ -1,14 +1,19 @@
 import { getGoogleAuthorizeURL } from '@/utils/auth'
 import { Google } from '@mui/icons-material'
 import Button from 'polarkit/components/ui/atoms/button'
+import { UserSignupAttribution } from '@polar-sh/sdk'
 
 interface GoogleLoginButtonProps {
   returnTo?: string
+  signup?: UserSignupAttribution
 }
 
-const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ returnTo }) => {
+const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ returnTo, signup }) => {
   return (
-    <a href={getGoogleAuthorizeURL({ returnTo })}>
+    <a href={getGoogleAuthorizeURL({
+      returnTo,
+      attribution: JSON.stringify(signup)
+    })}>
       <Button
         variant="secondary"
         wrapperClassNames="space-x-3 p-2.5 px-5"

--- a/clients/apps/web/src/components/Auth/Login.tsx
+++ b/clients/apps/web/src/components/Auth/Login.tsx
@@ -1,9 +1,64 @@
+'use client'
+
 import { LabeledSeparator } from 'polarkit/components/ui/atoms'
 import GithubLoginButton from '../Auth/GithubLoginButton'
 import MagicLinkLoginForm from '../Auth/MagicLinkLoginForm'
 import GoogleLoginButton from './GoogleLoginButton'
+import { UserSignupAttribution } from '@polar-sh/sdk'
+import { useSearchParams, usePathname } from 'next/navigation'
 
-const Login = ({ returnTo }: { returnTo?: string }) => {
+const Login = ({
+  returnTo,
+  returnParams,
+  signup
+}: {
+  returnTo?: string
+  returnParams?: Record<string, string>
+  signup?: UserSignupAttribution
+}) => {
+  let loginProps = {}
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  if (signup) {
+    if (!returnTo) {
+      returnTo = `/dashboard/create`
+    }
+
+    signup.path = pathname
+
+    const host = (typeof window !== 'undefined') ? window.location.host : ''
+    if (host) {
+      signup.host = host
+    }
+
+    const utm = {
+      source: searchParams.get('utm_source') ?? '',
+      medium: searchParams.get('utm_medium') ?? '',
+      campaign: searchParams.get('utm_campaign') ?? '',
+    }
+    if (utm.source) {
+      signup.utm_source = utm.source
+    }
+    if (utm.medium) {
+      signup.utm_medium = utm.medium
+    }
+    if (utm.campaign) {
+      signup.utm_campaign = utm.campaign
+    }
+
+    loginProps = { signup }
+  }
+
+  if (returnTo) {
+    const returnToParams = new URLSearchParams(returnParams)
+    if (returnToParams) {
+      returnTo = `${returnTo || ''}?${returnToParams}`
+    }
+
+    loginProps = { returnTo, ...loginProps }
+  }
+
   return (
     <div className="flex flex-col gap-y-4">
       <div className="flex w-full flex-col gap-y-4">
@@ -11,14 +66,14 @@ const Login = ({ returnTo }: { returnTo?: string }) => {
           text="Continue with GitHub"
           size="large"
           fullWidth
-          returnTo={returnTo}
           posthogProps={{
             view: 'Login Page',
           }}
+          {...loginProps}
         />
-        <GoogleLoginButton returnTo={returnTo} />
+        <GoogleLoginButton {...loginProps} />
         <LabeledSeparator label="Or" />
-        <MagicLinkLoginForm returnTo={returnTo} />
+        <MagicLinkLoginForm {...loginProps} />
       </div>
       <div className="dark:text-polar-500 text-sm text-gray-400">
         By using Polar you agree to our{' '}

--- a/clients/apps/web/src/components/Auth/MagicLinkLoginForm.tsx
+++ b/clients/apps/web/src/components/Auth/MagicLinkLoginForm.tsx
@@ -3,7 +3,7 @@
 import { useSendMagicLink } from '@/hooks/magicLink'
 import { setValidationErrors } from '@/utils/api/errors'
 import { FormControl } from '@mui/material'
-import { ResponseError, ValidationError } from '@polar-sh/sdk'
+import { UserSignupAttribution, ResponseError, ValidationError } from '@polar-sh/sdk'
 import Button from 'polarkit/components/ui/atoms/button'
 import Input from 'polarkit/components/ui/atoms/input'
 import {
@@ -17,10 +17,12 @@ import { SubmitHandler, useForm } from 'react-hook-form'
 
 interface MagicLinkLoginFormProps {
   returnTo?: string
+  signup?: UserSignupAttribution
 }
 
 const MagicLinkLoginForm: React.FC<MagicLinkLoginFormProps> = ({
   returnTo,
+  signup,
 }) => {
   const form = useForm<{ email: string }>()
   const { control, handleSubmit, setError } = form
@@ -30,7 +32,7 @@ const MagicLinkLoginForm: React.FC<MagicLinkLoginFormProps> = ({
   const onSubmit: SubmitHandler<{ email: string }> = async ({ email }) => {
     setLoading(true)
     try {
-      sendMagicLink(email, returnTo)
+      sendMagicLink(email, returnTo, signup)
     } catch (e) {
       if (e instanceof ResponseError) {
         const body = await e.response.json()

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -68,7 +68,7 @@ const LandingPageTopbar = () => {
       <Modal
         isShown={isModalShown}
         hide={hideModal}
-        modalContent={<AuthModal type="login" />}
+        modalContent={<AuthModal />}
         className="lg:w-full lg:max-w-[480px]"
       />
     </div>

--- a/clients/apps/web/src/components/Layout/Public/Topbar.tsx
+++ b/clients/apps/web/src/components/Layout/Public/Topbar.tsx
@@ -7,7 +7,6 @@ import {
   Organization,
   Platforms,
   UserRead,
-  UserSignupType,
 } from '@polar-sh/sdk'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -52,7 +51,6 @@ const Topbar = ({
           <GithubLoginButton
             text="Connect with GitHub"
             returnTo={returnTo}
-            userSignupType={UserSignupType.BACKER}
           />
         )}
         {!hasOrgs && (

--- a/clients/apps/web/src/components/Layout/Public/TopbarRight.tsx
+++ b/clients/apps/web/src/components/Layout/Public/TopbarRight.tsx
@@ -40,7 +40,7 @@ const TopbarRight = ({
           <Modal
             isShown={isModalShown}
             hide={hideModal}
-            modalContent={<AuthModal type="login" return_to={loginReturnTo} />}
+            modalContent={<AuthModal returnTo={loginReturnTo} />}
             className="lg:w-full lg:max-w-[480px]"
           />
         </>

--- a/clients/apps/web/src/components/Pledge/PledgeCheckoutFundOnCompletion.tsx
+++ b/clients/apps/web/src/components/Pledge/PledgeCheckoutFundOnCompletion.tsx
@@ -6,7 +6,7 @@ import {
   ClockIcon,
   UserCircleIcon,
 } from '@heroicons/react/24/outline'
-import { Issue, Organization, UserSignupType } from '@polar-sh/sdk'
+import { Issue, Organization } from '@polar-sh/sdk'
 import { usePathname, useRouter } from 'next/navigation'
 import Button from 'polarkit/components/ui/atoms/button'
 import MoneyInput from 'polarkit/components/ui/atoms/moneyinput'
@@ -210,7 +210,6 @@ const NotLoggedInBanner = () => {
         text="Continue with GitHub"
         fullWidth={true}
         returnTo={pathname || '/funding'}
-        userSignupType={UserSignupType.BACKER}
       />
     </div>
   )

--- a/clients/apps/web/src/hooks/magicLink.ts
+++ b/clients/apps/web/src/hooks/magicLink.ts
@@ -1,16 +1,20 @@
 'use client'
 
 import { api } from '@/utils/api'
+import { UserSignupAttribution, MagicLinkRequest } from '@polar-sh/sdk'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
 
 export const useSendMagicLink = () => {
   const router = useRouter()
   const func = useCallback(
-    async (email: string, return_to?: string) => {
-      await api.magicLink.magicLinkRequest({
-        body: { email, return_to },
-      })
+    async (email: string, return_to?: string, signup?: UserSignupAttribution) => {
+      const body: MagicLinkRequest = {
+        email,
+        return_to,
+        attribution: signup,
+      }
+      await api.magicLink.magicLinkRequest({ body })
       const searchParams = new URLSearchParams({ email: email })
       router.push(`/login/magic-link/request?${searchParams}`)
     },

--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -6,7 +6,7 @@ import {
   IntegrationsGithubApiRedirectToOrganizationInstallationRequest,
   IntegrationsGithubRepositoryBenefitApiIntegrationsGithubRepositoryBenefitUserAuthorizeRequest,
   IntegrationsGoogleApiIntegrationsGoogleAuthorizeRequest,
-  MagicLinkApiMagicLinkAuthenticateRequest,
+  MagicLinkApiMagicLinkAuthenticateRequest
 } from '@polar-sh/sdk'
 
 export const getGitHubAuthorizeURL = (
@@ -19,8 +19,8 @@ export const getGitHubAuthorizeURL = (
   if (params.returnTo !== undefined) {
     searchParams.set('return_to', params.returnTo)
   }
-  if (params.userSignupType !== undefined) {
-    searchParams.set('user_signup_type', params.userSignupType)
+  if (params.attribution !== undefined) {
+    searchParams.set('attribution', params.attribution)
   }
   return `${getServerURL()}/v1/integrations/github/authorize?${searchParams}`
 }
@@ -32,8 +32,8 @@ export const getGoogleAuthorizeURL = (
   if (params.returnTo !== undefined) {
     searchParams.set('return_to', params.returnTo)
   }
-  if (params.userSignupType !== undefined) {
-    searchParams.set('user_signup_type', params.userSignupType)
+  if (params.attribution !== undefined) {
+    searchParams.set('attribution', params.attribution)
   }
   return `${getServerURL()}/v1/integrations/google/authorize?${searchParams}`
 }

--- a/clients/packages/sdk/openapi/source.json
+++ b/clients/packages/sdk/openapi/source.json
@@ -2596,22 +2596,6 @@
                         }
                     },
                     {
-                        "name": "user_signup_type",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/UserSignupType"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "User Signup Type"
-                        }
-                    },
-                    {
                         "name": "return_to",
                         "in": "query",
                         "required": false,
@@ -2625,6 +2609,22 @@
                                 }
                             ],
                             "title": "Return To"
+                        }
+                    },
+                    {
+                        "name": "attribution",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Attribution"
                         }
                     }
                 ],
@@ -16244,22 +16244,6 @@
                 ],
                 "parameters": [
                     {
-                        "name": "user_signup_type",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/UserSignupType"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "User Signup Type"
-                        }
-                    },
-                    {
                         "name": "return_to",
                         "in": "query",
                         "required": false,
@@ -16273,6 +16257,22 @@
                                 }
                             ],
                             "title": "Return To"
+                        }
+                    },
+                    {
+                        "name": "attribution",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Attribution"
                         }
                     }
                 ],
@@ -26594,6 +26594,16 @@
                             }
                         ],
                         "title": "Return To"
+                    },
+                    "attribution": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/UserSignupAttribution"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 },
                 "type": "object",
@@ -35933,14 +35943,133 @@
                 ],
                 "title": "UserSetAccount"
             },
-            "UserSignupType": {
-                "type": "string",
-                "enum": [
-                    "maintainer",
-                    "backer",
-                    "imported"
-                ],
-                "title": "UserSignupType"
+            "UserSignupAttribution": {
+                "properties": {
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "creator",
+                                    "pledge",
+                                    "donation",
+                                    "purchase",
+                                    "subscription",
+                                    "newsletter_subscription"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent"
+                    },
+                    "order": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Order"
+                    },
+                    "subscription": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription"
+                    },
+                    "pledge": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pledge"
+                    },
+                    "donation": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Donation"
+                    },
+                    "path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Path"
+                    },
+                    "host": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Host"
+                    },
+                    "utm_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Utm Source"
+                    },
+                    "utm_medium": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Utm Medium"
+                    },
+                    "utm_campaign": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Utm Campaign"
+                    }
+                },
+                "type": "object",
+                "title": "UserSignupAttribution"
             },
             "UserStripePortalSession": {
                 "properties": {

--- a/clients/packages/sdk/openapi/updated.json
+++ b/clients/packages/sdk/openapi/updated.json
@@ -2536,22 +2536,6 @@
                         }
                     },
                     {
-                        "name": "user_signup_type",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/UserSignupType"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "User Signup Type"
-                        }
-                    },
-                    {
                         "name": "return_to",
                         "in": "query",
                         "required": false,
@@ -2565,6 +2549,22 @@
                                 }
                             ],
                             "title": "Return To"
+                        }
+                    },
+                    {
+                        "name": "attribution",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Attribution"
                         }
                     }
                 ],
@@ -16073,22 +16073,6 @@
                 ],
                 "parameters": [
                     {
-                        "name": "user_signup_type",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/UserSignupType"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "User Signup Type"
-                        }
-                    },
-                    {
                         "name": "return_to",
                         "in": "query",
                         "required": false,
@@ -16102,6 +16086,22 @@
                                 }
                             ],
                             "title": "Return To"
+                        }
+                    },
+                    {
+                        "name": "attribution",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Attribution"
                         }
                     }
                 ],
@@ -25821,6 +25821,16 @@
                             }
                         ],
                         "title": "Return To"
+                    },
+                    "attribution": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/UserSignupAttribution"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 },
                 "type": "object",
@@ -34964,14 +34974,133 @@
                 ],
                 "title": "UserSetAccount"
             },
-            "UserSignupType": {
-                "type": "string",
-                "enum": [
-                    "maintainer",
-                    "backer",
-                    "imported"
-                ],
-                "title": "UserSignupType"
+            "UserSignupAttribution": {
+                "properties": {
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "creator",
+                                    "pledge",
+                                    "donation",
+                                    "purchase",
+                                    "subscription",
+                                    "newsletter_subscription"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent"
+                    },
+                    "order": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Order"
+                    },
+                    "subscription": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription"
+                    },
+                    "pledge": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pledge"
+                    },
+                    "donation": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid4"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Donation"
+                    },
+                    "path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Path"
+                    },
+                    "host": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Host"
+                    },
+                    "utm_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Utm Source"
+                    },
+                    "utm_medium": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Utm Medium"
+                    },
+                    "utm_campaign": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Utm Campaign"
+                    }
+                },
+                "type": "object",
+                "title": "UserSignupAttribution"
             },
             "UserStripePortalSession": {
                 "properties": {

--- a/clients/packages/sdk/src/client/apis/IntegrationsGithubApi.ts
+++ b/clients/packages/sdk/src/client/apis/IntegrationsGithubApi.ts
@@ -22,7 +22,6 @@ import type {
   LookupUserRequest,
   OrganizationBillingPlan,
   OrganizationCheckPermissionsInput,
-  UserSignupType,
   WebhookResponse,
 } from '../models/index';
 
@@ -41,8 +40,8 @@ export interface IntegrationsGithubApiInstallRequest {
 
 export interface IntegrationsGithubApiIntegrationsGithubAuthorizeRequest {
     paymentIntentId?: string;
-    userSignupType?: UserSignupType;
     returnTo?: string;
+    attribution?: string;
 }
 
 export interface IntegrationsGithubApiIntegrationsGithubCallbackRequest {
@@ -211,12 +210,12 @@ export class IntegrationsGithubApi extends runtime.BaseAPI {
             queryParameters['payment_intent_id'] = requestParameters['paymentIntentId'];
         }
 
-        if (requestParameters['userSignupType'] != null) {
-            queryParameters['user_signup_type'] = requestParameters['userSignupType'];
-        }
-
         if (requestParameters['returnTo'] != null) {
             queryParameters['return_to'] = requestParameters['returnTo'];
+        }
+
+        if (requestParameters['attribution'] != null) {
+            queryParameters['attribution'] = requestParameters['attribution'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/clients/packages/sdk/src/client/apis/IntegrationsGoogleApi.ts
+++ b/clients/packages/sdk/src/client/apis/IntegrationsGoogleApi.ts
@@ -16,12 +16,11 @@
 import * as runtime from '../runtime';
 import type {
   HTTPValidationError,
-  UserSignupType,
 } from '../models/index';
 
 export interface IntegrationsGoogleApiIntegrationsGoogleAuthorizeRequest {
-    userSignupType?: UserSignupType;
     returnTo?: string;
+    attribution?: string;
 }
 
 export interface IntegrationsGoogleApiIntegrationsGoogleCallbackRequest {
@@ -42,12 +41,12 @@ export class IntegrationsGoogleApi extends runtime.BaseAPI {
     async integrationsGoogleAuthorizeRaw(requestParameters: IntegrationsGoogleApiIntegrationsGoogleAuthorizeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<any>> {
         const queryParameters: any = {};
 
-        if (requestParameters['userSignupType'] != null) {
-            queryParameters['user_signup_type'] = requestParameters['userSignupType'];
-        }
-
         if (requestParameters['returnTo'] != null) {
             queryParameters['return_to'] = requestParameters['returnTo'];
+        }
+
+        if (requestParameters['attribution'] != null) {
+            queryParameters['attribution'] = requestParameters['attribution'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/clients/packages/sdk/src/client/models/index.ts
+++ b/clients/packages/sdk/src/client/models/index.ts
@@ -7866,6 +7866,12 @@ export interface MagicLinkRequest {
      * @memberof MagicLinkRequest
      */
     return_to?: string | null;
+    /**
+     * 
+     * @type {UserSignupAttribution}
+     * @memberof MagicLinkRequest
+     */
+    attribution?: UserSignupAttribution | null;
 }
 /**
  * 
@@ -16000,17 +16006,87 @@ export interface UserSetAccount {
      */
     account_id: string;
 }
-
 /**
  * 
  * @export
+ * @interface UserSignupAttribution
  */
-export const UserSignupType = {
-    MAINTAINER: 'maintainer',
-    BACKER: 'backer',
-    IMPORTED: 'imported'
+export interface UserSignupAttribution {
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    intent?: UserSignupAttributionIntentEnum | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    order?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    subscription?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    pledge?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    donation?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    path?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    host?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    utm_source?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    utm_medium?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserSignupAttribution
+     */
+    utm_campaign?: string | null;
+}
+
+
+/**
+ * @export
+ */
+export const UserSignupAttributionIntentEnum = {
+    CREATOR: 'creator',
+    PLEDGE: 'pledge',
+    DONATION: 'donation',
+    PURCHASE: 'purchase',
+    SUBSCRIPTION: 'subscription',
+    NEWSLETTER_SUBSCRIPTION: 'newsletter_subscription'
 } as const;
-export type UserSignupType = typeof UserSignupType[keyof typeof UserSignupType];
+export type UserSignupAttributionIntentEnum = typeof UserSignupAttributionIntentEnum[keyof typeof UserSignupAttributionIntentEnum];
 
 /**
  * 

--- a/server/migrations/versions/2024-10-10-1546_add_user_signup_attribution.py
+++ b/server/migrations/versions/2024-10-10-1546_add_user_signup_attribution.py
@@ -1,0 +1,148 @@
+"""add user signup attribution
+
+Revision ID: e283628da3fc
+Revises: 314683b1504d
+Create Date: 2024-10-10 15:46:51.351637
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "e283628da3fc"
+down_revision = "314683b1504d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "meta",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+    op.add_column(
+        "magic_links",
+        sa.Column(
+            "signup_attribution",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+    # Set historical signup intents
+    op.execute(
+        """
+        WITH user_pledges AS (
+            SELECT
+                pledges.by_user_id AS user_id,
+                pledges.id AS event_id,
+                pledges.created_at AS event_created_at,
+                RANK() OVER (PARTITION BY pledges.by_user_id ORDER BY pledges.created_at ASC) AS event_rank,
+                'pledge' AS event_type
+            FROM pledges
+            WHERE pledges.by_user_id IS NOT NULL
+        ), user_donations AS (
+            SELECT
+                donations.by_user_id AS user_id,
+                donations.id AS event_id,
+                donations.created_at AS event_created_at,
+                RANK() OVER (PARTITION BY donations.by_user_id ORDER BY donations.created_at ASC) AS event_rank,
+                'donation' AS event_type
+            FROM donations
+            WHERE donations.by_user_id IS NOT NULL
+        ), user_purchases AS (
+            SELECT
+                orders.user_id AS user_id,
+                orders.id AS event_id,
+                orders.created_at AS event_created_at,
+                RANK() OVER (PARTITION BY orders.user_id ORDER BY orders.created_at ASC) AS event_rank,
+                'purchase' AS event_type
+            FROM orders
+            WHERE 1 = 1
+                AND orders.user_id IS NOT NULL
+                AND orders.subscription_id IS NULL
+        ), user_subscriptions AS (
+            SELECT
+                subscriptions.user_id AS user_id,
+                subscriptions.id AS event_id,
+                subscriptions.created_at AS event_created_at,
+                RANK() OVER (PARTITION BY subscriptions.user_id ORDER BY subscriptions.created_at ASC) AS event_rank,
+                'subscription' AS event_type
+            FROM subscriptions
+            WHERE 1 = 1
+                AND subscriptions.user_id IS NOT NULL
+                AND subscriptions.stripe_subscription_id IS NOT NULL
+        ), user_newsletter_subscriptions AS (
+            SELECT
+                subscriptions.user_id AS user_id,
+                subscriptions.id AS event_id,
+                subscriptions.created_at AS event_created_at,
+                RANK() OVER (PARTITION BY subscriptions.user_id ORDER BY subscriptions.created_at ASC) AS event_rank,
+                'newsletter_subscription' AS event_type
+            FROM subscriptions
+            WHERE 1 = 1
+                AND subscriptions.user_id IS NOT NULL
+                AND subscriptions.stripe_subscription_id IS NULL
+        ), user_creators AS (
+            SELECT
+                uo.user_id AS user_id,
+                uo.organization_id AS event_id,
+                uo.created_at AS event_created_at,
+                RANK() OVER (PARTITION BY uo.user_id ORDER BY uo.created_at ASC) AS event_rank,
+                'creator' AS event_type
+            FROM user_organizations AS uo
+        ), user_events AS (
+            SELECT * FROM user_pledges
+            UNION SELECT * FROM user_donations
+            UNION SELECT * FROM user_purchases
+            UNION SELECT * FROM user_subscriptions
+            UNION SELECT * FROM user_newsletter_subscriptions
+            UNION SELECT * FROM user_creators
+        ), attribution_rank AS (
+            SELECT
+                ue.*,
+                users.email,
+                users.created_at,
+                RANK() OVER (PARTITION BY ue.user_id ORDER BY event_created_at ASC) AS rank
+            FROM user_events AS ue
+            JOIN users ON users.id = ue.user_id
+        ), attributions AS (
+            SELECT
+                *,
+                CASE
+                    WHEN event_type = 'pledge' THEN json_build_object('intent', 'pledge', 'pledge', event_id)
+                    WHEN event_type = 'donation' THEN json_build_object('intent', 'donation', 'donation', event_id)
+                    WHEN event_type = 'purchase' THEN json_build_object('intent', 'purchase', 'order', event_id)
+                    WHEN event_type = 'subscription' THEN json_build_object('intent', 'subscription', 'subscription', event_id)
+                    WHEN event_type = 'newsletter_subscription' THEN json_build_object('intent', 'newsletter_subscription', 'subscription', event_id)
+                    WHEN event_type = 'creator' THEN json_build_object('intent', 'creator')
+                    ELSE NULL
+                END AS signup_attribution
+            FROM attribution_rank WHERE rank = 1
+        )
+        UPDATE users
+        SET meta = json_build_object('signup', attributions.signup_attribution)
+        FROM attributions
+        WHERE 1 = 1
+            AND attributions.signup_attribution IS NOT NULL
+            AND users.id = attributions.user_id
+        """
+    )
+
+
+def downgrade() -> None:
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.drop_column("users", "meta")
+    op.drop_column("magic_links", "signup_attribution")
+    # ### end Alembic commands ###

--- a/server/polar/enums.py
+++ b/server/polar/enums.py
@@ -6,12 +6,6 @@ class Platforms(StrEnum):
     github = "github"
 
 
-class UserSignupType(StrEnum):
-    maintainer = "maintainer"
-    backer = "backer"
-    imported = "imported"
-
-
 class PaymentProcessor(StrEnum):
     stripe = "stripe"
 

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -1,3 +1,4 @@
+from typing import Any
 from uuid import UUID
 
 import structlog
@@ -95,7 +96,7 @@ async def github_authorize(
     signup_attribution: UserSignupAttributionQuery,
     payment_intent_id: str | None = None,
 ) -> RedirectResponse:
-    state = {}
+    state: dict[str, Any] = {}
     if payment_intent_id:
         state["payment_intent_id"] = payment_intent_id
 

--- a/server/polar/integrations/github/endpoints.py
+++ b/server/polar/integrations/github/endpoints.py
@@ -102,9 +102,7 @@ async def github_authorize(
     state["return_to"] = return_to
 
     if signup_attribution:
-        state["signup_attribution"] = signup_attribution.model_dump_json(
-            exclude_unset=True
-        )
+        state["signup_attribution"] = signup_attribution.model_dump(exclude_unset=True)
 
     if is_user(auth_subject):
         state["user_id"] = str(auth_subject.subject.id)
@@ -153,7 +151,7 @@ async def github_callback(
 
     state_signup_attribution = state_data.get("signup_attribution")
     if state_signup_attribution:
-        state_signup_attribution = UserSignupAttribution.model_validate_json(
+        state_signup_attribution = UserSignupAttribution.model_validate(
             state_signup_attribution
         )
 

--- a/server/polar/integrations/google/endpoints.py
+++ b/server/polar/integrations/google/endpoints.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from fastapi import Depends, Request
 from fastapi.responses import RedirectResponse
@@ -43,7 +44,7 @@ async def google_authorize(
     return_to: ReturnTo,
     signup_attribution: UserSignupAttributionQuery,
 ) -> RedirectResponse:
-    state = {}
+    state: dict[str, Any] = {}
 
     state["return_to"] = return_to
 

--- a/server/polar/integrations/google/endpoints.py
+++ b/server/polar/integrations/google/endpoints.py
@@ -48,9 +48,7 @@ async def google_authorize(
     state["return_to"] = return_to
 
     if signup_attribution:
-        state["signup_attribution"] = signup_attribution.model_dump_json(
-            exclude_unset=True
-        )
+        state["signup_attribution"] = signup_attribution.model_dump(exclude_unset=True)
 
     if is_user(auth_subject):
         state["user_id"] = str(auth_subject.subject.id)
@@ -96,7 +94,7 @@ async def google_callback(
 
     state_signup_attribution = state_data.get("signup_attribution")
     if state_signup_attribution:
-        state_signup_attribution = UserSignupAttribution.model_validate_json(
+        state_signup_attribution = UserSignupAttribution.model_validate(
             state_signup_attribution
         )
 

--- a/server/polar/integrations/loops/service.py
+++ b/server/polar/integrations/loops/service.py
@@ -1,6 +1,5 @@
 from typing import Unpack
 
-from polar.enums import UserSignupType
 from polar.models import Issue, Organization, User
 from polar.postgres import AsyncSession
 from polar.user_organization.service import (
@@ -15,12 +14,8 @@ class Loops:
     async def user_signup(
         self,
         user: User,
-        signup_type: UserSignupType | None = None,
         **properties: Unpack[Properties],
     ) -> None:
-        if signup_type == UserSignupType.imported:
-            return
-
         properties = {
             "isMaintainer": False,
             "isBacker": False,
@@ -31,10 +26,6 @@ class Loops:
             "userId": str(user.id),
             **properties,
         }
-        if signup_type is not None:
-            properties["isMaintainer"] = signup_type == UserSignupType.maintainer
-            properties["isBacker"] = signup_type == UserSignupType.backer
-
         enqueue_job("loops.send_event", user.email, "User Signed Up", **properties)
 
     async def user_update(self, user: User, **properties: Unpack[Properties]) -> None:

--- a/server/polar/kit/db/models/base.py
+++ b/server/polar/kit/db/models/base.py
@@ -67,3 +67,7 @@ class RecordModel(TimestampedModel):
             id_value = insp.identity[0]
             return f"{self.__class__.__name__}(id={id_value!r})"
         return f"{self.__class__.__name__}(id=None)"
+
+    @classmethod
+    def generate_id(cls) -> UUID:
+        return generate_uuid()

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -68,6 +68,8 @@ def _validate_email_dns(email: str) -> str:
         return email
 
 
+UUID4ToStr = Annotated[UUID4, PlainSerializer(lambda v: str(v), return_type=str)]
+
 EmailStrDNS = Annotated[EmailStr, AfterValidator(_validate_email_dns)]
 
 HttpUrlToStr = Annotated[HttpUrl, PlainSerializer(lambda v: str(v), return_type=str)]

--- a/server/polar/magic_link/endpoints.py
+++ b/server/polar/magic_link/endpoints.py
@@ -30,16 +30,21 @@ async def request_magic_link(
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     magic_link, token = await magic_link_service.request(
-        session, magic_link_request.email, source="user_login"
+        session,
+        magic_link_request.email,
+        source="user_login",
+        signup_attribution=magic_link_request.attribution,
     )
 
     await magic_link_service.send(
         magic_link,
         token,
         base_url=str(settings.generate_frontend_url("/login/magic-link/authenticate")),
-        extra_url_params={"return_to": magic_link_request.return_to}
-        if magic_link_request.return_to
-        else {},
+        extra_url_params=(
+            {"return_to": magic_link_request.return_to}
+            if magic_link_request.return_to
+            else {}
+        ),
     )
 
 

--- a/server/polar/magic_link/schemas.py
+++ b/server/polar/magic_link/schemas.py
@@ -5,6 +5,9 @@ from pydantic import UUID4, EmailStr, field_validator
 
 from polar.kit.http import get_safe_return_url
 from polar.kit.schemas import EmailStrDNS, Schema
+from polar.user.schemas.user import (
+    UserSignupAttribution,
+)
 
 MagicLinkSource = Literal["user_login", "article_links"]
 
@@ -12,6 +15,7 @@ MagicLinkSource = Literal["user_login", "article_links"]
 class MagicLinkRequest(Schema):
     email: EmailStrDNS
     return_to: str | None = None
+    attribution: UserSignupAttribution | None = None
 
     @field_validator("return_to")
     @classmethod
@@ -22,6 +26,7 @@ class MagicLinkRequest(Schema):
 class MagicLinkCreate(Schema):
     token_hash: str
     user_email: EmailStr
+    signup_attribution: UserSignupAttribution | None = None
     user_id: UUID4 | None = None
     source: MagicLinkSource
     expires_at: datetime.datetime | None = None

--- a/server/polar/models/magic_link.py
+++ b/server/polar/models/magic_link.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, ForeignKey, String, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.config import settings
@@ -30,6 +32,10 @@ class MagicLink(RecordModel):
     )
 
     source: Mapped[str] = mapped_column(String, nullable=True)
+
+    signup_attribution: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=dict
+    )
 
     @declared_attr
     def user(cls) -> Mapped[User | None]:

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -56,9 +56,3 @@ class SubscriptionCreateEmail(Schema):
     product_id: UUID4 = Field(
         description="The ID of the product. **Must be the free subscription tier**."
     )
-
-
-class SubscriptionsImported(Schema):
-    """Result of a subscription import operation."""
-
-    count: int

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -428,7 +428,7 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
                     session,
                     customer_email,
                     signup_attribution=UserSignupAttribution(
-                        intent="order",
+                        intent="subscription",
                         subscription=subscription.id,
                     ),
                 )

--- a/server/polar/user/schemas/user.py
+++ b/server/polar/user/schemas/user.py
@@ -1,10 +1,11 @@
 import uuid
-from typing import Self
+from typing import Annotated, Literal, Self
 
+from fastapi import Depends
 from pydantic import UUID4, EmailStr, Field
 
 from polar.auth.scope import Scope
-from polar.kit.schemas import Schema, TimestampedSchema
+from polar.kit.schemas import Schema, TimestampedSchema, UUID4ToStr
 from polar.models.user import OAuthPlatform
 from polar.models.user import User as UserModel
 
@@ -62,3 +63,53 @@ class UserStripePortalSession(Schema):
 
 class UserScopes(Schema):
     scopes: list[Scope]
+
+
+###############################################################################
+# USER ATTRIBUTION
+###############################################################################
+
+
+class UserSignupAttribution(Schema):
+    intent: (
+        Literal[
+            "creator",
+            "pledge",
+            "donation",
+            "purchase",
+            "subscription",
+            "newsletter_subscription",
+        ]
+        | None
+    ) = None
+
+    # Flywheel sources
+    order: UUID4ToStr | None = None
+    subscription: UUID4ToStr | None = None
+    pledge: UUID4ToStr | None = None
+    donation: UUID4ToStr | None = None
+
+    # Website source
+    path: str | None = None
+    host: str | None = None
+
+    # UTM parameters
+    utm_source: str | None = None
+    utm_medium: str | None = None
+    utm_campaign: str | None = None
+
+
+UserSignupAttributionQueryJSON = str | None
+
+
+async def get_signup_attribution(
+    attribution: UserSignupAttributionQueryJSON = None,
+) -> UserSignupAttribution | None:
+    if attribution:
+        return UserSignupAttribution.model_validate_json(attribution)
+    return None
+
+
+UserSignupAttributionQuery = Annotated[
+    UserSignupAttribution | None, Depends(get_signup_attribution)
+]


### PR DESCRIPTION
Get better at tracking initial intent for using Polar. Making it easier to customize onboarding and designing the pathways to onboard users depending on intended use. 

Currently, we rely on an organization to be created to determine a creator. However, this can cause sub-optimal flows where a user signups to become a creator, but doesn't create an organization. Upon return they are treated as a buyer and we don't have a way to distinguish or continue their journey.