### PR TITLE
server/meter: fix count aggregation computation when no event

### DIFF
--- a/server/polar/meter/aggregation.py
+++ b/server/polar/meter/aggregation.py
@@ -18,7 +18,7 @@ class CountAggregation(BaseModel):
     func: Literal[AggregationFunction.cnt] = AggregationFunction.cnt
 
     def get_sql_column(self, model: type[Any]) -> Any:
-        return func.count()
+        return func.count(model.id)
 
     def get_sql_clause(self, model: type[Any]) -> ColumnExpressionArgument[bool]:
         return true()


### PR DESCRIPTION
- server/meter: fix count aggregation computation when no event