### PR TITLE
Add the ability to bulk select webhooks

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -1,4 +1,5 @@
 import { enums, schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
 import Input from '@polar-sh/ui/components/atoms/Input'
 import {
   Select,
@@ -16,7 +17,7 @@ import {
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
 import Link from 'next/link'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo, type MouseEvent } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 type CreateOrUpdate =
@@ -112,17 +113,52 @@ export const FieldFormat = () => {
 }
 
 export const FieldEvents = () => {
-  const form = useFormContext<CreateOrUpdate>()
+  const { control, setValue, watch } = useFormContext<CreateOrUpdate>()
+
+  const allEvents = useMemo(
+    () => Object.values(enums.webhookEventTypeValues),
+    [],
+  )
+
+  const currentEvents = watch('events')
+
+  const allSelected = useMemo(
+    () => allEvents.every((event) => currentEvents?.includes(event)),
+    [currentEvents, allEvents],
+  )
+
+  const onToggleAll = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+
+      let values: Array<schemas['WebhookEventType']> = []
+      if (!allSelected) {
+        values = allEvents
+      }
+      setValue('events', values)
+    },
+    [setValue, allSelected, allEvents],
+  )
+
   return (
     <div className="flex flex-col gap-4">
-      <h2 className="text-md leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-        Events
-      </h2>
+      <div className="flex flex-row items-center">
+        <h2 className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Events
+        </h2>
+
+        <div className="flex-auto text-right">
+          <Button onClick={onToggleAll} variant="secondary" size="sm">
+            {!allSelected ? 'Select All' : 'Unselect All'}
+          </Button>
+        </div>
+      </div>
+
       <div className="flex flex-col gap-y-2">
-        {Object.values(enums.webhookEventTypeValues).map((event) => (
+        {allEvents.map((event) => (
           <FormField
             key={event}
-            control={form.control}
+            control={control}
             name="events"
             render={({ field }) => {
               const href = `https://polar.sh/docs/api-reference/webhooks/${event}`
@@ -131,7 +167,7 @@ export const FieldEvents = () => {
                 <FormItem className="flex flex-row items-center space-y-0 space-x-3">
                   <FormControl>
                     <Checkbox
-                      defaultChecked={
+                      checked={
                         field.value ? field.value.includes(event) : false
                       }
                       onCheckedChange={(checked) => {


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes https://github.com/polarsource/polar/issues/7780

This PR will add the ability to bulk select webhooks, similar to what we offer for access tokens.

### Test Instructions

1. Check out this branch (`feature/bulk-select-webhooks`) locally
2. Go to http://127.0.0.1:3000/dashboard/ORGANISATION/settings/webhooks
3. Click **Add endpoint**
4. Click **Select all** in the modal

## 🖼️ Screenshots/Recordings


https://github.com/user-attachments/assets/1c2869bd-9e6e-4ea9-9375-d8098058ae46




## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
