### PR TITLE
fix(client): disable "Create" button when form has validation errors

### DIFF
--- a/clients/apps/web/src/components/Benefit/CreateBenefitModalContent.tsx
+++ b/clients/apps/web/src/components/Benefit/CreateBenefitModalContent.tsx
@@ -46,6 +46,7 @@ const CreateBenefitModalContent = ({
   const createSubscriptionBenefit = useCreateBenefit(organization.id)
 
   const form = useForm<schemas['BenefitCreate']>({
+    mode: 'onChange',
     defaultValues: {
       organization_id: organization.id,
       type: type ? type : 'custom',
@@ -121,7 +122,10 @@ const CreateBenefitModalContent = ({
                 className="self-start"
                 type="button"
                 loading={createSubscriptionBenefit.isPending}
-                disabled={createSubscriptionBenefit.isPending}
+                disabled={
+                  createSubscriptionBenefit.isPending ||
+                  !form.formState.isValid
+                }
                 onClick={handleSubmit(handleCreateNewBenefit)}
               >
                 Create


### PR DESCRIPTION
### Description:

This PR fixes an #5812 issue where the “Create” button in the CreateBenefitModal was clickable even when subform validation failed.

### What’s changed
Enabled mode: `onChange` in the useForm config to ensure real-time isValid updates.
Updated the button to disable itself when `formState.isValid === false`.
Confirmed` useFormContext()` usage in subcomponents triggers correct validation state on setError() calls.

### Why this change makes sense

- Prevents submission of incomplete/invalid forms caused by logic in subcomponents (e.g. GitHub repository validation).
- Improves UX by giving users immediate visual feedback.
- Leverages built-in `react-hook-form` APIs for consistency and future maintainability.

### How to test

1. Open the “Create Benefit” modal.
2. Select a GitHub repository benefit.
3. Simulate an invalid state (e.g., selecting a personal organization).
4. Ensure the Create button is disabled.
5. Fix the validation error and verify the button becomes enabled again.