### PR TITLE
sdk/overlays: fix empty security scheme being removed from unauthenticated endpoints

### DIFF
--- a/sdk/overlays/security.yml
+++ b/sdk/overlays/security.yml
@@ -19,6 +19,6 @@ actions:
         type: http
         scheme: bearer
         description: "You can generate an **Organization Access Token** from your organization's settings."
-  - target: "$.paths.*.*[?(!@.security[?(@.customer_session)])].security"
-    description: Remove security from individual paths, unless it's a customer session
+  - target: "$.paths.*.*[?(!@.security[?(@.customer_session || !@.*)])].security"
+    description: Remove security from individual paths, unless it's a customer session or empty security object
     remove: true


### PR DESCRIPTION

I need to regenerate the SDK and update the OpenAPI spec afterwards.