### PR TITLE
clients/apps/app: filter subscription orders by id

### DIFF
--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
@@ -43,17 +43,14 @@ export default function Index() {
   } = useSubscription(id as string)
 
   const { data: subscriptionOrders } = useOrders(organization?.id, {
-    customerId: subscription?.customer.id,
-    productId: subscription?.product.id,
+    customer_id: subscription?.customer.id,
+    product_id: subscription?.product.id,
+    subscription_id: id,
   })
 
   const flatSubscriptionOrders = useMemo(() => {
-    const allOrders =
-      subscriptionOrders?.pages.flatMap((page) => page.items) ?? []
-    return allOrders.filter(
-      (order) => order.subscription_id === subscription?.id,
-    )
-  }, [subscriptionOrders, subscription?.id])
+    return subscriptionOrders?.pages.flatMap((page) => page.items) ?? []
+  }, [subscriptionOrders])
 
   if (!subscription) {
     return (


### PR DESCRIPTION
<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

**Related Issue**: Fixes https://github.com/polarsource/polar/issues/7947

<!-- Brief description of what this PR does -->

## 🎯 What

- Filter `flatSubscriptionOrders` on mobile so only the current subscription's orders remain

## 🤔 Why

- This confused support and end users when reviewing a subscription

## 🔧 How

- The `useMemo` now flattens all pages and filters them by `order.subscription_id === subscription?.id` before rendering

## 🧪 Testing

<!-- Check all that apply -->

- [x] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

<!-- Provide step-by-step instructions for reviewers to test your changes -->

1. Run mobile app locally
2. Sign in, open any subscription, confirm only its own orders appear

## 🖼️ Screenshots/Recordings

<!-- Include screenshots or recordings if your changes affect the UI -->
<!-- You can drag and drop images directly into this text area -->

| Before | After |
|--------|--------|
| <img width="1170" height="2532" alt="before" src="https://github.com/user-attachments/assets/1145677a-e428-4c18-815e-4804c5fe6b72" /> | <img width="1170" height="2532" alt="now" src="https://github.com/user-attachments/assets/760f4877-31ac-4efd-b404-fa025216cf94" /> |

## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
