### PR TITLE
Fix app onboarding redirect issue

### DIFF
--- a/clients/apps/app/app/(authenticated)/onboarding/index.tsx
+++ b/clients/apps/app/app/(authenticated)/onboarding/index.tsx
@@ -5,6 +5,7 @@ import { ThemedText } from '@/components/Shared/ThemedText'
 import { useCreateOrganization } from '@/hooks/polar/organizations'
 import { useTheme } from '@/hooks/theme'
 import { OrganizationContext } from '@/providers/OrganizationProvider'
+import { queryClient } from '@/utils/query'
 import { themes } from '@/utils/theme'
 import { ClientResponseError, schemas } from '@polar-sh/client'
 import { Stack, useRouter } from 'expo-router'
@@ -71,6 +72,7 @@ export default function Onboarding() {
       try {
         const organization = await createOrganization.mutateAsync(data)
         setOrganization(organization)
+        await queryClient.refetchQueries({ queryKey: ['organizations'] })
         router.replace('/')
       } catch (error) {
         if (error instanceof ClientResponseError) {


### PR DESCRIPTION
## 📋 Summary

During onboarding when you create your first org you don't get redirected back to the home screen, the screen re-renders and you see this 👇 

<img width="403" height="894" alt="Screenshot 2025-11-28 at 14 06 45" src="https://github.com/user-attachments/assets/797196e8-476d-4f8d-83d0-4981efcd01a2" />

This PR fixes that so after org creation, you are taken to the home screen.
