### PR TITLE
Persist business name across checkouts

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -496,11 +496,7 @@ class CheckoutService:
 
             # Auto-select business customer if they have both a billing name & billing address
             # since that means they've previously checked the is_business_customer checkbox
-            if (
-                checkout.customer.billing_name is not None
-                and checkout.customer.billing_address is not None
-                and checkout.customer.billing_address.has_address()
-            ):
+            if checkout.customer.billing_name is not None:
                 checkout.is_business_customer = True
 
         if checkout.payment_processor == PaymentProcessor.stripe:


### PR DESCRIPTION
Fixes #7854 

Feels a bit hacky since we don't store `is_business_customer` directly from the checkout on the customer, so I use the required fields from the checkouts when `is_business_customer` is set to know if `is_business_customer` was checked previously 😵 