### PR TITLE
server: Hide downloadable endpoint

### DIFF
--- a/server/polar/customer_portal/endpoints/downloadables.py
+++ b/server/polar/customer_portal/endpoints/downloadables.py
@@ -57,6 +57,7 @@ async def list(
         410: {"description": "Expired signature"},
     },
     name="customer_portal.downloadables.get",
+    tags=[APITag.private],
 )
 async def get(
     token: str,


### PR DESCRIPTION
Not intended to be used as an API endpoint. It's the URL that our list
endpoint yields to download the file itself using the presigned token
that is not exposed directly.
