### PR TITLE
Refresh customer portal UI after changes

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSettings.tsx
@@ -11,6 +11,7 @@ import Button from '@polar-sh/ui/components/atoms/Button'
 import { Separator } from '@polar-sh/ui/components/ui/separator'
 import { getThemePreset } from '@polar-sh/ui/hooks/theming'
 import { useTheme } from 'next-themes'
+import { useRouter } from 'next/navigation'
 import { twMerge } from 'tailwind-merge'
 import { Modal } from '../Modal'
 import { useModal } from '../Modal/useModal'
@@ -34,6 +35,7 @@ export const CustomerPortalSettings = ({
   setupIntentParams,
 }: CustomerPortalSettingsProps) => {
   const api = createClientSideAPI(customerSessionToken)
+  const router = useRouter()
 
   const {
     isShown: isAddPaymentMethodModalOpen,
@@ -103,6 +105,7 @@ export const CustomerPortalSettings = ({
             customer={customer}
             onSuccess={() => {
               revalidate(`customer_portal`)
+              router.refresh()
             }}
             themingPreset={themingPreset}
           />
@@ -118,6 +121,7 @@ export const CustomerPortalSettings = ({
             api={api}
             onPaymentMethodAdded={() => {
               revalidate(`customer_portal`)
+              router.refresh()
               hideAddPaymentMethodModal()
             }}
             setupIntentParams={setupIntentParams}

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscriptions.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscriptions.tsx
@@ -6,6 +6,7 @@ import { DataTable } from '@polar-sh/ui/components/atoms/DataTable'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { getThemePreset } from '@polar-sh/ui/hooks/theming'
 import { useTheme } from 'next-themes'
+import { useRouter } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
 import { InlineModal } from '../Modal/InlineModal'
 import { useModal } from '../Modal/useModal'
@@ -67,6 +68,7 @@ export const InactiveSubscriptionsOverview = ({
   api,
   customerSessionToken,
 }: SubscriptionsOverviewProps) => {
+  const router = useRouter()
   const theme = useTheme()
   const themingPreset = getThemePreset(
     organization.slug,
@@ -227,6 +229,7 @@ export const InactiveSubscriptionsOverview = ({
           onSuccess={async () => {
             hideRetryPaymentModal()
             await revalidate(`customer_portal`)
+            router.refresh()
           }}
           themingPreset={themingPreset}
         />

--- a/clients/apps/web/src/components/Subscriptions/CustomerCancellationModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CustomerCancellationModal.tsx
@@ -20,6 +20,7 @@ import {
   RadioGroupItem,
 } from '@polar-sh/ui/components/ui/radio-group'
 import { ThemingPresetProps } from '@polar-sh/ui/hooks/theming'
+import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from '../Toast/use-toast'
@@ -56,6 +57,8 @@ const CustomerCancellationModal = ({
   themingPreset,
   ...props
 }: CustomerCancellationModalProps) => {
+  const router = useRouter()
+
   const handleCancel = useCallback(() => {
     onAbort?.()
     props.hide()
@@ -91,9 +94,10 @@ const CustomerCancellationModal = ({
         title: 'Subscription Cancelled',
         description: `Subscription was cancelled successfully`,
       })
+      router.refresh()
       props.hide()
     },
-    [subscription.id, cancelSubscription, setError, props],
+    [subscription.id, cancelSubscription, setError, props, router],
   )
 
   const onReasonSelect = (value: schemas['CustomerCancellationReason']) => {

--- a/clients/apps/web/src/components/Subscriptions/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CustomerChangePlanModal.tsx
@@ -227,6 +227,7 @@ const CustomerChangePlanModal = ({
         description: `Subscription was updated successfully`,
       })
       onUserSubscriptionUpdate(data)
+      router.refresh()
       hide()
     }
   }, [

--- a/clients/apps/web/src/components/Subscriptions/CustomerSubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CustomerSubscriptionDetails.tsx
@@ -15,6 +15,7 @@ import { getThemePreset } from '@polar-sh/ui/hooks/theming'
 import { formatCurrencyAndAmount } from '@polar-sh/ui/lib/money'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import CustomerPortalSubscription from '../CustomerPortal/CustomerPortalSubscription'
@@ -64,6 +65,7 @@ const CustomerSubscriptionDetails = ({
   const organization = subscription.product.organization
 
   const uncancelSubscription = useCustomerUncancelSubscription(api)
+  const router = useRouter()
 
   const primaryAction = useMemo(() => {
     if (
@@ -91,12 +93,13 @@ const CustomerSubscriptionDetails = ({
         onClick: async () => {
           await uncancelSubscription.mutateAsync({ id: subscription.id })
           await revalidate(`customer_portal`)
+          router.refresh()
         },
       }
     }
 
     return null
-  }, [subscription, isCanceled, organization, uncancelSubscription])
+  }, [subscription, isCanceled, organization, uncancelSubscription, router])
 
   const subscriptionBaseAmount = useMemo(() => {
     const price = subscription.product.prices.find(


### PR DESCRIPTION
Fixes #8007

The Customer Portal UI was not updating automatically after subscription changes (plan changes, cancellations, uncancellations, billing updates, and payment method changes) because it uses server-side data fetching with Next.js Server Components.

While the mutations correctly invalidated React Query caches and called revalidate('customer_portal') to invalidate the Next.js cache, the client components didn't know to refresh and fetch the updated data.

Solution: Added router.refresh() after successful mutations in:
- CustomerChangePlanModal: After changing subscription plan
- CustomerCancellationModal: After canceling subscription
- CustomerSubscriptionDetails: After uncanceling subscription
- CustomerPortalSettings: After updating billing details or payment methods
- CustomerPortalSubscriptions: After retrying payment

