### PR TITLE
Show taxable amount after discount

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -806,16 +806,26 @@ const BaseCheckoutForm = ({
                         intervalCount={intervalCount}
                       />
                     </DetailRow>
+
                     {checkout.discount && (
-                      <DetailRow
-                        title={`${checkout.discount.name} (${getDiscountDisplay(checkout.discount)})`}
-                      >
-                        {formatCurrencyNumber(
-                          -checkout.discountAmount,
-                          checkout.currency,
-                          checkout.discountAmount % 100 === 0 ? 0 : 2,
-                        )}
-                      </DetailRow>
+                      <>
+                        <DetailRow
+                          title={`${checkout.discount.name} (${getDiscountDisplay(checkout.discount)})`}
+                        >
+                          {formatCurrencyNumber(
+                            -checkout.discountAmount,
+                            checkout.currency,
+                            checkout.discountAmount % 100 === 0 ? 0 : 2,
+                          )}
+                        </DetailRow>
+                        <DetailRow title="Taxable amount">
+                          {formatCurrencyNumber(
+                            checkout.netAmount,
+                            checkout.currency,
+                            checkout.netAmount % 100 === 0 ? 0 : 2,
+                          )}
+                        </DetailRow>
+                      </>
                     )}
 
                     <DetailRow title="Taxes">


### PR DESCRIPTION
Fixes #7746 

Without discount: subtotal + taxes + total

<img width="459" height="130" alt="image" src="https://github.com/user-attachments/assets/1ed94528-f40f-4bc7-a3e0-56871425bc9f" />

With discount: subtotal + discount + taxable amount + taxes + total

<img width="465" height="191" alt="image" src="https://github.com/user-attachments/assets/d043f09c-8814-42f4-a4ff-21d87fc0f749" />

