### PR TITLE
Changelog: Ability to load all changes to RSS

### DIFF
--- a/docs/changelog/recent.mdx
+++ b/docs/changelog/recent.mdx
@@ -1,4 +1,5 @@
 ---
+rss: true
 title: Product Updates
 description: Stay up to date with the latest changes and improvements to Polar.
 ---


### PR DESCRIPTION
**Context**
A user reached out to us asking for all changes be fetch-able through RSS.

Mintlify said (in a support case with them) that only the latest update is being shown in RSS today as we do not have rss: true set in the configuration of the frontmatter (as follows):

"Thanks for reaching out - we only update the XML feed after it's created for your docs (by adding rss: true to the front matter of your page).

That's likely why you're only seeing the newer updates!"

**Solution**
Add `rss: true` to the changelog/recent.mdx page