### PR TITLE
server/worker: fix issues with tasks using the Redis instance

### DIFF
--- a/server/tests/fixtures/worker.py
+++ b/server/tests/fixtures/worker.py
@@ -24,6 +24,7 @@ async def job_context(session: AsyncSession, redis: Redis) -> AsyncIterator[JobC
 
     yield {
         "redis": ArqRedis(redis.connection_pool),
+        "raw_redis": redis,
         "async_engine": engine,
         "async_sessionmaker": cast(AsyncSessionMaker, sessionmaker),
         "job_id": "fake_job_id",


### PR DESCRIPTION
ARQ instance doesn't decode responses, which causes issues with our logic using Redis, esp. GitHub tokens cache.

Create another dedicated connection pool with decoding enabled to avoid this.