### PR TITLE
feat: add $0 seat pricing option

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -380,7 +380,10 @@ export const ProductPriceSeatBasedItem: React.FC<
                 }
                 rules={{
                   required: 'This field is required',
-                  min: { value: 50, message: 'Price must be greater than 0.5' },
+                  min: {
+                    value: 0,
+                    message: 'Price must be greater than or equal to 0',
+                  },
                 }}
                 render={({ field }) => (
                   <FormItem>

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -76,6 +76,15 @@ PriceAmount = Annotated[
         description="The price in cents.",
     ),
 ]
+SeatPriceAmount = Annotated[
+    int,
+    Field(
+        ...,
+        ge=0,
+        le=MAXIMUM_PRICE_AMOUNT,
+        description="The price per seat in cents. Can be 0 for free tiers.",
+    ),
+]
 PriceCurrency = Annotated[
     str,
     Field(
@@ -164,7 +173,7 @@ class ProductPriceSeatTier(Schema):
         ge=1,
         description="Maximum number of seats (inclusive). None for unlimited.",
     )
-    price_per_seat: PriceAmount = Field(
+    price_per_seat: SeatPriceAmount = Field(
         description="Price per seat in cents for this tier"
     )
 


### PR DESCRIPTION
This change enables seat-based pricing tiers to be set to $0/seat, allowing for pricing schemas such as:
- 1-3 seats: free ($0/seat)
- 4+ seats: $10/seat ($1000/seat in cents)

Backend changes:
- Added new SeatPriceAmount type with minimum value of 0 (vs PriceAmount minimum of 50)
- Updated ProductPriceSeatTier schema to use SeatPriceAmount for price_per_seat field
- Other price types (fixed, custom) maintain $0.50 minimum to cover payment processing

Frontend changes:
- Updated ProductPricingSection form validation to allow $0 for seat prices
- Changed minimum validation from 50 cents to 0 cents for seat-based pricing tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
