### PR TITLE
clients/dashboard: Show total revenue amount

### DIFF
--- a/clients/apps/web/src/components/Widgets/RevenueWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/RevenueWidget.tsx
@@ -48,9 +48,10 @@ export const RevenueWidget = ({ className }: RevenueWidgetProps) => {
         <h2 className="text-xl">
           $
           {getCentsInDollarString(
-            revenueMetrics.data?.periods[
-              revenueMetrics.data?.periods.length - 1
-            ].revenue ?? 0,
+            revenueMetrics.data?.periods.reduce(
+              (acc, curr) => acc + curr.revenue,
+              0,
+            ) ?? 0,
             false,
           )}
         </h2>


### PR DESCRIPTION
Closes #4591 

This PR updates the `Revenue` card in the dashboard home page to show total revenue.

<img width="1045" alt="Screenshot 2024-12-07 at 20 57 01" src="https://github.com/user-attachments/assets/e35a5e98-70c8-4634-b8c2-a6ecf4219f49">
