### PR TITLE
clients/web: fix typing following schema updates

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -193,7 +193,7 @@ export const ProductPricingSection = ({
   )
   const [legacyMigration, setLegacyMigration] = useState(false)
 
-  const [amountType, setAmountType] = useState<'fixed' | 'custom' | 'free'>(
+  const [amountType, setAmountType] = useState(
     prices.length > 0 && (prices as schemas['ProductPrice'][])[0].amount_type
       ? (prices as schemas['ProductPrice'][])[0].amount_type
       : 'fixed',

--- a/clients/apps/web/src/utils/account.ts
+++ b/clients/apps/web/src/utils/account.ts
@@ -19,6 +19,7 @@ export const ACCOUNT_STATUS_DISPLAY_NAMES: Record<schemas['Status'], string> = {
   onboarding_started: 'Onboarding incomplete',
   under_review: 'Under review',
   active: 'Active',
+  denied: 'Denied',
 }
 
 export const ACCOUNT_TYPE_ICON: Record<schemas['AccountType'], React.FC> = {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6002,25 +6002,30 @@ export interface components {
             /** Amount */
             amount: number | null;
             /**
+             * Discount Amount
+             * @description Discount amount in cents.
+             */
+            discount_amount: number | null;
+            /**
+             * Net Amount
+             * @description Amount in cents, after discounts but before taxes.
+             */
+            net_amount: number | null;
+            /**
              * Tax Amount
-             * @description Computed tax amount to pay in cents.
+             * @description Sales tax amount in cents.
              */
             tax_amount: number | null;
+            /**
+             * Total Amount
+             * @description Amount in cents, after discounts and taxes.
+             */
+            total_amount: number | null;
             /**
              * Currency
              * @description Currency code of the checkout session.
              */
             currency: string | null;
-            /**
-             * Subtotal Amount
-             * @description Subtotal amount in cents, including discounts and before tax.
-             */
-            subtotal_amount: number | null;
-            /**
-             * Total Amount
-             * @description Total amount to pay in cents, including discounts and after tax.
-             */
-            total_amount: number | null;
             /**
              * Product Id
              * Format: uuid4
@@ -6089,6 +6094,11 @@ export interface components {
             payment_processor_metadata: {
                 [key: string]: string;
             };
+            /**
+             * Subtotal Amount
+             * @deprecated
+             */
+            subtotal_amount: number | null;
             /** Metadata */
             metadata: {
                 [key: string]: string | number | boolean;
@@ -6602,10 +6612,22 @@ export interface components {
          * @description Schema to update an existing checkout link.
          */
         CheckoutLinkUpdate: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /**
              * Products
              * @description List of products that will be available to select at checkout.
@@ -7064,25 +7086,30 @@ export interface components {
             /** Amount */
             amount: number | null;
             /**
+             * Discount Amount
+             * @description Discount amount in cents.
+             */
+            discount_amount: number | null;
+            /**
+             * Net Amount
+             * @description Amount in cents, after discounts but before taxes.
+             */
+            net_amount: number | null;
+            /**
              * Tax Amount
-             * @description Computed tax amount to pay in cents.
+             * @description Sales tax amount in cents.
              */
             tax_amount: number | null;
+            /**
+             * Total Amount
+             * @description Amount in cents, after discounts and taxes.
+             */
+            total_amount: number | null;
             /**
              * Currency
              * @description Currency code of the checkout session.
              */
             currency: string | null;
-            /**
-             * Subtotal Amount
-             * @description Subtotal amount in cents, including discounts and before tax.
-             */
-            subtotal_amount: number | null;
-            /**
-             * Total Amount
-             * @description Total amount to pay in cents, including discounts and after tax.
-             */
-            total_amount: number | null;
             /**
              * Product Id
              * Format: uuid4
@@ -7151,6 +7178,11 @@ export interface components {
             payment_processor_metadata: {
                 [key: string]: string;
             };
+            /**
+             * Subtotal Amount
+             * @deprecated
+             */
+            subtotal_amount: number | null;
             /**
              * Products
              * @description List of products available to select.
@@ -7237,25 +7269,30 @@ export interface components {
             /** Amount */
             amount: number | null;
             /**
+             * Discount Amount
+             * @description Discount amount in cents.
+             */
+            discount_amount: number | null;
+            /**
+             * Net Amount
+             * @description Amount in cents, after discounts but before taxes.
+             */
+            net_amount: number | null;
+            /**
              * Tax Amount
-             * @description Computed tax amount to pay in cents.
+             * @description Sales tax amount in cents.
              */
             tax_amount: number | null;
+            /**
+             * Total Amount
+             * @description Amount in cents, after discounts and taxes.
+             */
+            total_amount: number | null;
             /**
              * Currency
              * @description Currency code of the checkout session.
              */
             currency: string | null;
-            /**
-             * Subtotal Amount
-             * @description Subtotal amount in cents, including discounts and before tax.
-             */
-            subtotal_amount: number | null;
-            /**
-             * Total Amount
-             * @description Total amount to pay in cents, including discounts and after tax.
-             */
-            total_amount: number | null;
             /**
              * Product Id
              * Format: uuid4
@@ -7325,6 +7362,11 @@ export interface components {
                 [key: string]: string;
             };
             /**
+             * Subtotal Amount
+             * @deprecated
+             */
+            subtotal_amount: number | null;
+            /**
              * Products
              * @description List of products available to select.
              */
@@ -7365,7 +7407,7 @@ export interface components {
              */
             custom_field_data?: {
                 [key: string]: string | number | boolean | null;
-            } | null;
+            };
             /**
              * Product Id
              * @description ID of the product to checkout. Must be present in the checkout's product list.
@@ -7386,10 +7428,22 @@ export interface components {
             customer_billing_address?: components["schemas"]["Address"] | null;
             /** Customer Tax Id */
             customer_tax_id?: string | null;
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /**
              * Discount Id
              * @description ID of the discount to apply to the checkout.
@@ -7440,7 +7494,7 @@ export interface components {
              */
             custom_field_data?: {
                 [key: string]: string | number | boolean | null;
-            } | null;
+            };
             /**
              * Product Id
              * @description ID of the product to checkout. Must be present in the checkout's product list.
@@ -8048,10 +8102,22 @@ export interface components {
          * @description Schema to update a custom field of type checkbox.
          */
         CustomFieldUpdateCheckbox: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /** Slug */
@@ -8068,10 +8134,22 @@ export interface components {
          * @description Schema to update a custom field of type date.
          */
         CustomFieldUpdateDate: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /** Slug */
@@ -8088,10 +8166,22 @@ export interface components {
          * @description Schema to update a custom field of type number.
          */
         CustomFieldUpdateNumber: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /** Slug */
@@ -8108,10 +8198,22 @@ export interface components {
          * @description Schema to update a custom field of type select.
          */
         CustomFieldUpdateSelect: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /** Slug */
@@ -8128,10 +8230,22 @@ export interface components {
          * @description Schema to update a custom field of type text.
          */
         CustomFieldUpdateText: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /** Slug */
@@ -9496,10 +9610,22 @@ export interface components {
         };
         /** CustomerUpdate */
         CustomerUpdate: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /**
              * External Id
              * @description The ID of the customer in your system. This must be unique within the organization. Once set, it can't be updated.
@@ -10452,10 +10578,22 @@ export interface components {
          * @description Schema to update a discount.
          */
         DiscountUpdate: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /** Code */
@@ -12333,10 +12471,22 @@ export interface components {
         MeterSortProperty: "created_at" | "-created_at" | "name" | "-name";
         /** MeterUpdate */
         MeterUpdate: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /**
              * Name
              * @description The name of the meter. Will be shown on customer's invoices and usage.
@@ -14261,7 +14411,7 @@ export interface components {
             /** Public Url */
             readonly public_url: string;
         };
-        ProductPrice: components["schemas"]["ProductPriceFixed"] | components["schemas"]["ProductPriceCustom"] | components["schemas"]["ProductPriceFree"];
+        ProductPrice: components["schemas"]["ProductPriceFixed"] | components["schemas"]["ProductPriceCustom"] | components["schemas"]["ProductPriceFree"] | components["schemas"]["ProductPriceMeteredUnit"];
         /**
          * ProductPriceCustom
          * @description A pay-what-you-want price for a product.
@@ -14487,6 +14637,94 @@ export interface components {
             amount_type: "free";
         };
         /**
+         * ProductPriceMeter
+         * @description A meter associated to a metered price.
+         */
+        ProductPriceMeter: {
+            /**
+             * Id
+             * Format: uuid4
+             * @description The ID of the object.
+             */
+            id: string;
+            /**
+             * Name
+             * @description The name of the meter.
+             */
+            name: string;
+        };
+        /**
+         * ProductPriceMeteredUnit
+         * @description A metered, usage-based, price for a product, with a fixed unit price.
+         */
+        ProductPriceMeteredUnit: {
+            /**
+             * Created At
+             * Format: date-time
+             * @description Creation timestamp of the object.
+             */
+            created_at: string;
+            /**
+             * Modified At
+             * @description Last modification timestamp of the object.
+             */
+            modified_at: string | null;
+            /**
+             * Id
+             * Format: uuid4
+             * @description The ID of the price.
+             */
+            id: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            amount_type: "metered_unit";
+            /**
+             * Is Archived
+             * @description Whether the price is archived and no longer available.
+             */
+            is_archived: boolean;
+            /**
+             * Product Id
+             * Format: uuid4
+             * @description The ID of the product owning the price.
+             */
+            product_id: string;
+            /** @deprecated */
+            type: components["schemas"]["ProductPriceType"];
+            /** @deprecated */
+            recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
+            /**
+             * Price Currency
+             * @description The currency.
+             */
+            price_currency: string;
+            /**
+             * Unit Amount
+             * @description The price per unit in cents.
+             */
+            unit_amount: number;
+            /**
+             * Included Units
+             * @description The number of units included in the price. They will be deducted from the total.
+             */
+            included_units: number;
+            /**
+             * Cap Amount
+             * @description The maximum amount in cents that can be charged, regardless of the number of units consumed.
+             */
+            cap_amount: number | null;
+            /**
+             * Meter Id
+             * Format: uuid4
+             * @description The ID of the meter associated to the price.
+             */
+            meter_id: string;
+            /** @description The meter associated to the price. */
+            meter: components["schemas"]["ProductPriceMeter"];
+        };
+        /**
          * ProductPriceType
          * @enum {string}
          */
@@ -14567,10 +14805,22 @@ export interface components {
          * @description Schema to update a product.
          */
         ProductUpdate: {
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Key-value object allowing you to store additional information.
+             *
+             *     The key must be a string with a maximum length of **40 characters**.
+             *     The value must be either:
+             *
+             *     * A string with a maximum length of **500 characters**
+             *     * An integer
+             *     * A boolean
+             *
+             *     You can store up to **50 key-value pairs**.
+             */
             metadata?: {
                 [key: string]: string | number | boolean;
-            } | null;
+            };
             /** Name */
             name?: string | null;
             /**
@@ -15059,7 +15309,7 @@ export interface components {
          * Status
          * @enum {string}
          */
-        Status: "created" | "onboarding_started" | "under_review" | "active";
+        Status: "created" | "onboarding_started" | "under_review" | "denied" | "active";
         /**
          * Storefront
          * @description Schema of a public storefront.
@@ -25869,6 +26119,7 @@ export const productMediaFileReadServiceValues: ReadonlyArray<components["schema
 export const productPriceCustomAmount_typeValues: ReadonlyArray<components["schemas"]["ProductPriceCustom"]["amount_type"]> = ["custom"];
 export const productPriceFixedAmount_typeValues: ReadonlyArray<components["schemas"]["ProductPriceFixed"]["amount_type"]> = ["fixed"];
 export const productPriceFreeAmount_typeValues: ReadonlyArray<components["schemas"]["ProductPriceFree"]["amount_type"]> = ["free"];
+export const productPriceMeteredUnitAmount_typeValues: ReadonlyArray<components["schemas"]["ProductPriceMeteredUnit"]["amount_type"]> = ["metered_unit"];
 export const productPriceTypeValues: ReadonlyArray<components["schemas"]["ProductPriceType"]> = ["one_time", "recurring"];
 export const productSortPropertyValues: ReadonlyArray<components["schemas"]["ProductSortProperty"]> = ["created_at", "-created_at", "name", "-name", "price_amount_type", "-price_amount_type", "price_amount", "-price_amount"];
 export const propertyAggregationFuncValues: ReadonlyArray<components["schemas"]["PropertyAggregation"]["func"]> = ["avg", "max", "min", "sum"];
@@ -25880,7 +26131,7 @@ export const rewardPaidNotificationTypeValues: ReadonlyArray<components["schemas
 export const rewardStateValues: ReadonlyArray<components["schemas"]["RewardState"]> = ["pending", "paid"];
 export const scopeValues: ReadonlyArray<components["schemas"]["Scope"]> = ["openid", "profile", "email", "user:read", "admin", "web_default", "organizations:read", "organizations:write", "custom_fields:read", "custom_fields:write", "discounts:read", "discounts:write", "checkout_links:read", "checkout_links:write", "checkouts:read", "checkouts:write", "products:read", "products:write", "benefits:read", "benefits:write", "events:read", "events:write", "meters:read", "meters:write", "files:read", "files:write", "subscriptions:read", "subscriptions:write", "customers:read", "customers:write", "customer_sessions:write", "orders:read", "refunds:read", "refunds:write", "metrics:read", "webhooks:read", "webhooks:write", "external_organizations:read", "license_keys:read", "license_keys:write", "repositories:read", "repositories:write", "issues:read", "issues:write", "customer_portal:read", "customer_portal:write"];
 export const stateValues: ReadonlyArray<components["schemas"]["State"]> = ["open", "closed"];
-export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["created", "onboarding_started", "under_review", "active"];
+export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["created", "onboarding_started", "under_review", "denied", "active"];
 export const subTypeValues: ReadonlyArray<components["schemas"]["SubType"]> = ["user", "organization"];
 export const subscriptionProrationBehaviorValues: ReadonlyArray<components["schemas"]["SubscriptionProrationBehavior"]> = ["invoice", "prorate"];
 export const subscriptionRecurringIntervalValues: ReadonlyArray<components["schemas"]["SubscriptionRecurringInterval"]> = ["month", "year"];

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -16,7 +16,6 @@ from polar.custom_field.attachment import AttachedCustomField
 from polar.custom_field.data import (
     CustomFieldDataInputMixin,
     CustomFieldDataOutputMixin,
-    OptionalCustomFieldDataInputMixin,
 )
 from polar.discount.schemas import (
     DiscountFixedBase,
@@ -31,7 +30,6 @@ from polar.kit.metadata import (
     MetadataField,
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import (
     EmailStrDNS,
@@ -239,7 +237,7 @@ class CheckoutCreatePublic(Schema):
     )
 
 
-class CheckoutUpdateBase(OptionalCustomFieldDataInputMixin, Schema):
+class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     product_id: UUID4 | None = Field(
         default=None,
         description=(
@@ -265,7 +263,7 @@ class CheckoutUpdateBase(OptionalCustomFieldDataInputMixin, Schema):
     customer_tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
 
 
-class CheckoutUpdate(OptionalMetadataInputMixin, CheckoutUpdateBase):
+class CheckoutUpdate(MetadataInputMixin, CheckoutUpdateBase):
     """Update an existing checkout session using an access token."""
 
     discount_id: UUID4 | None = Field(
@@ -290,7 +288,7 @@ class CheckoutUpdatePublic(CheckoutUpdateBase):
     )
 
 
-class CheckoutConfirmBase(CustomFieldDataInputMixin, CheckoutUpdatePublic): ...
+class CheckoutConfirmBase(CheckoutUpdatePublic): ...
 
 
 class CheckoutConfirmStripe(CheckoutConfirmBase):

--- a/server/polar/checkout_link/schemas.py
+++ b/server/polar/checkout_link/schemas.py
@@ -8,7 +8,6 @@ from polar.enums import PaymentProcessor
 from polar.kit.metadata import (
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import (
     IDSchema,
@@ -100,7 +99,7 @@ CheckoutLinkCreate = (
 )
 
 
-class CheckoutLinkUpdate(OptionalMetadataInputMixin):
+class CheckoutLinkUpdate(MetadataInputMixin):
     """Schema to update an existing checkout link."""
 
     products: list[UUID4] | None = Field(

--- a/server/polar/custom_field/data.py
+++ b/server/polar/custom_field/data.py
@@ -43,15 +43,6 @@ class CustomFieldDataInputMixin(BaseModel):
     )
 
 
-class OptionalCustomFieldDataInputMixin(BaseModel):
-    custom_field_data: dict[str, str | int | bool | datetime.datetime | None] | None = (
-        Field(
-            default=None,
-            description="Key-value object storing custom field values.",
-        )
-    )
-
-
 class CustomFieldDataOutputMixin(BaseModel):
     custom_field_data: dict[str, str | int | bool | datetime.datetime | None] = Field(
         default_factory=dict,

--- a/server/polar/custom_field/schemas.py
+++ b/server/polar/custom_field/schemas.py
@@ -5,7 +5,6 @@ from pydantic import Discriminator, Field, StringConstraints, TypeAdapter
 from polar.kit.metadata import (
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import (
     ClassName,
@@ -102,7 +101,7 @@ CustomFieldCreate = Annotated[
 ]
 
 
-class CustomFieldUpdateBase(OptionalMetadataInputMixin, Schema):
+class CustomFieldUpdateBase(MetadataInputMixin, Schema):
     """Schema to update an existing custom field."""
 
     name: Name | None = None

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -9,7 +9,6 @@ from polar.kit.address import Address
 from polar.kit.metadata import (
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import (
     CUSTOMER_ID_EXAMPLE,
@@ -62,7 +61,7 @@ class CustomerCreate(MetadataInputMixin, Schema):
     )
 
 
-class CustomerUpdate(OptionalMetadataInputMixin, Schema):
+class CustomerUpdate(MetadataInputMixin, Schema):
     external_id: str | None = Field(
         default=None,
         description=_external_id_description,

--- a/server/polar/discount/schemas.py
+++ b/server/polar/discount/schemas.py
@@ -16,7 +16,6 @@ from pydantic import (
 from polar.kit.metadata import (
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import (
     ClassName,
@@ -245,7 +244,7 @@ class DiscountPercentageRepeatDurationCreate(
     """
 
 
-class DiscountUpdate(OptionalMetadataInputMixin, Schema):
+class DiscountUpdate(MetadataInputMixin, Schema):
     """
     Schema to update a discount.
     """

--- a/server/polar/kit/metadata.py
+++ b/server/polar/kit/metadata.py
@@ -65,12 +65,6 @@ class MetadataInputMixin(BaseModel):
     )
 
 
-class OptionalMetadataInputMixin(BaseModel):
-    metadata: MetadataField | None = Field(
-        default=None, serialization_alias="user_metadata"
-    )
-
-
 class MetadataOutputMixin(BaseModel):
     metadata: dict[str, str | int | bool] = Field(
         validation_alias=AliasChoices("user_metadata", "metadata")

--- a/server/polar/meter/schemas.py
+++ b/server/polar/meter/schemas.py
@@ -7,7 +7,6 @@ from pydantic import UUID4, Field
 from polar.kit.metadata import (
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
 from polar.meter.aggregation import Aggregation
@@ -38,7 +37,7 @@ class MeterCreate(Schema, MetadataInputMixin):
     )
 
 
-class MeterUpdate(Schema, OptionalMetadataInputMixin):
+class MeterUpdate(Schema, MetadataInputMixin):
     name: str | None = Field(None, description=_name_description, min_length=3)
     filter: Filter | None = Field(None, description=_filter_description)
     aggregation: Aggregation | None = Field(None, description=_aggregation_description)

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -16,7 +16,6 @@ from polar.kit.db.models import Model
 from polar.kit.metadata import (
     MetadataInputMixin,
     MetadataOutputMixin,
-    OptionalMetadataInputMixin,
 )
 from polar.kit.schemas import (
     EmptyStrToNoneValidator,
@@ -262,7 +261,7 @@ ProductPriceUpdate = Annotated[
 ]
 
 
-class ProductUpdate(OptionalMetadataInputMixin, Schema):
+class ProductUpdate(MetadataInputMixin, Schema):
     """
     Schema to update a product.
     """

--- a/server/polar/webhook/schemas.py
+++ b/server/polar/webhook/schemas.py
@@ -1,6 +1,12 @@
 from typing import Annotated
 
-from pydantic import UUID4, AnyUrl, Field, PlainSerializer, UrlConstraints
+from pydantic import (
+    UUID4,
+    AnyUrl,
+    Field,
+    PlainSerializer,
+    UrlConstraints,
+)
 
 from polar.kit.schemas import Schema, TimestampedSchema
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
@@ -32,6 +38,7 @@ EndpointSecret = Annotated[
     Field(
         description="The secret used to sign the webhook events.",
         examples=["f_z6mfSpxkjogyw3FkA2aH2gYE5huxruNf34MpdWMcA"],
+        min_length=1,
     ),
 ]
 EndpointEvents = Annotated[

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -1896,6 +1896,37 @@ class TestUpdate:
 
         assert checkout.user_metadata == {"key": "value"}
 
+    async def test_valid_metadata_reset(
+        self,
+        session: AsyncSession,
+        locker: Locker,
+        checkout_one_time_free: Checkout,
+    ) -> None:
+        checkout = await checkout_service.update(
+            session,
+            locker,
+            checkout_one_time_free,
+            CheckoutUpdate(metadata={}),
+        )
+
+        assert checkout.user_metadata == {}
+
+    async def test_valid_metadata_untouched(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        checkout_one_time_free: Checkout,
+    ) -> None:
+        checkout_one_time_free.user_metadata = {"key": "value"}
+        await save_fixture(checkout_one_time_free)
+
+        checkout = await checkout_service.update(
+            session, locker, checkout_one_time_free, CheckoutUpdate()
+        )
+
+        assert checkout.user_metadata == {"key": "value"}
+
     async def test_valid_customer_metadata(
         self,
         session: AsyncSession,


### PR DESCRIPTION
- clients/web: fix typing following schema updates
- clients/packages/client: update OpenAPI client
- server: don't allow `None` values for metadata and custom field data
- server/webhook: ensure secret is not empty