### PR TITLE
clients/web: update product benefits only when they are changed

### DIFF
--- a/clients/apps/web/src/components/Products/ProductPage/ProductPageContextView.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPageContextView.tsx
@@ -80,12 +80,16 @@ export const ProductPageContextView = ({
         return
       }
 
-      await updateBenefits.mutateAsync({
-        id: product.id,
-        body: {
-          benefits: enabledBenefitIds,
-        },
-      })
+      const newBenefitSet = new Set(enabledBenefitIds)
+      const oldBenefitSet = new Set(product.benefits.map((b) => b.id))
+      if (newBenefitSet.symmetricDifference(oldBenefitSet).size > 0) {
+        await updateBenefits.mutateAsync({
+          id: product.id,
+          body: {
+            benefits: enabledBenefitIds,
+          },
+        })
+      }
 
       router.push(
         getStatusRedirect(


### PR DESCRIPTION
Fix #6665

- clients/web: update product benefits only when they are changed
