### PR TITLE
server/transaction: fix payout not working if refunded payments appear at the end

### DIFF
--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -445,6 +445,13 @@ class PayoutTransactionService(BaseTransactionService):
             )
         )
 
+        # Sort payment_balance_transactions by increasing transferable amount
+        # This way, if we have negative transferrable amount, they'll increase the outstanding amount
+        # and be compensated by the positive transferrable amounts coming after
+        payment_balance_transactions.sort(
+            key=lambda balance_transaction: balance_transaction.transferable_amount
+        )
+
         # Compute transfers out of each payment balance, making sure to subtract the outstanding amount
         transfers: list[tuple[str, int, Transaction]] = []
         for balance_transaction in payment_balance_transactions:


### PR DESCRIPTION
If a refunded payment appear last, or if it's big enough, we can't compensate its outstanding amount with subsequent transfers, leaving us with an outstanding amount.

To solve that, we simply sort the transactions by their transferrable amount, so the negative one appear first and can be compensated by the positive ones appearing after.