### PR TITLE
Consistent decimal usage for money input

### DIFF
--- a/clients/packages/ui/src/components/atoms/MoneyInput.tsx
+++ b/clients/packages/ui/src/components/atoms/MoneyInput.tsx
@@ -63,6 +63,19 @@ const MoneyInput = (props: Props) => {
     }
   }, [value, previousValue])
 
+  const updateValue = useCallback(
+    (newValue: string) => {
+      if (_onChange) {
+        const centsValue = getCents(newValue)
+        setPreviousValue(centsValue)
+        _onChange(centsValue)
+      }
+
+      setInternalValue(newValue)
+    },
+    [_onChange],
+  )
+
   const onChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const input = e.target.value
@@ -103,15 +116,9 @@ const MoneyInput = (props: Props) => {
         }
       }
 
-      if (_onChange) {
-        const centsValue = getCents(newValue)
-        setPreviousValue(centsValue)
-        _onChange(centsValue)
-      }
-
-      setInternalValue(newValue)
+      updateValue(newValue)
     },
-    [_onChange],
+    [updateValue],
   )
 
   const onBlur = useCallback(
@@ -120,20 +127,14 @@ const MoneyInput = (props: Props) => {
       if (internalValue?.endsWith('.')) {
         const strippedValue = internalValue.replace(/\.$/, '')
 
-        if (_onChange) {
-          const centsValue = getCents(strippedValue)
-          setPreviousValue(centsValue)
-          _onChange(centsValue)
-        }
-
-        setInternalValue(strippedValue)
+        updateValue(strippedValue)
       }
 
       if (_onBlur) {
         _onBlur(e)
       }
     },
-    [_onBlur, _onChange, internalValue],
+    [_onBlur, internalValue, updateValue],
   )
 
   const onKeyDown = useCallback(
@@ -158,13 +159,7 @@ const MoneyInput = (props: Props) => {
           !Number.isNaN(parsedValue) ? parsedValue + step : step
         ).toFixed(2)
 
-        if (_onChange) {
-          const centsValue = getCents(newValue)
-          setPreviousValue(centsValue)
-          _onChange(centsValue)
-        }
-
-        setInternalValue(newValue)
+        updateValue(newValue)
       }
 
       if (e.key === 'ArrowDown') {
@@ -175,13 +170,7 @@ const MoneyInput = (props: Props) => {
           !Number.isNaN(parsedValue) ? parsedValue - step : -step,
         ).toFixed(2)
 
-        if (_onChange) {
-          const centsValue = getCents(newValue)
-          setPreviousValue(centsValue)
-          _onChange(centsValue)
-        }
-
-        setInternalValue(newValue)
+        updateValue(newValue)
       }
 
       // Prevent multiple decimal points
@@ -192,7 +181,7 @@ const MoneyInput = (props: Props) => {
         e.preventDefault()
       }
     },
-    [step, _onChange],
+    [step, updateValue],
   )
 
   return (


### PR DESCRIPTION
Fixes #6245 

Avoid `type="number"` inputs because its behavior is pretty inconsistent across browsers/locales/…

Main changes:

 - Copied over the `keydown` handler from `UnitAmountInput` for form interactivity consistency (I like the pattern)
 - Added arrow up / down handlers to step the input per 10 cents (didn't copy to `UnitAmountInput` since that would need auto-step detection to be good UX, in my opinion)
 - Accepts both `,` and `.` as input but converts commas to periods on the fly
 - Make sure it supports pasting in differently formatted numbers (e.g. from spreadsheets)

Some of these changes are regex kungfu 101, frankly it could use some unit tests for future maintenance but that's not really set up in the `clients` workspace, can be added later. If / when multi-currency support is added this'll need another makeover (mainly because e.g. JPY doesn't have cents) and that might be a good time to solidify some of these efforts.

https://github.com/user-attachments/assets/e0e6770d-4b4e-4f3d-897a-f8c6f3d32ef8


