### PR TITLE
fix: dashboard sidebar header

### DIFF
--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -47,7 +47,8 @@ export const DashboardSidebar = () => {
     <Sidebar variant="inset" collapsible="icon">
       <SidebarHeader
         className={twMerge(
-          'flex md:pt-3.5',
+          'flex',
+          CONFIG.IS_SANDBOX ? 'md:pt-10' : 'md:pt-3.5',
           isCollapsed
             ? 'flex-row items-center justify-between gap-y-4 md:flex-col md:items-start md:justify-start'
             : 'flex-row items-center justify-between',


### PR DESCRIPTION
In this PR, fixed the display of the sandbox banner on dashboard

## Before:
<img width="1470" alt="Screenshot 2025-03-17 at 10 55 04 PM" src="https://github.com/user-attachments/assets/b5a55644-7c80-4c13-aca4-cc504ac8f414" />

## After:
<img width="1470" alt="Screenshot 2025-03-17 at 10 55 21 PM" src="https://github.com/user-attachments/assets/d878d333-f095-4a12-b60f-bd11746ef964" />
