### PR TITLE
Fix double webhook call

### DIFF
--- a/server/.vscode/launch.json
+++ b/server/.vscode/launch.json
@@ -15,8 +15,10 @@
       "name": "API",
       "type": "python",
       "env": {
-        "PYDEVD_DISABLE_FILE_VALIDATION": "1"
+        "PYDEVD_DISABLE_FILE_VALIDATION": "1",
+        "AUTHLIB_INSECURE_TRANSPORT": "true"
       },
+      "envFile": "${workspaceFolder}/.env",
       "request": "launch",
       "module": "uvicorn",
       "args": [
@@ -29,7 +31,7 @@
         "--port",
         "8000"
       ],
-      "justMyCode": false
+      "justMyCode": false,
     }
   ]
 }

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -572,14 +572,13 @@ class ProductService:
                 )
 
         session.add(product)
+        await session.flush()
 
         if added_benefits or deleted_benefits:
             enqueue_job(
                 "subscription.subscription.update_product_benefits_grants", product.id
             )
             enqueue_job("order.update_product_benefits_grants", product.id)
-
-        await self._after_product_updated(session, product)
 
         return product, added_benefits, deleted_benefits
 


### PR DESCRIPTION
This PR would fix: https://github.com/polarsource/polar/issues/6665

Main issue is that: https://github.com/DomiR/polar/blob/6ec6d23aed2dc88ccc2cda2540cb5c2cc971b780/clients/apps/web/src/components/Products/ProductPage/ProductPageContextView.tsx#L83 calls product update and update benefits.

On the backend, updating benefits will also trigger the `product.update` webhook, which is why the webhook is called when creating a product as well (which is probably also not desired, as there is a product.create webhook).

In the frontend `useUpdateProductBenefits` is only called in 3 places:
- [ProductStep.tsx](https://github.com/DomiR/polar/blob/6ec6d23aed2dc88ccc2cda2540cb5c2cc971b780/clients/apps/web/src/components/Onboarding/ProductStep.tsx#L77): Product creation → product.create webhook, then product.update because of the benefits update
- [CreateProductPage.tsx](https://github.com/DomiR/polar/blob/6ec6d23aed2dc88ccc2cda2540cb5c2cc971b780/clients/apps/web/src/components/Products/CreateProductPage.tsx#L64): Product creation → product.create webhook, then product.update because of the benefits
- [ProductPageContextView](https://github.com/DomiR/polar/blob/6ec6d23aed2dc88ccc2cda2540cb5c2cc971b780/clients/apps/web/src/components/Products/ProductPage/ProductPageContextView.tsx#L59) Product Update and **Culprit** → will call product.update hook for updating product, then again for benefit update

I don't have a complete picture of your architecture, so I'm proposing to remove the product.update webhook for benefits update. Another solution could be to create a benefits.update webhook, if necessary.