### PR TITLE
Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Client: Tests 🎨"


### PR DESCRIPTION
Potential fix for [https://github.com/polarsource/polar/security/code-scanning/59](https://github.com/polarsource/polar/security/code-scanning/59)

The fix involves adding a `permissions` key to the workflow. The `contents: read` permission is sufficient for most workflows that only need to access the repository's contents without making modifications. In case the individual jobs have specific permission needs (e.g., `pull-requests: write`), those can be defined at the job level.

To resolve the issue:
1. Add a `permissions` block at the workflow level to apply minimal permissions (`contents: read`) to all jobs.
2. If any job requires additional permissions, define those explicitly within the job's configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
