### PR TITLE
metrics: Handle non-1-aligned periods for joining cumulative revenue

### DIFF
--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -42,6 +42,13 @@ class MetricsService:
             end_date.year, end_date.month, end_date.day, 23, 59, 59, 999999, timezone
         )
 
+        # Truncate start_timestamp to the beginning of the interval period
+        # This ensures the timestamp series aligns with how daily metrics are grouped
+        if interval == TimeInterval.month:
+            start_timestamp = start_timestamp.replace(day=1)
+        elif interval == TimeInterval.year:
+            start_timestamp = start_timestamp.replace(month=1, day=1)
+
         timestamp_series = get_timestamp_series_cte(
             start_timestamp, end_timestamp, interval
         )


### PR DESCRIPTION
Otherwise we get no records to join on and thus no results.