### PR TITLE
Add preview capabilities to the meter creation process

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/meters/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/meters/ClientPage.tsx
@@ -45,7 +45,7 @@ const ClientPage = ({
   })
 
   const { data, hasNextPage, fetchNextPage } = useMetersInfinite(
-    organization?.id,
+    organization.id,
     {
       sorting: [sorting],
       query,
@@ -64,7 +64,10 @@ const ClientPage = ({
     hide: hideEditMeterModal,
   } = useModal()
 
-  const meters = data?.pages.flatMap((page) => page.items) ?? []
+  const meters = useMemo(
+    () => data?.pages.flatMap((page) => page.items) ?? [],
+    [data],
+  )
 
   const selectedMeter = useMemo(() => {
     return meters?.find((meter) => meter.id === selectedMeterId)

--- a/clients/apps/web/src/components/Meter/MeterCreationModal.tsx
+++ b/clients/apps/web/src/components/Meter/MeterCreationModal.tsx
@@ -1,9 +1,10 @@
+import { useEvents } from '@/hooks/queries/events'
 import { useCreateMeter } from '@/hooks/queries/meters'
 import { setValidationErrors } from '@/utils/api/errors'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { Form } from '@polar-sh/ui/components/ui/form'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from '../Toast/use-toast'
 import MeterForm from './MeterForm'
@@ -39,8 +40,23 @@ export const MeterCreationModal = ({
       },
     },
   })
-  const { handleSubmit, setError } = form
+  const { handleSubmit, setError, getValues } = form
   const createMeter = useCreateMeter(organization.id)
+
+  const [previewFilter, setPreviewFilter] = useState<string | null>(null)
+  const { data: events } = useEvents(
+    organization.id,
+    {
+      filter: previewFilter,
+    },
+    previewFilter !== null,
+  )
+  console.log(events) // TODO: show those events in the preview
+
+  const updatePreview = useCallback(() => {
+    const filter = getValues('filter')
+    setPreviewFilter(filter ? JSON.stringify(filter) : null)
+  }, [getValues])
 
   const onSubmit = useCallback(
     async (body: schemas['MeterCreate']) => {
@@ -77,6 +93,9 @@ export const MeterCreationModal = ({
           >
             <MeterForm />
             <Button type="submit">Create Meter</Button>
+            <Button type="button" variant="secondary" onClick={updatePreview}>
+              Preview
+            </Button>
           </form>
         </Form>
       </div>

--- a/clients/apps/web/src/hooks/queries/events.ts
+++ b/clients/apps/web/src/hooks/queries/events.ts
@@ -45,6 +45,7 @@ export const useEvents = (
     NonNullable<operations['events:list']['parameters']['query']>,
     'organization_id'
   >,
+  enabled: boolean = true,
 ) => {
   return useQuery({
     queryKey: ['events', { organizationId, ...(parameters || {}) }],
@@ -57,6 +58,7 @@ export const useEvents = (
         }),
       ),
     retry: defaultRetry,
+    enabled,
   })
 }
 export const useEventNames = (

--- a/clients/apps/web/src/hooks/queries/events.ts
+++ b/clients/apps/web/src/hooks/queries/events.ts
@@ -25,8 +25,16 @@ export const useInfiniteEvents = (
         }),
       ),
     initialPageParam: 1,
-    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
-      lastPageParam === lastPage.pagination.max_page ? null : lastPageParam + 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (
+        lastPageParam === lastPage.pagination.max_page ||
+        lastPage.items.length === 0
+      ) {
+        return null
+      }
+
+      return lastPageParam + 1
+    },
     retry: defaultRetry,
   })
 }

--- a/clients/apps/web/src/hooks/queries/meters.ts
+++ b/clients/apps/web/src/hooks/queries/meters.ts
@@ -13,7 +13,7 @@ export const useMetersInfinite = (
   organizationId: string,
   parameters?: Omit<
     NonNullable<operations['meters:list']['parameters']['query']>,
-    'organization_id'
+    'organization_id' | 'page'
   >,
 ) =>
   useInfiniteQuery({
@@ -31,9 +31,17 @@ export const useMetersInfinite = (
         }),
       ),
     retry: defaultRetry,
-    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
-      lastPageParam === lastPage.pagination.max_page ? null : lastPageParam + 1,
     initialPageParam: 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (
+        lastPageParam === lastPage.pagination.max_page ||
+        lastPage.items.length === 0
+      ) {
+        return null
+      }
+
+      return lastPageParam + 1
+    },
   })
 
 export const useMeters = (

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -21492,6 +21492,8 @@ export interface operations {
     "events:list": {
         parameters: {
             query?: {
+                /** @description Filter events following filter clauses. JSON string following the same schema a meter filter clause.  */
+                filter?: string | null;
                 /** @description Filter events after this timestamp. */
                 start_timestamp?: string | null;
                 /** @description Filter events before this timestamp. */

--- a/server/tests/event/test_endpoints.py
+++ b/server/tests/event/test_endpoints.py
@@ -1,0 +1,82 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from polar.kit.utils import utc_now
+from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
+from polar.models import Organization, UserOrganization
+from tests.fixtures.auth import AuthSubjectFixture
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_event
+
+
+@pytest.mark.asyncio
+class TestListEvents:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events/")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
+    async def test_missing_scope(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get("/v1/events/")
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_invalid_filter(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get("/v1/events/", params={"filter": "hello"})
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_filter(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        event1 = await create_event(
+            save_fixture,
+            organization=organization,
+            timestamp=utc_now() - timedelta(days=1),
+            metadata={"tokens": 10},
+        )
+        event2 = await create_event(
+            save_fixture,
+            organization=organization,
+            timestamp=utc_now() + timedelta(days=1),
+            metadata={"tokens": 100},
+        )
+
+        filter = Filter(
+            conjunction=FilterConjunction.and_,
+            clauses=[
+                FilterClause(
+                    property="tokens",
+                    operator=FilterOperator.gt,
+                    value=50,
+                )
+            ],
+        )
+        response = await client.get(
+            "/v1/events/", params={"filter": filter.model_dump_json()}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+
+        assert json["pagination"]["total_count"] == 1
+        assert json["items"][0]["id"] == str(event2.id)


### PR DESCRIPTION

- clients/web: add preview machinery to meter creation
- clients/web: fix infinite query of meters and events
- clients/packages/client: update OpenAPI client
- server/event: add a filter query parameter to events list endpoint
  