### PR TITLE
server/benefits: use compute backoff function on benefit logic to avoid thundering herd problem

### DIFF
--- a/server/polar/benefit/benefits/discord.py
+++ b/server/polar/benefit/benefits/discord.py
@@ -14,6 +14,7 @@ from polar.models import Customer, Organization, User
 from polar.models.benefit import BenefitDiscord, BenefitDiscordProperties
 from polar.models.benefit_grant import BenefitGrantDiscordProperties
 from polar.models.customer import CustomerOAuthAccount, CustomerOAuthPlatform
+from polar.worker import compute_backoff
 
 from .base import (
     BenefitActionRequiredError,
@@ -77,7 +78,7 @@ class BenefitDiscordService(
                     status_code=e.response.status_code, body=e.response.text
                 )
             error_bound_logger.warning("HTTP error while adding member")
-            raise BenefitRetriableError(5 * 2**attempt) from e
+            raise BenefitRetriableError(compute_backoff(attempt)) from e
 
         bound_logger.debug("Benefit granted")
 
@@ -117,7 +118,7 @@ class BenefitDiscordService(
                     status_code=e.response.status_code, body=e.response.text
                 )
             error_bound_logger.warning("HTTP error while removing member")
-            raise BenefitRetriableError(5 * 2**attempt) from e
+            raise BenefitRetriableError(compute_backoff(attempt)) from e
 
         bound_logger.debug("Benefit revoked")
 

--- a/server/polar/benefit/benefits/github_repository.py
+++ b/server/polar/benefit/benefits/github_repository.py
@@ -19,6 +19,7 @@ from polar.models.benefit import (
 from polar.models.benefit_grant import BenefitGrantGitHubRepositoryProperties
 from polar.models.customer import CustomerOAuthPlatform
 from polar.posthog import posthog
+from polar.worker import compute_backoff
 
 from .base import (
     BenefitActionRequiredError,
@@ -103,7 +104,7 @@ class BenefitGitHubRepositoryService(
         except RateLimitExceeded as e:
             raise BenefitRetriableError(int(e.retry_after.total_seconds())) from e
         except (RequestTimeout, RequestError) as e:
-            raise BenefitRetriableError(2**attempt) from e
+            raise BenefitRetriableError(compute_backoff(attempt)) from e
 
         bound_logger.debug("Benefit granted")
 
@@ -169,7 +170,7 @@ class BenefitGitHubRepositoryService(
         except RateLimitExceeded as e:
             raise BenefitRetriableError(int(e.retry_after.total_seconds())) from e
         except (RequestTimeout, RequestError) as e:
-            raise BenefitRetriableError(2**attempt) from e
+            raise BenefitRetriableError(compute_backoff(attempt)) from e
 
         bound_logger.debug("Benefit revoked")
 


### PR DESCRIPTION
- server/benefits: use compute backoff function on benefit logic to avoid thundering herd problem