### PR TITLE
Tweak Logfire reporting

### DIFF
--- a/server/polar/logging.py
+++ b/server/polar/logging.py
@@ -94,6 +94,7 @@ class Logging[RendererType]:
                             "dramatiq",
                             "authlib",
                             "logfire",
+                            "apscheduler",
                         ]
                     },
                 },

--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -153,6 +153,8 @@ broker = RedisBroker(
     ],
 )
 
+broker.add_middleware(LogfireMiddleware())
+broker.add_middleware(LogContextMiddleware())
 broker.add_middleware(
     middleware.Retries(
         max_retries=settings.WORKER_MAX_RETRIES,
@@ -166,8 +168,6 @@ broker.add_middleware(MaxRetriesMiddleware())
 broker.add_middleware(SQLAlchemyMiddleware())
 broker.add_middleware(RedisMiddleware())
 broker.add_middleware(scheduler_middleware)
-broker.add_middleware(LogfireMiddleware())
-broker.add_middleware(LogContextMiddleware())
 dramatiq.set_broker(broker)
 dramatiq.set_encoder(JSONEncoder())
 


### PR DESCRIPTION

- server/worker: put logfire middleware first so it wraps retry messages inside the span
- server/worker: improve Logfire reports for scheduler process
  