### PR TITLE
clients/web: derive teams instead of effect + state in useListTeams hook

### DIFF
--- a/clients/apps/web/src/hooks/team.ts
+++ b/clients/apps/web/src/hooks/team.ts
@@ -1,21 +1,17 @@
-import { Organization } from '@polar-sh/sdk'
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { useAuth } from './auth'
 
 export const useListTeams = () => {
   const { currentUser, userOrganizations: allOrganizations } = useAuth()
 
-  const [teams, setTeams] = useState<Organization[]>([])
-
-  useEffect(() => {
-    // Kind of a hack.
-    // Filter out the users own organization if it exists.
-    // This organiztaion can not have extra members, and can not be a "Team".
+  // Kind of a hack.
+  // Filter out the users own organization if it exists.
+  // This organiztaion can not have extra members, and can not be a "Team".
+  const teams = useMemo(() => {
     const allTeams = allOrganizations.filter(
       (o) => o.slug !== currentUser?.email,
     )
-
-    setTeams(allTeams)
+    return allTeams
   }, [allOrganizations, currentUser])
 
   return teams


### PR DESCRIPTION
Instead of using an effect + state we can derive the teams directly from the data. This simplifies the code a bit, but also makes the UX a bit better since on the first render the list won't be empty until the effect has run