### PR TITLE
Don't register for push on simulator/emulator

### DIFF
--- a/clients/apps/app/providers/NotificationsProvider.tsx
+++ b/clients/apps/app/providers/NotificationsProvider.tsx
@@ -21,6 +21,10 @@ function handleRegistrationError(errorMessage: string) {
 }
 
 async function registerForPushNotificationsAsync() {
+  if (!Device.isDevice) {
+    return
+  }
+
   if (Platform.OS === 'android') {
     Notifications.setNotificationChannelAsync('default', {
       name: 'default',
@@ -30,37 +34,33 @@ async function registerForPushNotificationsAsync() {
     })
   }
 
-  if (Device.isDevice) {
-    const { status: existingStatus } = await Notifications.getPermissionsAsync()
-    let finalStatus = existingStatus
-    if (existingStatus !== 'granted') {
-      const { status } = await Notifications.requestPermissionsAsync()
-      finalStatus = status
-    }
-    if (finalStatus !== 'granted') {
-      handleRegistrationError(
-        'Permission not granted to get push token for push notification!',
-      )
-      return
-    }
-    const projectId =
-      Constants?.expoConfig?.extra?.eas?.projectId ??
-      Constants?.easConfig?.projectId
-    if (!projectId) {
-      handleRegistrationError('Project ID not found')
-    }
-    try {
-      const pushTokenString = (
-        await Notifications.getExpoPushTokenAsync({
-          projectId,
-        })
-      ).data
-      return pushTokenString
-    } catch (e: unknown) {
-      handleRegistrationError(`${e}`)
-    }
-  } else {
-    handleRegistrationError('Must use physical device for push notifications')
+  const { status: existingStatus } = await Notifications.getPermissionsAsync()
+  let finalStatus = existingStatus
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync()
+    finalStatus = status
+  }
+  if (finalStatus !== 'granted') {
+    handleRegistrationError(
+      'Permission not granted to get push token for push notification!',
+    )
+    return
+  }
+  const projectId =
+    Constants?.expoConfig?.extra?.eas?.projectId ??
+    Constants?.easConfig?.projectId
+  if (!projectId) {
+    handleRegistrationError('Project ID not found')
+  }
+  try {
+    const pushTokenString = (
+      await Notifications.getExpoPushTokenAsync({
+        projectId,
+      })
+    ).data
+    return pushTokenString
+  } catch (e: unknown) {
+    handleRegistrationError(`${e}`)
   }
 }
 


### PR DESCRIPTION
## 📋 Summary

Currently when running the app in a simulator/emulator you get faced with this error:

```
ERROR  [Error: Uncaught (in promise, id: 0) Error: Must use physical device for push notifications]

Code: NotificationsProvider.tsx
  18 | function handleRegistrationError(errorMessage: string) {
  19 |   // alert(errorMessage);
> 20 |   throw new Error(errorMessage)
     |                  ^
  21 | }
  22 |
  23 | async function registerForPushNotificationsAsync() {
```

This is because we're explicitly throwing an error if the following statement is true: `if (!Device.device)`.

## 🎯 What

Instead of always throwing an error in a simulator/emulator this PR will instead just return early.
