### PR TITLE
Fix for issue #6780 : benefits: file upload of 2 GB fails

### DIFF
--- a/clients/apps/web/src/components/FileUpload/index.ts
+++ b/clients/apps/web/src/components/FileUpload/index.ts
@@ -10,16 +10,13 @@ export type FileObject<
 > = T & {
   isUploading: boolean
   uploadedBytes: number
-  buffer?: ArrayBuffer
 }
 
 const buildFileObject = <T extends FileRead | schemas['FileUpload']>(
   file: T,
-  buffer?: ArrayBuffer,
 ): FileObject<T> => {
   return {
     ...file,
-    buffer,
     isUploading: false,
     uploadedBytes: file.is_uploaded ? file.size : 0,
   }
@@ -54,6 +51,10 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
     buildFileObjects(initialFiles) as unknown as FileObject<T>[],
   )
 
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [lastError, setLastError] = useState<string | null>(null)
+  const [totalUploadingFiles, setTotalUploadingFiles] = useState(0)
+
   const setFiles = (callback: (prev: FileObject<T>[]) => FileObject<T>[]) => {
     setFilesState((prev) => {
       const updated = callback(prev)
@@ -84,11 +85,8 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
     })
   }
 
-  const onFileCreate = (
-    response: schemas['FileUpload'],
-    buffer: ArrayBuffer,
-  ) => {
-    const newFile = buildFileObject(response, buffer)
+  const onFileCreate = (response: schemas['FileUpload']) => {
+    const newFile = buildFileObject(response)
     newFile.isUploading = true
     setFiles((prev) => {
       return [...prev, newFile as unknown as FileObject<T>]
@@ -118,30 +116,73 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
     })
   }
 
-  const onDrop = (acceptedFiles: File[], fileRejections: FileRejection[]) => {
-    for (const file of acceptedFiles) {
-      const reader = new FileReader()
-      reader.onload = async () => {
-        const buffer = reader.result
-        if (buffer instanceof ArrayBuffer) {
-          const upload = new Upload({
-            service,
-            organization,
-            file,
-            buffer,
-            onFileCreate,
-            onFileUploadProgress,
-            onFileUploaded,
-          })
-          await upload.run()
-        }
+  const onDrop = async (
+    acceptedFiles: File[],
+    fileRejections: FileRejection[],
+  ) => {
+    if (acceptedFiles.length === 0 && fileRejections.length > 0) {
+      setLastError('Some files were rejected. See console for details.')
+      if (onFilesRejected) {
+        onFilesRejected(fileRejections)
       }
-      reader.readAsArrayBuffer(file)
+      return
     }
 
-    if (onFilesRejected) {
-      onFilesRejected(fileRejections)
+    setIsProcessing(true)
+    setLastError(null)
+    setTotalUploadingFiles(acceptedFiles.length)
+
+    const uploadPromises = acceptedFiles.map(async (file) => {
+      const upload = new Upload({
+        service,
+        organization,
+        file,
+        onFileCreate,
+        onFileUploadProgress,
+        onFileUploaded,
+        onError: (msg, error) => {
+          console.error(`Upload failed for ${file.name}: ${msg}`, error)
+          return false
+        },
+      })
+      return { file, result: await upload.run() }
+    })
+
+    const results = await Promise.allSettled(uploadPromises)
+    const errors = results
+      .filter((result) => result.status === 'rejected' || !result.value.result)
+      .map((result) => {
+        if (result.status === 'rejected') {
+          return {
+            fileName: (result as any).value?.file?.name || 'Unknown file',
+            error: (result as PromiseRejectedResult).reason.toString(),
+          }
+        }
+        return {
+          fileName: result.value.file.name,
+          error: 'Upload failed',
+        }
+      })
+
+    if (errors.length > 0) {
+      setLastError(
+        `Failed to upload ${errors.length} file(s). See details below.`,
+      )
     }
+
+    if (fileRejections.length > 0) {
+      setLastError((prev) =>
+        prev
+          ? `${prev} Some files were rejected.`
+          : 'Some files were rejected. See console for details.',
+      )
+      if (onFilesRejected) {
+        onFilesRejected(fileRejections)
+      }
+    }
+
+    setIsProcessing(false)
+    setTotalUploadingFiles(0)
   }
 
   const dropzone = useDropzone({
@@ -155,6 +196,9 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
     setFiles,
     updateFile,
     removeFile,
+    isProcessing,
+    lastError,
+    totalUploadingFiles,
     ...dropzone,
   }
 }

--- a/server/polar/file/schemas.py
+++ b/server/polar/file/schemas.py
@@ -26,6 +26,12 @@ class DownloadableFileCreate(FileCreateBase):
     """Schema to create a file to be associated with the downloadables benefit."""
 
     service: Literal[FileServiceTypes.downloadable]
+    size: int = Field(
+        description=(
+            "Size of the file. A maximum of 10 GB is allowed for downloadable files."
+        ),
+        le=10 * 1024 * 1024 * 1024,
+    )
 
 
 class ProductMediaFileCreate(FileCreateBase):


### PR DESCRIPTION
### Description
This PR fixes issue #6780 where file uploads larger than 2 GB were failing.

Closes #6780

### Changes
- Updated upload handler to slice directly from the `File` object per chunk (no full-file reads).
- Removed whole-file checksum at create; compute per-chunk SHA‑256 instead.
- Optimized memory usage during multipart uploads (O(chunk) instead of O(file)).
- Added loader and surfaced error state in the UI while processing.
- Increased downloadable files limit to 10 GB (frontend maxSize, backend validation).

### Testing
- Uploaded files of 50 MB, 1 GB, 2 GB and 6GB successfully.
- Verified smaller files still work as expected.

https://github.com/user-attachments/assets/5d5f5ff6-60cc-42de-8ccd-13fd8848f510



