### PR TITLE
feat: implement retry follow ups

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -272,9 +272,9 @@ class Settings(BaseSettings):
     # Dunning Configuration
     DUNNING_RETRY_INTERVALS: list[timedelta] = [
         timedelta(days=2),  # First retry after 2 days
-        timedelta(days=8),  # Second retry after 10 days (2 + 8)
-        timedelta(days=6),  # Third retry after 14 days (2 + 8 + 6)
-        timedelta(days=5),  # Fourth retry after 21 days (2 + 8 + 6 + 5)
+        timedelta(days=5),  # Second retry after 7 days (2 + 5)
+        timedelta(days=7),  # Third retry after 14 days (2 + 5 + 7)
+        timedelta(days=7),  # Fourth retry after 21 days (2 + 5 + 7 + 7)
     ]
 
     model_config = SettingsConfigDict(

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -270,7 +270,6 @@ class Settings(BaseSettings):
     ]
 
     # Dunning Configuration
-    DUNNING_FIRST_RETRY_DELAY: timedelta = timedelta(days=3)
     DUNNING_RETRY_INTERVALS: list[timedelta] = [
         timedelta(days=2),  # First retry after 2 days
         timedelta(days=8),  # Second retry after 10 days (2 + 8)

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -12,6 +13,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
+from polar.kit.utils import utc_now
 from polar.models import (
     Customer,
     Order,
@@ -53,6 +55,20 @@ class OrderRepository(
             .options(*options)
         )
         return await self.get_one_or_none(statement)
+
+    async def get_due_dunning_orders(self, *, options: Options = ()) -> Sequence[Order]:
+        """Get orders that are due for dunning retry based on next_payment_attempt_at."""
+
+        statement = (
+            self.get_base_statement()
+            .where(
+                Order.next_payment_attempt_at.is_not(None),
+                Order.next_payment_attempt_at <= utc_now(),
+            )
+            .order_by(Order.next_payment_attempt_at.asc())
+            .options(*options)
+        )
+        return await self.get_all(statement)
 
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization]

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1324,9 +1324,6 @@ class OrderService:
     async def _count_failed_payment_attempts(
         self, session: AsyncSession, order: Order
     ) -> int:
-        """Count the number of failed payment attempts for an order."""
-        from polar.payment.repository import PaymentRepository
-
         payment_repo = PaymentRepository.from_session(session)
         statement = payment_repo.get_base_statement().where(
             Payment.order_id == order.id, Payment.status == PaymentStatus.failed

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -59,10 +59,12 @@ from polar.models import (
     Transaction,
     User,
 )
+from polar.models.held_balance import HeldBalance
 from polar.models.order import OrderBillingReason, OrderStatus
 from polar.models.payment import PaymentStatus
 from polar.models.product import ProductBillingType
 from polar.models.subscription import SubscriptionStatus
+from polar.models.subscription_meter import SubscriptionMeter
 from polar.models.transaction import TransactionType
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.notifications.notification import (
@@ -1319,14 +1321,15 @@ class OrderService:
 
         return order
 
-    async def _count_failed_payment_attempts(self, session: AsyncSession, order: Order) -> int:
+    async def _count_failed_payment_attempts(
+        self, session: AsyncSession, order: Order
+    ) -> int:
         """Count the number of failed payment attempts for an order."""
         from polar.payment.repository import PaymentRepository
 
         payment_repo = PaymentRepository.from_session(session)
         statement = payment_repo.get_base_statement().where(
-            Payment.order_id == order.id,
-            Payment.status == PaymentStatus.failed
+            Payment.order_id == order.id, Payment.status == PaymentStatus.failed
         )
         result = await session.execute(statement)
         return len(result.scalars().all())

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -148,7 +148,8 @@ async def process_dunning() -> None:
         order_repository = OrderRepository.from_session(session)
         due_orders = await order_repository.get_due_dunning_orders()
 
-        for order in due_orders:
+    for order in due_orders:
+        async with AsyncSessionMaker() as session:
             try:
                 await order_service.process_dunning_order(session, order)
             except Exception as e:
@@ -158,4 +159,3 @@ async def process_dunning() -> None:
                     order_id=order.id,
                     error=str(e),
                 )
-                continue

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -12,7 +12,7 @@ from polar.payment_method.repository import PaymentMethodRepository
 from polar.product.repository import ProductRepository
 from polar.subscription.repository import SubscriptionRepository
 from polar.transaction.service.balance import PaymentTransactionForChargeDoesNotExist
-from polar.worker import AsyncSessionMaker, TaskPriority, actor, can_retry
+from polar.worker import AsyncSessionMaker, CronTrigger, TaskPriority, actor, can_retry
 
 from .repository import OrderRepository
 from .service import order as order_service
@@ -134,3 +134,26 @@ async def order_invoice(order_id: uuid.UUID) -> None:
             raise OrderDoesNotExist(order_id)
 
         await order_service.generate_invoice(session, order)
+
+
+@actor(
+    actor_name="order.process_dunning",
+    cron_trigger=CronTrigger.from_crontab("0 * * * *"),
+    priority=TaskPriority.MEDIUM,
+)
+async def process_dunning() -> None:
+    """Process all orders that are due for dunning (payment retry)."""
+    async with AsyncSessionMaker() as session:
+        order_repository = OrderRepository.from_session(session)
+        due_orders = await order_repository.get_due_dunning_orders()
+
+        for order in due_orders:
+            try:
+                await order_service.process_dunning_order(session, order)
+            except Exception as e:
+                log.error(
+                    "Failed to process dunning order",
+                    order_id=order.id,
+                    error=str(e),
+                )
+                continue

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -1,5 +1,6 @@
 import uuid
 
+import sentry_sdk
 import structlog
 from dramatiq import Retry
 from sqlalchemy.orm import joinedload
@@ -151,6 +152,7 @@ async def process_dunning() -> None:
             try:
                 await order_service.process_dunning_order(session, order)
             except Exception as e:
+                sentry_sdk.capture_exception(e, extra={"order_id": str(order.id)})
                 log.error(
                     "Failed to process dunning order",
                     order_id=order.id,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1446,14 +1446,12 @@ class SubscriptionService:
             subscription, update_dict={"status": SubscriptionStatus.active}
         )
 
-        # Trigger subscription updated events
         await self._after_subscription_updated(
             session,
             subscription,
             previous_status=previous_status,
             previous_ends_at=previous_ends_at,
         )
-        # Grant benefits for this subscription
         await self.enqueue_benefits_grants(session, subscription)
 
         return subscription

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1433,5 +1433,30 @@ class SubscriptionService:
 
         return subscription
 
+    async def mark_active(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> Subscription:
+        """Mark a subscription as active. Used when payment succeeds after being past due."""
+
+        previous_status = subscription.status
+        previous_ends_at = subscription.ends_at
+
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.update(
+            subscription, update_dict={"status": SubscriptionStatus.active}
+        )
+
+        # Trigger subscription updated events
+        await self._after_subscription_updated(
+            session,
+            subscription,
+            previous_status=previous_status,
+            previous_ends_at=previous_ends_at,
+        )
+        # Grant benefits for this subscription
+        await self.enqueue_benefits_grants(session, subscription)
+
+        return subscription
+
 
 subscription = SubscriptionService()

--- a/server/tests/integrations/stripe/test_payment.py
+++ b/server/tests/integrations/stripe/test_payment.py
@@ -71,7 +71,7 @@ class TestHandleFailure:
         updated_order = await order_repo.get_by_id(order.id)
         assert updated_order is not None
         assert updated_order.next_payment_attempt_at is not None
-        expected_retry_date = utc_now() + timedelta(days=3)
+        expected_retry_date = utc_now() + timedelta(days=2)
         assert updated_order.next_payment_attempt_at == expected_retry_date
 
         updated_subscription = await subscription_repo.get_by_id(subscription.id)

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1444,8 +1444,8 @@ class TestHandlePaymentFailure:
 
         # Then
         assert result_order.next_payment_attempt_at is not None
-        # Should schedule second retry (8 days from now, as per DUNNING_RETRY_INTERVALS[1])
-        expected_retry_date = utc_now() + timedelta(days=8)
+        # Should schedule second retry (5 days from now, as per DUNNING_RETRY_INTERVALS[1])
+        expected_retry_date = utc_now() + timedelta(days=5)
         assert result_order.next_payment_attempt_at == expected_retry_date
 
         mock_mark_past_due.assert_not_called()
@@ -1495,8 +1495,8 @@ class TestHandlePaymentFailure:
 
         # Then
         assert result_order.next_payment_attempt_at is not None
-        # Should schedule third retry (6 days from now, as per DUNNING_RETRY_INTERVALS[2])
-        expected_retry_date = utc_now() + timedelta(days=6)
+        # Should schedule third retry (7 days from now, as per DUNNING_RETRY_INTERVALS[2])
+        expected_retry_date = utc_now() + timedelta(days=7)
         assert result_order.next_payment_attempt_at == expected_retry_date
 
         mock_mark_past_due.assert_not_called()
@@ -1590,8 +1590,8 @@ class TestHandlePaymentFailure:
 
         # Then
         assert result_order.next_payment_attempt_at is not None
-        # Should schedule second retry (8 days) since only 1 failed payment exists
-        expected_retry_date = utc_now() + timedelta(days=8)
+        # Should schedule second retry (5 days) since only 1 failed payment exists
+        expected_retry_date = utc_now() + timedelta(days=5)
         assert result_order.next_payment_attempt_at == expected_retry_date
 
         mock_mark_past_due.assert_not_called()

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -36,6 +36,7 @@ from polar.models.checkout import CheckoutStatus
 from polar.models.discount import DiscountFixed
 from polar.models.order import OrderBillingReason, OrderStatus
 from polar.models.organization import Organization
+from polar.models.payment import PaymentStatus
 from polar.models.product import ProductBillingType
 from polar.models.subscription import SubscriptionStatus
 from polar.models.transaction import TransactionType
@@ -73,7 +74,6 @@ from tests.fixtures.random_objects import (
     create_payment_method,
     create_subscription,
 )
-from polar.models.payment import PaymentStatus
 from tests.fixtures.stripe import construct_stripe_invoice
 from tests.transaction.conftest import create_transaction
 

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1301,7 +1301,7 @@ class TestHandlePaymentFailure:
 
         # Then
         assert result_order.next_payment_attempt_at is not None
-        expected_retry_date = utc_now() + timedelta(days=3)
+        expected_retry_date = utc_now() + timedelta(days=2)
         assert result_order.next_payment_attempt_at == expected_retry_date
 
         mock_mark_past_due.assert_called_once_with(session, subscription)

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -7,6 +7,7 @@ from polar.kit.db.postgres import AsyncSession
 from polar.kit.utils import utc_now
 from polar.models import Organization, Product
 from polar.models.order import OrderBillingReason, OrderStatus
+from polar.models.payment import PaymentStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.order.repository import OrderRepository
 from polar.order.service import order as order_service
@@ -20,7 +21,6 @@ from tests.fixtures.random_objects import (
     create_payment_method,
     create_subscription,
 )
-from polar.models.payment import PaymentStatus
 
 
 @pytest.mark.asyncio

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -1,0 +1,195 @@
+from datetime import timedelta
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.utils import utc_now
+from polar.models import Organization, Product
+from polar.models.order import OrderBillingReason, OrderStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.order.repository import OrderRepository
+from polar.order.tasks import process_dunning
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_customer,
+    create_order,
+    create_payment_method,
+    create_subscription,
+)
+
+
+@pytest.mark.asyncio
+class TestProcessDunning:
+    async def test_order_without_subscription_skipped(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        # Given
+        customer = await create_customer(save_fixture, organization=organization)
+        past_time = utc_now() - timedelta(hours=1)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            billing_reason=OrderBillingReason.purchase,
+        )
+        order.next_payment_attempt_at = past_time
+        await save_fixture(order)
+
+        enqueue_job_mock = mocker.patch("polar.order.service.enqueue_job")
+
+        # When
+        await process_dunning()
+
+        # Then
+        enqueue_job_mock.assert_not_called()
+
+    async def test_order_in_future_skipped(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        # Given
+        customer = await create_customer(save_fixture, organization=organization)
+        future_time = utc_now() + timedelta(hours=1)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            billing_reason=OrderBillingReason.purchase,
+        )
+        order.next_payment_attempt_at = future_time
+        await save_fixture(order)
+
+        enqueue_job_mock = mocker.patch("polar.order.service.enqueue_job")
+
+        # When
+        await process_dunning()
+
+        # Then
+        enqueue_job_mock.assert_not_called()
+
+    async def test_cancelled_subscription_order_cleared_from_dunning(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        # Given
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.canceled,
+        )
+        past_time = utc_now() - timedelta(hours=1)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.pending,
+            billing_reason=OrderBillingReason.subscription_cycle,
+        )
+        order.next_payment_attempt_at = past_time
+        await save_fixture(order)
+
+        # When
+        await process_dunning()
+
+        # Then
+        repository = OrderRepository.from_session(session)
+        updated_order = await repository.get_by_id(order.id)
+        assert updated_order is not None
+        assert updated_order.next_payment_attempt_at is None
+
+    async def test_subscription_without_payment_method_skipped(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        # Given
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+        )
+        subscription.payment_method_id = None
+        await save_fixture(subscription)
+
+        past_time = utc_now() - timedelta(hours=1)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.pending,
+            billing_reason=OrderBillingReason.subscription_cycle,
+        )
+        order.next_payment_attempt_at = past_time
+        await save_fixture(order)
+
+        enqueue_job_mock = mocker.patch("polar.order.service.enqueue_job")
+
+        # When
+        await process_dunning()
+
+        # Then
+        enqueue_job_mock.assert_not_called()
+
+    async def test_valid_order_triggers_payment_retry(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        # Given
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+        )
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        subscription.payment_method = payment_method
+        await save_fixture(subscription)
+
+        past_time = utc_now() - timedelta(hours=1)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.pending,
+            billing_reason=OrderBillingReason.subscription_cycle,
+        )
+        order.next_payment_attempt_at = past_time
+        await save_fixture(order)
+
+        enqueue_job_mock = mocker.patch("polar.order.service.enqueue_job")
+
+        # When
+        await process_dunning()
+
+        # Then
+        enqueue_job_mock.assert_called_once_with(
+            "order.trigger_payment",
+            order_id=order.id,
+            payment_method_id=subscription.payment_method_id,
+        )

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -288,9 +288,9 @@ class TestProcessDunning:
         # When: retry attempt fails
         result_order = await order_service.handle_payment_failure(session, order)
 
-        # Then: next retry is scheduled according to second interval (8 days)
+        # Then: next retry is scheduled according to second interval (5 days)
         assert result_order.next_payment_attempt_at is not None
-        expected_next_attempt = utc_now() + timedelta(days=8)
+        expected_next_attempt = utc_now() + timedelta(days=5)
         time_diff = abs(
             (
                 result_order.next_payment_attempt_at - expected_next_attempt

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -98,6 +98,7 @@ class TestProcessDunning:
             product=product,
             customer=customer,
             status=OrderStatus.pending,
+            stripe_invoice_id="inv_1",
         )
         order1.next_payment_attempt_at = past_time
         await save_fixture(order1)
@@ -107,6 +108,7 @@ class TestProcessDunning:
             product=product,
             customer=customer,
             status=OrderStatus.pending,
+            stripe_invoice_id="inv_2",
         )
         order2.next_payment_attempt_at = past_time
         await save_fixture(order2)


### PR DESCRIPTION
# Context
- Add a new worker to process dunning orders
- Handle the dunning process:
  - Retry the payment up to 4 times. If it fails, the subscription is marked as cancelled.
  - If any of those fail, the subscription is marked as active and the benefits are granted again.