### PR TITLE
Fix: Redis Service Allows Unauthorized Privilege Escalation in .devcontainer/docker-compose.yaml

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
     network_mode: service:db
 
   redis:
+    security_opt:
+      - "no-new-privileges:true"
     image: redis:alpine
     restart: unless-stopped
     network_mode: service:db


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'redis' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** .devcontainer/docker-compose.yaml
- **Lines Affected:** 18 - 18

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `.devcontainer/docker-compose.yaml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.