### PR TITLE
Add "Select All" toggle to OAuth set up

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -133,7 +133,7 @@ const AccessTokenForm = ({ update }: { update?: boolean }) => {
           )}
         />
       )}
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
         <div className="flex flex-row items-center">
           <h2 className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
             Scopes

--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -31,7 +31,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useCallback, useState, type MouseEvent } from 'react'
+import { useCallback, useMemo, useState, type MouseEvent } from 'react'
 import { useForm, useFormContext } from 'react-hook-form'
 import { ConfirmModal } from '../Modal/ConfirmModal'
 import { toast, useToast } from '../Toast/use-toast'
@@ -48,14 +48,20 @@ interface AccessTokenUpdate {
 }
 
 const AccessTokenForm = ({ update }: { update?: boolean }) => {
-  const { control, setValue } = useFormContext<
+  const { control, setValue, watch } = useFormContext<
     AccessTokenCreate | AccessTokenUpdate
   >()
 
   const sortedScopes = Array.from(enums.availableScopeValues).sort((a, b) =>
     a.localeCompare(b),
   )
-  const [allSelected, setSelectAll] = useState(false)
+
+  const currentScopes = watch('scopes')
+
+  const allSelected = useMemo(
+    () => sortedScopes.every((scope) => currentScopes.includes(scope)),
+    [currentScopes, sortedScopes],
+  )
 
   const onToggleAll = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
@@ -66,7 +72,6 @@ const AccessTokenForm = ({ update }: { update?: boolean }) => {
         values = sortedScopes
       }
       setValue('scopes', values)
-      setSelectAll(!allSelected)
     },
     [setValue, allSelected, sortedScopes],
   )


### PR DESCRIPTION
Includes a tiny fix for the issue where _Select All_ was always the default state of the button, even if all scopes were previously selected (or all checkboxes were marked manually) by deriving the `allSelected` state instead of tracking it manually.