### PR TITLE
clients/web: fix auth modal width on medium screens

### DIFF
--- a/clients/apps/web/src/components/Auth/GetStartedButton.tsx
+++ b/clients/apps/web/src/components/Auth/GetStartedButton.tsx
@@ -83,7 +83,7 @@ const GetStartedButton: React.FC<GetStartedButtonProps> = ({
             }}
           />
         }
-        className="lg:w-full lg:max-w-[480px]"
+        className="max-w-[480px]"
       />
     </>
   )

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -52,7 +52,7 @@ const LandingPageTopbar = () => {
         isShown={isModalShown}
         hide={hideModal}
         modalContent={<AuthModal />}
-        className="lg:w-full lg:max-w-[480px]"
+        className="max-w-[480px]"
       />
     </div>
   )

--- a/clients/apps/web/src/components/Layout/Public/TopbarRight.tsx
+++ b/clients/apps/web/src/components/Layout/Public/TopbarRight.tsx
@@ -57,7 +57,7 @@ const TopbarRight = ({
             isShown={isModalShown}
             hide={hideModal}
             modalContent={<AuthModal returnTo={loginReturnTo} />}
-            className="lg:w-full lg:max-w-[480px]"
+            className="max-w-[480px]"
           />
         </>
       )}


### PR DESCRIPTION
Fixing the size of auth modal on iPads, medium screens.

## Before
![image](https://github.com/user-attachments/assets/fa4a8bdc-5130-4397-9d3c-fea2c22d9f86)

## After
![image](https://github.com/user-attachments/assets/f6e0eeee-6900-4c26-ad02-78dfeff23978)
