### PR TITLE
website: Better Signup CTA

### DIFF
--- a/clients/apps/web/src/components/Auth/AuthModal.tsx
+++ b/clients/apps/web/src/components/Auth/AuthModal.tsx
@@ -20,7 +20,7 @@ export const AuthModal = ({
   const copy =
     isSignup ? (
       <p className="dark:text-polar-500 text-xl text-gray-500">
-        Join thousands of developers getting paid to code on their passions
+        Join thousands of developers &amp; startups monetizing their products with Polar.
       </p>
     ) : null
 

--- a/clients/apps/web/src/components/Auth/GithubLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/GithubLoginButton.tsx
@@ -48,7 +48,6 @@ const GithubLoginButton = (props: {
           props.size === 'large' ? largeStyle : smallStyle,
           props.className,
         )}
-        variant="secondary"
         className={twMerge(props.size == 'large' && 'text-md p-5')}
         fullWidth={props.fullWidth}
       >

--- a/clients/apps/web/src/components/Auth/Login.tsx
+++ b/clients/apps/web/src/components/Auth/Login.tsx
@@ -83,7 +83,7 @@ const Login = ({
         <LabeledSeparator label="Or" />
         <MagicLinkLoginForm {...loginProps} />
       </div>
-      <div className="dark:text-polar-500 text-sm text-gray-400">
+      <div className="dark:text-polar-500 mt-6 text-center text-xs text-gray-400">
         By using Polar you agree to our{' '}
         <a
           className="dark:text-polar-300 text-gray-600"
@@ -91,14 +91,13 @@ const Login = ({
         >
           Terms of Service
         </a>{' '}
-        and understand our{' '}
+        and {' '}
         <a
           className="dark:text-polar-300 text-gray-600"
           href="https://polar.sh/legal/privacy"
         >
           Privacy Policy
         </a>
-        .
       </div>
     </div>
   )

--- a/clients/apps/web/src/components/Auth/MagicLinkLoginForm.tsx
+++ b/clients/apps/web/src/components/Auth/MagicLinkLoginForm.tsx
@@ -69,7 +69,7 @@ const MagicLinkLoginForm: React.FC<MagicLinkLoginFormProps> = ({
             return (
               <FormItem>
                 <FormControl className="w-full">
-                  <div className="flex w-full flex-row items-center gap-2">
+                  <div className="flex w-full flex-col gap-2">
                     <Input
                       type="email"
                       required
@@ -78,8 +78,8 @@ const MagicLinkLoginForm: React.FC<MagicLinkLoginFormProps> = ({
                       data-1p-ignore
                       {...field}
                     />
-                    <Button type="submit" loading={loading} disabled={loading}>
-                      Sign in
+                    <Button type="submit" variant="secondary" loading={loading} disabled={loading}>
+                      Continue with email
                     </Button>
                   </div>
                 </FormControl>

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -51,7 +51,7 @@ export const Hero = () => {
                 <input
                   autoFocus={!isPhone}
                   className="w-44 border-none border-transparent bg-transparent p-0 focus:border-transparent focus:ring-0"
-                  placeholder="product-name"
+                  placeholder="storename"
                   value={slug}
                   onChange={(e) => setSlug(slugify(e.target.value))}
                 />

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -60,7 +60,7 @@ export const Hero = () => {
             </div>
           </div>
           <p className="hidden dark:text-polar-500 text-balance text-xs text-gray-500 md:block">
-            We only earn once you do - 4% + 40¢ per transaction.
+            We only earn when you do - 4% + 40¢ per transaction.
           </p>
         </div>
       </div>

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -56,7 +56,7 @@ export const Hero = () => {
                   onChange={(e) => setSlug(slugify(e.target.value))}
                 />
               </div>
-              <GetStartedButton className="px-3" orgSlug={slug} size="default" text="Start for free" />
+              <GetStartedButton className="px-3" orgSlug={slug} size="lg" text="Start for free" />
             </div>
           </div>
           <p className="hidden dark:text-polar-500 text-balance text-xs text-gray-500 md:block">

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -4,6 +4,7 @@ import { Section } from '@/components/Landing/Section'
 import { TopbarNavigation } from '@/components/Landing/TopbarNavigation'
 import { BrandingMenu } from '@/components/Layout/Public/BrandingMenu'
 import Footer from '@/components/Organization/Footer'
+import GetStartedButton from '@/components/Auth/GetStartedButton'
 import { motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import Button from 'polarkit/components/ui/atoms/button'
@@ -71,6 +72,7 @@ const LandingPageTopbar = () => {
       />
       <div className="flex flex-row items-center gap-x-4">
         <Button onClick={onLoginClick} variant="secondary">Open Dashboard</Button>
+        <GetStartedButton className="px-3" size="default" />
       </div>
       <Modal
         isShown={isModalShown}


### PR DESCRIPTION
- **clients: Add GetStartedButton in topbar on landing pages**
- **clients: Call organization name storename in Hero**
- **clients: Make GitHub login/signup primary**
- **clients: Copy to reflect vs. hope for sales**
- **clients: Signup modal copy change**
- **clients: Bigger main signup CTA**
