### PR TITLE
Fix outdated link for careers

### DIFF
--- a/clients/apps/web/src/app/humans.txt/route.tsx
+++ b/clients/apps/web/src/app/humans.txt/route.tsx
@@ -48,7 +48,7 @@ export async function GET() {
 
                     https://github.com/polarsource/polar
 
-                Wanna work with us? https://polar.sh/careers
+                Wanna work with us? https://polar.sh/company#open-roles
 
     `,
     {


### PR DESCRIPTION
Hi,
While reading the code I noticed that the `humans.txt` (nice touch btw! 😅) has an outdated link pointing to a page which is 404. I've added the /company route to it + the hash reference for the roles since the MDX plugin creates an anchor for it.