### PR TITLE
server/custom_field: allow `None` value in custom_field_data output schema

### DIFF
--- a/server/polar/custom_field/data.py
+++ b/server/polar/custom_field/data.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
 
 
 class CustomFieldDataMixin:
-    custom_field_data: Mapped[dict[str, str | int | bool | datetime.datetime]] = (
-        mapped_column(JSONB, nullable=False, default=dict)
-    )
+    custom_field_data: Mapped[
+        dict[str, str | int | bool | datetime.datetime | None]
+    ] = mapped_column(JSONB, nullable=False, default=dict)
 
     # Make the type checker happy, but we should make sure actual models
     # declare an organization attribute by themselves.


### PR DESCRIPTION
Fix #4899