### PR TITLE
server/checkout: set payment_processor_metadata type to be dict[str, str] in output schema

### DIFF
--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -342,7 +342,7 @@ class CheckoutBase(CustomFieldDataOutputMixin, IDSchema, TimestampedSchema):
         validation_alias=AliasChoices("customer_tax_id_number", "customer_tax_id")
     )
 
-    payment_processor_metadata: dict[str, Any]
+    payment_processor_metadata: dict[str, str]
 
 
 class CheckoutProduct(ProductBase):


### PR DESCRIPTION
Allows Speakeasy to correctly type it and not removing its content while parsing