### PR TITLE
fix: resolve pydantic deprecation warnings

### DIFF
--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -89,7 +89,7 @@ def test_generator(overrides: dict[str, Any], id: str, invoice: Invoice) -> None
     path = Path(__file__).parent / f"test_invoice_{id}.pdf"
     path.unlink(missing_ok=True)
 
-    generator = InvoiceGenerator(invoice.copy(update=overrides))
+    generator = InvoiceGenerator(invoice.model_copy(update=overrides))
     generator.generate()
     generator.output(str(path))
 


### PR DESCRIPTION
## PR Summary
This small PR resolves the deprecation warnings of the Pydantic library, which you can find in the [CI logs](https://github.com/polarsource/polar/actions/runs/16525722732/job/46738393015#step:13:236):
```python
PydanticDeprecatedSince20: The `copy` method is deprecated; use `model_copy` instead. See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at 
```