### PR TITLE
Use unique id for subrow

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
@@ -222,7 +222,7 @@ const DeliveriesTable: React.FC<DeliveriesTableProps> = ({
             if (row.isSubRow) {
               return undefined
             }
-            return [{ ...row, isSubRow: true }]
+            return [{ ...row, isSubRow: true, id: `${row.id}_subrow` }]
           }}
           isLoading={deliveriesHook}
         />


### PR DESCRIPTION
When a subrow is opened on a data table, we have to set its own unique id, otherwise the subrow will have the same id as its parent which will cause issues, see [this](https://github.com/polarsource/polar/issues/5205) and [this](https://github.com/polarsource/polar/issues/5060) issue.