### PR TITLE
Improve support for wallet methods in checkout embed and document procesure

### DIFF
--- a/clients/.changeset/slow-rabbits-change.md
+++ b/clients/.changeset/slow-rabbits-change.md
@@ -1,0 +1,5 @@
+---
+'@polar-sh/checkout': patch
+---
+
+Add permissions policy to the iframe for better compatibility with wallet payment methods

--- a/clients/apps/web/src/app/(main)/docs/(mdx)/checkout/page.mdx
+++ b/clients/apps/web/src/app/(main)/docs/(mdx)/checkout/page.mdx
@@ -111,6 +111,12 @@ const PurchaseLink = () => {
 export default PurchaseLink
 ```
 
+### Enabling Wallet Payment Methods (Apple Pay, Google Pay, etc.)
+
+By default, wallet payment methods such as Apple Pay and Google Pay are not enabled when embedding our checkout form into your website. For security reasons, your website domain needs to be manually validated.
+
+To enable wallet payment methods on your website, please [email us](mailto:support@polar.sh?subject=Enable%20Wallet%20Payment%20Methods&body=Please%20enable%20wallet%20payment%20methods%20for%20the%20following%20domain%3A%20%5Byour-domain.com%5D%0AOrganization%20Slug%3A%20%5Byour-organization-slug%5D%0A%0A) with your organization slug and the domain you wish to allow.
+
 ## API
 
 If you want to integrate more deeply the checkout process with your website or application, you can use our dedicated API.

--- a/clients/packages/checkout/src/embed.ts
+++ b/clients/packages/checkout/src/embed.ts
@@ -158,6 +158,8 @@ class EmbedCheckout {
     iframe.style.zIndex = '2147483647'
     iframe.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
     iframe.style.colorScheme = 'auto'
+    // @ts-ignore
+    iframe.allow = `payment 'self' ${__POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__.split(',').join(' ')}`
     document.body.appendChild(iframe)
 
     const embedCheckout = new EmbedCheckout(iframe, loader)


### PR DESCRIPTION
Fix #4600

After investigating, it looks like enabling Apple Pay in embed checkout requires two things:

1. Proper permissions policy on the iframe tag (and only the iframe, phew!). *Done*
2. Allowing the hosting domain on Stripe 👇

For now, I chose to go for a simple manual approach with a notice in the docs about how to do that (i.e. contact us and we'll do it manually). If it becomes a common request, it'll be fairly to offer a form to do that in the org settings (Stripe has an API for that).