### PR TITLE
task/customer_meter: Remove unneeded order on events and id IN

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -239,9 +239,7 @@ class BillingEntryService:
         units = await meter_service.get_quantity(
             session,
             meter,
-            events_statement.with_only_columns(Event.id)
-            .where(Event.source == EventSource.user)
-            .order_by(None),
+            events_statement.where(Event.source == EventSource.user),
         )
         credit_events_statement = events_statement.where(
             Event.is_meter_credit.is_(True)
@@ -288,9 +286,7 @@ class BillingEntryService:
         units = await meter_service.get_quantity(
             session,
             meter,
-            events_statement.with_only_columns(Event.id)
-            .where(Event.source == EventSource.user)
-            .order_by(None),
+            events_statement.where(Event.source == EventSource.user),
         )
         credit_events_statement = events_statement.where(
             Event.is_meter_credit.is_(True)

--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -141,7 +141,7 @@ class CustomerMeterService:
             if customer_meter.last_balanced_event_id == last_event.id:
                 return customer_meter, False
 
-            usage_events_statement = events_statement.with_only_columns(Event.id).where(
+            usage_events_statement = events_statement.where(
                 Event.source == EventSource.user
             )
             usage_units = await meter_service.get_quantity(
@@ -178,7 +178,7 @@ class CustomerMeterService:
         if last_event is None:
             return 0
 
-        usage_events_statement = events_statement.with_only_columns(Event.id).where(
+        usage_events_statement = events_statement.where(
             Event.source == EventSource.user
         )
         usage_units = await meter_service.get_quantity(

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -462,11 +462,11 @@ class MeterService:
         self,
         session: AsyncSession,
         meter: Meter,
-        events_statement: Select[tuple[uuid.UUID]],
+        events_statement: Select[tuple[Event]],
     ) -> float:
-        statement = select(
+        statement = events_statement.with_only_columns(
             func.coalesce(meter.aggregation.get_sql_column(Event), 0)
-        ).where(Event.id.in_(events_statement))
+        ).order_by(None)
         result = await session.scalar(statement)
         return result or 0.0
 


### PR DESCRIPTION
Hopefully this speeds up queries where we dont need to select and order events just to do an IN query. Looks like 1/3 of the time in my testing.
