### PR TITLE
Subscription revoke: Don't send both cancellation and revocation email

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1205,7 +1205,7 @@ class SubscriptionService:
 
         # Revokation both cancels & revokes simultaneously.
         # Send webhook for both, but avoid duplicate email to customers.
-        if revoked:
+        if not revoked:
             await self.send_cancellation_email(session, subscription)
 
     async def _on_subscription_revoked(


### PR DESCRIPTION
**DO NOT MERGE**

~We had a bug in our logic that was trying to prevent sending both emails
at the same time. This bug is now fixed.~

This code actually makes us send the revocation email twice 🤔 Therefore we shouldn't merge it.