### PR TITLE
organization_access_token: Add `SANDBOX_` to tokens when in sandbox env

### DIFF
--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -32,6 +32,7 @@ from .sorting import OrganizationAccessTokenSortProperty
 log: Logger = structlog.get_logger()
 
 TOKEN_PREFIX = "polar_oat_"
+TOKEN_PREFIX_SANDBOX = "polar_sandbox_oat_"
 
 
 class OrganizationAccessTokenService:
@@ -105,8 +106,14 @@ class OrganizationAccessTokenService:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
         )
+
+        if settings.is_sandbox():
+            token_prefix = TOKEN_PREFIX_SANDBOX
+        else:
+            token_prefix = TOKEN_PREFIX
+
         token, token_hash = generate_token_hash_pair(
-            secret=settings.SECRET, prefix=TOKEN_PREFIX
+            secret=settings.SECRET, prefix=token_prefix
         )
         organization_access_token = OrganizationAccessToken(
             **create_schema.model_dump(

--- a/server/polar/personal_access_token/service.py
+++ b/server/polar/personal_access_token/service.py
@@ -18,7 +18,13 @@ from polar.postgres import AsyncSession
 
 log: Logger = structlog.get_logger()
 
-TOKEN_PREFIX = "polar_pat_"
+# We no longer allow the creation of Personal Access Tokens (PATs), so the
+# below prefix is now unused in active code. However, customers may still
+# actively be using PATs for API authentication and we continue to support
+# that.
+# The prefix is listed here for later reference.
+#
+# TOKEN_PREFIX = "polar_pat_"
 
 
 class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):


### PR DESCRIPTION
Tested with tokens created inside and outside of sandbox, both on `main`.

- Token created on `main` ("before this change") works on this branch ✅
- Token created on this branch works on this branch ✅ 