### PR TITLE
feat(orders): Add export button and export API

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/ClientPage.tsx
@@ -6,6 +6,7 @@ import { OrderStatus } from '@/components/Orders/OrderStatus'
 import ProductSelect from '@/components/Products/ProductSelect'
 import { useMetrics } from '@/hooks/queries/metrics'
 import { useOrders } from '@/hooks/queries/orders'
+import { getServerURL } from '@/utils/api'
 import {
   DataTablePaginationState,
   DataTableSortingState,
@@ -13,8 +14,10 @@ import {
   serializeSearchParams,
 } from '@/utils/datatable'
 import { getChartRangeParams } from '@/utils/metrics'
+import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import Avatar from '@polar-sh/ui/components/atoms/Avatar'
+import Button from '@polar-sh/ui/components/atoms/Button'
 import {
   DataTable,
   DataTableColumnDef,
@@ -246,6 +249,16 @@ const ClientPage: React.FC<ClientPageProps> = ({
     product_id: productId,
   })
 
+  const onExport = () => {
+    const productIds =
+      productId?.map((id) => `&product_id=${id}`).join('') || ''
+    const url = new URL(
+      `${getServerURL()}/v1/orders/export?organization_id=${organization.id}${productIds}`,
+    )
+
+    window.open(url, '_blank')
+  }
+
   return (
     <DashboardBody wide>
       <div className="flex flex-col gap-8">
@@ -259,6 +272,15 @@ const ClientPage: React.FC<ClientPageProps> = ({
               includeArchived
             />
           </div>
+          <Button
+            onClick={onExport}
+            className="flex flex-row items-center"
+            variant={'secondary'}
+            wrapperClassNames="gap-x-2"
+          >
+            <FileDownloadOutlined fontSize="inherit" />
+            <span>Export</span>
+          </Button>
         </div>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <MiniMetricChartBox

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -1,10 +1,14 @@
-from fastapi import Depends, Query
+from collections.abc import AsyncGenerator
+
+from fastapi import Depends, Query, Response
+from fastapi.responses import StreamingResponse
 from pydantic import UUID4
 
 from polar.customer.schemas.customer import CustomerID
 from polar.exceptions import ResourceNotFound
+from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
-from polar.kit.pagination import ListResource, PaginationParamsQuery
+from polar.kit.pagination import ListResource, PaginationParams, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.models import Order
 from polar.models.product import ProductBillingType
@@ -85,6 +89,63 @@ async def list(
         [OrderSchema.model_validate(result) for result in results],
         count,
         pagination,
+    )
+
+
+@router.get("/export", summary="Export Subscriptions")
+async def export(
+    auth_subject: auth.OrdersRead,
+    organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
+        None, title="OrganizationID Filter", description="Filter by organization ID."
+    ),
+    product_id: MultipleQueryFilter[ProductID] | None = Query(
+        None, title="ProductID Filter", description="Filter by product ID."
+    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> Response:
+    """Export orders as a CSV file."""
+
+    async def create_csv() -> AsyncGenerator[str, None]:
+        csv_writer = IterableCSVWriter(dialect="excel")
+        # CSV header
+        yield csv_writer.getrow(
+            (
+                "Email",
+                "Created At",
+                "Product",
+                "Amount",
+                "Currency",
+                "Status",
+                "Invoice number",
+            )
+        )
+
+        (results, _) = await order_service.list(
+            session,
+            auth_subject,
+            organization_id=organization_id,
+            product_id=product_id,
+            pagination=PaginationParams(limit=1000000, page=1),
+        )
+
+        for order in results:
+            yield csv_writer.getrow(
+                (
+                    order.customer.email,
+                    order.created_at.isoformat(),
+                    order.product.name,
+                    order.net_amount / 100,
+                    order.currency,
+                    order.status,
+                    order.invoice_number,
+                )
+            )
+
+    filename = "polar-orders.csv"
+    return StreamingResponse(
+        create_csv(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
     )
 
 

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -167,6 +167,120 @@ class TestGetOrder:
 
 
 @pytest.mark.asyncio
+class TestExportOrders:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/orders/export")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_not_organization_member(
+        self, client: AsyncClient, orders: list[Order]
+    ) -> None:
+        response = await client.get("/v1/orders/export")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv; charset=utf-8"
+        assert (
+            response.headers["content-disposition"]
+            == "attachment; filename=polar-orders.csv"
+        )
+
+        # Should only have header row since user is not a member
+        csv_lines = response.text.strip().split("\r\n")
+        assert len(csv_lines) == 1
+        assert (
+            csv_lines[0]
+            == "Email,Created At,Product,Amount,Currency,Status,Invoice number"
+        )
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes={Scope.orders_read}),
+    )
+    async def test_user_valid(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        orders: list[Order],
+    ) -> None:
+        response = await client.get("/v1/orders/export")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv; charset=utf-8"
+        assert (
+            response.headers["content-disposition"]
+            == "attachment; filename=polar-orders.csv"
+        )
+
+        csv_lines = response.text.strip().split("\r\n")
+        assert len(csv_lines) == len(orders) + 1  # +1 for header
+
+        # Verify header
+        assert (
+            csv_lines[0]
+            == "Email,Created At,Product,Amount,Currency,Status,Invoice number"
+        )
+
+        # Verify data row contains expected fields
+        order = orders[0]
+        data_row = csv_lines[1]
+        assert order.customer.email in data_row
+        assert order.product.name in data_row
+        assert order.currency in data_row
+        assert order.status.value in data_row
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="organization", scopes={Scope.orders_read}),
+    )
+    async def test_organization(self, client: AsyncClient, orders: list[Order]) -> None:
+        response = await client.get("/v1/orders/export")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv; charset=utf-8"
+
+        csv_lines = response.text.strip().split("\r\n")
+        assert len(csv_lines) == len(orders) + 1
+
+    @pytest.mark.auth
+    async def test_filter_by_product(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        order1 = await create_order(
+            save_fixture,
+            stripe_invoice_id="INVOICE_1",
+            product=product,
+            customer=customer,
+        )
+        order2 = await create_order(
+            save_fixture,
+            stripe_invoice_id="INVOICE_2",
+            product=product_second,
+            customer=customer,
+        )
+
+        # Filter by product - should only get order1
+        response = await client.get(
+            "/v1/orders/export",
+            params={"product_id": str(product.id)},
+        )
+
+        assert response.status_code == 200
+        csv_lines = response.text.strip().split("\r\n")
+        assert len(csv_lines) == 2  # Header + 1 order
+
+        # Verify only the filtered order is in the export by checking invoice numbers
+        assert order1.invoice_number in csv_lines[1]
+        assert order2.invoice_number not in response.text
+
+
+@pytest.mark.asyncio
 class TesGetOrdersStatistics:
     async def test_anonymous(self, client: AsyncClient) -> None:
         response = await client.get("/v1/orders/statistics")


### PR DESCRIPTION
<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

**Related Issue**: Fixes #7095

Allows to filter by product ID, and maps the button to the same filter that is selected in the dashboard.

## 🎯 What

<!-- Describe what changes you've made -->

## 🤔 Why

<!-- Explain why this change is needed -->

## 🔧 How

<!-- Describe the approach you took to implement the changes -->

## 🧪 Testing

<!-- Check all that apply -->

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

<!-- Provide step-by-step instructions for reviewers to test your changes -->

1.
2.
3.

## 🖼️ Screenshots/Recordings

<!-- Include screenshots or recordings if your changes affect the UI -->
<!-- You can drag and drop images directly into this text area -->
<img width="1176" height="364" alt="Screenshot 2025-10-21 at 09 25 24" src="https://github.com/user-attachments/assets/49f742bc-9d64-4192-a61f-4ad86872e681" />
[polar-orders.csv](https://github.com/user-attachments/files/23015862/polar-orders.3.csv)

## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have updated the relevant tests
- [X] All tests pass locally
- [X] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
