### PR TITLE
Add internal_notes field to Organization model for backoffice

### DIFF
--- a/server/migrations/versions/2025-10-30-1047_add_organization_internal_notes.py
+++ b/server/migrations/versions/2025-10-30-1047_add_organization_internal_notes.py
@@ -1,0 +1,26 @@
+"""Add organization internal_notes
+
+Revision ID: c1u8i3khu6t3
+Revises: 8a77908046f4
+Create Date: 2025-10-30 10:47:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c1u8i3khu6t3"
+down_revision = "8a77908046f4"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("organizations", sa.Column("internal_notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "internal_notes")

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -552,6 +552,7 @@ async def update(
         "name": organization.name,
         "slug": organization.slug,
         "customer_invoice_prefix": organization.customer_invoice_prefix,
+        "internal_notes": organization.internal_notes,
         "feature_flags": {
             field_name: organization.feature_settings.get(field_name, False)
             for field_name in OrganizationFeatureSettings.model_fields.keys()
@@ -1371,28 +1372,40 @@ async def get(
                     ):
                         text("Edit")
             with tag.div(classes="grid grid-cols-1 lg:grid-cols-2 gap-4"):
-                with description_list.DescriptionList[Organization](
-                    description_list.DescriptionListAttrItem(
-                        "id", "ID", clipboard=True
-                    ),
-                    description_list.DescriptionListAttrItem(
-                        "slug", "Slug", clipboard=True
-                    ),
-                    description_list.DescriptionListDateTimeItem(
-                        "created_at", "Created At"
-                    ),
-                    description_list.DescriptionListDateTimeItem(
-                        "created_at", "Created At"
-                    ),
-                    description_list.DescriptionListLinkItem(
-                        "website", "Website", external=True
-                    ),
-                    description_list.DescriptionListAttrItem(
-                        "email", "Support email", clipboard=True
-                    ),
-                    description_list.DescriptionListSocialsItem("Social Links"),
-                ).render(request, organization):
-                    pass
+                with tag.div(classes="flex flex-col gap-4"):
+                    with description_list.DescriptionList[Organization](
+                        description_list.DescriptionListAttrItem(
+                            "id", "ID", clipboard=True
+                        ),
+                        description_list.DescriptionListAttrItem(
+                            "slug", "Slug", clipboard=True
+                        ),
+                        description_list.DescriptionListDateTimeItem(
+                            "created_at", "Created At"
+                        ),
+                        description_list.DescriptionListDateTimeItem(
+                            "created_at", "Created At"
+                        ),
+                        description_list.DescriptionListLinkItem(
+                            "website", "Website", external=True
+                        ),
+                        description_list.DescriptionListAttrItem(
+                            "email", "Support email", clipboard=True
+                        ),
+                        description_list.DescriptionListSocialsItem("Social Links"),
+                    ).render(request, organization):
+                        pass
+
+                    with tag.div(classes="card card-border w-full shadow-sm bg-warning/10"):
+                        with tag.div(classes="card-body"):
+                            with tag.h3(classes="card-title text-sm"):
+                                text("Internal Notes")
+                            with tag.div(classes="text-sm whitespace-pre-line"):
+                                if organization.internal_notes:
+                                    text(organization.internal_notes)
+                                else:
+                                    with tag.span(classes="text-base-content-secondary italic"):
+                                        text("No internal notes")
                 # Simple users table
                 with tag.div(classes="card card-border w-full shadow-sm"):
                     with tag.div(classes="card-body"):

--- a/server/polar/backoffice/organizations/forms.py
+++ b/server/polar/backoffice/organizations/forms.py
@@ -64,6 +64,15 @@ class UpdateOrganizationForm(forms.BaseForm):
             to_upper=True, min_length=3, pattern=r"^[a-zA-Z0-9\-]+[a-zA-Z0-9]$"
         ),
     ]
+    internal_notes: Annotated[
+        str | None,
+        forms.TextAreaField(rows=4),
+        Field(
+            default=None,
+            title="Internal Notes",
+            description="Internal notes for support team (not visible to organization)",
+        ),
+    ]
     feature_flags: Annotated[
         OrganizationFeatureSettings | None,
         forms.SubFormField(OrganizationFeatureSettings),

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Text,
     UniqueConstraint,
     Uuid,
     and_,
@@ -138,6 +139,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     email: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
     website: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
+    internal_notes: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     socials: Mapped[list[OrganizationSocials]] = mapped_column(
         JSONB, nullable=False, default=list
     )


### PR DESCRIPTION
This commit implements internal notes functionality for organizations to help the support team track additional information like escalation contacts and other internal details.

Changes:
- Add internal_notes text field to Organization model
- Create database migration for the new field
- Update backoffice UpdateOrganizationForm to include internal_notes
- Display internal_notes in organization detail page with highlighted card
- All linting checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
