### PR TITLE
server/kit: use dedicated schema for metadata query parameter

### DIFF
--- a/server/polar/kit/metadata.py
+++ b/server/polar/kit/metadata.py
@@ -76,6 +76,29 @@ class MetadataOutputMixin(BaseModel):
     )
 
 
+def add_metadata_query_schema(openapi_schema: dict[str, Any]) -> dict[str, Any]:
+    openapi_schema["components"]["schemas"]["MetadataQuery"] = {
+        "anyOf": [
+            {
+                "type": "object",
+                "additionalProperties": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "boolean"},
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "array", "items": {"type": "integer"}},
+                        {"type": "array", "items": {"type": "boolean"}},
+                    ]
+                },
+            },
+            {"type": "null"},
+        ],
+        "title": "MetadataQuery",
+    }
+    return openapi_schema
+
+
 def get_metadata_query_openapi_schema() -> dict[str, Any]:
     return {
         "name": "metadata",
@@ -83,23 +106,7 @@ def get_metadata_query_openapi_schema() -> dict[str, Any]:
         "required": False,
         "style": "deepObject",
         "schema": {
-            "anyOf": [
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "anyOf": [
-                            {"type": "string"},
-                            {"type": "integer"},
-                            {"type": "boolean"},
-                            {"type": "array", "items": {"type": "string"}},
-                            {"type": "array", "items": {"type": "integer"}},
-                            {"type": "array", "items": {"type": "boolean"}},
-                        ]
-                    },
-                },
-                {"type": "null"},
-            ],
-            "title": "Metadata",
+            "$ref": "#/components/schemas/MetadataQuery",
         },
         "description": (
             "Filter by metadata key-value pairs. "

--- a/server/polar/openapi.py
+++ b/server/polar/openapi.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
 from polar.config import Environment, settings
+from polar.kit.metadata import add_metadata_query_schema
 
 
 class OpenAPIExternalDoc(TypedDict):
@@ -127,6 +128,9 @@ def set_openapi_generator(app: FastAPI) -> None:
             servers=app.servers,
             separate_input_output_schemas=app.separate_input_output_schemas,
         )
+
+        openapi_schema = add_metadata_query_schema(openapi_schema)
+
         return openapi_schema
 
     app.openapi = _openapi_generator  # type: ignore[method-assign]


### PR DESCRIPTION
Plays better with Speakeasy + will ease things when we add it to other endpoints