### PR TITLE
Fix email renderer path for cross-platform compatibility

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -40,6 +40,7 @@ def _validate_email_renderer_binary_path(value: Path) -> Path:
 
 env = Environment(os.getenv("POLAR_ENV", Environment.development))
 env_file = ".env.testing" if env == Environment.testing else ".env"
+file_extension = ".exe" if os.name == "nt" else ""
 
 
 class Settings(BaseSettings):
@@ -114,7 +115,12 @@ class Settings(BaseSettings):
     # Emails
     EMAIL_RENDERER_BINARY_PATH: Annotated[
         Path, AfterValidator(_validate_email_renderer_binary_path)
-    ] = Path(__file__).parent.parent / "emails" / "bin" / "react-email-pkg"
+    ] = (
+        Path(__file__).parent.parent
+        / "emails"
+        / "bin"
+        / f"react-email-pkg{file_extension}"
+    )
     EMAIL_SENDER: EmailSender = EmailSender.logger
     RESEND_API_KEY: str = ""
     EMAIL_FROM_NAME: str = "Polar"


### PR DESCRIPTION
When running on **Windows 11**, I encountered this error even after executing the `uv run task emails` command. It didn't work until I fixed the path.

```
PS C:\Coding\polar\server> uv run task db_migrate
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Coding\polar\server\scripts\db.py", line 8, in <module>
    from polar.config import settings
  File "C:\Coding\polar\server\polar\config.py", line 304, in <module>
    settings = Settings()
               ^^^^^^^^^^
  File "C:\Coding\polar\server\.venv\Lib\site-packages\pydantic_settings\main.py", line 176, in __init__
    super().__init__(
  File "C:\Coding\polar\server\.venv\Lib\site-packages\pydantic\main.py", line 214, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
EMAIL_RENDERER_BINARY_PATH
  Value error,
        The provided email renderer binary path C:\Coding\polar\server\emails\bin\react-email-pkg is not a valid file path
        or does not exist.

        If you're in local development, you should build the email renderer binary
        by running the following command:

        uv run task emails

         [type=value_error, input_value=WindowsPath('C:/Coding/po...ls/bin/react-email-pkg'), input_type=WindowsPath]
    For further information visit https://errors.pydantic.dev/2.10/v/value_error
``` 