### PR TITLE
fix: hover state landing sdks

### DIFF
--- a/clients/apps/web/src/components/Landing/SDKs.tsx
+++ b/clients/apps/web/src/components/Landing/SDKs.tsx
@@ -59,24 +59,28 @@ const itemVariants = {
 export default function FrameworkSelector() {
   return (
     <motion.div
-      className="flex w-full flex-row items-center justify-center gap-x-4 md:w-3/4 md:gap-x-24 md:self-center"
+      className="flex h-24 w-full flex-row items-center justify-center gap-x-4 md:w-3/4 md:gap-x-24 md:self-center"
       variants={containerVariants}
       initial="hidden"
       whileInView="visible"
       viewport={{ once: true }}
     >
       {frameworks.map((framework) => (
-        <motion.div
+        <Link
           key={framework.name}
-          className="dark:hover:bg-polar-950 group flex flex-1 flex-col items-center justify-center hover:bg-gray-100"
-          variants={itemVariants}
+          href={framework.href}
+          className="h-full w-full"
         >
-          <Link key={framework.name} href={framework.href}>
+          <motion.div
+            key={framework.name}
+            className="dark:hover:bg-polar-900 group flex h-full w-full flex-1 flex-col items-center justify-center rounded-md hover:bg-gray-100"
+            variants={itemVariants}
+          >
             <div className="flex flex-col opacity-50 transition-all duration-200 group-hover:opacity-100">
               {framework.icon}
             </div>
-          </Link>
-        </motion.div>
+          </motion.div>
+        </Link>
       ))}
     </motion.div>
   )


### PR DESCRIPTION
# UI Enhancement

## Problem

The current hover state for SDK cards is subtle and lacks visual consistency height, also no contrast in dark mode. This affects usability and discoverability.

| Before |
|--------|
| <img width="1440" alt="455001118-8438394f-bebf-495a-8045-8e5fedabe077" src="https://github.com/user-attachments/assets/981757c7-d11c-4092-a552-6dd0dac494aa" /> |

---

## Proposed Change

- Add contrast for hover background in dark mode.
- Apply same height for all hovers.
- Add slight rounded borders for design consistency.

| After |
|-------|
| <img width="1433" alt="Screenshot 2025-06-13 at 20 23 59" src="https://github.com/user-attachments/assets/714f80d7-ab46-4682-93f4-1521ddfc84b3" /> |