### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   linters:
     name: "Server: Linters 📝"


### PR DESCRIPTION
Potential fix for [https://github.com/polarsource/polar/security/code-scanning/62](https://github.com/polarsource/polar/security/code-scanning/62)

To fix the issue, we should add a `permissions` block to explicitly define the least privileges required for the workflow. Since the workflow involves tasks such as checking out code, running tests, and setting up environments, `contents: read` should suffice for most steps. For any specific tasks requiring write access (e.g., pushing updates), we can add granular permissions at the job level. The `permissions` block will be added at the workflow level to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
