### PR TITLE
server: Avoid returning an empty country string from IP lookup

### DIFF
--- a/server/polar/checkout/ip_geolocation.py
+++ b/server/polar/checkout/ip_geolocation.py
@@ -64,7 +64,11 @@ def get_ip_country(client: IPGeolocationClient, ip: str) -> str | None:
     Returns:
         Country alpha-2 code.
     """
-    return cast(str | None, client.getCountry(ip))
+    ret = cast(str | None, client.getCountry(ip))
+    # Convert empty str into None response to ease empty case checking
+    if ret == "":
+        return None
+    return ret
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Always return None for the empty case instead to avoid a complex API in
its usage and errors as seen in the past 24h as a result of an empty
string.
