### PR TITLE
"Get started with metering" code snippet doesn't work on the Meter Page (Sandbox)

### DIFF
--- a/clients/apps/web/src/components/Meter/MeterGetStarted.tsx
+++ b/clients/apps/web/src/components/Meter/MeterGetStarted.tsx
@@ -1,5 +1,5 @@
-import { schemas } from '@polar-sh/client'
 import { CONFIG } from '@/utils/config'
+import { schemas } from '@polar-sh/client'
 
 import {
   SyntaxHighlighterClient,
@@ -53,8 +53,12 @@ export const MeterGetStarted = ({ meter }: MeterGetStartedProps) => {
             code={`import { Polar } from "@polar-sh/sdk";
 
 const polar = new Polar({
-  accessToken: process.env["POLAR_ACCESS_TOKEN"] ?? "",${CONFIG.IS_SANDBOX ? `
-  server: "sandbox",` : ''}
+  accessToken: process.env["POLAR_ACCESS_TOKEN"] ?? "",${
+    CONFIG.IS_SANDBOX
+      ? `
+  server: "sandbox",`
+      : ''
+  }
 });
 
 export const GET = async (req: Request, res: Response) => {


### PR DESCRIPTION
## 📋 Summary

Hey Team,

I've noticed, that for `sandbox` web interface, the meter code snippet from Meter Page (`https://sandbox.polar.sh/dashboard/{orgId}/usage-billing/meters?selectedMeter={meterId}`) doesn't work.


<img width="1388" height="1065" alt="image" src="https://github.com/user-attachments/assets/0ef9edad-e0ed-4639-a59b-397d7e83da98" />


It throws with the following issue, even though the TOKEN is valid.
```
API error occurred: Status 401
Body: {"error": "invalid_token", "error_description": "The access token provided is expired, revoked, malformed, or invalid for other reasons."}
```

It's likely because of default `server` points to `production`, rather than `sandbox`. Defining it in config does the trick:

```
const polar = new Polar({
    accessToken: "{TOKEN}",
    server: "sandbox"
});
```

The following PR changes extend the page code snippet with the missing field (`server: 'sandbox'`) in SDK configuration. 
