### PR TITLE
ops: disable Sentry tracing and replay

### DIFF
--- a/clients/apps/web/sentry.client.config.ts
+++ b/clients/apps/web/sentry.client.config.ts
@@ -10,7 +10,9 @@ Sentry.init({
   environment: CONFIG.ENVIRONMENT,
 
   // Add optional integrations for additional features
-  integrations: [Sentry.httpClientIntegration(), Sentry.replayIntegration()],
+  integrations: [Sentry.httpClientIntegration()],
+
+  enableTracing: false,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 0.1,
@@ -18,10 +20,10 @@ Sentry.init({
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: 0,
 
   // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/clients/apps/web/sentry.edge.config.ts
+++ b/clients/apps/web/sentry.edge.config.ts
@@ -11,6 +11,7 @@ Sentry.init({
   environment: CONFIG.ENVIRONMENT,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+  enableTracing: false,
   tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.

--- a/clients/apps/web/sentry.server.config.ts
+++ b/clients/apps/web/sentry.server.config.ts
@@ -10,6 +10,7 @@ Sentry.init({
   environment: CONFIG.ENVIRONMENT,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+  enableTracing: false,
   tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.

--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -112,6 +112,7 @@ class PostHogIntegration(Integration):
 def configure_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
+        enable_tracing=False,
         traces_sample_rate=0.1,
         profiles_sample_rate=0.1,
         release=os.environ.get("RELEASE_VERSION", "development"),


### PR DESCRIPTION
We don't really use them, so better to save a bit of money for the time being