### PR TITLE
server: Increase license key activation limit

### DIFF
--- a/server/polar/benefit/schemas.py
+++ b/server/polar/benefit/schemas.py
@@ -235,7 +235,7 @@ class BenefitLicenseKeyExpirationProperties(Schema):
 
 
 class BenefitLicenseKeyActivationProperties(Schema):
-    limit: int = Field(gt=0, le=50)
+    limit: int = Field(gt=0, le=1000)
     enable_customer_admin: bool
 
 

--- a/server/polar/license_key/schemas.py
+++ b/server/polar/license_key/schemas.py
@@ -142,7 +142,7 @@ class LicenseKeyActivationRead(LicenseKeyActivationBase):
 class LicenseKeyUpdate(Schema):
     status: LicenseKeyStatus | None = None
     usage: int = 0
-    limit_activations: int | None = Field(gt=0, le=50, default=None)
+    limit_activations: int | None = Field(gt=0, le=1000, default=None)
     limit_usage: int | None = Field(gt=0, default=None)
     expires_at: datetime | None = None
 


### PR DESCRIPTION
Fixes #5124 

Our previous limit of `50` was a bit arbitrary and set from the POV of
it being devices, e.g iTunes limitations of 5 Apple devices.

However, a customer has a use case where hundreds make sense so
increasing this to `1000`.

Only problem is that our customer portal does not paginate this
resource, but the liklihood of that being used here is low. Better done
than perfect for now.