### PR TITLE
#4466 Enrich /webhooks/deliveries endpoint to include webhook endpoint schema

### DIFF
--- a/server/polar/models/webhook_delivery.py
+++ b/server/polar/models/webhook_delivery.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models.base import RecordModel
 from polar.models.webhook_event import WebhookEvent
+from polar.models.webhook_endpoint import WebhookEndpoint
 
 
 class WebhookDelivery(RecordModel):
@@ -16,6 +17,10 @@ class WebhookDelivery(RecordModel):
         nullable=False,
         index=True,
     )
+
+    @declared_attr
+    def webhook_endpoint(cls) -> Mapped[WebhookEndpoint]:
+        return relationship("WebhookEndpoint", lazy="raise")
 
     webhook_event_id: Mapped[UUID] = mapped_column(
         Uuid,

--- a/server/polar/webhook/schemas.py
+++ b/server/polar/webhook/schemas.py
@@ -128,3 +128,6 @@ class WebhookDelivery(TimestampedSchema):
     webhook_event: WebhookEvent = Field(
         description="The webhook event sent by this delivery."
     )
+    webhook_endpoint: WebhookEndpoint = Field(
+        description="The webhook endpoint called by this delivery."
+    )

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -195,7 +195,10 @@ class WebhookService:
                     readable_endpoints_statement.with_only_columns(WebhookEndpoint.id)
                 ),
             )
-            .options(joinedload(WebhookDelivery.webhook_event))
+            .options(
+                contains_eager(WebhookDelivery.webhook_endpoint),
+                joinedload(WebhookDelivery.webhook_event),
+            )
             .order_by(desc(WebhookDelivery.created_at))
         )
 

--- a/server/tests/webhooks/test_endpoints.py
+++ b/server/tests/webhooks/test_endpoints.py
@@ -250,6 +250,12 @@ class TestListWebhookDeliveries:
         json = response.json()
         assert len(json["items"]) == 1
         assert json["items"][0]["id"] == str(webhook_delivery.id)
+        assert json["items"][0]["webhook_endpoint"]["id"] == str(
+            webhook_endpoint_organization.id
+        )
+        assert json["items"][0]["webhook_endpoint"]["url"] == str(
+            webhook_endpoint_organization.url
+        )
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="organization", scopes={Scope.webhooks_write})
@@ -266,3 +272,9 @@ class TestListWebhookDeliveries:
         json = response.json()
         assert len(json["items"]) == 1
         assert json["items"][0]["id"] == str(webhook_delivery.id)
+        assert json["items"][0]["webhook_endpoint"]["id"] == str(
+            webhook_endpoint_organization.id
+        )
+        assert json["items"][0]["webhook_endpoint"]["url"] == str(
+            webhook_endpoint_organization.url
+        )


### PR DESCRIPTION
[WIP]
Addresses #4466 

P.S.
I believe backend changes should be deployed first before deploying frontend ones, so there would be no downtime/errors window as a result of frontend updating first.