### PR TITLE
Order+Subscription+Checkout tables: Don't explicitly set column sizes

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -148,7 +148,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'net_amount',
       enableSorting: true,
-      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Amount" />
       ),
@@ -180,7 +179,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'status',
       enableSorting: true,
-      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),
@@ -193,7 +191,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'created_at',
       enableSorting: true,
-      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/ClientPage.tsx
@@ -170,7 +170,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'created_at',
       enableSorting: true,
-      size: 70,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),
@@ -184,7 +183,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'status',
       enableSorting: true,
-      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
@@ -168,7 +168,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
       id: 'customer',
       accessorKey: 'customer',
       enableSorting: true,
-      size: 150,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Customer" />
       ),
@@ -190,7 +189,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'status',
       enableSorting: true,
-      size: 50,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),
@@ -201,7 +199,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'started_at',
       enableSorting: true,
-      size: 85,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Subscription Date" />
       ),
@@ -212,7 +209,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     {
       accessorKey: 'current_period_end',
       enableSorting: true,
-      size: 85,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Renewal Date" />
       ),


### PR DESCRIPTION
Setting the `size` on the columns was breaking responsiveness on smaller
screens or when displayed in a narrow browser window.

This a revert of commit 3ea4d9feee85690dc5abf2e084d8be4d3f8adad7.
