### PR TITLE
Potential fix for code scanning alert no. 58: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: none
+
 jobs:
   backup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/polarsource/polar/security/code-scanning/58](https://github.com/polarsource/polar/security/code-scanning/58)

To fix this issue, we will add a `permissions` block at the root of the workflow to explicitly restrict permissions to the minimum required. Since this workflow does not use `GITHUB_TOKEN` for any operations, we can set all permissions to `none`. This ensures the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
