### PR TITLE
fix(docs): Escape $ to avoid formatting as mathematics

### DIFF
--- a/docs/features/seat-based-pricing.mdx
+++ b/docs/features/seat-based-pricing.mdx
@@ -10,7 +10,7 @@ Seat-based pricing allows you to sell products where a billing manager purchases
 
 - Team subscriptions where one billing manager pays for multiple users
 - Organizational licenses with per-seat pricing
-- Products with volume-based tiering (e.g., $10/seat for 1-4 seats, $9/seat for 5+)
+- Products with volume-based tiering (e.g., \$10/seat for 1-4 seats, \$9/seat for 5+)
 </Info>
 
 ## How it works


### PR DESCRIPTION
<img width="652" height="61" alt="Screenshot 2025-10-21 at 16 21 21" src="https://github.com/user-attachments/assets/570017ad-3d52-496a-af2b-b603a2caabb0" />  
 

➡️ 


<img width="647" height="73" alt="Screenshot 2025-10-21 at 16 21 24" src="https://github.com/user-attachments/assets/e5502810-86c4-4f7b-bf8c-5daf5ec768fd" />
