### PR TITLE
Create meters for new customers if there are existing events

### DIFF
--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator, Iterable, Sequence
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Select, exists, func, select, update
+from sqlalchemy import Select, func, select, update
 
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
 from polar.kit.repository import (
@@ -12,7 +12,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionMixin,
 )
 from polar.kit.utils import utc_now
-from polar.models import Customer, Event, UserOrganization
+from polar.models import Customer, UserOrganization
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.worker import enqueue_job
 
@@ -42,20 +42,10 @@ class CustomerRepository(
         yield customer
         assert customer.id is not None, "Customer.id is None"
 
-        # If the customer has an external_id, check if there are existing events
-        # for that external_id. If so, touch meters to trigger meter calculations.
+        # If the customer has an external_id, enqueue a meter update job
+        # to create meters for any pre-existing events with that external_id.
         if customer.external_id is not None:
-            has_events_statement = select(
-                exists(
-                    select(1).where(
-                        Event.external_customer_id == customer.external_id,
-                        Event.organization_id == customer.organization_id,
-                    )
-                )
-            )
-            has_events = await self.session.scalar(has_events_statement)
-            if has_events:
-                await self.touch_meters([customer])
+            enqueue_job("customer_meter.update_customer", customer.id)
 
         enqueue_job("customer.webhook", WebhookEventType.customer_created, customer.id)
 


### PR DESCRIPTION
Customers with pre-existing events for their external_id will not have meters linked until they ingest another event. This fixes that.

This code errs on the safe side of things to only run when it will be relevant because I didn't want to stray too much from the current implementation. Maybe that's unnecessary and we can skip the `has_events` logic and just run `touch_meters` always (or when there's an `external_id` – if `external_id` is not null the meters will definitely all be empty)
