### PR TITLE
Potential fix for code scanning alert no. 60: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -1,5 +1,8 @@
 name: Client
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/polarsource/polar/security/code-scanning/60](https://github.com/polarsource/polar/security/code-scanning/60)

To fix the problem, add a `permissions` key to the workflow file `.github/workflows/test_client.yaml`. This key can be added either at the root level (before the `jobs:` key) to apply to all jobs, or individually within each job (`build`, `build_storybook`) if different permissions are needed per job. Since neither job appears to require write access to repository contents or other resources (they only build and test), the minimal permission required is `contents: read`. The best fix is to add the following block near the top of the workflow file, after the `name:` and before the `on:` block:

```yaml
permissions:
  contents: read
```

No imports or additional methods are required; only the YAML configuration needs to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
