### PR TITLE
server/emails: set organization from/reply-to for customer emails

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -308,8 +308,8 @@ envVarGroups:
         value: resend
       - key: POLAR_EMAIL_FROM_NAME
         value: Polar
-      - key: POLAR_EMAIL_FROM_EMAIL_ADDRESS
-        value: noreply@notifications.polar.sh
+      - key: POLAR_EMAIL_FROM_DOMAIN
+        value: notifications.polar.sh
       - key: POLAR_ENV
         value: production
       - key: POLAR_FRONTEND_BASE_URL
@@ -426,8 +426,8 @@ envVarGroups:
         value: resend
       - key: POLAR_EMAIL_FROM_NAME
         value: "[SANDBOX] Polar"
-      - key: POLAR_EMAIL_FROM_EMAIL_ADDRESS
-        value: noreply@notifications.sandbox.polar.sh
+      - key: POLAR_EMAIL_FROM_DOMAIN
+        value: notifications.sandbox.polar.sh
       - key: POLAR_ENV
         value: sandbox
       - key: POLAR_FRONTEND_BASE_URL

--- a/server/emails/src/components/OrganizationHeader.tsx
+++ b/server/emails/src/components/OrganizationHeader.tsx
@@ -1,18 +1,44 @@
-import { Section, Text } from '@react-email/components'
+import { Column, Img, Link, Row, Section, Text } from '@react-email/components'
+import type { OrganizationProps } from '../types'
 
 interface HeaderProps {
-  organization: {
-    name: string
-    slug: string
+  organization: OrganizationProps
+}
+
+const LinkWrapper = ({
+  href,
+  children,
+}: {
+  href: string | null
+  children: React.ReactNode
+}) => {
+  if (!href) {
+    return <>{children}</>
   }
+  return <Link href={href}>{children}</Link>
 }
 
 const Header = ({ organization }: HeaderProps) => (
-  <Section className="pt-[10px]">
-    <Text className="my-0 text-lg font-bold text-gray-900">
-      {organization.name}
-    </Text>
-  </Section>
+  <LinkWrapper href={organization.website_url}>
+    <Section className="pt-[10px]">
+      <Row>
+        {organization.logo_url && (
+          <Column className="w-10">
+            <Img
+              alt={organization.name}
+              src={organization.logo_url}
+              className="size-8"
+            />
+          </Column>
+        )}
+        <Column>
+          <Text className="my-0 text-lg font-bold text-gray-900">
+            {organization.name}
+          </Text>
+        </Column>
+      </Row>
+    </Section>
+  </LinkWrapper>
 )
 
 export default Header

--- a/server/emails/src/emails/customer_session_code.tsx
+++ b/server/emails/src/emails/customer_session_code.tsx
@@ -4,12 +4,10 @@ import IntroWithHi from '../components/IntroWithHi'
 import OrganizationHeader from '../components/OrganizationHeader'
 import OTPCode from '../components/OTPCode'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps } from '../types'
 
 interface CustomerSessionCodeProps {
-  organization: {
-    name: string
-    slug: string
-  }
+  organization: OrganizationProps
   code: string
   code_lifetime_minutes: number
   url: string
@@ -54,6 +52,9 @@ CustomerSessionCode.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   code: 'ABC123',
   code_lifetime_minutes: 30,

--- a/server/emails/src/emails/customer_session_code.tsx
+++ b/server/emails/src/emails/customer_session_code.tsx
@@ -13,7 +13,6 @@ interface CustomerSessionCodeProps {
   code: string
   code_lifetime_minutes: number
   url: string
-  current_year: number
 }
 
 export function CustomerSessionCode({
@@ -59,7 +58,6 @@ CustomerSessionCode.PreviewProps = {
   code: 'ABC123',
   code_lifetime_minutes: 30,
   url: 'https://polar.sh/acme-inc/portal/authenticate',
-  current_year: new Date().getFullYear(),
 }
 
 export default CustomerSessionCode

--- a/server/emails/src/emails/email_update.tsx
+++ b/server/emails/src/emails/email_update.tsx
@@ -8,7 +8,6 @@ import Wrapper from '../components/Wrapper'
 interface EmailUpdateProps {
   token_lifetime_minutes: number
   url: string
-  current_year: number
 }
 
 export function EmailUpdate({ token_lifetime_minutes, url }: EmailUpdateProps) {
@@ -48,7 +47,6 @@ export function EmailUpdate({ token_lifetime_minutes, url }: EmailUpdateProps) {
 EmailUpdate.PreviewProps = {
   token_lifetime_minutes: 30,
   url: 'https://polar.sh/settings/account/email/update?token=abc123',
-  current_year: new Date().getFullYear(),
 }
 
 export default EmailUpdate

--- a/server/emails/src/emails/oauth2_leaked_client.tsx
+++ b/server/emails/src/emails/oauth2_leaked_client.tsx
@@ -9,7 +9,6 @@ interface OAuth2LeakedClientProps {
   notifier: string
   url?: string
   client_name: string
-  current_year: number
 }
 
 export function OAuth2LeakedClient({
@@ -94,7 +93,6 @@ OAuth2LeakedClient.PreviewProps = {
   notifier: 'GitHub',
   url: 'https://github.com/example/repo',
   client_name: 'My OAuth2 App',
-  current_year: new Date().getFullYear(),
 }
 
 export default OAuth2LeakedClient

--- a/server/emails/src/emails/oauth2_leaked_token.tsx
+++ b/server/emails/src/emails/oauth2_leaked_token.tsx
@@ -8,7 +8,6 @@ interface OAuth2LeakedTokenProps {
   notifier: string
   url?: string
   client_name: string
-  current_year: number
 }
 
 export function OAuth2LeakedToken({
@@ -77,7 +76,6 @@ OAuth2LeakedToken.PreviewProps = {
   notifier: 'GitHub',
   url: 'https://github.com/example/repo',
   client_name: 'My OAuth2 App',
-  current_year: new Date().getFullYear(),
 }
 
 export default OAuth2LeakedToken

--- a/server/emails/src/emails/order_confirmation.tsx
+++ b/server/emails/src/emails/order_confirmation.tsx
@@ -21,7 +21,6 @@ interface OrderConfirmationProps {
     name: string
   }
   url: string
-  current_year: number
 }
 
 export function OrderConfirmation({
@@ -71,7 +70,6 @@ OrderConfirmation.PreviewProps = {
     name: 'Premium Subscription',
   },
   url: 'https://polar.sh/acme-inc/portal/orders/12345',
-  current_year: new Date().getFullYear(),
 }
 
 export default OrderConfirmation

--- a/server/emails/src/emails/order_confirmation.tsx
+++ b/server/emails/src/emails/order_confirmation.tsx
@@ -11,15 +11,11 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface OrderConfirmationProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-  }
+  organization: OrganizationProps
+  product: ProductProps
   url: string
 }
 
@@ -65,9 +61,13 @@ OrderConfirmation.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Premium Subscription',
+    benefits: [],
   },
   url: 'https://polar.sh/acme-inc/portal/orders/12345',
 }

--- a/server/emails/src/emails/organization_access_token_leaked.tsx
+++ b/server/emails/src/emails/organization_access_token_leaked.tsx
@@ -8,7 +8,6 @@ interface OrganizationAccessTokenLeakedProps {
   notifier: string
   url?: string
   organization_access_token: string
-  current_year: number
 }
 
 export function OrganizationAccessTokenLeaked({
@@ -81,7 +80,6 @@ OrganizationAccessTokenLeaked.PreviewProps = {
   notifier: 'GitHub',
   url: 'https://github.com/example/repo',
   organization_access_token: 'token_abc123',
-  current_year: new Date().getFullYear(),
 }
 
 export default OrganizationAccessTokenLeaked

--- a/server/emails/src/emails/personal_access_token_leaked.tsx
+++ b/server/emails/src/emails/personal_access_token_leaked.tsx
@@ -8,7 +8,6 @@ interface PersonalAccessTokenLeakedProps {
   notifier: string
   url?: string
   personal_access_token: string
-  current_year: number
 }
 
 export function PersonalAccessTokenLeaked({
@@ -80,7 +79,6 @@ PersonalAccessTokenLeaked.PreviewProps = {
   notifier: 'GitHub',
   url: 'https://github.com/example/repo',
   personal_access_token: 'token_xyz789',
-  current_year: new Date().getFullYear(),
 }
 
 export default PersonalAccessTokenLeaked

--- a/server/emails/src/emails/subscription_cancellation.tsx
+++ b/server/emails/src/emails/subscription_cancellation.tsx
@@ -20,7 +20,6 @@ interface SubscriptionCancellationProps {
     ends_at: string // ISO date string
   }
   url: string
-  current_year: number
 }
 
 function BenefitsSection({
@@ -114,7 +113,6 @@ SubscriptionCancellation.PreviewProps = {
     ends_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days from now
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
-  current_year: new Date().getFullYear(),
 }
 
 export default SubscriptionCancellation

--- a/server/emails/src/emails/subscription_cancellation.tsx
+++ b/server/emails/src/emails/subscription_cancellation.tsx
@@ -4,29 +4,18 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { BenefitProps, OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionCancellationProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-    benefits: Array<{
-      description: string
-    }>
-  }
+  organization: OrganizationProps
+  product: ProductProps
   subscription: {
     ends_at: string // ISO date string
   }
   url: string
 }
 
-function BenefitsSection({
-  benefits,
-}: {
-  benefits: Array<{ description: string }>
-}) {
+function BenefitsSection({ benefits }: { benefits: BenefitProps[] }) {
   // Only render if there are actual benefits to display
   if (benefits.length === 0) {
     return null
@@ -100,6 +89,9 @@ SubscriptionCancellation.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Premium Subscription',

--- a/server/emails/src/emails/subscription_confirmation.tsx
+++ b/server/emails/src/emails/subscription_confirmation.tsx
@@ -14,7 +14,6 @@ interface SubscriptionConfirmationProps {
     name: string
   }
   url: string
-  current_year: number
 }
 
 export function SubscriptionConfirmation({
@@ -63,7 +62,6 @@ SubscriptionConfirmation.PreviewProps = {
     name: 'Premium Subscription',
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
-  current_year: new Date().getFullYear(),
 }
 
 export default SubscriptionConfirmation

--- a/server/emails/src/emails/subscription_confirmation.tsx
+++ b/server/emails/src/emails/subscription_confirmation.tsx
@@ -4,15 +4,11 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionConfirmationProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-  }
+  organization: OrganizationProps
+  product: ProductProps
   url: string
 }
 
@@ -57,9 +53,13 @@ SubscriptionConfirmation.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Premium Subscription',
+    benefits: [],
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
 }

--- a/server/emails/src/emails/subscription_cycled.tsx
+++ b/server/emails/src/emails/subscription_cycled.tsx
@@ -4,15 +4,11 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionCycledProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-  }
+  organization: OrganizationProps
+  product: ProductProps
   url: string
 }
 
@@ -57,10 +53,13 @@ SubscriptionCycled.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
-    proration_behavior: 'create_prorations',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Basic Plan',
+    benefits: [],
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
 }

--- a/server/emails/src/emails/subscription_past_due.tsx
+++ b/server/emails/src/emails/subscription_past_due.tsx
@@ -4,18 +4,11 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionPastDueProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-    benefits: Array<{
-      description: string
-    }>
-  }
+  organization: OrganizationProps
+  product: ProductProps
   subscription: {
     ends_at: string // ISO date string
   }
@@ -76,6 +69,9 @@ SubscriptionPastDue.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Premium Subscription',

--- a/server/emails/src/emails/subscription_past_due.tsx
+++ b/server/emails/src/emails/subscription_past_due.tsx
@@ -20,7 +20,6 @@ interface SubscriptionPastDueProps {
     ends_at: string // ISO date string
   }
   url: string
-  current_year: number
   payment_url?: string
 }
 
@@ -90,7 +89,6 @@ SubscriptionPastDue.PreviewProps = {
     ends_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days from now
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
-  current_year: new Date().getFullYear(),
   payment_url: 'https://invoice.stripe.com/i/acct_123/test',
 }
 

--- a/server/emails/src/emails/subscription_revoked.tsx
+++ b/server/emails/src/emails/subscription_revoked.tsx
@@ -4,15 +4,11 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionRevokedProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-  }
+  organization: OrganizationProps
+  product: ProductProps
   url: string
 }
 
@@ -60,9 +56,13 @@ SubscriptionRevoked.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Premium Subscription',
+    benefits: [],
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
 }

--- a/server/emails/src/emails/subscription_revoked.tsx
+++ b/server/emails/src/emails/subscription_revoked.tsx
@@ -14,7 +14,6 @@ interface SubscriptionRevokedProps {
     name: string
   }
   url: string
-  current_year: number
 }
 
 export function SubscriptionRevoked({
@@ -66,7 +65,6 @@ SubscriptionRevoked.PreviewProps = {
     name: 'Premium Subscription',
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
-  current_year: new Date().getFullYear(),
 }
 
 export default SubscriptionRevoked

--- a/server/emails/src/emails/subscription_uncanceled.tsx
+++ b/server/emails/src/emails/subscription_uncanceled.tsx
@@ -4,15 +4,11 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionUncanceledProps {
-  organization: {
-    name: string
-    slug: string
-  }
-  product: {
-    name: string
-  }
+  organization: OrganizationProps
+  product: ProductProps
   url: string
 }
 
@@ -57,9 +53,13 @@ SubscriptionUncanceled.PreviewProps = {
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Premium Subscription',
+    benefits: [],
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
 }

--- a/server/emails/src/emails/subscription_uncanceled.tsx
+++ b/server/emails/src/emails/subscription_uncanceled.tsx
@@ -14,7 +14,6 @@ interface SubscriptionUncanceledProps {
     name: string
   }
   url: string
-  current_year: number
 }
 
 export function SubscriptionUncanceled({
@@ -63,7 +62,6 @@ SubscriptionUncanceled.PreviewProps = {
     name: 'Premium Subscription',
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
-  current_year: new Date().getFullYear(),
 }
 
 export default SubscriptionUncanceled

--- a/server/emails/src/emails/subscription_updated.tsx
+++ b/server/emails/src/emails/subscription_updated.tsx
@@ -4,24 +4,18 @@ import Button from '../components/Button'
 import Footer from '../components/Footer'
 import OrganizationHeader from '../components/OrganizationHeader'
 import Wrapper from '../components/Wrapper'
+import type { OrganizationProps, ProductProps } from '../types'
 
 interface SubscriptionUpdatedProps {
-  organization: {
-    name: string
-    slug: string
-    proration_behavior: 'always_invoice' | 'create_prorations'
-  }
-  product: {
-    name: string
-    benefits: Array<{ description: string }>
-  }
-  previous_product: {
-    name: string
-  }
+  proration_behavior: 'always_invoice' | 'create_prorations'
+  organization: OrganizationProps
+  product: ProductProps
+  previous_product: ProductProps
   url: string
 }
 
 export function SubscriptionUpdated({
+  proration_behavior,
   organization,
   product,
   previous_product,
@@ -55,7 +49,7 @@ export function SubscriptionUpdated({
         <BodyText>
           The changes take effect immediately. Your new billing amount will be
           reflected in your next billing cycle
-          {organization.proration_behavior == 'create_prorations'
+          {proration_behavior == 'create_prorations'
             ? ' as well as the pro-rata changes within this cycle.'
             : '. If needed, your card will be charged the pro-rata amount for the change at this time.'}
         </BodyText>
@@ -80,10 +74,13 @@ export function SubscriptionUpdated({
 }
 
 SubscriptionUpdated.PreviewProps = {
+  proration_behavior: 'create_prorations',
   organization: {
     name: 'Acme Inc.',
     slug: 'acme-inc',
-    proration_behavior: 'create_prorations',
+    logo_url:
+      'https://polar-public-sandbox-files.s3.amazonaws.com/organization_avatar/b3281d01-7b90-4a5b-8225-e8e150f4009c/9e5f848b-8b1d-4592-9fe1-7cad2cfa53ee/unicorn-dev-logo.png',
+    website_url: 'https://www.example.com',
   },
   product: {
     name: 'Basic Plan',
@@ -95,6 +92,7 @@ SubscriptionUpdated.PreviewProps = {
   },
   previous_product: {
     name: 'Pro Plan',
+    benefits: [],
   },
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
 }

--- a/server/emails/src/types.ts
+++ b/server/emails/src/types.ts
@@ -1,0 +1,15 @@
+export interface OrganizationProps {
+  name: string
+  slug: string
+  logo_url: string | null
+  website_url: string | null
+}
+
+export interface BenefitProps {
+  description: string
+}
+
+export interface ProductProps {
+  name: string
+  benefits: BenefitProps[]
+}

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -136,7 +136,8 @@ class Settings(BaseSettings):
     EMAIL_SENDER: EmailSender = EmailSender.logger
     RESEND_API_KEY: str = ""
     EMAIL_FROM_NAME: str = "Polar"
-    EMAIL_FROM_EMAIL_ADDRESS: str = "noreply@notifications.polar.sh"
+    EMAIL_FROM_DOMAIN: str = "notifications.polar.sh"
+    EMAIL_FROM_LOCAL: str = "mail"
 
     # Github App
     GITHUB_CLIENT_ID: str = ""

--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -87,10 +87,7 @@ class CustomerSessionService:
         body = render_email_template(
             "customer_session_code",
             {
-                "organization": {
-                    "name": organization.name,
-                    "slug": organization.slug,
-                },
+                "organization": organization.email_props,
                 "code": code,
                 "code_lifetime_minutes": code_lifetime_minutes,
                 "url": settings.generate_frontend_url(

--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -1,4 +1,3 @@
-import datetime
 import secrets
 import string
 import uuid
@@ -97,7 +96,6 @@ class CustomerSessionService:
                 "url": settings.generate_frontend_url(
                     f"/{organization.slug}/portal/authenticate"
                 ),
-                "current_year": datetime.datetime.now().year,
             },
         )
 

--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -97,6 +97,7 @@ class CustomerSessionService:
         )
 
         enqueue_email(
+            **organization.email_from_reply,
             to_email_addr=customer.email,
             subject=f"Access your {organization.name} purchases",
             html_content=body,

--- a/server/polar/email/sender.py
+++ b/server/polar/email/sender.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, TypedDict
 
 import httpx
 import structlog
@@ -14,7 +14,7 @@ from polar.worker import enqueue_job
 log: Logger = structlog.get_logger()
 
 DEFAULT_FROM_NAME = settings.EMAIL_FROM_NAME
-DEFAULT_FROM_EMAIL_ADDRESS = settings.EMAIL_FROM_EMAIL_ADDRESS
+DEFAULT_FROM_EMAIL_ADDRESS = f"{settings.EMAIL_FROM_LOCAL}@{settings.EMAIL_FROM_DOMAIN}"
 DEFAULT_REPLY_TO_NAME = "Polar Support"
 DEFAULT_REPLY_TO_EMAIL_ADDRESS = "support@polar.sh"
 
@@ -125,6 +125,13 @@ class ResendEmailSender(EmailSender):
             subject=subject,
             email_id=email["id"],
         )
+
+
+class EmailFromReply(TypedDict):
+    from_name: str
+    from_email_addr: str
+    reply_to_name: str
+    reply_to_email_addr: str
 
 
 def enqueue_email(

--- a/server/polar/email_update/service.py
+++ b/server/polar/email_update/service.py
@@ -1,4 +1,3 @@
-import datetime
 from math import ceil
 from urllib.parse import urlencode
 
@@ -84,7 +83,6 @@ class EmailUpdateService(ResourceServiceReader[EmailVerification]):
             {
                 "token_lifetime_minutes": token_lifetime_minutes,
                 "url": f"{base_url}?{urlencode(url_params)}",
-                "current_year": datetime.datetime.now().year,
             },
         )
 

--- a/server/polar/login_code/service.py
+++ b/server/polar/login_code/service.py
@@ -67,7 +67,6 @@ class LoginCodeService:
             {
                 "code": code,
                 "code_lifetime_minutes": code_lifetime_minutes,
-                "current_year": datetime.datetime.now().year,
             },
         )
 

--- a/server/polar/models/benefit.py
+++ b/server/polar/models/benefit.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from sqlalchemy import Boolean, ForeignKey, String, Text, Uuid
@@ -75,3 +75,9 @@ class Benefit(MetadataMixin, RecordModel):
         return relationship(
             "BenefitGrant", lazy="raise", back_populates="benefit", viewonly=True
         )
+
+    @property
+    def email_props(self) -> dict[str, Any]:
+        return {
+            "description": self.description,
+        }

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.config import settings
+from polar.email.sender import DEFAULT_REPLY_TO_EMAIL_ADDRESS, EmailFromReply
 from polar.enums import SubscriptionProrationBehavior
 from polar.kit.db.models import RateLimitGroupMixin, RecordModel
 from polar.kit.extensions.sqlalchemy import StringEnum
@@ -267,4 +268,13 @@ class Organization(RateLimitGroupMixin, RecordModel):
             "slug": self.slug,
             "logo_url": self.avatar_url,
             "website_url": self.website,
+        }
+
+    @property
+    def email_from_reply(self) -> EmailFromReply:
+        return {
+            "from_name": f"{self.name} (via {settings.EMAIL_FROM_NAME})",
+            "from_email_addr": f"{self.slug}@{settings.EMAIL_FROM_DOMAIN}",
+            "reply_to_name": self.name,
+            "reply_to_email_addr": self.email or DEFAULT_REPLY_TO_EMAIL_ADDRESS,
         }

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -259,3 +259,12 @@ class Organization(RateLimitGroupMixin, RecordModel):
     def statement_descriptor_prefixed(self) -> str:
         # Cannot use *. Setting separator to # instead.
         return f"{settings.STRIPE_STATEMENT_DESCRIPTOR}# {self.statement_descriptor}"
+
+    @property
+    def email_props(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "slug": self.slug,
+            "logo_url": self.avatar_url,
+            "website_url": self.website,
+        }

--- a/server/polar/models/product.py
+++ b/server/polar/models/product.py
@@ -1,6 +1,6 @@
 import hashlib
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from sqlalchemy import (
@@ -201,3 +201,10 @@ class Product(MetadataMixin, RecordModel):
         h.update(str(last_modified).encode("utf-8"))
         etag = h.hexdigest()
         return etag
+
+    @property
+    def email_props(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "benefits": [benefit.email_props for benefit in self.benefits],
+        }

--- a/server/polar/oauth2/service/oauth2_client.py
+++ b/server/polar/oauth2/service/oauth2_client.py
@@ -1,4 +1,3 @@
-import datetime
 from collections.abc import Sequence
 
 import structlog
@@ -99,7 +98,6 @@ class OAuth2ClientService(ResourceServiceReader[OAuth2Client]):
                 "client_name": client.client_name,
                 "notifier": notifier,
                 "url": url or "",
-                "current_year": datetime.datetime.now().year,
             },
         )
 

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -1,4 +1,3 @@
-import datetime
 import time
 from typing import cast
 
@@ -101,7 +100,6 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
                 "client_name": oauth2_client.client_name,
                 "notifier": notifier,
                 "url": url or "",
-                "current_year": datetime.datetime.now().year,
             },
         )
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1345,7 +1345,6 @@ class OrderService:
                 "url": settings.generate_frontend_url(
                     f"/{organization.slug}/portal?customer_session_token={token}&id={order.id}"
                 ),
-                "current_year": datetime.now().year,
             },
         )
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1340,6 +1340,7 @@ class OrderService:
         )
 
         enqueue_email(
+            **organization.email_from_reply,
             to_email_addr=customer.email,
             subject=f"Your {product.name} order confirmation",
             html_content=body,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1331,17 +1331,8 @@ class OrderService:
         body = render_email_template(
             "order_confirmation",
             {
-                "organization": {
-                    "name": organization.name,
-                    "slug": organization.slug,
-                },
-                "product": {
-                    "name": product.name,
-                    "benefits": [
-                        {"description": benefit.description}
-                        for benefit in product.benefits
-                    ],
-                },
+                "organization": organization.email_props,
+                "product": product.email_props,
                 "url": settings.generate_frontend_url(
                     f"/{organization.slug}/portal?customer_session_token={token}&id={order.id}"
                 ),

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import cast
 
 from fastapi import Depends, Query, Response, status
@@ -320,7 +319,6 @@ async def invite_member(
             "invite_url": settings.generate_frontend_url(
                 f"/dashboard/{organization.slug}"
             ),
-            "current_year": datetime.datetime.now().year,
         },
     )
 

--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -1,6 +1,5 @@
 import uuid
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -174,7 +173,6 @@ class OrganizationAccessTokenService:
                 "organization_access_token": organization_access_token.comment,
                 "notifier": notifier,
                 "url": url or "",
-                "current_year": datetime.now().year,
             },
         )
 

--- a/server/polar/personal_access_token/service.py
+++ b/server/polar/personal_access_token/service.py
@@ -78,7 +78,6 @@ class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):
                 "personal_access_token": personal_access_token.comment,
                 "notifier": notifier,
                 "url": url or "",
-                "current_year": datetime.now().year,
             },
         )
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1745,6 +1745,7 @@ class SubscriptionService:
         subject = subject_template.format(product=product)
 
         enqueue_email(
+            **organization.email_from_reply,
             to_email_addr=subscription.customer.email,
             subject=subject,
             html_content=body,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1744,7 +1744,6 @@ class SubscriptionService:
             "url": settings.generate_frontend_url(
                 f"/{featured_organization.slug}/portal?customer_session_token={token}&id={subscription.id}"
             ),
-            "current_year": datetime.now().year,
         }
 
         # Add extra context if provided

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1792,7 +1792,7 @@ async def test_send_change_email(
     )
 
     await subscription_service.send_subscription_updated_email(
-        session, subscription, product, product
+        session, subscription, product, product, SubscriptionProrationBehavior.prorate
     )
 
 


### PR DESCRIPTION
Fix #6562

- server/emails: set organization from/reply-to for customer emails
- server/emails: add organization logo to customer emails
- server/emails: remove current_year property
