### PR TITLE
Fix scroll on settings with many orgs

### DIFF
--- a/clients/apps/app/app/(authenticated)/settings/index.tsx
+++ b/clients/apps/app/app/(authenticated)/settings/index.tsx
@@ -48,7 +48,7 @@ export default function Index() {
         <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
       }
       contentInset={{ bottom: 16 }}
-      contentContainerStyle={{ flex: 1 }}
+      contentContainerStyle={{ flexGrow: 1 }}
     >
       <Stack.Screen options={{ title: 'Settings' }} />
       <SafeAreaView style={SettingsStyle.container}>


### PR DESCRIPTION
## 📋 Summary

If a user has many orgs it's not possible to scroll down to delete/log out in the settings screen, this PR fixes that.
