### PR TITLE
Make it easier to read local OTP

### DIFF
--- a/server/polar/login_code/service.py
+++ b/server/polar/login_code/service.py
@@ -3,6 +3,7 @@ import secrets
 import string
 from math import ceil
 
+import structlog
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
@@ -18,6 +19,8 @@ from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
 from polar.user.schemas import UserSignupAttribution
 from polar.user.service import user as user_service
+
+log = structlog.get_logger()
 
 
 class LoginCodeError(PolarError): ...
@@ -75,6 +78,16 @@ class LoginCodeService:
         )
 
         enqueue_email(to_email_addr=email, subject=subject, html_content=body)
+
+        if settings.is_development():
+            log.info(
+                "\n"
+                "╔══════════════════════════════════════════════════════════╗\n"
+                "║                                                          ║\n"
+                f"║                   🔑 LOGIN CODE: {code}                  ║\n"
+                "║                                                          ║\n"
+                "╚══════════════════════════════════════════════════════════╝"
+            )
 
     async def authenticate(
         self,


### PR DESCRIPTION
## 📋 Summary

When logging in locally we output the OTP code in the terminal. However my eyes have grown quite weary so it takes me way too long to find the code.

This PR fixes that by outputting the OTP explicitly in the logs.

## 🖼️ Screenshots/Recordings

| Before | After  |
|--------|--------|
| <img width="1346" height="974" alt="Screenshot 2025-11-25 at 14 58 50" src="https://github.com/user-attachments/assets/00966b54-3d1e-4b7d-9da9-f2dc36499784" /> | <img width="548" height="149" alt="Screenshot 2025-11-25 at 14 58 57" src="https://github.com/user-attachments/assets/63d5d8e8-0aeb-48af-935c-20847d41655a" /> |





## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
