### PR TITLE
server/processor_transaction: don't expand data.source when fetching balance transactions from Stripe

### DIFF
--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -380,16 +380,18 @@ class StripeService:
         account_id: str | None = None,
         payout: str | None = None,
         type: str | None = None,
+        expand: list[str] | None = None,
     ) -> AsyncIterator[stripe_lib.BalanceTransaction]:
         params: stripe_lib.BalanceTransaction.ListParams = {
             "limit": 100,
             "stripe_account": account_id,
-            "expand": ["data.source"],
         }
         if payout is not None:
             params["payout"] = payout
         if type is not None:
             params["type"] = type
+        if expand is not None:
+            params["expand"] = expand
 
         result = await stripe_lib.BalanceTransaction.list_async(**params)
         return result.auto_paging_iter()

--- a/server/polar/transaction/service/processor_fee.py
+++ b/server/polar/transaction/service/processor_fee.py
@@ -182,7 +182,7 @@ class ProcessorFeeTransactionService(BaseTransactionService):
         transactions: list[Transaction] = []
 
         balance_transactions = await stripe_service.list_balance_transactions(
-            type="stripe_fee"
+            type="stripe_fee", expand=["data.source"]
         )
         async for balance_transaction in balance_transactions:
             transaction = await self.get_by(


### PR DESCRIPTION
- server/processor_transaction: don't expand data.source when fetching balance transactions from Stripe