### PR TITLE
clients: Don't filter countries in checkout by Stripe Connect

### DIFF
--- a/clients/apps/web/src/components/Accounts/AccountCreateModal.tsx
+++ b/clients/apps/web/src/components/Accounts/AccountCreateModal.tsx
@@ -178,7 +178,7 @@ const AccountCreateModal = ({
             )}
 
             <div>
-              <CountryPicker onChange={onChangeCountry} value={country} />
+              <CountryPicker onChange={onChangeCountry} value={country} stripeConnectOnly={true} />
               <p className="dark:text-polar-500 mt-2 text-justify text-xs text-gray-500">
                 If this is a personal account, please select your country of
                 residence. If this is an organization or business, select the

--- a/clients/apps/web/src/utils/config.ts
+++ b/clients/apps/web/src/utils/config.ts
@@ -15,7 +15,7 @@ const stringToNumber = (
  * document.querySelectorAll('.PressableContext').forEach((d) => { if (d.checked && d.name !== '') { whitelist.push(d.name) } })
  * whitelist.join(',')
  *
- * All countries supported by Stripe except Gibraltar (transfers not supported)
+ * All countries supported by Stripe Connect Express except Gibraltar (transfers not supported)
  *
  */
 const STRIPE_COUNTRIES =


### PR DESCRIPTION
Bug due to bad (legacy) naming of config variable `STRIPE_COUNTRIES`. It reflects countries supported and enabled by us in Stripe Connect Express (for payouts), but sounds like available countries for Stripe overall. So it was used as a filter in checkout too.

Will rename the config variable to avoid future confusion, but wanted to get a quick fix out without turbo/next modifications of env variables.

Now our `CountryPicker` lists all countries by default in the world and only filters by Stripe Connect countries in case `stripeConnectOnly` is set to `true`