### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -1,5 +1,8 @@
 name: Server
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/polarsource/polar/security/code-scanning/61](https://github.com/polarsource/polar/security/code-scanning/61)

To fix this issue, we will add a `permissions` block to the root of the workflow file to apply the least privileges required for all jobs. This will ensure that the `GITHUB_TOKEN` only has `read` access to contents, as there is no indication that `write` permissions are needed. If any job requires additional permissions, they can be defined at the job level to override the default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
