### PR TITLE
Add a pricing page

### DIFF
--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingCTA.tsx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingCTA.tsx
@@ -1,0 +1,21 @@
+import GetStartedButton from '@/components/Auth/GetStartedButton'
+
+export default function PricingCTA() {
+  return (
+    <div className="not-prose mt-16 flex flex-col items-center gap-y-4 py-8">
+      <h2 className="text-pretty text-center text-2xl text-gray-700 md:text-3xl md:!leading-tight dark:text-white">
+        Start selling in minutes
+      </h2>
+
+      <p className="max-w-sm text-center text-gray-500 dark:text-gray-400">
+        We pride ourselves on being the fastest way to integrate payments into
+        your stack.
+      </p>
+
+      <GetStartedButton
+        size="lg"
+        className="rounded-full bg-white font-medium text-black hover:bg-gray-100 dark:bg-white dark:text-black"
+      />
+    </div>
+  )
+}

--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingCTA.tsx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingCTA.tsx
@@ -7,14 +7,14 @@ export default function PricingCTA() {
         Start selling in minutes
       </h2>
 
-      <p className="max-w-sm text-center text-gray-500 dark:text-gray-400">
+      <p className="dark:text-polar-400 max-w-sm text-center text-gray-500">
         We pride ourselves on being the fastest way to integrate payments into
         your stack.
       </p>
 
       <GetStartedButton
         size="lg"
-        className="rounded-full bg-white font-medium text-black hover:bg-gray-100 dark:bg-white dark:text-black"
+        className="dark:bg-polar-700 dark:hover:bg-polar-600 rounded-full border bg-white font-medium text-black hover:bg-white dark:text-white"
       />
     </div>
   )

--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingCard.tsx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingCard.tsx
@@ -1,0 +1,33 @@
+export default function PricingCard({
+  title,
+  description,
+  footer,
+}: {
+  title: string
+  description: React.ReactNode
+  footer?: React.ReactNode
+}) {
+  return (
+    <div className="dark:border-polar-700 dark:bg-polar-900 flex h-full flex-col justify-between overflow-hidden rounded-2xl border border-transparent">
+      <div className="dark:bg-polar-900 flex flex-none flex-col gap-y-6 rounded-t-2xl bg-white p-8 md:p-10">
+        <div className="flex h-full flex-col gap-y-2 md:gap-y-4">
+          <h3 className="dark:text-polar-500 text-polar-700 text-pretty text-base">
+            {title}
+          </h3>
+          {typeof description === 'string' ? (
+            <p className="w-full flex-grow text-2xl text-gray-700 md:max-w-96 md:text-4xl dark:text-white">
+              {description}
+            </p>
+          ) : (
+            description
+          )}
+        </div>
+      </div>
+      {footer && (
+        <div className="dark:bg-polar-700 dark:text-polar-500 flex-1 space-y-2 rounded-b-2xl bg-gray-100 px-8 py-4 text-sm/6 tabular-nums text-gray-400 md:px-10 md:py-6">
+          {footer}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingGrid.tsx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingGrid.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import PricingCard from './PricingCard'
+
+export default function PricingGrid() {
+  return (
+    <div className="not-prose space-y-8">
+      <div className="mx-auto grid w-full max-w-md grid-cols-1 gap-8 md:max-w-3xl md:grid-cols-2">
+        <PricingCard
+          title="Transaction fees"
+          description="4% + 40¢"
+          footer={
+            <>
+              <p>
+                This transaction fee covers Stripe&apos;s processing fee of 2.9%
+                + 30¢.
+              </p>
+              <p>Additional fees from Stripe may be passed on, including:</p>
+              <ul>
+                <li>+1.5% for international (non-US) cards</li>
+                <li>+0.5% for subscription payments</li>
+              </ul>
+            </>
+          }
+        />
+        <PricingCard
+          title="Payout fees"
+          description="No extra fees"
+          footer={
+            <>
+              <p>
+                Stripe charges $2 per month of active payouts, and 0.25% + $0.25
+                per payout.
+              </p>
+
+              <p>
+                Additionally, cross-border fees for currency conversion of 0.25%
+                (EU) or 1% (other countries) will be charged too.
+              </p>
+
+              <p>
+                This cost will be passed on and Polar does not take any profit
+                on them.
+              </p>
+            </>
+          }
+        />
+      </div>
+
+      <p className="dark:text-polar-700 mx-auto max-w-md text-pretty text-center text-base text-gray-400">
+        Large or fast-growing business?{' '}
+        <Link
+          href="/support"
+          className="dark:hover:text-polar-600 font-medium text-inherit underline decoration-1 underline-offset-2 hover:text-gray-500 hover:no-underline"
+        >
+          Reach out to us
+        </Link>{' '}
+        to discuss custom pricing that better fits your needs.
+      </p>
+    </div>
+  )
+}

--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingGrid.tsx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingGrid.tsx
@@ -49,7 +49,7 @@ export default function PricingGrid() {
       <p className="dark:text-polar-600 mx-auto max-w-md text-pretty text-center text-base text-gray-400">
         Large or fast-growing business?{' '}
         <Link
-          href="/support"
+          href="https://docs.polar.sh/support"
           className="dark:hover:text-polar-500 font-medium text-inherit underline decoration-1 underline-offset-2 hover:text-gray-500 hover:no-underline"
         >
           Reach out to us

--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingGrid.tsx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/PricingGrid.tsx
@@ -46,11 +46,11 @@ export default function PricingGrid() {
         />
       </div>
 
-      <p className="dark:text-polar-700 mx-auto max-w-md text-pretty text-center text-base text-gray-400">
+      <p className="dark:text-polar-600 mx-auto max-w-md text-pretty text-center text-base text-gray-400">
         Large or fast-growing business?{' '}
         <Link
           href="/support"
-          className="dark:hover:text-polar-600 font-medium text-inherit underline decoration-1 underline-offset-2 hover:text-gray-500 hover:no-underline"
+          className="dark:hover:text-polar-500 font-medium text-inherit underline decoration-1 underline-offset-2 hover:text-gray-500 hover:no-underline"
         >
           Reach out to us
         </Link>{' '}

--- a/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/page.mdx
+++ b/clients/apps/web/src/app/(main)/(landing)/(mdx)/pricing/page.mdx
@@ -1,0 +1,20 @@
+---
+title: Pricing
+keywords: pricing, pricing, polar, open source
+---
+
+import Link from 'next/link'
+import PricingGrid from './PricingGrid'
+import PricingCTA from './PricingCTA'
+
+<InnerHeaderWrapper>
+  # An open-source & transparent Merchant of Record
+</InnerHeaderWrapper>
+
+<BodyWrapper>
+  <PricingGrid />
+</BodyWrapper>
+
+<InnerWrapper>
+  <PricingCTA />
+</InnerWrapper>

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -90,6 +90,9 @@ const LandingPageDesktopNavigation = () => {
             </NavLink>
           </li>
           <li>
+            <NavLink href="/pricing">Pricing</NavLink>
+          </li>
+          <li>
             <NavLink href="https://docs.polar.sh">Docs</NavLink>
           </li>
           <li>


### PR DESCRIPTION
Related to #6247 

Decided to take a stab on the pricing page. Overall approach and copy is up for discussion of course, thought it was nice to keep it basic as a first version.

<img width="1121" height="1618" alt="" src="https://github.com/user-attachments/assets/3cff60d0-e6c1-48c2-b8e4-d72eca291e1c" />

<img width="1121" height="1618" alt="" src="https://github.com/user-attachments/assets/e719bbb4-5e45-4ffb-bde4-36b6b62b5299" />

