### PR TITLE
server/worker: manage enqueued job as a decorator of actor function instead of middleware

### DIFF
--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -8,7 +8,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from polar.config import settings
 from polar.logging import Logger, generate_correlation_id
-from polar.worker import flush_enqueued_jobs, set_job_queue_manager
+from polar.worker import set_job_queue_manager
 
 
 class LogCorrelationIdMiddleware:
@@ -35,12 +35,14 @@ class FlushEnqueuedWorkerJobsMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        set_job_queue_manager()
+        job_queue_manager = set_job_queue_manager()
 
         await self.app(scope, receive, send)
 
         if not settings.is_testing():
-            await flush_enqueued_jobs(dramatiq.get_broker(), scope["state"]["redis"])
+            await job_queue_manager.flush(
+                dramatiq.get_broker(), scope["state"]["redis"]
+            )
 
 
 class PathRewriteMiddleware:


### PR DESCRIPTION
- server/worker: manage enqueued job as a decorator of actor function instead of middleware