### PR TITLE
fix(order): Use order description instead of product name

### DIFF
--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -133,7 +133,7 @@ async def export(
                 (
                     order.customer.email,
                     order.created_at.isoformat(),
-                    order.product.name if order.product is not None else "",
+                    order.description,
                     order.net_amount / 100,
                     order.currency,
                     order.status,

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -227,7 +227,7 @@ class TestExportOrders:
         data_row = csv_lines[1]
         assert order.product is not None
         assert order.customer.email in data_row
-        assert order.product.name in data_row
+        assert order.description in data_row
         assert order.currency in data_row
         assert order.status.value in data_row
 


### PR DESCRIPTION
Checking the product name was a quick fix to avoid linting errors in `main`.