### PR TITLE
devcontainer: rely on devcontainers/features/node:1 to install pnpm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22"
     },
-    "ghcr.io/devcontainers-contrib/features/pnpm:2": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker": {}
 	},
 


### PR DESCRIPTION
The original devcontainers-contrib repo has disappeared, which blocks codespace installation.
The pnpm installation is done anyway by devcontainers/features/node:1.

See: https://github.com/devcontainers/features/tree/main/src/node