### PR TITLE
Disable tablet support for the app

### DIFF
--- a/clients/apps/app/app.json
+++ b/clients/apps/app/app.json
@@ -11,7 +11,7 @@
     "owner": "polar-sh",
 
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "com.polarsource.Polar",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false


### PR DESCRIPTION
## 📋 Summary

We will not initially be supporting tablets in our app, so this PR will disable that feature.

## 🎯 What

This PR will set `supportsTablet` to `false` according to Expo's [documentation](https://docs.expo.dev/distribution/app-stores/#responsive-design).