### PR TITLE
fix(server/api): add worker health status to `/healthz` endpoint

### DIFF
--- a/server/polar/health/endpoints.py
+++ b/server/polar/health/endpoints.py
@@ -31,7 +31,7 @@ async def healthz(
 
         if data is None:
             raise Exception("Worker health check failed")
-    except RedisError as e:
+    except Exception as e:
         raise HTTPException(status_code=503, detail="Worker is not available") from e
 
     return {"api_status": "ok", "worker_status": "ok"}

--- a/server/polar/worker.py
+++ b/server/polar/worker.py
@@ -76,6 +76,11 @@ class QueueName(Enum):
     github_crawl = "arq:queue:github_crawl"
 
 
+class ArqHealthCheckKey(Enum):
+    default = QueueName.default.value + ":health-check"
+    github_crawl = QueueName.github_crawl.value + ":health-check"
+
+
 def get_redis_settings() -> RedisSettings:
     redis_settings = RedisSettings.from_dsn(settings.redis_url)
     redis_settings.retry_on_error = REDIS_RETRY_ON_ERRROR  # type: ignore  # https://github.com/python-arq/arq/pull/446


### PR DESCRIPTION
## Description

fixes #4464

This PR adds `worker_status` key to the `/healthz` endpoint by querying the health check key used by `arq` as mentioned in the discussions. 