### PR TITLE
server/payment_method: handle upsert payment method from Stripe if it was soft-deleted

### DIFF
--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -44,9 +44,10 @@ class PaymentMethodRepository(
         processor_id: str,
         *,
         options: Options = (),
+        include_deleted: bool = False,
     ) -> PaymentMethod | None:
         statement = (
-            self.get_base_statement()
+            self.get_base_statement(include_deleted=include_deleted)
             .where(
                 PaymentMethod.customer_id == customer,
                 PaymentMethod.processor == processor,

--- a/server/polar/payment_method/service.py
+++ b/server/polar/payment_method/service.py
@@ -50,6 +50,7 @@ class PaymentMethodService:
             customer.id,
             PaymentProcessor.stripe,
             stripe_payment_method.id,
+            include_deleted=True,
             options=repository.get_eager_options(),
         )
         if payment_method is None:
@@ -63,6 +64,7 @@ class PaymentMethodService:
         payment_method.method_metadata = stripe_payment_method[
             stripe_payment_method.type
         ]
+        payment_method.deleted_at = None  # Restore if it was soft-deleted
 
         return await repository.update(payment_method, flush=flush)
 


### PR DESCRIPTION
Fix #7668

- server/payment_method: handle upsert payment method from Stripe if it was soft-deleted
