### PR TITLE
Fix "Deselect all" on product selector

### DIFF
--- a/clients/apps/web/src/components/Products/ProductSelect.tsx
+++ b/clients/apps/web/src/components/Products/ProductSelect.tsx
@@ -59,7 +59,7 @@ const ProductsCommandGroup = ({
           {!areAllSelected ? (
             <>Select all {groupedProducts[productPriceType].length}</>
           ) : (
-            <>Unselect all</>
+            <>Deselect all</>
           )}
         </div>
       </CommandItem>
@@ -245,7 +245,9 @@ const ProductSelect: React.FC<ProductSelectProps> = ({
                   productPriceType="one_time"
                   onSelectProduct={onSelectProduct}
                   onSelectProductType={onSelectProductType}
-                  selectedProducts={selectedProducts || []}
+                  selectedProducts={
+                    value.length > 0 ? selectedProducts || [] : []
+                  }
                 />
                 <CommandSeparator />
                 <ProductsCommandGroup
@@ -253,7 +255,9 @@ const ProductSelect: React.FC<ProductSelectProps> = ({
                   productPriceType="recurring"
                   onSelectProduct={onSelectProduct}
                   onSelectProductType={onSelectProductType}
-                  selectedProducts={selectedProducts || []}
+                  selectedProducts={
+                    value.length > 0 ? selectedProducts || [] : []
+                  }
                 />
               </>
             ) : (


### PR DESCRIPTION
Even is `useSelectedProducts` is disabled when `value.length === 0`, the cached value persists.

We should only use the `selectedProducts` if `value.length > 1` (when it will actually resemble the products defined by array of id's in `value`).