### PR TITLE
server/benefit: add a flag on benefit service to check if we should revoke benefit individually or not

### DIFF
--- a/server/polar/benefit/benefits/base.py
+++ b/server/polar/benefit/benefits/base.py
@@ -84,6 +84,8 @@ class BenefitServiceProtocol(Protocol[B, BP, BGP]):
     session: AsyncSession
     redis: Redis
 
+    should_revoke_individually: bool = False
+
     def __init__(self, session: AsyncSession, redis: Redis) -> None:
         self.session = session
         self.redis = redis

--- a/server/polar/benefit/benefits/license_keys.py
+++ b/server/polar/benefit/benefits/license_keys.py
@@ -26,6 +26,8 @@ class BenefitLicenseKeysService(
         BenefitGrantLicenseKeysProperties,
     ]
 ):
+    should_revoke_individually = True
+
     async def grant(
         self,
         benefit: BenefitLicenseKeys,


### PR DESCRIPTION
Useful for license keys where we generate a single key for each grant, contrary to other benefits where the side effect is global and should only revoked for the last remaining grant (like GitHub Repository invitation)