### PR TITLE
sdk: add an overlay to remove readOnly flags

### DIFF
--- a/sdk/overlays/read_only.yml
+++ b/sdk/overlays/read_only.yml
@@ -1,0 +1,7 @@
+overlay: 1.0.0
+info:
+  title: Overlay to automatically remove "readOnly" from schemas properties
+  version: 0.0.1
+actions:
+  - target: "$.components.schemas.*.properties.*.readOnly"
+    remove: true


### PR DESCRIPTION
Prevents Speakeasy from generating "Input" models because of webhooks schemas which are wrongfully considered as payload schemas (due to how they're documented in FastAPI).

We've our own hygiene of separating input and output schemas, so this should not harm the validity of the output SDK.