### PR TITLE
ops: remove path filtering on server/client tests CI since they are required in our branch protection rules

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - "clients/**"
-      - ".github/workflows/test_client.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - "server/**"
-      - ".github/workflows/test_server.yaml"
 
 permissions:
   contents: read


### PR DESCRIPTION
- ops: remove path filtering on server/client tests CI since they are required in our branch protection rules