### PR TITLE
Pieterbeulque/metered pricing with credits

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutCard.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutCard.tsx
@@ -36,10 +36,8 @@ export const CheckoutCard = ({
       />
 
       {product.benefits.length > 0 ? (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <h1 className="font-medium dark:text-white">Included</h1>
-          </div>
+        <div className="flex flex-col gap-2">
+          <h1 className="font-medium dark:text-white">Included</h1>
           <div className="flex flex-col gap-y-2">
             {/* @ts-ignore */}
             <BenefitList benefits={product.benefits} toggle={true} />

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
@@ -39,7 +39,7 @@ const CustomerPortalOrder = ({
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false)
 
   const { data: benefitGrants } = useCustomerBenefitGrants(api, {
-    order_id: order.id,
+    checkout_id: order.checkout_id,
     limit: 100,
     sorting: ['type'],
   })

--- a/clients/apps/web/src/components/Products/BenefitList.tsx
+++ b/clients/apps/web/src/components/Products/BenefitList.tsx
@@ -13,8 +13,8 @@ const BenefitRow = ({
   children: ReactNode
 }) => {
   return (
-    <div className="flex flex-row items-center gap-x-3">
-      <span className="flex h-4 w-4 items-center justify-center text-2xl text-black dark:text-white">
+    <div className="dark:text-polar-100 flex flex-row items-center gap-x-2 text-gray-600">
+      <span className="dark:text-polar-200 flex h-4 w-4 items-center justify-center text-2xl text-gray-600">
         {icon}
       </span>
       <span className="text-sm">{children}</span>
@@ -52,7 +52,7 @@ export const BenefitList = ({
       {shown.map((benefit) => (
         <BenefitRow
           key={benefit.id}
-          icon={resolveBenefitIcon(benefit.type, 'h-3 w-3')}
+          icon={resolveBenefitIcon(benefit.type, 'h-4 w-4')}
         >
           {benefit.description}
         </BenefitRow>
@@ -63,7 +63,7 @@ export const BenefitList = ({
             toggled.map((benefit) => (
               <BenefitRow
                 key={benefit.id}
-                icon={resolveBenefitIcon(benefit.type, 'h-3 w-3')}
+                icon={resolveBenefitIcon(benefit.type, 'h-4 w-4')}
               >
                 {benefit.description}
               </BenefitRow>

--- a/clients/apps/web/src/components/Shared/AmountLabel.tsx
+++ b/clients/apps/web/src/components/Shared/AmountLabel.tsx
@@ -36,7 +36,7 @@ const AmountLabel: React.FC<AmountLabelProps> = ({
   return (
     <div className="flex flex-row items-baseline">
       {formatCurrencyAndAmount(amount, currency, minimumFractionDigits)}
-      <span className="text-[0.5em]">{intervalDisplay}</span>
+      <span className="text-[max(12px,_0.5em)]">{intervalDisplay}</span>
     </div>
   )
 }

--- a/clients/packages/checkout/src/components/AmountLabel.tsx
+++ b/clients/packages/checkout/src/components/AmountLabel.tsx
@@ -32,9 +32,16 @@ const AmountLabel: React.FC<AmountLabelProps> = ({
     }
   }, [interval])
 
+  const minimumFractionDigits = useMemo(
+    // Show 0 decimals if a round number, show default decimals (2 for USD) otherwise
+    // This will trip when we add multi-currency (e.g. for JPY etc)
+    () => (amount % 100 === 0 ? 0 : 2),
+    [amount],
+  )
+
   return (
     <div className="flex flex-row items-baseline gap-x-1">
-      {formatCurrencyNumber(amount, currency, 0)}
+      {formatCurrencyNumber(amount, currency, minimumFractionDigits)}
       <span className="text-[max(12px,_0.5em)]">{intervalDisplay}</span>
     </div>
   )

--- a/clients/packages/checkout/src/components/AmountLabel.tsx
+++ b/clients/packages/checkout/src/components/AmountLabel.tsx
@@ -33,7 +33,7 @@ const AmountLabel: React.FC<AmountLabelProps> = ({
   }, [interval])
 
   return (
-    <div className="flex flex-row items-baseline">
+    <div className="flex flex-row items-baseline gap-x-1">
       {formatCurrencyNumber(amount, currency, 0)}
       <span className="text-[0.5em]">{intervalDisplay}</span>
     </div>

--- a/clients/packages/checkout/src/components/AmountLabel.tsx
+++ b/clients/packages/checkout/src/components/AmountLabel.tsx
@@ -35,7 +35,7 @@ const AmountLabel: React.FC<AmountLabelProps> = ({
   return (
     <div className="flex flex-row items-baseline gap-x-1">
       {formatCurrencyNumber(amount, currency, 0)}
-      <span className="text-[0.5em]">{intervalDisplay}</span>
+      <span className="text-[max(12px,_0.5em)]">{intervalDisplay}</span>
     </div>
   )
 }

--- a/clients/packages/checkout/src/components/CheckoutPricing.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricing.tsx
@@ -115,7 +115,7 @@ const CheckoutPricing = ({
             {meteredPrices.map((price) => (
               <div
                 key={price.id}
-                className="dark:text-polar-500 flex flex-row items-center gap-x-2 text-sm text-gray-400"
+                className="dark:text-polar-100 flex flex-row items-center gap-x-2 text-sm text-gray-600"
               >
                 <GaugeIcon className="h-4 w-4" />
                 <ProductPriceLabel

--- a/clients/packages/checkout/src/components/CheckoutPricing.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricing.tsx
@@ -111,7 +111,9 @@ const CheckoutPricing = ({
 
         {meteredPrices.length > 0 && (
           <div className="text-sm">
-            <h2 className="mb-2 font-semibold">+ Additional Metered Usage</h2>
+            <h2 className="mb-2 text-base font-medium">
+              + Additional metered usage
+            </h2>
             {meteredPrices.map((price) => (
               <div
                 key={price.id}

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -12,7 +12,7 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({ price }) => {
         Number.parseFloat(price.unitAmount),
         price.priceCurrency,
       )}
-      <span className="dark:text-polar-400 text-[.75em] text-gray-500">
+      <span className="dark:text-polar-400 text-[max(12px,_0.5em)] text-gray-500">
         / unit
       </span>
     </div>

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -7,12 +7,14 @@ interface MeteredPriceLabelProps {
 
 const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({ price }) => {
   return (
-    <div className="flex flex-row items-baseline gap-x-[.5em]">
+    <div className="flex flex-row items-baseline gap-x-1">
       {formatUnitAmount(
         Number.parseFloat(price.unitAmount),
         price.priceCurrency,
-      )}{' '}
-      <span className="text-[.75em] text-gray-500">/unit</span>
+      )}
+      <span className="dark:text-polar-400 text-[.75em] text-gray-500">
+        / unit
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
Ignore the first few commits, that fixes some styling inconsistencies that rubbed me the wrong way while trying to debug this issue, haha.

The actual fix for #5972 is the single line in bce56a5:

```diff
  const { data: benefitGrants } = useCustomerBenefitGrants(api, {
 -  order_id: order.id,
 +  checkout_id: order.checkout_id,
    limit: 100,
    sorting: ['type'],
  })
```

As mentioned in #5972, when benefits are granted through a subscription, the `order_id` is set to `null` on the `benefits_grant` table, so we can't retrieve the benefits by `order_id`.

By searching for checkout ID, this will work, because `customer_benefit_grant_service.list` implements filtering on `checkout_id` by an `OR` on `subscription_id` or `order_id`.