### PR TITLE
server: Remove `[Polar]` prefix in email

### DIFF
--- a/server/polar/notifications/tasks/email.py
+++ b/server/polar/notifications/tasks/email.py
@@ -48,6 +48,6 @@ async def notifications_send(
 
             enqueue_email(
                 to_email_addr=user.email,
-                subject=f"[Polar] {subject}",
+                subject=subject,
                 html_content=body,
             )


### PR DESCRIPTION
Fixes #5196 

Unnecessary & duplicate information was the sender name is `Polar`
