### PR TITLE
server/alembic: avoid Alembic to treat percent-encoded characters in SQLAlchemy URL as interpolation markers.

### DIFF
--- a/server/migrations/env.py
+++ b/server/migrations/env.py
@@ -23,7 +23,11 @@ if config.config_file_name is not None:
 # target_metadata = mymodel.Base.metadata
 target_metadata = Model.metadata
 
-config.set_main_option("sqlalchemy.url", settings.get_postgres_dsn("asyncpg"))
+config.set_main_option(
+    "sqlalchemy.url",
+    # Escape %-encoding signs to avoid Alembic treating them as interpolation markers
+    settings.get_postgres_dsn("asyncpg").replace("%", "%%"),
+)
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/server/scripts/db.py
+++ b/server/scripts/db.py
@@ -13,7 +13,8 @@ cli = typer.Typer()
 
 
 def get_sync_postgres_dsn() -> str:
-    return str(settings.get_postgres_dsn("psycopg2"))
+    # Escape %-encoding signs to avoid Alembic treating them as interpolation markers
+    return settings.get_postgres_dsn("psycopg2").replace("%", "%%")
 
 
 def get_config() -> Config:


### PR DESCRIPTION
- server/alembic: avoid Alembic to treat percent-encoded characters in SQLAlchemy URL as interpolation markers.