### PR TITLE
Issue-6183: check validity of tax address

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1541,7 +1541,9 @@ class CheckoutService:
     async def _update_checkout_tax(
         self, session: AsyncSession, checkout: Checkout
     ) -> Checkout:
-        if not (checkout.is_payment_form_required and checkout.product.is_tax_applicable):
+        if not (
+            checkout.is_payment_form_required and checkout.product.is_tax_applicable
+        ):
             checkout.tax_amount = 0
             checkout.tax_processor_id = None
             return checkout

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -797,7 +797,11 @@ class CheckoutService:
                     }
                 )
 
-        if checkout.require_billing_address or checkout.is_business_customer:
+        if (
+            checkout.require_billing_address
+            or checkout.is_business_customer
+            or checkout.is_payment_form_required
+        ):
             if (
                 checkout.customer_billing_address is None
                 or not checkout.customer_billing_address.has_address()
@@ -1541,7 +1545,16 @@ class CheckoutService:
     async def _update_checkout_tax(
         self, session: AsyncSession, checkout: Checkout
     ) -> Checkout:
-        if not (checkout.is_payment_required and checkout.product.is_tax_applicable):
+        # For setup intents (first month free), we still need to validate the address
+        # even though no payment is currently required, because the subscription will
+        # need automatic tax enabled for future billing
+        if not (
+            (checkout.is_payment_required and checkout.product.is_tax_applicable)
+            or (
+                checkout.is_payment_setup_required
+                and checkout.product.is_tax_applicable
+            )
+        ):
             checkout.tax_amount = 0
             checkout.tax_processor_id = None
             return checkout

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -800,7 +800,7 @@ class CheckoutService:
         if (
             checkout.require_billing_address
             or checkout.is_business_customer
-            or checkout.is_payment_form_required
+            or (checkout.is_payment_setup_required and not checkout.is_payment_required)
         ):
             if (
                 checkout.customer_billing_address is None

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -797,11 +797,7 @@ class CheckoutService:
                     }
                 )
 
-        if (
-            checkout.require_billing_address
-            or checkout.is_business_customer
-            or (checkout.is_payment_setup_required and not checkout.is_payment_required)
-        ):
+        if checkout.require_billing_address or checkout.is_business_customer:
             if (
                 checkout.customer_billing_address is None
                 or not checkout.customer_billing_address.has_address()
@@ -1545,16 +1541,7 @@ class CheckoutService:
     async def _update_checkout_tax(
         self, session: AsyncSession, checkout: Checkout
     ) -> Checkout:
-        # For setup intents (first month free), we still need to validate the address
-        # even though no payment is currently required, because the subscription will
-        # need automatic tax enabled for future billing
-        if not (
-            (checkout.is_payment_required and checkout.product.is_tax_applicable)
-            or (
-                checkout.is_payment_setup_required
-                and checkout.product.is_tax_applicable
-            )
-        ):
+        if not (checkout.is_payment_form_required and checkout.product.is_tax_applicable):
             checkout.tax_amount = 0
             checkout.tax_processor_id = None
             return checkout

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2671,23 +2671,9 @@ class TestConfirm:
     @pytest.mark.parametrize(
         "customer_billing_address,expected_tax_metadata",
         [
+            ({"country": "FR"}, {"tax_country": "FR"}),
             (
-                {
-                    "line1": "123 Main St",
-                    "postal_code": "75001",
-                    "city": "Paris",
-                    "country": "FR",
-                },
-                {"tax_country": "FR"},
-            ),
-            (
-                {
-                    "line1": "456 Oak Ave",
-                    "postal_code": "H2Y 1C6",
-                    "city": "Quebec",
-                    "state": "CA-QC",
-                    "country": "CA",
-                },
+                {"country": "CA", "state": "CA-QC"},
                 {"tax_country": "CA", "tax_state": "QC"},
             ),
         ],
@@ -3110,19 +3096,14 @@ class TestConfirm:
 
     async def test_setup_intent_address_validation(
         self,
-        stripe_service_mock: MagicMock,
+        calculate_tax_mock: AsyncMock,
         session: AsyncSession,
         locker: Locker,
         auth_subject: AuthSubject[Anonymous],
         checkout_discount_percentage_100: Checkout,
     ) -> None:
-        # Test that address validation works for setup intents (first month free)
-        # where is_payment_required is False but is_payment_form_required is True
-        stripe_service_mock.create_customer.return_value = SimpleNamespace(
-            id="STRIPE_CUSTOMER_ID"
-        )
-        stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+        calculate_tax_mock.side_effect = IncompleteTaxLocation(
+            stripe_lib.InvalidRequestError("ERROR", "ERROR")
         )
 
         # Verify this is a setup intent scenario
@@ -3130,7 +3111,6 @@ class TestConfirm:
         assert checkout_discount_percentage_100.is_payment_setup_required is True
         assert checkout_discount_percentage_100.is_payment_form_required is True
 
-        # Test that confirmation fails without billing address
         with pytest.raises(PolarRequestValidationError) as e:
             await checkout_service.confirm(
                 session,
@@ -3142,39 +3122,16 @@ class TestConfirm:
                         "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
                         "customer_name": "Customer Name",
                         "customer_email": "customer@example.com",
-                        # Missing billing address
+                        "customer_billing_address": {
+                            "line1": "123 Main St",
+                            "postal_code": "12345",
+                            "city": "New York",
+                            "state": "US-CA",
+                            "country": "US",
+                        },
                     }
                 ),
             )
-
-        errors = e.value.errors()
-        error_locations = {error["loc"] for error in errors}
-        assert ("body", "customer_billing_address") in error_locations
-
-        # Test that confirmation succeeds with complete billing address
-        checkout = await checkout_service.confirm(
-            session,
-            locker,
-            auth_subject,
-            checkout_discount_percentage_100,
-            CheckoutConfirmStripe.model_validate(
-                {
-                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
-                    "customer_name": "Customer Name",
-                    "customer_email": "customer@example.com",
-                    "customer_billing_address": {
-                        "line1": "123 Main St",
-                        "postal_code": "12345",
-                        "city": "New York",
-                        "state": "US-NY",
-                        "country": "US",
-                    },
-                }
-            ),
-        )
-
-        assert checkout.status == CheckoutStatus.confirmed
-        stripe_service_mock.create_setup_intent.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -3295,35 +3252,3 @@ class TestHandleFailure:
             await discount_redemption_repository.get_by_id(discount_redemption.id)
             is None
         )
-
-    async def test_valid_calculate_tax(
-        self,
-        session: AsyncSession,
-        auth_subject: AuthSubject[User | Organization],
-        calculate_tax_mock: AsyncMock,
-        user_organization: UserOrganization,
-        product_one_time: Product,
-    ) -> None:
-        calculate_tax_mock.return_value = {
-            "processor_id": "TAX_PROCESSOR_ID",
-            "amount": 100,
-            "taxability_reason": TaxabilityReason.standard_rated,
-            "tax_rate": {},
-        }
-
-        price = product_one_time.prices[0]
-        assert isinstance(price, ProductPriceFixed)
-
-        checkout = await checkout_service.create(
-            session,
-            CheckoutPriceCreate(
-                product_price_id=price.id,
-                customer_billing_address=Address.model_validate({"country": "FR"}),
-            ),
-            auth_subject,
-        )
-
-        assert checkout.tax_amount == 100
-        assert checkout.tax_processor_id == "TAX_PROCESSOR_ID"
-        assert checkout.customer_billing_address is not None
-        assert checkout.customer_billing_address.country == "FR"


### PR DESCRIPTION
Fixes #6183 
Regular payments (is_payment_required is True): Only require full addresses if require_billing_address is True or is_business_customer is True
Setup intents (is_payment_required is False but is_payment_setup_required is True): Require full addresses for tax calculation
Free products (is_payment_required is False and is_payment_setup_required is False): Don't require full addresses