### PR TITLE
Configure meters straight from onboarding

### DIFF
--- a/clients/apps/web/src/components/Benefit/MeterCredit/BenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/MeterCredit/BenefitForm.tsx
@@ -34,7 +34,7 @@ export const MeterCreditBenefitForm = ({
 }: {
   organization: schemas['Organization']
 }) => {
-  const { data: meters } = useMeters(organization.id, {
+  const { data: meters, refetch } = useMeters(organization.id, {
     sorting: ['name'],
   })
 
@@ -55,7 +55,18 @@ export const MeterCreditBenefitForm = ({
       //
       // This is an open issue with Radix UI since 2024
       // (https://github.com/radix-ui/primitives/issues/2817)
-      setTimeout(() => setValue('properties.meter_id', meter.id), 200)
+
+      // To work around this, we run an explicit `refetch` that we can await
+      // and then set the value in a double requestAnimationFrame callback.
+      // First rAF ensures this component is updated,
+      // second rAF ensures the <SelectContent /> was updated too.
+      await refetch()
+
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          setValue('properties.meter_id', meter.id)
+        })
+      })
     },
     [setValue],
   )

--- a/clients/apps/web/src/components/Benefit/MeterCredit/BenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/MeterCredit/BenefitForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { PlusIcon } from '@heroicons/react/24/outline'
+import { PlusIcon } from '@heroicons/react/20/solid'
 import { schemas } from '@polar-sh/client'
 import Alert from '@polar-sh/ui/components/atoms/Alert'
 import Input from '@polar-sh/ui/components/atoms/Input'
@@ -72,8 +72,7 @@ export const MeterCreditBenefitForm = ({
     <>
       {meters.items.length === 0 ? (
         <Alert color="gray">
-          <p className="text-center">
-            To start using meter credits,{' '}
+          <p className="text-center text-sm">
             <button
               onClick={(e) => {
                 e.preventDefault()
@@ -82,8 +81,9 @@ export const MeterCreditBenefitForm = ({
               type="button"
               className="font-medium underline"
             >
-              set up your first meter!
-            </button>
+              Set up your first meter
+            </button>{' '}
+            to start using meter credits
           </p>
         </Alert>
       ) : (

--- a/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
+++ b/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
@@ -1,0 +1,136 @@
+import { useEventNames } from '@/hooks/queries/events'
+import { useCreateMeter } from '@/hooks/queries/meters'
+import { setValidationErrors } from '@/utils/api/errors'
+import { isValidationError, schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import { Form } from '@polar-sh/ui/components/ui/form'
+import { useCallback } from 'react'
+import { useForm } from 'react-hook-form'
+import { useToast } from '../Toast/use-toast'
+import MeterForm from './MeterForm'
+
+interface CreateMeterModalContentProps {
+  organization: schemas['Organization']
+  onSelectMeter: (meter: schemas['Meter']) => void
+  hideModal: () => void
+}
+
+const CreateMeterModalContent = ({
+  organization,
+  hideModal,
+  onSelectMeter,
+}: CreateMeterModalContentProps) => {
+  const { toast } = useToast()
+
+  const form = useForm<schemas['MeterCreate']>({
+    defaultValues: {
+      filter: {
+        conjunction: 'and',
+        clauses: [
+          {
+            conjunction: 'or',
+            clauses: [
+              {
+                property: 'name',
+                operator: 'eq',
+                value: '',
+              },
+            ],
+          },
+        ],
+      },
+      aggregation: {
+        func: 'count',
+      },
+    },
+  })
+
+  const {
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = form
+
+  const createMeter = useCreateMeter(organization.id)
+
+  const { data: eventNames } = useEventNames(organization.id, {
+    limit: 1,
+    sorting: ['-occurrences'],
+  })
+  const flatEventNames = eventNames?.pages.flatMap((page) => page.items) ?? []
+
+  const handleCreateNewMeter = useCallback(
+    async (body: schemas['MeterCreate']) => {
+      const { data: meter, error } = await createMeter.mutateAsync(body)
+      if (error) {
+        if (isValidationError(error.detail)) {
+          setValidationErrors(error.detail, setError)
+        } else {
+          setError('root', { message: error.detail })
+        }
+        return
+      }
+
+      toast({
+        title: `Meter ${meter.name} created`,
+        description: `Meter successfully created.`,
+      })
+
+      onSelectMeter(meter)
+      hideModal()
+    },
+    [createMeter, hideModal, onSelectMeter, setError, toast],
+  )
+
+  return (
+    <div className="flex flex-col gap-y-6 overflow-y-auto px-8 py-10">
+      <div>
+        <h2 className="text-lg">Create Meter</h2>
+        <div className="dark:text-polar-500 mt-2 space-y-2 text-sm text-gray-500">
+          <p>
+            Meters are aggregated filters on ingested events. They are used to
+            calculate your customer&apos;s usage of whatever you choose to
+            measure.
+          </p>
+          <p>
+            For example, if you want to measure the number of API calls your
+            customer makes, you can create a meter that counts the number of
+            events with an arbitrary name like <code>api_call</code>.
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-y-6">
+        <Form {...form}>
+          <form className="flex flex-col gap-y-6">
+            <MeterForm eventNames={flatEventNames} />
+            {errors.root && (
+              <p className="text-destructive-foreground text-sm">
+                {errors.root.message}
+              </p>
+            )}
+            <div className="mt-4 flex flex-row items-center gap-x-4">
+              <Button
+                className="self-start"
+                type="button"
+                loading={createMeter.isPending}
+                disabled={createMeter.isPending || !form.formState.isValid}
+                onClick={handleSubmit(handleCreateNewMeter)}
+              >
+                Create
+              </Button>
+              <Button
+                variant="ghost"
+                className="self-start"
+                onClick={hideModal}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </div>
+  )
+}
+
+export default CreateMeterModalContent

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -390,8 +390,6 @@ const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
   const amountType = watch(`prices.${index}.amount_type`)
   const recurringInterval = watch('recurring_interval')
 
-  const { data: meters } = useMeters(organization.id)
-
   const prices = watch('prices')
   const staticPriceIndex = prices
     ? (prices as schemas['ProductPrice'][]).findIndex(isStaticPrice)

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -175,7 +175,7 @@ export const ProductPriceMeteredUnitItem: React.FC<
 > = ({ organization, index }) => {
   const { control, setValue } = useFormContext<ProductFormType>()
 
-  const { data: meters } = useMeters(organization.id, {
+  const { data: meters, refetch } = useMeters(organization.id, {
     sorting: ['name'],
   })
 
@@ -193,7 +193,18 @@ export const ProductPriceMeteredUnitItem: React.FC<
       //
       // This is an open issue with Radix UI since 2024
       // (https://github.com/radix-ui/primitives/issues/2817)
-      setTimeout(() => setValue(`prices.${index}.meter_id`, meter.id), 200)
+
+      // To work around this, we run an explicit `refetch` that we can await
+      // and then set the value in a double requestAnimationFrame callback.
+      // First rAF ensures this component is updated,
+      // second rAF ensures the <SelectContent /> was updated too.
+      await refetch()
+
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          setValue(`prices.${index}.meter_id`, meter.id)
+        })
+      })
     },
     [setValue, index],
   )
@@ -214,7 +225,6 @@ export const ProductPriceMeteredUnitItem: React.FC<
             <button
               onClick={(e) => {
                 e.preventDefault()
-                console.log('create meter modal wtf')
                 showCreateMeterModal()
               }}
               type="button"


### PR DESCRIPTION
Fixes #6092

### Before

<img width="1510" height="854" alt="image" src="https://github.com/user-attachments/assets/162dbbb7-0f97-4b6a-a5a6-ce1908585c68" />

_Select a meter_ opens an empty select dropdown makes this basically a dead end in the onboarding flow.

### After

Added a brief alert that lets you create a meter straight from the metered pricing & meter credits sections.

**Metered pricing**

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/46e5110d-e3a4-47fa-8c8e-40108a1ab1ae" />

**Meter credits**

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/aa8a85d6-28a6-460f-afcc-cbac58d1a017" />

From there a new modal opens to create a new meter directly:

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/bb02fdfc-c179-49c1-817c-f9c2054346a8" />

Upon completion, the new meter is selected and you can continue.

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/f93d4500-e9a7-480a-8171-da5988e53167" />

### Known issues / questions

**Usefulness in terms of UX**: This improves on the current version, which is effectively a dead end. However, I wonder if the whole setup is a bit too technical. You're basically required to set up event ingestion too for this to make sense. This can't/won't be the case in the context of onboarding, which is also I didn't include e.g. the events preview from the in-app meter configuration.  
This makes me wonder whether onboarding / initial product setup could be done differently (more of a wizard-style), I'm thinking about onboarding flows that have a similar SDK setup requirement (like Sentry or Posthog).

**Pagination**: the `GET /meters` endpoint is paginated by default, returning 10 items per page. This leads to unexpected behavior when a user has more than 10 meters. I don't know how common this is, but I've decided to not to dive into it since it's unlikely a user will have more than 10 during onboarding 😁 The laziest fix would be to return more than 10 items from the endpoint by default, which I think would be fine, but this could use a proper fix outside the scope of this issue. 

**A `requestAnimationFrame` of shame**: I'm having trouble automatically selecting the freshly created meter in the form. [It seems to be that Radix UI's select component rejects any value updates that don't exist as child items](https://github.com/radix-ui/primitives/issues/2817) of `<SelectContent>`. Combined with React Query's asynchronous cache invalidation, this is pretty difficult to fix.

Basically, in `onSelectMeter` we have to:
1. Wait until `meters` is updated from the query invalidation from the mutation callback
2. Wait for a render cycle to update the children in `<SelectContent>`
3. Only then can we call `setValue` with the new `meter.id`.
 
A `setTimeout` would work around this, but might lead to inconsistent behavior on slower networks. Explicitly awaiting a refresh and then making sure the state was reflected in the UI through a double `requestAnimationFrame` should work consistently, but it's a noticeable flash in the UX. The less hacky workaround is to not auto-select the freshly created meter, but the trade-off then is arguably worse UX.