### PR TITLE
Hide "Change Plan" during trial

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/CustomerSubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CustomerSubscriptionDetails.tsx
@@ -65,7 +65,8 @@ const CustomerSubscriptionDetails = ({
   const primaryAction = useMemo(() => {
     if (
       organization.subscription_settings.allow_customer_updates &&
-      !isCanceled
+      !isCanceled &&
+      subscription.status !== 'trialing'
     ) {
       return {
         label: 'Change Plan',


### PR DESCRIPTION
Not ideal, but better than showing a form that will never work.

Follow up in #7577 