### PR TITLE
fix: wrap long title text in products view

### DIFF
--- a/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
@@ -120,7 +120,7 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
           <div className="flex flex-row items-center gap-6">
             <div className="flex flex-row items-center gap-4">
               <ProductThumbnail product={product} />
-              <h1 className="text-2xl">{product.name}</h1>
+              <h1 className="text-2xl text-wrap">{product.name}</h1>
             </div>
             <div className="flex flex-row items-center gap-4">
               <Status


### PR DESCRIPTION
> From [the ticket](https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01K7957CAYX7FST4HS818HS769/)

fix the following:

<img width="889" height="713" alt="Screenshot 2025-10-11 at 3 35 12 PM" src="https://github.com/user-attachments/assets/54eddb1d-f492-4ba7-8fb4-b3307d9d623d" />
