### PR TITLE
Update better-auth.mdx

### DIFF
--- a/docs/integrate/sdk/adapters/better-auth.mdx
+++ b/docs/integrate/sdk/adapters/better-auth.mdx
@@ -333,7 +333,7 @@ To set up the Polar `webhooks` plugin with the BetterAuth client, follow the ste
 
 <Steps>
   <Step title="Configure Webhook Endpoints in Polar">
-    Configure a Webhook endpoint in your Polar Organization Settings page by following [this guide](/integrate/webhooks/endpoints). Webhook endpoint is configured at /polar/webhooks.
+    Configure a Webhook endpoint in your Polar Organization Settings page by following [this guide](/integrate/webhooks/endpoints). Webhook endpoint is configured at `/api/auth/polar/webhooks`.
   </Step>
   <Step title="Add the Webhook Secret">
     Add the obtained webhook secret to your application environment as an environment variable (to be used as `process.env.POLAR_WEBHOOK_SECRET`):


### PR DESCRIPTION
As hashed out with [a customer](https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01K19XS4NKHVA0Q7KSJB5T09K2/), the right path to the webhooks is `/api/auth/polar/webhooks`.

This is deduced from:
- Polar Webhooks Plugin - https://github.com/polarsource/polar-adapters/blob/main/packages/polar-betterauth/src/plugins/webhooks.ts#L166C18-L167, that sets the pathname to /polar/webhooks.
- Better Auth's Context Object - https://github.com/better-auth/better-auth/blob/5eca9389338a900149786bb09b4d802a80e4c668/docs/content/docs/concepts/plugins.mdx#L89:~:text=baseURL%20and%20more.-,Context%20Object,-appName%3A%20The%20name, that sets the basePath as /api/auth.

