### PR TITLE
Check for `expires_at` when activating license keys

### DIFF
--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -230,6 +230,10 @@ class LicenseKeyService:
                 "This license key can not be activated."
             )
 
+        if license_key.expires_at:
+            if utc_now() >= license_key.expires_at:
+                raise NotPermitted("License key has expired.")
+
         if not license_key.limit_activations:
             raise NotPermitted(
                 "This license key does not support activations. "


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #7042

## 🎯 What

Adds a check for `expires_at` when activating a license key

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
