### PR TITLE
Use initials as fallback mechanism in avatar

### DIFF
--- a/clients/packages/ui/src/components/atoms/Avatar.tsx
+++ b/clients/packages/ui/src/components/atoms/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 const Avatar = ({
@@ -15,15 +16,10 @@ const Avatar = ({
 }) => {
   const initials = getInitials(name)
 
-  let showInitials = true
-  if (avatar_url) {
-    // Skip rendering initials in case of `avatar_url`
-    // Unless from Gravatar since they offer a transparent image in case of no avatar
-    // Also have to check for `http` first to avoid running `new URL` on internal NextJS asset paths
-    const avatarHost = avatar_url.startsWith('http')
-      ? new URL(avatar_url).host
-      : null
-    showInitials = avatarHost === 'www.gravatar.com'
+  const [showInitials, setShowInitials] = useState(avatar_url === null)
+
+  const onError = () => {
+    setShowInitials(true)
   }
 
   return (
@@ -33,12 +29,11 @@ const Avatar = ({
         className,
       )}
     >
-      {showInitials && (
+      {!avatar_url || showInitials ? (
         <div className="absolute inset-0 flex items-center justify-center bg-transparent">
           <span>{initials}</span>
         </div>
-      )}
-      {avatar_url && (
+      ) : (
         <>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
@@ -46,6 +41,7 @@ const Avatar = ({
             src={avatar_url}
             height={height}
             width={width}
+            onError={onError}
             className="z-[1] aspect-square rounded-full object-cover"
           />
         </>

--- a/clients/packages/ui/src/components/atoms/Avatar.tsx
+++ b/clients/packages/ui/src/components/atoms/Avatar.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { twMerge } from 'tailwind-merge'
+import { cn } from '@/lib/utils'
+import { ComponentProps, useState } from 'react'
 
 const Avatar = ({
   name,
@@ -16,19 +16,25 @@ const Avatar = ({
 }) => {
   const initials = getInitials(name)
 
+  // We render the image with opacity: 0 until it's successfully loaded.
+  // Not doing so can result in a flash of the `alt` text when a 404
+  // is returned from browser cache.
+  const [hasLoaded, setHasLoaded] = useState(false)
   const [showInitials, setShowInitials] = useState(avatar_url === null)
+
+  const onLoad = () => {
+    setHasLoaded(true)
+    setShowInitials(false)
+  }
 
   const onError = () => {
     setShowInitials(true)
+    setHasLoaded(true)
   }
-
-  useEffect(() => {
-    setShowInitials(avatar_url === null)
-  }, [avatar_url])
 
   return (
     <div
-      className={twMerge(
+      className={cn(
         'dark:bg-polar-900 dark:border-polar-700 relative z-[2] flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border-2 border-gray-200 bg-gray-50 text-sm',
         className,
       )}
@@ -45,8 +51,12 @@ const Avatar = ({
             src={avatar_url}
             height={height}
             width={width}
+            onLoad={onLoad}
             onError={onError}
-            className="z-[1] aspect-square rounded-full object-cover"
+            className={cn(
+              'z-[1] aspect-square rounded-full object-cover',
+              hasLoaded ? 'opacity-100' : 'opacity-0',
+            )}
           />
         </>
       )}
@@ -54,7 +64,11 @@ const Avatar = ({
   )
 }
 
-export default Avatar
+const AvatarWrapper = (props: ComponentProps<typeof StatefulAvatar>) => {
+  return <Avatar {...props} key={props.avatar_url} />
+}
+
+export default AvatarWrapper
 
 const getInitials = (fullName: string) => {
   const allNames = fullName.trim().split(' ')

--- a/clients/packages/ui/src/components/atoms/Avatar.tsx
+++ b/clients/packages/ui/src/components/atoms/Avatar.tsx
@@ -64,7 +64,7 @@ const Avatar = ({
   )
 }
 
-const AvatarWrapper = (props: ComponentProps<typeof StatefulAvatar>) => {
+const AvatarWrapper = (props: ComponentProps<typeof Avatar>) => {
   return <Avatar {...props} key={props.avatar_url} />
 }
 

--- a/clients/packages/ui/src/components/atoms/Avatar.tsx
+++ b/clients/packages/ui/src/components/atoms/Avatar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { cn } from '@/lib/utils'
 import { ComponentProps, useState } from 'react'
 

--- a/clients/packages/ui/src/components/atoms/Avatar.tsx
+++ b/clients/packages/ui/src/components/atoms/Avatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 const Avatar = ({
@@ -21,6 +21,10 @@ const Avatar = ({
   const onError = () => {
     setShowInitials(true)
   }
+
+  useEffect(() => {
+    setShowInitials(avatar_url === null)
+  }, [avatar_url])
 
   return (
     <div

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -111,10 +111,10 @@ class CustomerBase(MetadataOutputMixin, TimestampedSchema, IDSchema):
         description="Timestamp for when the customer was soft deleted."
     )
 
-    @computed_field(examples=["https://www.gravatar.com/avatar/xxx?d=blank"])
+    @computed_field(examples=["https://www.gravatar.com/avatar/xxx?d=404"])
     def avatar_url(self) -> str:
         email_hash = hashlib.sha256(self.email.lower().encode()).hexdigest()
-        return f"https://www.gravatar.com/avatar/{email_hash}?d=blank"
+        return f"https://www.gravatar.com/avatar/{email_hash}?d=404"
 
 
 class Customer(CustomerBase):


### PR DESCRIPTION
Fixes #5795 

The current logic relied on always rendering the initials, and rendering the avatar on top of that if it was available. Because Gravatar can return a blank image when no avatar matches, this was a nice fallback mechanism.

However, that breaks when you host a transparent PNG on Gravatar as your avatar.

With this change, I try to make the logic a bit more straight-forward:

 - If there's not an image, render initials
 - If there's an image, attempt to render it
 - If the image loading fails, fall back to rendering initials

We can swap the `d=` parameter on Gravatar to `404` to accommodate this behavior.

The only drawback would be a small FOUC where the initials render only when Gravatar returns a 404, which could be a reason not to merge this. In my tests it's not annoying—as Gravatar is really fast—and the current implementation also has a "FOUC" in the other direction (rendering the initials until the image is loaded), which is arguably more distracting for a user.

As far as I can tell, the customers list is the only place where Gravatar is used, so that's where I tested this change.