### PR TITLE
Fix product price configurator

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -691,7 +691,7 @@ const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
   )
 
   return (
-    <div className="flex flex-col rounded-2xl border border-gray-100">
+    <div className="dark:border-polar-700 dark:divide-polar-700 flex flex-col divide-y divide-gray-100 rounded-2xl border border-gray-100">
       <input type="hidden" {...register(`prices.${index}.id`)} />
       <FormField
         control={control}
@@ -764,7 +764,7 @@ const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
         }}
       />
       {amountType && amountType !== 'free' && (
-        <div className="flex flex-col gap-3 border-t border-gray-100 p-4">
+        <div className="flex flex-col gap-3 p-4">
           {amountType === 'fixed' && <ProductPriceFixedItem index={index} />}
           {amountType === 'custom' && <ProductPriceCustomItem index={index} />}
           {amountType === 'seat_based' && (
@@ -900,7 +900,7 @@ export const ProductPricingSection = ({
                 className={`flex flex-col gap-3 rounded-2xl border p-4 font-normal transition-colors not-aria-disabled:cursor-pointer ${
                   productType === option
                     ? 'dark:bg-polar-700 dark:border-polar-600/50 border-gray-200 bg-gray-50'
-                    : 'dark:border-polar-700 dark:hover:border-polar-700 dark:not-aria-disabled:hover:bg-polar-700 dark:bg-polar-800 border-gray-100 not-aria-disabled:hover:border-gray-200'
+                    : 'dark:border-polar-700 dark:not-aria-disabled:hover:border-polar-700 dark:not-aria-disabled:hover:bg-polar-700 dark:bg-polar-800 border-gray-100 not-aria-disabled:hover:border-gray-200'
                 }`}
                 aria-disabled={update}
               >


### PR DESCRIPTION
Fixes #7819 

https://github.com/user-attachments/assets/71a54f4f-657a-48d5-9771-bfcfc785e399

Jumped through a few hoops to get `prices` to validate, eventually decided instead to just validate the `amount_type` of the placeholder price and that works too.

Also includes a quick redesign of the product type selector, merging the billing frequency in the nested radio card. Some other tweaks as well. I think we can still tweak the specific configuration options per price type but I didn't want to spend more time on it now (and/or cause conflicts with ongoing seat-based work).