### PR TITLE
clients/packages/checkout: add React 19 as a peer dependency

### DIFF
--- a/clients/.changeset/calm-pianos-allow.md
+++ b/clients/.changeset/calm-pianos-allow.md
@@ -1,0 +1,5 @@
+---
+'@polar-sh/checkout': patch
+---
+
+Allow React 19 as a peer dependency

--- a/clients/packages/checkout/package.json
+++ b/clients/packages/checkout/package.json
@@ -50,6 +50,6 @@
   "peerDependencies": {
     "@stripe/react-stripe-js": "^3.1.1",
     "@stripe/stripe-js": "^5.6.0",
-    "react": "^18"
+    "react": "^18 || ^19"
   }
 }


### PR DESCRIPTION

Fix #5097