### PR TITLE
feat: remove navigation from customer portal sign-in page

### DIFF
--- a/clients/apps/web/src/app/(main)/[organization]/portal/request/layout.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/request/layout.tsx
@@ -1,0 +1,16 @@
+import { Toaster } from '@/components/Toast/Toaster'
+
+export default function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 px-4 py-8">
+      <div className="w-full max-w-md">
+        {children}
+      </div>
+      <Toaster />
+    </div>
+  )
+}


### PR DESCRIPTION
fixes : #6864

### PR Description

**Problem:** The Customer Portal sign-in page (`/:organization/portal/request`) was displaying navigation elements that were inaccessible and looked unprofessional, especially on mobile where an empty navigation dropdown appeared.

**Solution:** Simplified the request page layout to be a clean, minimal sign-in interface that focuses only on the email input form without any navigation elements.

**Changes:**
- Replaced complex portal layout with minimal centered layout
- Removed Navigation component and organization header
- Kept essential functionality (Toaster, form rendering)

**Files changed:** `clients/apps/web/src/app/(main)/[organization]/portal/request/layout.tsx`