### PR TITLE
events: Add hierarchical query param to listing

### DIFF
--- a/clients/apps/web/src/components/Events/EventRow.tsx
+++ b/clients/apps/web/src/components/Events/EventRow.tsx
@@ -43,6 +43,7 @@ export const EventRow = ({
     organization.id,
     {
       parent_id: event.id,
+      hierarchical: true,
       limit: PAGE_SIZE,
     },
     isExpanded && hasChildren && depth < 1 && renderChildren,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27208,7 +27208,6 @@ export interface operations {
           | 'America/Coral_Harbour'
           | 'America/Cordoba'
           | 'America/Costa_Rica'
-          | 'America/Coyhaique'
           | 'America/Creston'
           | 'America/Cuiaba'
           | 'America/Curacao'
@@ -31654,8 +31653,10 @@ export interface operations {
           | null
         /** @description Query to filter events. */
         query?: string | null
-        /** @description Filter events by parent event ID. When not specified, returns root events only. */
+        /** @description Filter events by parent event ID when hierarchical is set to true. When not specified or null, returns root events only. */
         parent_id?: string | null
+        /** @description When true, filters by parent_id (root events if not specified). When false, returns all events regardless of hierarchy. */
+        hierarchical?: boolean
         /** @description Page number, defaults to 1. */
         page?: number
         /** @description Size of a page, defaults to 10. Maximum is 100. */
@@ -33827,7 +33828,6 @@ export const pathsV1MetricsGetParametersQueryTimezoneValues: ReadonlyArray<
   'America/Coral_Harbour',
   'America/Cordoba',
   'America/Costa_Rica',
-  'America/Coyhaique',
   'America/Creston',
   'America/Cuiaba',
   'America/Curacao',

--- a/server/polar/event/endpoints.py
+++ b/server/polar/event/endpoints.py
@@ -82,7 +82,11 @@ async def list(
     ),
     parent_id: EventID | None = Query(
         None,
-        description="Filter events by parent event ID. When not specified, returns root events only.",
+        description="Filter events by parent event ID when hierarchical is set to true. When not specified or null, returns root events only.",
+    ),
+    hierarchical: bool = Query(
+        False,
+        description="When true, filters by parent_id (root events if not specified). When false, returns all events regardless of hierarchy.",
     ),
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[EventSchema]:
@@ -124,6 +128,7 @@ async def list(
         sorting=sorting,
         query=query,
         parent_id=parent_id,
+        hierarchical=hierarchical,
     )
 
     return ListResource.from_paginated_results(

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -177,6 +177,7 @@ class EventService:
         ),
         query: str | None = None,
         parent_id: uuid.UUID | None = None,
+        hierarchical: bool = False,
     ) -> tuple[Sequence[Event], int]:
         repository = EventRepository.from_session(session)
         statement = await self._build_filtered_statement(
@@ -197,10 +198,11 @@ class EventService:
             query=query,
         )
 
-        if parent_id is not None:
-            statement = statement.where(Event.parent_id == parent_id)
-        else:
-            statement = statement.where(Event.parent_id.is_(None))
+        if hierarchical:
+            if parent_id is not None:
+                statement = statement.where(Event.parent_id == parent_id)
+            else:
+                statement = statement.where(Event.parent_id.is_(None))
 
         return await repository.paginate(
             statement, limit=pagination.limit, page=pagination.page

--- a/server/tests/event/test_endpoints.py
+++ b/server/tests/event/test_endpoints.py
@@ -144,12 +144,15 @@ class TestListEvents:
         json = response.json()
 
         items = json["items"]
-        assert len(items) == 2
+        assert len(items) == 5
 
-        # Root events should be sorted newest to oldest
-        assert items[0]["id"] == str(root_event2.id)  # 5 hours ago
-        assert items[1]["id"] == str(root_event1.id)  # 10 hours ago
-        assert items[1]["child_count"] == 3
+        # All events should be sorted newest to oldest
+        assert items[0]["id"] == str(child2.id)  # 1 hours ago
+        assert items[1]["id"] == str(child3.id)  # 2 hours ago
+        assert items[2]["id"] == str(child1.id)  # 3 hours ago
+        assert items[3]["id"] == str(root_event2.id)  # 5 hours ago
+        assert items[4]["id"] == str(root_event1.id)  # 10 hours ago
+        assert items[4]["child_count"] == 3
 
         # Query children with descending sort
         response = await client.get(
@@ -158,6 +161,7 @@ class TestListEvents:
                 "organization_id": str(organization.id),
                 "parent_id": str(root_event1.id),
                 "sorting": "-timestamp",
+                "hierarchical": "true",
             },
         )
 
@@ -182,6 +186,137 @@ class TestListEvents:
         json = response.json()
 
         items = json["items"]
+        assert len(items) == 5
+
+        # All events should be sorted oldest to newest
+        assert items[0]["id"] == str(root_event1.id)  # 10 hours ago
+        assert items[1]["id"] == str(root_event2.id)  # 5 hours ago
+        assert items[2]["id"] == str(child1.id)  # 3 hours ago
+        assert items[3]["id"] == str(child3.id)  # 2 hours ago
+        assert items[4]["id"] == str(child2.id)  # 1 hours ago
+
+        # Query children with ascending sort
+        response = await client.get(
+            "/v1/events/",
+            params={
+                "organization_id": str(organization.id),
+                "parent_id": str(root_event1.id),
+                "sorting": "timestamp",
+                "hierarchical": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        children = json["items"]
+        assert len(children) == 3
+        assert children[0]["id"] == str(child1.id)  # 3 hours ago
+        assert children[1]["id"] == str(child3.id)  # 2 hours ago
+        assert children[2]["id"] == str(child2.id)  # 1 hour ago
+
+    @pytest.mark.auth
+    async def test_hierarchical_false(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Test that children are sorted according to sorting parameter."""
+        base_time = utc_now()
+
+        root_event1 = await create_event(
+            save_fixture,
+            organization=organization,
+            name="root1",
+            timestamp=base_time - timedelta(hours=10),
+        )
+
+        root_event2 = await create_event(
+            save_fixture,
+            organization=organization,
+            name="root2",
+            timestamp=base_time - timedelta(hours=5),
+        )
+
+        child1 = await create_event(
+            save_fixture,
+            organization=organization,
+            name="child1",
+            parent_id=root_event1.id,
+            timestamp=base_time - timedelta(hours=3),
+        )
+
+        child2 = await create_event(
+            save_fixture,
+            organization=organization,
+            name="child2",
+            parent_id=root_event1.id,
+            timestamp=base_time - timedelta(hours=1),
+        )
+
+        child3 = await create_event(
+            save_fixture,
+            organization=organization,
+            name="child3",
+            parent_id=root_event1.id,
+            timestamp=base_time - timedelta(hours=2),
+        )
+
+        # Test descending sort (newest first)
+        response = await client.get(
+            "/v1/events/",
+            params={
+                "organization_id": str(organization.id),
+                "sorting": "-timestamp",
+                "hierarchical": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+
+        items = json["items"]
+        assert len(items) == 2
+
+        # Root events should be sorted newest to oldest
+        assert items[0]["id"] == str(root_event2.id)  # 5 hours ago
+        assert items[1]["id"] == str(root_event1.id)  # 10 hours ago
+        assert items[1]["child_count"] == 3
+
+        # Query children with descending sort
+        response = await client.get(
+            "/v1/events/",
+            params={
+                "organization_id": str(organization.id),
+                "parent_id": str(root_event1.id),
+                "sorting": "-timestamp",
+                "hierarchical": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        children = json["items"]
+        assert len(children) == 3
+        assert children[0]["id"] == str(child2.id)  # 1 hour ago
+        assert children[1]["id"] == str(child3.id)  # 2 hours ago
+        assert children[2]["id"] == str(child1.id)  # 3 hours ago
+
+        # Test ascending sort (oldest first)
+        response = await client.get(
+            "/v1/events/",
+            params={
+                "organization_id": str(organization.id),
+                "sorting": "timestamp",
+                "hierarchical": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+
+        items = json["items"]
         assert len(items) == 2
 
         # Root events should be sorted oldest to newest
@@ -195,6 +330,7 @@ class TestListEvents:
                 "organization_id": str(organization.id),
                 "parent_id": str(root_event1.id),
                 "sorting": "timestamp",
+                "hierarchical": "true",
             },
         )
 


### PR DESCRIPTION
If it is set to true, we look at the parent id to determine the filtering. If it is set to false, we always return all events.

This makes the listing endpoint default to the current behavior of listing all events independent on if they have any parent_ids.