### PR TITLE
server/subscription: allow subscription scheduler to run even if long overdue

### DIFF
--- a/server/migrations/versions/2025-09-03-1601_reset_subscription_scheduler_locked.py
+++ b/server/migrations/versions/2025-09-03-1601_reset_subscription_scheduler_locked.py
@@ -1,0 +1,28 @@
+"""Reset Subscription.scheduler_locked
+
+Revision ID: 4b946a507b1e
+Revises: d15c9bf2d716
+Create Date: 2025-09-03 16:01:18.612931
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "4b946a507b1e"
+down_revision = "d15c9bf2d716"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE subscriptions SET scheduler_locked = FALSE WHERE scheduler_locked = TRUE;"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -116,6 +116,7 @@ class SubscriptionJobStore(BaseJobStore):
                 subscription_id, current_period_end = result._tuple()
                 trigger = DateTrigger(current_period_end, datetime.UTC)
                 job_kwargs = {
+                    **(self._scheduler._job_defaults if self._scheduler else {}),
                     "trigger": trigger,
                     "executor": self.executor,
                     "func": enqueue_subscription_cycle,
@@ -124,7 +125,7 @@ class SubscriptionJobStore(BaseJobStore):
                     "id": f"subscriptions:cycle:{subscription_id}",
                     "name": None,
                     "next_run_time": trigger.run_date,
-                    **(self._scheduler._job_defaults if self._scheduler else {}),
+                    "misfire_grace_time": None,
                 }
                 job = Job(self._scheduler, **job_kwargs)
                 jobs.append(job)


### PR DESCRIPTION
Fix #6655

- server/subscription: allow subscription scheduler to run even if long overdue
- server/subscription: reset scheduler_locked flag after successful cycle
