### PR TITLE
docs: Do not require authentication to view documentation

### DIFF
--- a/clients/apps/web/src/middleware.ts
+++ b/clients/apps/web/src/middleware.ts
@@ -17,6 +17,13 @@ const AUTHENTICATED_ROUTES = [
 ]
 
 const requiresAuthentication = (request: NextRequest): boolean => {
+  if (
+    request.nextUrl.hostname === 'docs.polar.sh' ||
+    request.nextUrl.pathname.startsWith('/docs/')
+  ) {
+    return false
+  }
+
   return AUTHENTICATED_ROUTES.some((route) =>
     route.test(request.nextUrl.pathname),
   )


### PR DESCRIPTION
Closes #4637

This PR implements logic to ensure authentication is not required to view documentation.