### PR TITLE
clients/packages/ui: fix double scrollbar

### DIFF
--- a/clients/packages/ui/src/components/ui/sidebar.tsx
+++ b/clients/packages/ui/src/components/ui/sidebar.tsx
@@ -141,7 +141,7 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper flex min-h-svh lg:overflow-clip w-full has-[[data-variant=inset]]:bg-sidebar",
               className
             )}
             ref={ref}


### PR DESCRIPTION
Fixes double scrollbars. The outer scrollbar is unnecessary. Currently it always overflows by `.5rem` (caused by padding-top of the child). As best as I can tell there's never a reason to overflow the outermost wrapper, so fixed via clipping.

<img width="1131" alt="Screenshot 2025-03-06 at 13 46 51-2" src="https://github.com/user-attachments/assets/29478d30-5d5a-43bd-bfb1-6c116bc6eb93" />

