### PR TITLE
ops: fix Vercel build in CI

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Pull Vercel Environment Information
         working-directory: clients/apps/web
-        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
- ops: fix Vercel build in CI
- Potential fix for code scanning alert no. 86: Workflow does not contain permissions
- ops: disable automatic Vercel deploy on main branch
- ops: revamp deploy workflow