### PR TITLE
server/customer_meter: pass external_customer_id parameter properly to service method

### DIFF
--- a/server/polar/customer_meter/endpoints.py
+++ b/server/polar/customer_meter/endpoints.py
@@ -59,6 +59,7 @@ async def list(
         auth_subject,
         organization_id=organization_id,
         customer_id=customer_id,
+        external_customer_id=external_customer_id,
         meter_id=meter_id,
         pagination=pagination,
         sorting=sorting,


### PR DESCRIPTION
- server/customer_meter: pass external_customer_id parameter properly to service method