### PR TITLE
server/migrations: make payout processor_id non unique

### DIFF
--- a/server/migrations/versions/2025-06-02-1629_create_payout.py
+++ b/server/migrations/versions/2025-06-02-1629_create_payout.py
@@ -63,7 +63,7 @@ def upgrade() -> None:
         op.f("ix_payouts_modified_at"), "payouts", ["modified_at"], unique=False
     )
     op.create_index(
-        op.f("ix_payouts_processor_id"), "payouts", ["processor_id"], unique=True
+        op.f("ix_payouts_processor_id"), "payouts", ["processor_id"], unique=False
     )
     op.create_index(op.f("ix_payouts_status"), "payouts", ["status"], unique=False)
 


### PR DESCRIPTION
- server/migrations: make payout processor_id non unique
- clients/web: re-add account status banner
- clients/web: reorganize payouts page and adapt to new API
- clients/packages/client: update OpenAPI client
- server/payout: expose fees
- server/payout: add a list endpoint
- server/payout: implement dedicated Payout model and module, refactor logic into it