### PR TITLE
server/checkout: set an arbitrary amount on PWYW product if nothing is set

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -415,7 +415,7 @@ class CheckoutService(ResourceServiceReader[Checkout]):
         elif isinstance(price, ProductPriceCustom):
             currency = price.price_currency
             if amount is None:
-                amount = price.preset_amount
+                amount = price.preset_amount or 1000
         elif isinstance(price, ProductPriceFree):
             amount = None
             currency = None


### PR DESCRIPTION
Prevents a client error from Stripe complaining the amount is 0

Doh: do it for `client_create` too!