### PR TITLE
server/worker: revamp SQLAlchemy and Redis middlewares with globals

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -181,6 +181,10 @@ class Settings(BaseSettings):
 
     # Logfire
     LOGFIRE_TOKEN: str | None = None
+    LOGFIRE_IGNORED_ACTORS: set[str] = {
+        "organization_access_token.record_usage",
+        "personal_access_token.record_usage",
+    }
 
     # Plain
     PLAIN_REQUEST_SIGNING_SECRET: str | None = None

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -81,6 +81,7 @@ async def get_db_session(
 
 
 __all__ = [
+    "AsyncEngine",
     "AsyncSession",
     "sql",
     "create_async_engine",

--- a/server/polar/redis.py
+++ b/server/polar/redis.py
@@ -1,5 +1,3 @@
-import contextlib
-from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 import redis.asyncio as _async_redis
@@ -24,9 +22,8 @@ REDIS_RETRY = Retry(default_backoff(), retries=50)
 ProcessName: TypeAlias = Literal["app", "worker", "script"]
 
 
-@contextlib.asynccontextmanager
-async def create_redis(process_name: ProcessName) -> AsyncGenerator[Redis, None]:
-    redis = cast(
+def create_redis(process_name: ProcessName) -> Redis:
+    return cast(
         Redis,
         _async_redis.Redis.from_url(
             settings.redis_url,
@@ -36,8 +33,6 @@ async def create_redis(process_name: ProcessName) -> AsyncGenerator[Redis, None]
             client_name=f"{settings.ENV.value}.{process_name}",
         ),
     )
-    yield redis
-    await redis.close(True)
 
 
 async def get_redis(request: Request) -> Redis:

--- a/server/tests/fixtures/worker.py
+++ b/server/tests/fixtures/worker.py
@@ -1,10 +1,10 @@
-from collections.abc import AsyncIterator
+from collections.abc import Iterator
 from typing import Any
 
 import dramatiq
 import pytest
-import pytest_asyncio
 from dramatiq.middleware.current_message import CurrentMessage
+from pytest_mock import MockerFixture
 
 from polar.config import settings
 from polar.kit.db.postgres import AsyncSession
@@ -17,16 +17,16 @@ def set_job_queue_manager_context() -> None:
     set_job_queue_manager()
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def set_middleware_context(session: AsyncSession, redis: Redis) -> None:
-    SQLAlchemyMiddleware._get_async_sessionmaker_context.set(
-        lambda: session,  # type: ignore[arg-type]
-    )
-    RedisMiddleware._redis_context.set(redis)
+@pytest.fixture(autouse=True)
+def patch_middlewares(
+    mocker: MockerFixture, session: AsyncSession, redis: Redis
+) -> None:
+    mocker.patch.object(SQLAlchemyMiddleware, "get_async_session", new=lambda: session)
+    mocker.patch.object(RedisMiddleware, "get", new=lambda: redis)
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def current_message() -> AsyncIterator[dramatiq.Message[Any]]:
+@pytest.fixture(autouse=True)
+def current_message() -> Iterator[dramatiq.Message[Any]]:
     message = dramatiq.Message[Any](
         queue_name="default",
         actor_name="actor",


### PR DESCRIPTION
- server/worker: revamp SQLAlchemy and Redis middlewares with globals
- server/worker: ignore some noisy tasks in Logfire telemetry