### PR TITLE
Add cursor: pointer to dropdowns and selects

### DIFF
--- a/clients/packages/ui/src/components/atoms/Select.tsx
+++ b/clients/packages/ui/src/components/atoms/Select.tsx
@@ -30,7 +30,7 @@ const SelectTrigger = ({
   <SelectTriggerPrimitive
     ref={ref}
     className={twMerge(
-      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300',
+      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300',
       className,
     )}
     {...props}
@@ -74,7 +74,7 @@ const SelectItem = ({
 }: React.ComponentProps<typeof SelectItemPrimitive>) => (
   <SelectItemPrimitive
     ref={ref}
-    className={twMerge(className, 'rounded-lg')}
+    className={twMerge(className, 'cursor-pointer rounded-lg')}
     {...props}
   >
     {children}

--- a/clients/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/clients/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -39,7 +39,7 @@ const DropdownMenuItem = ({
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs px-2 py-1.5 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4! [&_svg]:shrink-0',
+      'focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-xs px-2 py-1.5 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4! [&_svg]:shrink-0',
       className,
     )}
     {...props}


### PR DESCRIPTION
## 📋 Summary

This PR adds some missing `cursor: pointer` to our selects and dropdowns.

## 🖼️ Screenshots/Recordings


| Dropdown | Select  |
|--------|--------|
| <img width="380" height="211" alt="Screenshot 2025-11-24 at 17 31 46" src="https://github.com/user-attachments/assets/d1c0436d-72cf-47d8-b594-0f784b921e65" /> | <img width="492" height="181" alt="Screenshot 2025-11-24 at 17 31 41" src="https://github.com/user-attachments/assets/44feb27f-d99a-4560-b499-8aafd376604e" /> |


## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
