### PR TITLE
server/external_event: avoid to throw error if trying to enqueue an existing event

### DIFF
--- a/server/polar/external_event/repository.py
+++ b/server/polar/external_event/repository.py
@@ -27,6 +27,14 @@ class ExternalEventRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_by_source_and_external_id(
+        self, source: ExternalEventSource, external_id: str
+    ) -> ExternalEvent | None:
+        statement = self.get_base_statement().where(
+            ExternalEvent.source == source, ExternalEvent.external_id == external_id
+        )
+        return await self.get_one_or_none(statement)
+
     def get_sorting_clause(self, property: ExternalEventSortProperty) -> SortingClause:
         match property:
             case ExternalEventSortProperty.created_at:

--- a/server/polar/external_event/service.py
+++ b/server/polar/external_event/service.py
@@ -40,6 +40,11 @@ class ExternalEventService:
         data: dict[str, Any],
     ) -> ExternalEvent:
         repository = ExternalEventRepository.from_session(session)
+
+        event = await repository.get_by_source_and_external_id(source, external_id)
+        if event is not None:
+            return event
+
         event = await repository.create(
             ExternalEvent(
                 source=source, task_name=task_name, external_id=external_id, data=data

--- a/server/tests/external_event/test_service.py
+++ b/server/tests/external_event/test_service.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.external_event.service import external_event as external_event_service
+from polar.models import ExternalEvent
+from polar.models.external_event import ExternalEventSource
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.fixture
+def enqueue_job_mock(mocker: MockerFixture) -> AsyncMock:
+    return mocker.patch("polar.external_event.service.enqueue_job")
+
+
+@pytest.mark.asyncio
+class TestEnqueue:
+    async def test_basic(
+        self, session: AsyncSession, enqueue_job_mock: AsyncMock
+    ) -> None:
+        event = await external_event_service.enqueue(
+            session, ExternalEventSource.stripe, "task_name", "EXTERNAL_EVENT_ID", {}
+        )
+
+        assert event.source == ExternalEventSource.stripe
+        assert event.task_name == "task_name"
+        assert event.external_id == "EXTERNAL_EVENT_ID"
+
+        enqueue_job_mock.assert_called_once_with("task_name", event.id)
+
+    async def test_already_existing(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        enqueue_job_mock: AsyncMock,
+    ) -> None:
+        existing_event = ExternalEvent(
+            source=ExternalEventSource.stripe,
+            task_name="task_name",
+            external_id="EXTERNAL_EVENT_ID",
+            data={},
+        )
+        await save_fixture(existing_event)
+
+        event = await external_event_service.enqueue(
+            session, ExternalEventSource.stripe, "task_name", "EXTERNAL_EVENT_ID", {}
+        )
+
+        assert event == existing_event
+
+        enqueue_job_mock.assert_not_called()


### PR DESCRIPTION
- server/external_event: avoid to throw error if trying to enqueue an existing event