### PR TITLE
server/webhook: introduce mechanism to ensure webhook events are delivered in order

### DIFF
--- a/server/polar/models/webhook_delivery.py
+++ b/server/polar/models/webhook_delivery.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 from polar.kit.db.models.base import RecordModel
 
 if TYPE_CHECKING:
+    from .webhook_endpoint import WebhookEndpoint
     from .webhook_event import WebhookEvent
 
 
@@ -19,6 +20,10 @@ class WebhookDelivery(RecordModel):
         nullable=False,
         index=True,
     )
+
+    @declared_attr
+    def webhook_endpoint(cls) -> Mapped["WebhookEndpoint"]:
+        return relationship("WebhookEndpoint", lazy="raise")
 
     webhook_event_id: Mapped[UUID] = mapped_column(
         Uuid,

--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -54,15 +54,14 @@ async def _webhook_event_send(
         bound_log.info("Event already succeeded, skipping")
         return
 
-    # TODO: Quick fix 2025-09-12
-    # if not await webhook_service.is_latest_event(session, event):
-    #     log.info(
-    #         "Earlier events need to be delivered first, retrying later",
-    #         id=event.id,
-    #         type=event.type,
-    #         webhook_endpoint_id=event.webhook_endpoint_id,
-    #     )
-    #     raise Retry()
+    if not await webhook_service.is_latest_event(session, event):
+        log.info(
+            "Earlier events need to be delivered first, retrying later",
+            id=event.id,
+            type=event.type,
+            webhook_endpoint_id=event.webhook_endpoint_id,
+        )
+        raise Retry()
 
     ts = utc_now()
 


### PR DESCRIPTION
Fix #6751

- server/webhook: introduce mechanism to ensure webhook events are delivered in order
