### PR TITLE
Default button-type to 'button'

### DIFF
--- a/clients/packages/ui/src/components/atoms/Button.tsx
+++ b/clients/packages/ui/src/components/atoms/Button.tsx
@@ -54,6 +54,7 @@ const Button = React.forwardRef<
       fullWidth,
       disabled,
       children,
+      type = 'button',
       ...props
     },
     ref,
@@ -66,6 +67,7 @@ const Button = React.forwardRef<
         )}
         ref={ref}
         disabled={disabled || loading}
+        type={type}
         {...props}
       >
         {loading ? (


### PR DESCRIPTION
Avoid cases where Cancellation-button are nested in Forms, and accidentally submits forms.