### PR TITLE
server/sentry: Reenable Dramatiq integration

### DIFF
--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -37,7 +37,7 @@ def configure_sentry() -> None:
         environment=settings.ENV,
         integrations=[
             FastApiIntegration(transaction_style="endpoint"),
-            # DramatiqIntegration(),
+            DramatiqIntegration(),
         ],
     )
 


### PR DESCRIPTION
Given Francois comment here https://github.com/polarsource/polar/issues/5798\#issuecomment-2987077486, we should reenable the Dramatiq integration. Right now we are a bit blind for things happening in the workers.
