### PR TITLE
server/transaction: trigger only once payout per account per run

### DIFF
--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -534,6 +534,7 @@ class PayoutTransactionService(BaseTransactionService):
     ) -> Sequence[Transaction]:
         statement = (
             select(Transaction)
+            .distinct(Transaction.account_id)
             .where(
                 Transaction.type == TransactionType.payout,
                 Transaction.processor == PaymentProcessor.stripe,
@@ -541,6 +542,7 @@ class PayoutTransactionService(BaseTransactionService):
                 Transaction.created_at < utc_now() - delay,
             )
             .options(joinedload(Transaction.account))
+            .order_by(Transaction.account_id, Transaction.created_at)
         )
         result = await session.execute(statement)
         return result.scalars().all()

--- a/server/tests/transaction/conftest.py
+++ b/server/tests/transaction/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator, Sequence
+from datetime import datetime
 from typing import TypeVar
 
 import pytest_asyncio
@@ -46,8 +47,10 @@ async def create_transaction(
     donation: Donation | None = None,
     charge_id: str | None = None,
     dispute_id: str | None = None,
+    created_at: datetime | None = None,
 ) -> Transaction:
     transaction = Transaction(
+        created_at=created_at,
         type=type,
         processor=PaymentProcessor.stripe,
         currency="usd",


### PR DESCRIPTION
Fix #4196