### PR TITLE
UI fixups: Table and details column sizes

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -148,6 +148,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'net_amount',
       enableSorting: true,
+      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Amount" />
       ),
@@ -179,6 +180,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'status',
       enableSorting: true,
+      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),
@@ -191,6 +193,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'created_at',
       enableSorting: true,
+      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -138,7 +138,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
               avatar_url={customer.avatar_url}
               name={customer.name || customer.email}
             />
-            <div className="fw-medium hover:line-clamp-x overflow-hidden text-ellipsis">
+            <div className="fw-medium overflow-hidden text-ellipsis">
               {customer.email}
             </div>
           </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -138,7 +138,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
               avatar_url={customer.avatar_url}
               name={customer.name || customer.email}
             />
-            <div className="fw-medium">{customer.email}</div>
+            <div className="fw-medium hover:line-clamp-x overflow-hidden text-ellipsis">
+              {customer.email}
+            </div>
           </div>
         )
       },

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/ClientPage.tsx
@@ -204,7 +204,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
             {customerEmail ? (
               <>
                 <Avatar avatar_url={null} name={customerEmail} />
-                <div className="fw-medium">{customerEmail}</div>
+                <div className="fw-medium overflow-hidden text-ellipsis">
+                  {customerEmail}
+                </div>
               </>
             ) : (
               <>—</>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/ClientPage.tsx
@@ -170,6 +170,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'created_at',
       enableSorting: true,
+      size: 70,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),
@@ -183,6 +184,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'status',
       enableSorting: true,
+      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
@@ -168,6 +168,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
       id: 'customer',
       accessorKey: 'customer',
       enableSorting: true,
+      size: 150,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Customer" />
       ),
@@ -189,6 +190,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'status',
       enableSorting: true,
+      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),
@@ -199,6 +201,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'started_at',
       enableSorting: true,
+      size: 85,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Subscription Date" />
       ),
@@ -209,6 +212,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'current_period_end',
       enableSorting: true,
+      size: 85,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Renewal Date" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
@@ -179,7 +179,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
               avatar_url={customer.avatar_url}
               name={customer.name || customer.email}
             />
-            <div className="fw-medium">{customer.email}</div>
+            <div className="fw-medium overflow-hidden text-ellipsis">
+              {customer.email}
+            </div>
           </div>
         )
       },

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ClientPage.tsx
@@ -16,6 +16,7 @@ import {
   DataTableColumnHeader,
 } from '@polar-sh/ui/components/atoms/DataTable'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import Input from '@polar-sh/ui/components/atoms/Input'
 import { useState } from 'react'
 
 export default function ClientPage({
@@ -131,13 +132,13 @@ function InviteDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-900">
         <h3 className="mb-4 text-lg font-medium">Invite User</h3>
-        <input
+        <Input
           type="email"
           placeholder="Enter email address"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="mb-4 w-full rounded-md border border-gray-300 px-3 py-2 dark:border-gray-700"
           autoFocus
+          className="mb-4"
         />
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={onClose}>

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -163,11 +163,30 @@ export const CustomerContextView = ({
         )}
       </ShadowBox>
       <ShadowBox className="dark:border-polar-800 flex flex-col gap-4 border-gray-200 bg-white p-6 md:gap-0 md:shadow-sm lg:rounded-2xl">
-        {!customer.deleted_at && <DetailRow label="ID" value={customer.id} />}
-        <DetailRow label="Email" value={customer.email} />
-        <DetailRow label="Name" value={customer.name} />
-        <DetailRow label="Tax ID" value={customer.tax_id} />
+        {!customer.deleted_at && (
+          <DetailRow
+            labelClassName="flex-none basis-24"
+            label="ID"
+            value={customer.id}
+          />
+        )}
         <DetailRow
+          labelClassName="flex-none basis-24"
+          label="Email"
+          value={customer.email}
+        />
+        <DetailRow
+          labelClassName="flex-none basis-24"
+          label="Name"
+          value={customer.name}
+        />
+        <DetailRow
+          labelClassName="flex-none basis-24"
+          label="Tax ID"
+          value={customer.tax_id}
+        />
+        <DetailRow
+          labelClassName="flex-none basis-24"
           label="Created At"
           value={<FormattedDateTime datetime={customer.created_at} />}
         />
@@ -175,15 +194,33 @@ export const CustomerContextView = ({
       <ShadowBox className="dark:border-polar-800 flex flex-col gap-4 border-gray-200 bg-white p-6 md:shadow-sm lg:rounded-2xl">
         <h4 className="text-lg">Billing Address</h4>
         <div className="flex flex-col gap-4 md:gap-0">
-          <DetailRow label="Line 1" value={customer.billing_address?.line1} />
-          <DetailRow label="Line 2" value={customer.billing_address?.line2} />
-          <DetailRow label="City" value={customer.billing_address?.city} />
-          <DetailRow label="State" value={customer.billing_address?.state} />
           <DetailRow
+            labelClassName="flex-none basis-24"
+            label="Line 1"
+            value={customer.billing_address?.line1}
+          />
+          <DetailRow
+            labelClassName="flex-none basis-24"
+            label="Line 2"
+            value={customer.billing_address?.line2}
+          />
+          <DetailRow
+            labelClassName="flex-none basis-24"
+            label="City"
+            value={customer.billing_address?.city}
+          />
+          <DetailRow
+            labelClassName="flex-none basis-24"
+            label="State"
+            value={customer.billing_address?.state}
+          />
+          <DetailRow
+            labelClassName="flex-none basis-24"
             label="Postal Code"
             value={customer.billing_address?.postal_code}
           />
           <DetailRow
+            labelClassName="flex-none basis-24"
             label="Country"
             value={customer.billing_address?.country}
           />

--- a/clients/apps/web/src/components/Shared/DetailRow.tsx
+++ b/clients/apps/web/src/components/Shared/DetailRow.tsx
@@ -5,17 +5,26 @@ export interface DetailRowProps {
   value: React.ReactNode
   action?: React.ReactNode
   valueClassName?: string
+  labelClassName?: string
 }
 
 export const DetailRow = ({
   label,
+  labelClassName = '',
   value,
   valueClassName = '',
   action,
 }: DetailRowProps) => {
   return (
     <div className="flex flex-col text-sm md:flex-row md:items-baseline md:justify-between md:gap-4">
-      <h3 className="dark:text-polar-500 flex-1 text-gray-500">{label}</h3>
+      <h3
+        className={twMerge(
+          'dark:text-polar-500 flex-1 text-gray-500',
+          labelClassName,
+        )}
+      >
+        {label}
+      </h3>
       <span
         className={twMerge(
           'dark:md:hover:bg-polar-800 group flex flex-1 flex-row flex-nowrap items-center justify-between gap-x-2 rounded-md transition-colors duration-75 md:px-2.5 md:py-1 hover:md:bg-gray-100',

--- a/clients/packages/ui/src/components/atoms/datatable/DataTable.tsx
+++ b/clients/packages/ui/src/components/atoms/datatable/DataTable.tsx
@@ -141,7 +141,10 @@ export function DataTable<TData, TValue>({
               >
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      style={{ width: header.column.getSize() }}
+                    >
                       {header.isPlaceholder
                         ? null
                         : flexRender(
@@ -200,7 +203,10 @@ export function DataTable<TData, TValue>({
                         return (
                           <React.Fragment key={cell.id}>
                             {colSpan ? (
-                              <TableCell colSpan={colSpan}>
+                              <TableCell
+                                colSpan={colSpan}
+                                style={{ width: cell.column.getSize() }}
+                              >
                                 {flexRender(
                                   cell.column.columnDef.cell,
                                   cell.getContext(),


### PR DESCRIPTION
- Organization members: Use our own `<Input>` instead of `<input>`
- Orders table: Stop emails from overflowing into amount column
- Order+Subscription+Checkout tables: Stop email filling into next column
- DataTable: Allow setting `size` on columns
- Order+Subscription+Checkout tables: Make status+date columns smaller


### What it looks like

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tbody>
    <tr>
      <td><img width="449" height="212" alt="Screenshot 2025-07-21 at 09 11 03" src="https://github.com/user-attachments/assets/b24004c7-85c0-4f1b-9f42-bf92199784f1" /></td>
      <td><img width="440" height="223" alt="Screenshot 2025-07-22 at 10 42 15" src="https://github.com/user-attachments/assets/acdb2a34-5311-476e-b8f0-32b79678b6ec" /></td>
    </tr>
    <tr>
      <td><img width="375" height="265" alt="orders_before" src="https://github.com/user-attachments/assets/9237907b-a052-48c0-bee9-cb3929c3c79f" /></td>
       <td><img width="501" height="125" alt="orders_after" src="https://github.com/user-attachments/assets/81b98336-22fa-47e0-a9e4-21ce3079a896" /></td>
    </tr>
  </tbody>
</table>
