### PR TITLE
server/product: allow to list without organization_id parameter with user access token

### DIFF
--- a/server/polar/product/service/product.py
+++ b/server/polar/product/service/product.py
@@ -93,17 +93,6 @@ class ProductService(ResourceServiceReader[Product]):
 
         if organization_id is not None:
             statement = statement.where(Product.organization_id.in_(organization_id))
-        elif not is_organization(auth_subject):
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "missing",
-                        "loc": ("query", "organization_id"),
-                        "msg": "Field is required.",
-                        "input": None,
-                    }
-                ]
-            )
 
         if query is not None:
             statement = statement.where(Product.name.ilike(f"%{query}%"))

--- a/server/tests/product/service/test_product.py
+++ b/server/tests/product/service/test_product.py
@@ -70,7 +70,6 @@ class TestList:
             session,
             auth_subject,
             pagination=PaginationParams(1, 10),
-            organization_id=[products[0].organization_id],
         )
 
         assert count == 0
@@ -91,7 +90,6 @@ class TestList:
             session,
             auth_subject,
             pagination=PaginationParams(1, 10),
-            organization_id=[products[0].organization_id],
         )
 
         assert count == 2


### PR DESCRIPTION
This was a relicate from the time when Products API was "public". Now that it can only be queried by creators to get their own products, this limitation doesn't make any more sense.