### PR TITLE
fix: Hide benefits section in cancellation email if no benefits are p…

### DIFF
--- a/server/polar/subscription/email_templates/cancellation.html
+++ b/server/polar/subscription/email_templates/cancellation.html
@@ -5,12 +5,14 @@
 <p>We're sorry to see you go! Your subscription to <strong>{{ product.name }}</strong> will remain active until <strong>{{ subscription.ends_at.strftime("%B %d, %Y") }}</strong>, after which it will be canceled.</p>
 <p>If you change your mind, you can renew your subscription anytime before the end date.</p>
 
+{% if product.benefits %}
 <p>Meanwhile, you will continue to have access to the following benefits:</p>
 <ul>
-  {% for benefit in product.benefits %}
+    {% for benefit in product.benefits %}
     <li>{{ benefit.description }}</li>
-  {% endfor %}
+    {% endfor %}
 </ul>
+{% endif %}
 
 <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
     <tr>


### PR DESCRIPTION
### Description

Fixes #6242

This PR ensures that the "Meanwhile, you will continue to have access to the following benefits:" section in cancellation emails only appears if the product has actual benefits.

### Fix

- Updated condition to check that `product.benefits` is not empty before rendering the section.

### Before

The benefits section was rendered even if no benefits existed, leading to an empty or confusing email.

### After

The section is hidden when no benefits exist. Verified with two test emails (with and without benefits).

(Here, Benefits Data are dummy) 
✅ Screenshot with benefits:
 
<img width="751" height="830" alt="Screenshot 2025-07-22 200954" src="https://github.com/user-attachments/assets/deb066b6-ca00-4d66-9bc9-68ce868eab3c" />




✅ Screenshot without benefits:

<img width="749" height="613" alt="Screenshot 2025-07-22 200817" src="https://github.com/user-attachments/assets/a3a82838-89d4-4f29-a87d-c20417918bbf" />
]

