### PR TITLE
server/sentry: Disable Dramatiq integration again

### DIFF
--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -37,7 +37,7 @@ def configure_sentry() -> None:
         environment=settings.ENV,
         integrations=[
             FastApiIntegration(transaction_style="endpoint"),
-            DramatiqIntegration(),
+            # DramatiqIntegration(),
         ],
     )
 


### PR DESCRIPTION
Still a leading contender for being the culprit of OOM.
