### PR TITLE
Add destructive prop to <DropDownMenuItem /> and unify UI across dropdowns

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/ClientPage.tsx
@@ -160,7 +160,7 @@ const CustomerHeader = ({
             Edit Customer
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={showDeleteCustomerModal}>
+          <DropdownMenuItem destructive onClick={showDeleteCustomerModal}>
             Delete Customer
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/[benefitId]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/[benefitId]/ClientPage.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@polar-sh/ui/components/ui/dropdown-menu'
 import { useCallback } from 'react'
@@ -119,9 +120,12 @@ const ClientPage: React.FC<ClientPageProps> = ({
                   Copy ID
                 </DropdownMenuItem>
                 {benefit?.deletable && (
-                  <DropdownMenuItem onClick={toggleDelete}>
-                    Delete
-                  </DropdownMenuItem>
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem destructive onClick={toggleDelete}>
+                      Delete Benefit
+                    </DropdownMenuItem>
+                  </>
                 )}
               </DropdownMenuContent>
             </DropdownMenu>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/checkout-links/[checkoutLinkId]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/checkout-links/[checkoutLinkId]/ClientPage.tsx
@@ -101,7 +101,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
                 align="end"
                 className="dark:bg-polar-800 bg-gray-50 shadow-lg"
               >
-                <DropdownMenuItem onClick={showDeleteModal}>
+                <DropdownMenuItem destructive onClick={showDeleteModal}>
                   Delete Checkout Link
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/ClientPage.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@polar-sh/ui/components/ui/dropdown-menu'
 import { useRouter } from 'next/navigation'
@@ -262,13 +263,15 @@ const ClientPage: React.FC<ClientPageProps> = ({
               <DropdownMenuItem onClick={handleCopyDiscountId(discount)}>
                 Copy Discount ID
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => {
                   setDiscountToDelete(discount)
                   toggleDiscountModal()
                 }}
+                destructive
               >
-                Delete
+                Delete Discount
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/meters/(list)/[meterId]/ClientPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/meters/(list)/[meterId]/ClientPage.tsx
@@ -99,7 +99,10 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization, meter }) => {
                 align="end"
                 className="dark:bg-polar-800 bg-gray-50 shadow-lg"
               >
-                <DropdownMenuItem onClick={handleArchiveMeter}>
+                <DropdownMenuItem
+                  destructive={!meter.archived_at}
+                  onClick={handleArchiveMeter}
+                >
                   {meter.archived_at ? 'Unarchive' : 'Archive'} Meter
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/clients/apps/web/src/components/Products/ProductListItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductListItem.tsx
@@ -189,11 +189,7 @@ export const ProductListItem = ({
                     Edit Product
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuItem
-                  onClick={handleContextMenuCallback(showModal)}
-                >
-                  Archive Product
-                </DropdownMenuItem>
+
                 <DropdownMenuItem
                   onClick={handleContextMenuCallback(() => {
                     router.push(
@@ -202,6 +198,13 @@ export const ProductListItem = ({
                   })}
                 >
                   Duplicate Product
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  destructive
+                  onClick={handleContextMenuCallback(showModal)}
+                >
+                  Archive Product
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
@@ -193,9 +193,6 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
                         Integrate Checkout
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={showArchiveModal}>
-                        Archive Product
-                      </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={() => {
                           router.push(
@@ -204,6 +201,10 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
                         }}
                       >
                         Duplicate Product
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem destructive onClick={showArchiveModal}>
+                        Archive Product
                       </DropdownMenuItem>
                     </>
                   )}

--- a/clients/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/clients/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -34,12 +34,16 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 const DropdownMenuItem = ({
   ref,
   className,
+  destructive,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) => (
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  destructive?: boolean
+}) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
       'focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-xs px-2 py-1.5 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4! [&_svg]:shrink-0',
+      destructive && 'text-destructive focus:text-white',
       className,
     )}
     {...props}


### PR DESCRIPTION
## 📋 Summary

This PR will do three things:

1. Add a `destructive` prop to <DropDownMenuItem /> which will display that item with a red text
2. Update dropdowns across the dashboard to add that prop to a destructive action (e.g archiving a product)
3. Make sure the copy is consistent across the dashboard (e.g `Delete Benefit` instead of just `Delete`)


## 🖼️ Screenshots/Recordings
Here's a few examples:

| Discount | Checkout Link | Product |
|--------|--------|--------|
| <img width="250" height="186" alt="Screenshot 2025-11-25 at 13 26 18" src="https://github.com/user-attachments/assets/ad928ea2-2875-46f7-afbf-6c9e4e9de1e0" /> | <img width="247" height="118" alt="Screenshot 2025-11-25 at 13 26 13" src="https://github.com/user-attachments/assets/93774704-d49c-4882-baf2-962354b6085b" /> | <img width="397" height="294" alt="Screenshot 2025-11-25 at 13 26 07" src="https://github.com/user-attachments/assets/d7d1ab70-9728-43a9-9990-3e00d04b7c8b" /> |









## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
