### PR TITLE
server/discount: cap duration_in_months at 999 to avoid blowing up end date calculation

### DIFF
--- a/server/migrations/versions/2025-10-23-1039_set_dicount_duration_in_months_to_999_.py
+++ b/server/migrations/versions/2025-10-23-1039_set_dicount_duration_in_months_to_999_.py
@@ -1,0 +1,32 @@
+"""Set Dicount.duration_in_months to 999 max
+
+Revision ID: e87a34881c93
+Revises: bd5e68a512cd
+Create Date: 2025-10-23 10:39:12.488423
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "e87a34881c93"
+down_revision = "bd5e68a512cd"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE discounts
+        SET duration_in_months = 999
+        WHERE duration_in_months > 999
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/server/polar/discount/schemas.py
+++ b/server/polar/discount/schemas.py
@@ -2,7 +2,7 @@ import inspect
 from datetime import datetime
 from typing import Annotated, Any, Literal, Self
 
-from annotated_types import Ge
+from annotated_types import Ge, Le
 from pydantic import (
     UUID4,
     AfterValidator,
@@ -124,6 +124,7 @@ DurationInMonths = Annotated[
         """)
     ),
     Ge(1),
+    Le(999),
 ]
 Amount = Annotated[
     int,


### PR DESCRIPTION
Fix #7429

- server/discount: cap duration_in_months at 999 to avoid blowing up end date calculation
