### PR TITLE
logfire: Use Render service name always, fall back to server/worker

### DIFF
--- a/server/polar/logfire.py
+++ b/server/polar/logfire.py
@@ -81,10 +81,7 @@ def _scrubbing_callback(match: logfire.ScrubMatch) -> Any | None:
 
 
 def configure_logfire(service_name: Literal["server", "worker"]) -> None:
-    if service_name == "worker":
-        resolved_service_name = os.environ.get("RENDER_SERVICE_NAME", service_name)
-    else:
-        resolved_service_name = service_name
+    resolved_service_name = os.environ.get("RENDER_SERVICE_NAME", service_name)
 
     logfire.configure(
         send_to_logfire="if-token-present",


### PR DESCRIPTION
This means that the service name for the server becomes 'api'