### PR TITLE
server/order: revoke subscription during dunning process if past due deadline is reached

### DIFF
--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -976,6 +976,7 @@ async def create_subscription(
     user_metadata: dict[str, Any] | None = None,
     scheduler_locked_at: datetime | None = None,
     seats: int | None = None,
+    past_due_at: datetime | None = None,
 ) -> Subscription:
     prices = prices or product.prices
 
@@ -1033,6 +1034,7 @@ async def create_subscription(
         user_metadata=user_metadata or {},
         scheduler_locked_at=scheduler_locked_at,
         seats=seats,
+        past_due_at=past_due_at,
     )
     await save_fixture(subscription)
 

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -222,7 +222,7 @@ class TestProcessDunningOrder:
 
         # Then
         assert (
-            "Order subscription has no payment method, skipping dunning" in caplog.text
+            "Order subscription has no payment method, record a failure" in caplog.text
         )
 
     async def test_valid_order_triggers_payment_retry(


### PR DESCRIPTION

- server/order: revoke subscription during dunning process if past due deadline is reached
- server/order: directly trigger a payment failure when creating cycle order if no payment method asociated
  