### PR TITLE
Backoffice[DatatableActions]: Use HTML-popover based Dropdown

### DIFF
--- a/server/polar/web_backoffice/components/_datatable.py
+++ b/server/polar/web_backoffice/components/_datatable.py
@@ -1,4 +1,6 @@
 import contextlib
+import random
+import string
 import typing
 from collections.abc import Callable, Generator, Sequence
 from datetime import datetime
@@ -217,24 +219,33 @@ class DatatableActionsColumn(Generic[M], DatatableColumn[M]):
 
     def render(self, request: Request, item: M) -> Generator[None] | None:
         item_id = getattr(item, "id")
-        with tag.details(classes="dropdown"):
-            with tag.summary(type="button", classes="btn btn-ghost m-1"):
-                with tag.div(classes="font-normal icon-ellipsis-vertical"):
-                    pass
 
-            displayed_actions = [
-                action for action in self.actions if not action.is_hidden(request, item)
-            ]
-            if not displayed_actions:
-                return None
+        displayed_actions = [
+            action for action in self.actions if not action.is_hidden(request, item)
+        ]
+        if not displayed_actions:
+            return None
 
-            with tag.ul(
-                classes="menu dropdown-content bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm",
-            ):
-                for action in displayed_actions:
-                    with tag.li():
-                        with action.render(request, item):
-                            pass
+        popover_id = "".join(random.choice(string.ascii_letters) for i in range(6))
+        with tag.button(
+            classes="btn btn-ghost m-1",
+            style=f"anchor-name:--anchor-{popover_id}",
+            popovertarget=f"popover-{popover_id}",
+        ):
+            with tag.div(classes="font-normal icon-ellipsis-vertical"):
+                pass
+
+        with tag.ul(
+            classes="dropdown menu w-52 rounded-box bg-base-100 shadow-sm",
+            popover=True,
+            id=f"popover-{popover_id}",
+            style=f"position-anchor:--anchor-{popover_id}",
+        ):
+            for action in displayed_actions:
+                with tag.li():
+                    with action.render(request, item):
+                        pass
+
         return None
 
 


### PR DESCRIPTION
We switch to using the new HTML-based popover attribute for the dropdown
in DatatableActions, as the old CSS-based one would be cut off by the
table bounding box meaning that it would not be visible when used in the
last row.

This was due to the table having `position: relative` and a parent
component having `overflow-x-auto`. We can't remove those because they
allow for nice scroll behavior on small screens.

See: https://daisyui.com/components/dropdown/#method-2-popover-api-and-anchor-positioning