### PR TITLE
server/benefit: fix benefit license key schema adding validation to non-input schema

### DIFF
--- a/server/polar/benefit/strategies/license_keys/schemas.py
+++ b/server/polar/benefit/strategies/license_keys/schemas.py
@@ -18,15 +18,20 @@ class BenefitLicenseKeyExpirationProperties(Schema):
     timeframe: Literal["year", "month", "day"]
 
 
-class BenefitLicenseKeyActivationProperties(Schema):
+class BenefitLicenseKeyActivationCreateProperties(Schema):
     limit: int = Field(gt=0, le=50)
+    enable_customer_admin: bool
+
+
+class BenefitLicenseKeyActivationProperties(Schema):
+    limit: int
     enable_customer_admin: bool
 
 
 class BenefitLicenseKeysCreateProperties(Schema):
     prefix: str | None = None
     expires: BenefitLicenseKeyExpirationProperties | None = None
-    activations: BenefitLicenseKeyActivationProperties | None = None
+    activations: BenefitLicenseKeyActivationCreateProperties | None = None
     limit_usage: int | None = Field(gt=0, default=None)
 
 

--- a/server/tests/license_key/test_endpoints.py
+++ b/server/tests/license_key/test_endpoints.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 
 from polar.auth.models import AuthSubject
 from polar.benefit.strategies.license_keys.schemas import (
-    BenefitLicenseKeyActivationProperties,
+    BenefitLicenseKeyActivationCreateProperties,
     BenefitLicenseKeysCreateProperties,
 )
 from polar.kit.pagination import PaginationParams
@@ -224,7 +224,7 @@ class TestLicenseKeyEndpoints:
             product=product,
             properties=BenefitLicenseKeysCreateProperties(
                 prefix="testing",
-                activations=BenefitLicenseKeyActivationProperties(
+                activations=BenefitLicenseKeyActivationCreateProperties(
                     limit=2, enable_customer_admin=True
                 ),
             ),


### PR DESCRIPTION
- server/benefit: fix benefit license key schema adding validation to non-input schema