### PR TITLE
docs: add wildcard org redirect url

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/*/[[...route]]/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/*/[[...route]]/page.tsx
@@ -1,0 +1,28 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getLastVisitedOrg } from '@/utils/cookies'
+import { getUserOrganizations } from '@/utils/user'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ route: string[] }>
+}) {
+  const { route } = await params
+
+  const api = getServerSideAPI()
+  const userOrganizations = await getUserOrganizations(api)
+
+  if (userOrganizations.length === 0) {
+    redirect('/dashboard/create')
+  }
+
+  const org = userOrganizations.find(
+    (org) => org.slug === getLastVisitedOrg(cookies()),
+  )
+
+  const targetOrg = org?.slug ?? userOrganizations[0].slug
+
+  redirect(`/dashboard/${targetOrg}/${route.join('/')}`)
+}

--- a/docs/features/analytics.mdx
+++ b/docs/features/analytics.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Analytics"
 
 ## Sales Metrics
 
-Polar offers a professional metrics dashboard out of the box. So you can stay focused on increasing revenue vs. how to measure it.
+Polar offers [a professional metrics dashboard](https://polar.sh/dashboard/*/analytics) out of the box. So you can stay focused on increasing revenue vs. how to measure it.
 
 <img
   className="block dark:hidden"

--- a/docs/features/benefits/introduction.mdx
+++ b/docs/features/benefits/introduction.mdx
@@ -35,4 +35,4 @@ This approach is a bit different from other platforms, but offers many advantage
 You can manage benefits in two ways:
 
 1. Directly within a product create/edit form
-2. Or via `Benefits` in your dashboard
+2. Or via [**Benefits**](https://polar.sh/dashboard/*/benefits) in your dashboard

--- a/docs/features/checkout/links.mdx
+++ b/docs/features/checkout/links.mdx
@@ -15,7 +15,7 @@ creates a checkout session for customers.
 
 ## Create a Checkout Link
 
-Checkout Links can be managed from the **Checkout Links** tabs of the Products section. Click on **New Link** to create a new one.
+Checkout Links can be managed from the [**Checkout Links**](https://polar.sh/dashboard/*/products/checkout-links) tabs of the Products section. Click on **New Link** to create a new one.
 
 <Frame>
   <img

--- a/docs/features/discounts.mdx
+++ b/docs/features/discounts.mdx
@@ -16,7 +16,7 @@ Discounts are a way to reduce the price of a product or subscription. They can b
 
 ## Create a discount
 
-Go to the **Products** page and click on the **Discounts** tab.
+Go to the **Products** page and click on the [**Discounts**](https://polar.sh/dashboard/*/products/discounts) tab.
 
 #### Name
 

--- a/docs/features/finance/accounts.mdx
+++ b/docs/features/finance/accounts.mdx
@@ -11,7 +11,7 @@ You need to setup an account so that we can issue [payouts](/features/finance/pa
 <img className="block dark:hidden" src="/assets/features/finance/accounts/onboarding.light.jpeg" />
 <img className="hidden dark:block" src="/assets/features/finance/accounts/onboarding.dark.jpeg" />
 
-1. Go to the `Finance` page in your Polar dashboard
+1. Go to the [**Finance**](https://polar.sh/dashboard/*/finance) page in your Polar dashboard
 2. Click `Setup` in the card shown above in your dashboard
 3. Choose account type & follow their setup instructions
 

--- a/docs/features/finance/balance.mdx
+++ b/docs/features/finance/balance.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Account Balance"
 description: "Monitor your Polar balance without hidden fees"
 ---
 
-You can see your available balance for payout at any time under your `Finance` page.
+You can see your available balance for payout at any time under your [**Finance**](https://polar.sh/dashboard/*/finance) page.
 
 Polar Balance
 --------------------

--- a/docs/features/orders.mdx
+++ b/docs/features/orders.mdx
@@ -14,7 +14,7 @@ sidebarTitle: "Orders & Subscriptions"
   src="/assets/features/orders/overview.dark.png"
 />
 
-The sales view shows you all sales in a paginated list.
+The [**Sales**](https://polar.sh/dashboard/*/sales) view shows you all sales in a paginated list.
 
 ## Order & Subscription Details
 

--- a/docs/features/products.mdx
+++ b/docs/features/products.mdx
@@ -21,6 +21,8 @@ Subscriptions or pay once products are both considered a product in Polar (API &
 
 ## Create a product
 
+Go to [**Products**](https://polar.sh/dashboard/*/products) page and click on the **New Product** button.
+
 ### Name & Description
 
 Starting off with the basic.

--- a/docs/features/usage-based-billing/introduction.mdx
+++ b/docs/features/usage-based-billing/introduction.mdx
@@ -77,7 +77,7 @@ Get up and running in 5 minutes
 
 <Steps>
   <Step title="Enable Usage Based Billing">
-    Usage Based Billing is currently in Alpha. Enable it by navigating to the Organization Settings and toggling the "Usage Based Billing" switch.
+    Usage Based Billing is currently in Alpha. Enable it by navigating to the [Organization Settings](https://polar.sh/dashboard/*/settings) and toggling the "Usage Based Billing" switch.
 
   </Step>
   <Step title="Create a Meter">

--- a/docs/features/usage-based-billing/meters.mdx
+++ b/docs/features/usage-based-billing/meters.mdx
@@ -9,7 +9,7 @@ import Meters from "/snippets/usage/meters.mdx";
 
 ## Creating a Meter
 
-To create a meter, navigate to the Meters page in the sidebar and click the "Create Meter" button.
+To create a meter, navigate to the [**Meters**](https://polar.sh/dashboard/*/usage-billing/meters) page in the sidebar and click the "Create Meter" button.
 
 <img
   className="block dark:hidden"

--- a/docs/integrate/webhooks/endpoints.mdx
+++ b/docs/integrate/webhooks/endpoints.mdx
@@ -24,7 +24,7 @@ formatting. Making it a breeze to setup in-chat notifications for your team.
 
 <Steps>
   <Step title="Add new endpoint">
-    Head over to your organization settings and click on the `Add Endpoint` button to create a new webhook.
+    Head over to [your organization settings](https://polar.sh/dashboard/*/settings/webhooks) and click on the `Add Endpoint` button to create a new webhook.
 
     <img className="block dark:hidden" src="/assets/integrate/webhooks/create.light.png" />
     <img className="hidden dark:block" src="/assets/integrate/webhooks/create.dark.png" />


### PR DESCRIPTION
This PR adds a route to handle redirects from docs where the user's organization is unknown. The route gets user's last visited organization and redirects user to the desired dashboard page.

I've also updated the docs to add a couple of new quick links that should improve DX.

This is inspired by Supabase, where they have similar feature, but for projects: `https://supabase.com/dashboard/project/_`

For further development there might be need to add a organization selector before redirection in case user have multiple organizations, similarly as Supabase does with projects.