### PR TITLE
Show benefit grants on customer page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/ClientPage.tsx
@@ -4,7 +4,7 @@ import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { SubscriptionStatus as SubscriptionStatusComponent } from '@/components/Subscriptions/SubscriptionStatus'
 import SubscriptionStatusSelect from '@/components/Subscriptions/SubscriptionStatusSelect'
 import SubscriptionTiersSelect from '@/components/Subscriptions/SubscriptionTiersSelect'
-import { useListSubscriptions, useProducts } from '@/hooks/queries'
+import { useSubscriptions, useProducts } from '@/hooks/queries'
 import { getServerURL } from '@/utils/api'
 import {
   DataTablePaginationState,
@@ -137,7 +137,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     )
   }
 
-  const subscriptionsHook = useListSubscriptions(organization.id, {
+  const subscriptionsHook = useSubscriptions(organization.id, {
     ...getAPIParams(pagination, sorting),
     ...(productId ? { product_id: productId } : {}),
     ...(status !== 'any'

--- a/clients/apps/web/src/components/Benefit/BenefitPage.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitPage.tsx
@@ -1,4 +1,4 @@
-import { useBenefitGrants } from '@/hooks/queries/benefits'
+import { useGrantsForBenefit } from '@/hooks/queries/benefits'
 import {
   DataTablePaginationState,
   DataTableSortingState,
@@ -41,7 +41,7 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
 
   const router = useRouter()
 
-  const { data: benefitGrants, isLoading } = useBenefitGrants({
+  const { data: benefitGrants, isLoading } = useGrantsForBenefit({
     benefitId: benefit.id,
     organizationId: organization.id,
     ...getAPIParams(pagination, sorting),

--- a/clients/apps/web/src/components/Benefit/utils.tsx
+++ b/clients/apps/web/src/components/Benefit/utils.tsx
@@ -33,25 +33,6 @@ export const resolveBenefitIcon = (
   return resolveBenefitCategoryIcon(type, className)
 }
 
-export const resolveBenefitTypeDisplayName = (
-  type: schemas['BenefitType'] | 'usage',
-) => {
-  switch (type) {
-    case 'usage':
-      return 'Usage'
-    case 'discord':
-      return 'Discord Server Invite'
-    case 'github_repository':
-      return 'GitHub Repository Access'
-    case 'downloadables':
-      return 'Downloadable Files'
-    case 'license_keys':
-      return 'License Keys'
-    default:
-      return 'Custom'
-  }
-}
-
 export const DiscordIcon = ({
   className,
   size = 16,

--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -65,6 +65,7 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
     useBenefitGrants(customer.organization_id, {
       customer_id: [customer.id],
       limit: 999,
+      sorting: ['-granted_at'],
     })
 
   const [selectedMetric, setSelectedMetric] =

--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -6,8 +6,8 @@ import AmountLabel from '@/components/Shared/AmountLabel'
 import { SubscriptionStatusLabel } from '@/components/Subscriptions/utils'
 import {
   ParsedMetricsResponse,
-  useListSubscriptions,
   useMetrics,
+  useSubscriptions,
 } from '@/hooks/queries'
 import { useOrders } from '@/hooks/queries/orders'
 import { getChartRangeParams } from '@/utils/metrics'
@@ -46,7 +46,7 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
   )
 
   const { data: subscriptions, isLoading: subscriptionsLoading } =
-    useListSubscriptions(customer.organization_id, {
+    useSubscriptions(customer.organization_id, {
       customer_id: customer.id,
       limit: 999,
       sorting: ['-started_at'],

--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -8,6 +8,7 @@ import {
   ParsedMetricsResponse,
   useMetrics,
   useSubscriptions,
+  useBenefitGrants,
 } from '@/hooks/queries'
 import { useOrders } from '@/hooks/queries/orders'
 import { getChartRangeParams } from '@/utils/metrics'
@@ -51,6 +52,13 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
       limit: 999,
       sorting: ['-started_at'],
     })
+
+  const { data: benefitGrants } = useBenefitGrants(customer.organization_id, {
+    customer_id: [customer.id],
+    limit: 999,
+  })
+
+  console.log('Benefit grants data:', benefitGrants)
 
   const [selectedMetric, setSelectedMetric] =
     React.useState<keyof schemas['Metrics']>('revenue')

--- a/clients/apps/web/src/hooks/queries/benefits.ts
+++ b/clients/apps/web/src/hooks/queries/benefits.ts
@@ -203,3 +203,27 @@ export const useGrantsForBenefit = ({
 		},
 		retry: defaultRetry,
 	});
+
+export const useBenefitGrants = (
+	organizationId?: string,
+	parameters?: Omit<
+		NonNullable<operations['benefit-grants:list']['parameters']['query']>,
+		'organization_id'
+	>,
+) =>
+	useQuery({
+		queryKey: ['benefit-grants', { organizationId, ...(parameters || {}) }],
+		queryFn: () =>
+			unwrap(
+				api.GET('/v1/benefit-grants/', {
+					params: {
+						query: {
+							organization_id: organizationId,
+							...parameters,
+						},
+					},
+				}),
+			),
+		retry: defaultRetry,
+		enabled: !!organizationId,
+	});

--- a/clients/apps/web/src/hooks/queries/benefits.ts
+++ b/clients/apps/web/src/hooks/queries/benefits.ts
@@ -168,7 +168,7 @@ export const useDeleteBenefit = (orgId?: string) =>
 		},
 	});
 
-export const useBenefitGrants = ({
+export const useGrantsForBenefit = ({
 	benefitId,
 	organizationId,
 	limit = 30,

--- a/clients/apps/web/src/hooks/queries/subscriptions.ts
+++ b/clients/apps/web/src/hooks/queries/subscriptions.ts
@@ -4,7 +4,7 @@ import { operations, schemas, unwrap } from '@polar-sh/client'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
-export const useListSubscriptions = (
+export const useSubscriptions = (
   organizationId?: string,
   parameters?: Omit<
     NonNullable<operations['subscriptions:list']['parameters']['query']>,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5707,6 +5707,11 @@ export interface components {
             properties: components["schemas"]["BenefitGrantMeterCreditProperties"];
             previous_properties?: components["schemas"]["BenefitGrantMeterCreditProperties"] | null;
         };
+        /**
+         * BenefitGrantSortProperty
+         * @enum {string}
+         */
+        BenefitGrantSortProperty: "created_at" | "-created_at" | "granted_at" | "-granted_at" | "revoked_at" | "-revoked_at";
         BenefitGrantWebhook: components["schemas"]["BenefitGrantDiscordWebhook"] | components["schemas"]["BenefitGrantCustomWebhook"] | components["schemas"]["BenefitGrantGitHubRepositoryWebhook"] | components["schemas"]["BenefitGrantDownloadablesWebhook"] | components["schemas"]["BenefitGrantLicenseKeysWebhook"] | components["schemas"]["BenefitGrantMeterCreditWebhook"];
         /**
          * BenefitGrantedEvent
@@ -20413,6 +20418,8 @@ export interface operations {
                 page?: number;
                 /** @description Size of a page, defaults to 10. Maximum is 100. */
                 limit?: number;
+                /** @description Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order. */
+                sorting?: components["schemas"]["BenefitGrantSortProperty"][] | null;
             };
             header?: never;
             path?: never;
@@ -26934,6 +26941,7 @@ export const benefitGitHubRepositoryCreateTypeValues: ReadonlyArray<components["
 export const benefitGitHubRepositoryCreatePropertiesPermissionValues: ReadonlyArray<components["schemas"]["BenefitGitHubRepositoryCreateProperties"]["permission"]> = ["pull", "triage", "push", "maintain", "admin"];
 export const benefitGitHubRepositoryPropertiesPermissionValues: ReadonlyArray<components["schemas"]["BenefitGitHubRepositoryProperties"]["permission"]> = ["pull", "triage", "push", "maintain", "admin"];
 export const benefitGrantGitHubRepositoryPropertiesPermissionValues: ReadonlyArray<components["schemas"]["BenefitGrantGitHubRepositoryProperties"]["permission"]> = ["pull", "triage", "push", "maintain", "admin"];
+export const benefitGrantSortPropertyValues: ReadonlyArray<components["schemas"]["BenefitGrantSortProperty"]> = ["created_at", "-created_at", "granted_at", "-granted_at", "revoked_at", "-revoked_at"];
 export const benefitGrantedEventNameValues: ReadonlyArray<components["schemas"]["BenefitGrantedEvent"]["name"]> = ["benefit.granted"];
 export const benefitLicenseKeyExpirationPropertiesTimeframeValues: ReadonlyArray<components["schemas"]["BenefitLicenseKeyExpirationProperties"]["timeframe"]> = ["year", "month", "day"];
 export const benefitLicenseKeysCreateTypeValues: ReadonlyArray<components["schemas"]["BenefitLicenseKeysCreate"]["type"]> = ["license_keys"];

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1116,6 +1116,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/benefit-grants/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Benefit Grants
+         * @description List benefit grants across all benefits for the authenticated organization.
+         *
+         *     **Scopes**: `benefits:read` `benefits:write`
+         */
+        get: operations["benefit-grants:list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/webhooks/endpoints": {
         parameters: {
             query?: never;
@@ -5205,6 +5227,8 @@ export interface components {
             /** @description The error information if the benefit grant failed with an unrecoverable error. */
             error?: components["schemas"]["BenefitGrantError"] | null;
             customer: components["schemas"]["Customer"];
+            /** Benefit */
+            benefit: components["schemas"]["Benefit"];
             /** Properties */
             properties: components["schemas"]["BenefitGrantDiscordProperties"] | components["schemas"]["BenefitGrantGitHubRepositoryProperties"] | components["schemas"]["BenefitGrantDownloadablesProperties"] | components["schemas"]["BenefitGrantLicenseKeysProperties"] | components["schemas"]["BenefitGrantCustomProperties"];
         };
@@ -20363,6 +20387,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ResourceNotFound"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    "benefit-grants:list": {
+        parameters: {
+            query?: {
+                /** @description Filter by organization ID. */
+                organization_id?: string | string[] | null;
+                /** @description Filter by customer ID. */
+                customer_id?: string | string[] | null;
+                /** @description Filter by granted status. If `true`, only granted benefits will be returned. If `false`, only revoked benefits will be returned.  */
+                is_granted?: boolean | null;
+                /** @description Page number, defaults to 1. */
+                page?: number;
+                /** @description Size of a page, defaults to 10. Maximum is 100. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListResource_BenefitGrant_"];
                 };
             };
             /** @description Validation Error */

--- a/server/polar/api.py
+++ b/server/polar/api.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from polar.account.endpoints import router as accounts_router
 from polar.auth.endpoints import router as auth_router
 from polar.benefit.endpoints import router as benefits_router
+from polar.benefit.grant.endpoints import router as benefit_grants_router
 from polar.checkout.endpoints import router as checkout_router
 from polar.checkout_link.endpoints import router as checkout_link_router
 from polar.custom_field.endpoints import router as custom_field_router
@@ -80,6 +81,8 @@ router.include_router(auth_router)
 router.include_router(oauth2_router)
 # /benefits
 router.include_router(benefits_router)
+# /benefit-grants
+router.include_router(benefit_grants_router)
 # /webhooks
 router.include_router(webhook_router)
 # /products

--- a/server/polar/benefit/grant/endpoints.py
+++ b/server/polar/benefit/grant/endpoints.py
@@ -1,0 +1,70 @@
+from fastapi import Depends, Query
+
+from polar.customer.schemas.customer import CustomerID
+from polar.kit.pagination import ListResource, PaginationParamsQuery
+from polar.kit.schemas import MultipleQueryFilter
+from polar.openapi import APITag
+from polar.organization.schemas import OrganizationID
+from polar.postgres import AsyncSession, get_db_session
+from polar.routing import APIRouter
+
+from ..auth import BenefitsRead
+from ..schemas import BenefitGrant
+from .service import benefit_grant as benefit_grant_service
+
+router = APIRouter(prefix="/benefit-grants", tags=["benefit-grants", APITag.public])
+
+
+@router.get(
+    "/",
+    response_model=ListResource[BenefitGrant],
+    summary="List Benefit Grants",
+)
+async def list(
+    auth_subject: BenefitsRead,
+    pagination: PaginationParamsQuery,
+    organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
+        None, title="OrganizationID Filter", description="Filter by organization ID."
+    ),
+    customer_id: MultipleQueryFilter[CustomerID] | None = Query(
+        None, title="CustomerID Filter", description="Filter by customer ID."
+    ),
+    is_granted: bool | None = Query(
+        None,
+        description=(
+            "Filter by granted status. "
+            "If `true`, only granted benefits will be returned. "
+            "If `false`, only revoked benefits will be returned. "
+        ),
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> ListResource[BenefitGrant]:
+    """List benefit grants across all benefits for the authenticated organization."""
+
+    # Extract the first organization_id if provided, otherwise use the auth subject's organization
+    if organization_id is not None and len(organization_id) > 0:
+        org_id = organization_id[0]
+    else:
+        # Use the authenticated organization
+        if hasattr(auth_subject.subject, "id"):
+            org_id = auth_subject.subject.id
+        else:
+            # If auth subject doesn't have organization, we need to handle this case
+            # For now, require organization_id to be provided
+            from polar.exceptions import BadRequest
+
+            raise BadRequest("organization_id parameter is required")
+
+    results, count = await benefit_grant_service.list_by_organization(
+        session,
+        org_id,
+        is_granted=is_granted,
+        customer_id=customer_id,
+        pagination=pagination,
+    )
+
+    return ListResource.from_paginated_results(
+        [BenefitGrant.model_validate(result) for result in results],
+        count,
+        pagination,
+    )

--- a/server/polar/benefit/grant/endpoints.py
+++ b/server/polar/benefit/grant/endpoints.py
@@ -11,6 +11,7 @@ from polar.routing import APIRouter
 from ..auth import BenefitsRead
 from ..schemas import BenefitGrant
 from .service import benefit_grant as benefit_grant_service
+from .sorting import ListSorting
 
 router = APIRouter(prefix="/benefit-grants", tags=["benefit-grants", APITag.public])
 
@@ -23,6 +24,7 @@ router = APIRouter(prefix="/benefit-grants", tags=["benefit-grants", APITag.publ
 async def list(
     auth_subject: BenefitsRead,
     pagination: PaginationParamsQuery,
+    sorting: ListSorting,
     organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
         None, title="OrganizationID Filter", description="Filter by organization ID."
     ),
@@ -61,6 +63,7 @@ async def list(
         is_granted=is_granted,
         customer_id=customer_id,
         pagination=pagination,
+        sorting=sorting,
     )
 
     return ListResource.from_paginated_results(

--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -9,13 +9,18 @@ from polar.kit.repository import (
     RepositoryBase,
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
+    RepositorySortingMixin,
+    SortingClause,
 )
 from polar.models import Benefit, BenefitGrant, Customer, Product, ProductBenefit
 from polar.models.benefit import BenefitType
 from polar.models.benefit_grant import BenefitGrantScope
 
+from .sorting import BenefitGrantSortProperty
+
 
 class BenefitGrantRepository(
+    RepositorySortingMixin[BenefitGrant, BenefitGrantSortProperty],
     RepositorySoftDeletionIDMixin[BenefitGrant, UUID],
     RepositorySoftDeletionMixin[BenefitGrant],
     RepositoryBase[BenefitGrant],
@@ -128,3 +133,12 @@ class BenefitGrantRepository(
             BenefitGrant.deleted_at.is_(None),
         )
         return await self.get_all(statement)
+
+    def get_sorting_clause(self, property: BenefitGrantSortProperty) -> SortingClause:
+        match property:
+            case BenefitGrantSortProperty.created_at:
+                return BenefitGrant.created_at
+            case BenefitGrantSortProperty.granted_at:
+                return BenefitGrant.granted_at
+            case BenefitGrantSortProperty.revoked_at:
+                return BenefitGrant.revoked_at

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -1,3 +1,4 @@
+import builtins
 from collections.abc import Sequence
 from typing import Any, Literal, TypeVar, Unpack, overload
 from uuid import UUID
@@ -13,6 +14,7 @@ from polar.eventstream.service import publish as eventstream_publish
 from polar.exceptions import PolarError
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.services import ResourceServiceReader
+from polar.kit.sorting import Sorting
 from polar.logging import Logger
 from polar.models import Benefit, BenefitGrant, Customer, Product
 from polar.models.benefit_grant import BenefitGrantScope
@@ -30,6 +32,7 @@ from ..strategies import (
 )
 from .repository import BenefitGrantRepository
 from .scope import scope_to_args
+from .sorting import BenefitGrantSortProperty
 
 log: Logger = structlog.get_logger()
 
@@ -137,7 +140,11 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         is_granted: bool | None = None,
         customer_id: Sequence[UUID] | None = None,
         pagination: PaginationParams,
+        sorting: builtins.list[Sorting[BenefitGrantSortProperty]] = [
+            (BenefitGrantSortProperty.created_at, True)
+        ],
     ) -> tuple[Sequence[BenefitGrant], int]:
+        repository = BenefitGrantRepository.from_session(session)
         statement = (
             select(BenefitGrant)
             .join(Benefit, BenefitGrant.benefit_id == Benefit.id)
@@ -145,7 +152,6 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 Benefit.organization_id == organization_id,
                 BenefitGrant.deleted_at.is_(None),
             )
-            .order_by(BenefitGrant.created_at.desc())
             .options(
                 joinedload(BenefitGrant.customer),
                 joinedload(BenefitGrant.benefit).joinedload(Benefit.organization),
@@ -158,7 +164,11 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         if customer_id is not None:
             statement = statement.where(BenefitGrant.customer_id.in_(customer_id))
 
-        return await paginate(session, statement, pagination=pagination)
+        statement = repository.apply_sorting(statement, sorting)
+
+        return await repository.paginate(
+            statement, limit=pagination.limit, page=pagination.page
+        )
 
     async def grant_benefit(
         self,

--- a/server/polar/benefit/grant/sorting.py
+++ b/server/polar/benefit/grant/sorting.py
@@ -1,0 +1,18 @@
+from enum import StrEnum
+from typing import Annotated
+
+from fastapi import Depends
+
+from polar.kit.sorting import Sorting, SortingGetter
+
+
+class BenefitGrantSortProperty(StrEnum):
+    created_at = "created_at"
+    granted_at = "granted_at"
+    revoked_at = "revoked_at"
+
+
+ListSorting = Annotated[
+    list[Sorting[BenefitGrantSortProperty]],
+    Depends(SortingGetter(BenefitGrantSortProperty, ["-created_at"])),
+]

--- a/server/polar/benefit/schemas.py
+++ b/server/polar/benefit/schemas.py
@@ -114,6 +114,7 @@ benefit_schema_map: dict[BenefitType, type[Benefit]] = {
 
 class BenefitGrant(BenefitGrantBase):
     customer: Customer
+    benefit: "Benefit"
     properties: BenefitGrantProperties
 
 


### PR DESCRIPTION
Adds a new table on the customers page.

<img width="1326" height="684" alt="image" src="https://github.com/user-attachments/assets/1ba5c34d-e11a-4697-8289-4c99222b2bf9" />

I decided to add a specific `benefit-grants` endpoint in line with the other endpoints, the existing endpoint to check for grants was `/benefits/{id}/grants` which would require looping over all existing benefits to see if a grant existed for that customer. I think this is better then. Not sure if we should expose it as a public API but I don't think there's much harm in doing so.

