### PR TITLE
docs: Update Codex MCP configuration to use URL-based setup

### DIFF
--- a/docs/integrate/mcp.mdx
+++ b/docs/integrate/mcp.mdx
@@ -111,18 +111,36 @@ For sandbox:
 
 Add the following to your `~/.codex/config.toml`:
 
-```sh
+```toml
+[features]
+rmcp_client = true
+
 [mcp_servers.polar]
-command = "npx"
-args = ["-y", "mcp-remote", "https://mcp.polar.sh/mcp/polar-mcp"]
+type = "http"
+url = "https://mcp.polar.sh/mcp/polar-mcp"
+```
+
+Then run:
+
+```sh
+codex mcp login polar
 ```
 
 For sandbox:
 
-```sh
+```toml
+[features]
+rmcp_client = true
+
 [mcp_servers.polar_sandbox]
-command = "npx"
-args = ["-y", "mcp-remote", "https://mcp.polar.sh/mcp/polar-sandbox"]
+type = "http"
+url = "https://mcp.polar.sh/mcp/polar-sandbox"
+```
+
+Then run:
+
+```sh
+codex mcp login polar_sandbox
 ```
 
 ### Claude Code


### PR DESCRIPTION
Updated the Codex section in the MCP documentation to use the new URL-based configuration instead of the command-based approach. This simplifies setup by using the native HTTP transport type.

Changes:
- Added rmcp_client feature flag requirement
- Changed from npx/mcp-remote to type="http" with url parameter
- Added codex mcp login command for authentication
- Updated both production and sandbox examples