### PR TITLE
clients/web: don't immediately redirect to external success URL if checkout is not fully succeeded

### DIFF
--- a/clients/apps/web/src/app/checkout/[clientSecret]/confirmation/page.tsx
+++ b/clients/apps/web/src/app/checkout/[clientSecret]/confirmation/page.tsx
@@ -3,8 +3,8 @@ import CheckoutLayout from '@/components/Checkout/CheckoutLayout'
 import { getServerURL } from '@/utils/api'
 import { PolarCore } from '@polar-sh/sdk/core'
 import { checkoutsClientGet } from '@polar-sh/sdk/funcs/checkoutsClientGet'
-import { ResourceNotFound } from '@polar-sh/sdk/models/errors/resourcenotfound'
 import { ExpiredCheckoutError } from '@polar-sh/sdk/models/errors/expiredcheckouterror'
+import { ResourceNotFound } from '@polar-sh/sdk/models/errors/resourcenotfound'
 import { notFound, redirect } from 'next/navigation'
 
 export default async function Page({
@@ -43,6 +43,8 @@ export default async function Page({
     <CheckoutLayout checkout={checkout} embed={embed === 'true'} theme={theme}>
       <CheckoutConfirmation
         checkout={checkout}
+        embed={embed === 'true'}
+        theme={theme}
         customerSessionToken={customer_session_token}
       />
     </CheckoutLayout>

--- a/clients/apps/web/src/app/checkout/[clientSecret]/page.tsx
+++ b/clients/apps/web/src/app/checkout/[clientSecret]/page.tsx
@@ -5,8 +5,8 @@ import {
 } from '@polar-sh/checkout/providers'
 import { PolarCore } from '@polar-sh/sdk/core'
 import { checkoutsClientGet } from '@polar-sh/sdk/funcs/checkoutsClientGet'
-import { ResourceNotFound } from '@polar-sh/sdk/models/errors/resourcenotfound'
 import { ExpiredCheckoutError } from '@polar-sh/sdk/models/errors/expiredcheckouterror'
+import { ResourceNotFound } from '@polar-sh/sdk/models/errors/resourcenotfound'
 import { notFound, redirect } from 'next/navigation'
 import ClientPage from './ClientPage'
 
@@ -39,8 +39,12 @@ export default async function Page({
     }
   }
 
-  if (checkout.status !== 'open') {
+  if (checkout.status === 'succeeded') {
     redirect(checkout.successUrl)
+  }
+
+  if (checkout.status !== 'open') {
+    redirect(`/checkout/${checkout.clientSecret}/confirmation`)
   }
 
   return (

--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { CONFIG } from '@/utils/config'
+import { useCheckoutConfirmedRedirect } from '@/hooks/checkout'
 import {
   CheckoutForm,
   CheckoutProductSwitcher,
   CheckoutPWYWForm,
 } from '@polar-sh/checkout/components'
-import { PolarEmbedCheckout } from '@polar-sh/checkout/embed'
 import { useCheckoutFulfillmentListener } from '@polar-sh/checkout/hooks'
 import { useCheckout, useCheckoutForm } from '@polar-sh/checkout/providers'
 import type { CheckoutConfirmStripe } from '@polar-sh/sdk/models/components/checkoutconfirmstripe'
@@ -18,7 +17,6 @@ import ShadowBox, {
 import { useThemePreset } from '@polar-sh/ui/hooks/theming'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import { useTheme } from 'next-themes'
-import { useRouter } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { CheckoutCard } from './CheckoutCard'
@@ -48,7 +46,6 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
     theme,
   )
 
-  const router = useRouter()
   const [fullLoading, setFullLoading] = useState(false)
   const loading = useMemo(
     () => confirmLoading || fullLoading,
@@ -61,6 +58,11 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
   const label = useMemo(
     () => fullfillmentLabel || loadingLabel,
     [fullfillmentLabel, loadingLabel],
+  )
+  const checkoutConfirmedRedirect = useCheckoutConfirmedRedirect(
+    embed,
+    theme,
+    listenFulfillment,
   )
 
   const confirm = useCallback(
@@ -78,59 +80,14 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
         throw error
       }
 
-      if (checkout.embedOrigin) {
-        PolarEmbedCheckout.postMessage(
-          {
-            event: 'confirmed',
-          },
-          checkout.embedOrigin,
-        )
-      }
-
-      const parsedURL = new URL(confirmedCheckout.successUrl)
-      const isInternalURL = confirmedCheckout.successUrl.startsWith(
-        CONFIG.FRONTEND_BASE_URL,
-      )
-
-      if (isInternalURL) {
-        if (embed) {
-          parsedURL.searchParams.set('embed', 'true')
-          if (theme) {
-            parsedURL.searchParams.set('theme', theme)
-          }
-        }
-      }
-
-      parsedURL.searchParams.set(
-        'customer_session_token',
+      await checkoutConfirmedRedirect(
+        checkout,
         confirmedCheckout.customerSessionToken,
       )
 
-      // For external success URL, make sure the checkout is processed before redirecting
-      // It ensures the user will have an up-to-date status when they are redirected,
-      // especially if the external URL doesn't implement proper webhook handling
-      if (!isInternalURL) {
-        await listenFulfillment()
-      }
-
-      if (checkout.embedOrigin) {
-        PolarEmbedCheckout.postMessage(
-          {
-            event: 'success',
-            successURL: parsedURL.toString(),
-            redirect: !isInternalURL,
-          },
-          checkout.embedOrigin,
-        )
-      }
-
-      if (isInternalURL || !embed) {
-        router.push(parsedURL.toString())
-      }
-
       return confirmedCheckout
     },
-    [checkout, _confirm, embed, listenFulfillment, router, theme],
+    [_confirm, checkout, checkoutConfirmedRedirect],
   )
 
   if (embed) {

--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -1,0 +1,73 @@
+import { PolarEmbedCheckout } from '@polar-sh/checkout/embed'
+import type { CheckoutPublic } from '@polar-sh/sdk/models/components/checkoutpublic'
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+import { CONFIG } from '@/utils/config'
+
+export const useCheckoutConfirmedRedirect = (
+  embed: boolean,
+  theme?: 'light' | 'dark',
+  listenFulfillment?: () => Promise<void>,
+) => {
+  const router = useRouter()
+  return useCallback(
+    async (
+      checkout: CheckoutPublic,
+      customerSessionToken: string | undefined,
+    ) => {
+      if (checkout.embedOrigin) {
+        PolarEmbedCheckout.postMessage(
+          {
+            event: 'confirmed',
+          },
+          checkout.embedOrigin,
+        )
+      }
+
+      const parsedURL = new URL(checkout.successUrl)
+      const isInternalURL = checkout.successUrl.startsWith(
+        CONFIG.FRONTEND_BASE_URL,
+      )
+
+      if (isInternalURL) {
+        if (embed) {
+          parsedURL.searchParams.set('embed', 'true')
+          if (theme) {
+            parsedURL.searchParams.set('theme', theme)
+          }
+        }
+      }
+
+      if (customerSessionToken) {
+        parsedURL.searchParams.set(
+          'customer_session_token',
+          customerSessionToken,
+        )
+      }
+
+      // For external success URL, make sure the checkout is processed before redirecting
+      // It ensures the user will have an up-to-date status when they are redirected,
+      // especially if the external URL doesn't implement proper webhook handling
+      if (!isInternalURL && listenFulfillment) {
+        await listenFulfillment()
+      }
+
+      if (checkout.embedOrigin) {
+        PolarEmbedCheckout.postMessage(
+          {
+            event: 'success',
+            successURL: parsedURL.toString(),
+            redirect: !isInternalURL,
+          },
+          checkout.embedOrigin,
+        )
+      }
+
+      if (isInternalURL || !embed) {
+        router.push(parsedURL.toString())
+      }
+    },
+    [router, embed, theme, listenFulfillment],
+  )
+}

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -925,6 +925,10 @@ class CheckoutService:
             await order_service.create_from_checkout(session, checkout, payment_intent)
 
         checkout.status = CheckoutStatus.succeeded
+        checkout.payment_processor_metadata = {
+            **checkout.payment_processor_metadata,
+            "intent_status": payment_intent.status,
+        }
         session.add(checkout)
 
         await self._after_checkout_updated(session, checkout)
@@ -955,6 +959,10 @@ class CheckoutService:
 
         # Put back checkout in open state so the customer can try another payment method
         checkout.status = CheckoutStatus.open
+        payment_processor_metadata = checkout.payment_processor_metadata
+        payment_processor_metadata.pop("intent_status", None)
+        payment_processor_metadata.pop("intent_client_secret", None)
+        checkout.payment_processor_metadata = payment_processor_metadata
         session.add(checkout)
 
         # Make sure to remove the Discount Redemptions


### PR DESCRIPTION
- clients/web: don't immediately redirect to external success URL if checkout is not fully succeeded
- server/checkout: put back in open state after a payment failure to allow customers to retry