### PR TITLE
Bump API paginatation max limit to align with events limit

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -250,7 +250,7 @@ class Settings(BaseSettings):
     PAYOUT_INVOICES_PREFIX: str = "POLAR-"
 
     # Application behaviours
-    API_PAGINATION_MAX_LIMIT: int = 100
+    API_PAGINATION_MAX_LIMIT: int = 300
 
     ACCOUNT_PAYOUT_DELAY: timedelta = timedelta(seconds=1)
     ACCOUNT_PAYOUT_MINIMUM_BALANCE: int = 1000


### PR DESCRIPTION
With this change https://github.com/polarsource/polar/commit/f03b0d6c404300520d4ec14db824261585165e36 if we have between 100 and 300 events the user is not seeing any pages and also not the events.