### PR TITLE
Remove capitalization from benefit description

### DIFF
--- a/clients/apps/web/src/components/Benefit/BenefitGrant.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitGrant.tsx
@@ -264,9 +264,7 @@ export const BenefitGrant = ({ api, benefitGrant }: BenefitGrantProps) => {
           </span>
         </div>
         <div className="flex flex-col">
-          <h3 className="text-sm font-medium capitalize">
-            {benefit.description}
-          </h3>
+          <h3 className="text-sm font-medium">{benefit.description}</h3>
           <p className="dark:text-polar-500 flex flex-row gap-x-1 truncate text-sm text-gray-500">
             {benefitsDisplayNames[benefit.type]}
           </p>


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes https://github.com/polarsource/polar/issues/7776

Currently we capitalize the benefit description in the customer portal which can interfere with branding (e.g iPhone). This PR removes that capitalization.

<img width="585" height="422" alt="Screenshot 2025-11-18 at 16 29 18" src="https://github.com/user-attachments/assets/7db2e641-b902-4205-a83b-3e22664c1819" />


## 🖼️ Screenshots/Recordings

| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2025-11-18 at 16 29 06" src="https://github.com/user-attachments/assets/7ab1a78d-5715-4ffb-a838-eacefa2e5d4b" /> | <img width="1840" height="1134" alt="Screenshot 2025-11-18 at 16 29 00" src="https://github.com/user-attachments/assets/f327a0ef-7ba6-42d8-9b26-cb8fffe73acc" /> |


## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
