### PR TITLE
server/order: fix subscription creation order when metered prices are involved

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   redis:
     image: redis
@@ -61,12 +59,12 @@ services:
       - POLICY_FILE=/tmp/config/policy.json
       - ACCESS_KEY=${POLAR_AWS_ACCESS_KEY_ID}
       - SECRET_ACCESS_KEY=${POLAR_AWS_SECRET_ACCESS_KEY}
-    entrypoint: [
-      "bash",
-      "-c",
-      "chmod +x /tmp/config/local.sh && chmod +x /tmp/config/configure.sh && /tmp/config/local.sh /tmp/config/configure.sh"
-    ]
-
+    entrypoint:
+      [
+        "bash",
+        "-c",
+        "chmod +x /tmp/config/local.sh && chmod +x /tmp/config/configure.sh && /tmp/config/local.sh /tmp/config/configure.sh",
+      ]
 
 volumes:
   postgres_data:

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -79,7 +79,7 @@ from polar.organization.repository import OrganizationRepository
 from polar.organization.service import organization as organization_service
 from polar.payment.repository import PaymentRepository
 from polar.payment_method.repository import PaymentMethodRepository
-from polar.product.guard import is_custom_price
+from polar.product.guard import is_custom_price, is_static_price
 from polar.product.repository import ProductPriceRepository
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import subscription as subscription_service
@@ -537,6 +537,9 @@ class OrderService:
 
         items: list[OrderItem] = []
         for price in prices:
+            # Don't create an item for metered prices
+            if not is_static_price(price):
+                continue
             if is_custom_price(price):
                 item = OrderItem.from_price(price, 0, checkout.amount)
             else:


### PR DESCRIPTION
Fix #6622

- server/order: fix subscription creation order when metered prices are involved
- server: remove deprecated version field in docker-compose.yml
