### PR TITLE
[Internal-only] Add daily and weekly subscription intervals [part 1, backend]

### DIFF
--- a/clients/apps/web/src/utils/testdata.ts
+++ b/clients/apps/web/src/utils/testdata.ts
@@ -49,6 +49,7 @@ export const user: schemas['UserRead'] = {
   id: 'xxxabc-123',
   oauth_accounts: [],
   account_id: null,
+  is_admin: false,
 }
 
 export const payout: schemas['Payout'] = {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15848,7 +15848,7 @@ export interface components {
          * SubscriptionRecurringInterval
          * @enum {string}
          */
-        SubscriptionRecurringInterval: "month" | "year";
+        SubscriptionRecurringInterval: "day" | "week" | "month" | "year";
         /** SubscriptionRevoke */
         SubscriptionRevoke: {
             /** @description Customer reason for cancellation.
@@ -25759,7 +25759,7 @@ export const scopeValues: ReadonlyArray<components["schemas"]["Scope"]> = ["open
 export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["created", "onboarding_started", "under_review", "denied", "active"];
 export const subTypeValues: ReadonlyArray<components["schemas"]["SubType"]> = ["user", "organization"];
 export const subscriptionProrationBehaviorValues: ReadonlyArray<components["schemas"]["SubscriptionProrationBehavior"]> = ["invoice", "prorate"];
-export const subscriptionRecurringIntervalValues: ReadonlyArray<components["schemas"]["SubscriptionRecurringInterval"]> = ["month", "year"];
+export const subscriptionRecurringIntervalValues: ReadonlyArray<components["schemas"]["SubscriptionRecurringInterval"]> = ["day", "week", "month", "year"];
 export const subscriptionSortPropertyValues: ReadonlyArray<components["schemas"]["SubscriptionSortProperty"]> = ["customer", "-customer", "status", "-status", "started_at", "-started_at", "current_period_end", "-current_period_end", "amount", "-amount", "product", "-product", "discount", "-discount"];
 export const subscriptionStatusValues: ReadonlyArray<components["schemas"]["SubscriptionStatus"]> = ["incomplete", "incomplete_expired", "trialing", "active", "past_due", "canceled", "unpaid"];
 export const taxIDFormatValues: ReadonlyArray<components["schemas"]["TaxIDFormat"]> = ["ad_nrt", "ae_trn", "ar_cuit", "au_abn", "au_arn", "bg_uic", "bh_vat", "bo_tin", "br_cnpj", "br_cpf", "ca_bn", "ca_gst_hst", "ca_pst_bc", "ca_pst_mb", "ca_pst_sk", "ca_qst", "ch_uid", "ch_vat", "cl_tin", "cn_tin", "co_nit", "cr_tin", "de_stn", "do_rcn", "ec_ruc", "eg_tin", "es_cif", "eu_oss_vat", "eu_vat", "gb_vat", "ge_vat", "hk_br", "hr_oib", "hu_tin", "id_npwp", "il_vat", "in_gst", "is_vat", "jp_cn", "jp_rn", "jp_trn", "ke_pin", "kr_brn", "kz_bin", "li_uid", "mx_rfc", "my_frp", "my_itn", "my_sst", "ng_tin", "no_vat", "no_voec", "nz_gst", "om_vat", "pe_ruc", "ph_tin", "ro_tin", "rs_pib", "ru_inn", "ru_kpp", "sa_vat", "sg_gst", "sg_uen", "si_tin", "sv_nit", "th_vat", "tr_tin", "tw_vat", "ua_vat", "us_ein", "uy_ruc", "ve_rif", "vn_tin", "za_vat"];

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6657,7 +6657,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -6897,7 +6897,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -9226,7 +9226,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -9477,7 +9477,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -10142,7 +10142,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -11173,7 +11173,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -13729,7 +13729,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -14600,7 +14600,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring
@@ -14691,7 +14691,7 @@ export interface components {
              * @description The description of the product.
              */
             description?: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * ProductPriceCreateList
@@ -15210,7 +15210,7 @@ export interface components {
              * @description The description of the product.
              */
             description: string | null;
-            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
+            /** @description The recurring interval of the product. If `None`, the product is a one-time purchase.Note that the `day` and `week` values are for internal Polar staff use only. */
             recurring_interval: components["schemas"]["SubscriptionRecurringInterval"] | null;
             /**
              * Is Recurring

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -16399,6 +16399,8 @@ export interface components {
             id: string;
             /** Accepted Terms Of Service */
             accepted_terms_of_service: boolean;
+            /** Is Admin */
+            is_admin: boolean;
             /** Identity Verified */
             identity_verified: boolean;
             identity_verification_status: components["schemas"]["IdentityVerificationStatus"];

--- a/server/polar/enums.py
+++ b/server/polar/enums.py
@@ -27,14 +27,20 @@ class AccountType(StrEnum):
 
 
 class SubscriptionRecurringInterval(StrEnum):
+    day = "day"
+    week = "week"
     month = "month"
     year = "year"
 
-    def as_literal(self) -> Literal["month", "year"]:
+    def as_literal(self) -> Literal["day", "week", "month", "year"]:
         return self.value
 
     def get_next_period(self, d: datetime, leap: int = 1) -> datetime:
         match self:
+            case SubscriptionRecurringInterval.day:
+                return d + relativedelta(days=leap)
+            case SubscriptionRecurringInterval.week:
+                return d + relativedelta(weeks=leap)
             case SubscriptionRecurringInterval.month:
                 return d + relativedelta(months=leap)
             case SubscriptionRecurringInterval.year:

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -211,6 +211,8 @@ class ProductCreate(MetadataInputMixin, Schema):
         description=(
             "The recurring interval of the product. "
             "If `None`, the product is a one-time purchase."
+            ""
+            "Note that the `day` and `week` values are for internal Polar staff use only."
         ),
     )
     prices: ProductPriceCreateList = Field(
@@ -500,6 +502,8 @@ class ProductBase(IDSchema, TimestampedSchema):
     recurring_interval: SubscriptionRecurringInterval | None = Field(
         description="The recurring interval of the product. "
         "If `None`, the product is a one-time purchase."
+        ""
+        "Note that the `day` and `week` values are for internal Polar staff use only."
     )
     is_recurring: bool = Field(description="Whether the product is a subscription.")
     is_archived: bool = Field(

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -5,8 +5,7 @@ from fastapi import Depends, Query, Response
 from fastapi.responses import StreamingResponse
 
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
-from polar.enums import SubscriptionRecurringInterval
-from polar.exceptions import NotPermitted, ResourceNotFound
+from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParams, PaginationParamsQuery
@@ -195,16 +194,6 @@ async def update(
     subscription = await subscription_service.get(session, auth_subject, id)
     if subscription is None:
         raise ResourceNotFound()
-
-    if (
-        subscription_update.recurring_interval
-        not in (
-            SubscriptionRecurringInterval.month,
-            SubscriptionRecurringInterval.year,
-        )
-        and not auth_subject.subject.is_admin
-    ):
-        raise NotPermitted()
 
     log.info(
         "subscription.update",

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -5,7 +5,8 @@ from fastapi import Depends, Query, Response
 from fastapi.responses import StreamingResponse
 
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
-from polar.exceptions import ResourceNotFound
+from polar.enums import SubscriptionRecurringInterval
+from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParams, PaginationParamsQuery
@@ -194,6 +195,16 @@ async def update(
     subscription = await subscription_service.get(session, auth_subject, id)
     if subscription is None:
         raise ResourceNotFound()
+
+    if (
+        subscription_update.recurring_interval
+        not in (
+            SubscriptionRecurringInterval.month,
+            SubscriptionRecurringInterval.year,
+        )
+        and not auth_subject.subject.is_admin
+    ):
+        raise NotPermitted()
 
     log.info(
         "subscription.update",

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -25,6 +25,7 @@ class OAuthAccountRead(TimestampedSchema):
 class UserRead(UserBase, TimestampedSchema):
     id: uuid.UUID
     accepted_terms_of_service: bool
+    is_admin: bool
     identity_verified: bool
     identity_verification_status: IdentityVerificationStatus
     oauth_accounts: list[OAuthAccountRead]


### PR DESCRIPTION
Add daily and weekly Subscription recurrence intervals.

- [ ] Only allow creating a daily or weekly subscription if you're an admin
- [ ] Make sure the OpenAPI and `v1` types are up to date
- [ ] Update Speakeasy?
