### PR TITLE
Validate minimum_limit

### DIFF
--- a/server/polar/event/endpoints.py
+++ b/server/polar/event/endpoints.py
@@ -234,8 +234,8 @@ async def list_statistics_timeseries(
                 {
                     "loc": ("query",),
                     "msg": (
-                        "The interval is too big. "
-                        "Try to change the interval or reduce the date range."
+                        "The interval does not match the date range. "
+                        "Try to change the interval or adjust the date range."
                     ),
                     "type": "value_error",
                     "input": (start_date, end_date, interval),

--- a/server/polar/kit/time_queries.py
+++ b/server/polar/kit/time_queries.py
@@ -62,4 +62,5 @@ MIN_INTERVAL_DAYS: dict[TimeInterval, int] = {
 
 
 def is_under_limits(start_date: date, end_date: date, interval: TimeInterval) -> bool:
-    return end_date.toordinal() - start_date.toordinal() <= MAX_INTERVAL_DAYS[interval]
+    days = end_date.toordinal() - start_date.toordinal()
+    return days >= MIN_INTERVAL_DAYS[interval] and days <= MAX_INTERVAL_DAYS[interval]

--- a/server/polar/meter/endpoints.py
+++ b/server/polar/meter/endpoints.py
@@ -138,8 +138,8 @@ async def quantities(
                 {
                     "loc": ("query",),
                     "msg": (
-                        "The interval is too big. "
-                        "Try to change the interval or reduce the date range."
+                        "The interval does not match the date range. "
+                        "Try to change the interval or adjust the date range."
                     ),
                     "type": "value_error",
                     "input": (start_timestamp, end_timestamp, interval),

--- a/server/polar/metrics/endpoints.py
+++ b/server/polar/metrics/endpoints.py
@@ -73,8 +73,8 @@ async def get(
                 {
                     "loc": ("query",),
                     "msg": (
-                        "The interval is too big. "
-                        "Try to change the interval or reduce the date range."
+                        "The interval does not match the date range. "
+                        "Try to change the interval or adjust the date range."
                     ),
                     "type": "value_error",
                     "input": (start_date, end_date, interval),


### PR DESCRIPTION
I think this can break the analytics in the native app, as monthly is no longer a valid interval for date ranges < 60 days.

 cc @sebastianekstrom