### PR TITLE
server/discount: add a maximum to amount, to avoid Stripe error

### DIFF
--- a/server/polar/discount/schemas.py
+++ b/server/polar/discount/schemas.py
@@ -134,6 +134,7 @@ Amount = Annotated[
     Field(
         description="Fixed amount to discount from the invoice total.",
         ge=0,
+        le=999999999999,
     ),
 ]
 Currency = Annotated[


### PR DESCRIPTION
Fix #6428

- server/discount: add a maximum to amount, to avoid Stripe error
