### PR TITLE
Ops/separate-workers

### DIFF
--- a/.github/workflows/deploy_server.sh
+++ b/.github/workflows/deploy_server.sh
@@ -3,23 +3,16 @@
 set -euo pipefail
 
 IMG="ghcr.io/polarsource/polar@${1}"
+declare -A servers=(
+  ["srv-ci4r87h8g3ne0dmvvl60"]="${RENDER_DEPLOY_KEY_API}"
+  ["srv-csth45d6l47c73ekphf0"]="${RENDER_DEPLOY_KEY_WORKER}"
+  ["srv-crkocgbtq21c73ddsdbg"]="${RENDER_DEPLOY_KEY_API_SANDBOX}"
+  ["srv-csth45d6l47c73ekphdg"]="${RENDER_DEPLOY_KEY_WORKER_SANDBOX}"
+)
 
-# Deploy api
-curl -X POST \
+for server_id in "${!servers[@]}"; do
+  deploy_key=${servers[$server_id]}
+  curl -X POST \
     --silent --show-error --fail-with-body \
-    "https://api.render.com/deploy/srv-ci4r87h8g3ne0dmvvl60?key=${RENDER_DEPLOY_KEY_API}&imgURL=${IMG}"
-
-# Deploy worker
-curl -X POST \
-    --silent --show-error --fail-with-body \
-    "https://api.render.com/deploy/srv-csth45d6l47c73ekphf0?key=${RENDER_DEPLOY_KEY_WORKER}&imgURL=${IMG}"
-
-# Deploy api-sandbox
-curl -X POST \
-    --silent --show-error --fail-with-body \
-    "https://api.render.com/deploy/srv-crkocgbtq21c73ddsdbg?key=${RENDER_DEPLOY_KEY_API_SANDBOX}&imgURL=${IMG}"
-
-# Deploy worker-sandbox
-curl -X POST \
-    --silent --show-error --fail-with-body \
-    "https://api.render.com/deploy/srv-csth45d6l47c73ekphdg?key=${RENDER_DEPLOY_KEY_WORKER_SANDBOX}&imgURL=${IMG}"
+    "https://api.render.com/deploy/${server_id}?key=${deploy_key}&imgURL=${IMG}"
+done

--- a/render.yaml
+++ b/render.yaml
@@ -69,7 +69,7 @@ services:
       - fromGroup: stripe-production
       - fromGroup: logfire-server
 
-  # Worker
+  # Workers
   - type: worker
     name: worker
     runtime: image
@@ -79,7 +79,7 @@ services:
         fromRegistryCreds:
           name: Registry Credentials (by fvoron)
     plan: standard
-    dockerCommand: uv run python -m run_worker --default-worker-num 2
+    dockerCommand: uv run python -m run_worker --worker-num 2 --scheduler default
     region: ohio
     numInstances: 1
     autoDeploy: false # deploys are triggered by github actions
@@ -121,6 +121,57 @@ services:
       - fromGroup: backend-production
       - fromGroup: stripe-production
       - fromGroup: logfire-worker
+
+  - type: worker
+    name: worker-github
+    runtime: image
+    image:
+      url: ghcr.io/polarsource/polar:latest
+      creds:
+        fromRegistryCreds:
+          name: Registry Credentials (by fvoron)
+    plan: starter
+    dockerCommand: uv run python -m run_worker github
+    region: ohio
+    numInstances: 1
+    autoDeploy: false # deploys are triggered by github actions
+    envVars:
+      - key: POLAR_POSTGRES_DATABASE
+        fromDatabase:
+          name: db
+          property: database
+      - key: POLAR_POSTGRES_HOST
+        fromDatabase:
+          name: db
+          property: host
+      - key: POLAR_POSTGRES_PORT
+        fromDatabase:
+          name: db
+          property: port
+      - key: POLAR_POSTGRES_PWD
+        fromDatabase:
+          name: db
+          property: password
+      - key: POLAR_POSTGRES_USER
+        fromDatabase:
+          name: db
+          property: user
+      - key: POLAR_REDIS_HOST
+        fromService:
+          type: redis
+          name: redis
+          property: host
+      - key: POLAR_REDIS_PORT
+        fromService:
+          type: redis
+          name: redis
+          property: port
+      - key: POLAR_REDIS_DB
+        value: 0
+      # - fromGroup: google-production
+      # - fromGroup: github-production
+      # - fromGroup: backend-production
+      # - fromGroup: stripe-production
 
   - type: redis
     name: redis
@@ -195,7 +246,7 @@ services:
       - fromGroup: backend-sandbox
       - fromGroup: stripe-sandbox
 
-  # Worker
+  # Workers
   - type: worker
     name: worker-sandbox
     runtime: image
@@ -205,7 +256,7 @@ services:
         fromRegistryCreds:
           name: Registry Credentials (by fvoron)
     plan: standard
-    dockerCommand: uv run python -m run_worker --default-worker-num 2
+    dockerCommand: uv run python -m run_worker --worker-num 2 --scheduler default
     region: ohio
     numInstances: 1
     autoDeploy: false # deploys are triggered by github actions
@@ -244,6 +295,55 @@ services:
       - fromGroup: github-sandbox
       - fromGroup: backend-sandbox
       - fromGroup: stripe-sandbox
+
+  - type: worker
+    name: worker-github-sandbox
+    runtime: image
+    image:
+      url: ghcr.io/polarsource/polar:latest
+      creds:
+        fromRegistryCreds:
+          name: Registry Credentials (by fvoron)
+    plan: standard
+    dockerCommand: uv run python -m run_worker github
+    region: ohio
+    numInstances: 1
+    autoDeploy: false # deploys are triggered by github actions
+    envVars:
+      - key: POLAR_POSTGRES_DATABASE
+        value: polar_sandbox
+      - key: POLAR_POSTGRES_HOST
+        fromDatabase:
+          name: db
+          property: host
+      - key: POLAR_POSTGRES_PORT
+        fromDatabase:
+          name: db
+          property: port
+      - key: POLAR_POSTGRES_PWD
+        fromDatabase:
+          name: db
+          property: password
+      - key: POLAR_POSTGRES_USER
+        fromDatabase:
+          name: db
+          property: user
+      - key: POLAR_REDIS_HOST
+        fromService:
+          type: redis
+          name: redis
+          property: host
+      - key: POLAR_REDIS_PORT
+        fromService:
+          type: redis
+          name: redis
+          property: port
+      - key: POLAR_REDIS_DB
+        value: 1
+      # - fromGroup: google-sandbox
+      # - fromGroup: github-sandbox
+      # - fromGroup: backend-sandbox
+      # - fromGroup: stripe-sandbox
 
 databases:
   - name: db

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -86,7 +86,7 @@ backoffice = [
 
 [tool.taskipy.tasks]
 api = { cmd = "task verify_github_app && env AUTHLIB_INSECURE_TRANSPORT=true uvicorn polar.app:app --reload --workers 1 --host 127.0.0.1 --port 8000", help = "run api service" }
-worker = { cmd = "watchfiles 'python -m run_worker' polar", help = "run worker" }
+worker = { cmd = "watchfiles 'python -m run_worker --scheduler default' polar", help = "run worker" }
 test = { cmd = "POLAR_ENV=testing python -m pytest --cov polar/ --cov-report=term-missing", help = "run all tests" }
 test_fast = { cmd = "POLAR_ENV=testing python -m pytest -n auto -p no:sugar --no-cov", help = "run all tests, but fast" }
 lint = { cmd = "ruff format . && ruff check --fix .", help = "run linters with autofix" }


### PR DESCRIPTION
Environment groups are commented in a first step, because Render doesn't support environments in blueprints.

So we need to create the services first, move them manually from the UI to the right environement and *then* attach their environment groups.