### PR TITLE
Allow for clearing discount date

### DIFF
--- a/clients/apps/web/src/components/Discounts/DiscountForm.tsx
+++ b/clients/apps/web/src/components/Discounts/DiscountForm.tsx
@@ -356,7 +356,9 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                     <FormLabel>Starts at</FormLabel>
                     <DateTimePicker
                       value={field.value || undefined}
-                      onChange={field.onChange}
+                      onChange={(value) => {
+                        field.onChange(value || null)
+                      }}
                       disabled={[
                         { before: now },
                         ...(endsAt ? [{ after: new Date(endsAt) }] : []),
@@ -376,7 +378,9 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                     <FormLabel>Ends at</FormLabel>
                     <DateTimePicker
                       value={field.value || undefined}
-                      onChange={field.onChange}
+                      onChange={(value) => {
+                        field.onChange(value || null)
+                      }}
                       disabled={{
                         before: startsAt ? new Date(startsAt) : now,
                       }}


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes https://github.com/polarsource/polar/issues/8042

This PR will allow for clearing/resetting a discounts start and end date.

## 🎯 What

Currently it's not possible to:

1. Create a discount with a start and/or end date
2. Edit the discount and remove start and/or end date

## 🔧 How

If no date is set, pass `null` as a value.

## 🖼️ Screenshots/Recordings


https://github.com/user-attachments/assets/ae3365eb-c377-4b3c-aedc-477c196f9e44




## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
