### PR TITLE
Add `dirty` boolean on customers

### DIFF
--- a/server/migrations/versions/2025-11-28-1506_add_dirty_flag_to_customer.py
+++ b/server/migrations/versions/2025-11-28-1506_add_dirty_flag_to_customer.py
@@ -1,0 +1,51 @@
+"""add dirty flag to customer
+
+Revision ID: 856fff9b3dfe
+Revises: f5223877acbb
+Create Date: 2025-11-28 15:06:40.120064
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "856fff9b3dfe"
+down_revision = "f5223877acbb"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Add dirty column with default False
+    op.add_column(
+        "customers",
+        sa.Column("dirty", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+    # Set dirty = TRUE where meters_dirtied_at IS NOT NULL
+    op.execute(
+        """
+        UPDATE customers
+        SET dirty = TRUE
+        WHERE meters_dirtied_at IS NOT NULL
+        """
+    )
+
+    # Create index on dirty column
+    op.create_index(
+        op.f("ix_customers_dirty"),
+        "customers",
+        ["dirty"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    # Drop index
+    op.drop_index(op.f("ix_customers_dirty"), table_name="customers")
+
+    # Drop column
+    op.drop_column("customers", "dirty")

--- a/server/polar/customer_meter/scheduler.py
+++ b/server/polar/customer_meter/scheduler.py
@@ -44,6 +44,7 @@ class CustomerMeterJobStore(BaseJobStore):
         statement = (
             select(Customer)
             .where(
+                Customer.dirty.is_(True),
                 Customer.meters_dirtied_at.is_not(None),
                 or_(
                     Customer.meters_dirtied_at

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -161,6 +161,9 @@ class Customer(MetadataMixin, RecordModel):
     meters_updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True, default=None, index=True
     )
+    dirty: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, index=True
+    )
 
     invoice_next_number: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 


### PR DESCRIPTION
This would exclude customers from being queued again during customer meter updates when tasks take longer than the debounce threshold.