### PR TITLE
task/subscription: Remove unneeded order on events

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -239,9 +239,9 @@ class BillingEntryService:
         units = await meter_service.get_quantity(
             session,
             meter,
-            events_statement.with_only_columns(Event.id).where(
-                Event.source == EventSource.user
-            ),
+            events_statement.with_only_columns(Event.id)
+            .where(Event.source == EventSource.user)
+            .order_by(None),
         )
         credit_events_statement = events_statement.where(
             Event.is_meter_credit.is_(True)
@@ -288,9 +288,9 @@ class BillingEntryService:
         units = await meter_service.get_quantity(
             session,
             meter,
-            events_statement.with_only_columns(Event.id).where(
-                Event.source == EventSource.user
-            ),
+            events_statement.with_only_columns(Event.id)
+            .where(Event.source == EventSource.user)
+            .order_by(None),
         )
         credit_events_statement = events_statement.where(
             Event.is_meter_credit.is_(True)


### PR DESCRIPTION
This should save us between 50-90% of time spent on this query for specific customers
