### PR TITLE
Fix EAS build

### DIFF
--- a/clients/apps/app/app.json
+++ b/clients/apps/app/app.json
@@ -16,7 +16,10 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "icon": "./assets/images/ios-dark.png"
+      "icon": "./assets/images/ios-dark.png",
+      "entitlements": {
+        "com.apple.developer.applesignin": ["Default"]
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/clients/packages/client/package.json
+++ b/clients/packages/client/package.json
@@ -6,6 +6,12 @@
   "type": "module",
   "private": true,
   "version": "0.0.0",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "generate": "openapi-typescript http://127.0.0.1:8000/openapi.json --enum-values -o ./src/v1.ts && prettier --write ./src && pnpm run build",
     "test:ts": "tsc --noEmit",


### PR DESCRIPTION
## 📋 Summary

This PR fixes two issues with the EAS build for our iOS app:

1. Since we recently added support for `Continue with Apple` we needed to make changes related to that in our `app.json`
2. The Metro bundler wasn't able to find the proper build files for the `@polar-sh` package (Metro doesn't support the `exports` object).

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
