### PR TITLE
 Issue: #6302 - license key validation

### DIFF
--- a/server/polar/customer_portal/endpoints/license_keys.py
+++ b/server/polar/customer_portal/endpoints/license_keys.py
@@ -38,7 +38,7 @@ router = APIRouter(
 
 
 ActivationNotPermitted = {
-    "description": "License key activation not required or permitted (limit reached).",
+    "description": "License key activation not supported or limit reached. Use /validate endpoint for licenses without activations.",
     "model": NotPermitted.schema(),
 }
 

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -225,7 +225,10 @@ class LicenseKeyService:
         activate: LicenseKeyActivate,
     ) -> LicenseKeyActivation:
         if not license_key.limit_activations:
-            raise NotPermitted("License key does not require activation")
+            raise NotPermitted(
+                "This license key does not support activations. "
+                "Use the /validate endpoint instead to check license validity."
+            )
 
         current_activation_count = await self.get_activation_count(
             session,


### PR DESCRIPTION
Issue #6302

Updated the error message to be more descriptive and actionable, educating integrators that they should use the `/validate` endpoint instead.

@frankie567 kindly review