### PR TITLE
event: Add labels to events

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/events/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/events/ClientPage.tsx
@@ -4,7 +4,6 @@ import { CustomerSelector } from '@/components/Customer/CustomerSelector'
 import { EventCreationGuideModal } from '@/components/Events/EventCreationGuideModal'
 import { EventMetadataFilter } from '@/components/Events/EventMetadataFilter'
 import { Events } from '@/components/Events/Events'
-import { useEventDisplayName } from '@/components/Events/utils'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import DateRangePicker from '@/components/Metrics/DateRangePicker'
 import { Modal } from '@/components/Modal'
@@ -47,6 +46,46 @@ import { twMerge } from 'tailwind-merge'
 import z from 'zod'
 
 const PAGE_SIZE = 100
+
+// Replace this after migrating /v1/events/names to use labels.
+const useEventDisplayName = (eventName: schemas['Event']['name']) => {
+  return useMemo(() => {
+    switch (eventName) {
+      case 'benefit.granted':
+        return 'Benefit Granted'
+      case 'benefit.cycled':
+        return 'Benefit Cycled'
+      case 'benefit.updated':
+        return 'Benefit Updated'
+      case 'benefit.revoked':
+        return 'Benefit Revoked'
+      case 'subscription.cycled':
+        return 'Subscription Cycled'
+      case 'subscription.revoked':
+        return 'Subscription Revoked'
+      case 'subscription.product_updated':
+        return 'Subscription Product Updated'
+      case 'order.paid':
+        return 'Order Paid'
+      case 'order.refunded':
+        return 'Order Refunded'
+      case 'subscription.seats_updated':
+        return 'Subscription Seats Updated'
+      case 'customer.created':
+        return 'Customer Created'
+      case 'customer.updated':
+        return 'Customer Updated'
+      case 'customer.deleted':
+        return 'Customer Deleted'
+      case 'meter.credited':
+        return 'Meter Credited'
+      case 'meter.reset':
+        return 'Meter Reset'
+      default:
+        return eventName
+    }
+  }, [eventName])
+}
 
 const EventName = ({ eventName }: { eventName: schemas['EventName'] }) => {
   const displayName = useEventDisplayName(eventName.name)

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/events/[eventId]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/events/[eventId]/ClientPage.tsx
@@ -2,7 +2,6 @@
 
 import { CustomerContextView } from '@/components/Customer/CustomerContextView'
 import { EventRow } from '@/components/Events/EventRow'
-import { useEventDisplayName } from '@/components/Events/utils'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { useEvent, useInfiniteEvents } from '@/hooks/queries/events'
 import { formatSubCentCurrency } from '@/utils/formatters'
@@ -41,8 +40,6 @@ export default function EventDetailPage({
     if (!childrenData) return []
     return childrenData.pages.flatMap((page) => page.items)
   }, [childrenData])
-
-  const eventDisplayName = useEventDisplayName(event?.name ?? '')
 
   if (!event) {
     return null
@@ -83,7 +80,7 @@ export default function EventDetailPage({
     >
       <div className="flex flex-col gap-y-4">
         <div className="flex flex-row items-center justify-between gap-x-4">
-          <h3 className="text-4xl">{eventDisplayName}</h3>
+          <h3 className="text-4xl">{event.label}</h3>
           {'_cost' in event.metadata && event.metadata._cost && (
             <h3 className="dark:text-polar-500 font-mono text-4xl text-gray-400">
               {formatSubCentCurrency(Number(event.metadata._cost?.amount ?? 0))}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/spans/[spanId]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/usage-billing/spans/[spanId]/ClientPage.tsx
@@ -3,7 +3,6 @@
 import Chart from '@/components/Chart/Chart'
 import { CustomerStatBox } from '@/components/Customer/CustomerStatBox'
 import { Events } from '@/components/Events/Events'
-import { useEventDisplayName } from '@/components/Events/utils'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import DateRangePicker from '@/components/Metrics/DateRangePicker'
 import IntervalPicker from '@/components/Metrics/IntervalPicker'
@@ -91,7 +90,7 @@ export default function SpanDetailPage({
   const firstStat = hierarchyStats?.totals?.[0]
   const eventName = firstStat?.name ?? ''
   const eventLabel = firstStat?.label ?? eventName
-  const eventDisplayName = useEventDisplayName(eventLabel)
+  const eventDisplayName = firstStat?.label ?? ''
 
   const costMetrics = useMemo(() => {
     if (!hierarchyStats?.totals || hierarchyStats.totals.length === 0) {

--- a/clients/apps/web/src/components/Events/EventRow.tsx
+++ b/clients/apps/web/src/components/Events/EventRow.tsx
@@ -15,7 +15,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { EventCustomer } from './EventCustomer'
 import { EventSourceBadge } from './EventSourceBadge'
-import { useEventCard, useEventCostBadge, useEventDisplayName } from './utils'
+import { useEventCard, useEventCostBadge } from './utils'
 
 const PAGE_SIZE = 10
 
@@ -83,7 +83,6 @@ export const EventRow = ({
     [event, isExpanded],
   )
 
-  const eventDisplayName = useEventDisplayName(event.name)
   const eventCard = useEventCard(event)
   const eventCostBadge = useEventCostBadge(event)
 
@@ -137,7 +136,7 @@ export const EventRow = ({
               </div>
             )}
             <div className="flex flex-row items-center gap-x-4">
-              <span className="text-xs">{eventDisplayName}</span>
+              <span className="text-xs">{event.label}</span>
               <EventSourceBadge source={event.source} />
               {event.child_count > 0 && (
                 <span className="dark:text-polar-500 dark:bg-polar-700 text-xxs rounded-md bg-gray-100 px-2 py-1 text-gray-500 capitalize">

--- a/clients/apps/web/src/components/Events/utils.tsx
+++ b/clients/apps/web/src/components/Events/utils.tsx
@@ -7,45 +7,6 @@ import { SubscriptionEventCard } from './EventCard/SubscriptionEventCard'
 import { UserEventCard } from './EventCard/UserEventCard'
 import { EventCostBadge } from './EventCostBadge'
 
-export const useEventDisplayName = (eventName: schemas['Event']['name']) => {
-  return useMemo(() => {
-    switch (eventName) {
-      case 'benefit.granted':
-        return 'Benefit Granted'
-      case 'benefit.cycled':
-        return 'Benefit Cycled'
-      case 'benefit.updated':
-        return 'Benefit Updated'
-      case 'benefit.revoked':
-        return 'Benefit Revoked'
-      case 'subscription.cycled':
-        return 'Subscription Cycled'
-      case 'subscription.revoked':
-        return 'Subscription Revoked'
-      case 'subscription.product_updated':
-        return 'Subscription Product Updated'
-      case 'order.paid':
-        return 'Order Paid'
-      case 'order.refunded':
-        return 'Order Refunded'
-      case 'subscription.seats_updated':
-        return 'Subscription Seats Updated'
-      case 'customer.created':
-        return 'Customer Created'
-      case 'customer.updated':
-        return 'Customer Updated'
-      case 'customer.deleted':
-        return 'Customer Deleted'
-      case 'meter.credited':
-        return 'Meter Credited'
-      case 'meter.reset':
-        return 'Meter Reset'
-      default:
-        return eventName
-    }
-  }, [eventName])
-}
-
 export const useEventCard = (event: schemas['Event']) => {
   return useMemo(() => {
     switch (event.source) {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5694,6 +5694,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -7003,6 +7008,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -7566,6 +7576,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -7689,6 +7704,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
@@ -11907,6 +11927,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -12084,6 +12109,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
@@ -13925,6 +13955,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
@@ -17053,6 +17088,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -17147,6 +17187,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
@@ -18213,6 +18258,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -18349,6 +18399,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
@@ -21588,6 +21643,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -21714,6 +21774,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -21837,6 +21902,11 @@ export interface components {
        */
       parent_id?: string | null
       /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
        * @constant
@@ -21901,6 +21971,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Source
        * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
@@ -22567,6 +22642,11 @@ export interface components {
        * @description The ID of the parent event.
        */
       parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
       /**
        * Name
        * @description The name of the event.

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -236,7 +236,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         )
 
     def get_eager_options(self) -> Options:
-        return (joinedload(Event.customer),)
+        return (joinedload(Event.customer), joinedload(Event.event_types))
 
     async def list_with_closure_table(
         self,

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -215,6 +215,7 @@ class BaseEvent(IDSchema):
         default=None,
         description="The ID of the parent event.",
     )
+    label: str = Field(description="Human readable label of the event type.")
 
 
 class SystemEventBase(BaseEvent):

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -29,6 +29,25 @@ class SystemEvent(StrEnum):
     customer_deleted = "customer.deleted"
 
 
+SYSTEM_EVENT_LABELS: dict[str, str] = {
+    "benefit.granted": "Benefit Granted",
+    "benefit.cycled": "Benefit Cycled",
+    "benefit.updated": "Benefit Updated",
+    "benefit.revoked": "Benefit Revoked",
+    "subscription.cycled": "Subscription Cycled",
+    "subscription.revoked": "Subscription Revoked",
+    "subscription.product_updated": "Subscription Product Updated",
+    "order.paid": "Order Paid",
+    "order.refunded": "Order Refunded",
+    "subscription.seats_updated": "Subscription Seats Updated",
+    "customer.created": "Customer Created",
+    "customer.updated": "Customer Updated",
+    "customer.deleted": "Customer Deleted",
+    "meter.credited": "Meter Credited",
+    "meter.reset": "Meter Reset",
+}
+
+
 class MeterCreditedMetadata(TypedDict):
     meter_id: str
     units: int

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -207,6 +207,17 @@ class Event(Model, MetadataMixin):
     def event_types(cls) -> Mapped["EventType | None"]:
         return relationship("EventType", lazy="raise")
 
+    @property
+    def label(self) -> str:
+        if self.source == EventSource.system:
+            # Lazy import to avoid a circular dependency
+            from polar.event.system import SYSTEM_EVENT_LABELS
+
+            return SYSTEM_EVENT_LABELS.get(self.name, self.name)
+        if self.event_types is not None:
+            return self.event_types.label
+        return self.name
+
     @hybrid_property
     def is_meter_credit(self) -> bool:
         return (

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -66,7 +66,14 @@ class TestList:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        await create_event(save_fixture, organization=organization)
+        event_type_repository = EventTypeRepository.from_session(session)
+        event_type = await event_type_repository.get_or_create(
+            "TEST_EVENT", organization.id
+        )
+
+        await create_event(
+            save_fixture, organization=organization, event_type=event_type
+        )
 
         events, count = await event_service.list(
             session, auth_subject, pagination=PaginationParams(1, 10)
@@ -74,6 +81,7 @@ class TestList:
 
         assert len(events) == 1
         assert count == 1
+        assert events[0].label == event_type.label
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1735,6 +1735,7 @@ async def create_event(
     external_id: str | None = None,
     parent_id: uuid.UUID | None = None,
     metadata: dict[str, str | int | bool | float | Any] | None = None,
+    event_type: EventType | None = None,
 ) -> Event:
     event = Event(
         timestamp=timestamp or utc_now(),
@@ -1746,6 +1747,7 @@ async def create_event(
         parent_id=parent_id,
         organization=organization,
         user_metadata=metadata or {},
+        event_type_id=event_type.id if event_type else None,
     )
     await save_fixture(event)
     return event


### PR DESCRIPTION
This moves the system event labels to the backend, with the introduction of user event labels.

All events now have a label that can either be updated by the user or set by the system.

The labels for system events are not typed as a hardcoded string for two reasons:
1. We want to be able to change the copy without breaking the API
2. We dont want to have multiple definitions of the labels
