### PR TITLE
dx: fix VS Code mypy configuration to dramatically speed up things

### DIFF
--- a/polar.code-workspace
+++ b/polar.code-workspace
@@ -17,5 +17,7 @@
 		// Set the Python interpreter globally, so VS Code stops complaining about invalid interpreter on other folders
 		// Also fix the Ruff extension
 		"python.defaultInterpreterPath": "${workspaceFolder:server}/.venv/bin/python",
+    // Use our own version of mypy, to avoid cache conflicts between the extension version and our own version
+		"mypy-type-checker.importStrategy": "fromEnvironment",
 	}
 }

--- a/server/.vscode/settings.json
+++ b/server/.vscode/settings.json
@@ -25,5 +25,6 @@
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "ruff.lint.args": ["--config=ruff.vscode.toml"]
+  "ruff.lint.args": ["--config=ruff.vscode.toml"],
+  "mypy-type-checker.preferDaemon": true
 }


### PR DESCRIPTION
That damned extension was implicitly using its builtin version instead of our own. The result? The two of them were constantly overriding the cache, so mypy was very often starting from cold!