### PR TITLE
server/order: don't try to revoke subscription if already cancelled on last dunning attempt

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1587,8 +1587,9 @@ class OrderService:
                 order, update_dict={"next_payment_attempt_at": None}
             )
 
-            if order.subscription is not None:
-                await subscription_service.revoke(session, order.subscription)
+            subscription = order.subscription
+            if subscription is not None and subscription.can_cancel(immediately=True):
+                await subscription_service.revoke(session, subscription)
 
             return order
 


### PR DESCRIPTION
- server/order: don't try to revoke subscription if already cancelled on last dunning attempt