### PR TITLE
Give ourselves a bit of headroom updating customer meters

### DIFF
--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -113,7 +113,7 @@ class CustomerMeterService:
         async with locker.lock(
             f"customer_meter:{customer.id}:{meter.id}",
             timeout=5.0,
-            blocking_timeout=0.2,
+            blocking_timeout=2.0,
         ):
             repository = CustomerMeterRepository.from_session(session)
             customer_meter = await repository.get_by_customer_and_meter(


### PR DESCRIPTION
This was 5 seconds back when we got ourselves in a bit of trouble, then got decreased to `0.1` to exit early to avoid the loop of retry/lock/retry/lock/…

[See the diff here](https://github.com/polarsource/polar/pull/7140/files)

Now, 200ms is a bit low, so let's introduce a bit more headroom again.