### PR TITLE
Add a minimum release age to our PNPM config

### DIFF
--- a/clients/pnpm-workspace.yaml
+++ b/clients/pnpm-workspace.yaml
@@ -11,3 +11,5 @@ onlyBuiltDependencies:
   - esbuild
   - sharp
   - unrs-resolver
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
## 📋 Summary

Due to the [Shai Hulud](https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains) exploit yesterday this PR will add a `minimumReleaseAge` requirement for all our dependencies, ensuring that a package needs to be at least 24 hours old before we download it (see [PNPM docs](https://pnpm.io/settings#minimumreleaseage))


## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
