### PR TITLE
tax: Ignore rate limit error in Sandbox

### DIFF
--- a/server/tests/kit/test_tax.py
+++ b/server/tests/kit/test_tax.py
@@ -1,0 +1,79 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+import stripe as stripe_lib
+
+from polar.kit.address import Address, CountryAlpha2
+from polar.kit.tax import TaxCode, calculate_tax
+
+
+@pytest.fixture
+def sample_address() -> Address:
+    return Address(
+        line1="123 Main St",
+        line2=None,
+        postal_code="10001",
+        city="New York",
+        state="US-NY",
+        country=CountryAlpha2("US"),
+    )
+
+
+@pytest.mark.asyncio
+class TestCalculateTaxRateLimit:
+    async def test_rate_limit_swallowed_in_sandbox(
+        self, sample_address: Address
+    ) -> None:
+        rate_limit_error = stripe_lib.RateLimitError(
+            message="You have exceeded the Calculate Tax API rate limit in test mode.",
+            http_status=429,
+        )
+
+        with (
+            patch(
+                "polar.kit.tax.stripe_service.create_tax_calculation",
+                side_effect=rate_limit_error,
+            ),
+            patch("polar.kit.tax.settings.is_sandbox", return_value=True),
+        ):
+            result = await calculate_tax(
+                identifier=uuid.uuid4(),
+                currency="usd",
+                amount=1000,
+                tax_code=TaxCode.general_electronically_supplied_services,
+                address=sample_address,
+                tax_ids=[],
+                customer_exempt=False,
+            )
+
+            assert result["amount"] == 0
+            assert result["taxability_reason"] is None
+            assert result["tax_rate"] is None
+            assert result["processor_id"].startswith("taxcalc_sandbox_")
+
+    async def test_rate_limit_raised_in_production(
+        self, sample_address: Address
+    ) -> None:
+        rate_limit_error = stripe_lib.RateLimitError(
+            message="You have exceeded the Calculate Tax API rate limit.",
+            http_status=429,
+        )
+
+        with (
+            patch(
+                "polar.kit.tax.stripe_service.create_tax_calculation",
+                side_effect=rate_limit_error,
+            ),
+            patch("polar.kit.tax.settings.is_sandbox", return_value=False),
+        ):
+            with pytest.raises(stripe_lib.RateLimitError):
+                await calculate_tax(
+                    identifier=uuid.uuid4(),
+                    currency="usd",
+                    amount=1000,
+                    tax_code=TaxCode.general_electronically_supplied_services,
+                    address=sample_address,
+                    tax_ids=[],
+                    customer_exempt=False,
+                )


### PR DESCRIPTION
When we are rate limited in the sandbox env we return 0 for the tax calculation.
