### PR TITLE
clients/web: fix liking to Ads benefits documentation

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/benefits/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/benefits/ClientPage.tsx
@@ -307,7 +307,7 @@ ${formattedDisplays}
         <p className="dark:text-polar-400 text-sm text-gray-600">
           Use this ID when{' '}
           <Link
-            href="/docs/ads"
+            href="/docs/benefits/ads"
             target="_blank"
             rel="noopener"
             className="text-blue-500 hover:text-blue-400 dark:text-blue-400 dark:hover:text-blue-300"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/ClientPage.tsx
@@ -283,7 +283,7 @@ ${formattedDisplays}
         <p className="dark:text-polar-400 text-sm text-gray-600">
           Use this ID when{' '}
           <Link
-            href="/docs/ads"
+            href="/docs/benefits/ads"
             target="_blank"
             rel="noopener"
             className="text-blue-500 hover:text-blue-400 dark:text-blue-400 dark:hover:text-blue-300"


### PR DESCRIPTION
The existing link from Benefits - Ads (`integrating` link) its broken.

<img width="460" alt="image" src="https://github.com/user-attachments/assets/dafc500d-c2a6-4162-bb2b-62b835113b02">
