### PR TITLE
revert: Incorrect payout account links in notifications (#6375)

### DIFF
--- a/clients/apps/web/src/components/Notifications/NotificationsPopover.tsx
+++ b/clients/apps/web/src/components/Notifications/NotificationsPopover.tsx
@@ -166,16 +166,13 @@ const MaintainerAccountUnderReview = ({
 }: {
   n: schemas['MaintainerAccountUnderReviewNotification']
 }) => {
-  const { payload } = n
   return (
     <Item n={n} iconClasses="bg-yellow-200 text-yellow-500">
       {{
         text: (
           <>
             Your{' '}
-            <InternalLink
-              href={`/dashboard/${payload.organization_name}/finance/account`}
-            >
+            <InternalLink href="/finance/account">
               <>payout account</>
             </InternalLink>{' '}
             is under review. Transfers are paused until we complete the review
@@ -193,16 +190,13 @@ const MaintainerAccountReviewed = ({
 }: {
   n: schemas['MaintainerAccountReviewedNotification']
 }) => {
-  const { payload } = n
   return (
     <Item n={n} iconClasses="bg-green-200 text-green-500">
       {{
         text: (
           <>
             Your{' '}
-            <InternalLink
-              href={`/dashboard/${payload.organization_name}/finance/account`}
-            >
+            <InternalLink href="/finance/account">
               <>payout account</>
             </InternalLink>{' '}
             has been reviewed successfully. Transfers are resumed.

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12448,8 +12448,6 @@ export interface components {
         MaintainerAccountReviewedNotificationPayload: {
             /** Account Type */
             account_type: string;
-            /** Organization Name */
-            organization_name: string;
         };
         /** MaintainerAccountUnderReviewNotification */
         MaintainerAccountUnderReviewNotification: {
@@ -12474,8 +12472,6 @@ export interface components {
         MaintainerAccountUnderReviewNotificationPayload: {
             /** Account Type */
             account_type: string;
-            /** Organization Name */
-            organization_name: string;
         };
         /** MaintainerCreateAccountNotification */
         MaintainerCreateAccountNotification: {

--- a/server/polar/notifications/notification.py
+++ b/server/polar/notifications/notification.py
@@ -42,7 +42,6 @@ class NotificationBase(Schema):
 
 class MaintainerAccountUnderReviewNotificationPayload(NotificationPayloadBase):
     account_type: str
-    organization_name: str
 
     def subject(self) -> str:
         return "Your Polar account is being reviewed"
@@ -59,7 +58,6 @@ class MaintainerAccountUnderReviewNotification(NotificationBase):
 
 class MaintainerAccountReviewedNotificationPayload(NotificationPayloadBase):
     account_type: str
-    organization_name: str
 
     def subject(self) -> str:
         return "Your Polar account review is now complete"

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -94,8 +94,7 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
                 notif=PartialNotification(
                     type=NotificationType.maintainer_account_under_review,
                     payload=MaintainerAccountUnderReviewNotificationPayload(
-                        account_type="organization",
-                        organization_name=organization.slug,
+                        account_type="organization"
                     ),
                 ),
             )
@@ -125,8 +124,7 @@ async def organization_reviewed(organization_id: uuid.UUID) -> None:
                 notif=PartialNotification(
                     type=NotificationType.maintainer_account_reviewed,
                     payload=MaintainerAccountReviewedNotificationPayload(
-                        account_type="organization",
-                        organization_name=organization.slug,
+                        account_type="organization"
                     ),
                 ),
             )

--- a/server/tests/notifications/test_email.py
+++ b/server/tests/notifications/test_email.py
@@ -114,12 +114,10 @@ async def test_all_notification_types() -> None:
         elif notification_type == NotificationType.maintainer_account_under_review:
             n = MaintainerAccountUnderReviewNotificationPayload(
                 account_type="Stripe Connect Express",
-                organization_name="test-org",
             )
         elif notification_type == NotificationType.maintainer_account_reviewed:
             n = MaintainerAccountReviewedNotificationPayload(
                 account_type="Stripe Connect Express",
-                organization_name="test-org",
             )
         elif notification_type == NotificationType.maintainer_new_product_sale:
             n = MaintainerNewProductSaleNotificationPayload(


### PR DESCRIPTION
This reverts commit 04fff8c2d55d9a805ef763ca3c07a3346d61feed.