### PR TITLE
fix: fix the Ctrl+ K that catches Chrome search bar on Windows

### DIFF
--- a/clients/apps/web/src/components/CommandPalette/commands/trigger.tsx
+++ b/clients/apps/web/src/components/CommandPalette/commands/trigger.tsx
@@ -23,7 +23,8 @@ export const useCommandPaletteTrigger = (onTrigger: () => void): void => {
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
       const controlKeyPressed = isMac(navigator) ? e.metaKey : e.ctrlKey
-      if (e.key === KEY && controlKeyPressed) {
+      if (e.key.toLowerCase() === KEY && controlKeyPressed) {
+        e.preventDefault()
         onTrigger()
       }
     }


### PR DESCRIPTION
fixes: #3577 

This PR fixes the bug that catches the Chrome search bar on Windows instead of Polar's by preventing the default behavior of the browser.