### PR TITLE
ops: temporarily disable environment groups on new services since Render *still* doesn't support to set environment in their blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -173,11 +173,11 @@ services:
           property: port
       - key: POLAR_REDIS_DB
         value: 0
-      - fromGroup: google-production
-      - fromGroup: github-production
-      - fromGroup: backend-production
-      - fromGroup: stripe-production
-      - fromGroup: logfire-worker
+      # - fromGroup: google-production
+      # - fromGroup: github-production
+      # - fromGroup: backend-production
+      # - fromGroup: stripe-production
+      # - fromGroup: logfire-worker
 
   - type: redis
     name: redis
@@ -351,10 +351,10 @@ services:
           property: port
       - key: POLAR_REDIS_DB
         value: 1
-      - fromGroup: google-sandbox
-      - fromGroup: github-sandbox
-      - fromGroup: backend-sandbox
-      - fromGroup: stripe-sandbox
+      # - fromGroup: google-sandbox
+      # - fromGroup: github-sandbox
+      # - fromGroup: backend-sandbox
+      # - fromGroup: stripe-sandbox
 
 databases:
   - name: db


### PR DESCRIPTION
- ops: temporarily disable environment groups on new services since Render *still* doesn't support to set environment in their blueprint