### PR TITLE
feat: enhance `API Reference` documentation and create `/` root endpoint

### DIFF
--- a/clients/apps/web/src/app/(main)/docs/api/(mdx)/page.mdx
+++ b/clients/apps/web/src/app/(main)/docs/api/(mdx)/page.mdx
@@ -3,19 +3,69 @@ title: API Reference
 description: The Polar API for polar.sh
 keywords: api, reference, polar, polar.sh
 ---
+import { CubeTransparentIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { ApiOutlined } from '@mui/icons-material'
+import Link from 'next/link'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'polarkit/components/ui/tooltip'
 
 # API Reference
 
 Welcome to the Polar API for polar.sh. This specification contains both the definitions of the Polar HTTP API and the Webhook API.
 
-### Feedback
+## Connecting
 
-If you have any feedback or comments, reach out in the Polar API-issue, or reach out on the Polar Discord server.
+<div className="flex items-center gap-2">
+  <ApiOutlined className="h-6 w-6" />
+  <h3 className="my-0">Polar API</h3>
+</div>
+
+The production API is the primary endpoint for live operations. It provides full access to all features. Follow more examples here: [https://docs.polar.sh/developers](https://docs.polar.sh/developers)
+
+<div className="flex items-center gap-2 rounded-lg border bg-card p-4 my-4">
+  <a className="no-underline cursor-default pointer-events-none">https://api.polar.sh</a>
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger>
+        <a href="https://api.polar.sh/">
+          <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+        </a>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Open Polar API endpoint</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+</div>
+
+<br />
+
+<div className="flex items-center gap-2">
+  <CubeTransparentIcon className="h-6 w-6" />
+  <h3 className="my-0">Sandbox API</h3>
+</div>
+
+To test Polar or work on your integration without worrying about actual money processing or breaking your live organization, you can use our sandbox environment. It's a dedicated server, completely isolated from the production instance where you can do all the experiments you want!
+
+Explore more about Sandbox API here: [https://docs.polar.sh/developers/sandbox](https://docs.polar.sh/developers/sandbox)
+
+<div className="flex items-center gap-2 rounded-lg border bg-card p-4 my-4">
+  <a className="no-underline cursor-default pointer-events-none">https://sandbox-api.polar.sh</a>
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger>
+        <a href="https://sandbox-api.polar.sh/">
+          <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+        </a>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Open Sandbox API endpoint</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+</div>
+
+## Feedback
+
+If you have any feedback or comments, reach out in the [Polar API-issue](https://github.com/polarsource/polar/issues/), or reach out on the [Polar Discord server](https://discord.gg/Pnhfz3UThd).
 
 We'd love to see what you've built with the API and to get your thoughts on how we can make the API better!
-
-### Connecting
-
-The Polar API is online at https://api.polar.sh.
-
-The [sandbox API](/docs/developers/sandbox) is at https://sandbox-api.polar.sh.

--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -41,7 +41,7 @@ from polar.openapi import OPENAPI_PARAMETERS, APITag, set_openapi_generator
 from polar.postgres import create_async_engine, create_sync_engine
 from polar.posthog import configure_posthog
 from polar.redis import Redis, create_redis
-from polar.root import router as root_router
+from polar.root.endpoints import router as root_router
 from polar.sentry import configure_sentry
 from polar.webhook.webhooks import document_webhooks
 from polar.worker import ArqRedis

--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -41,6 +41,7 @@ from polar.openapi import OPENAPI_PARAMETERS, APITag, set_openapi_generator
 from polar.postgres import create_async_engine, create_sync_engine
 from polar.posthog import configure_posthog
 from polar.redis import Redis, create_redis
+from polar.root import router as root_router
 from polar.sentry import configure_sentry
 from polar.webhook.webhooks import document_webhooks
 from polar.worker import ArqRedis
@@ -160,6 +161,9 @@ def create_app() -> FastAPI:
 
     # /healthz
     app.include_router(health_router)
+
+    # root endpoint
+    app.include_router(root_router)
 
     app.include_router(router)
     document_webhooks(app)

--- a/server/polar/root/endpoints.py
+++ b/server/polar/root/endpoints.py
@@ -4,11 +4,7 @@ router = APIRouter()
 
 
 @router.get("/")
-def get() -> dict[str, str]:
+async def get() -> dict[str, str]:
     return {
-        "message": """
-            Hello, World! This is the Polar API.
-
-            For more information, please visit the documentation at: https://docs.polar.sh/
-        """
+        "message": """Hello, World! Welcome to the Polar API for polar.sh. For more information on endpoints, please visit the documentation at: `https://docs.polar.sh/developers`"""
     }

--- a/server/polar/root/endpoints.py
+++ b/server/polar/root/endpoints.py
@@ -1,0 +1,14 @@
+from polar.routing import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/")
+def get() -> dict[str, str]:
+    return {
+        "message": """
+            Hello, World! This is the Polar API.
+
+            For more information, please visit the documentation at: https://docs.polar.sh/
+        """
+    }


### PR DESCRIPTION
closes #4497

[server]
- created root endpoint `/` with a helpful response and a direct link to the documentation for the user

[clients]
- enhanced the documentation at the endpoint `https://docs.polar.sh/api` to improve clarity and provide the user with next steps
- enhanced the feedback section to include links for GitHub issues and the discord server for easy success