### PR TITLE
server/order: create balances with amount taken from actual payment transaction

### DIFF
--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -425,7 +425,7 @@ class TestCreateOrderFromStripe:
         )
         assert (
             transaction_service_mock.create_balance_from_charge.call_args[1]["amount"]
-            == invoice_total
+            == payment_transaction.amount
         )
 
         platform_fee_transaction_service_mock.create_fees_reversal_balances.assert_called_once()


### PR DESCRIPTION
Take the amount from the order doesn't always work, as invoices may apply customer balances which won't reflect the actual payment amount