### PR TITLE
server/customer: fix customer update trying to set email to None when explicitly set

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -180,7 +180,7 @@ class CustomerService:
                     }
                 )
 
-            # Reset verification status
+            customer.email = customer_update.email
             customer.email_verified = False
 
         if (
@@ -220,7 +220,9 @@ class CustomerService:
 
         return await repository.update(
             customer,
-            update_dict=customer_update.model_dump(exclude_unset=True, by_alias=True),
+            update_dict=customer_update.model_dump(
+                exclude={"email"}, exclude_unset=True, by_alias=True
+            ),
         )
 
     async def delete(self, session: AsyncSession, customer: Customer) -> Customer:

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -255,6 +255,18 @@ class TestUpdate:
 
         assert customer.external_id == customer_external_id.external_id
 
+    async def test_valid_explicitly_none_email(
+        self, session: AsyncSession, customer: Customer
+    ) -> None:
+        updated_customer = await customer_service.update(
+            session,
+            customer,
+            CustomerUpdate(email=None),
+        )
+        await session.flush()
+
+        assert updated_customer.email == customer.email
+
 
 @pytest.mark.asyncio
 class TestDelete:


### PR DESCRIPTION
Fix #7642

- server/customer: fix customer update trying to set email to None when explicitly set
