### PR TITLE
server/meter: improve filtering support for model properties like timestamp

### DIFF
--- a/server/polar/meter/filter.py
+++ b/server/polar/meter/filter.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import AfterValidator, BaseModel, ConfigDict
 from sqlalchemy import (
     ColumnExpressionArgument,
     Dialect,
@@ -27,8 +27,13 @@ class FilterOperator(StrEnum):
     not_like = "not_like"
 
 
+def _strip_metadata_prefix(value: str) -> str:
+    prefix = "metadata."
+    return value[len(prefix) :] if value.startswith(prefix) else value
+
+
 class FilterClause(BaseModel):
-    property: str
+    property: Annotated[str, AfterValidator(_strip_metadata_prefix)]
     operator: FilterOperator
     value: str | int | bool
 

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -5,14 +5,19 @@ from uuid import UUID
 
 from sqlalchemy import (
     TIMESTAMP,
+    BigInteger,
     ColumnElement,
     ForeignKey,
     String,
     Uuid,
     and_,
     exists,
+    extract,
     or_,
     select,
+)
+from sqlalchemy import (
+    cast as sqla_cast,
 )
 from sqlalchemy.orm import (
     Mapped,
@@ -137,3 +142,9 @@ class Event(Model, MetadataMixin):
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:
         return relationship("Organization", lazy="raise")
+
+    _filterable_fields: dict[str, tuple[type[str | int | bool], Any]] = {
+        "timestamp": (int, sqla_cast(extract("epoch", timestamp), BigInteger)),
+        "name": (str, name),
+        "source": (str, source),
+    }

--- a/server/tests/meter/test_aggregation.py
+++ b/server/tests/meter/test_aggregation.py
@@ -1,0 +1,8 @@
+from polar.meter.aggregation import AggregationFunction, PropertyAggregation
+
+
+def test_strip_metadata_prefix() -> None:
+    aggregation = PropertyAggregation(
+        func=AggregationFunction.sum, property="metadata.property"
+    )
+    assert aggregation.property == "property"

--- a/server/tests/meter/test_filter.py
+++ b/server/tests/meter/test_filter.py
@@ -1,0 +1,16 @@
+from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
+
+
+def test_strip_metadata_prefix() -> None:
+    filter = Filter(
+        conjunction=FilterConjunction.and_,
+        clauses=[
+            FilterClause(
+                property="metadata.property", operator=FilterOperator.eq, value="value"
+            )
+        ],
+    )
+
+    clause = filter.clauses[0]
+    assert isinstance(clause, FilterClause)
+    assert clause.property == "property"

--- a/server/tests/meter/test_filter.py
+++ b/server/tests/meter/test_filter.py
@@ -1,4 +1,14 @@
+from datetime import timedelta
+
+import pytest
+
+from polar.event.repository import EventRepository
+from polar.kit.utils import utc_now
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
+from polar.models import Event, Organization
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_event
 
 
 def test_strip_metadata_prefix() -> None:
@@ -14,3 +24,52 @@ def test_strip_metadata_prefix() -> None:
     clause = filter.clauses[0]
     assert isinstance(clause, FilterClause)
     assert clause.property == "property"
+
+
+@pytest.mark.asyncio
+class TestFilter:
+    async def test_timestamp_clause(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        events = [
+            await create_event(
+                save_fixture,
+                organization=organization,
+                external_customer_id="customer_1",
+                timestamp=now - timedelta(days=1),
+            ),
+            await create_event(
+                save_fixture,
+                organization=organization,
+                external_customer_id="customer_1",
+                timestamp=now,
+            ),
+            await create_event(
+                save_fixture,
+                organization=organization,
+                external_customer_id="customer_1",
+                timestamp=now + timedelta(days=1),
+            ),
+        ]
+
+        filter = Filter(
+            conjunction=FilterConjunction.and_,
+            clauses=[
+                FilterClause(
+                    property="timestamp",
+                    operator=FilterOperator.lt,
+                    value=int(now.timestamp()),
+                )
+            ],
+        )
+
+        repository = EventRepository.from_session(session)
+        statement = repository.get_base_statement().where(filter.get_sql_clause(Event))
+        matching_events = await repository.get_all(statement)
+
+        assert len(matching_events) == 1
+        assert matching_events[0].id == events[0].id


### PR DESCRIPTION
- server/meter: improve filtering support for model properties like timestamp
- server/meter: automatically strip `metadata.` property prefix on filter clause and aggregation