### PR TITLE
clients/web: fix subscription cancellation payload following schema update

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/CancelSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CancelSubscriptionModal.tsx
@@ -70,20 +70,27 @@ const CancelSubscriptionModal = ({
 
   const onSubmit = useCallback(
     async (cancellation: SubscriptionCancelForm) => {
-      let body: schemas['SubscriptionCancel'] = {
+      const base = {
         customer_cancellation_reason: cancellation.customer_cancellation_reason,
       }
+      let body: schemas['SubscriptionRevoke'] | schemas['SubscriptionCancel']
       if (cancellation.cancellation_action === 'revoke') {
-        body.revoke = true
+        body = {
+          ...base,
+          revoke: true,
+        }
       } else {
-        body.cancel_at_period_end = true
+        body = {
+          ...base,
+          cancel_at_period_end: true,
+        }
       }
 
       await cancelSubscription.mutateAsync(body).then(({ error }) => {
         if (error) {
           if (error.detail)
             if (isValidationError(error.detail)) {
-              setValidationErrors(error.detail, form.setError)
+              setValidationErrors(error.detail, setError)
             } else {
               toast({
                 title: 'Customer Update Failed',

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -14186,18 +14186,6 @@ export interface components {
         };
         /** SubscriptionCancel */
         SubscriptionCancel: {
-            /**
-             * Cancel At Period End
-             * @description Cancel an active subscription once the current period ends.
-             *
-             *     Or uncancel a subscription currently set to be revoked at period end.
-             */
-            cancel_at_period_end?: boolean | null;
-            /**
-             * Revoke
-             * @description Cancel and revoke an active subscription immediately
-             */
-            revoke?: true | null;
             /** @description Customer reason for cancellation.
              *
              *     Helpful to monitor reasons behind churn for future improvements.
@@ -14229,6 +14217,13 @@ export interface components {
              *     conversation, i.e support.
              */
             customer_cancellation_comment?: string | null;
+            /**
+             * Cancel At Period End
+             * @description Cancel an active subscription once the current period ends.
+             *
+             *     Or uncancel a subscription currently set to be revoked at period end.
+             */
+            cancel_at_period_end: boolean;
         };
         /** SubscriptionCustomer */
         SubscriptionCustomer: {
@@ -14349,6 +14344,46 @@ export interface components {
          * @enum {string}
          */
         SubscriptionRecurringInterval: "month" | "year";
+        /** SubscriptionRevoke */
+        SubscriptionRevoke: {
+            /** @description Customer reason for cancellation.
+             *
+             *     Helpful to monitor reasons behind churn for future improvements.
+             *
+             *     Only set this in case your own service is requesting the reason from the
+             *     customer. Or you know based on direct conversations, i.e support, with
+             *     the customer.
+             *
+             *     * `too_expensive`: Too expensive for the customer.
+             *     * `missing_features`: Customer is missing certain features.
+             *     * `switched_service`: Customer switched to another service.
+             *     * `unused`: Customer is not using it enough.
+             *     * `customer_service`: Customer is not satisfied with the customer service.
+             *     * `low_quality`: Customer is unhappy with the quality.
+             *     * `too_complex`: Customer considers the service too complicated.
+             *     * `other`: Other reason(s). */
+            customer_cancellation_reason?: components["schemas"]["CustomerCancellationReason"] | null;
+            /**
+             * Customer Cancellation Comment
+             * @description Customer feedback and why they decided to cancel.
+             *
+             *     **IMPORTANT:**
+             *     Do not use this to store internal notes! It's intended to be input
+             *     from the customer and is therefore also available in their Polar
+             *     purchases library.
+             *
+             *     Only set this in case your own service is requesting the reason from the
+             *     customer. Or you copy a message directly from a customer
+             *     conversation, i.e support.
+             */
+            customer_cancellation_comment?: string | null;
+            /**
+             * Revoke
+             * @description Cancel and revoke an active subscription immediately
+             * @constant
+             */
+            revoke: true;
+        };
         /**
          * SubscriptionSortProperty
          * @enum {string}
@@ -14359,7 +14394,7 @@ export interface components {
          * @enum {string}
          */
         SubscriptionStatus: "incomplete" | "incomplete_expired" | "trialing" | "active" | "past_due" | "canceled" | "unpaid";
-        SubscriptionUpdate: components["schemas"]["SubscriptionUpdateProduct"] | components["schemas"]["SubscriptionCancel"];
+        SubscriptionUpdate: components["schemas"]["SubscriptionUpdateProduct"] | components["schemas"]["SubscriptionCancel"] | components["schemas"]["SubscriptionRevoke"];
         /** SubscriptionUpdateProduct */
         SubscriptionUpdateProduct: {
             /**

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -212,21 +212,7 @@ class SubscriptionUpdateProduct(Schema):
     )
 
 
-class SubscriptionCancel(Schema):
-    cancel_at_period_end: bool | None = Field(
-        None,
-        description=inspect.cleandoc(
-            """
-        Cancel an active subscription once the current period ends.
-
-        Or uncancel a subscription currently set to be revoked at period end.
-        """
-        ),
-    )
-    revoke: Literal[True] | None = Field(
-        None,
-        description="Cancel and revoke an active subscription immediately",
-    )
+class SubscriptionCancelBase(Schema):
     customer_cancellation_reason: CustomerCancellationReason | None = Field(
         None,
         description=inspect.cleandoc(
@@ -269,7 +255,25 @@ class SubscriptionCancel(Schema):
     )
 
 
+class SubscriptionCancel(SubscriptionCancelBase):
+    cancel_at_period_end: bool = Field(
+        description=inspect.cleandoc(
+            """
+        Cancel an active subscription once the current period ends.
+
+        Or uncancel a subscription currently set to be revoked at period end.
+        """
+        ),
+    )
+
+
+class SubscriptionRevoke(SubscriptionCancelBase):
+    revoke: Literal[True] = Field(
+        description="Cancel and revoke an active subscription immediately"
+    )
+
+
 SubscriptionUpdate = Annotated[
-    SubscriptionUpdateProduct | SubscriptionCancel,
+    SubscriptionUpdateProduct | SubscriptionCancel | SubscriptionRevoke,
     SetSchemaReference("SubscriptionUpdate"),
 ]

--- a/server/tests/test_sdk.py
+++ b/server/tests/test_sdk.py
@@ -1,17 +1,25 @@
 from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from polar_sdk import Polar
+from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
+from polar.integrations.stripe.service import StripeService
 from polar.kit.utils import utc_now
 from polar.models import Benefit, Customer, Organization, Product, UserOrganization
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_order, create_subscription
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_order,
+    create_subscription,
+)
+from tests.fixtures.stripe import construct_stripe_subscription
 
 
 @pytest_asyncio.fixture
@@ -114,6 +122,34 @@ class TestSDK:
         assert response is not None
 
         assert len(response.result.items) == len(subscriptions)
+
+    async def test_cancel_subscription(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        polar: Polar,
+        product: Product,
+        customer: Customer,
+        user_organization: UserOrganization,
+    ) -> None:
+        stripe_service_mock = MagicMock(spec=StripeService)
+        stripe_service_mock.cancel_subscription.return_value = (
+            construct_stripe_subscription(product=product)
+        )
+        mocker.patch(
+            "polar.subscription.service.stripe_service", new=stripe_service_mock
+        )
+
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        response = await polar.subscriptions.update_async(
+            id=str(subscription.id),
+            subscription_update={"cancel_at_period_end": True},  # type: ignore
+        )
+
+        assert response is not None
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user", scopes={Scope.checkouts_write})


### PR DESCRIPTION
- clients/web: fix subscription cancellation payload following schema update
- clients/packages/client: update OpenAPI client
- server/subscription: tweak schema so there is a clear separation between cancel and revoke