### PR TITLE
feat(invoice-number): Switch to a Polar global invoice sequence

### DIFF
--- a/server/migrations/versions/2025-10-21-1518_add_global_invoice_sequence.py
+++ b/server/migrations/versions/2025-10-21-1518_add_global_invoice_sequence.py
@@ -1,0 +1,45 @@
+"""add_global_invoice_sequence
+
+Revision ID: 1c01dfc86203
+Revises: 902dd5c6c2b7
+Create Date: 2025-10-21 15:18:00.469806
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "1c01dfc86203"
+down_revision = "902dd5c6c2b7"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Buffer to add to max existing invoice number
+    # This ensures clean separation between old per-org and new global numbering
+    BUFFER_SIZE = 10000
+
+    # Create the global invoice number sequence
+    op.execute("CREATE SEQUENCE invoice_number_seq START WITH 1")
+
+    # Initialize sequence to max existing invoice number + buffer
+    # Extract numeric part from "PREFIX-0001" format and find the maximum
+    op.execute(
+        f"""
+        SELECT setval('invoice_number_seq',
+            COALESCE(
+                (SELECT MAX(CAST(SPLIT_PART(invoice_number, '-', 2) AS INTEGER))
+                 FROM orders),
+                0
+            ) + {BUFFER_SIZE}
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP SEQUENCE IF EXISTS invoice_number_seq")

--- a/server/tests/fixtures/database.py
+++ b/server/tests/fixtures/database.py
@@ -46,6 +46,10 @@ async def initialize_test_database(worker_id: str) -> AsyncIterator[None]:
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
         await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'))
         await conn.run_sync(Model.metadata.create_all)
+        # Create global invoice number sequence (from migration)
+        await conn.execute(
+            text("CREATE SEQUENCE IF NOT EXISTS invoice_number_seq START WITH 1")
+        )
     await engine.dispose()
 
     yield


### PR DESCRIPTION

<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

**Related Issue**: Fixes #6994

Switch to a Polar global invoice sequence instead of a per organization invoice sequence.

By utilizing postgres SEQUENCE we can ensure that we will get a forever incrementing sequence for invoice numbers, that can be used by all organizations.

During a rollback the number will not get reused, but as long as each organization has a strictly increasing number sequence it should be legally OK.


## 🎯 What

* Adds a `SEQUENCE` for invoice numbers
* Uses the sequence for `get_next_invoice_number`.

## 🤔 Why

To avoid leaking volume information for a specific merchant, we want to have another invoice identifier.

## 🔧 How

<!-- Describe the approach you took to implement the changes -->

## 🧪 Testing

<!-- Check all that apply -->

- [X] I have tested these changes locally
- [X] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [X] I have added new tests for new functionality
- [X] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

<!-- Provide step-by-step instructions for reviewers to test your changes -->

1.
2.
3.

## 🖼️ Screenshots/Recordings

<!-- Include screenshots or recordings if your changes affect the UI -->
<!-- You can drag and drop images directly into this text area -->

## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have updated the relevant tests
- [X] All tests pass locally
- [X] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
