### PR TITLE
server/meter: fix filter clause when trying to work with non-integer numbers

### DIFF
--- a/server/polar/meter/filter.py
+++ b/server/polar/meter/filter.py
@@ -71,9 +71,9 @@ class FilterClause(BaseModel):
             # The property is a number
             (
                 func.jsonb_typeof(attr) == "number",
-                # Compare it with the value if it's an integer
-                self._get_comparison_clause(attr.as_integer(), self._get_number_value())
-                if isinstance(self.value, int)
+                # Compare it with the value if it's a number
+                self._get_comparison_clause(attr.as_float(), self._get_number_value())
+                if isinstance(self.value, int | float)
                 # Otherwise return false
                 else false(),
             ),

--- a/server/tests/meter/test_filter.py
+++ b/server/tests/meter/test_filter.py
@@ -215,3 +215,37 @@ class TestFilter:
         matching_events = await repository.get_all(statement)
 
         assert len(matching_events) == 2
+
+    async def test_number_comparisons_clause(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        events = [
+            await create_event(
+                save_fixture,
+                organization=organization,
+                external_customer_id="customer_1",
+                metadata={"value": 0.01},
+            ),
+            await create_event(
+                save_fixture,
+                organization=organization,
+                external_customer_id="customer_1",
+                metadata={"value": 10},
+            ),
+        ]
+        filter = Filter(
+            conjunction=FilterConjunction.and_,
+            clauses=[
+                FilterClause(property="value", operator=FilterOperator.gt, value=1)
+            ],
+        )
+
+        repository = EventRepository.from_session(session)
+        statement = repository.get_base_statement().where(filter.get_sql_clause(Event))
+        matching_events = await repository.get_all(statement)
+
+        assert len(matching_events) == 1
+        assert matching_events[0].id == events[1].id


### PR DESCRIPTION
Fix #7048

- server/meter: fix filter clause when trying to work with non-integer numbers
