### PR TITLE
Cancel & Modify Subscriptions

### DIFF
--- a/clients/apps/web/src/app/(main)/(topbar)/(backer)/purchases/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/(topbar)/(backer)/purchases/subscriptions/ClientPage.tsx
@@ -132,6 +132,18 @@ const SubscriptionItem = ({
     return null
   }
 
+  let nextEventTitle = null
+  let nextEventDate = null
+  if (!subscription.ended_at) {
+    if (subscription.ends_at) {
+      nextEventTitle = 'Expiry Date'
+      nextEventDate = new Date(subscription.ends_at)
+    } else if (subscription.current_period_end) {
+      nextEventTitle = 'Renewal Date'
+      nextEventDate = new Date(subscription.current_period_end)
+    }
+  }
+
   return (
     <ShadowBox className="flex w-full flex-col gap-y-6">
       <div className="flex flex-row items-start justify-between">
@@ -183,15 +195,13 @@ const SubscriptionItem = ({
             </span>
           </div>
         )}
-        {!subscription.ended_at && subscription.current_period_end && (
+        {nextEventTitle && nextEventDate && (
           <div className="flex flex-row items-center justify-between">
             <span className="dark:text-polar-500 text-gray-500">
-              {subscription.cancel_at_period_end
-                ? 'Expiry Date'
-                : 'Renewal Date'}
+              {nextEventTitle}
             </span>
             <span>
-              {new Date(subscription.current_period_end).toLocaleDateString(
+              {nextEventDate.toLocaleDateString(
                 'en-US',
                 {
                   year: 'numeric',

--- a/clients/apps/web/src/app/(main)/(topbar)/(backer)/purchases/subscriptions/[id]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/(topbar)/(backer)/purchases/subscriptions/[id]/ClientPage.tsx
@@ -25,4 +25,5 @@ const ClientPage = ({
   )
 }
 
+
 export default ClientPage

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
@@ -9,28 +9,37 @@ import SubscriptionStatusSelect from '@/components/Subscriptions/SubscriptionSta
 import SubscriptionTiersSelect from '@/components/Subscriptions/SubscriptionTiersSelect'
 import { subscriptionStatusDisplayNames } from '@/components/Subscriptions/utils'
 import {
+  useCancelSubscription,
   useCustomFields,
   useListSubscriptions,
   useProducts,
 } from '@/hooks/queries'
-import { MaintainerOrganizationContext } from '@/providers/maintainerOrganization'
 import { getServerURL } from '@/utils/api'
+import { setValidationErrors } from '@/utils/api/errors'
 import {
   DataTablePaginationState,
   DataTableSortingState,
   getAPIParams,
   serializeSearchParams,
 } from '@/utils/datatable'
-import { FileDownloadOutlined } from '@mui/icons-material'
+import {
+  AccessTimeOutlined,
+  ArrowBackOutlined,
+  CancelOutlined,
+  FileDownloadOutlined,
+} from '@mui/icons-material'
 import {
   Organization,
   Product,
+  ResponseError,
   Subscription,
+  SubscriptionCancel,
   SubscriptionStatus,
+  ValidationError,
 } from '@polar-sh/sdk'
 import { RowSelectionState } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
-import { FormattedDateTime } from 'polarkit/components/ui/atoms'
+import { FormattedDateTime, Pill } from 'polarkit/components/ui/atoms'
 import Avatar from 'polarkit/components/ui/atoms/avatar'
 import Button from 'polarkit/components/ui/atoms/button'
 import {
@@ -38,47 +47,122 @@ import {
   DataTableColumnDef,
   DataTableColumnHeader,
 } from 'polarkit/components/ui/atoms/datatable'
-import React, {
-  PropsWithChildren,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'polarkit/components/ui/atoms/select'
+import TextArea from 'polarkit/components/ui/atoms/textarea'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from 'polarkit/components/ui/form'
+import React, { MouseEvent, useCallback, useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 
-const StatusWrapper = ({
-  children,
+const CANCELLATION_REASONS: {
+  [key: string]: string
+} = {
+  unused: 'Unused',
+  too_expensive: 'Too Expensive',
+  missing_features: 'Missing Features',
+  switched_service: 'Switched Service',
+  customer_service: 'Customer Service',
+  low_quality: 'Low Quality',
+  too_complex: 'Too Complicated',
+  other: 'Other',
+}
+
+const getHumanCancellationReason = (
+  key: string | null,
+) => {
+  if (key && (key in CANCELLATION_REASONS)) {
+    return CANCELLATION_REASONS[key]
+  }
+  return null
+}
+
+const StatusLabel = ({
   color,
-}: PropsWithChildren<{ color: string }>) => {
+  dt,
+  icon,
+  children,
+}: {
+  color: string
+  dt?: string | null
+  icon?: React.ReactNode
+  children: React.ReactNode
+}) => {
+  let prettyEventDate = null
+  if (dt) {
+    const event = new Date(dt)
+    const now = new Date()
+    if (event.getFullYear() != now.getFullYear()) {
+      prettyEventDate = event.toLocaleDateString('en-US', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      })
+    } else {
+      prettyEventDate = event.toLocaleDateString('en-US', {
+        day: 'numeric',
+        month: 'short',
+      })
+    }
+  }
+
   return (
     <div className={`flex flex-row items-center gap-x-2`}>
       <span className={twMerge('h-2 w-2 rounded-full border-2', color)} />
       <span className="capitalize">{children}</span>
+      {prettyEventDate && (
+        <Pill color="gray" className="flex flex-row">
+          {icon}
+          <span className="!ml-1">{prettyEventDate}</span>
+        </Pill>
+      )}
     </div>
   )
 }
 
-const Status = ({
-  status,
-  cancelAtPeriodEnd,
-}: {
-  status: SubscriptionStatus
-  cancelAtPeriodEnd: boolean
-}) => {
-  switch (status) {
+const Status = ({ subscription }: { subscription: Subscription }) => {
+  switch (subscription.status) {
     case 'active':
+      if (!subscription.ends_at) {
+        return <StatusLabel color="border-emerald-500">Active</StatusLabel>
+      }
       return (
-        <StatusWrapper
-          color={cancelAtPeriodEnd ? 'border-yellow-500' : 'border-emerald-500'}
+        <StatusLabel
+          color="border-yellow-500"
+          dt={subscription.ends_at}
+          icon={<AccessTimeOutlined fontSize="inherit" />}
         >
-          {cancelAtPeriodEnd ? 'Ending' : 'Active'}
-        </StatusWrapper>
+          Ending
+        </StatusLabel>
+      )
+    case 'canceled':
+      return (
+        <StatusLabel
+          color="border-red-500"
+          dt={subscription.ended_at}
+          icon={<CancelOutlined fontSize="inherit" />}
+        >
+          Canceled
+        </StatusLabel>
       )
     default:
       return (
-        <StatusWrapper color="border-red-500">
-          {subscriptionStatusDisplayNames[status]}
-        </StatusWrapper>
+        <StatusLabel color="border-red-500">
+          {subscriptionStatusDisplayNames[subscription.status]}
+        </StatusLabel>
       )
   }
 }
@@ -88,7 +172,9 @@ interface ClientPageProps {
   pagination: DataTablePaginationState
   sorting: DataTableSortingState
   productId?: string
-  subscriptionStatus?: Extract<SubscriptionStatus, 'active' | 'canceled'>
+  subscriptionStatus?:
+    | Extract<SubscriptionStatus, 'active' | 'canceled'>
+    | 'any'
 }
 
 const ClientPage: React.FC<ClientPageProps> = ({
@@ -118,7 +204,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     }
 
     params.append('status', status)
-
     return params
   }
 
@@ -189,7 +274,11 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const subscriptionsHook = useListSubscriptions(organization.id, {
     ...getAPIParams(pagination, sorting),
     ...(productId ? { productId } : {}),
-    ...{ active: status === 'active' },
+    ...(status !== 'any'
+      ? {
+          active: status === 'active',
+        }
+      : {}),
   })
 
   const subscriptions = subscriptionsHook.data?.items || []
@@ -235,12 +324,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
         <DataTableColumnHeader column={column} title="Status" />
       ),
       cell: ({ row: { original: subscription } }) => {
-        return (
-          <Status
-            status={subscription.status}
-            cancelAtPeriodEnd={subscription.cancel_at_period_end}
-          />
-        )
+        return <Status subscription={subscription} />
       },
     },
     {
@@ -261,7 +345,13 @@ const ClientPage: React.FC<ClientPageProps> = ({
       ),
       cell: (props) => {
         const datetime = props.getValue() as string | null
-        return datetime ? <FormattedDateTime datetime={datetime} /> : '—'
+        return datetime &&
+          props.row.original.status === 'active' &&
+          !props.row.original.cancel_at_period_end ? (
+          <FormattedDateTime datetime={datetime} />
+        ) : (
+          '—'
+        )
       },
     },
     {
@@ -303,7 +393,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
             <div className="w-auto">
               <SubscriptionStatusSelect
                 statuses={['active', 'canceled']}
-                value={subscriptionStatus || 'active'}
+                value={subscriptionStatus || 'any'}
                 onChange={setStatus}
               />
             </div>
@@ -345,7 +435,12 @@ const ClientPage: React.FC<ClientPageProps> = ({
         )}
       </div>
       <InlineModal
-        modalContent={<SubscriptionModal subscription={selectedSubscription} />}
+        modalContent={
+          <SubscriptionModal
+            organization={organization}
+            subscription={selectedSubscription}
+          />
+        }
         isShown={isModalShown}
         hide={() => {
           setSelectedSubscriptionState({})
@@ -357,18 +452,88 @@ const ClientPage: React.FC<ClientPageProps> = ({
 }
 
 interface SubscriptionModalProps {
+  organization: Organization
   subscription?: Subscription
 }
 
-const SubscriptionModal = ({ subscription }: SubscriptionModalProps) => {
-  const { organization } = useContext(MaintainerOrganizationContext)
-  const { data: customFields } = useCustomFields(organization.id)
+type SubscriptionModalViews = 'overview' | 'cancel'
+
+const SubscriptionModal = ({
+  organization,
+  subscription,
+}: SubscriptionModalProps) => {
+  const [view, setView] = useState<SubscriptionModalViews>('overview')
 
   if (!subscription) return null
+
+  const isCancelled = subscription.status == 'canceled'
+
+  const viewClickHandler = (view: SubscriptionModalViews) => {
+    return (e: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+      e.preventDefault()
+      setView(view)
+    }
+  }
+
+  const onCancelClick = viewClickHandler('cancel')
+  const onOverviewClick = viewClickHandler('overview')
+
+  if (view == 'cancel') {
+    return (
+      <CancelSubscriptionView
+        subscription={subscription}
+        onOverviewClick={onOverviewClick}
+      />
+    )
+  }
 
   return (
     <div className="flex flex-col gap-8 overflow-y-auto px-8 py-12">
       <h2 className="mb-4 text-2xl">Subscription Details</h2>
+      <SubscriptionDetails
+        organization={organization}
+        subscription={subscription}
+      />
+      {!isCancelled && (
+        <Button
+          size="lg"
+          onClick={onCancelClick}
+          variant="secondary"
+          tabIndex={-1}
+        >
+          Cancel Subscription
+        </Button>
+      )}
+    </div>
+  )
+}
+
+interface SubscriptionDetailsProps extends SubscriptionModalProps {
+  subscription: Subscription
+}
+
+const SubscriptionDetails = ({
+  organization,
+  subscription,
+}: SubscriptionDetailsProps) => {
+  const { data: customFields } = useCustomFields(organization.id)
+
+  const cancellationReason = subscription.customer_cancellation_reason
+  const cancellationComment = subscription.customer_cancellation_comment
+
+  let nextEventDatetime: string | undefined = undefined
+  let cancellationDate: Date | undefined = undefined
+  if (subscription.ended_at) {
+    cancellationDate = new Date(subscription.ended_at)
+  } else if (subscription.ends_at) {
+    nextEventDatetime = subscription.ends_at
+    cancellationDate = new Date(subscription.ends_at)
+  } else if (subscription.current_period_end) {
+    nextEventDatetime = subscription.current_period_end
+  }
+
+  return (
+    <>
       <div className="flex flex-row items-center gap-4">
         <Avatar
           avatar_url={subscription.customer.avatar_url}
@@ -386,10 +551,7 @@ const SubscriptionModal = ({ subscription }: SubscriptionModalProps) => {
       <div className="flex flex-col gap-2">
         <div className="flex justify-between">
           <span className="dark:text-polar-500 text-gray-500">Status</span>
-          <Status
-            status={subscription.status}
-            cancelAtPeriodEnd={subscription.cancel_at_period_end}
-          />
+          <Status subscription={subscription} />
         </div>
         <div className="flex justify-between">
           <span className="dark:text-polar-500 text-gray-500">
@@ -399,15 +561,15 @@ const SubscriptionModal = ({ subscription }: SubscriptionModalProps) => {
             <FormattedDateTime datetime={subscription.created_at} />
           </span>
         </div>
-        {subscription.current_period_end && !subscription.ended_at && (
+        {nextEventDatetime && (
           <div className="flex justify-between">
             <span className="dark:text-polar-500 text-gray-500">
-              {subscription.cancel_at_period_end
+              {subscription.ends_at
                 ? 'Ending Date'
                 : 'Renewal Date'}
             </span>
             <span>
-              <FormattedDateTime datetime={subscription.current_period_end} />
+              <FormattedDateTime datetime={nextEventDatetime} />
             </span>
           </div>
         )}
@@ -470,6 +632,198 @@ const SubscriptionModal = ({ subscription }: SubscriptionModalProps) => {
           </div>
         </div>
       )}
+      {cancellationDate && (
+        <div className="flex flex-col gap-y-4">
+          <h3 className="text-lg">Cancellation Details</h3>
+          <div className="flex flex-col gap-y-2">
+            <div className="flex justify-between">
+              <span className="dark:text-polar-500 text-gray-500">Ends</span>
+              <span>
+                {cancellationDate.toLocaleDateString('en-US', {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric',
+                })}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="dark:text-polar-500 text-gray-500">Reason</span>
+              <span>
+                {cancellationReason
+                  ? getHumanCancellationReason(cancellationReason)
+                  : '—'}
+              </span>
+            </div>
+          </div>
+          {cancellationComment && (
+            <TextArea tabIndex={-1} readOnly resizable={false}>
+              {cancellationComment}
+            </TextArea>
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+interface CancelSubscriptionViewProps {
+  subscription: Subscription
+  onOverviewClick: (
+    e: MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ) => void
+}
+
+type CancellationAction = 'revoke' | 'cancel_at_period_end'
+
+interface SubscriptionCancelForm extends SubscriptionCancel {
+  cancellation_action: CancellationAction
+}
+
+const CancelSubscriptionView = ({
+  subscription,
+  onOverviewClick,
+}: CancelSubscriptionViewProps) => {
+  const cancelSubscription = useCancelSubscription()
+  const form = useForm<SubscriptionCancelForm>({
+    defaultValues: {
+      cancellation_action: 'cancel_at_period_end',
+      customer_cancellation_reason: undefined,
+    },
+  })
+  const { control, handleSubmit, setError, setValue } = form
+
+  const onSubmit = useCallback(
+    async (cancellation: SubscriptionCancelForm) => {
+      try {
+        let body: SubscriptionCancel = {
+          customer_cancellation_reason: cancellation.customer_cancellation_reason
+        }
+        if (cancellation.cancellation_action === 'revoke') {
+          body.revoke = true
+        } else {
+          body.cancel_at_period_end = true
+        }
+
+        await cancelSubscription.mutateAsync({
+          id: subscription.id,
+          body: body
+        })
+      } catch (e) {
+        if (e instanceof ResponseError) {
+          const body = await e.response.json()
+          if (e.response.status === 422) {
+            const validationErrors = body['detail'] as ValidationError[]
+            setValidationErrors(validationErrors, setError)
+          } else {
+            setError('root', { message: e.message })
+          }
+        }
+      }
+    },
+    [
+      cancelSubscription,
+      subscription.id,
+      setError,
+    ],
+  )
+
+  const reasons = Object.keys(CANCELLATION_REASONS)
+  let periodEndOutput: string | undefined = undefined
+  if (subscription.current_period_end) {
+    periodEndOutput = new Date(subscription.current_period_end).toLocaleDateString('en-US', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    })
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-8 overflow-y-auto px-8 py-12">
+      <div className="flex flex-row items-center gap-x-4">
+        <Button variant="ghost" size="icon" onClick={onOverviewClick}>
+          <ArrowBackOutlined fontSize="small" />
+        </Button>
+        <h2 className="text-xl">Cancel Subscription</h2>
+      </div>
+      <div className="flex h-full flex-col gap-4">
+        <Form {...form}>
+          <form
+            className="flex flex-grow flex-col justify-between gap-y-6"
+            onSubmit={handleSubmit(onSubmit)}
+          >
+            <div className="flex flex-col gap-y-6">
+              <FormField
+                control={control}
+                name="cancellation_action"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Cancellation Date</FormLabel>
+                    <FormControl>
+                      <Select
+                        value={field.value}
+                        onValueChange={(value: CancellationAction) => {
+                          setValue('cancellation_action', value)
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select Cancellation Time" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="revoke">Immediately</SelectItem>
+                          <SelectItem value="cancel_at_period_end">
+                            End of current period
+                            {periodEndOutput && (
+                              <>
+                                {'  '}<span>({periodEndOutput})</span>
+                              </>
+                            )}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="customer_cancellation_reason"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col gap-y-2">
+                    <div className="flex flex-col gap-2">
+                      <FormLabel>Customer Feedback</FormLabel>
+                      <FormDescription>
+                        Did the customer specify why they wanted to cancel?
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={undefined}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select customer cancellation reason" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {Object.values(reasons).map((reason) => (
+                            <SelectItem key={reason} value={reason}>
+                              {getHumanCancellationReason(reason)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <Button type="submit" variant={'destructive'} size="lg">
+              Cancel Subscription
+            </Button>
+          </form>
+        </Form>
+      </div>
     </div>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/page.tsx
@@ -18,7 +18,7 @@ export default async function Page({
   params: { organization: string }
   searchParams: DataTableSearchParams & {
     product_id?: string
-    status?: Extract<SubscriptionStatus, 'active' | 'canceled'>
+    status?: Extract<SubscriptionStatus, 'active' | 'canceled'> | 'any'
   }
 }) {
   const api = getServerSideAPI()
@@ -39,7 +39,7 @@ export default async function Page({
       pagination={pagination}
       sorting={sorting}
       productId={searchParams.product_id}
-      subscriptionStatus={searchParams.status}
+      subscriptionStatus={searchParams.status ?? 'active'}
     />
   )
 }

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -52,7 +52,7 @@ const CustomerPortalSubscription = ({
     cancelSubscription.isPending ||
     cancelSubscription.isSuccess ||
     !!subscription.ended_at ||
-    !!subscription.cancel_at_period_end
+    !!subscription.ends_at
 
   return (
     <>

--- a/clients/apps/web/src/components/Customization/utils.ts
+++ b/clients/apps/web/src/components/Customization/utils.ts
@@ -243,7 +243,9 @@ export const SUBSCRIPTION_ORDER_PREVIEW: CustomerSubscription = {
     new Date().setMonth(new Date().getMonth() + 1),
   ).toDateString(),
   cancel_at_period_end: false,
+  canceled_at: null,
   started_at: new Date().toDateString(),
+  ends_at: null,
   ended_at: null,
   user_id: '123',
   customer_id: '123',
@@ -267,4 +269,6 @@ export const SUBSCRIPTION_ORDER_PREVIEW: CustomerSubscription = {
     product_id: '123',
   },
   discount_id: null,
+  customer_cancellation_comment: null,
+  customer_cancellation_reason: null,
 }

--- a/clients/apps/web/src/components/Subscriptions/CustomerCancellationModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CustomerCancellationModal.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import {
+  CustomerSubscription,
+  CustomerCancellationReason,
+  CustomerSubscriptionCancel,
+  ResponseError,
+  ValidationError,
+} from '@polar-sh/sdk'
+import Button from 'polarkit/components/ui/atoms/button'
+import TextArea from 'polarkit/components/ui/atoms/textarea'
+import { Label } from 'polarkit/components/ui/label'
+import { UseMutationResult } from '@tanstack/react-query'
+import { setValidationErrors } from '@/utils/api/errors'
+import { Modal, ModalProps } from '@/components/Modal'
+import { RadioGroup, RadioGroupItem } from 'polarkit/components/ui/radio-group'
+import { useCallback, useState } from 'react'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from 'polarkit/components/ui/form'
+import { useForm } from 'react-hook-form'
+
+const CancellationReasonRadio = ({
+  value,
+  label,
+}: {
+  value: CustomerCancellationReason
+  label: string
+}) => {
+  return (
+    <div className="flex flex-row">
+      <RadioGroupItem value={value} id={`reason-${value}`} />
+      <Label className="ml-4 grow" htmlFor={`reason-${value}`}>
+        {label}
+      </Label>
+    </div>
+  )
+}
+
+interface CustomerCancellationModalProps
+  extends Omit<ModalProps, 'modalContent'> {
+  subscription: CustomerSubscription
+  cancelSubscription: UseMutationResult<CustomerSubscription, Error, { id: string, body: CustomerSubscriptionCancel }, unknown>
+  onAbort?: () => void
+}
+
+interface CustomerSubscriptionCancelForm extends CustomerSubscriptionCancel {
+  cancellation_comment: string | undefined
+}
+
+const CustomerCancellationModal = ({
+  subscription,
+  cancelSubscription,
+  onAbort,
+  ...props
+}: CustomerCancellationModalProps) => {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleCancel = useCallback(() => {
+    onAbort?.()
+    props.hide()
+  }, [onAbort, props])
+
+  const form = useForm<CustomerSubscriptionCancelForm>({
+    defaultValues: {
+      cancel_at_period_end: true,
+      cancellation_reason: undefined,
+      cancellation_comment: undefined,
+    },
+  })
+  const { control, handleSubmit, setError, setValue } = form
+
+  const handleCancellation = useCallback(
+    async (cancellation: CustomerSubscriptionCancel) => {
+      try {
+        setIsLoading(true)
+        await cancelSubscription.mutateAsync({
+          id: subscription.id,
+          body: cancellation
+        })
+        props.hide()
+      } catch (e) {
+        if (e instanceof ResponseError) {
+          const body = await e.response.json()
+          if (e.response.status === 422) {
+            const validationErrors = body['detail'] as ValidationError[]
+            setValidationErrors(validationErrors, setError)
+          } else {
+            setError('root', { message: e.message })
+          }
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [subscription.id, cancelSubscription, setError, props],
+  )
+
+  const onReasonSelect = (value: CustomerCancellationReason) => {
+    setValue('cancellation_reason', value ?? '')
+  }
+
+  return (
+    <Modal
+      {...props}
+      className="md:min-w-[600px]"
+      modalContent={
+        <div className="flex flex-col gap-y-6 p-12">
+          <div className="flex flex-col gap-y-2">
+            <h3 className="text-2xl">We&apos;re sorry to see you go!</h3>
+            <p className="dark:text-polar-500 text-balance leading-relaxed text-gray-500">
+              You&apos;re always welcome back! Let us know why you&apos;re
+              leaving to help us improve our product.
+            </p>
+          </div>
+          <Form {...form}>
+            <form onSubmit={handleSubmit(handleCancellation)}>
+              <FormField
+                control={control}
+                name="cancellation_reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <RadioGroup
+                        value={field.value ?? 'other'}
+                        onValueChange={onReasonSelect}
+                      >
+                        <CancellationReasonRadio
+                          value="unused"
+                          label="Not using it enough"
+                        />
+                        <CancellationReasonRadio
+                          value="too_expensive"
+                          label="Too expensive"
+                        />
+                        <CancellationReasonRadio
+                          value="missing_features"
+                          label="Missing features"
+                        />
+                        <CancellationReasonRadio
+                          value="switched_service"
+                          label="Switched to another service"
+                        />
+                        <CancellationReasonRadio
+                          value="customer_service"
+                          label="Customer service"
+                        />
+                        <CancellationReasonRadio
+                          value="low_quality"
+                          label="Not satisfied with the quality"
+                        />
+                        <CancellationReasonRadio
+                          value="too_complex"
+                          label="Too complicated"
+                        />
+                        <CancellationReasonRadio
+                          value="other"
+                          label="Other (please share below)"
+                        />
+                      </RadioGroup>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="cancellation_comment"
+                render={({ field }) => (
+                  <FormItem className="mt-8">
+                    <FormControl>
+                      <TextArea
+                        {...field}
+                        placeholder="Anything else you want to share? (Optional)"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex flex-row gap-x-4 pt-6">
+                <Button type="submit" variant="destructive" loading={isLoading}>
+                  Cancel Subscription
+                </Button>
+                <Button variant="ghost" onClick={handleCancel}>
+                  I&apos;ve changed my mind
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      }
+    />
+  )
+}
+
+export default CustomerCancellationModal

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionDetails.tsx
@@ -3,14 +3,17 @@
 import AmountLabel from '@/components/Shared/AmountLabel'
 import { SubscriptionStatusLabel } from '@/components/Subscriptions/utils'
 import { useCustomerCancelSubscription } from '@/hooks/queries'
-import { CustomerSubscription, PolarAPI } from '@polar-sh/sdk'
+import {
+  PolarAPI,
+  CustomerSubscription,
+} from '@polar-sh/sdk'
 import Avatar from 'polarkit/components/ui/atoms/avatar'
 import Button from 'polarkit/components/ui/atoms/button'
 import ShadowBox from 'polarkit/components/ui/atoms/shadowbox'
 import { useState } from 'react'
-import { ConfirmModal } from '../Modal/ConfirmModal'
 import { InlineModal } from '../Modal/InlineModal'
 import ChangePlanModal from './ChangePlanModal'
+import CustomerCancellationModal from './CustomerCancellationModal'
 
 export const SubscriptionDetails = ({
   subscription,
@@ -135,18 +138,11 @@ export const SubscriptionDetails = ({
             Unsubscribe
           </Button>
         )}
-        <ConfirmModal
+        <CustomerCancellationModal
           isShown={showCancelModal}
           hide={() => setShowCancelModal(false)}
-          title={`Unsubscribe from ${subscription.product.name}?`}
-          description={
-            "At the end of your billing period, you won't have access to your benefits anymore."
-          }
-          destructiveText="Unsubscribe"
-          onConfirm={() =>
-            cancelSubscription.mutateAsync({ id: subscription.id })
-          }
-          destructive
+          subscription={subscription}
+          cancelSubscription={cancelSubscription}
         />
       </div>
 

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
@@ -31,7 +31,11 @@ const SubscriptionStatusSelect: React.FC<SubscriptionStatusSelectProps> = ({
         <SelectValue placeholder="Select a status" />
       </SelectTrigger>
       <SelectContent>
-        {statuses.map((status, index) => (
+        <SelectItem value="any">
+          <span className="whitespace-nowrap">Any status</span>
+        </SelectItem>
+        <SelectSeparator />
+        {statuses.map((status) => (
           <React.Fragment key={status}>
             <SelectGroup>
               <SelectItem value={status} className="font-medium">
@@ -40,7 +44,6 @@ const SubscriptionStatusSelect: React.FC<SubscriptionStatusSelectProps> = ({
                 </div>
               </SelectItem>
             </SelectGroup>
-            {index < statuses.length - 1 && <SelectSeparator />}
           </React.Fragment>
         ))}
       </SelectContent>

--- a/clients/apps/web/src/components/Subscriptions/utils.tsx
+++ b/clients/apps/web/src/components/Subscriptions/utils.tsx
@@ -45,7 +45,7 @@ export const SubscriptionStatusLabel = ({
 
   switch (subscription.status) {
     case 'active':
-      return subscription.cancel_at_period_end ? 'To be cancelled' : 'Active'
+      return subscription.ends_at ? 'To be cancelled' : 'Active'
     default:
       return subscription.status.split('_').join(' ')
   }

--- a/clients/apps/web/src/hooks/queries/customerPortal.ts
+++ b/clients/apps/web/src/hooks/queries/customerPortal.ts
@@ -6,6 +6,7 @@ import {
   CustomerPortalLicenseKeysApiListRequest,
   CustomerPortalOrdersApiListRequest,
   CustomerPortalSubscriptionsApiListRequest,
+  CustomerSubscriptionCancel,
   CustomerSubscriptionUpdate,
   PolarAPI,
 } from '@polar-sh/sdk'
@@ -155,8 +156,11 @@ export const useCustomerUpdateSubscription = (api: PolarAPI) =>
 
 export const useCustomerCancelSubscription = (api: PolarAPI) =>
   useMutation({
-    mutationFn: (variables: { id: string }) => {
-      return api.customerPortalSubscriptions.cancel(variables)
+    mutationFn: (variables: {
+      id: string,
+      body: CustomerSubscriptionCancel
+    }) => {
+      return api.customerPortalSubscriptions.update(variables)
     },
     onSuccess: (_result, _variables, _ctx) => {
       queryClient.invalidateQueries({

--- a/clients/apps/web/src/hooks/queries/subscriptions.ts
+++ b/clients/apps/web/src/hooks/queries/subscriptions.ts
@@ -1,7 +1,7 @@
-import { SubscriptionsApiListRequest } from '@polar-sh/sdk'
-import { useQuery } from '@tanstack/react-query'
+import { SubscriptionsApiListRequest, SubscriptionCancel, ListResourceSubscription } from '@polar-sh/sdk'
+import { useQuery, useMutation } from '@tanstack/react-query'
 
-import { api } from '@/utils/api'
+import { api, queryClient } from '@/utils/api'
 import { defaultRetry } from './retry'
 
 export const useListSubscriptions = (
@@ -17,4 +17,39 @@ export const useListSubscriptions = (
       }),
     retry: defaultRetry,
     enabled: !!organizationId,
+  })
+
+export const useCancelSubscription = () =>
+  useMutation({
+    mutationFn: (variables: { id: string, body: SubscriptionCancel }) => {
+      return api.subscriptions.update(variables)
+    },
+    onSuccess: (result, _variables, _ctx) => {
+      queryClient.setQueriesData<ListResourceSubscription>(
+        {
+          queryKey: [
+            'subscriptions',
+            { organizationId: result.product.organization_id }
+          ],
+        },
+        (old) => {
+          if (!old) {
+            return {
+              items: [result],
+              pagination: {
+                total_count: 1,
+                max_page: 1,
+              },
+            }
+          } else {
+            return {
+              items: old.items.map((item) =>
+                item.id === result.id ? result : item,
+              ),
+              pagination: old.pagination,
+            }
+          }
+        },
+      )
+    },
   })

--- a/clients/packages/sdk/src/client/apis/SubscriptionsApi.ts
+++ b/clients/packages/sdk/src/client/apis/SubscriptionsApi.ts
@@ -15,6 +15,7 @@
 
 import * as runtime from '../runtime';
 import type {
+  AlreadyCanceledSubscription,
   CustomerIDFilter,
   DiscountIDFilter,
   HTTPValidationError,
@@ -22,7 +23,10 @@ import type {
   OrganizationIDFilter1,
   OrganizationId,
   ProductIDFilter,
+  ResourceNotFound,
+  Subscription,
   SubscriptionSortProperty,
+  SubscriptionUpdate,
 } from '../models/index';
 
 export interface SubscriptionsApiExportRequest {
@@ -38,6 +42,15 @@ export interface SubscriptionsApiListRequest {
     page?: number;
     limit?: number;
     sorting?: Array<SubscriptionSortProperty> | null;
+}
+
+export interface SubscriptionsApiRevokeRequest {
+    id: string;
+}
+
+export interface SubscriptionsApiUpdateRequest {
+    id: string;
+    body: SubscriptionUpdate;
 }
 
 /**
@@ -154,6 +167,102 @@ export class SubscriptionsApi extends runtime.BaseAPI {
      */
     async list(requestParameters: SubscriptionsApiListRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListResourceSubscription> {
         const response = await this.listRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Revoke a subscription, i.e cancel immediately.
+     * Revoke Subscription
+     */
+    async revokeRaw(requestParameters: SubscriptionsApiRevokeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Subscription>> {
+        if (requestParameters['id'] == null) {
+            throw new runtime.RequiredError(
+                'id',
+                'Required parameter "id" was null or undefined when calling revoke().'
+            );
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("pat", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/v1/subscriptions/{id}`.replace(`{${"id"}}`, encodeURIComponent(String(requestParameters['id']))),
+            method: 'DELETE',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response);
+    }
+
+    /**
+     * Revoke a subscription, i.e cancel immediately.
+     * Revoke Subscription
+     */
+    async revoke(requestParameters: SubscriptionsApiRevokeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Subscription> {
+        const response = await this.revokeRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Update a subscription of the authenticated customer or user.
+     * Update Subscription
+     */
+    async updateRaw(requestParameters: SubscriptionsApiUpdateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Subscription>> {
+        if (requestParameters['id'] == null) {
+            throw new runtime.RequiredError(
+                'id',
+                'Required parameter "id" was null or undefined when calling update().'
+            );
+        }
+
+        if (requestParameters['body'] == null) {
+            throw new runtime.RequiredError(
+                'body',
+                'Required parameter "body" was null or undefined when calling update().'
+            );
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("pat", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/v1/subscriptions/{id}`.replace(`{${"id"}}`, encodeURIComponent(String(requestParameters['id']))),
+            method: 'PATCH',
+            headers: headerParameters,
+            query: queryParameters,
+            body: requestParameters['body'],
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response);
+    }
+
+    /**
+     * Update a subscription of the authenticated customer or user.
+     * Update Subscription
+     */
+    async update(requestParameters: SubscriptionsApiUpdateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Subscription> {
+        const response = await this.updateRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/clients/packages/sdk/src/client/apis/UsersSubscriptionsApi.ts
+++ b/clients/packages/sdk/src/client/apis/UsersSubscriptionsApi.ts
@@ -15,7 +15,8 @@
 
 import * as runtime from '../runtime';
 import type {
-  AlreadyCanceledSubscription,
+  AlreadyCanceledUserSubscription,
+  CustomerSubscriptionCancel,
   HTTPValidationError,
   ListResourceUserSubscription,
   OrganizationIDFilter,
@@ -28,6 +29,7 @@ import type {
 
 export interface UsersSubscriptionsApiCancelRequest {
     id: string;
+    body: CustomerSubscriptionCancel;
 }
 
 export interface UsersSubscriptionsApiGetRequest {
@@ -55,7 +57,7 @@ export interface UsersSubscriptionsApiUpdateRequest {
 export class UsersSubscriptionsApi extends runtime.BaseAPI {
 
     /**
-     * Cancel a subscription.
+     * Cancel a users subscription.
      * Cancel Subscription
      */
     async cancelRaw(requestParameters: UsersSubscriptionsApiCancelRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserSubscription>> {
@@ -66,9 +68,18 @@ export class UsersSubscriptionsApi extends runtime.BaseAPI {
             );
         }
 
+        if (requestParameters['body'] == null) {
+            throw new runtime.RequiredError(
+                'body',
+                'Required parameter "body" was null or undefined when calling cancel().'
+            );
+        }
+
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
 
         if (this.configuration && this.configuration.accessToken) {
             const token = this.configuration.accessToken;
@@ -83,13 +94,14 @@ export class UsersSubscriptionsApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
+            body: requestParameters['body'],
         }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
 
     /**
-     * Cancel a subscription.
+     * Cancel a users subscription.
      * Cancel Subscription
      */
     async cancel(requestParameters: UsersSubscriptionsApiCancelRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserSubscription> {

--- a/clients/packages/sdk/src/client/models/index.ts
+++ b/clients/packages/sdk/src/client/models/index.ts
@@ -7963,6 +7963,23 @@ export type CustomerBenefitGrantSortProperty = typeof CustomerBenefitGrantSortPr
  * @export
  */
 export type CustomerBenefitGrantUpdate = { benefit_type: 'ads' } & CustomerBenefitGrantAdsUpdate | { benefit_type: 'custom' } & CustomerBenefitGrantCustomUpdate | { benefit_type: 'discord' } & CustomerBenefitGrantDiscordUpdate | { benefit_type: 'downloadables' } & CustomerBenefitGrantDownloadablesUpdate | { benefit_type: 'github_repository' } & CustomerBenefitGrantGitHubRepositoryUpdate | { benefit_type: 'license_keys' } & CustomerBenefitGrantLicenseKeysUpdate;
+
+/**
+ * 
+ * @export
+ */
+export const CustomerCancellationReason = {
+    CUSTOMER_SERVICE: 'customer_service',
+    LOW_QUALITY: 'low_quality',
+    MISSING_FEATURES: 'missing_features',
+    SWITCHED_SERVICE: 'switched_service',
+    TOO_COMPLEX: 'too_complex',
+    TOO_EXPENSIVE: 'too_expensive',
+    UNUSED: 'unused',
+    OTHER: 'other'
+} as const;
+export type CustomerCancellationReason = typeof CustomerCancellationReason[keyof typeof CustomerCancellationReason];
+
 /**
  * 
  * @export
@@ -8306,7 +8323,19 @@ export interface CustomerOrderSubscription {
      * @type {string}
      * @memberof CustomerOrderSubscription
      */
+    canceled_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerOrderSubscription
+     */
     started_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerOrderSubscription
+     */
+    ends_at: string | null;
     /**
      * 
      * @type {string}
@@ -8343,6 +8372,18 @@ export interface CustomerOrderSubscription {
      * @memberof CustomerOrderSubscription
      */
     checkout_id: string | null;
+    /**
+     * 
+     * @type {CustomerCancellationReason}
+     * @memberof CustomerOrderSubscription
+     */
+    customer_cancellation_reason: CustomerCancellationReason | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerOrderSubscription
+     */
+    customer_cancellation_comment: string | null;
 }
 
 
@@ -8625,7 +8666,19 @@ export interface CustomerSubscription {
      * @type {string}
      * @memberof CustomerSubscription
      */
+    canceled_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerSubscription
+     */
     started_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerSubscription
+     */
+    ends_at: string | null;
     /**
      * 
      * @type {string}
@@ -8664,6 +8717,18 @@ export interface CustomerSubscription {
     checkout_id: string | null;
     /**
      * 
+     * @type {CustomerCancellationReason}
+     * @memberof CustomerSubscription
+     */
+    customer_cancellation_reason: CustomerCancellationReason | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerSubscription
+     */
+    customer_cancellation_comment: string | null;
+    /**
+     * 
      * @type {string}
      * @memberof CustomerSubscription
      * @deprecated
@@ -8681,6 +8746,33 @@ export interface CustomerSubscription {
      * @memberof CustomerSubscription
      */
     price: ProductPrice;
+}
+
+
+/**
+ * 
+ * @export
+ * @interface CustomerSubscriptionCancel
+ */
+export interface CustomerSubscriptionCancel {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof CustomerSubscriptionCancel
+     */
+    cancel_at_period_end?: boolean | null;
+    /**
+     * 
+     * @type {CustomerCancellationReason}
+     * @memberof CustomerSubscriptionCancel
+     */
+    cancellation_reason?: CustomerCancellationReason | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CustomerSubscriptionCancel
+     */
+    cancellation_comment?: string | null;
 }
 
 
@@ -8783,15 +8875,21 @@ export const CustomerSubscriptionSortProperty = {
 export type CustomerSubscriptionSortProperty = typeof CustomerSubscriptionSortProperty[keyof typeof CustomerSubscriptionSortProperty];
 
 /**
+ * @type CustomerSubscriptionUpdate
+ * @export
+ */
+export type CustomerSubscriptionUpdate = CustomerSubscriptionCancel | CustomerSubscriptionUpdatePrice;
+
+/**
  * 
  * @export
- * @interface CustomerSubscriptionUpdate
+ * @interface CustomerSubscriptionUpdatePrice
  */
-export interface CustomerSubscriptionUpdate {
+export interface CustomerSubscriptionUpdatePrice {
     /**
-     * 
+     * Update subscription to another price.
      * @type {string}
-     * @memberof CustomerSubscriptionUpdate
+     * @memberof CustomerSubscriptionUpdatePrice
      */
     product_price_id: string;
 }
@@ -14834,7 +14932,19 @@ export interface OrderSubscription {
      * @type {string}
      * @memberof OrderSubscription
      */
+    canceled_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof OrderSubscription
+     */
     started_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof OrderSubscription
+     */
+    ends_at: string | null;
     /**
      * 
      * @type {string}
@@ -14871,6 +14981,18 @@ export interface OrderSubscription {
      * @memberof OrderSubscription
      */
     checkout_id: string | null;
+    /**
+     * 
+     * @type {CustomerCancellationReason}
+     * @memberof OrderSubscription
+     */
+    customer_cancellation_reason: CustomerCancellationReason | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof OrderSubscription
+     */
+    customer_cancellation_comment: string | null;
     /**
      * 
      * @type {string}
@@ -18815,7 +18937,19 @@ export interface Subscription {
      * @type {string}
      * @memberof Subscription
      */
+    canceled_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof Subscription
+     */
     started_at: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof Subscription
+     */
+    ends_at: string | null;
     /**
      * 
      * @type {string}
@@ -18852,6 +18986,18 @@ export interface Subscription {
      * @memberof Subscription
      */
     checkout_id: string | null;
+    /**
+     * 
+     * @type {CustomerCancellationReason}
+     * @memberof Subscription
+     */
+    customer_cancellation_reason: CustomerCancellationReason | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof Subscription
+     */
+    customer_cancellation_comment: string | null;
     /**
      * 
      * @type {{ [key: string]: MetadataValue; }}
@@ -18904,6 +19050,47 @@ export interface Subscription {
     discount: SubscriptionDiscount | null;
 }
 
+
+/**
+ * 
+ * @export
+ * @interface SubscriptionCancel
+ */
+export interface SubscriptionCancel {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SubscriptionCancel
+     */
+    cancel_at_period_end?: boolean | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SubscriptionCancel
+     */
+    revoke?: SubscriptionCancelRevokeEnum | null;
+    /**
+     * 
+     * @type {CustomerCancellationReason}
+     * @memberof SubscriptionCancel
+     */
+    customer_cancellation_reason?: CustomerCancellationReason | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SubscriptionCancel
+     */
+    customer_cancellation_comment?: string | null;
+}
+
+
+/**
+ * @export
+ */
+export const SubscriptionCancelRevokeEnum = {
+    TRUE: true
+} as const;
+export type SubscriptionCancelRevokeEnum = typeof SubscriptionCancelRevokeEnum[keyof typeof SubscriptionCancelRevokeEnum];
 
 /**
  * 
@@ -19048,6 +19235,25 @@ export const SubscriptionStatus = {
 } as const;
 export type SubscriptionStatus = typeof SubscriptionStatus[keyof typeof SubscriptionStatus];
 
+/**
+ * @type SubscriptionUpdate
+ * @export
+ */
+export type SubscriptionUpdate = SubscriptionCancel | SubscriptionUpdatePrice;
+
+/**
+ * 
+ * @export
+ * @interface SubscriptionUpdatePrice
+ */
+export interface SubscriptionUpdatePrice {
+    /**
+     * Update subscription to another price.
+     * @type {string}
+     * @memberof SubscriptionUpdatePrice
+     */
+    product_price_id: string;
+}
 /**
  * 
  * @export
@@ -21100,6 +21306,7 @@ export const WebhookEventType = {
     SUBSCRIPTION_UPDATED: 'subscription.updated',
     SUBSCRIPTION_ACTIVE: 'subscription.active',
     SUBSCRIPTION_CANCELED: 'subscription.canceled',
+    SUBSCRIPTION_UNCANCELED: 'subscription.uncanceled',
     SUBSCRIPTION_REVOKED: 'subscription.revoked',
     PRODUCT_CREATED: 'product.created',
     PRODUCT_UPDATED: 'product.updated',
@@ -21370,8 +21577,8 @@ export const WebhookSubscriptionActivePayloadTypeEnum = {
 export type WebhookSubscriptionActivePayloadTypeEnum = typeof WebhookSubscriptionActivePayloadTypeEnum[keyof typeof WebhookSubscriptionActivePayloadTypeEnum];
 
 /**
- * Sent when a subscription is canceled by the user.
- * They might still have access until the end of the current period.
+ * Sent when a subscription is canceled.
+ * Customers might still have access until the end of the current period.
  * 
  * **Discord & Slack support:** Full
  * @export
@@ -21463,6 +21670,37 @@ export const WebhookSubscriptionRevokedPayloadTypeEnum = {
     SUBSCRIPTION_REVOKED: 'subscription.revoked'
 } as const;
 export type WebhookSubscriptionRevokedPayloadTypeEnum = typeof WebhookSubscriptionRevokedPayloadTypeEnum[keyof typeof WebhookSubscriptionRevokedPayloadTypeEnum];
+
+/**
+ * Sent when a subscription is uncanceled.
+ * 
+ * **Discord & Slack support:** Full
+ * @export
+ * @interface WebhookSubscriptionUncanceledPayload
+ */
+export interface WebhookSubscriptionUncanceledPayload {
+    /**
+     * 
+     * @type {string}
+     * @memberof WebhookSubscriptionUncanceledPayload
+     */
+    type: WebhookSubscriptionUncanceledPayloadTypeEnum;
+    /**
+     * 
+     * @type {Subscription}
+     * @memberof WebhookSubscriptionUncanceledPayload
+     */
+    data: Subscription;
+}
+
+
+/**
+ * @export
+ */
+export const WebhookSubscriptionUncanceledPayloadTypeEnum = {
+    SUBSCRIPTION_UNCANCELED: 'subscription.uncanceled'
+} as const;
+export type WebhookSubscriptionUncanceledPayloadTypeEnum = typeof WebhookSubscriptionUncanceledPayloadTypeEnum[keyof typeof WebhookSubscriptionUncanceledPayloadTypeEnum];
 
 /**
  * Sent when a subscription is updated. This event fires for all changes to the subscription, including renewals.

--- a/server/migrations/versions/2025-01-02-2245_add_subscription_cancellation_attributes.py
+++ b/server/migrations/versions/2025-01-02-2245_add_subscription_cancellation_attributes.py
@@ -1,0 +1,84 @@
+"""add subscription cancellation attributes
+
+Revision ID: 81faf775fce0
+Revises: 58d5e316549f
+Create Date: 2025-01-02 22:45:35.324752
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "81faf775fce0"
+down_revision = "58d5e316549f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subscriptions",
+        sa.Column("canceled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("ends_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("customer_cancellation_reason", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("customer_cancellation_comment", sa.Text(), nullable=True),
+    )
+    op.execute(
+        """
+        WITH data AS (
+            SELECT
+                subs.id AS subscription_id,
+                subs.modified_at,
+                CASE
+                    WHEN subs.ended_at IS NOT NULL THEN subs.ended_at
+                    WHEN subs.cancel_at_period_end = 'true' AND subs.current_period_end IS NOT NULL THEN subs.current_period_end
+                    ELSE NULL
+                END AS ends_at
+            FROM subscriptions AS subs
+            WHERE 1 = 1
+                AND (
+                    subs.cancel_at_period_end = 'true'
+                    OR subs.ended_at IS NOT NULL
+                )
+        ), cancellations AS (
+            SELECT
+                data.*,
+                -- Prefer to avoid legacy NULL values for cancellations so we
+                -- try to perform our best guess here OR set it to `ends_at`.
+                -- Can separately write a script to pull from Stripe and update
+                -- legacy data if necessary.
+                CASE
+                    WHEN data.modified_at < data.ends_at THEN data.modified_at
+                    ELSE data.ends_at
+                END AS canceled_at
+            FROM data
+        )
+        UPDATE subscriptions
+        SET
+            ends_at = cancellations.ends_at,
+            canceled_at = cancellations.canceled_at
+        FROM cancellations
+        WHERE 1 = 1
+            AND subscriptions.id = cancellations.subscription_id
+            AND cancellations.ends_at IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subscriptions", "ends_at")
+    op.drop_column("subscriptions", "canceled_at")
+    op.drop_column("subscriptions", "customer_cancellation_comment")
+    op.drop_column("subscriptions", "customer_cancellation_reason")

--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -33,9 +33,9 @@ router = APIRouter(
     prefix="/subscriptions", tags=["subscriptions", APITag.documented, APITag.featured]
 )
 
-SubscriptionID = Annotated[UUID4, Path(description="Your subscription ID.")]
+SubscriptionID = Annotated[UUID4, Path(description="Customer subscription ID.")]
 SubscriptionNotFound = {
-    "description": "Your subscription was not found.",
+    "description": "Customer subscription was not found.",
     "model": ResourceNotFound.schema(),
 }
 

--- a/server/polar/customer_portal/schemas/subscription.py
+++ b/server/polar/customer_portal/schemas/subscription.py
@@ -1,9 +1,14 @@
+import inspect
 from datetime import datetime
+from typing import Annotated
 
 from pydantic import UUID4, AliasChoices, AliasPath, Field
 
-from polar.kit.schemas import Schema
-from polar.models.subscription import SubscriptionStatus
+from polar.kit.schemas import (
+    Schema,
+    SetSchemaReference,
+)
+from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.organization.schemas import Organization
 from polar.product.schemas import (
     BenefitPublicList,
@@ -19,8 +24,10 @@ class CustomerSubscriptionBase(SubscriptionBase):
     status: SubscriptionStatus
     current_period_start: datetime
     current_period_end: datetime | None
+    canceled_at: datetime | None
     cancel_at_period_end: bool
     started_at: datetime | None
+    ends_at: datetime | None
     ended_at: datetime | None
 
     customer_id: UUID4
@@ -49,5 +56,45 @@ class CustomerSubscription(CustomerSubscriptionBase):
     price: ProductPrice
 
 
-class CustomerSubscriptionUpdate(Schema):
-    product_price_id: UUID4
+class CustomerSubscriptionUpdatePrice(Schema):
+    product_price_id: UUID4 = Field(description="Update subscription to another price.")
+
+
+class CustomerSubscriptionCancel(Schema):
+    cancel_at_period_end: bool | None = Field(
+        None,
+        description=inspect.cleandoc(
+            """
+        Cancel an active subscription once the current period ends.
+
+        Or uncancel a subscription currently set to be revoked at period end.
+        """
+        ),
+    )
+
+    cancellation_reason: CustomerCancellationReason | None = Field(
+        None,
+        description=inspect.cleandoc(
+            """
+        Customers reason for cancellation.
+
+        * `too_expensive`: Too expensive for the customer.
+        * `missing_features`: Customer is missing certain features.
+        * `switched_service`: Customer switched to another service.
+        * `unused`: Customer is not using it enough.
+        * `customer_service`: Customer is not satisfied with the customer service.
+        * `low_quality`: Customer is unhappy with the quality.
+        * `too_complex`: Customer considers the service too complicated.
+        * `other`: Other reason(s).
+        """
+        ),
+    )
+    cancellation_comment: str | None = Field(
+        None, description="Customer feedback and why they decided to cancel."
+    )
+
+
+CustomerSubscriptionUpdate = Annotated[
+    CustomerSubscriptionUpdatePrice | CustomerSubscriptionCancel,
+    SetSchemaReference("CustomerSubscriptionUpdate"),
+]

--- a/server/polar/models/webhook_endpoint.py
+++ b/server/polar/models/webhook_endpoint.py
@@ -16,6 +16,7 @@ class WebhookEventType(StrEnum):
     subscription_updated = "subscription.updated"
     subscription_active = "subscription.active"
     subscription_canceled = "subscription.canceled"
+    subscription_uncanceled = "subscription.uncanceled"
     subscription_revoked = "subscription.revoked"
     product_created = "product.created"
     product_updated = "product.updated"

--- a/server/polar/subscription/email_templates/revoked.html
+++ b/server/polar/subscription/email_templates/revoked.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Your subscription has now ended</h1>
+<p>Thank you being a subscriber of <strong>{{ product.name }}</strong>.</p>
+<p>We hope to see you again in the future - you're always welcome back.</p>
+
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td align="center">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+                <tr>
+                    <td align="center">
+                        <a href="{{ url | safe }}" class="f-fallback button">View subscription</a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<!-- Sub copy -->
+<table class="body-sub" role="presentation">
+    <tr>
+        <td>
+            <p class="f-fallback sub">If you're having trouble with the button above, copy and paste the URL below into your web browser:</p>
+            <p class="f-fallback sub"><a href="{{ url | safe }}">{{ url | safe }}</a></p>
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/server/polar/subscription/email_templates/uncanceled.html
+++ b/server/polar/subscription/email_templates/uncanceled.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Your subscription is now uncanceled</h1>
+<p>Your subscription to <strong>{{ product.name }}</strong> is no longer canceled.</p>
+
+
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td align="center">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+                <tr>
+                    <td align="center">
+                        <a href="{{ url | safe }}" class="f-fallback button">Manage my subscription</a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<!-- Sub copy -->
+<table class="body-sub" role="presentation">
+    <tr>
+        <td>
+            <p class="f-fallback sub">If you're having trouble with the button above, copy and paste the URL below into your web browser:</p>
+            <p class="f-fallback sub"><a href="{{ url | safe }}">{{ url | safe }}</a></p>
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -162,7 +162,7 @@ async def update(
     auth_subject: auth.SubscriptionsWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> Subscription:
-    """Update a subscription of the authenticated customer or user."""
+    """Update a subscription."""
     subscription = await subscription_service.user_get(session, auth_subject, id)
     if subscription is None:
         raise ResourceNotFound()

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -952,18 +952,6 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
         if became_revoked:
             await self._on_subscription_revoked(session, subscription)
 
-        log.info(
-            "ON.UPDATE",
-            previous_status=previous_status,
-            previous_ends_at=previous_ends_at,
-            became_activated=became_activated,
-            ends_at=subscription.ends_at,
-            is_canceled=is_canceled,
-            updated_ends_at=updated_ends_at,
-            cancellation_changed=cancellation_changed,
-            became_revoked=became_revoked,
-        )
-
     async def _on_subscription_updated(
         self,
         session: AsyncSession,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -971,17 +971,7 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
             session, subscription, WebhookEventType.subscription_active
         )
 
-        # TODO: Copied this logic over. Why the extra check for customer
-        # confirmation vs. webhook/creator notification? Look into it, but avoid
-        # changing for now.
-        if (
-            subscription.started_at is not None
-            and subscription.started_at.date()
-            == subscription.current_period_start.date()
-            and not subscription.ends_at
-        ):
-            await self.send_confirmation_email(session, subscription)
-
+        await self.send_confirmation_email(session, subscription)
         await self._send_new_subscription_notification(session, subscription)
 
     async def _on_subscription_uncanceled(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -615,7 +615,8 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
 
         cancel = updates.cancel_at_period_end is True
         uncancel = updates.cancel_at_period_end is False
-        if not (updates.revoke or cancel or uncancel):
+        # Exit early unless we're asked to revoke, cancel or uncancel
+        if not any((updates.revoke, cancel, uncancel)):
             return subscription
 
         if updates.revoke and (cancel or uncancel):

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -872,16 +872,6 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
             # queue removal of grants
             await self.enqueue_benefits_grants(session, subscription)
 
-        # Trigger hooks since we update subscriptions directly upon cancellation
-        # Doing so upon Stripe webhooks would prevent us from truly
-        # knowing/identifying changes made, i.e cancellations.
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_ends_at=previous_ends_at,
-        )
-
         log.info(
             "subscription.canceled",
             id=subscription.id,
@@ -892,6 +882,16 @@ class SubscriptionService(ResourceServiceReader[Subscription]):
             reason=customer_reason,
         )
         session.add(subscription)
+
+        # Trigger hooks since we update subscriptions directly upon cancellation
+        # Doing so upon Stripe webhooks would prevent us from truly
+        # knowing/identifying changes made, i.e cancellations.
+        await self._after_subscription_updated(
+            session,
+            subscription,
+            previous_status=previous_status,
+            previous_ends_at=previous_ends_at,
+        )
         return subscription
 
     def update_cancellation_from_stripe(

--- a/server/tests/customer_portal/endpoints/test_subscription.py
+++ b/server/tests/customer_portal/endpoints/test_subscription.py
@@ -32,7 +32,6 @@ def stripe_service_mock(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_db_asserts
 class TestCustomerSubscriptionPriceUpdate:
     async def test_anonymous(
         self, client: AsyncClient, session: AsyncSession, subscription: Subscription
@@ -146,7 +145,6 @@ class TestCustomerSubscriptionPriceUpdate:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_db_asserts
 class TestCustomerSubscriptionUpdateCancel:
     async def test_anonymous(
         self,
@@ -237,7 +235,6 @@ class TestCustomerSubscriptionUpdateCancel:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_db_asserts
 class TestSubscriptionUpdateUncancel:
     async def test_anonymous(
         self,
@@ -342,7 +339,6 @@ class TestSubscriptionUpdateUncancel:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_db_asserts
 class TestCustomerSubscriptionCancel:
     async def test_anonymous(
         self,

--- a/server/tests/customer_portal/endpoints/test_subscription.py
+++ b/server/tests/customer_portal/endpoints/test_subscription.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,17 +6,11 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.integrations.stripe.service import StripeService
-from polar.models import (
-    Customer,
-    Organization,
-    Product,
-    ProductPriceFree,
-    Subscription,
-    UserOrganization,
-)
+from polar.models import Customer, Organization, Product, ProductPriceFree, Subscription
 from polar.models.product_price import ProductPriceType
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
+from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
@@ -39,44 +32,6 @@ def stripe_service_mock(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.mark.asyncio
-class TestListSubscriptions:
-    async def test_anonymous(
-        self, client: AsyncClient, organization: Organization
-    ) -> None:
-        response = await client.get("/v1/subscriptions/")
-
-        assert response.status_code == 401
-
-    @pytest.mark.auth
-    async def test_valid(
-        self,
-        save_fixture: SaveFixture,
-        client: AsyncClient,
-        user_organization: UserOrganization,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-            ended_at=datetime(2023, 6, 15),
-        )
-
-        response = await client.get("/v1/subscriptions/")
-
-        assert response.status_code == 200
-
-        json = response.json()
-        assert json["pagination"]["total_count"] == 1
-        for item in json["items"]:
-            assert "user" in item
-            assert "customer" in item
-            assert item["user"]["id"] == item["customer"]["id"]
-
-
-@pytest.mark.asyncio
 @pytest.mark.skip_db_asserts
 class TestCustomerSubscriptionPriceUpdate:
     async def test_anonymous(
@@ -84,115 +39,74 @@ class TestCustomerSubscriptionPriceUpdate:
     ) -> None:
         non_existing = uuid.uuid4()
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(product_price_id=str(non_existing)),
         )
         assert response.status_code == 401
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_non_existing_product(
-        self,
-        client: AsyncClient,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user_organization: UserOrganization,
-        product: Product,
-        customer: Customer,
+        self, client: AsyncClient, session: AsyncSession, subscription: Subscription
     ) -> None:
         non_existing = uuid.uuid4()
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(product_price_id=str(non_existing)),
         )
         assert response.status_code == 422
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_non_recurring_price(
         self,
         client: AsyncClient,
         session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
-        product: Product,
-        user_organization: UserOrganization,
-        customer: Customer,
+        subscription: Subscription,
     ) -> None:
         product = await create_product(save_fixture, organization=organization)
         price = await create_product_price_fixed(
             save_fixture, product=product, type=ProductPriceType.one_time
         )
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(product_price_id=str(price.id)),
         )
         assert response.status_code == 422
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_extraneous_tier(
         self,
         client: AsyncClient,
         subscription: Subscription,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user_organization: UserOrganization,
-        product: Product,
-        customer: Customer,
         product_organization_second: Product,
     ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
         price_id = product_organization_second.prices[0].id
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(product_price_id=str(price_id)),
         )
         assert response.status_code == 422
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_non_existing_stripe_subscription(
         self,
         client: AsyncClient,
+        subscription: Subscription,
         save_fixture: SaveFixture,
-        organization: Organization,
-        user_organization: UserOrganization,
-        product: Product,
-        customer: Customer,
         product_second: Product,
     ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
         price_id = product_second.prices[0].id
         subscription.stripe_subscription_id = None
         await save_fixture(subscription)
 
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(product_price_id=str(price_id)),
         )
         assert response.status_code == 400
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_valid(
         self,
         client: AsyncClient,
@@ -200,8 +114,6 @@ class TestCustomerSubscriptionPriceUpdate:
         save_fixture: SaveFixture,
         stripe_service_mock: MagicMock,
         customer: Customer,
-        organization: Organization,
-        user_organization: UserOrganization,
         product: Product,
         product_second: Product,
     ) -> None:
@@ -214,7 +126,7 @@ class TestCustomerSubscriptionPriceUpdate:
         new_price = product_second.prices[0]
         new_price_id = new_price.id
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(product_price_id=str(new_price_id)),
         )
         assert response.status_code == 200
@@ -234,13 +146,12 @@ class TestCustomerSubscriptionPriceUpdate:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
-class TestSubscriptionUpdateCancel:
+@pytest.mark.skip_db_asserts
+class TestCustomerSubscriptionUpdateCancel:
     async def test_anonymous(
         self,
-        save_fixture: SaveFixture,
         client: AsyncClient,
-        organization: Organization,
+        save_fixture: SaveFixture,
         product: Product,
         customer: Customer,
     ) -> None:
@@ -248,50 +159,41 @@ class TestSubscriptionUpdateCancel:
             save_fixture,
             product=product,
             customer=customer,
-            started_at=datetime(2023, 1, 1),
         )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
-                cancel_at_period_end=True,
-                customer_cancellation_reason="too_expensive",
-                customer_cancellation_comment="Inflation be crazy",
+                cancel_at_period_id=True,
             ),
         )
         assert response.status_code == 401
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_tampered(
         self,
-        save_fixture: SaveFixture,
         client: AsyncClient,
-        organization: Organization,
-        user_organization: UserOrganization,
-        product_organization_second: Product,
-        customer: Customer,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer_second: Customer,
     ) -> None:
         subscription = await create_active_subscription(
             save_fixture,
-            product=product_organization_second,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
+            product=product,
+            customer=customer_second,
         )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
-                cancel_at_period_end=True,
-                customer_cancellation_reason="too_expensive",
-                customer_cancellation_comment="Inflation be crazy",
+                cancel_at_period_id=True,
             ),
         )
         assert response.status_code == 404
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_valid(
         self,
-        save_fixture: SaveFixture,
         client: AsyncClient,
-        user_organization: UserOrganization,
+        save_fixture: SaveFixture,
         stripe_service_mock: MagicMock,
         product: Product,
         customer: Customer,
@@ -300,20 +202,19 @@ class TestSubscriptionUpdateCancel:
             save_fixture,
             product=product,
             customer=customer,
-            started_at=datetime(2023, 1, 1),
         )
 
-        reason = "too_expensive"
-        comment = "Inflation be crazy"
+        reason = "too_complex"
+        comment = "Too many settings"
 
         canceled = cloned_stripe_canceled_subscription(subscription)
         stripe_service_mock.cancel_subscription.return_value = canceled
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
                 cancel_at_period_end=True,
-                customer_cancellation_reason=reason,
-                customer_cancellation_comment=comment,
+                cancellation_reason=reason,
+                cancellation_comment=comment,
             ),
         )
         assert response.status_code == 200
@@ -326,16 +227,17 @@ class TestSubscriptionUpdateCancel:
 
         updated_subscription = response.json()
         current_period_end = updated_subscription["current_period_end"]
+        assert updated_subscription["id"] == str(subscription.id)
         assert updated_subscription["status"] == SubscriptionStatus.active
+        assert updated_subscription["ended_at"] is None
         assert updated_subscription["cancel_at_period_end"]
         assert updated_subscription["ends_at"] == current_period_end
-        assert updated_subscription["ended_at"] is None
         assert updated_subscription["customer_cancellation_reason"] == reason
         assert updated_subscription["customer_cancellation_comment"] == comment
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
+@pytest.mark.skip_db_asserts
 class TestSubscriptionUpdateUncancel:
     async def test_anonymous(
         self,
@@ -351,43 +253,40 @@ class TestSubscriptionUpdateUncancel:
             customer=customer,
         )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
                 cancel_at_period_end=False,
             ),
         )
         assert response.status_code == 401
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_tampered(
         self,
         save_fixture: SaveFixture,
         client: AsyncClient,
-        organization: Organization,
-        user_organization: UserOrganization,
         product_organization_second: Product,
         customer: Customer,
+        customer_second: Customer,
     ) -> None:
         subscription = await create_canceled_subscription(
             save_fixture,
             product=product_organization_second,
-            customer=customer,
+            customer=customer_second,
         )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
-                cancel_at_period_end=True,
+                cancel_at_period_end=False,
             ),
         )
         assert response.status_code == 404
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_uncancel_revoked(
         self,
         save_fixture: SaveFixture,
         client: AsyncClient,
-        organization: Organization,
-        user_organization: UserOrganization,
         product: Product,
         customer: Customer,
     ) -> None:
@@ -395,19 +294,18 @@ class TestSubscriptionUpdateUncancel:
             save_fixture, product=product, customer=customer, revoke=True
         )
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
                 cancel_at_period_end=False,
             ),
         )
         assert response.status_code == 410
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_valid(
         self,
         save_fixture: SaveFixture,
         client: AsyncClient,
-        user_organization: UserOrganization,
         stripe_service_mock: MagicMock,
         product: Product,
         customer: Customer,
@@ -425,7 +323,7 @@ class TestSubscriptionUpdateUncancel:
 
         stripe_service_mock.uncancel_subscription.return_value = uncanceled
         response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
                 cancel_at_period_end=False,
             ),
@@ -435,7 +333,6 @@ class TestSubscriptionUpdateUncancel:
             subscription.stripe_subscription_id,
         )
         updated_subscription = response.json()
-        current_period_end = updated_subscription["current_period_end"]
         assert updated_subscription["status"] == SubscriptionStatus.active
         assert updated_subscription["cancel_at_period_end"] is False
         assert updated_subscription["ends_at"] is None
@@ -445,13 +342,12 @@ class TestSubscriptionUpdateUncancel:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
-class TestSubscriptionUpdateRevoke:
+@pytest.mark.skip_db_asserts
+class TestCustomerSubscriptionCancel:
     async def test_anonymous(
         self,
-        save_fixture: SaveFixture,
         client: AsyncClient,
-        organization: Organization,
+        save_fixture: SaveFixture,
         product: Product,
         customer: Customer,
     ) -> None:
@@ -459,50 +355,37 @@ class TestSubscriptionUpdateRevoke:
             save_fixture,
             product=product,
             customer=customer,
-            started_at=datetime(2023, 1, 1),
         )
-        response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
-            json=dict(
-                revoke=True,
-                customer_cancellation_reason="too_expensive",
-                customer_cancellation_comment="Inflation be crazy",
-            ),
+
+        response = await client.delete(
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
         )
         assert response.status_code == 401
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_tampered(
         self,
-        save_fixture: SaveFixture,
         client: AsyncClient,
-        organization: Organization,
-        user_organization: UserOrganization,
-        product_organization_second: Product,
-        customer: Customer,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer_second: Customer,
     ) -> None:
         subscription = await create_active_subscription(
             save_fixture,
-            product=product_organization_second,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
+            product=product,
+            customer=customer_second,
         )
-        response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
-            json=dict(
-                revoke=True,
-                customer_cancellation_reason="too_expensive",
-                customer_cancellation_comment="Inflation be crazy",
-            ),
+
+        response = await client.delete(
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
         )
         assert response.status_code == 404
 
-    @pytest.mark.auth
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
     async def test_valid(
         self,
-        save_fixture: SaveFixture,
         client: AsyncClient,
-        user_organization: UserOrganization,
+        save_fixture: SaveFixture,
         stripe_service_mock: MagicMock,
         product: Product,
         customer: Customer,
@@ -511,106 +394,25 @@ class TestSubscriptionUpdateRevoke:
             save_fixture,
             product=product,
             customer=customer,
-            started_at=datetime(2023, 1, 1),
         )
 
-        reason = "too_expensive"
-        comment = "Inflation be crazy"
-
-        canceled = cloned_stripe_canceled_subscription(subscription, revoke=True)
-        stripe_service_mock.revoke_subscription.return_value = canceled
-        response = await client.patch(
-            f"/v1/subscriptions/{subscription.id}",
-            json=dict(
-                revoke=True,
-                customer_cancellation_reason=reason,
-                customer_cancellation_comment=comment,
-            ),
+        canceled = cloned_stripe_canceled_subscription(subscription)
+        stripe_service_mock.cancel_subscription.return_value = canceled
+        response = await client.delete(
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
         )
         assert response.status_code == 200
         assert stripe_service_mock.update_subscription_price.called is False
-        stripe_service_mock.revoke_subscription.assert_called_once_with(
-            subscription.stripe_subscription_id,
-            customer_reason=reason,
-            customer_comment=comment,
-        )
-
-        updated_subscription = response.json()
-        ended_at = updated_subscription["ended_at"]
-        assert ended_at
-        assert updated_subscription["status"] == SubscriptionStatus.canceled
-        assert updated_subscription["cancel_at_period_end"] is False
-        assert updated_subscription["ends_at"] == ended_at
-        assert updated_subscription["customer_cancellation_reason"] == reason
-        assert updated_subscription["customer_cancellation_comment"] == comment
-
-
-@pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
-class TestSubscriptionRevoke:
-    async def test_anonymous(
-        self,
-        save_fixture: SaveFixture,
-        client: AsyncClient,
-        organization: Organization,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
-        response = await client.delete(f"/v1/subscriptions/{subscription.id}")
-        assert response.status_code == 401
-
-    @pytest.mark.auth
-    async def test_tampered(
-        self,
-        save_fixture: SaveFixture,
-        client: AsyncClient,
-        organization: Organization,
-        user_organization: UserOrganization,
-        product_organization_second: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product_organization_second,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
-        response = await client.delete(f"/v1/subscriptions/{subscription.id}")
-        assert response.status_code == 404
-
-    @pytest.mark.auth
-    async def test_valid(
-        self,
-        save_fixture: SaveFixture,
-        client: AsyncClient,
-        user_organization: UserOrganization,
-        stripe_service_mock: MagicMock,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            started_at=datetime(2023, 1, 1),
-        )
-
-        canceled = cloned_stripe_canceled_subscription(subscription, revoke=True)
-        stripe_service_mock.revoke_subscription.return_value = canceled
-        response = await client.delete(f"/v1/subscriptions/{subscription.id}")
-        assert response.status_code == 200
-        assert stripe_service_mock.update_subscription_price.called is False
-        stripe_service_mock.revoke_subscription.assert_called_once_with(
+        stripe_service_mock.cancel_subscription.assert_called_once_with(
             subscription.stripe_subscription_id,
             customer_reason=None,
             customer_comment=None,
         )
 
         updated_subscription = response.json()
-        assert updated_subscription["status"] == SubscriptionStatus.canceled
+        current_period_end = updated_subscription["current_period_end"]
+        assert updated_subscription["id"] == str(subscription.id)
+        assert updated_subscription["status"] == SubscriptionStatus.active
+        assert updated_subscription["ended_at"] is None
+        assert updated_subscription["cancel_at_period_end"]
+        assert updated_subscription["ends_at"] == current_period_end

--- a/server/tests/fixtures/__init__.py
+++ b/server/tests/fixtures/__init__.py
@@ -9,6 +9,7 @@ from tests.fixtures.locker import *  # noqa: F401, F403
 from tests.fixtures.predictable_objects import *  # noqa: F401, F403
 from tests.fixtures.random_objects import *  # noqa: F401, F403
 from tests.fixtures.redis import *  # noqa: F401, F403
+from tests.fixtures.stripe import *  # noqa: F401, F403
 from tests.fixtures.webhook import *  # noqa: F401, F403
 from tests.fixtures.worker import *  # noqa: F401, F403
 

--- a/server/tests/fixtures/stripe.py
+++ b/server/tests/fixtures/stripe.py
@@ -1,0 +1,190 @@
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import stripe as stripe_lib
+
+from polar.models import (
+    Customer,
+    Discount,
+    Organization,
+    Subscription,
+)
+from polar.models.subscription import SubscriptionStatus
+
+
+def cloned_stripe_canceled_subscription(
+    subscription: Subscription,
+    revoke: bool = False,
+) -> stripe_lib.Subscription:
+    return cloned_stripe_subscription(
+        subscription,
+        revoke=revoke,
+        cancel_at_period_end=True,
+    )
+
+
+def cloned_stripe_subscription(
+    subscription: Subscription,
+    *,
+    customer: Customer | None = None,
+    price_id: str | None = None,
+    status: SubscriptionStatus | None = None,
+    cancel_at_period_end: bool | None = None,
+    revoke: bool = False,
+) -> stripe_lib.Subscription:
+    if price_id is None:
+        price_id = subscription.price.stripe_price_id
+
+    if cancel_at_period_end is None:
+        cancel_at_period_end = subscription.cancel_at_period_end
+
+    return construct_stripe_subscription(
+        customer=customer if customer else subscription.customer,
+        price_id=price_id,
+        status=status if status else subscription.status,
+        cancel_at_period_end=cancel_at_period_end,
+        revoke=revoke,
+    )
+
+
+def construct_stripe_subscription(
+    *,
+    customer: Customer | None = None,
+    organization: Organization | None = None,
+    price_id: str = "PRICE_ID",
+    status: SubscriptionStatus = SubscriptionStatus.incomplete,
+    latest_invoice: stripe_lib.Invoice | None = None,
+    cancel_at_period_end: bool = False,
+    metadata: dict[str, str] = {},
+    discount: Discount | None = None,
+    revoke: bool = False,
+) -> stripe_lib.Subscription:
+    now_timestamp = datetime.now(UTC).timestamp()
+    base_metadata: dict[str, str] = {
+        **(
+            {"organization_subscriber_id": str(organization.id)}
+            if organization is not None
+            else {}
+        ),
+    }
+
+    canceled_at = None
+    ended_at = None
+    if revoke:
+        ended_at = now_timestamp
+        canceled_at = now_timestamp
+        status = SubscriptionStatus.canceled
+        cancel_at_period_end = False
+    elif cancel_at_period_end:
+        canceled_at = now_timestamp
+
+    return stripe_lib.Subscription.construct_from(
+        {
+            "id": "SUBSCRIPTION_ID",
+            "customer": (
+                customer.stripe_customer_id if customer is not None else "CUSTOMER_ID"
+            ),
+            "status": status,
+            "items": {
+                "data": [
+                    {"price": {"id": price_id, "currency": "USD", "unit_amount": 1000}}
+                ]
+            },
+            "current_period_start": now_timestamp,
+            "current_period_end": now_timestamp + timedelta(days=30).seconds,
+            "cancel_at_period_end": cancel_at_period_end,
+            "canceled_at": canceled_at,
+            "ended_at": ended_at,
+            "latest_invoice": latest_invoice,
+            "metadata": {**base_metadata, **metadata},
+            "discount": (
+                {
+                    "coupon": {
+                        "id": discount.stripe_coupon_id,
+                        "metadata": {"discount_id": str(discount.id)},
+                    }
+                }
+                if discount is not None
+                else None
+            ),
+        },
+        None,
+    )
+
+
+def construct_stripe_customer(
+    *,
+    id: str = "CUSTOMER_ID",
+    email: str = "customer@example.com",
+    name: str | None = "Customer Name",
+) -> stripe_lib.Customer:
+    return stripe_lib.Customer.construct_from(
+        {
+            "id": id,
+            "email": email,
+            "name": name,
+            "address": {
+                "country": "FR",
+            },
+        },
+        None,
+    )
+
+
+def construct_stripe_invoice(
+    *,
+    id: str | None = "INVOICE_ID",
+    total: int = 12000,
+    tax: int = 2000,
+    amount_paid: int | None = None,
+    charge_id: str | None = "CHARGE_ID",
+    subscription_id: str | None = "SUBSCRIPTION_ID",
+    subscription_details: dict[str, Any] | None = None,
+    customer_id: str = "STRIPE_CUSTOMER_ID",
+    lines: list[tuple[str, bool, dict[str, str] | None]] = [("PRICE_ID", False, None)],
+    metadata: dict[str, str] = {},
+    billing_reason: str = "subscription_create",
+    customer_address: dict[str, Any] | None = {"country": "FR"},
+    paid_out_of_band: bool = False,
+    discount: Discount | None = None,
+    created: int | None = None,
+) -> stripe_lib.Invoice:
+    return stripe_lib.Invoice.construct_from(
+        {
+            "id": id,
+            "total": total,
+            "tax": tax,
+            "amount_paid": total if amount_paid is None else amount_paid,
+            "currency": "usd",
+            "charge": charge_id,
+            "subscription": subscription_id,
+            "subscription_details": subscription_details,
+            "customer": customer_id,
+            "customer_address": customer_address,
+            "lines": {
+                "data": [
+                    {
+                        "price": {"id": price_id, "metadata": metadata or {}},
+                        "proration": proration,
+                    }
+                    for price_id, proration, metadata in lines
+                ]
+            },
+            "metadata": metadata,
+            "billing_reason": billing_reason,
+            "paid_out_of_band": paid_out_of_band,
+            "discount": (
+                {
+                    "coupon": {
+                        "id": discount.stripe_coupon_id,
+                        "metadata": {"discount_id": str(discount.id)},
+                    }
+                }
+                if discount is not None
+                else None
+            ),
+            "created": created or int(time.time()),
+        },
+        None,
+    )

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, cast
@@ -46,63 +45,8 @@ from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.email import WatcherEmailRenderer, watch_email
 from tests.fixtures.random_objects import create_checkout, create_order
+from tests.fixtures.stripe import construct_stripe_invoice
 from tests.transaction.conftest import create_transaction
-
-
-def construct_stripe_invoice(
-    *,
-    id: str | None = "INVOICE_ID",
-    total: int = 12000,
-    tax: int = 2000,
-    amount_paid: int | None = None,
-    charge_id: str | None = "CHARGE_ID",
-    subscription_id: str | None = "SUBSCRIPTION_ID",
-    subscription_details: dict[str, Any] | None = None,
-    customer_id: str = "STRIPE_CUSTOMER_ID",
-    lines: list[tuple[str, bool, dict[str, str] | None]] = [("PRICE_ID", False, None)],
-    metadata: dict[str, str] = {},
-    billing_reason: str = "subscription_create",
-    customer_address: dict[str, Any] | None = {"country": "FR"},
-    paid_out_of_band: bool = False,
-    discount: Discount | None = None,
-    created: int | None = None,
-) -> stripe_lib.Invoice:
-    return stripe_lib.Invoice.construct_from(
-        {
-            "id": id,
-            "total": total,
-            "tax": tax,
-            "amount_paid": total if amount_paid is None else amount_paid,
-            "currency": "usd",
-            "charge": charge_id,
-            "subscription": subscription_id,
-            "subscription_details": subscription_details,
-            "customer": customer_id,
-            "customer_address": customer_address,
-            "lines": {
-                "data": [
-                    {
-                        "price": {"id": price_id, "metadata": metadata or {}},
-                        "proration": proration,
-                    }
-                    for price_id, proration, metadata in lines
-                ]
-            },
-            "metadata": metadata,
-            "billing_reason": billing_reason,
-            "paid_out_of_band": paid_out_of_band,
-            "discount": {
-                "coupon": {
-                    "id": discount.stripe_coupon_id,
-                    "metadata": {"discount_id": str(discount.id)},
-                }
-            }
-            if discount is not None
-            else None,
-            "created": created or int(time.time()),
-        },
-        None,
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -77,7 +77,6 @@ class TestListSubscriptions:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_db_asserts
 class TestCustomerSubscriptionPriceUpdate:
     async def test_anonymous(
         self, client: AsyncClient, session: AsyncSession, subscription: Subscription
@@ -234,7 +233,6 @@ class TestCustomerSubscriptionPriceUpdate:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
 class TestSubscriptionUpdateCancel:
     async def test_anonymous(
         self,
@@ -335,7 +333,6 @@ class TestSubscriptionUpdateCancel:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
 class TestSubscriptionUpdateUncancel:
     async def test_anonymous(
         self,
@@ -445,7 +442,6 @@ class TestSubscriptionUpdateUncancel:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
 class TestSubscriptionUpdateRevoke:
     async def test_anonymous(
         self,
@@ -546,7 +542,6 @@ class TestSubscriptionUpdateRevoke:
 
 
 @pytest.mark.asyncio
-@pytest.mark.http_auto_expunge
 class TestSubscriptionRevoke:
     async def test_anonymous(
         self,


### PR DESCRIPTION
Closes #4595

**Remaining (API)**
- [x] Tests for `DELETE /subscriptions/{id}`
- [x] Better documentation for `customer_reason` 
- [x] Fix reliance/usage of `cancel_at_period_end` now with `cancel_at`
- [x] Figure out a better `cancel_at` timestamp to avoid issues on slower networks...
- [x] Allow `DELETE /subscriptions` to set customer comment too
- [x] Tweak customer Cancellation notification email (subscription ending)
- [x] Send customer a Revoked notification email (fully cancelled)
- [x] Set `cancel_at_period_end` optimistically to keep API response up-to-date
- [x] Uncancel in subscription update

**Remaining (UI)**
- [x] Expose `cancellation_reason` & comment flag with the actual comment in details view
- [x] Better copy
- [x] Make it look beautiful 🤓


Follow-up enhancements
- [ ] Customer Portal: Ability to uncancel a subscription
- [ ] Dashboard: Ability to uncancel a subscription about to expire (`cancel_at_period_end`)
- [ ] API: Set proration setting on changing subscriptions
- [ ] Customer Portal: Prorate immediately upon annual subscription changes (better default)
- [ ] Dashboard: Admin controls to change subscription product & price with proration control
- [ ] Webhook & email: On subscription downgrade/upgrade
