### PR TITLE
fix: lack of required `server` parameters in docs

### DIFF
--- a/docs/features/customer-portal.mdx
+++ b/docs/features/customer-portal.mdx
@@ -54,7 +54,8 @@ import { CustomerPortal } from "@polar-sh/nextjs";
 
 export const GET = CustomerPortal({
   accessToken: process.env.POLAR_ACCESS_TOKEN,
-  getCustomerId: async (req) => '<value>'
+  getCustomerId: async (req) => '<value>',
+  server: 'sandbox' // Use sandbox if you're testing Polar - pass 'production' otherwise
 });
 ```
 


### PR DESCRIPTION
Docs example lack `server` parameter, which is required by TS. I expect it to be a mistake, as it's not required in any other method, but in case it's not, here is docs fix