### PR TITLE
clients: More prominent OTP border in light & dark mode

### DIFF
--- a/clients/apps/web/src/app/(main)/[organization]/portal/authenticate/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/authenticate/ClientPage.tsx
@@ -79,7 +79,7 @@ const ClientPage = ({ organization }: { organization: Organization }) => {
                             <InputOTPSlot
                               key={index}
                               index={index}
-                              className="h-16 w-16 text-2xl"
+                              className="h-16 w-16 text-2xl border-gray-300 dark:border-gray-600"
                             />
                           ))}
                         </InputOTPGroup>


### PR DESCRIPTION

<img width="901" alt="image" src="https://github.com/user-attachments/assets/02df05b5-513d-4b63-aa90-3d39db89ca24" />

<img width="802" alt="image" src="https://github.com/user-attachments/assets/4813c4c7-4aae-4316-a9e0-604e6bb75dd9" />
