### PR TITLE
server/worker: implement a basic health endpoint instead of builtin Prometheus metrics

### DIFF
--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -24,6 +24,8 @@ from polar.logging import Logger
 from polar.postgres import AsyncEngine, AsyncSession, create_async_engine
 from polar.redis import Redis, create_redis
 
+from .health import HealthMiddleware
+
 log: Logger = structlog.get_logger()
 
 _sqlalchemy_engine: AsyncEngine | None = None
@@ -351,7 +353,6 @@ broker = RedisBroker(
     middleware=[
         m()
         for m in (
-            middleware.Prometheus,
             middleware.AgeLimit,
             middleware.TimeLimit,
             middleware.ShutdownNotifications,
@@ -367,6 +368,7 @@ broker.add_middleware(
         min_backoff=settings.WORKER_MIN_BACKOFF_MILLISECONDS,
     )
 )
+broker.add_middleware(HealthMiddleware())
 broker.add_middleware(middleware.AsyncIO())
 broker.add_middleware(middleware.CurrentMessage())
 broker.add_middleware(MaxRetriesMiddleware())

--- a/server/polar/worker/health.py
+++ b/server/polar/worker/health.py
@@ -1,0 +1,45 @@
+import os
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import structlog
+from dramatiq.middleware import Middleware
+
+from polar.logging import Logger
+
+log: Logger = structlog.get_logger()
+
+HTTP_HOST = os.getenv("dramatiq_prom_host", "0.0.0.0")
+HTTP_PORT = int(os.getenv("dramatiq_prom_port", "9191"))
+
+
+class HealthMiddleware(Middleware):
+    @property
+    def forks(self) -> list[Callable[[], int]]:
+        return [_run_exposition_server]
+
+
+class _handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"status": "ok"}')
+
+    def log_message(self, format: str, *args: Any) -> None:
+        log.debug(format, *args)
+
+
+def _run_exposition_server() -> int:
+    log.debug("Starting exposition server...")
+
+    address = (HTTP_HOST, HTTP_PORT)
+    httpd = HTTPServer(address, _handler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        log.debug("Stopping exposition server...")
+        httpd.shutdown()
+
+    return 0


### PR DESCRIPTION
- server/worker: implement a basic health endpoint instead of builtin Prometheus metrics