### PR TITLE
Allow proceeding after clearing invalid discount code

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -190,6 +190,12 @@ const BaseCheckoutForm = ({
     } catch {}
   }, [update, clearErrors, resetField])
 
+  useEffect(() => {
+    if (!discountCode && !checkout.discount) {
+      clearErrors('discountCode')
+    }
+  }, [discountCode, checkout.discount, clearErrors])
+
   const updateBusinessCustomer = useCallback(
     async (isBusinessCustomer: boolean) => {
       try {


### PR DESCRIPTION
If you tried to apply an invalid discount code, you couldn't proceed with the checkout even if you cleared the discount input.