### PR TITLE
Hide cookie banner outside of EU

### DIFF
--- a/clients/apps/web/src/app/(main)/layout.tsx
+++ b/clients/apps/web/src/app/(main)/layout.tsx
@@ -1,13 +1,17 @@
 import { CookieConsent } from '@/components/Privacy/CookieConsent'
+import { headers } from 'next/headers'
 import { PropsWithChildren } from 'react'
 import { PolarThemeProvider } from '../providers'
 
 export default async function Layout({ children }: PropsWithChildren) {
+  const headersList = await headers()
+  const countryCode = headersList.get('x-vercel-ip-country')
+
   return (
     <PolarThemeProvider>
       <div className="dark:bg-polar-950 h-full bg-white dark:text-white">
         {children}
-        <CookieConsent />
+        <CookieConsent countryCode={countryCode} />
       </div>
     </PolarThemeProvider>
   )

--- a/clients/apps/web/src/components/Privacy/CookieConsent.tsx
+++ b/clients/apps/web/src/components/Privacy/CookieConsent.tsx
@@ -1,5 +1,6 @@
 // app/banner.js
 'use client'
+import { EU_COUNTRY_CODES } from '@/components/Privacy/countries'
 import { usePostHog } from '@/hooks/posthog'
 import { useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
@@ -16,7 +17,8 @@ export function cookieConsentGiven() {
   return localStorage.getItem('cookie_consent')
 }
 
-export function CookieConsent() {
+export function CookieConsent({ countryCode }: { countryCode: string | null }) {
+  const isEU = countryCode ? EU_COUNTRY_CODES.includes(countryCode) : false
   const [consentGiven, setConsentGiven] = useState<string | null>('')
   const { setPersistence } = usePostHog()
   const searchParams = useSearchParams()
@@ -66,6 +68,10 @@ export function CookieConsent() {
 
   const handleDeclineCookies = () => {
     declineCookies()
+  }
+
+  if (isEU) {
+    return null
   }
 
   return (


### PR DESCRIPTION
## 📋 Summary

Due to a regression during our React upgrade our cookie banner is now _always_ displayed, regardless if the user is in the EU or not. This PR fixes that by checking the [x-vercel-ip-country](https://vercel.com/docs/headers/request-headers#x-vercel-ip-country) header, provided by Vercel, to determine where the user is and hide the cookie banner if they are outside of the EU.

## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
