### PR TITLE
server/metrics: consider ends_at if available when querying active subscriptions

### DIFF
--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -279,9 +279,16 @@ def get_active_subscriptions_cte(
                         <= interval.sql_date_trunc(timestamp_column),
                     ),
                     or_(
-                        Subscription.ended_at.is_(None),
+                        func.coalesce(Subscription.ended_at, Subscription.ends_at).is_(
+                            None
+                        ),
                         interval.sql_date_trunc(
-                            cast(SQLColumnExpression[datetime], Subscription.ended_at)
+                            cast(
+                                SQLColumnExpression[datetime],
+                                func.coalesce(
+                                    Subscription.ended_at, Subscription.ends_at
+                                ),
+                            )
                         )
                         > interval.sql_date_trunc(timestamp_column),
                     ),

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -899,6 +899,7 @@ async def create_subscription(
     status: SubscriptionStatus = SubscriptionStatus.incomplete,
     started_at: datetime | None = None,
     ended_at: datetime | None = None,
+    ends_at: datetime | None = None,
     current_period_start: datetime | None = None,
     current_period_end: datetime | None = None,
     discount: Discount | None = None,
@@ -916,16 +917,16 @@ async def create_subscription(
     if product.is_legacy_recurring_price:
         recurring_interval = product.prices[0].recurring_interval
 
-    ends_at = None
     canceled_at = None
-    if revoke:
-        ended_at = now
-        ends_at = now
-        canceled_at = now
-        status = SubscriptionStatus.canceled
-    elif cancel_at_period_end:
-        ends_at = current_period_end
-        canceled_at = now
+    if ends_at is None:
+        if revoke:
+            ended_at = now
+            ends_at = now
+            canceled_at = now
+            status = SubscriptionStatus.canceled
+        elif cancel_at_period_end:
+            ends_at = current_period_end
+            canceled_at = now
 
     subscription = Subscription(
         stripe_subscription_id=stripe_subscription_id,

--- a/server/tests/metrics/test_service.py
+++ b/server/tests/metrics/test_service.py
@@ -47,6 +47,7 @@ class DiscountFixture(TypedDict):
 class SubscriptionFixture(TypedDict):
     started_at: date
     ended_at: NotRequired[date]
+    ends_at: NotRequired[date]
     product: str
     discount: NotRequired[str]
 
@@ -173,6 +174,11 @@ async def _create_fixtures(
             ended_at=(
                 _date_to_datetime(subscription_fixture["ended_at"])
                 if "ended_at" in subscription_fixture
+                else None
+            ),
+            ends_at=(
+                _date_to_datetime(subscription_fixture["ends_at"])
+                if "ends_at" in subscription_fixture
                 else None
             ),
             discount=discounts[subscription_fixture["discount"]]
@@ -723,6 +729,81 @@ class TestGetMetrics:
         assert feb.renewed_subscriptions_revenue == 0
         assert feb.active_subscriptions == 0
         assert feb.monthly_recurring_revenue == 0
+
+    @pytest.mark.auth
+    async def test_values_subscription_due_cancellation(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        user: User,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        subscriptions: dict[str, SubscriptionFixture] = {
+            "subscription_1": {
+                "started_at": date(2024, 1, 1),
+                "ends_at": date(2024, 3, 15),
+                "product": "free_subscription",
+            }
+        }
+        await _create_fixtures(
+            save_fixture, customer, organization, PRODUCTS, subscriptions, {}
+        )
+
+        metrics = await metrics_service.get_metrics(
+            session,
+            auth_subject,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 3, 1),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.month,
+        )
+
+        assert len(metrics.periods) == 3
+
+        jan = metrics.periods[0]
+        assert jan.orders == 0
+        assert jan.revenue == 0
+        assert jan.cumulative_revenue == 0
+        assert jan.average_order_value == 0
+        assert jan.one_time_products == 0
+        assert jan.one_time_products_revenue == 0
+        assert jan.new_subscriptions == 1
+        assert jan.new_subscriptions_revenue == 0
+        assert jan.renewed_subscriptions == 0
+        assert jan.renewed_subscriptions_revenue == 0
+        assert jan.active_subscriptions == 1
+        assert jan.monthly_recurring_revenue == 0
+
+        feb = metrics.periods[1]
+        assert feb.orders == 0
+        assert feb.revenue == 0
+        assert feb.cumulative_revenue == 0
+        assert feb.average_order_value == 0
+        assert feb.one_time_products == 0
+        assert feb.one_time_products_revenue == 0
+        assert feb.new_subscriptions == 0
+        assert feb.new_subscriptions_revenue == 0
+        assert feb.renewed_subscriptions == 0
+        assert feb.renewed_subscriptions_revenue == 0
+        assert feb.active_subscriptions == 1
+        assert feb.monthly_recurring_revenue == 0
+
+        mar = metrics.periods[2]
+        assert mar.orders == 0
+        assert mar.revenue == 0
+        assert mar.cumulative_revenue == 0
+        assert mar.average_order_value == 0
+        assert mar.one_time_products == 0
+        assert mar.one_time_products_revenue == 0
+        assert mar.new_subscriptions == 0
+        assert mar.new_subscriptions_revenue == 0
+        assert mar.renewed_subscriptions == 0
+        assert mar.renewed_subscriptions_revenue == 0
+        assert mar.active_subscriptions == 0
+        assert mar.monthly_recurring_revenue == 0
 
     @pytest.mark.auth
     async def test_mrr_subscription_forever_discount(


### PR DESCRIPTION
Fix #6257

- server/metrics: consider ends_at if available when querying active subscriptions
