### PR TITLE
fix: Pass default 100% width to ChartContainer to prevent overflow in dashboard's revenue chart 

### DIFF
--- a/clients/apps/web/src/components/Metrics/MetricChart.tsx
+++ b/clients/apps/web/src/components/Metrics/MetricChart.tsx
@@ -67,7 +67,7 @@ const MetricChart = forwardRef<HTMLDivElement, MetricChartProps>(
 		return (
 			<ChartContainer
 				ref={ref}
-				style={{ height: _height, width: _width }}
+				style={{ height: _height, width: _width || '100%' }}
 				config={{
 					current: {
 						label: "Current Period",


### PR DESCRIPTION
This patch adds default 100% width to `<ChartContainer/>` within `<MetricChart/>` to prevent overflow in mobile safari / webkit.

Hi! Visited polar.sh dashboard on my iPhone and noticed that the dashboard's revenue chart overflows (see screenrecording). This seems to only affect mobile webkit (not super surprised tbh...)

Let me know if you have some better way to solve this 🙂 !

Fixes https://github.com/polarsource/polar/issues/6749


https://github.com/user-attachments/assets/ee98e4d8-bc59-46f5-acbc-ef596621e9a9