### PR TITLE
GHA, release_packages: Pin `changesets` action to v1.5.1

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        # Pin to last known working version (see: https://github.com/changesets/action/issues/501)
+        uses: changesets/action@v1.5.1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm run release-packages


### PR DESCRIPTION
Latest versions of the `changesets` action is not correctly using the `cwd`-parameter.

Therefore we pin to that last known working version.

See: https://github.com/changesets/action/issues/501