### PR TITLE
Fix timezone issue with analytics

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/ClientPage.tsx
@@ -12,28 +12,41 @@ import ProductSelect from '@/components/Products/ProductSelect'
 import { ParsedMetricsResponse, useMetrics, useProducts } from '@/hooks/queries'
 import { fromISODate, toISODate } from '@/utils/metrics'
 import { schemas } from '@polar-sh/client'
+import { subMonths } from 'date-fns/subMonths'
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export default function ClientPage({
   organization,
-  limits,
-  startDate,
-  endDate,
+  earliestDateISOString,
+  startDateISOString,
+  endDateISOString,
   interval,
   productId,
 }: {
   organization: schemas['Organization']
-  limits: schemas['MetricsLimits']
-  startDate: Date
-  endDate: Date
+  earliestDateISOString: string
+  startDateISOString?: string
+  endDateISOString?: string
   interval: schemas['TimeInterval']
   productId?: string[]
 }) {
   const router = useRouter()
 
-  const minDate = useMemo(() => fromISODate(limits.min_date), [limits])
+  const minDate = useMemo(
+    () => fromISODate(earliestDateISOString),
+    [earliestDateISOString],
+  )
+
+  const [startDate, endDate] = useMemo(() => {
+    const today = new Date()
+    const startDate = startDateISOString
+      ? fromISODate(startDateISOString)
+      : subMonths(today, 1)
+    const endDate = endDateISOString ? fromISODate(endDateISOString) : today
+    return [startDate, endDate]
+  }, [startDateISOString, endDateISOString])
 
   const { data } = useMetrics({
     startDate,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/page.tsx
@@ -49,8 +49,11 @@ export default async function Page(props: {
     )
   }
 
-  const startDate = searchParams.start_date
-    ? fromISODate(searchParams.start_date)
+  const startDateISOString = searchParams.start_date ?? undefined
+  const endDateISOString = searchParams.end_date ?? undefined
+
+  const startDate = startDateISOString
+    ? fromISODate(startDateISOString)
     : defaultStartDate
   const endDate = searchParams.end_date
     ? endOfDay(fromISODate(searchParams.end_date))
@@ -111,9 +114,9 @@ export default async function Page(props: {
   return (
     <ClientPage
       organization={organization}
-      limits={limits}
-      startDate={startDate}
-      endDate={endDate}
+      earliestDateISOString={limits.min_date}
+      startDateISOString={startDateISOString}
+      endDateISOString={endDateISOString}
       interval={validInterval}
       productId={productId}
     />


### PR DESCRIPTION
Do not parse dates on server for analytics, just work with raw `YYYY-MM-DD` strings.

Could use some more love but this fixes the user-reported bug 😊 