### PR TITLE
server/worker: flush logfire after each task to avoid memory bursts

### DIFF
--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -131,6 +131,9 @@ class LogfireMiddleware(dramatiq.Middleware):
         if logfire_stack is not None:
             logfire_stack.close()
 
+        # THEORY: force flush logfire events after each task to avoid memory bursts
+        logfire.force_flush()
+
     def after_skip_message(
         self, broker: dramatiq.Broker, message: dramatiq.Message[Any]
     ) -> None:


### PR DESCRIPTION
- server/worker: flush logfire after each task to avoid memory bursts