### PR TITLE
fix(checkout-links): Prevent auto-escaping {CHECKOUT_ID} in success URL

### DIFF
--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkForm.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkForm.tsx
@@ -265,7 +265,7 @@ export const CheckoutLinkForm = ({
                   <Input
                     placeholder="https://example.com/success?checkout_id={CHECKOUT_ID}"
                     {...field}
-                    value={field.value || ''}
+                    value={decodeURIComponent(field.value || '')}
                   />
                 </FormControl>
                 <FormDescription className="text-xs">

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, TypedDict
+from urllib.parse import unquote
 from uuid import UUID
 
 from sqlalchemy import (
@@ -229,7 +230,8 @@ class Checkout(CustomFieldDataMixin, MetadataMixin, RecordModel):
                 f"/checkout/{self.client_secret}/confirmation"
             )
         try:
-            return self._success_url.format(CHECKOUT_ID=self.id)
+            decoded = unquote(self._success_url)
+            return decoded.format(CHECKOUT_ID=self.id)
         except KeyError:
             return self._success_url
 


### PR DESCRIPTION
### Summary
Fixes an issue where `{CHECKOUT_ID}` in the success URL was auto-escaped to `%7BCHECKOUT_ID%7D` after saving a checkout link.

### Why This Change Was Made
- Libraries like **pypandic** follow RFC 3986 and escape `{}` as `%7B`/`%7D`.
- This ensures the placeholder is kept as-is and replaced correctly when generating the final URL.

Fixes: #6300