### PR TITLE
Add exponential back-off retries to checkout rendering code

### DIFF
--- a/clients/apps/web/src/app/checkout/[clientSecret]/confirmation/page.tsx
+++ b/clients/apps/web/src/app/checkout/[clientSecret]/confirmation/page.tsx
@@ -28,7 +28,24 @@ export default async function Page(props: {
     ok,
     value: checkout,
     error,
-  } = await checkoutsClientGet(client, { clientSecret })
+  } = await checkoutsClientGet(
+    client,
+    {
+      clientSecret,
+    },
+    {
+      retries: {
+        strategy: 'backoff',
+        backoff: {
+          initialInterval: 200,
+          maxInterval: 2000,
+          exponent: 2,
+          maxElapsedTime: 15_000,
+        },
+        retryConnectionErrors: true,
+      },
+    },
+  )
 
   if (!ok) {
     if (error instanceof ResourceNotFound) {


### PR DESCRIPTION
Try to fix infrequent flakey checkouts by retrying on connection errors. We have about ± 10 occurrences per week, let's see if this fixes it.