### PR TITLE
event: Ensure that the cost aggregation doesnt update db

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -371,6 +371,10 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
 
                 event.user_metadata = aggregated
 
+            # Expunge the event from the session to prevent modifications from being persisted
+            # We're only modifying transient display fields (child_count, aggregated metadata)
+            self.session.expunge(event)
+
             events.append(event)
             total_count = row.total_count
 


### PR DESCRIPTION
Since we are aggregating the event objects in the hierarchical endpoint, if we don't expunge them from the session they will get committed and updated.
