### PR TITLE
server/order: reset subscription meters after issuing an update invoice

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -716,7 +716,10 @@ class OrderService:
         )
 
         # Reset the associated meters, if any
-        if billing_reason == OrderBillingReason.subscription_cycle:
+        if billing_reason in {
+            OrderBillingReason.subscription_cycle,
+            OrderBillingReason.subscription_update,
+        }:
             await subscription_service.reset_meters(session, subscription)
 
         # If the order total amount is zero, mark it as paid immediately

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -23,7 +23,7 @@ from polar.meter.aggregation import (
     Aggregation,
     CountAggregation,
 )
-from polar.meter.filter import Filter, FilterConjunction
+from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
 from polar.models import (
     Account,
     Benefit,
@@ -1565,12 +1565,16 @@ async def create_balance_transaction(
     return transaction
 
 
+METER_ID = uuid.uuid4()
+METER_TEST_EVENT = "TEST_EVENT"
+
+
 async def create_event(
     save_fixture: SaveFixture,
     *,
     organization: Organization,
     source: EventSource = EventSource.user,
-    name: str = "test",
+    name: str = METER_TEST_EVENT,
     timestamp: datetime | None = None,
     customer: Customer | None = None,
     external_customer_id: str | None = None,
@@ -1589,16 +1593,20 @@ async def create_event(
     return event
 
 
-METER_ID = uuid.uuid4()
-
-
 async def create_meter(
     save_fixture: SaveFixture,
     *,
     organization: Organization,
     id: uuid.UUID = METER_ID,
     name: str = "My Meter",
-    filter: Filter = Filter(conjunction=FilterConjunction.and_, clauses=[]),
+    filter: Filter = Filter(
+        conjunction=FilterConjunction.and_,
+        clauses=[
+            FilterClause(
+                property="name", operator=FilterOperator.eq, value=METER_TEST_EVENT
+            )
+        ],
+    ),
     aggregation: Aggregation = CountAggregation(),
     last_billed_event: Event | None = None,
 ) -> Meter:

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -36,6 +36,7 @@ from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
+    METER_TEST_EVENT,
     create_active_subscription,
     create_event,
     create_meter,
@@ -581,7 +582,9 @@ class TestGetQuantities:
                 conjunction=FilterConjunction.and_,
                 clauses=[
                     FilterClause(
-                        property="name", operator=FilterOperator.eq, value="test"
+                        property="name",
+                        operator=FilterOperator.eq,
+                        value=METER_TEST_EVENT,
                     )
                 ],
             ),


### PR DESCRIPTION
Fix #6625

- server/order: reset subscription meters after issuing an update invoice
