### PR TITLE
fix: Incorrect payout account links in notifications

### DIFF
--- a/clients/apps/web/src/components/Notifications/NotificationsPopover.tsx
+++ b/clients/apps/web/src/components/Notifications/NotificationsPopover.tsx
@@ -166,13 +166,16 @@ const MaintainerAccountUnderReview = ({
 }: {
   n: schemas['MaintainerAccountUnderReviewNotification']
 }) => {
+  const { payload } = n
   return (
     <Item n={n} iconClasses="bg-yellow-200 text-yellow-500">
       {{
         text: (
           <>
             Your{' '}
-            <InternalLink href="/finance/account">
+            <InternalLink
+              href={`/dashboard/${payload.organization_name}/finance/account`}
+            >
               <>payout account</>
             </InternalLink>{' '}
             is under review. Transfers are paused until we complete the review
@@ -190,13 +193,16 @@ const MaintainerAccountReviewed = ({
 }: {
   n: schemas['MaintainerAccountReviewedNotification']
 }) => {
+  const { payload } = n
   return (
     <Item n={n} iconClasses="bg-green-200 text-green-500">
       {{
         text: (
           <>
             Your{' '}
-            <InternalLink href="/finance/account">
+            <InternalLink
+              href={`/dashboard/${payload.organization_name}/finance/account`}
+            >
               <>payout account</>
             </InternalLink>{' '}
             has been reviewed successfully. Transfers are resumed.

--- a/server/polar/notifications/notification.py
+++ b/server/polar/notifications/notification.py
@@ -42,6 +42,7 @@ class NotificationBase(Schema):
 
 class MaintainerAccountUnderReviewNotificationPayload(NotificationPayloadBase):
     account_type: str
+    organization_name: str
 
     def subject(self) -> str:
         return "Your Polar account is being reviewed"
@@ -58,6 +59,7 @@ class MaintainerAccountUnderReviewNotification(NotificationBase):
 
 class MaintainerAccountReviewedNotificationPayload(NotificationPayloadBase):
     account_type: str
+    organization_name: str
 
     def subject(self) -> str:
         return "Your Polar account review is now complete"

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -94,7 +94,8 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
                 notif=PartialNotification(
                     type=NotificationType.maintainer_account_under_review,
                     payload=MaintainerAccountUnderReviewNotificationPayload(
-                        account_type="organization"
+                        account_type="organization",
+                        organization_name=organization.slug,
                     ),
                 ),
             )
@@ -124,7 +125,8 @@ async def organization_reviewed(organization_id: uuid.UUID) -> None:
                 notif=PartialNotification(
                     type=NotificationType.maintainer_account_reviewed,
                     payload=MaintainerAccountReviewedNotificationPayload(
-                        account_type="organization"
+                        account_type="organization",
+                        organization_name=organization.slug,
                     ),
                 ),
             )

--- a/server/tests/notifications/test_email.py
+++ b/server/tests/notifications/test_email.py
@@ -114,10 +114,12 @@ async def test_all_notification_types() -> None:
         elif notification_type == NotificationType.maintainer_account_under_review:
             n = MaintainerAccountUnderReviewNotificationPayload(
                 account_type="Stripe Connect Express",
+                organization_name="test-org",
             )
         elif notification_type == NotificationType.maintainer_account_reviewed:
             n = MaintainerAccountReviewedNotificationPayload(
                 account_type="Stripe Connect Express",
+                organization_name="test-org",
             )
         elif notification_type == NotificationType.maintainer_new_product_sale:
             n = MaintainerNewProductSaleNotificationPayload(


### PR DESCRIPTION
Updated the payout account links in MaintainerAccountUnderReview and MaintainerAccountReviewed notifications to include the organization name in the URL. This ensures users are directed to the correct organization's finance account page.

Currently, clicking `payout account` in the notification takes you to `https://polar.sh/finance/account` instead of `https://polar.sh/dashboard/ORG_SLUG/finance/account`.