### PR TITLE
Remove bitwise operator

### DIFF
--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -61,10 +61,13 @@ class CustomerComparator(Relationship.Comparator[Customer]):
         if isinstance(other, Customer):
             clause = Event.customer_id == other.id
             if other.external_id is not None:
-                clause |= and_(
-                    Event.external_customer_id.is_not(None),
-                    Event.external_customer_id == other.external_id,
-                    Event.organization_id == other.organization_id,
+                clause = or_(
+                    clause,
+                    and_(
+                        Event.external_customer_id.is_not(None),
+                        Event.external_customer_id == other.external_id,
+                        Event.organization_id == other.organization_id,
+                    ),
                 )
             return clause
 


### PR DESCRIPTION
Compound expression generates SQL missing parentheses, i.e. `A OR X AND Y AND Z` instead of `A OR (X AND Y AND Z)`, which leads to unexpected results.

See [SQL Alchemy docs](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.or_)