### PR TITLE
Login: Improve invalid email address error message

### DIFF
--- a/server/polar/kit/email.py
+++ b/server/polar/kit/email.py
@@ -25,8 +25,8 @@ def _validate_email_dns(email: str) -> str:
     except EmailNotValidError as e:
         raise PydanticCustomError(
             "value_error",
-            "value is not a valid email address: {reason}",
-            {"reason": str(e)},
+            "{email} is not a valid email address: {reason}",
+            {"email": email, "reason": str(e)},
         ) from e
     else:
         return email


### PR DESCRIPTION
Previously the error message would be
"value is not a valid email address: <REASON>"

Notwit'll say:
"<EMAIL> is not a valid email address: <REASON>"