### PR TITLE
Sidebar, account dropdown: Show "pointer" cursor to indicate clickable

### DIFF
--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -145,7 +145,7 @@ export const DashboardSidebar = ({
                   {organizations.map((org) => (
                     <DropdownMenuItem
                       key={org.id}
-                      className="flex cursor-pointer flex-row items-center gap-x-2"
+                      className="flex flex-row items-center gap-x-2"
                       onClick={() => navigateToOrganization(org)}
                     >
                       <Avatar
@@ -158,20 +158,17 @@ export const DashboardSidebar = ({
                   ))}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    className="cursor-pointer"
                     onClick={() => router.push('/dashboard/create')}
                   >
                     New Organization
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    className="cursor-pointer"
                     onClick={() => router.push('/dashboard/account')}
                   >
                     Account Settings
                   </DropdownMenuItem>
                   {!CONFIG.IS_SANDBOX && (
                     <DropdownMenuItem
-                      className="cursor-pointer"
                       onClick={() =>
                         router.push('https://sandbox.polar.sh/start')
                       }
@@ -181,7 +178,6 @@ export const DashboardSidebar = ({
                   )}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    className="cursor-pointer"
                     onClick={() =>
                       router.push(`${CONFIG.BASE_URL}/v1/auth/logout`)
                     }

--- a/clients/packages/ui/src/components/atoms/DropdownMenu.tsx
+++ b/clients/packages/ui/src/components/atoms/DropdownMenu.tsx
@@ -78,7 +78,7 @@ const DropdownMenuItem = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuItemPrimitive
     ref={ref}
-    className={twMerge('', className)}
+    className={twMerge(props?.onClick ? 'cursor-pointer' : '', className)}
     {...props}
   />
 ))


### PR DESCRIPTION
Previously, the items in the account dropdown were showing with the
neutral cursor. We now use the "pointer" cursor to indicate they're
clickable.