### PR TITLE
server/payout: The extraneous logging was unnecessary

### DIFF
--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -67,12 +67,6 @@ async def trigger_payout(payout_id: uuid.UUID) -> None:
             # while the payout has already been triggered.
             pass
         except stripe_lib.InvalidRequestError as e:
-            log.error(
-                "stripe_payout_invalid_request_error",
-                payout_id=str(payout_id),
-                error_message=str(e),
-                error_type=type(e).__name__,
-            )
             # Capture exception in Sentry for debugging purposes
             sentry_sdk.capture_exception(
                 e,


### PR DESCRIPTION
Enabling the Dramatiq middleware for Sentry made the capture_exception start working again.