### PR TITLE
Invoice: Fix case where right-side seller is very short

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -226,9 +226,7 @@ class Settings(BaseSettings):
         state="CA",
         country=CountryAlpha2("US"),
     )
-    INVOICES_ADDITIONAL_INFO: str | None = (
-        "[support@polar.sh](mailto:support@polar.sh)\n"
-    )
+    INVOICES_ADDITIONAL_INFO: str | None = "[support@polar.sh](mailto:support@polar.sh)"
     PAYOUT_INVOICES_PREFIX: str = "POLAR-"
 
     # Application behaviours

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -301,6 +301,7 @@ class InvoiceGenerator(FPDF):
                 text=self.data.seller_additional_info,
                 markdown=True,
             )
+        left_seller_end_y = self.get_y()
 
         # Customer on right column
         self.set_xy(110, addresses_y_start)
@@ -331,9 +332,11 @@ class InvoiceGenerator(FPDF):
                 text=self.data.customer_additional_info,
                 markdown=True,
             )
+        right_seller_end_y = self.get_y()
+        bottom = max(left_seller_end_y, right_seller_end_y)
 
         # Add spacing before table
-        self.set_y(self.get_y() + self.elements_y_margin)
+        self.set_y(bottom + self.elements_y_margin)
 
         # Invoice items table
         self.set_draw_color(*self.table_borders_color)  # Light grey color for borders

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -83,6 +83,13 @@ Thank you for your business!
             },
             "long_customer_name",
         ),
+        (
+            {
+                "customer_address": Address(country=CountryAlpha2("FR")),
+                "seller_additional_info": "[support@polar.sh](mailto:support@polar.sh)\nExtra line 1\nExtra line 2\nExtra line 3",
+            },
+            "long_seller_info",
+        ),
     ],
 )
 def test_generator(overrides: dict[str, Any], id: str, invoice: Invoice) -> None:


### PR DESCRIPTION
Fixes a case where the seller address would overlap with the line item table in cases where the right-side seller address was very short.
