### PR TITLE
ops: Stagger deployment of migrations

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -13,10 +13,19 @@ on:
         description: "Docker image digest to deploy"
         required: true
         type: string
-      render-service-ids:
-        description: "Comma-separated list of Render service IDs to deploy to"
+      render-api-service-id:
+        description: "Render API service ID"
         required: true
         type: string
+      render-worker-service-ids:
+        description: "Comma-separated list of Render worker service IDs"
+        required: true
+        type: string
+      has-migrations:
+        description: "Whether this deployment includes database migrations"
+        required: false
+        type: boolean
+        default: false
       skip-backend:
         description: "Skip backend deployment if no backend changes"
         required: false
@@ -88,8 +97,11 @@ jobs:
 
       - name: Deploy Backend to Render
         run: |
-          IFS=',' read -ra SERVICE_IDS <<< "${{ inputs.render-service-ids }}"
-          ./.github/workflows/deploy_server.sh ${{ inputs.docker-digest }} "${SERVICE_IDS[@]}"
+          ./.github/workflows/deploy_server.sh \
+            ${{ inputs.docker-digest }} \
+            ${{ inputs.has-migrations }} \
+            "${{ inputs.render-api-service-id }}" \
+            "${{ inputs.render-worker-service-ids }}"
         env:
           RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      migrations: ${{ steps.filter.outputs.migrations }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -34,6 +35,8 @@ jobs:
               - 'clients/**'
               - '.github/workflows/deploy.yml'
               - '.github/workflows/deploy-environment.yml'
+            migrations:
+              - 'server/migrations/**'
 
   build:
     name: "Build Docker Image 🐳"
@@ -103,7 +106,9 @@ jobs:
     with:
       environment: sandbox
       docker-digest: ${{ needs.build.outputs.digest }}
-      render-service-ids: "srv-crkocgbtq21c73ddsdbg,srv-d089jj7diees73934kgg"
+      render-api-service-id: "srv-crkocgbtq21c73ddsdbg"
+      render-worker-service-ids: "srv-d089jj7diees73934kgg"
+      has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
     secrets:
@@ -122,7 +127,9 @@ jobs:
     with:
       environment: production
       docker-digest: ${{ needs.build.outputs.digest }}
-      render-service-ids: "srv-ci4r87h8g3ne0dmvvl60,srv-d4k6otfgi27c73cicnpg,srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0"
+      render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
+      render-worker-service-ids: "srv-d4k6otfgi27c73cicnpg,srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0"
+      has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
     secrets:


### PR DESCRIPTION
If we have migrations, we can run the API deployment first since it will run the migration. If that succeeds we can deploy the workers, and they will be able to be deployed without any issues with mismatching schemas.
