### PR TITLE
tasks: Add `db_reparent` task

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -91,6 +91,7 @@ lint_check = { cmd = "ruff format --check . && ruff check .", help = "run ruff l
 lint_types = { cmd = "mypy polar scripts tests", help = "run mypy type verify" }
 db_migrate = { cmd = "python -m scripts.db upgrade", help = "run alembic upgrade" }
 db_recreate = { cmd = "python -m scripts.db recreate", help = "drop and recreate database" }
+db_reparent = { cmd = "python -m scripts.db reparent", help = "try to auto-fix conflicting migrations" }
 clean = { cmd = "find * -name '*.pyc' -delete && find * -name '__pycache__' -delete", help = "clean up .pyc and __pycache__" }
 verify_github_app = { cmd = "python -m polar.verify_github_app", help = "verify that the github app is correctly configured" }
 generate_dev_jwks = { cmd = "python -m polar.kit.jwk polar_dev > ./.jwks.json", help = "generate a development JWKS file" }

--- a/server/scripts/db.py
+++ b/server/scripts/db.py
@@ -1,4 +1,6 @@
 import os
+import re
+import subprocess
 
 import typer
 from alembic.command import upgrade as alembic_upgrade
@@ -14,10 +16,95 @@ def get_sync_postgres_dsn() -> str:
     return str(settings.get_postgres_dsn("psycopg2"))
 
 
-def _upgrade(revision: str = "head") -> None:
+def get_config() -> Config:
     config_file = os.path.join(os.path.dirname(__file__), "../alembic.ini")
     config = Config(config_file)
     config.set_main_option("sqlalchemy.url", get_sync_postgres_dsn())
+    return config
+
+
+def _reparent(force: bool = False) -> None:
+    # 1. Find which alembic head is on `main`
+    # `alembic heads`
+    p_out = subprocess.run(
+        ["uv", "run", "alembic", "heads"],
+        capture_output=True,
+        text=True,
+    )
+    p_out.check_returncode()
+    heads = [line.removesuffix(" (head)") for line in p_out.stdout.strip().split("\n")]
+
+    if force:
+        pass
+    elif len(heads) == 1:
+        print("Found just 1 head, so there shouldn't be a need to reparent. Exiting")
+        return
+    elif len(heads) > 2:
+        print("Found more than 2 heads unclear what we should do. Exiting")
+        return
+
+    main_head = None
+    branch_head = None
+    main_migration_file = None
+    branch_migration_file = None
+    for head in heads:
+        # `git grep {head} main -- "server/migrations/versions/*"`
+        p_out = subprocess.run(
+            ["git", "grep", "-l", head, "main", "--", "migrations/versions/*"],
+            capture_output=True,
+            text=True,
+        )
+        if p_out.returncode == 0:
+            main_head = head
+            main_migration_file = p_out.stdout.strip().removeprefix("main:")
+
+    for head in heads:
+        # `git grep {head} HEAD -- "server/migrations/versions/*"`
+        p_out = subprocess.run(
+            ["git", "grep", "-l", head, "HEAD", "--", "migrations/versions/*"],
+            capture_output=True,
+            text=True,
+        )
+        if p_out.returncode == 0:
+            branch_head = head
+            branch_migration_file = p_out.stdout.strip().removeprefix("HEAD:")
+
+    if (
+        not main_head
+        or not branch_head
+        or not main_migration_file
+        or not branch_migration_file
+    ):
+        return
+
+    print(f"""
+`main` head: {main_head} ({main_migration_file})
+branch head: {branch_head} ({branch_migration_file})
+""")
+
+    re_down_revision = re.compile(r'down_revision = "([^"]+)"')
+
+    # 2. Manipulate the other head to be based off head from `main`-branch
+    with open(branch_migration_file, "r+") as f:
+        f_contents = f.read()
+
+        previous_parent = list(re_down_revision.finditer(f_contents))[0].group(1)
+        f_new_contents = re_down_revision.sub(
+            f'down_revision = "{main_head}"', f_contents
+        )
+        f_new_contents = re.sub(
+            "Revises: [a-f0-9]+", f"Revises: {main_head}", f_new_contents
+        )
+
+        print(f"Updating {branch_migration_file}")
+        print(f'`down_revision` was "{previous_parent}"')
+        print(f'`down_revision` updated to "{main_head}"')
+        f.seek(0)
+        f.write(f_new_contents)
+
+
+def _upgrade(revision: str = "head") -> None:
+    config = get_config()
     alembic_upgrade(config, revision)
 
 
@@ -42,6 +129,20 @@ def upgrade(
 def recreate() -> None:
     assert_dev_or_testing()
     _recreate()
+
+
+@cli.command(
+    help="Try to move a conflicting head migration on the current branch on top o fthe latest migration on `main`"
+)
+def reparent(
+    force: bool = typer.Option(
+        False,
+        "-f",
+        "--force",
+        help="Update latest migration even if there aren't multiple heads",
+    ),
+) -> None:
+    _reparent(force=force)
 
 
 def assert_dev_or_testing() -> None:


### PR DESCRIPTION
This task tries to auto-fix conflicting migrations by reparenting the
head migration from this branch on top of the head migration on the
`main` branch.