### PR TITLE
fix: show 0 in average order value when no order is placed

### DIFF
--- a/clients/apps/web/src/utils/metrics.ts
+++ b/clients/apps/web/src/utils/metrics.ts
@@ -316,7 +316,7 @@ export const computeCumulativeValue = (
       const nonZeroValues = values.filter((value) => value !== 0)
       return (
         nonZeroValues.reduce((acc, value) => acc + value, 0) /
-        nonZeroValues.length
+        (nonZeroValues.length || 1)
       )
     case 'lastValue':
       return values[values.length - 1]


### PR DESCRIPTION
Before with with an account that has just been created (show $NaN in average order value):
![image](https://github.com/user-attachments/assets/e5f9b6e8-44d7-4d95-bbd5-529f5b60195f)
After:
![image](https://github.com/user-attachments/assets/efca55e9-cee6-41ae-b17c-079e21f2b6b0)

This prevents division by zero, which returns NaN.