### PR TITLE
Fix for issue #6780 : benefits: file upload of 2 GB fails with correc…

### DIFF
--- a/server/polar/file/schemas.py
+++ b/server/polar/file/schemas.py
@@ -26,6 +26,12 @@ class DownloadableFileCreate(FileCreateBase):
     """Schema to create a file to be associated with the downloadables benefit."""
 
     service: Literal[FileServiceTypes.downloadable]
+    size: int = Field(
+        description=(
+            "Size of the file. A maximum of 10 GB is allowed for downloadable files."
+        ),
+        le=10 * 1024 * 1024 * 1024,
+    )
 
 
 class ProductMediaFileCreate(FileCreateBase):


### PR DESCRIPTION
### Description
This PR fixes issue #6780 where file uploads larger than 2 GB were failing.

Closes #6780

### Changes
- Updated upload handler to slice directly from the `File` object per chunk (no full-file reads).
- Removed whole-file checksum at create; compute per-chunk SHA‑256 instead.
- Optimized memory usage during multipart uploads (O(chunk) instead of O(file)).
- Added loader and surfaced error state in the UI while processing.
- Increased downloadable files limit to 10 GB (frontend maxSize, backend validation).
- Removed the `buffer` and implemented through `file` instead in `Upload.ts`

### Testing
- Uploaded files of 50 MB, 1 GB, 2 GB and 6GB successfully.
- Verified smaller files still work as expected.

https://github.com/user-attachments/assets/5d5f5ff6-60cc-42de-8ccd-13fd8848f510
