### PR TITLE
server/subscription: add lock around Stripe subscription update to prevent race condition

### DIFF
--- a/server/polar/integrations/stripe/tasks.py
+++ b/server/polar/integrations/stripe/tasks.py
@@ -12,6 +12,7 @@ from polar.checkout.service import NotConfirmedCheckout
 from polar.exceptions import PolarTaskError
 from polar.external_event.service import external_event as external_event_service
 from polar.integrations.stripe.schemas import PaymentIntentSuccessWebhook, ProductType
+from polar.locker import Locker
 from polar.logging import Logger
 from polar.order.service import (
     NotAnOrderInvoice,
@@ -27,7 +28,7 @@ from polar.payment.service import payment as payment_service
 from polar.payout.service import payout as payout_service
 from polar.pledge.service import pledge as pledge_service
 from polar.refund.service import refund as refund_service
-from polar.subscription.service import SubscriptionDoesNotExist
+from polar.subscription.service import SubscriptionDoesNotExist, SubscriptionLocked
 from polar.subscription.service import subscription as subscription_service
 from polar.transaction.service.dispute import (
     DisputeClosed,
@@ -36,7 +37,14 @@ from polar.transaction.service.dispute import (
     dispute_transaction as dispute_transaction_service,
 )
 from polar.user.service import user as user_service
-from polar.worker import AsyncSessionMaker, TaskPriority, actor, can_retry, get_retries
+from polar.worker import (
+    AsyncSessionMaker,
+    RedisMiddleware,
+    TaskPriority,
+    actor,
+    can_retry,
+    get_retries,
+)
 
 from . import payment
 from .service import stripe as stripe_service
@@ -290,11 +298,13 @@ async def customer_subscription_updated(event_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         async with external_event_service.handle_stripe(session, event_id) as event:
             subscription = cast(stripe_lib.Subscription, event.stripe_data.data.object)
+            redis = RedisMiddleware.get()
+            locker = Locker(redis)
             try:
                 await subscription_service.update_from_stripe(
-                    session, stripe_subscription=subscription
+                    session, locker, stripe_subscription=subscription
                 )
-            except SubscriptionDoesNotExist as e:
+            except (SubscriptionDoesNotExist, SubscriptionLocked) as e:
                 log.warning(e.message, event_id=event.id)
                 # Retry because Stripe webhooks order is not guaranteed,
                 # so we might not have been able to handle subscription.created yet!
@@ -314,11 +324,13 @@ async def customer_subscription_deleted(event_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         async with external_event_service.handle_stripe(session, event_id) as event:
             subscription = cast(stripe_lib.Subscription, event.stripe_data.data.object)
+            redis = RedisMiddleware.get()
+            locker = Locker(redis)
             try:
                 await subscription_service.update_from_stripe(
-                    session, stripe_subscription=subscription
+                    session, locker, stripe_subscription=subscription
                 )
-            except SubscriptionDoesNotExist as e:
+            except (SubscriptionDoesNotExist, SubscriptionLocked) as e:
                 log.warning(e.message, event_id=event.id)
                 # Retry because Stripe webhooks order is not guaranteed,
                 # so we might not have been able to handle subscription.created yet!

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -21,7 +21,7 @@ from polar.routing import APIRouter
 from . import auth, sorting
 from .schemas import Subscription as SubscriptionSchema
 from .schemas import SubscriptionID, SubscriptionUpdate
-from .service import AlreadyCanceledSubscription
+from .service import AlreadyCanceledSubscription, SubscriptionLocked
 from .service import subscription as subscription_service
 
 log = structlog.get_logger()
@@ -177,6 +177,10 @@ async def get(
             "model": AlreadyCanceledSubscription.schema(),
         },
         404: SubscriptionNotFound,
+        409: {
+            "description": "Subscription is pending an update.",
+            "model": SubscriptionLocked.schema(),
+        },
     },
 )
 async def update(
@@ -197,9 +201,10 @@ async def update(
         customer_id=auth_subject.subject.id,
         updates=subscription_update,
     )
-    return await subscription_service.update(
-        session, locker, subscription, update=subscription_update
-    )
+    async with subscription_service.lock(locker, subscription):
+        return await subscription_service.update(
+            session, locker, subscription, update=subscription_update
+        )
 
 
 @router.delete(
@@ -213,6 +218,10 @@ async def update(
             "model": AlreadyCanceledSubscription.schema(),
         },
         404: SubscriptionNotFound,
+        409: {
+            "description": "Subscription is pending an update.",
+            "model": SubscriptionLocked.schema(),
+        },
     },
 )
 async def revoke(
@@ -229,7 +238,5 @@ async def revoke(
     log.info(
         "subscription.revoke", id=id, admin_id=auth_subject.subject.id, immediate=True
     )
-    async with locker.lock(
-        f"subscription:{subscription.id}", timeout=5, blocking_timeout=5
-    ):
+    async with subscription_service.lock(locker, subscription):
         return await subscription_service.revoke(session, subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1,5 +1,6 @@
+import contextlib
 import uuid
-from collections.abc import Sequence
+from collections.abc import AsyncGenerator, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Literal, cast, overload
@@ -144,7 +145,7 @@ class SubscriptionNotActiveOnStripe(SubscriptionError):
         super().__init__(message, 400)
 
 
-class SubscriptionUpdatePending(SubscriptionError):
+class SubscriptionLocked(SubscriptionError):
     def __init__(self, subscription: Subscription) -> None:
         self.subscription = subscription
         message = "This subscription is pending an update."
@@ -679,6 +680,20 @@ class SubscriptionService:
             subscription.customer_id,
         )
 
+    @contextlib.asynccontextmanager
+    async def lock(
+        self, locker: Locker, subscription: Subscription
+    ) -> AsyncGenerator[Subscription]:
+        lock_name = f"subscription:{subscription.id}"
+        if await locker.is_locked(lock_name):
+            raise SubscriptionLocked(subscription)
+        async with locker.lock(
+            lock_name,
+            timeout=10.0,  # Quite long, but we've experienced slow responses from Stripe in test mode
+            blocking_timeout=1,
+        ):
+            yield subscription
+
     async def update(
         self,
         session: AsyncSession,
@@ -687,54 +702,46 @@ class SubscriptionService:
         *,
         update: SubscriptionUpdate,
     ) -> Subscription:
-        lock_name = f"subscription:{subscription.id}"
-        if await locker.is_locked(lock_name):
-            raise SubscriptionUpdatePending(subscription)
-        async with locker.lock(
-            lock_name,
-            timeout=10.0,  # Quite long, but we've experienced slow responses from Stripe in test mode
-            blocking_timeout=1,
-        ):
-            if isinstance(update, SubscriptionUpdateProduct):
-                if subscription.revoked or subscription.cancel_at_period_end:
-                    raise AlreadyCanceledSubscription(subscription)
-                return await self.update_product(
-                    session,
-                    subscription,
-                    product_id=update.product_id,
-                    proration_behavior=update.proration_behavior,
-                )
+        if isinstance(update, SubscriptionUpdateProduct):
+            if subscription.revoked or subscription.cancel_at_period_end:
+                raise AlreadyCanceledSubscription(subscription)
+            return await self.update_product(
+                session,
+                subscription,
+                product_id=update.product_id,
+                proration_behavior=update.proration_behavior,
+            )
 
-            if isinstance(update, SubscriptionUpdateDiscount):
-                return await self.update_discount(
-                    session,
-                    locker,
-                    subscription,
-                    discount_id=update.discount_id,
-                )
+        if isinstance(update, SubscriptionUpdateDiscount):
+            return await self.update_discount(
+                session,
+                locker,
+                subscription,
+                discount_id=update.discount_id,
+            )
 
-            if isinstance(update, SubscriptionCancel):
-                cancel = update.cancel_at_period_end is True
-                uncancel = update.cancel_at_period_end is False
+        if isinstance(update, SubscriptionCancel):
+            cancel = update.cancel_at_period_end is True
+            uncancel = update.cancel_at_period_end is False
 
-                if uncancel:
-                    return await self.uncancel(session, subscription)
+            if uncancel:
+                return await self.uncancel(session, subscription)
 
-                return await self.cancel(
-                    session,
-                    subscription,
-                    customer_reason=update.customer_cancellation_reason,
-                    customer_comment=update.customer_cancellation_comment,
-                )
+            return await self.cancel(
+                session,
+                subscription,
+                customer_reason=update.customer_cancellation_reason,
+                customer_comment=update.customer_cancellation_comment,
+            )
 
-            if isinstance(update, SubscriptionRevoke):
-                return await self._perform_cancellation(
-                    session,
-                    subscription,
-                    customer_reason=update.customer_cancellation_reason,
-                    customer_comment=update.customer_cancellation_comment,
-                    immediately=True,
-                )
+        if isinstance(update, SubscriptionRevoke):
+            return await self._perform_cancellation(
+                session,
+                subscription,
+                customer_reason=update.customer_cancellation_reason,
+                customer_comment=update.customer_cancellation_comment,
+                immediately=True,
+            )
 
     async def update_product(
         self,
@@ -1018,7 +1025,11 @@ class SubscriptionService:
             await self._perform_cancellation(session, subscription, immediately=True)
 
     async def update_from_stripe(
-        self, session: AsyncSession, *, stripe_subscription: stripe_lib.Subscription
+        self,
+        session: AsyncSession,
+        locker: Locker,
+        *,
+        stripe_subscription: stripe_lib.Subscription,
     ) -> Subscription:
         """
         Since Stripe manages the billing cycle, listen for their webhooks and update the
@@ -1032,45 +1043,46 @@ class SubscriptionService:
         if subscription is None:
             raise SubscriptionDoesNotExist(stripe_subscription.id)
 
-        previous_status = subscription.status
-        previous_is_canceled = subscription.canceled
+        async with self.lock(locker, subscription):
+            previous_status = subscription.status
+            previous_is_canceled = subscription.canceled
 
-        subscription.status = SubscriptionStatus(stripe_subscription.status)
-        subscription.current_period_start = _from_timestamp(
-            stripe_subscription.current_period_start
-        )
-        subscription.current_period_end = _from_timestamp(
-            stripe_subscription.current_period_end
-        )
-        subscription.set_started_at()
-        self.update_cancellation_from_stripe(subscription, stripe_subscription)
-        # Reset discount if it has expired
-        if (
-            len(stripe_subscription.discounts) == 0
-            and subscription.discount is not None
-        ):
-            subscription.discount = None
-
-        # Update payment method
-        if stripe_subscription.default_payment_method is not None:
-            stripe_payment_method = await stripe_service.get_payment_method(
-                get_expandable_id(stripe_subscription.default_payment_method)
+            subscription.status = SubscriptionStatus(stripe_subscription.status)
+            subscription.current_period_start = _from_timestamp(
+                stripe_subscription.current_period_start
             )
-            payment_method = await payment_method_service.upsert_from_stripe(
-                session, subscription.customer, stripe_payment_method
+            subscription.current_period_end = _from_timestamp(
+                stripe_subscription.current_period_end
             )
-            subscription.payment_method = payment_method
+            subscription.set_started_at()
+            self.update_cancellation_from_stripe(subscription, stripe_subscription)
+            # Reset discount if it has expired
+            if (
+                len(stripe_subscription.discounts) == 0
+                and subscription.discount is not None
+            ):
+                subscription.discount = None
 
-        subscription = await repository.update(subscription)
+            # Update payment method
+            if stripe_subscription.default_payment_method is not None:
+                stripe_payment_method = await stripe_service.get_payment_method(
+                    get_expandable_id(stripe_subscription.default_payment_method)
+                )
+                payment_method = await payment_method_service.upsert_from_stripe(
+                    session, subscription.customer, stripe_payment_method
+                )
+                subscription.payment_method = payment_method
 
-        await self.enqueue_benefits_grants(session, subscription)
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
-        )
-        return subscription
+            subscription = await repository.update(subscription)
+
+            await self.enqueue_benefits_grants(session, subscription)
+            await self._after_subscription_updated(
+                session,
+                subscription,
+                previous_status=previous_status,
+                previous_is_canceled=previous_is_canceled,
+            )
+            return subscription
 
     async def _perform_cancellation(
         self,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -684,6 +684,28 @@ class TestRevoke:
 
 
 @pytest.mark.asyncio
+class TestCancel:
+    async def test_repeat_cancel_raises(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_canceled_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        assert subscription.cancel_at_period_end is True
+
+        with pytest.raises(AlreadyCanceledSubscription):
+            await subscription_service.cancel(session, subscription)
+
+
+@pytest.mark.asyncio
 class TestUncancel:
     async def test_not_canceled(
         self,
@@ -728,111 +750,6 @@ class TestUncancel:
         assert updated_subscription.ends_at is None
         assert updated_subscription.canceled_at is None
 
-
-@pytest.mark.asyncio
-class TestUpdateFromStripe:
-    async def test_not_existing_subscription(
-        self, session: AsyncSession, product: Product
-    ) -> None:
-        stripe_subscription = construct_stripe_subscription(product=product)
-
-        with pytest.raises(SubscriptionDoesNotExist):
-            await subscription_service.update_from_stripe(
-                session, stripe_subscription=stripe_subscription
-            )
-
-    async def test_valid(
-        self,
-        enqueue_benefits_grants_mock: MagicMock,
-        stripe_service_mock: MagicMock,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        stripe_payment_method = build_stripe_payment_method(
-            customer=customer.stripe_customer_id,
-        )
-        stripe_service_mock.get_payment_method.return_value = stripe_payment_method
-        stripe_subscription = construct_stripe_subscription(
-            product=product,
-            status=SubscriptionStatus.active,
-            default_payment_method=stripe_payment_method.id,
-        )
-        subscription = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            stripe_subscription_id=stripe_subscription.id,
-        )
-        assert subscription.started_at is None
-
-        updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
-        )
-
-        assert updated_subscription.status == SubscriptionStatus.active
-        assert updated_subscription.started_at is not None
-        assert updated_subscription.payment_method is not None
-        assert (
-            updated_subscription.payment_method.processor_id == stripe_payment_method.id
-        )
-
-        enqueue_benefits_grants_mock.assert_called_once()
-
-    async def test_discount_reset(
-        self,
-        enqueue_benefits_grants_mock: MagicMock,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        product: Product,
-        customer: Customer,
-        discount_percentage_50: Discount,
-    ) -> None:
-        stripe_subscription = construct_stripe_subscription(
-            product=product, status=SubscriptionStatus.active, discounts=[]
-        )
-        subscription = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            stripe_subscription_id=stripe_subscription.id,
-            discount=discount_percentage_50,
-        )
-        assert subscription.discount is not None
-
-        updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
-        )
-
-        assert updated_subscription.discount is None
-
-    async def test_valid_cancel_at_period_end(
-        self,
-        enqueue_benefits_grants_mock: MagicMock,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        subscription_hooks: Hooks,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-        )
-        stripe_subscription = cloned_stripe_canceled_subscription(subscription)
-
-        updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
-        )
-
-        assert updated_subscription.status == SubscriptionStatus.active
-        assert updated_subscription.cancel_at_period_end is True
-
-        enqueue_benefits_grants_mock.assert_called_once()
-        assert_hooks_called_once(subscription_hooks, {"updated", "canceled"})
-
     async def test_uncancel_active(
         self,
         mocker: MockerFixture,
@@ -851,64 +768,6 @@ class TestUpdateFromStripe:
 
         with pytest.raises(BadRequest):
             await subscription_service.uncancel(session, subscription)
-
-    async def test_repeat_cancel_raises(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        subscription_hooks: Hooks,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_canceled_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-        )
-        assert subscription.cancel_at_period_end is True
-
-        with pytest.raises(AlreadyCanceledSubscription):
-            await subscription_service.cancel(session, subscription)
-
-    async def test_send_cancel_hooks_once(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        subscription_hooks: Hooks,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-        )
-        assert subscription.cancel_at_period_end is False
-        stripe_subscription = cloned_stripe_subscription(
-            subscription, cancel_at_period_end=True
-        )
-
-        updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
-        )
-
-        assert updated_subscription.status == SubscriptionStatus.active
-        assert updated_subscription.cancel_at_period_end is True
-        assert updated_subscription.ends_at
-        assert updated_subscription.canceled_at
-        assert_hooks_called_once(subscription_hooks, {"updated", "canceled"})
-        reset_hooks(subscription_hooks)
-
-        repeat_cancellation = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
-        )
-        assert repeat_cancellation.status == SubscriptionStatus.active
-        assert repeat_cancellation.cancel_at_period_end is True
-        assert repeat_cancellation.ends_at
-        assert repeat_cancellation.canceled_at
-        assert_hooks_called_once(subscription_hooks, {"updated"})
 
     async def test_uncancel_already_revoked(
         self,
@@ -933,10 +792,158 @@ class TestUpdateFromStripe:
         with pytest.raises(ResourceUnavailable):
             await subscription_service.uncancel(session, subscription)
 
-    async def test_valid_uncancel(
+
+@pytest.mark.asyncio
+class TestUpdateFromStripe:
+    async def test_not_existing_subscription(
+        self, session: AsyncSession, locker: Locker, product: Product
+    ) -> None:
+        stripe_subscription = construct_stripe_subscription(product=product)
+
+        with pytest.raises(SubscriptionDoesNotExist):
+            await subscription_service.update_from_stripe(
+                session, locker, stripe_subscription=stripe_subscription
+            )
+
+    async def test_valid(
+        self,
+        enqueue_benefits_grants_mock: MagicMock,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        locker: Locker,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        stripe_payment_method = build_stripe_payment_method(
+            customer=customer.stripe_customer_id,
+        )
+        stripe_service_mock.get_payment_method.return_value = stripe_payment_method
+        stripe_subscription = construct_stripe_subscription(
+            product=product,
+            status=SubscriptionStatus.active,
+            default_payment_method=stripe_payment_method.id,
+        )
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            stripe_subscription_id=stripe_subscription.id,
+        )
+        assert subscription.started_at is None
+
+        updated_subscription = await subscription_service.update_from_stripe(
+            session, locker, stripe_subscription=stripe_subscription
+        )
+
+        assert updated_subscription.status == SubscriptionStatus.active
+        assert updated_subscription.started_at is not None
+        assert updated_subscription.payment_method is not None
+        assert (
+            updated_subscription.payment_method.processor_id == stripe_payment_method.id
+        )
+
+        enqueue_benefits_grants_mock.assert_called_once()
+
+    async def test_discount_reset(
+        self,
+        enqueue_benefits_grants_mock: MagicMock,
+        session: AsyncSession,
+        locker: Locker,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        discount_percentage_50: Discount,
+    ) -> None:
+        stripe_subscription = construct_stripe_subscription(
+            product=product, status=SubscriptionStatus.active, discounts=[]
+        )
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            stripe_subscription_id=stripe_subscription.id,
+            discount=discount_percentage_50,
+        )
+        assert subscription.discount is not None
+
+        updated_subscription = await subscription_service.update_from_stripe(
+            session, locker, stripe_subscription=stripe_subscription
+        )
+
+        assert updated_subscription.discount is None
+
+    async def test_valid_cancel_at_period_end(
+        self,
+        enqueue_benefits_grants_mock: MagicMock,
+        session: AsyncSession,
+        locker: Locker,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        stripe_subscription = cloned_stripe_canceled_subscription(subscription)
+
+        updated_subscription = await subscription_service.update_from_stripe(
+            session, locker, stripe_subscription=stripe_subscription
+        )
+
+        assert updated_subscription.status == SubscriptionStatus.active
+        assert updated_subscription.cancel_at_period_end is True
+
+        enqueue_benefits_grants_mock.assert_called_once()
+        assert_hooks_called_once(subscription_hooks, {"updated", "canceled"})
+
+    async def test_send_cancel_hooks_once(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
+        locker: Locker,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        assert subscription.cancel_at_period_end is False
+        stripe_subscription = cloned_stripe_subscription(
+            subscription, cancel_at_period_end=True
+        )
+
+        updated_subscription = await subscription_service.update_from_stripe(
+            session, locker, stripe_subscription=stripe_subscription
+        )
+
+        assert updated_subscription.status == SubscriptionStatus.active
+        assert updated_subscription.cancel_at_period_end is True
+        assert updated_subscription.ends_at
+        assert updated_subscription.canceled_at
+        assert_hooks_called_once(subscription_hooks, {"updated", "canceled"})
+        reset_hooks(subscription_hooks)
+
+        repeat_cancellation = await subscription_service.update_from_stripe(
+            session, locker, stripe_subscription=stripe_subscription
+        )
+        assert repeat_cancellation.status == SubscriptionStatus.active
+        assert repeat_cancellation.cancel_at_period_end is True
+        assert repeat_cancellation.ends_at
+        assert repeat_cancellation.canceled_at
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+    async def test_valid_uncancel(
+        self,
+        session: AsyncSession,
+        locker: Locker,
         save_fixture: SaveFixture,
         subscription_hooks: Hooks,
         product: Product,
@@ -956,7 +963,7 @@ class TestUpdateFromStripe:
         )
 
         updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
+            session, locker, stripe_subscription=stripe_subscription
         )
 
         assert updated_subscription.status == SubscriptionStatus.active
@@ -969,6 +976,7 @@ class TestUpdateFromStripe:
         self,
         mocker: MockerFixture,
         session: AsyncSession,
+        locker: Locker,
         save_fixture: SaveFixture,
         subscription_hooks: Hooks,
         product: Product,
@@ -985,7 +993,7 @@ class TestUpdateFromStripe:
         )
 
         updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
+            session, locker, stripe_subscription=stripe_subscription
         )
 
         assert updated_subscription.status == SubscriptionStatus.canceled
@@ -1009,6 +1017,7 @@ class TestUpdateFromStripe:
         self,
         mocker: MockerFixture,
         session: AsyncSession,
+        locker: Locker,
         save_fixture: SaveFixture,
         organization: Organization,
         subscription_hooks: Hooks,
@@ -1026,7 +1035,7 @@ class TestUpdateFromStripe:
         )
 
         updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
+            session, locker, stripe_subscription=stripe_subscription
         )
 
         assert updated_subscription.status == SubscriptionStatus.active
@@ -1040,7 +1049,7 @@ class TestUpdateFromStripe:
         )
 
         updated_subscription = await subscription_service.update_from_stripe(
-            session, stripe_subscription=stripe_subscription
+            session, locker, stripe_subscription=stripe_subscription
         )
 
         assert updated_subscription.status == SubscriptionStatus.canceled


### PR DESCRIPTION
Fix #6475

- server/subscription: add lock around Stripe subscription update to prevent race condition
