### PR TITLE
fix MoneyInput bug when deleting last integer part

### DIFF
--- a/clients/packages/ui/src/components/atoms/MoneyInput.tsx
+++ b/clients/packages/ui/src/components/atoms/MoneyInput.tsx
@@ -152,10 +152,12 @@ const MoneyInput = (props: Props) => {
       if (internalValue) {
         let nextValue = internalValue
 
+        // Add 0 as integer part if value starts with `.`
         if (nextValue.startsWith('.')) {
           nextValue = `0${nextValue}`
         }
 
+        // Strip trailing decimal point
         if (nextValue.endsWith('.')) {
           nextValue = nextValue.replace(/\.$/, '')
         }


### PR DESCRIPTION
 Related Issue: Fixes #7561

  ## 🎯 What

 Ensure fractional-only entries (.99) no longer force a leading zero while typing, but reintroduce it on blur so the displayed amount remains a valid currency string.

  ## 🤔 Why

Removing the first digit before the decimal was inserting 0, which pushed the caret to the end and interrupted editing. Users should be able to keep typing in place, yet still see a normalized currency value after leaving the field.

  ## 🔧 How

Modified the `onChange` of `MoneyInput` so that after it calls `.toFixed` we check if it would insert a leading `0` and strip it if it does. This allows user to continue typing without interruptions.

  ## 🧪 Testing

  - [x] I have tested these changes locally
  - [x] All existing tests pass (uv run task test for backend, pnpm test for frontend)
  - [ ] I have added new tests for new functionality
  - [x] I have run linting and type checking (uv run task lint && uv run task lint_types for backend)

  ### Test Instructions

  1. Open a screen that uses `MoneyInput`.
  2. Enter 8.99, click after 8, press backspace, and continue typing to confirm the caret stays in place.
  3. Leave the field to verify .99 normalizes to 0.99.

## 🖼️ Screenshots/Recordings


https://github.com/user-attachments/assets/0c4f39d2-ffd0-45cf-a989-72e5e83e619e



## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
