### PR TITLE
server/refund: skip tax transaction reversal if managed by Stripe

### DIFF
--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -560,7 +560,11 @@ class RefundService(ResourceServiceReader[Refund]):
             )
 
             # Revert the tax transaction in the tax processor ledger
-            if order.tax_transaction_processor_id and order.tax_amount > 0:
+            if (
+                order.stripe_invoice_id is None  # Tax managed via Stripe Billing
+                and order.tax_transaction_processor_id
+                and order.tax_amount > 0
+            ):
                 if refund.total_amount == order.total_amount:
                     tax_transaction_processor = (
                         await stripe_service.revert_tax_transaction(


### PR DESCRIPTION
Fix #8201

- server/refund: skip tax transaction reversal if managed by Stripe
