### PR TITLE
server/refund: don't try to revert tax transaction if no tax has been collected

### DIFF
--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -542,7 +542,7 @@ class RefundService(ResourceServiceReader[Refund]):
             )
 
             # Revert the tax transaction in the tax processor ledger
-            if order.tax_transaction_processor_id:
+            if order.tax_transaction_processor_id and order.tax_amount > 0:
                 if refund.total_amount == order.total_amount:
                     tax_transaction_processor = (
                         await stripe_service.revert_tax_transaction(


### PR DESCRIPTION
Fix #7070

- server/refund: don't try to revert tax transaction if no tax has been collected
