### PR TITLE
server/scripts: prevent tax_filing_imports from locking too much rows

### DIFF
--- a/server/scripts/tax_filing_imports.py
+++ b/server/scripts/tax_filing_imports.py
@@ -249,7 +249,7 @@ async def tax_filing_import(
 
                     process_row(batch_row, transaction, pending_transactions, session)
 
-                await session.flush()
+                await session.commit()
                 progress.update(process_task, advance=len(batch))
 
         if unmatching_transactions:


### PR DESCRIPTION
- server/scripts: prevent tax_filing_imports from locking too much rows