### PR TITLE
Update service.py

### DIFF
--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -224,6 +224,12 @@ class LicenseKeyService:
         license_key: LicenseKey,
         activate: LicenseKeyActivate,
     ) -> LicenseKeyActivation:
+        if not license_key.is_active():
+            raise NotPermitted(
+                "License key is no longer active. "
+                "This license key can not be activated."
+            )
+
         if not license_key.limit_activations:
             raise NotPermitted(
                 "This license key does not support activations. "


### PR DESCRIPTION
A [customer reached out](https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01K1QM93FK1NEXJD8TJ3EXQHD3/) that they were able to activate license keys which already had revoked status. I found that while we do check for license key status in `validate` function, we miss checking the status of the license key (or calling the validate function).
This PR aims to ensure that the license key status is checked before it goes through activation flow.