### PR TITLE
website: Rename `Login` to `Open Dashboard`

### DIFF
--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -60,7 +60,7 @@ export const Hero = () => {
             </div>
           </div>
           <p className="hidden dark:text-polar-500 text-balance text-xs text-gray-500 md:block">
-            Up and running in two minutes. We only earn once you do - 4% + 40¢ per transaction.
+            We only earn once you do - 4% + 40¢ per transaction.
           </p>
         </div>
       </div>

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -70,7 +70,7 @@ const LandingPageTopbar = () => {
         size={100}
       />
       <div className="flex flex-row items-center gap-x-4">
-        <Button onClick={onLoginClick}>Login</Button>
+        <Button onClick={onLoginClick} variant="secondary">Open Dashboard</Button>
       </div>
       <Modal
         isShown={isModalShown}


### PR DESCRIPTION
- **clients: Shorten pricing copy next to signup nudge**
- **clients: Rename `Login` to `Open Dashboard` on website + different variant**
