### PR TITLE
ops: don't link new workers to env groups yet...

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -168,11 +168,11 @@ services:
           property: port
       - key: POLAR_REDIS_DB
         value: 0
-      - fromGroup: google-production
-      - fromGroup: github-production
-      - fromGroup: backend-production
-      - fromGroup: stripe-production
-      - fromGroup: logfire-worker
+      # - fromGroup: google-production
+      # - fromGroup: github-production
+      # - fromGroup: backend-production
+      # - fromGroup: stripe-production
+      # - fromGroup: logfire-worker
 
   - type: redis
     name: redis
@@ -348,10 +348,10 @@ services:
           property: port
       - key: POLAR_REDIS_DB
         value: 1
-      - fromGroup: google-sandbox
-      - fromGroup: github-sandbox
-      - fromGroup: backend-sandbox
-      - fromGroup: stripe-sandbox
+      # - fromGroup: google-sandbox
+      # - fromGroup: github-sandbox
+      # - fromGroup: backend-sandbox
+      # - fromGroup: stripe-sandbox
 
 databases:
   - name: db


### PR DESCRIPTION
We need to manually move them to their corresponding environment before in Render; because it's not supported in the Blueprint syntax.