### PR TITLE
fix(frontpage/landing): close sidebar when login modal is opened

### DIFF
--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -137,49 +137,49 @@ const LandingPageMobileNavigation = () => {
 
 	const onLoginClick = () => {
 		posthog.capture("global:user:login:click");
-    sidebar.toggleSidebar();
+		sidebar.toggleSidebar();
 		showModal();
 	};
 
 	return (
-    <>
-		<Sidebar className="md:hidden">
-			<SidebarHeader className="p-4">
-				<BrandingMenu logoVariant="icon" />
-			</SidebarHeader>
-			<SidebarContent className="px-6 py-2 flex flex-col gap-y-6">
-				<div className="flex flex-col gap-y-1">
-					{mobileNavigationItems.map((item) => {
-						return (
-							<NavLink
-								key={item.title}
-								className="text-xl tracking-tight"
-								isActive={item.isActive}
-								target={item.target}
-								href={item.href}
-								onClick={sidebar.toggleSidebar}
-							>
-								{item.title}
-							</NavLink>
-						);
-					})}
-				</div>
-				<NavLink
-					href="#"
-					onClick={onLoginClick}
-					className="text-xl tracking-tight"
-				>
-					Login
-				</NavLink>
-			</SidebarContent>
-		</Sidebar>
+		<>
+			<Sidebar className="md:hidden">
+				<SidebarHeader className="p-4">
+					<BrandingMenu logoVariant="icon" />
+				</SidebarHeader>
+				<SidebarContent className="px-6 py-2 flex flex-col gap-y-6">
+					<div className="flex flex-col gap-y-1">
+						{mobileNavigationItems.map((item) => {
+							return (
+								<NavLink
+									key={item.title}
+									className="text-xl tracking-tight"
+									isActive={item.isActive}
+									target={item.target}
+									href={item.href}
+									onClick={sidebar.toggleSidebar}
+								>
+									{item.title}
+								</NavLink>
+							);
+						})}
+					</div>
+					<NavLink
+						href="#"
+						onClick={onLoginClick}
+						className="text-xl tracking-tight"
+					>
+						Login
+					</NavLink>
+				</SidebarContent>
+			</Sidebar>
 			<Modal
 				isShown={isModalShown}
 				hide={hideModal}
 				modalContent={<AuthModal />}
 				className="lg:w-full lg:max-w-[480px]"
 			/>
-    </>
+		</>
 	);
 };
 

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -137,10 +137,12 @@ const LandingPageMobileNavigation = () => {
 
 	const onLoginClick = () => {
 		posthog.capture("global:user:login:click");
+    sidebar.toggleSidebar();
 		showModal();
 	};
 
 	return (
+    <>
 		<Sidebar className="md:hidden">
 			<SidebarHeader className="p-4">
 				<BrandingMenu logoVariant="icon" />
@@ -170,13 +172,14 @@ const LandingPageMobileNavigation = () => {
 					Login
 				</NavLink>
 			</SidebarContent>
+		</Sidebar>
 			<Modal
 				isShown={isModalShown}
 				hide={hideModal}
 				modalContent={<AuthModal />}
 				className="lg:w-full lg:max-w-[480px]"
 			/>
-		</Sidebar>
+    </>
 	);
 };
 

--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -365,7 +365,7 @@ const LandingPageFooter = () => {
 	return (
 		<motion.div
 			initial="initial"
-			className="flex w-full flex-col items-center"
+			className="flex w-full flex-col items-center relative"
 			variants={{ initial: { opacity: 0 }, animate: { opacity: 1 } }}
 			transition={{ duration: 0.5, ease: "easeInOut" }}
 			whileInView="animate"


### PR DESCRIPTION
When login modal was opened from the sidebar, any button inside the modal wouldn't work (see video).

This patch moves the modal outside the sidebar, and closes the sidebar to get the full focus to the modal.

Closes https://github.com/polarsource/polar/issues/6889

https://github.com/user-attachments/assets/4cc9ea04-d46f-4896-8f37-b3feba931ad9

