### PR TITLE
fix: make product description optional on create product page

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductInfoSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductInfoSection.tsx
@@ -52,9 +52,6 @@ export const ProductInfoSection = ({ className }: ProductInfoSectionProps) => {
         <FormField
           control={control}
           name="description"
-          rules={{
-            required: 'This field is required',
-          }}
           render={({ field }) => (
             <FormItem className="flex flex-col gap-2">
               <div className="flex flex-row items-center justify-between">


### PR DESCRIPTION
fixes #4373 

This PR removes the `rules.required` from the description form field. 