### PR TITLE
Fix tax ID formatting

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -171,7 +171,18 @@ export const CustomerContextView = ({
         <DetailRow
           labelClassName="flex-none md:basis-24"
           label="Tax ID"
-          value={customer.tax_id}
+          value={
+            customer.tax_id ? (
+              <span className="flex flex-row items-center gap-1.5">
+                <span>{customer.tax_id[0]}</span>
+                <span className="font-mono text-xs opacity-70">
+                  {customer.tax_id[1].toLocaleUpperCase().replace('_', ' ')}
+                </span>
+              </span>
+            ) : (
+              '—'
+            )
+          }
         />
         <DetailRow
           labelClassName="flex-none md:basis-24"

--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -478,7 +478,20 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
               <DetailRow label="Name" value={customer.name} />
               <DetailRow
                 label="Tax ID"
-                value={customer.tax_id ? customer.tax_id[0] : null}
+                value={
+                  customer.tax_id ? (
+                    <span className="flex flex-row items-center gap-1.5">
+                      <span>{customer.tax_id[0]}</span>
+                      <span className="font-mono text-xs opacity-70">
+                        {customer.tax_id[1]
+                          .toLocaleUpperCase()
+                          .replace('_', ' ')}
+                      </span>
+                    </span>
+                  ) : (
+                    '—'
+                  )
+                }
               />
               <DetailRow
                 label="Created At"


### PR DESCRIPTION
I didn't want to introduce a dict just for formatting, but it does change

`BE0737.541.478eu_vat`

to

<img width="286" height="33" alt="image" src="https://github.com/user-attachments/assets/55451865-70ce-439e-902a-23029a48e1e8" />
