### PR TITLE
Link Correction

### DIFF
--- a/docs/guides/subscription-downgrades.mdx
+++ b/docs/guides/subscription-downgrades.mdx
@@ -38,7 +38,7 @@ description: "Learn how to downgrade a subscription as a merchant or a customer.
 </Steps>
 
 <Info>
-    Note that merchants can disable customer-level upgrades or downgrades in the portal [by toggling OFF **Allow price change** setting](/docs/guides/disable-subscription-changes-in-customer-portal). 
+    Note that merchants can disable customer-level upgrades or downgrades in the portal [by toggling OFF **Allow price change** setting](/guides/disable-subscription-changes-in-customer-portal). 
 </Info>
 
 ## Downgrading a subscription as a customer


### PR DESCRIPTION
The link to "How to disable subscription upgrades/downgrades in customer portal" is not working in downgrades guide. Corrected it.