### PR TITLE
clients: Clarify PWYW price input

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -84,7 +84,7 @@ export const ProductPriceCustomItem: React.FC<ProductPriceCustomItemProps> = ({
   const { control, register, setValue } = useFormContext<ProductFormType>()
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex w-40 flex-col gap-4">
       <input type="hidden" {...register(`prices.${index}.id`)} />
       <input type="hidden" {...register(`prices.${index}.amount_type`)} />
       <FormField


### PR DESCRIPTION
Received great feedback that putting the minimum and suggested amounts
next to each other made it appear as a `max-min` range input. But by
placing them vertically, the brain resets after the minimum and better
picks up that the next field is different, i.e suggested amount vs.
maximum.
