### PR TITLE
server/invoice: fix PDF generation when customer/seller name doesn't fit on a single line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,5 @@ playground.py
 
 .jwks.json
 *.mmdb
-server/tests/invoice/test_invoice.pdf
+server/tests/invoice/test_invoice*.pdf
 supervisord.pid

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -273,8 +273,9 @@ class InvoiceGenerator(FPDF):
 
         # Seller on left column
         self.set_font(style="B")
-        self.cell(
-            h=self.cell_height(),
+        self.multi_cell(
+            80,
+            self.cell_height(),
             text=self.data.seller_name,
             new_x=XPos.LMARGIN,
             new_y=YPos.NEXT,
@@ -302,8 +303,9 @@ class InvoiceGenerator(FPDF):
             h=self.cell_height(), text="Bill to", new_x=XPos.LEFT, new_y=YPos.NEXT
         )
         self.set_font(style="B")
-        self.cell(
-            h=self.cell_height(),
+        self.multi_cell(
+            80,
+            self.cell_height(),
             text=self.data.customer_name,
             new_x=XPos.LEFT,
             new_y=YPos.NEXT,


### PR DESCRIPTION
- server/invoice: fix PDF generation when customer/seller name doesn't fit on a single line