### PR TITLE
server/checkout: validate required custom fields only at confirmation, not create/update

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -370,7 +370,9 @@ class CheckoutService(ResourceServiceReader[Checkout]):
             currency = None
 
         custom_field_data = validate_custom_field_data(
-            product.attached_custom_fields, checkout_create.custom_field_data
+            product.attached_custom_fields,
+            checkout_create.custom_field_data,
+            validate_required=False,
         )
 
         checkout = Checkout(
@@ -1413,7 +1415,7 @@ class CheckoutService(ResourceServiceReader[Checkout]):
         self,
         session: AsyncSession,
         checkout: Checkout,
-        checkout_update: CheckoutUpdate | CheckoutUpdatePublic,
+        checkout_update: CheckoutUpdate | CheckoutUpdatePublic | CheckoutConfirm,
         ip_geolocation_client: ip_geolocation.IPGeolocationClient | None = None,
     ) -> Checkout:
         if checkout.status != CheckoutStatus.open:
@@ -1582,6 +1584,7 @@ class CheckoutService(ResourceServiceReader[Checkout]):
             custom_field_data = validate_custom_field_data(
                 checkout.product.attached_custom_fields,
                 checkout_update.custom_field_data,
+                validate_required=isinstance(checkout_update, CheckoutConfirm),
             )
             checkout.custom_field_data = custom_field_data
 

--- a/server/polar/custom_field/data.py
+++ b/server/polar/custom_field/data.py
@@ -74,9 +74,13 @@ def validate_custom_field_data(
     data: dict[str, Any],
     *,
     error_loc_prefix: Sequence[str] = ("body", "custom_field_data"),
+    validate_required: bool = True,
 ) -> dict[str, Any]:
     schema = build_custom_field_data_schema(
-        [(f.custom_field, f.required) for f in attached_custom_fields]
+        [
+            (f.custom_field, validate_required and f.required)
+            for f in attached_custom_fields
+        ]
     )
     try:
         return schema.model_validate(data).model_dump(mode="json")


### PR DESCRIPTION
Fix #4993