### PR TITLE
clients/web: format charts monthly tick with full year to avoid confusion with daily tick

### DIFF
--- a/clients/apps/web/src/components/Metrics/MetricChart.tsx
+++ b/clients/apps/web/src/components/Metrics/MetricChart.tsx
@@ -139,7 +139,6 @@ const MetricChart = forwardRef<HTMLDivElement, MetricChartProps>(
                   })
                 case 'year':
                   return value.toLocaleDateString('en-US', {
-                    month: 'short',
                     year: 'numeric',
                   })
                 default:


### PR DESCRIPTION
- clients/web: format charts monthly tick with full year to avoid confusion with daily tick