### PR TITLE
clients/feedback: fix various low hanging feedback

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -223,7 +223,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     <DashboardBody>
       <div className="flex flex-col gap-8">
         <div className="flex items-center justify-between gap-2">
-          <div className="max-w-auto w-full">
+          <div className="w-auto">
             <ProductSelect
               productsByPriceType={productsByPriceType}
               value={productSelectValue}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -223,7 +223,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     <DashboardBody>
       <div className="flex flex-col gap-8">
         <div className="flex items-center justify-between gap-2">
-          <div className="w-full max-w-[180px]">
+          <div className="max-w-auto w-full">
             <ProductSelect
               productsByPriceType={productsByPriceType}
               value={productSelectValue}

--- a/clients/apps/web/src/components/Layout/Section.tsx
+++ b/clients/apps/web/src/components/Layout/Section.tsx
@@ -17,7 +17,7 @@ export const Section = ({
   return (
     <div
       className={twMerge(
-        'relative flex flex-col gap-12 py-12 md:flex-row md:gap-32 md:py-16',
+        'relative flex flex-col gap-12 py-12 2xl:flex-row 2xl:gap-32 2xl:py-16',
         className,
       )}
     >
@@ -37,7 +37,7 @@ const SectionDescription = ({
   description?: string
 }) => {
   return (
-    <div className="flex w-full flex-shrink-0 flex-col gap-y-6 md:w-2/5">
+    <div className="flex w-full max-w-96 flex-col gap-y-6">
       {icon}
       <div className="flex flex-col gap-y-2">
         <h2 className="text-lg font-medium">{title}</h2>

--- a/clients/apps/web/src/components/Products/ProductBenefitsForm.tsx
+++ b/clients/apps/web/src/components/Products/ProductBenefitsForm.tsx
@@ -241,13 +241,12 @@ const BenefitsContainer = ({
   onCreateNewBenefit,
   type,
 }: BenefitsContainerProps) => {
-  const [open, setOpen] = useState(false)
-
-  const { organization } = useContext(MaintainerOrganizationContext)
-
   const hasEnabledBenefits = benefits.some((benefit) => {
     return enabledBenefits.some((b) => b.id === benefit.id)
   })
+  const [open, setOpen] = useState(hasEnabledBenefits)
+
+  const { organization } = useContext(MaintainerOrganizationContext)
 
   if (benefits.length === 0 && !onCreateNewBenefit) {
     return null
@@ -257,30 +256,30 @@ const BenefitsContainer = ({
     <div className="flex flex-col gap-2">
       <div
         className={twMerge(
-          'dark:bg-polar-800 dark:hover:border-polar-700 group flex flex-row items-center justify-between gap-2 rounded-xl border border-transparent bg-gray-100 px-4 py-3 text-sm transition-colors dark:border-transparent',
-          hasEnabledBenefits ? '' : 'cursor-pointer hover:border-gray-200',
+          'dark:bg-polar-800 dark:hover:border-polar-700 group flex cursor-pointer flex-row items-center justify-between gap-2 rounded-xl border border-transparent bg-gray-100 px-4 py-3 text-sm transition-colors hover:border-gray-200 dark:border-transparent',
         )}
-        onClick={() => !hasEnabledBenefits && setOpen((v) => !v)}
+        onClick={() => setOpen((v) => !v)}
         role="button"
       >
         <div className="flex flex-row items-center gap-x-3">
           {resolveBenefitCategoryIcon(type, 'small', 'h-4 w-4')}
           <span>{title}</span>
         </div>
-        <span className="flex flex-row gap-x-4">
+        <span className="flex flex-row items-center gap-x-4">
+          {hasEnabledBenefits ? (
+            <div className="h-2 w-2 rounded-full bg-blue-500" />
+          ) : null}
           <span className="dark:text-polar-500 font-mono text-xs text-gray-500">
             {benefits.length}
           </span>
-          {!hasEnabledBenefits ? (
-            open ? (
-              <ChevronUpIcon className="h-4 w-4 opacity-30 group-hover:opacity-100" />
-            ) : (
-              <ChevronDownIcon className="h-4 w-4 opacity-30 group-hover:opacity-100" />
-            )
-          ) : null}
+          {open ? (
+            <ChevronUpIcon className="h-4 w-4 opacity-30 group-hover:opacity-100" />
+          ) : (
+            <ChevronDownIcon className="h-4 w-4 opacity-30 group-hover:opacity-100" />
+          )}
         </span>
       </div>
-      {open || hasEnabledBenefits ? (
+      {open ? (
         <div className="dark:border-polar-700 mb-2 flex flex-col gap-y-4 rounded-2xl border border-gray-200 p-4">
           {benefits.length > 0 ? (
             <div className="flex flex-col">

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -317,6 +317,10 @@ export const ProductPricingSection = ({
     }
   }, [update, pricingType, replace, amountType])
 
+  if (update && amountType === 'free') {
+    return null
+  }
+
   return (
     <Section
       icon={<AttachMoneyOutlined fontSize="medium" />}

--- a/clients/apps/web/src/hooks/products.ts
+++ b/clients/apps/web/src/hooks/products.ts
@@ -77,7 +77,7 @@ export const useRecurringBillingLabel = (
 export const useProductsByPriceType = (
   organizationId: string,
 ): Record<ProductPriceType, Product[]> => {
-  const { data: products } = useProducts(organizationId)
+  const { data: products } = useProducts(organizationId, { limit: 100 })
   return useMemo(
     () => ({
       [ProductPriceType.ONE_TIME]:


### PR DESCRIPTION
Fixes a few issues mentioned by @michael-andreuzza.

- Better layout on Product Create/Edit Page
- Benefit groups with enabled benefits are now collapsable
- Sales Dropdown are automatically adjusting its size
- Bump query limit on products when retrieving them in price type groupings (which previously made sales dropdown not show all products) 
- Skip rendering price section in edit-mode, if price is free