### PR TITLE
feat(web): improve landing page performance

### DIFF
--- a/clients/apps/web/src/app/layout.tsx
+++ b/clients/apps/web/src/app/layout.tsx
@@ -78,12 +78,6 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin={''}
-        />
         <link
           href="/favicon.png"
           rel="icon"

--- a/clients/apps/web/src/components/Landing/Adapters.tsx
+++ b/clients/apps/web/src/components/Landing/Adapters.tsx
@@ -9,6 +9,7 @@ import {
   TabsTrigger,
 } from '@polar-sh/ui/components/atoms/Tabs'
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo } from 'react'
 import {
@@ -201,15 +202,16 @@ export const Adapters = () => {
                   </div>
                 </div>
 
-                <div
-                  className="dark:bg-polar-800 flex flex-col justify-center bg-gray-100 p-8 text-sm md:w-1/2 md:p-16"
-                  style={{
-                    backgroundImage: 'url(/assets/landing/abstract.jpg)',
-                    backgroundSize: 'cover',
-                    backgroundPosition: 'center',
-                  }}
-                >
-                  <div className="dark:bg-polar-900 rounded-lg bg-white p-4">
+                <div className="dark:bg-polar-800 relative flex flex-col justify-center bg-gray-100 p-8 text-sm md:w-1/2 md:p-16">
+                  <Image
+                    className="absolute inset-0 h-full w-full object-cover"
+                    src="/assets/landing/abstract.jpg"
+                    fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1280px) 75vw, 640px"
+                    loading="lazy"
+                    alt=""
+                  />
+                  <div className="dark:bg-polar-900 z-[1] rounded-lg bg-white p-4">
                     <SyntaxHighlighterClient
                       lang="typescript"
                       code={adapter.code}

--- a/clients/apps/web/src/components/Landing/Benefits.tsx
+++ b/clients/apps/web/src/components/Landing/Benefits.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
@@ -152,15 +153,21 @@ export const Benefits = () => {
         />
       </div>
       <motion.div
-        className="flex aspect-square flex-1 grow flex-col bg-cover bg-center p-8 md:aspect-auto md:p-16"
-        style={{
-          backgroundImage: `url(${items[activeItem].image})`,
-        }}
+        className="relative flex flex-1 grow flex-col p-8 md:p-16"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 1 }}
-      />
+      >
+        <Image
+          className="absolute inset-0 h-full w-full object-cover"
+          src={items[activeItem].image}
+          fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1280px) 75vw, 640px"
+          loading="lazy"
+          alt={items[activeItem].title}
+        />
+      </motion.div>
     </div>
   )
 }

--- a/clients/apps/web/src/components/Landing/Checkout.tsx
+++ b/clients/apps/web/src/components/Landing/Checkout.tsx
@@ -1,13 +1,49 @@
-import CheckoutComponent from '@/components/Checkout/Checkout'
 import { CHECKOUT_PREVIEW } from '@/components/Customization/utils'
 import { ArrowOutwardOutlined } from '@mui/icons-material'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import Link from 'next/link'
-import { DummyCheckoutContextProvider } from '../Checkout/DummyCheckoutContextProvider'
+import { Suspense, lazy, useEffect, useRef, useState } from 'react'
+
+const CheckoutComponent = lazy(() => import('@/components/Checkout/Checkout'))
+const DummyCheckoutContextProvider = lazy(() =>
+  import('../Checkout/DummyCheckoutContextProvider').then((module) => ({
+    default: module.DummyCheckoutContextProvider,
+  })),
+)
+
+const useIntersectionObserver = () => {
+  const [isVisible, setIsVisible] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.1 },
+    )
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, isVisible }
+}
 
 export const Checkout = () => {
+  const { ref, isVisible } = useIntersectionObserver()
+
   return (
-    <div className="dark:bg-polar-900 rounded-4xl hidden w-full flex-col overflow-hidden bg-white md:flex">
+    <div
+      ref={ref}
+      className="dark:bg-polar-900 rounded-4xl hidden w-full flex-col overflow-hidden bg-white md:flex"
+    >
       <div className="flex flex-col items-center gap-y-8 px-8 pt-8 md:px-16 md:pt-16">
         <span className="dark:text-polar-500 text-lg text-gray-400">
           Built for simplicity
@@ -29,9 +65,17 @@ export const Checkout = () => {
       </div>
       <div className="relative h-[490px] overflow-hidden">
         <div className="shadow-3xl rounded-4xl pointer-events-none absolute left-8 right-8 top-16 flex flex-col items-center md:left-16 md:right-16">
-          <DummyCheckoutContextProvider checkout={CHECKOUT_PREVIEW}>
-            <CheckoutComponent />
-          </DummyCheckoutContextProvider>
+          <Suspense
+            fallback={
+              <div className="dark:bg-polar-700 h-full w-full animate-pulse rounded-lg bg-gray-300" />
+            }
+          >
+            {isVisible && (
+              <DummyCheckoutContextProvider checkout={CHECKOUT_PREVIEW}>
+                <CheckoutComponent />
+              </DummyCheckoutContextProvider>
+            )}
+          </Suspense>
         </div>
       </div>
     </div>

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -2,6 +2,7 @@
 
 import GetStartedButton from '@/components/Auth/GetStartedButton'
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 import { twMerge } from 'tailwind-merge'
 export const Hero = ({ className }: { className?: string }) => {
   const containerVariants = {
@@ -30,14 +31,13 @@ export const Hero = ({ className }: { className?: string }) => {
       whileInView="visible"
       viewport={{ once: true }}
     >
-      <div
-        className="absolute inset-0 -z-10"
-        style={{
-          backgroundImage: 'url(/assets/landing/hero.jpg)',
-          backgroundSize: 'cover',
-          backgroundPosition: '50% 70%',
-          backgroundRepeat: 'no-repeat',
-        }}
+      <Image
+        src="/assets/landing/hero.jpg"
+        className="absolute inset-0 -z-10 h-full w-full object-cover object-[50%_70%]"
+        priority
+        fill
+        sizes="(max-width: 768px) 100vw, (max-width: 1280px) 100vw, 1280px"
+        alt=""
       />
       <motion.h1
         className="text-balance text-5xl !leading-tight tracking-tight text-white md:px-0 md:text-7xl dark:text-white"

--- a/clients/apps/web/src/components/Landing/LandingPage.tsx
+++ b/clients/apps/web/src/components/Landing/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Hero } from '@/components/Landing/Hero/Hero'
 import { MerchantOfRecord } from '@/components/Landing/MOR'
 import { Testimonials } from '@/components/Landing/Testimonials'
 import Avatar from '@polar-sh/ui/components/atoms/Avatar'
+import Image from 'next/image'
 import Link from 'next/link'
 import { Adapters } from './Adapters'
 import { Benefits } from './Benefits'
@@ -48,8 +49,12 @@ export const PageContent = () => {
           <div className="flex flex-col items-center gap-y-4">
             <Avatar
               name="Guillermo Rauch"
-              className="h-16 w-16"
               avatar_url="/assets/landing/testamonials/rauch.jpg"
+              className="h-16 w-16"
+              width={64}
+              height={64}
+              loading="lazy"
+              CustomImageComponent={Image}
             />
             <div className="flex flex-col">
               <span className="">Guillermo Rauch</span>

--- a/clients/apps/web/src/components/Landing/Testimonials.tsx
+++ b/clients/apps/web/src/components/Landing/Testimonials.tsx
@@ -1,4 +1,5 @@
 import Avatar from '@polar-sh/ui/components/atoms/Avatar'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export const testimonials = [
@@ -288,7 +289,15 @@ export const Testamonial = ({
     >
       <div className="flex flex-col gap-y-4 pt-1.5">
         <div className="flex flex-row items-center gap-x-3">
-          <Avatar className="h-12 w-12" avatar_url={avatar} name={name} />
+          <Avatar
+            name={name}
+            avatar_url={avatar}
+            className="h-12 w-12"
+            width={48}
+            height={48}
+            loading="lazy"
+            CustomImageComponent={Image}
+          />
           <div className="flex flex-col text-sm">
             <div className="flex flex-row items-center gap-x-2">
               <span>{name}</span>

--- a/clients/apps/web/src/components/Landing/Usage.tsx
+++ b/clients/apps/web/src/components/Landing/Usage.tsx
@@ -9,6 +9,7 @@ import {
   TabsTrigger,
 } from '@polar-sh/ui/components/atoms/Tabs'
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo } from 'react'
 import {
@@ -217,15 +218,16 @@ export const Usage = () => {
                   </div>
                 </div>
 
-                <div
-                  className="dark:bg-polar-800 flex flex-col justify-center bg-gray-100 p-8 text-sm md:w-1/2 md:p-16"
-                  style={{
-                    backgroundImage: 'url(/assets/landing/abstract_02.jpg)',
-                    backgroundSize: 'cover',
-                    backgroundPosition: 'center',
-                  }}
-                >
-                  <div className="dark:bg-polar-900 rounded-lg bg-white p-4">
+                <div className="dark:bg-polar-800 relative flex flex-col justify-center bg-gray-100 p-8 text-sm md:w-1/2 md:p-16">
+                  <Image
+                    className="absolute inset-0 h-full w-full object-cover"
+                    src="/assets/landing/abstract_02.jpg"
+                    fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1280px) 75vw, 640px"
+                    loading="lazy"
+                    alt=""
+                  />
+                  <div className="dark:bg-polar-900 z-[1] rounded-lg bg-white p-4">
                     <SyntaxHighlighterClient
                       lang="typescript"
                       code={strategy.code}

--- a/clients/apps/web/src/components/Landing/molecules/SplitPromo.tsx
+++ b/clients/apps/web/src/components/Landing/molecules/SplitPromo.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { Check } from 'lucide-react'
+import Image from 'next/image'
 import React from 'react'
 
 interface SplitPromoProps {
@@ -83,15 +84,21 @@ export const SplitPromo: React.FC<SplitPromoProps> = ({
         </motion.div>
       </div>
       <motion.div
-        className="flex aspect-square flex-1 bg-cover bg-center p-8 md:p-16"
-        style={{
-          backgroundImage: `url(${image})`,
-        }}
+        className="relative flex aspect-square flex-1 p-8 md:p-16"
         variants={containerVariants}
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
-      />
+      >
+        <Image
+          className="absolute inset-0 h-full w-full object-cover"
+          src={image}
+          fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1280px) 100vw, 1280px"
+          loading="lazy"
+          alt={title}
+        />
+      </motion.div>
     </motion.div>
   )
 }

--- a/clients/apps/web/src/components/SyntaxHighlighterShiki/SyntaxHighlighterClient.tsx
+++ b/clients/apps/web/src/components/SyntaxHighlighterShiki/SyntaxHighlighterClient.tsx
@@ -6,14 +6,16 @@ import {
   Highlighter,
   ShikiError,
   createHighlighter,
-} from 'shiki/bundle/full'
+} from 'shiki/bundle/web'
 import { themeConfig, themesList, transformers } from '../../../shiki.config'
 
+const highlighterPromise = createHighlighter({
+  langs: ['bash', 'js'],
+  themes: themesList,
+})
+
 const getHighlighter = async (): Promise<Highlighter> => {
-  return createHighlighter({
-    langs: ['bash', 'js'],
-    themes: themesList,
-  })
+  return highlighterPromise
 }
 
 const loadLanguage = async (

--- a/clients/packages/ui/src/components/atoms/Avatar.tsx
+++ b/clients/packages/ui/src/components/atoms/Avatar.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { ComponentProps, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  ComponentProps,
+  ComponentType,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 
 const Avatar = ({
   name,
@@ -9,12 +16,16 @@ const Avatar = ({
   className,
   height,
   width,
+  loading = 'eager',
+  CustomImageComponent,
 }: {
   name: string
   avatar_url: string | null
   className?: string
   height?: number | undefined
   width?: number | undefined
+  loading?: React.ImgHTMLAttributes<HTMLImageElement>['loading']
+  CustomImageComponent?: ComponentType<any> // Used mainly to pass next/image
 }) => {
   const initials = getInitials(name)
 
@@ -45,6 +56,8 @@ const Avatar = ({
     }
   }, [imgRef.current])
 
+  const ImageElement = CustomImageComponent || 'img'
+
   return (
     <div
       className={cn(
@@ -59,12 +72,13 @@ const Avatar = ({
       ) : (
         <>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+          <ImageElement
             ref={imgRef}
             alt={name}
             src={avatar_url}
             height={height}
             width={width}
+            loading={loading}
             onLoad={onLoad}
             onError={onError}
             className={cn(


### PR DESCRIPTION
Hi team 👋 

First off, huge thanks to the Polar team for building such a great product and saving time from people's lives. Better-Auth + Polar is truly a chef’s kiss! 🔥 

While exploring the landing page, I noticed several opportunities to reduce bandwidth costs, improve performance, and boost the chances of retaining potential customers. After some optimizations, we went from:
* Before: 101 requests, 4.9 MB transferred
* After: 54 requests, 1.2 MB transferred (📉 75% reduction)

-----

**Changes & Rationale**

1. 🧹 Removed unused preconnects  
   - There were preconnect links to `fonts.gstatic.com` and `fonts.googleapis.com`, but I couldn’t find any font usage. May have been leftovers.

2. 🖼️ Optimized background images  
   - Several large images (some ~800 KB) were loaded as CSS background images, which can’t be lazy-loaded.  
   - Converted them to use next/image (already in the project), allowing lazy-loading and modern formats (WebP/AVIF).  
   - Added sizes attributes for better responsiveness.  
   - Hero image is preloaded to improve LCP.

3. ⏳ Deferred Stripe loading  
   - `LandingCheckout` was triggering Stripe and other API calls on page load (191kb).  
   - Changed it to lazy-load when visible to avoid unnecessary network/API calls to improve initial load.  
   - Perhaps a fake image would be enough instead of recreating a dummy checkout?

4. 📦 Reduced Shiki bundle size  
   - Changed `import 'shiki/bundle/full'` to `import 'shiki/bundle/web'`, which is about half the size.  
   - Cached the highlighter instance to avoid recreating it multiple times. This reduces overhead for repeated highlight operations.

5. 👤 Optimized testimonial avatars  
   - Passed a custom image element prop to `@ui/.../Avatar.tsx` to use `next/image`, reducing testimonial avatar size from ~40 KB each to ~1 KB.

Thank you for taking the time to review this! I’m happy to make any further changes or adjustments based on your feedback 🚀