### PR TITLE
fix(checkout): Use minimum amount for PWYW placeholder

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -390,7 +390,11 @@ class CheckoutService:
         elif is_custom_price(price):
             currency = price.price_currency
             if amount is None:
-                amount = price.preset_amount or settings.CUSTOM_PRICE_PRESET_FALLBACK
+                amount = (
+                    price.preset_amount
+                    or price.minimum_amount
+                    or settings.CUSTOM_PRICE_PRESET_FALLBACK
+                )
         else:
             amount = 0
             currency = price.price_currency if is_currency_price(price) else "usd"
@@ -553,7 +557,11 @@ class CheckoutService:
             currency = price.price_currency
         elif is_custom_price(price):
             currency = price.price_currency
-            amount = price.preset_amount or settings.CUSTOM_PRICE_PRESET_FALLBACK
+            amount = (
+                price.preset_amount
+                or price.minimum_amount
+                or settings.CUSTOM_PRICE_PRESET_FALLBACK
+            )
         elif is_currency_price(price):
             currency = price.price_currency
 
@@ -639,7 +647,11 @@ class CheckoutService:
             currency = price.price_currency
         elif is_custom_price(price):
             currency = price.price_currency
-            amount = price.preset_amount or settings.CUSTOM_PRICE_PRESET_FALLBACK
+            amount = (
+                price.preset_amount
+                or price.minimum_amount
+                or settings.CUSTOM_PRICE_PRESET_FALLBACK
+            )
         elif is_currency_price(price):
             currency = price.price_currency
 
@@ -1406,7 +1418,9 @@ class CheckoutService:
                 checkout.currency = price.price_currency
             elif is_custom_price(price):
                 checkout.amount = (
-                    price.preset_amount or settings.CUSTOM_PRICE_PRESET_FALLBACK
+                    price.preset_amount
+                    or price.minimum_amount
+                    or settings.CUSTOM_PRICE_PRESET_FALLBACK
                 )
                 checkout.currency = price.price_currency
             elif is_currency_price(price):

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -13,6 +13,7 @@ from polar.auth.scope import Scope
 from polar.checkout.repository import CheckoutRepository
 from polar.checkout.schemas import CheckoutProductCreate
 from polar.checkout.service import checkout as checkout_service
+from polar.config import settings
 from polar.enums import SubscriptionRecurringInterval
 from polar.integrations.stripe.service import StripeService
 from polar.kit.tax import calculate_tax
@@ -27,6 +28,7 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.checkout import CheckoutStatus
+from polar.models.organization import Organization
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -35,6 +37,9 @@ from tests.fixtures.random_objects import (
     create_organization,
     create_product,
 )
+
+MINIMUM_AMOUNT = 2500
+PRESET_AMOUNT = 5000
 
 
 @pytest.fixture(
@@ -91,6 +96,42 @@ async def create_blocked_product(
     )
     await save_fixture(user_organization)
     return product
+
+
+@pytest_asyncio.fixture
+async def product_custom_price_minimum(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    return await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=None,
+        prices=[(MINIMUM_AMOUNT, None, None)],
+    )
+
+
+@pytest_asyncio.fixture
+async def product_custom_price_preset(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    return await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=None,
+        prices=[(MINIMUM_AMOUNT, None, PRESET_AMOUNT)],
+    )
+
+
+@pytest_asyncio.fixture
+async def product_custom_price_no_amounts(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    return await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=None,
+        prices=[(None, None, None)],
+    )
 
 
 @pytest.mark.asyncio
@@ -357,6 +398,60 @@ class TestCreateCheckout:
         json = response.json()
         assert json["external_customer_id"] == "external_customer_id_value"
         assert json["customer_external_id"] == "external_customer_id_value"
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
+    async def test_custom_price_uses_minimum(
+        self,
+        api_prefix: str,
+        client: AsyncClient,
+        product_custom_price_minimum: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            f"{api_prefix}/",
+            json={
+                "products": [str(product_custom_price_minimum.id)],
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["amount"] == MINIMUM_AMOUNT
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
+    async def test_custom_price_prefers_preset(
+        self,
+        api_prefix: str,
+        client: AsyncClient,
+        product_custom_price_preset: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            f"{api_prefix}/",
+            json={
+                "product_id": str(product_custom_price_preset.id),
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["amount"] == PRESET_AMOUNT
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
+    async def test_custom_price_uses_fallback(
+        self,
+        api_prefix: str,
+        client: AsyncClient,
+        product_custom_price_no_amounts: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            f"{api_prefix}/",
+            json={
+                "product_id": str(product_custom_price_no_amounts.id),
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["amount"] == settings.CUSTOM_PRICE_PRESET_FALLBACK
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Changes

Updates the checkout creation logic to correctly prioritize the `minimum_amount` from the product's price settings before falling back to the default.

Fixes #6450