### PR TITLE
Admins: Allow access to the dashboard of all orgs

### DIFF
--- a/server/polar/account/repository.py
+++ b/server/polar/account/repository.py
@@ -67,6 +67,9 @@ class AccountRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(Account.admin_id == user.id)
         elif is_organization(auth_subject):
             # Only the admin of the account can access it

--- a/server/polar/benefit/repository.py
+++ b/server/polar/benefit/repository.py
@@ -30,6 +30,9 @@ class BenefitRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Benefit.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/checkout/repository.py
+++ b/server/polar/checkout/repository.py
@@ -62,6 +62,9 @@ class CheckoutRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Product.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -69,6 +69,9 @@ class CheckoutLinkRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 CheckoutLink.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -108,6 +108,9 @@ class CustomerRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Customer.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/customer_meter/repository.py
+++ b/server/polar/customer_meter/repository.py
@@ -69,6 +69,9 @@ class CustomerMeterRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Customer.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -82,6 +82,9 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Event.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/file/repository.py
+++ b/server/polar/file/repository.py
@@ -25,6 +25,9 @@ class FileRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 File.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/license_key/repository.py
+++ b/server/polar/license_key/repository.py
@@ -89,6 +89,9 @@ class LicenseKeyRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 LicenseKey.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/meter/repository.py
+++ b/server/polar/meter/repository.py
@@ -23,6 +23,9 @@ class MeterRepository(RepositoryBase[Meter], RepositoryIDMixin[Meter, UUID]):
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Meter.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -85,14 +85,17 @@ def _get_readable_orders_statement(
     statement = select(Order.id).join(Product, onclause=Order.product_id == Product.id)
 
     if is_user(auth_subject):
-        statement = statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.deleted_at.is_(None),
+        user = auth_subject.subject
+        # If user is admin, do not automatically restrict to the admin user's org
+        if not user.is_admin:
+            statement = statement.where(
+                Product.organization_id.in_(
+                    select(UserOrganization.organization_id).where(
+                        UserOrganization.user_id == user.id,
+                        UserOrganization.deleted_at.is_(None),
+                    )
                 )
             )
-        )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)
 
@@ -230,14 +233,17 @@ def get_active_subscriptions_cte(
         Product, onclause=Subscription.product_id == Product.id
     )
     if is_user(auth_subject):
-        readable_subscriptions_statement = readable_subscriptions_statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.deleted_at.is_(None),
+        user = auth_subject.subject
+        # If user is admin, do not automatically restrict to the admin user's org
+        if not user.is_admin:
+            readable_subscriptions_statement = readable_subscriptions_statement.where(
+                Product.organization_id.in_(
+                    select(UserOrganization.organization_id).where(
+                        UserOrganization.user_id == auth_subject.subject.id,
+                        UserOrganization.deleted_at.is_(None),
+                    )
                 )
             )
-        )
     elif is_organization(auth_subject):
         readable_subscriptions_statement = readable_subscriptions_statement.where(
             Product.organization_id == auth_subject.subject.id
@@ -331,14 +337,17 @@ def get_checkouts_cte(
     )
 
     if is_user(auth_subject):
-        readable_checkouts_statement = readable_checkouts_statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.deleted_at.is_(None),
+        user = auth_subject.subject
+        # If user is admin, do not automatically restrict to the admin user's org
+        if not user.is_admin:
+            readable_checkouts_statement = readable_checkouts_statement.where(
+                Product.organization_id.in_(
+                    select(UserOrganization.organization_id).where(
+                        UserOrganization.user_id == auth_subject.subject.id,
+                        UserOrganization.deleted_at.is_(None),
+                    )
                 )
             )
-        )
     elif is_organization(auth_subject):
         readable_checkouts_statement = readable_checkouts_statement.where(
             Product.organization_id == auth_subject.subject.id

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -108,6 +108,9 @@ class OrderRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Customer.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -91,6 +91,10 @@ class OrganizationRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
+
             statement = statement.where(
                 Organization.id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/organization_access_token/repository.py
+++ b/server/polar/organization_access_token/repository.py
@@ -52,6 +52,9 @@ class OrganizationAccessTokenRepository(
     ) -> Select[tuple[OrganizationAccessToken]]:
         statement = self.get_base_statement()
         user = auth_subject.subject
+        # Admin users have access to all organizations
+        if user.is_admin:
+            return statement
         statement = statement.where(
             OrganizationAccessToken.organization_id.in_(
                 select(UserOrganization.organization_id).where(

--- a/server/polar/payment/repository.py
+++ b/server/polar/payment/repository.py
@@ -40,6 +40,9 @@ class PaymentRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Payment.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -92,6 +92,9 @@ class PayoutRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.join(Payout.account).where(
                 Account.admin_id == user.id
             )

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -73,6 +73,9 @@ class ProductRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Product.organization_id.in_(
                     select(UserOrganization.organization_id).where(
@@ -152,6 +155,9 @@ class ProductPriceRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Product.organization_id.in_(
                     select(UserOrganization.organization_id).where(

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -106,6 +106,9 @@ class SubscriptionRepository(
 
         if is_user(auth_subject):
             user = auth_subject.subject
+            # Admin users have access to all organizations
+            if user.is_admin:
+                return statement
             statement = statement.where(
                 Product.organization_id.in_(
                     select(UserOrganization.organization_id).where(


### PR DESCRIPTION
This PR lets a user with `.is_admin is True` access any organization's dashboard and query their data via the API.
This is to allow us to more easily help users having issues.