### PR TITLE
fix: add validation for non-negative revenue fields in organization details

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -450,6 +450,7 @@ export const OrganizationDetailsForm: React.FC<
                     <Input
                       {...field}
                       type="number"
+                      min="0"
                       value={field.value || ''}
                       placeholder="1000"
                     />
@@ -554,6 +555,7 @@ export const OrganizationDetailsForm: React.FC<
                         <Input
                           {...field}
                           type="number"
+                          min="0"
                           value={field.value || ''}
                           placeholder="1000"
                         />

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -69,14 +69,14 @@ class OrganizationDetails(Schema):
         ..., description="Main customer acquisition channels."
     )
     future_annual_revenue: int = Field(
-        ..., description="Estimated revenue in the next 12 months"
+        ..., ge=0, description="Estimated revenue in the next 12 months"
     )
     switching: bool = Field(True, description="Switching from another platform?")
     switching_from: (
         Literal["paddle", "lemon_squeezy", "gumroad", "stripe", "other"] | None
     ) = Field(None, description="Which platform the organization is migrating from.")
     previous_annual_revenue: int = Field(
-        0, description="Revenue from last year if applicable."
+        0, ge=0, description="Revenue from last year if applicable."
     )
 
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -123,6 +123,60 @@ class TestUpdateOrganization:
         json = response.json()
         assert json["name"] == "Updated"
 
+    @pytest.mark.auth
+    async def test_negative_revenue_validation(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Test negative future_annual_revenue
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "details": {
+                    "about": "Test company",
+                    "product_description": "SaaS product",
+                    "intended_use": "API integration",
+                    "customer_acquisition": ["website"],
+                    "future_annual_revenue": -1000,
+                    "switching": False,
+                    "previous_annual_revenue": 25000,
+                }
+            },
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("future_annual_revenue" in str(error) for error in error_detail)
+
+    @pytest.mark.auth
+    async def test_negative_previous_revenue_validation(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Test negative previous_annual_revenue
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "details": {
+                    "about": "Test company",
+                    "product_description": "SaaS product",
+                    "intended_use": "API integration",
+                    "customer_acquisition": ["website"],
+                    "future_annual_revenue": 50000,
+                    "switching": False,
+                    "previous_annual_revenue": -5000,
+                }
+            },
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("previous_annual_revenue" in str(error) for error in error_detail)
+
 
 @pytest.mark.asyncio
 class TestInviteOrganization:


### PR DESCRIPTION
# Context

Fixes #6157 