### PR TITLE
fix(docker): Correct internal container port mapping

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   redis:
     image: redis
     ports:
-      - "${POLAR_REDIS_PORT}:${POLAR_REDIS_PORT}"
+      - "${POLAR_REDIS_PORT}:6379"
 
   db:
     image: postgres:15.1-bullseye
@@ -17,7 +17,7 @@ services:
       - postgres_data:/var/lib/postgresql/data/
       - ./init-readonly-user.sql:/docker-entrypoint-initdb.d/init-readonly-user.sql
     ports:
-      - "${POLAR_POSTGRES_PORT}:${POLAR_POSTGRES_PORT}"
+      - "${POLAR_POSTGRES_PORT}:5432"
     expose:
       - ${POLAR_POSTGRES_PORT}
     healthcheck:


### PR DESCRIPTION
The Redis and PostgreSQL containers listen on fixed internal ports (6379 and 5432, respectively). The previous docker-compose configuration incorrectly mapped the dynamic host port to the internal port, causing a mismatch if the host port was not the default. This PR updates the mapping to point the host port to the correct, static internal port for both the services.

Fixes #7013