### PR TITLE
server/checkout: set customer_email and customer_name as plain `str` in output schema

### DIFF
--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -334,8 +334,8 @@ class CheckoutBase(CustomFieldDataOutputMixin, IDSchema, TimestampedSchema):
     )
 
     customer_id: UUID4 | None
-    customer_name: CustomerName | None
-    customer_email: CustomerEmail | None
+    customer_name: str | None = Field(description="Name of the customer.")
+    customer_email: str | None = Field(description="Email address of the customer.")
     customer_ip_address: CustomerIPAddress | None
     customer_billing_address: CustomerBillingAddress | None
     customer_tax_id: str | None = Field(


### PR DESCRIPTION
The risk of keeping the validated type is that, for any reason, our validation constraints change, we break outputting past data that have been properly validated before that.

The good practice is then to avoid any validation when outputting data and trust what we have in DB.

Fix #4890