### PR TITLE
docs: update setup instructions for GitHub App and add Stripe setup details

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,7 +66,7 @@ Once done, the script will automatically create `server/.env` and `clients/apps/
 If you want to work with GitHub login and issue funding, you'll need to have a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) for your development environment. Our script is able to help in this task by passing the following parameters:
 
 ```sh
-./dev/setup-environment --setup-github-app --backend-external-url mydomain.ngrok.dev
+./dev/setup-environment --setup-github-app --backend-external-url https://mydomain.ngrok.dev
 ```
 
 Note that you'll need a valid external URL that'll route to your development server. For this task, we recommend to use [ngrok](https://ngrok.com/).
@@ -82,7 +82,28 @@ Your browser will open a new page and you'll be prompted to **create a GitHub Ap
 
 **Optional: setup Stripe**
 
-Currently, this setup script doesn't support to create a [Stripe Sandbox](https://docs.stripe.com/sandboxes). If you want a ready-to-use Stripe Sandbox, contact us and we'll happily provide you one.
+If you want to work with payments and subscriptions, you'll need to set up a Stripe development environment:
+
+1. **Create a Stripe account** at [https://dashboard.stripe.com/register](https://dashboard.stripe.com/register)
+
+2. **Enable billing** in your Stripe account by visiting [Stripe Billing Starter Guide](https://dashboard.stripe.com/billing/starter-guide)
+
+3. **Copy your API keys** from the [Stripe API Keys page](https://dashboard.stripe.com/test/apikeys) and add them to your `server/.env` file:
+   ```
+   STRIPE_SECRET_KEY=sk_test_...
+   STRIPE_PUBLISHABLE_KEY=pk_test_...
+   ```
+
+4. **Create a webhook endpoint** to handle Stripe events:
+   - Go to [Stripe Webhooks](https://dashboard.stripe.com/test/webhooks)
+   - Click "Add endpoint"
+   - Set the endpoint URL to: `https://your-domain.ngrok-free.app/v1/integrations/stripe/webhook`
+   - Set enabled events to: `*` (all events)
+   - Set API version to: `2025-02-24.acacia`
+   - Copy the webhook signing secret and add it to your `server/.env` file:
+     ```
+     STRIPE_WEBHOOK_SECRET=whsec_...
+     ```
 
 ### Setup backend
 

--- a/dev/setup-environment
+++ b/dev/setup-environment
@@ -30,7 +30,7 @@ from yaspin.spinners import Spinners
 ROOT_PATH = pathlib.Path(__file__).parent.parent
 IS_CODESPACES = os.getenv("CODESPACES", "false") == "true"
 SETUP_PAGE = """
-<form id="setup-form" action="https://github.com/organizations/polarsource/settings/apps/new" method="post">
+<form id="setup-form" action="https://github.com/settings/apps/new" method="post">
  Register a GitHub App Manifest: <input type="text" name="manifest" id="manifest"><br>
  <input type="submit" value="Submit">
 </form>


### PR DESCRIPTION
# Context

This mainly PR mainly adds instructions on how to properly setup Stripe integration. Aside of that I modify 2 things:

- Add https in the front of `--backend-external-url`, if not added the integration fails
- Modify the url to create a new app to `https://github.com/settings/apps/new` as new contributors are not part of Polar organization usually.