### PR TITLE
server/worker: revamp JobQueueManager with a context manager

### DIFF
--- a/server/polar/kit/repository/base.py
+++ b/server/polar/kit/repository/base.py
@@ -79,8 +79,8 @@ class RepositoryBase(Generic[M]):
         return result.scalars().unique().all()
 
     async def stream(self, statement: Select[tuple[M]]) -> AsyncGenerator[M, None]:
-        results = await self.session.stream(statement)
-        async for result in results.unique().scalars():
+        results = await self.session.stream_scalars(statement)
+        async for result in results.unique():
             yield result
 
     async def paginate(

--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -394,7 +394,6 @@ __all__ = [
     "RedisMiddleware",
     "scheduler_middleware",
     "enqueue_job",
-    "flush_enqueued_jobs",
     "get_retries",
     "can_retry",
 ]

--- a/server/tests/fixtures/worker.py
+++ b/server/tests/fixtures/worker.py
@@ -9,12 +9,17 @@ from pytest_mock import MockerFixture
 from polar.config import settings
 from polar.kit.db.postgres import AsyncSession
 from polar.redis import Redis
-from polar.worker import RedisMiddleware, SQLAlchemyMiddleware, set_job_queue_manager
+from polar.worker import (
+    JobQueueManager,
+    RedisMiddleware,
+    SQLAlchemyMiddleware,
+    _job_queue_manager,
+)
 
 
 @pytest.fixture(autouse=True)
 def set_job_queue_manager_context() -> None:
-    set_job_queue_manager()
+    _job_queue_manager.set(JobQueueManager())
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
- server/worker: revamp JobQueueManager with a context manager
- server/meter: tweak create_billing_entries memory usage
- server/worker: manage enqueued job as a decorator of actor function instead of middleware