### PR TITLE
Fix for issue #6864: hide navigation on Customer Portal sign-in page

### DIFF
--- a/clients/apps/web/src/app/(main)/[organization]/portal/Navigation.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/Navigation.tsx
@@ -47,6 +47,15 @@ export const Navigation = ({
   const currentPath = usePathname()
   const searchParams = useSearchParams()
 
+  // Hide navigation on routes where portal access is being requested or authenticated
+  const hideNav =
+    currentPath.endsWith('/portal/request') ||
+    currentPath.endsWith('/portal/authenticate')
+
+  if (hideNav) {
+    return null
+  }
+
   const buildPath = (path: string) => {
     return `${path}?${searchParams.toString()}`
   }
@@ -63,7 +72,7 @@ export const Navigation = ({
             className={twMerge(
               'dark:text-polar-500 dark:hover:bg-polar-800 border border-transparent px-4 py-2 font-medium text-gray-500 transition-colors duration-75 hover:bg-gray-100',
               link.isActive(currentPath) &&
-                themePreset.polar.customerPortalNavigationItemActive,
+              themePreset.polar.customerPortalNavigationItemActive,
               themePreset.polar.customerPortalNavigationItem,
             )}
             prefetch


### PR DESCRIPTION
## 📋 Summary
**Related Issue:** Fixes #6864 (Customer Portal navigation visible on request/authenticate pages)

### 🎯 What
Hide the customer portal navigation on:
- `/:organization/portal/request`
- `/:organization/portal/authenticate`

Keep navigation visible for all other customer portal routes.

### 🤔 Why
- These routes are pre-auth entry points and don’t need the sidebar.  
- On mobile, the nav collapsed into a dropdown with no active item, which looked broken.  
- Improves UX consistency for the authentication flow.

### 🔧 How
- Updated `Navigation.tsx` to return `null` when `usePathname()` ends with `/portal/request` or `/portal/authenticate`.  

### 🧪 Testing
- [x] I have tested these changes locally  
- [x] All existing tests pass (`pnpm test` for frontend)  
- [x] I have run linting and type checking  

**Test Instructions:**
1. Go to `/:organization/portal/request` → verify no sidebar or mobile dropdown is shown.  
2. Submit an email → you should be redirected to `/:organization/portal/authenticate`. Verify no sidebar or mobile dropdown is shown there either.  
3. After entering a valid code and being redirected to the portal (e.g., `/:organization/portal/overview`), verify the navigation appears and the correct item highlights.  
4. Check mobile view → ensure no empty select is shown on the two auth-related pages.  

### 🖼️ Screenshots/Recordings
**Before:** Request/authenticate pages display sidebar or empty mobile dropdown.  
<img width="1899" height="1030" alt="image" src="https://github.com/user-attachments/assets/fcfffae4-009f-431c-864b-7b9aae372af2" />

**After:** No navigation shown on those pages; normal on all other portal routes.  
<img width="1903" height="1052" alt="image" src="https://github.com/user-attachments/assets/1f496ac7-e4f0-4472-aaf3-1954797b7dcf" />

---

**Changes touched:**
- `clients/apps/web/src/app/(main)/[organization]/portal/Navigation.tsx`
