### PR TITLE
Bypass middleware on `/ingest` routes

### DIFF
--- a/clients/apps/web/src/middleware.ts
+++ b/clients/apps/web/src/middleware.ts
@@ -68,10 +68,11 @@ export const config = {
     /*
      * Match all request paths except for the ones starting with:
      * - api (API routes)
+     * - ingest (Posthog)
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+    '/((?!api|ingest|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 }


### PR DESCRIPTION
Related to Sentry DASHBOARD-1FH