### PR TITLE
server/auth: make sure auth tokens are ASCII before trying to handle them

### DIFF
--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -46,6 +46,8 @@ def get_bearer_token(request: Request) -> str | None:
     scheme, value = get_authorization_scheme_param(authorization)
     if not scheme or not value or scheme.lower() != "bearer":
         return None
+    if not value.isascii():
+        return None
     return value
 
 

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -62,7 +62,7 @@ class AuthService:
         cookie: str = settings.USER_SESSION_COOKIE_KEY,
     ) -> UserSession | None:
         token = request.cookies.get(cookie)
-        if token is None:
+        if token is None or not token.isascii():
             return None
 
         user_session = await self._get_user_session_by_token(session, token)


### PR DESCRIPTION
- server/auth: make sure auth tokens are ASCII before trying to handle them