### PR TITLE
Fix crash on settings screen when using multiple accounts

### DIFF
--- a/clients/apps/app/app/(authenticated)/settings/index.tsx
+++ b/clients/apps/app/app/(authenticated)/settings/index.tsx
@@ -77,7 +77,7 @@ export default function Index() {
               </MiniButton>
             </View>
             <View style={SettingsStyle.organizationsContainer}>
-              {organizationData?.items?.map((organization) => (
+              {organizationData?.items.map((organization) => (
                 <TouchableOpacity
                   key={organization?.id}
                   style={[
@@ -87,10 +87,8 @@ export default function Index() {
                     },
                   ]}
                   onPress={() => {
-                    if (organization) {
-                      setOrganization(organization)
-                      router.back()
-                    }
+                    setOrganization(organization)
+                    router.back()
                   }}
                   activeOpacity={0.6}
                 >
@@ -119,9 +117,7 @@ export default function Index() {
           </View>
           <View style={{ gap: 16 }}>
             <View>
-              <ThemedText style={[SettingsStyle.title]}>
-                !!!! Danger zone {user?.email}
-              </ThemedText>
+              <ThemedText style={[SettingsStyle.title]}>Danger zone</ThemedText>
               <ThemedText style={{ color: colors.subtext }}>
                 Irreversible actions for this account
               </ThemedText>

--- a/clients/apps/app/hooks/auth.ts
+++ b/clients/apps/app/hooks/auth.ts
@@ -27,7 +27,7 @@ export const useLogout = () => {
 
   const signOut = useCallback(async () => {
     try {
-      if (notificationRecipient) {
+      if (notificationRecipient?.id) {
         deleteNotificationRecipient
           .mutateAsync(notificationRecipient.id)
           .catch(() => {})

--- a/clients/apps/app/hooks/polar/notifications.ts
+++ b/clients/apps/app/hooks/polar/notifications.ts
@@ -70,8 +70,8 @@ export const useListNotificationRecipients = (): UseQueryResult<
 }
 
 export const useGetNotificationRecipient = (
-  expoPushToken: string,
-): UseQueryResult<NotificationRecipient, Error> => {
+  expoPushToken: string | undefined,
+): UseQueryResult<NotificationRecipient | null, Error> => {
   const { session } = useSession()
 
   return useQuery({
@@ -87,9 +87,10 @@ export const useGetNotificationRecipient = (
         },
       )
 
-      return response.json().then((data) => data.items[0])
+      const data = await response.json()
+      return data.items?.[0] ?? null
     },
-    enabled: !!expoPushToken,
+    enabled: !!expoPushToken && !!session,
   })
 }
 


### PR DESCRIPTION
## 📋 Summary

The app crashes on the Settings screen when switching between accounts on the same device.

Repro steps:
1. Log in as `User A`
2. Log out
3. Log in as `User B`
4. Navigate to the settings screen
5. App crashes

The `useLogout` hook calls `useGetNotificationRecipient(expoPushToken)` which executes immediately when the Settings screen mounts. When User B logs in, the query fetches notification recipients filtered by the device's push token. Since User B doesn't own User A's notification recipient, the API returns { items: [] }.
