### PR TITLE
Scroll to error message when creating a product

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -71,15 +71,17 @@ export const ProductPriceFixedItem: React.FC<ProductPriceFixedItemProps> = ({
             <FormItem className="grow">
               <div className="flex items-center gap-2">
                 <FormControl>
-                  <MoneyInput
-                    name={field.name}
-                    value={field.value}
-                    onChange={(v) => {
-                      field.onChange(v)
-                      setValue(`prices.${index}.id`, '')
-                    }}
-                    placeholder={0}
-                  />
+                  <div ref={field.ref} tabIndex={-1}>
+                    <MoneyInput
+                      name={field.name}
+                      value={field.value}
+                      onChange={(v) => {
+                        field.onChange(v)
+                        setValue(`prices.${index}.id`, '')
+                      }}
+                      placeholder={0}
+                    />
+                  </div>
                 </FormControl>
               </div>
               <FormMessage />
@@ -113,15 +115,17 @@ export const ProductPriceCustomItem: React.FC<ProductPriceCustomItemProps> = ({
             <FormItem className="flex flex-1 flex-col gap-0.5">
               <FormLabel>Minimum amount</FormLabel>
               <FormControl>
-                <MoneyInput
-                  name={field.name}
-                  value={field.value}
-                  onChange={(v) => {
-                    field.onChange(v)
-                    setValue(`prices.${index}.id`, '')
-                  }}
-                  placeholder={1000}
-                />
+                <div ref={field.ref} tabIndex={-1}>
+                  <MoneyInput
+                    name={field.name}
+                    value={field.value}
+                    onChange={(v) => {
+                      field.onChange(v)
+                      setValue(`prices.${index}.id`, '')
+                    }}
+                    placeholder={1000}
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -143,15 +147,17 @@ export const ProductPriceCustomItem: React.FC<ProductPriceCustomItemProps> = ({
             <FormItem className="flex flex-1 flex-col gap-0.5">
               <FormLabel>Suggested amount</FormLabel>
               <FormControl>
-                <MoneyInput
-                  name={field.name}
-                  value={field.value}
-                  onChange={(v) => {
-                    field.onChange(v)
-                    setValue(`prices.${index}.id`, '')
-                  }}
-                  placeholder={5000}
-                />
+                <div ref={field.ref} tabIndex={-1}>
+                  <MoneyInput
+                    name={field.name}
+                    value={field.value}
+                    onChange={(v) => {
+                      field.onChange(v)
+                      setValue(`prices.${index}.id`, '')
+                    }}
+                    placeholder={5000}
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -386,15 +392,17 @@ export const ProductPriceSeatBasedItem: React.FC<
                       Price per seat
                     </FormLabel>
                     <FormControl>
-                      <MoneyInput
-                        name={field.name}
-                        value={field.value}
-                        onChange={(v) => {
-                          field.onChange(v)
-                          setValue(`prices.${index}.id`, '')
-                        }}
-                        placeholder={1000}
-                      />
+                      <div ref={field.ref} tabIndex={-1}>
+                        <MoneyInput
+                          name={field.name}
+                          value={field.value}
+                          onChange={(v) => {
+                            field.onChange(v)
+                            setValue(`prices.${index}.id`, '')
+                          }}
+                          placeholder={1000}
+                        />
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -718,6 +726,7 @@ const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
                       }
                     >
                       <SelectTrigger
+                        ref={field.ref}
                         className={twMerge(
                           field.value
                             ? ''


### PR DESCRIPTION
## 📋 Summary

Currently when creating a product you will not be scrolled to every validation error, only the product name. This is due to us not properly passing `ref`'s

⚠️ The diff for this PR is a bit messy due to indentation, so best viewed with the `&w=1` parameter: https://github.com/polarsource/polar/pull/8040/files?diff=unified&w=1.


## 🖼️ Screenshots/Recordings


https://github.com/user-attachments/assets/79910368-1edb-4096-8a1e-a6a62e1daf82


## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
