### PR TITLE
fix(server): missing only built dependencies

### DIFF
--- a/server/emails/package.json
+++ b/server/emails/package.json
@@ -38,5 +38,11 @@
       "host"
     ],
     "outputPath": "bin"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
Hi, thank you for the project!

This pr aims to fix following warning after running `uv run task emails`:

<img width="864" alt="image" src="https://github.com/user-attachments/assets/466fb267-7c06-481d-92e0-18ebd8fffaa2" />

Because pnpm v10 blocks lifecycle scripts by default, allowing only those listed in onlyBuiltDependencies to execute their postinstall scripts.