### PR TITLE
server/kit/tax: fix Vietnam Tax ID not correctly validated

### DIFF
--- a/server/polar/kit/tax.py
+++ b/server/polar/kit/tax.py
@@ -10,6 +10,7 @@ import stdnum.cl.rut
 import stdnum.exceptions
 import stdnum.in_.gstin
 import stdnum.tr.vkn
+import stdnum.vn.mst
 import stripe as stripe_lib
 import structlog
 from pydantic import Field
@@ -276,6 +277,15 @@ class INGSTValidator(ValidatorProtocol):
             raise InvalidTaxID(number, country) from e
 
 
+class VNTINValidator(ValidatorProtocol):
+    def validate(self, number: str, country: str) -> str:
+        number = stdnum.vn.mst.compact(number)
+        try:
+            return stdnum.vn.mst.validate(number)
+        except stdnum.exceptions.ValidationError as e:
+            raise InvalidTaxID(number, country) from e
+
+
 def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
     match tax_id_type:
         case TaxIDFormat.ca_gst_hst:
@@ -286,6 +296,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return TRTINValidator()
         case TaxIDFormat.in_gst:
             return INGSTValidator()
+        case TaxIDFormat.vn_tin:
+            return VNTINValidator()
         case _:
             return StdNumValidator(tax_id_type)
 

--- a/server/tests/checkout/test_tax.py
+++ b/server/tests/checkout/test_tax.py
@@ -27,6 +27,7 @@ from polar.kit.tax import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("12531909-2", "CL", ("125319092", TaxIDFormat.cl_tin)),
         ("4540536920", "TR", ("4540536920", TaxIDFormat.tr_tin)),
         ("27AAPFU0939F1ZV", "IN", ("27AAPFU0939F1ZV", TaxIDFormat.in_gst)),
+        ("0100233488", "VN", ("0100233488", TaxIDFormat.vn_tin)),
     ],
 )
 def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:


### PR DESCRIPTION
Fix #8197

- server/kit/tax: fix Vietnam Tax ID not correctly validated
