### PR TITLE
Improve email styling

### DIFF
--- a/server/polar/email/email_templates/base.html
+++ b/server/polar/email/email_templates/base.html
@@ -556,7 +556,7 @@
                       <div class="f-fallback">
                         {% if featured_organization is defined %}
                         <h3 class="email-masthead_feat">
-                          {{ featured_organization.slug }}
+                          {{ featured_organization.name }}
                         </h3>
                         {% else %}
                         <a

--- a/server/polar/email/email_templates/base.html
+++ b/server/polar/email/email_templates/base.html
@@ -53,7 +53,7 @@
       body,
       td,
       th {
-        font-family: "Inter", Helvetica, Arial, sans-serif;
+        font-family: "Inter", system-ui, Helvetica, Arial, sans-serif;
       }
 
       h1 {

--- a/server/polar/email/email_templates/base.html
+++ b/server/polar/email/email_templates/base.html
@@ -126,7 +126,7 @@
         border-left: 18px solid #0062ff;
         display: inline-block;
         color: #fff !important;
-        font-weight: medium;
+        font-weight: 500;
         text-decoration: none;
         border-radius: 8px;
         -webkit-text-size-adjust: none;

--- a/server/polar/email/email_templates/base.html
+++ b/server/polar/email/email_templates/base.html
@@ -7,10 +7,15 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="supported-color-schemes" content="light dark" />
     <title></title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+    />
     <style type="text/css" rel="stylesheet" media="all">
-      /* Base ------------------------------ */
-
+      /* Add fonts both as <link> and @import for maximum compatibility */
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
+
+      /* Base ------------------------------ */
 
       body {
         width: 100% !important;

--- a/server/polar/email/email_templates/base.html
+++ b/server/polar/email/email_templates/base.html
@@ -9,11 +9,11 @@
     <title></title>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
     />
     <style type="text/css" rel="stylesheet" media="all">
       /* Add fonts both as <link> and @import for maximum compatibility */
-      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap");
 
       /* Base ------------------------------ */
 

--- a/server/tests/notifications/testdata/test_MaintainerCreateAccountNotificationPayload.html
+++ b/server/tests/notifications/testdata/test_MaintainerCreateAccountNotificationPayload.html
@@ -9,10 +9,15 @@ Create a payout account for orgname now to receive funds
     <meta name="color-scheme" content="light dark" />
     <meta name="supported-color-schemes" content="light dark" />
     <title></title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    />
     <style type="text/css" rel="stylesheet" media="all">
-      /* Base ------------------------------ */
+      /* Add fonts both as <link> and @import for maximum compatibility */
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap");
 
-      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
+      /* Base ------------------------------ */
 
       body {
         width: 100% !important;
@@ -50,7 +55,7 @@ Create a payout account for orgname now to receive funds
       body,
       td,
       th {
-        font-family: "Inter", Helvetica, Arial, sans-serif;
+        font-family: "Inter", system-ui, Helvetica, Arial, sans-serif;
       }
 
       h1 {
@@ -123,7 +128,7 @@ Create a payout account for orgname now to receive funds
         border-left: 18px solid #0062ff;
         display: inline-block;
         color: #fff !important;
-        font-weight: medium;
+        font-weight: 500;
         text-decoration: none;
         border-radius: 8px;
         -webkit-text-size-adjust: none;

--- a/server/tests/notifications/testdata/test_MaintainerNewPaidSubscriptionNotification.html
+++ b/server/tests/notifications/testdata/test_MaintainerNewPaidSubscriptionNotification.html
@@ -9,10 +9,15 @@ Congrats! You have a new subscriber on My Paid Tier ($5.00/month)!
     <meta name="color-scheme" content="light dark" />
     <meta name="supported-color-schemes" content="light dark" />
     <title></title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    />
     <style type="text/css" rel="stylesheet" media="all">
-      /* Base ------------------------------ */
+      /* Add fonts both as <link> and @import for maximum compatibility */
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap");
 
-      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
+      /* Base ------------------------------ */
 
       body {
         width: 100% !important;
@@ -50,7 +55,7 @@ Congrats! You have a new subscriber on My Paid Tier ($5.00/month)!
       body,
       td,
       th {
-        font-family: "Inter", Helvetica, Arial, sans-serif;
+        font-family: "Inter", system-ui, Helvetica, Arial, sans-serif;
       }
 
       h1 {
@@ -123,7 +128,7 @@ Congrats! You have a new subscriber on My Paid Tier ($5.00/month)!
         border-left: 18px solid #0062ff;
         display: inline-block;
         color: #fff !important;
-        font-weight: medium;
+        font-weight: 500;
         text-decoration: none;
         border-radius: 8px;
         -webkit-text-size-adjust: none;

--- a/server/tests/notifications/testdata/test_MaintainerNewProductSaleNotification.html
+++ b/server/tests/notifications/testdata/test_MaintainerNewProductSaleNotification.html
@@ -9,10 +9,15 @@ Congrats! You've made a new sale ($5.00)!
     <meta name="color-scheme" content="light dark" />
     <meta name="supported-color-schemes" content="light dark" />
     <title></title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    />
     <style type="text/css" rel="stylesheet" media="all">
-      /* Base ------------------------------ */
+      /* Add fonts both as <link> and @import for maximum compatibility */
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap");
 
-      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
+      /* Base ------------------------------ */
 
       body {
         width: 100% !important;
@@ -50,7 +55,7 @@ Congrats! You've made a new sale ($5.00)!
       body,
       td,
       th {
-        font-family: "Inter", Helvetica, Arial, sans-serif;
+        font-family: "Inter", system-ui, Helvetica, Arial, sans-serif;
       }
 
       h1 {
@@ -123,7 +128,7 @@ Congrats! You've made a new sale ($5.00)!
         border-left: 18px solid #0062ff;
         display: inline-block;
         color: #fff !important;
-        font-weight: medium;
+        font-weight: 500;
         text-decoration: none;
         border-radius: 8px;
         -webkit-text-size-adjust: none;


### PR DESCRIPTION
I bought the (incredibly well-executed) Devouring Details course and got this order confirmation:

| **Gmail** | **Mail.app** |
|-----------|-------------|
| <img width="1066" height="683" alt="image" src="https://github.com/user-attachments/assets/0594a4ab-0db1-4bce-a851-3e0fc4c676f1" /> | <img width="973" height="652" alt="image" src="https://github.com/user-attachments/assets/4f4bf1d9-dd68-4f97-a310-6d197617f918" /> |

Figured that could be a bit better, or (I'm sorry) time to devour some details.

This PR fixes:

 - Custom font not loading properly in Gmail
 - Faux bold issues in Mail.app
 - Use organization name instead of slug

Resulting in:

| **Gmail** | **Mail.app** |
|-----------|-------------|
| <img width="1066" height="681" alt="image" src="https://github.com/user-attachments/assets/b17d8bec-525b-47ea-8f95-8b7d5e3d74fd" /> | <img width="969" height="648" alt="image" src="https://github.com/user-attachments/assets/e3eb542d-11dd-4719-802f-7f42d066cbd1" /> |

Two things that are more aesthetically consistent with the customer portal that I'd consider doing:
 - Switch the email backgrounds to the same gray as the customer portal
 - Switch the font from Inter to Geist