### PR TITLE
Invoice numbering: Change to default to customer indexed instead of org

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -80,7 +80,7 @@ class OrganizationOrderSettings(TypedDict):
 
 
 _default_order_settings: OrganizationOrderSettings = {
-    "invoice_numbering": InvoiceNumbering.organization,
+    "invoice_numbering": InvoiceNumbering.customer,
 }
 
 


### PR DESCRIPTION
From the changes introduced in #7460 we can now change the default to be invoice numbering per customer instead of for the whole organization.