### PR TITLE
server/kit/address: add an AddressInput variant to handle restricted countries we have in DB + add Speakeasy enum

### DIFF
--- a/server/polar/account/schemas.py
+++ b/server/polar/account/schemas.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from pydantic import BeforeValidator, Field
 
 from polar.enums import AccountType
-from polar.kit.address import Address
+from polar.kit.address import Address, AddressInput
 from polar.kit.schemas import Schema
 from polar.models.account import Account as AccountModel
 from polar.organization.schemas import Organization
@@ -168,7 +168,7 @@ class AccountUpdate(Schema):
         default=None,
         description="Billing name that should appear on the reverse invoice.",
     )
-    billing_address: Address | None = Field(
+    billing_address: AddressInput | None = Field(
         default=None,
         description="Billing address that should appear on the reverse invoice.",
     )

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -26,7 +26,7 @@ from polar.discount.schemas import (
     DiscountRepeatDurationBase,
 )
 from polar.enums import PaymentProcessor
-from polar.kit.address import Address
+from polar.kit.address import Address, AddressInput
 from polar.kit.email import EmailStrDNS
 from polar.kit.metadata import (
     METADATA_DESCRIPTION,
@@ -85,9 +85,11 @@ CustomerIPAddress = Annotated[
         description="IP address of the customer. Used to detect tax location.",
     ),
 ]
+CustomerBillingAddressInput = Annotated[
+    AddressInput, Field(description="Billing address of the customer.")
+]
 CustomerBillingAddress = Annotated[
-    Address,
-    Field(description="Billing address of the customer."),
+    Address, Field(description="Billing address of the customer.")
 ]
 SuccessURL = Annotated[
     HttpUrl | None,
@@ -179,7 +181,7 @@ class CheckoutCreateBase(CustomFieldDataInputMixin, MetadataInputMixin, Schema):
     customer_email: CustomerEmail | None = None
     customer_ip_address: CustomerIPAddress | None = None
     customer_billing_name: Annotated[str | None, EmptyStrToNoneValidator] = None
-    customer_billing_address: CustomerBillingAddress | None = None
+    customer_billing_address: CustomerBillingAddressInput | None = None
     customer_tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
     customer_metadata: MetadataField = Field(
         default_factory=dict, description=_customer_metadata_description
@@ -291,7 +293,7 @@ class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     customer_name: Annotated[CustomerName | None, EmptyStrToNoneValidator] = None
     customer_email: CustomerEmail | None = None
     customer_billing_name: Annotated[str | None, EmptyStrToNoneValidator] = None
-    customer_billing_address: CustomerBillingAddress | None = None
+    customer_billing_address: CustomerBillingAddressInput | None = None
     customer_tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
 
 

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -36,7 +36,7 @@ from polar.exceptions import (
 )
 from polar.integrations.stripe.schemas import ProductType
 from polar.integrations.stripe.service import stripe as stripe_service
-from polar.kit.address import Address
+from polar.kit.address import AddressInput
 from polar.kit.crypto import generate_token
 from polar.kit.operator import attrgetter
 from polar.kit.pagination import PaginationParams
@@ -1634,7 +1634,7 @@ class CheckoutService:
             return checkout
 
         try:
-            address = Address.model_validate({"country": country})
+            address = AddressInput.model_validate({"country": country})
         except PydanticValidationError:
             return checkout
 

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -236,7 +236,7 @@ class Settings(BaseSettings):
         line2="PMB 61301",
         postal_code="94104",
         city="San Francisco",
-        state="CA",
+        state="US-CA",
         country=CountryAlpha2("US"),
     )
     INVOICES_ADDITIONAL_INFO: str | None = "[support@polar.sh](mailto:support@polar.sh)"

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -6,10 +6,9 @@ from typing import Annotated, Literal
 
 from annotated_types import Ge
 from pydantic import AfterValidator, DirectoryPath, Field, PostgresDsn
-from pydantic_extra_types.country import CountryAlpha2
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from polar.kit.address import Address
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.jwk import JWKSFile
 
 

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import Path
 from pydantic import UUID4, Field, computed_field
 
-from polar.kit.address import Address
+from polar.kit.address import Address, AddressInput
 from polar.kit.email import EmailStrDNS
 from polar.kit.metadata import (
     MetadataInputMixin,
@@ -50,7 +50,7 @@ class CustomerCreate(MetadataInputMixin, Schema):
     name: str | None = Field(
         default=None, description=_name_description, examples=[_name_example]
     )
-    billing_address: Address | None = None
+    billing_address: AddressInput | None = None
     tax_id: TaxID | None = None
     organization_id: OrganizationID | None = Field(
         default=None,
@@ -68,7 +68,7 @@ class CustomerUpdateBase(MetadataInputMixin, Schema):
     name: str | None = Field(
         default=None, description=_name_description, examples=[_name_example]
     )
-    billing_address: Address | None = None
+    billing_address: AddressInput | None = None
     tax_id: TaxID | None = None
 
 

--- a/server/polar/customer_portal/schemas/customer.py
+++ b/server/polar/customer_portal/schemas/customer.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from pydantic import UUID4, AfterValidator, TypeAdapter
 
-from polar.kit.address import Address
+from polar.kit.address import Address, AddressInput
 from polar.kit.http import get_safe_return_url
 from polar.kit.schemas import (
     ClassName,
@@ -35,7 +35,7 @@ class CustomerPortalCustomer(IDSchema, TimestampedSchema):
 
 class CustomerPortalCustomerUpdate(Schema):
     billing_name: Annotated[str | None, EmptyStrToNoneValidator] = None
-    billing_address: Address | None = None
+    billing_address: AddressInput | None = None
     tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
 
 

--- a/server/polar/kit/address.py
+++ b/server/polar/kit/address.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Annotated, Any, NotRequired, Self, TypedDict, 
 
 import pycountry
 from pydantic import BaseModel, BeforeValidator, Field, model_validator
+from pydantic.json_schema import WithJsonSchema
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.types import TypeDecorator
@@ -30,12 +31,35 @@ if TYPE_CHECKING:
 
     class CountryAlpha2(StrEnum):
         pass
-else:
-    CountryAlpha2 = StrEnum(
-        "CountryAlpha2", [(country, country) for country in SUPPORTED_COUNTRIES]
-    )
 
-CountryAlpha2Field = Annotated[CountryAlpha2, BeforeValidator(str.upper)]
+    class CountryAlpha2Input(StrEnum):
+        pass
+else:
+    CountryAlpha2 = Annotated[
+        StrEnum("CountryAlpha2", [(country, country) for country in ALL_COUNTRIES]),
+        WithJsonSchema(
+            {
+                "type": "string",
+                "title": "CountryAlpha2",
+                "enum": list(ALL_COUNTRIES),
+                "x-speakeasy-enums": list(ALL_COUNTRIES),
+            }
+        ),
+    ]
+    CountryAlpha2Input = Annotated[
+        StrEnum(
+            "CountryAlpha2Input",
+            [(country, country) for country in SUPPORTED_COUNTRIES],
+        ),
+        WithJsonSchema(
+            {
+                "type": "string",
+                "title": "CountryAlpha2Input",
+                "enum": list(SUPPORTED_COUNTRIES),
+                "x-speakeasy-enums": list(SUPPORTED_COUNTRIES),
+            }
+        ),
+    ]
 
 
 class USState(StrEnum):
@@ -120,7 +144,7 @@ class Address(BaseModel):
     postal_code: EmptyStrToNone | None = None
     city: EmptyStrToNone | None = None
     state: EmptyStrToNone | None = None
-    country: CountryAlpha2Field = Field(examples=["US", "SE", "FR"])
+    country: CountryAlpha2 = Field(examples=["US", "SE", "FR"])
 
     @model_validator(mode="after")
     def validate_state(self) -> Self:
@@ -190,6 +214,12 @@ class Address(BaseModel):
                 lines.append(self.country)
 
         return "\n".join(lines)
+
+
+class AddressInput(Address):
+    country: Annotated[CountryAlpha2Input, BeforeValidator(str.upper)] = Field(  # type: ignore
+        examples=["US", "SE", "FR"]
+    )
 
 
 class AddressType(TypeDecorator[Any]):

--- a/server/polar/kit/address.py
+++ b/server/polar/kit/address.py
@@ -1,14 +1,41 @@
 from enum import StrEnum
-from typing import Any, NotRequired, Self, TypedDict, cast
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired, Self, TypedDict, cast
 
 import pycountry
-from pydantic import BaseModel, Field, model_validator
-from pydantic_extra_types.country import CountryAlpha2
+from pydantic import BaseModel, BeforeValidator, Field, model_validator
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.types import TypeDecorator
 
 from polar.kit.schemas import EmptyStrToNone
+
+
+class CountryData:
+    alpha_2: str
+
+
+ALL_COUNTRIES: set[str] = {
+    cast(CountryData, country).alpha_2 for country in pycountry.countries
+}
+SUPPORTED_COUNTRIES: set[str] = ALL_COUNTRIES - {
+    # US Trade Embargos
+    "CU",
+    "IR",
+    "KP",
+    "SY",
+    "RU",
+}
+
+if TYPE_CHECKING:
+
+    class CountryAlpha2(StrEnum):
+        pass
+else:
+    CountryAlpha2 = StrEnum(
+        "CountryAlpha2", [(country, country) for country in SUPPORTED_COUNTRIES]
+    )
+
+CountryAlpha2Field = Annotated[CountryAlpha2, BeforeValidator(str.upper)]
 
 
 class USState(StrEnum):
@@ -93,7 +120,7 @@ class Address(BaseModel):
     postal_code: EmptyStrToNone | None = None
     city: EmptyStrToNone | None = None
     state: EmptyStrToNone | None = None
-    country: CountryAlpha2 = Field(examples=["US", "SE", "FR"])
+    country: CountryAlpha2Field = Field(examples=["US", "SE", "FR"])
 
     @model_validator(mode="after")
     def validate_state(self) -> Self:

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -9,7 +9,7 @@ from polar.custom_field.data import CustomFieldDataOutputMixin
 from polar.customer.schemas.customer import CustomerBase
 from polar.discount.schemas import DiscountMinimal
 from polar.exceptions import ResourceNotFound
-from polar.kit.address import Address
+from polar.kit.address import Address, AddressInput
 from polar.kit.metadata import MetadataOutputMixin
 from polar.kit.schemas import IDSchema, MergeJSONSchema, Schema, TimestampedSchema
 from polar.models.order import OrderBillingReason, OrderStatus
@@ -187,7 +187,7 @@ class OrderUpdateBase(Schema):
             "Can't be updated after the invoice is generated."
         )
     )
-    billing_address: Address | None = Field(
+    billing_address: AddressInput | None = Field(
         description=(
             "The address of the customer that should appear on the invoice. "
             "Can't be updated after the invoice is generated."

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -32,7 +32,7 @@ from polar.integrations.stripe.schemas import ProductType
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.integrations.stripe.utils import get_expandable_id
 from polar.invoice.service import invoice as invoice_service
-from polar.kit.address import Address
+from polar.kit.address import Address, AddressInput
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
@@ -1113,7 +1113,7 @@ class OrderService:
         if customer.billing_address is not None:
             billing_address = customer.billing_address
         elif not _is_empty_customer_address(invoice.customer_address):
-            billing_address = Address.model_validate(invoice.customer_address)
+            billing_address = AddressInput.model_validate(invoice.customer_address)
         # Try to retrieve the country from the payment method
         elif invoice.charge is not None:
             charge = await stripe_service.get_charge(get_expandable_id(invoice.charge))

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -36,7 +36,7 @@ from polar.enums import AccountType, PaymentProcessor, SubscriptionRecurringInte
 from polar.exceptions import PaymentNotReady, PolarRequestValidationError
 from polar.integrations.stripe.schemas import ProductType
 from polar.integrations.stripe.service import StripeService
-from polar.kit.address import Address
+from polar.kit.address import AddressInput
 from polar.kit.tax import (
     IncompleteTaxLocation,
     TaxabilityReason,
@@ -715,7 +715,7 @@ class TestCreate:
             session,
             CheckoutPriceCreate(
                 product_price_id=price.id,
-                customer_billing_address=Address.model_validate({"country": "FR"}),
+                customer_billing_address=AddressInput.model_validate({"country": "FR"}),
                 customer_tax_id="FR61954506077",
             ),
             auth_subject,
@@ -795,7 +795,7 @@ class TestCreate:
             session,
             CheckoutPriceCreate(
                 product_price_id=price.id,
-                customer_billing_address=Address.model_validate({"country": "US"}),
+                customer_billing_address=AddressInput.model_validate({"country": "US"}),
             ),
             auth_subject,
         )
@@ -826,7 +826,7 @@ class TestCreate:
             session,
             CheckoutPriceCreate(
                 product_price_id=price.id,
-                customer_billing_address=Address.model_validate({"country": "FR"}),
+                customer_billing_address=AddressInput.model_validate({"country": "FR"}),
             ),
             auth_subject,
         )
@@ -989,7 +989,7 @@ class TestCreate:
             session,
             CheckoutPriceCreate(
                 product_price_id=price.id,
-                customer_billing_address=Address.model_validate({"country": "FR"}),
+                customer_billing_address=AddressInput.model_validate({"country": "FR"}),
             ),
             auth_subject,
         )
@@ -1336,11 +1336,11 @@ class TestCreate:
         "address,require_billing_address",
         [
             (None, False),
-            (Address.model_validate({"country": "FR"}), False),
-            (Address.model_validate({"country": "FR", "city": "Lyon"}), True),
-            (Address.model_validate({"country": "CA", "state": "CA-QC"}), False),
+            (AddressInput.model_validate({"country": "FR"}), False),
+            (AddressInput.model_validate({"country": "FR", "city": "Lyon"}), True),
+            (AddressInput.model_validate({"country": "CA", "state": "CA-QC"}), False),
             (
-                Address.model_validate(
+                AddressInput.model_validate(
                     {"country": "CA", "state": "CA-QC", "city": "Quebec"}
                 ),
                 True,
@@ -1353,7 +1353,7 @@ class TestCreate:
     )
     async def test_implicit_require_billing_address(
         self,
-        address: Address | None,
+        address: AddressInput | None,
         require_billing_address: bool,
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
@@ -2055,7 +2055,7 @@ class TestUpdate:
             locker,
             checkout_one_time_custom,
             CheckoutUpdate(
-                customer_billing_address=Address.model_validate({"country": "FR"}),
+                customer_billing_address=AddressInput.model_validate({"country": "FR"}),
                 customer_tax_id="FR61954506077",
             ),
         )
@@ -2078,7 +2078,7 @@ class TestUpdate:
             locker,
             checkout_one_time_custom,
             CheckoutUpdate(
-                customer_billing_address=Address.model_validate({"country": "US"}),
+                customer_billing_address=AddressInput.model_validate({"country": "US"}),
                 customer_tax_id=None,
             ),
         )
@@ -2104,7 +2104,7 @@ class TestUpdate:
             locker,
             checkout_one_time_fixed,
             CheckoutUpdate(
-                customer_billing_address=Address.model_validate({"country": "US"}),
+                customer_billing_address=AddressInput.model_validate({"country": "US"}),
             ),
         )
 
@@ -2132,7 +2132,7 @@ class TestUpdate:
             locker,
             checkout_one_time_fixed,
             CheckoutUpdate(
-                customer_billing_address=Address.model_validate({"country": "FR"}),
+                customer_billing_address=AddressInput.model_validate({"country": "FR"}),
             ),
         )
 
@@ -2305,7 +2305,7 @@ class TestUpdate:
             locker,
             checkout_tax_not_applicable,
             CheckoutUpdate(
-                customer_billing_address=Address.model_validate({"country": "FR"}),
+                customer_billing_address=AddressInput.model_validate({"country": "FR"}),
             ),
         )
 

--- a/server/tests/checkout/test_tax.py
+++ b/server/tests/checkout/test_tax.py
@@ -1,5 +1,4 @@
 import pytest
-from pydantic_extra_types.country import CountryAlpha2
 
 from polar.kit.tax import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
 
@@ -26,9 +25,7 @@ from polar.kit.tax import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("234567899", "CA", ("234567899", TaxIDFormat.ca_bn)),
     ],
 )
-def test_validate_tax_id_valid(
-    number: str, country: CountryAlpha2, expected: TaxID
-) -> None:
+def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:
     validated_tax_id = validate_tax_id(number, country)
     assert validated_tax_id == expected
 
@@ -42,6 +39,6 @@ def test_validate_tax_id_valid(
         ("GB980780684", "foo"),
     ],
 )
-def test_validate_tax_id_invalid(number: str, country: CountryAlpha2) -> None:
+def test_validate_tax_id_invalid(number: str, country: str) -> None:
     with pytest.raises(InvalidTaxID):
         validate_tax_id(number, country)

--- a/server/tests/customer_portal/service/test_customer.py
+++ b/server/tests/customer_portal/service/test_customer.py
@@ -7,7 +7,7 @@ from polar.customer_portal.schemas.customer import CustomerPortalCustomerUpdate
 from polar.customer_portal.service.customer import customer as customer_service
 from polar.exceptions import PolarRequestValidationError
 from polar.integrations.stripe.service import StripeService
-from polar.kit.address import Address, CountryAlpha2
+from polar.kit.address import Address, AddressInput, CountryAlpha2, CountryAlpha2Input
 from polar.kit.tax import TaxIDFormat
 from polar.models import Organization
 from polar.postgres import AsyncSession
@@ -83,7 +83,7 @@ class TestUpdate:
                 session,
                 customer,
                 CustomerPortalCustomerUpdate(
-                    billing_address=Address(country=CountryAlpha2("GB")),
+                    billing_address=AddressInput(country=CountryAlpha2Input("GB")),
                 ),
             )
 
@@ -122,7 +122,7 @@ class TestUpdate:
             customer,
             CustomerPortalCustomerUpdate(
                 billing_name="Polar Software Inc.",
-                billing_address=Address(country=CountryAlpha2("FR")),
+                billing_address=AddressInput(country=CountryAlpha2Input("FR")),
                 tax_id="FR61954506077",
             ),
         )

--- a/server/tests/customer_portal/service/test_customer.py
+++ b/server/tests/customer_portal/service/test_customer.py
@@ -1,14 +1,13 @@
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic_extra_types.country import CountryAlpha2
 from pytest_mock import MockerFixture
 
 from polar.customer_portal.schemas.customer import CustomerPortalCustomerUpdate
 from polar.customer_portal.service.customer import customer as customer_service
 from polar.exceptions import PolarRequestValidationError
 from polar.integrations.stripe.service import StripeService
-from polar.kit.address import Address
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.tax import TaxIDFormat
 from polar.models import Organization
 from polar.postgres import AsyncSession

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -3,10 +3,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pydantic_extra_types.country import CountryAlpha2
 
 from polar.invoice.generator import Invoice, InvoiceGenerator, InvoiceItem
-from polar.kit.address import Address
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.tax import TaxabilityReason
 
 

--- a/server/tests/invoice/test_service.py
+++ b/server/tests/invoice/test_service.py
@@ -1,8 +1,7 @@
 import pytest
-from pydantic_extra_types.country import CountryAlpha2
 
 from polar.invoice.service import invoice as invoice_service
-from polar.kit.address import Address
+from polar.kit.address import Address, CountryAlpha2
 from polar.models import Customer, Product
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_order

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -8,7 +8,6 @@ import pytest
 import pytest_asyncio
 import stripe as stripe_lib
 from freezegun import freeze_time
-from pydantic_extra_types.country import CountryAlpha2
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import joinedload
 
@@ -18,7 +17,7 @@ from polar.enums import PaymentProcessor, SubscriptionRecurringInterval
 from polar.held_balance.service import held_balance as held_balance_service
 from polar.integrations.stripe.schemas import ProductType
 from polar.integrations.stripe.service import StripeService
-from polar.kit.address import Address
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.math import polar_round
 from polar.kit.pagination import PaginationParams

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -4,13 +4,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic_extra_types.country import CountryAlpha2
 from pytest_mock import MockerFixture
 
 from polar.config import settings
 from polar.exceptions import PolarRequestValidationError
 from polar.integrations.stripe.service import StripeService
-from polar.kit.address import Address
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.utils import utc_now
 from polar.locker import Locker
 from polar.models import Organization, Transaction, User


### PR DESCRIPTION
- server/kit/address: add an AddressInput variant to handle restricted countries we have in DB + add Speakeasy enum
- Reapply "server/kit/address: use defined enum for country field"