### PR TITLE
Add new edit product page (products/:id/edit)

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/[id]/edit/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/[id]/edit/ClientPage.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { EditProductPage } from '@/components/Products/EditProductPage'
+import { schemas } from '@polar-sh/client'
+
+export default function Page({
+  organization,
+  product,
+}: {
+  organization: schemas['Organization']
+  product: schemas['Product']
+}) {
+  return <EditProductPage product={product} organization={organization} />
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/[id]/edit/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/[id]/edit/page.tsx
@@ -1,0 +1,30 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { getProductById } from '@/utils/product'
+import { Metadata } from 'next'
+import ClientPage from './ClientPage'
+
+export async function generateMetadata(props: {
+  params: Promise<{ organization: string; id: string }>
+}): Promise<Metadata> {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const product = await getProductById(api, params.id)
+  return {
+    title: `Edit ${product.name}`,
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string; id: string }>
+}) {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+  const product = await getProductById(api, params.id)
+
+  return <ClientPage organization={organization} product={product} />
+}

--- a/clients/apps/web/src/components/Products/CreateProductPage.tsx
+++ b/clients/apps/web/src/components/Products/CreateProductPage.tsx
@@ -4,7 +4,7 @@ import {
   useUpdateProductBenefits,
 } from '@/hooks/queries'
 import { setProductValidationErrors } from '@/utils/api/errors'
-import { ProductCreateForm, productToCreateForm } from '@/utils/product'
+import { ProductEditOrCreateForm, productToCreateForm } from '@/utils/product'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { Form } from '@polar-sh/ui/components/ui/form'
@@ -65,7 +65,7 @@ export const CreateProductPage = ({
     }
   }
 
-  const form = useForm<ProductCreateForm>({
+  const form = useForm<ProductEditOrCreateForm>({
     defaultValues: getDefaultValues(),
   })
   const { handleSubmit, setError } = form
@@ -74,7 +74,7 @@ export const CreateProductPage = ({
   const updateBenefits = useUpdateProductBenefits(organization)
 
   const onSubmit = useCallback(
-    async (productCreate: ProductCreateForm) => {
+    async (productCreate: ProductEditOrCreateForm) => {
       const { full_medias, metadata, ...productCreateRest } = productCreate
 
       const { data: product, error } = await createProduct.mutateAsync({

--- a/clients/apps/web/src/components/Products/ProductListItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductListItem.tsx
@@ -178,6 +178,17 @@ export const ProductListItem = ({
                   Integrate Checkout
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
+                {product.is_archived ? null : (
+                  <DropdownMenuItem
+                    onClick={handleContextMenuCallback(() => {
+                      router.push(
+                        `/dashboard/${organization.slug}/products/${product.id}/edit`,
+                      )
+                    })}
+                  >
+                    Edit Product
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   onClick={handleContextMenuCallback(showModal)}
                 >

--- a/clients/apps/web/src/components/Products/ProductPage/ProductMetricsView.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductMetricsView.tsx
@@ -35,7 +35,7 @@ export const ProductMetricsView = ({
     : ['average_order_value', 'cumulative_revenue']
 
   return (
-    <div className="flex flex-col gap-y-12">
+    <div className="grid grid-cols-1 gap-12 lg:grid-cols-2">
       {product.is_recurring ? (
         <>
           {subscriptionMetrics.map((metric) => (

--- a/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
@@ -27,7 +27,6 @@ import { DashboardBody } from '../../Layout/DashboardLayout'
 import { ProductThumbnail } from '../ProductThumbnail'
 import { ProductMetricsView } from './ProductMetricsView'
 import { ProductOverview } from './ProductOverview'
-import { ProductPageContextView } from './ProductPageContextView'
 
 const ProductTypeDisplayColor: Record<string, string> = {
   subscription: 'bg-emerald-100 text-emerald-500 dark:bg-emerald-950',
@@ -144,74 +143,83 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
           </div>
         }
         header={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button size="icon" variant="secondary">
-                <MoreVert fontSize="small" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onClick={() => {
-                  if (typeof navigator !== 'undefined') {
-                    navigator.clipboard.writeText(product.id)
+          <div className="flex flex-row items-center justify-between gap-2">
+            {product.is_archived ? null : (
+              <div>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => {
+                    router.push(
+                      `/dashboard/${organization.slug}/products/${product.id}/edit`,
+                    )
+                  }}
+                >
+                  Edit Product
+                </Button>
+              </div>
+            )}
+            <div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="icon" variant="secondary">
+                    <MoreVert fontSize="small" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onClick={() => {
+                      if (typeof navigator !== 'undefined') {
+                        navigator.clipboard.writeText(product.id)
 
-                    toast({
-                      title: 'Product ID Copied',
-                      description: 'Product ID copied to clipboard',
-                    })
-                  }
-                }}
-              >
-                Copy Product ID
-              </DropdownMenuItem>
-              {!product.is_archived && (
-                <>
-                  <DropdownMenuItem
-                    onClick={() => {
-                      router.push(
-                        `/dashboard/${organization.slug}/onboarding/integrate?productId=${product.id}`,
-                      )
+                        toast({
+                          title: 'Product ID Copied',
+                          description: 'Product ID copied to clipboard',
+                        })
+                      }
                     }}
                   >
-                    Integrate Checkout
+                    Copy Product ID
                   </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={showArchiveModal}>
-                    Archive Product
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => {
-                      router.push(
-                        `/dashboard/${organization.slug}/products/new?fromProductId=${product.id}`,
-                      )
-                    }}
-                  >
-                    Duplicate Product
-                  </DropdownMenuItem>
-                </>
-              )}
-              {product.is_archived && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={showUnarchiveModal}>
-                    Unarchive Product
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  {!product.is_archived && (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          router.push(
+                            `/dashboard/${organization.slug}/onboarding/integrate?productId=${product.id}`,
+                          )
+                        }}
+                      >
+                        Integrate Checkout
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={showArchiveModal}>
+                        Archive Product
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          router.push(
+                            `/dashboard/${organization.slug}/products/new?fromProductId=${product.id}`,
+                          )
+                        }}
+                      >
+                        Duplicate Product
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                  {product.is_archived && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={showUnarchiveModal}>
+                        Unarchive Product
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
         }
-        contextViewClassName="hidden md:block"
-        contextView={
-          product.is_archived ? undefined : (
-            <ProductPageContextView
-              organization={organization}
-              product={product}
-            />
-          )
-        }
-        wide
       >
         <TabsList className="pb-8">
           <TabsTrigger value="overview">Overview</TabsTrigger>

--- a/clients/apps/web/src/utils/product.ts
+++ b/clients/apps/web/src/utils/product.ts
@@ -83,14 +83,17 @@ const _getProductById = async (
 // Tell React to memoize it for the duration of the request
 export const getProductById = cache(_getProductById)
 
-export type ProductCreateForm = Omit<schemas['ProductCreate'], 'metadata'> &
+export type ProductEditOrCreateForm = Omit<
+  schemas['ProductCreate'],
+  'metadata'
+> &
   ProductFullMediasMixin & {
     metadata: { key: string; value: string | number | boolean }[]
   }
 
 export const productToCreateForm = (
   product: schemas['Product'],
-): ProductCreateForm => {
+): ProductEditOrCreateForm => {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   // We want to omit a few fields from the product to create a new product form.
   // This approach somewhat wonky, the alternative is omitting them which forces us


### PR DESCRIPTION
## 📋 Summary

This PR will replace the product edit sidebar with a new product edit page (`products/:id/edit`).

The approach is fairly straightforward;

1. Add a new edit route (`products/:id/edit`)
2. Repurpose the sidebar (`ProductPageContextView.tsx`) to its own page
3. Do some UI tweaks for the product page and the metrics screen to adapt to its new layout without a sidebar


## 🖼️ Screenshots/Recordings

| Product page before | Product page after  |
|--------|--------|
| <img width="3084" height="3600" alt="127 0 0 1_3000_dashboard_beppson_products_c528f9b6-b93d-4e28-927e-85fcd9b3cbcf (2)" src="https://github.com/user-attachments/assets/37c9a57c-04bf-4627-8ba5-76c82ccfaddf" /> | <img width="3084" height="3600" alt="127 0 0 1_3000_dashboard_beppson_products_c528f9b6-b93d-4e28-927e-85fcd9b3cbcf (1)" src="https://github.com/user-attachments/assets/21ff048a-0707-4660-a587-7d2642b5fba7" /> |


| Edit page | Metrics page  |
|--------|--------|
| <img width="3084" height="3600" alt="127 0 0 1_3000_dashboard_beppson_products_c528f9b6-b93d-4e28-927e-85fcd9b3cbcf (4)" src="https://github.com/user-attachments/assets/a36be7ab-3de9-4f6a-b368-ab45fdb59005" /> | <img width="3084" height="3600" alt="127 0 0 1_3000_dashboard_beppson_products_c528f9b6-b93d-4e28-927e-85fcd9b3cbcf (3)" src="https://github.com/user-attachments/assets/c778889f-2a9a-475f-8544-2f6581a9d93e" /> |


## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
