### PR TITLE
docs: add oder.paid and oder.updated webhooks to overview

### DIFF
--- a/docs/integrate/webhooks/events.mdx
+++ b/docs/integrate/webhooks/events.mdx
@@ -134,6 +134,18 @@ In order to properly implement logic for handling subscriptions, you should look
   horizontal
 ></Card>
 <Card
+  title="order.paid"
+  icon="link"
+  href="/api-reference/webhooks/order.paid"
+  horizontal
+></Card>
+<Card
+  title="order.updated"
+  icon="link"
+  href="/api-reference/webhooks/order.updated"
+  horizontal
+></Card>
+<Card
   title="order.refunded"
   icon="link"
   href="/api-reference/webhooks/order.refunded"


### PR DESCRIPTION
Just saw the [new order webhooks](https://github.com/polarsource/polar/commit/1572eaa21edf354e5bcd24df735d258d3aecfd2c) are not on the overview page