### PR TITLE
Avoid blocking clicks behind toast

### DIFF
--- a/clients/apps/web/src/components/Toast/index.tsx
+++ b/clients/apps/web/src/components/Toast/index.tsx
@@ -11,7 +11,7 @@ const ToastViewport = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Viewport
     ref={ref}
-    className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px] md:p-10"
+    className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-4 sm:right-4 sm:top-auto sm:flex-col sm:p-0 md:bottom-10 md:right-10 md:max-w-[420px]"
     {...props}
   />
 ))


### PR DESCRIPTION
Noticed something annoying when toasts overlap interactive elements

### Current
https://github.com/user-attachments/assets/75fd4690-4715-457d-bfe3-f114c13d0e57

### Changes
https://github.com/user-attachments/assets/9327da55-b6dd-40f9-b547-d264173e6d1c




