### PR TITLE
clients/checkout: Fix checkout page background cut off

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutLayout.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutLayout.tsx
@@ -22,7 +22,7 @@ const CheckoutLayout: React.FC<
 
   return (
     <PolarThemeProvider>
-      <div className="dark:bg-polar-950 h-full bg-gray-100 md:h-screen dark:text-white">
+      <div className="dark:bg-polar-950 h-full bg-gray-100 dark:text-white">
         <PublicLayout className="gap-y-0 py-6 md:py-12" wide footer={false}>
           {children}
         </PublicLayout>


### PR DESCRIPTION
Fixes #4295 
Fix the checkout page background being cut off, by removing the `md:h-screen` class.

Before
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/507e9321-4ecc-4e09-b836-89b200cb339f">


After
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3d12011e-1eb3-4586-91b6-3c782f22f291">
