### PR TITLE
Allow users to reset max redemptions on discounts

### DIFF
--- a/clients/apps/web/src/components/Discounts/DiscountForm.tsx
+++ b/clients/apps/web/src/components/Discounts/DiscountForm.tsx
@@ -404,7 +404,13 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                       <Input
                         {...field}
                         type="number"
-                        value={field.value || undefined}
+                        value={field.value ?? ''}
+                        onChange={(e) => {
+                          const value = e.target.value
+                          field.onChange(
+                            value === '' ? null : parseInt(value, 10),
+                          )
+                        }}
                         min={1}
                       />
                     </FormControl>


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes https://github.com/polarsource/polar/issues/8168

This PR will allow users to reset the `max_redemptions` field on discounts to `null`.

## Steps to reproduce
1. Go to `/discounts`
2. Create a new discount with 20 max redemptions
3. Save the discount
4. Edit the discount and reset the max redemptions field
5. Save the discount