### PR TITLE
API schema: Set a specific name on `CheckoutLinkCreate`

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6495,6 +6495,7 @@ export interface components {
             /** Url */
             readonly url: string;
         };
+        CheckoutLinkCreate: components["schemas"]["CheckoutLinkCreateProductPrice"] | components["schemas"]["CheckoutLinkCreateProduct"] | components["schemas"]["CheckoutLinkCreateProducts"];
         /**
          * CheckoutLinkCreateProduct
          * @description Schema to create a new checkout link from a a single product.
@@ -21654,7 +21655,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["CheckoutLinkCreateProductPrice"] | components["schemas"]["CheckoutLinkCreateProduct"] | components["schemas"]["CheckoutLinkCreateProducts"];
+                "application/json": components["schemas"]["CheckoutLinkCreate"];
             };
         };
         responses: {

--- a/server/polar/checkout_link/schemas.py
+++ b/server/polar/checkout_link/schemas.py
@@ -14,6 +14,7 @@ from polar.kit.schemas import (
     IDSchema,
     MergeJSONSchema,
     Schema,
+    SetSchemaReference,
     TimestampedSchema,
 )
 from polar.organization.schemas import OrganizationID
@@ -102,11 +103,12 @@ class CheckoutLinkCreateProducts(CheckoutLinkCreateBase):
     )
 
 
-CheckoutLinkCreate = (
+CheckoutLinkCreate = Annotated[
     CheckoutLinkCreateProductPrice
     | CheckoutLinkCreateProduct
-    | CheckoutLinkCreateProducts
-)
+    | CheckoutLinkCreateProducts,
+    SetSchemaReference("CheckoutLinkCreate"),
+]
 
 
 class CheckoutLinkUpdate(MetadataInputMixin):


### PR DESCRIPTION
This makes it so that Speakeasy generates much shorter Go SDK typenames.

It would previously generate typenames like:

    operations.CheckoutLinksCreateCheckoutLinkCreateTypeCheckoutLinkCreateProducts

with this change this becomes

    components.CreateCheckoutLinkCreateByPrice

Yes! It actually changes from an `operation.` to a `component.