### PR TITLE
fix: allow to delete last payment method

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSettings.tsx
@@ -76,7 +76,7 @@ export const CustomerPortalSettings = ({
               customer={customer}
               paymentMethod={pm}
               api={api}
-              deletable={paymentMethods.items.length > 1}
+              deletable={true}
             />
           ))}
         </WellContent>


### PR DESCRIPTION
# Context
Seems that we blocked from deleting the last payment method to avoid upgrading from free subscriptions to paid ones. But there are other guards in place, and probably the last payment method can be deleted.