### PR TITLE
Update MeterSelect.tsx

### DIFF
--- a/clients/apps/web/src/components/Meter/MeterSelect.tsx
+++ b/clients/apps/web/src/components/Meter/MeterSelect.tsx
@@ -15,7 +15,7 @@ const MeterSelect: React.FC<
     allOption?: boolean
   }
 > = ({ organizationId, allOption, className, ...props }) => {
-  const { data } = useMeters(organizationId, { sorting: ['name'] })
+  const { data } = useMeters(organizationId, { sorting: ['name'], limit: 30 })
   const meters = data?.items ?? []
 
   return (


### PR DESCRIPTION
A temporary fix for #6495 by fetching 30 meters from the API vs the default 10.