### PR TITLE
Fallback to same-tab navigation when window.open fails

### DIFF
--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -71,7 +71,12 @@ const DownloadInvoice = ({
     if (response.error) {
       return
     }
-    window.open(response.data.url, '_blank')
+    const newWindow = window.open(response.data.url, '_blank')
+
+    if (!newWindow) {
+      window.location.href = response.data.url
+    }
+
     setLoading(false)
     hide()
   }, [order, api, hide, invoiceURL])


### PR DESCRIPTION
Quick fix for #6111 

This UX is suboptimal. An improvement could be falling back to an in-app dialog titled "Your invoice is ready to download" and another download button which is a simple `<a download>` to the pre-signed URL.