### PR TITLE
Potential fix for code scanning alert no. 57: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,5 +1,8 @@
 name: Chromatic
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/polarsource/polar/security/code-scanning/57](https://github.com/polarsource/polar/security/code-scanning/57)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow involves reading the repository contents and interacting with Chromatic, it should have `contents: read` permission at a minimum. If additional permissions are required for specific steps, they should be added explicitly and scoped narrowly. The block can be placed at the root of the workflow to apply globally or inside the job to apply specifically to `chromatic-deployment`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
