### PR TITLE
Create customer meter on benefit grant

### DIFF
--- a/server/tests/benefit/strategies/test_meter_credit.py
+++ b/server/tests/benefit/strategies/test_meter_credit.py
@@ -1,0 +1,74 @@
+import pytest
+
+from polar.benefit.grant.service import benefit_grant as benefit_grant_service
+from polar.customer_meter.repository import CustomerMeterRepository
+from polar.models import Customer, Organization, Subscription
+from polar.models.benefit import BenefitType
+from polar.postgres import AsyncSession
+from polar.redis import Redis
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit, create_meter
+
+
+@pytest.mark.asyncio
+class TestMeterCreditBenefitIntegration:
+    """
+    Integration tests for meter credit benefits.
+
+    These tests verify the end-to-end flow of granting meter credit benefits
+    and ensuring CustomerMeter records are created correctly.
+    """
+
+    async def test_grant_creates_customer_meter(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        subscription: Subscription,
+    ) -> None:
+        """
+        Test that granting a meter credit benefit creates a CustomerMeter immediately.
+
+        This verifies that active_meters will include the meter right after
+        subscribing to a product with a meter credit benefit.
+        """
+        # Create a meter for the organization
+        meter = await create_meter(save_fixture, organization=organization)
+
+        # Create a meter credit benefit
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={
+                "meter_id": str(meter.id),
+                "units": 100,
+                "rollover": False,
+            },
+        )
+
+        # Grant the benefit to the customer
+        grant = await benefit_grant_service.grant_benefit(
+            session, redis, customer, benefit, subscription=subscription
+        )
+
+        # Verify the grant was created
+        assert grant is not None
+        assert grant.is_granted
+        assert grant.customer_id == customer.id
+        assert grant.benefit_id == benefit.id
+
+        # Verify a CustomerMeter was created
+        customer_meter_repo = CustomerMeterRepository.from_session(session)
+        customer_meter = await customer_meter_repo.get_by_customer_and_meter(
+            customer.id, meter.id
+        )
+
+        assert customer_meter is not None
+        assert customer_meter.customer_id == customer.id
+        assert customer_meter.meter_id == meter.id
+        assert customer_meter.credited_units == 100
+        assert customer_meter.consumed_units == 0
+        assert customer_meter.balance == 100


### PR DESCRIPTION
Customer meters are only created on first event ingestion to avoid creating unnecessary meters. However, this meant customers with granted meter credits had no meter to track their balance until their first event. This made it impossible to:

- Display remaining credits before first usage
- Reliably determine if credits remain (you had to assume missing meter = full credits available)

This PR creates customer meters when a meter credit benefit is granted, ensuring there's always a proper "empty state" showing all credits remaining for new customers while still avoiding unnecessary meter creation for customers without granted credits.
