### PR TITLE
Onboarding: Don't show "Back to Dashboard" during onboarding

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/(create)/create/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/(create)/create/ClientPage.tsx
@@ -7,17 +7,20 @@ export interface ClientPageProps {
   slug?: string
   validationErrors?: schemas['ValidationError'][]
   error?: string
+  hasExistingOrg: boolean
 }
 
 export default function ClientPage({
   slug,
   validationErrors,
   error,
+  hasExistingOrg,
 }: ClientPageProps) {
   return (
     <OrganizationStep
       slug={slug}
       validationErrors={validationErrors}
+      hasExistingOrg={hasExistingOrg}
       error={error}
     />
   )

--- a/clients/apps/web/src/app/(main)/dashboard/(create)/create/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/(create)/create/page.tsx
@@ -13,9 +13,9 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page({
-  searchParams: { slug, auto },
+  searchParams: { slug, auto, existing_org },
 }: {
-  searchParams: { slug?: string; auto?: string }
+  searchParams: { slug?: string; auto?: string; existing_org?: boolean }
 }) {
   let validationErrors: schemas['ValidationError'][] = []
   let error: string | undefined = undefined
@@ -42,5 +42,11 @@ export default async function Page({
     }
   }
 
-  return <ClientPage validationErrors={validationErrors} error={error} />
+  return (
+    <ClientPage
+      hasExistingOrg={!!existing_org}
+      validationErrors={validationErrors}
+      error={error}
+    />
+  )
 }

--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -158,7 +158,9 @@ export const DashboardSidebar = ({
                   ))}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    onClick={() => router.push('/dashboard/create')}
+                    onClick={() =>
+                      router.push('/dashboard/create?existing_org=1')
+                    }
                   >
                     New Organization
                   </DropdownMenuItem>

--- a/clients/apps/web/src/components/Onboarding/OrganizationStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/OrganizationStep.tsx
@@ -30,15 +30,17 @@ export interface OrganizationStepProps {
   slug?: string
   validationErrors?: schemas['ValidationError'][]
   error?: string
+  hasExistingOrg: boolean
 }
 
 export const OrganizationStep = ({
   slug: initialSlug,
   validationErrors,
   error,
+  hasExistingOrg,
 }: OrganizationStepProps) => {
   const posthog = usePostHog()
-  const { currentUser, setUserOrganizations, userOrganizations } = useAuth()
+  const { currentUser, setUserOrganizations } = useAuth()
 
   const form = useForm<{ name: string; slug: string; terms: boolean }>({
     defaultValues: {
@@ -117,9 +119,13 @@ export const OrganizationStep = ({
     await revalidate(`users:${currentUser?.id}:organizations`)
     setUserOrganizations((orgs) => [...orgs, organization])
 
+    let queryParams = ''
+    if (hasExistingOrg) {
+      queryParams = '?existing_org=1'
+    }
     router.push(
       getStatusRedirect(
-        `/dashboard/${organization.slug}/onboarding/product`,
+        `/dashboard/${organization.slug}/onboarding/product${queryParams}`,
         'Organization created',
         'You can now create your first product',
       ),
@@ -283,7 +289,7 @@ export const OrganizationStep = ({
                 >
                   Create
                 </Button>
-                {userOrganizations.length > 0 && (
+                {hasExistingOrg && (
                   <Link href={`/dashboard`} className="w-full">
                     <Button variant="secondary" fullWidth>
                       Back to Dashboard

--- a/clients/apps/web/src/components/Onboarding/ProductStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductStep.tsx
@@ -203,7 +203,7 @@ export const ProductStep = () => {
                 Create Product
               </Button>
               <Link href={`/dashboard/${organization.slug}`}>
-                <Button variant="secondary">Cancel</Button>
+                <Button variant="secondary">Skip</Button>
               </Link>
             </div>
           </div>


### PR DESCRIPTION
This PR:
- Removes the "Back to Dashboard"-button that was shown during onboarding. It still shows when the user creates their second organization.
- Renames "Cancel"-button in the product step of the onboarding to "Skip"
