### PR TITLE
Add hit slop to "Remove image" button

### DIFF
--- a/clients/apps/web/src/components/Products/ProductMediasField/FileListItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductMediasField/FileListItem.tsx
@@ -79,9 +79,11 @@ export const FileListItem = ({
         <button
           type="button"
           onClick={onDelete}
-          className="absolute top-4 right-4 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white"
+          className="absolute top-0 right-0 flex h-[44px] w-[44px] cursor-pointer items-center justify-center"
         >
-          <ClearOutlined fontSize="inherit" />
+          <div className="flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+            <ClearOutlined fontSize="inherit" />
+          </div>
         </button>
       )}
       {isUploading && (


### PR DESCRIPTION
## 📋 Summary

The button for removing image is only 16x16px larger which makes it hard to click. This PR will add some hit slop to that button, increasing the clickable area to 44x44px (as recommended by Apple).

## 🖼️ Screenshots/Recordings

| Before | After  |
|--------|--------|
| <img width="730" height="343" alt="Screenshot 2025-11-25 at 13 48 34" src="https://github.com/user-attachments/assets/99d05657-e358-4f26-b986-37f5a99d8e65" /> | <img width="719" height="326" alt="Screenshot 2025-11-25 at 13 48 20" src="https://github.com/user-attachments/assets/4c7d56cc-2175-4e39-948f-647fae6ac382" /> |


## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
