### PR TITLE
server/benefit/strategies: keep account_id in GitHub/Discord benefit after revoke

### DIFF
--- a/server/polar/benefit/strategies/discord/service.py
+++ b/server/polar/benefit/strategies/discord/service.py
@@ -143,7 +143,10 @@ class BenefitDiscordService(
 
         bound_logger.debug("Benefit revoked")
 
-        return {}
+        # Keep account_id in case we need to re-grant later
+        return {
+            "account_id": grant_properties.get("account_id"),
+        }
 
     async def requires_update(
         self, benefit: Benefit, previous_properties: BenefitDiscordProperties

--- a/server/polar/benefit/strategies/github_repository/service.py
+++ b/server/polar/benefit/strategies/github_repository/service.py
@@ -211,7 +211,10 @@ class BenefitGitHubRepositoryService(
 
             bound_logger.debug("Benefit revoked")
 
-            return {}
+            # Keep account_id in case we need to re-grant later
+            return {
+                "account_id": grant_properties.get("account_id"),
+            }
 
     async def requires_update(
         self, benefit: Benefit, previous_properties: BenefitGitHubRepositoryProperties

--- a/server/polar/models/benefit_grant.py
+++ b/server/polar/models/benefit_grant.py
@@ -179,6 +179,7 @@ class BenefitGrant(RecordModel):
 
     def set_grant_failed(self, error: Exception) -> None:
         self.granted_at = None
+        self.revoked_at = None
         self.error = BenefitGrantError(
             message=str(error),
             type=error.__class__.__name__,


### PR DESCRIPTION
- server/benefit/strategies: keep account_id in GitHub/Discord benefit after revoke
- server/benefit/grant: reset revoked_at when granting a benefit again, even if there is an action required error