### PR TITLE
Development Environment Setup Fixes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,11 +2,11 @@
 
 Polar's stack consist of the following elements:
 
-* A backend written in Python, exposing a REST API and workers;
-* A frontend written in JavaScript;
-* A PostgreSQL database;
-* A Redis database;
-* A S3-compatible storage.
+-   A backend written in Python, exposing a REST API and workers;
+-   A frontend written in JavaScript;
+-   A PostgreSQL database;
+-   A Redis database;
+-   A S3-compatible storage.
 
 ```mermaid
 flowchart TD
@@ -59,6 +59,7 @@ For the Polar stack to run properly, it needs quite a bunch of settings defined 
 ```sh
 ./dev/setup-environment
 ```
+
 Once done, the script will automatically create `server/.env` and `clients/apps/web/.env.local` files with the necessary environment variables.
 
 **Optional: setup GitHub App**
@@ -75,9 +76,11 @@ Your browser will open a new page and you'll be prompted to **create a GitHub Ap
 
 > [!TIP]
 > If you run on **GitHub Codespaces**, you can just run it like this:
+>
 > ```sh
 > ./dev/setup-environment --setup-github-app
 > ```
+>
 > The script will automatically use your external GitHub Codespace URL.
 
 **Optional: setup Stripe**
@@ -137,11 +140,17 @@ pnpm install
 
 The backend consists of an API server, a general-purpose worker and a worker dedicated to GitHub synchronization. You can run them like this:
 
+**1. Create a test database**
+
+```sh
+./dev/create-test-db
+```
+
+**2. Apply the database migrations**
+
 ```sh
 cd server
 ```
-
-**1. Apply the database migrations**
 
 ```sh
 uv run task db_migrate
@@ -150,7 +159,7 @@ uv run task db_migrate
 > [!NOTE]
 > You don't necessarily need to run it each time you start the server, but it's a good idea to regularly do it nonetheless.
 
-**2. Start server and workers**
+**3. Start server and workers**
 
 ```sh
 uv run task api

--- a/dev/create-test-db
+++ b/dev/create-test-db
@@ -5,8 +5,19 @@ set -e
 host="localhost"
 user="polar"
 password="polar"
-test_database="polar_test"
+test_database="polar"
 
+# Create role if it doesn't exist
+if ! PGPASSWORD=$password psql -h "$host" -U "postgres" -tAc "SELECT 1 FROM pg_roles WHERE rolname='$user'" | grep -q 1; then
+  PGPASSWORD=$password psql -h "$host" -U "postgres" -c "CREATE ROLE $user WITH LOGIN PASSWORD '$password';"
+else
+  echo "Role $user already exists."
+fi
+
+# Grant CREATEDB privilege to the role
+PGPASSWORD=$password psql -h "$host" -U "postgres" -c "ALTER ROLE $user CREATEDB;"
+
+# Create database if it doesn't exist
 if ! PGPASSWORD=$password psql -h "$host" -U "$user" -d "postgres" -tAc "SELECT 1 FROM pg_database WHERE datname='$test_database'" | grep -q 1; then
   PGPASSWORD=$password psql -h "$host" -U "$user" -d "postgres" -c "CREATE DATABASE $test_database;"
 else

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   redis:
     image: redis
@@ -61,12 +59,12 @@ services:
       - POLICY_FILE=/tmp/config/policy.json
       - ACCESS_KEY=${POLAR_AWS_ACCESS_KEY_ID}
       - SECRET_ACCESS_KEY=${POLAR_AWS_SECRET_ACCESS_KEY}
-    entrypoint: [
-      "bash",
-      "-c",
-      "chmod +x /tmp/config/local.sh && chmod +x /tmp/config/configure.sh && /tmp/config/local.sh /tmp/config/configure.sh"
-    ]
-
+    entrypoint:
+      [
+        "bash",
+        "-c",
+        "chmod +x /tmp/config/local.sh && chmod +x /tmp/config/configure.sh && /tmp/config/local.sh /tmp/config/configure.sh",
+      ]
 
 volumes:
   postgres_data:


### PR DESCRIPTION
While setting up the development environment for polar I've noticed some small things that didn't fully work for me which I fixed in this PR;

- The DEVELOPMENT.md Guide is currently not mentioning that the create-test-db script needs to be run to create a Postgres Database.
- The create-test-db script creates a database called polar-test but the env setup script uses the database "polar"
- The migrations also fail initially because there is no user "polar", so I added the creation of it to the create-test-db script and added the required CREATEDB permission
- Just a very minor thing but it seems that the "version" specified in docker-compose has no impact so it throws a Warning when running "docker compose up -d"