### PR TITLE
Preserve span params when navigating back from event

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/components/SpansTitle.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/components/SpansTitle.tsx
@@ -3,6 +3,7 @@
 import { EventCostCreationGuideModal } from '@/components/Events/EventCostCreationGuideModal'
 import { Modal } from '@/components/Modal'
 import { useModal } from '@/components/Modal/useModal'
+import { useNavigationHistory } from '@/providers/navigationHistory'
 import { schemas } from '@polar-sh/client'
 import { ChevronRightIcon, CircleQuestionMarkIcon } from 'lucide-react'
 import Link from 'next/link'
@@ -27,11 +28,15 @@ export function SpansTitle({
     hide: hideEventCostCreationGuide,
   } = useModal()
 
+  const { withPotentialPreviousParams } = useNavigationHistory()
   const searchParams = useSearchParams()
   const startDate = searchParams.get('startDate') ?? getDefaultStartDate()
   const endDate = searchParams.get('endDate') ?? getDefaultEndDate()
   const interval = searchParams.get('interval') ?? DEFAULT_INTERVAL
   const searchString = getCostsSearchParams(startDate, endDate, interval)
+
+  const spanIdPath = `/dashboard/${organization.slug}/analytics/costs/${eventType?.id}`
+  const backLink = withPotentialPreviousParams(spanIdPath)
 
   return (
     <div className="flex flex-row items-center justify-between gap-1.5">
@@ -44,11 +49,7 @@ export function SpansTitle({
         {eventType && (
           <>
             <ChevronRightIcon className="dark:text-polar-500 size-5 text-gray-400" />
-            <Link
-              href={`/dashboard/${organization.slug}/analytics/costs/${eventType.id}${searchString ? `?${searchString}` : ''}`}
-            >
-              {eventType.label}
-            </Link>
+            <Link href={backLink}>{eventType.label}</Link>
           </>
         )}
       </h2>

--- a/clients/apps/web/src/app/layout.tsx
+++ b/clients/apps/web/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { GeistSans } from 'geist/font/sans'
 import { PHASE_PRODUCTION_BUILD } from 'next/constants'
 import { Metadata } from 'next/types'
 import {
+  NavigationHistoryProvider,
   PolarNuqsProvider,
   PolarPostHogProvider,
   PolarQueryClientProvider,
@@ -147,8 +148,10 @@ export default async function RootLayout({
           <PolarPostHogProvider>
             <PolarQueryClientProvider>
               <PolarNuqsProvider>
-                <SandboxBanner />
-                {children}
+                <NavigationHistoryProvider>
+                  <SandboxBanner />
+                  {children}
+                </NavigationHistoryProvider>
               </PolarNuqsProvider>
             </PolarQueryClientProvider>
           </PolarPostHogProvider>

--- a/clients/apps/web/src/app/providers.tsx
+++ b/clients/apps/web/src/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cookieConsentGiven } from '@/components/Privacy/CookieConsent'
+import { NavigationHistoryProvider } from '@/providers/navigationHistory'
 import { getQueryClient } from '@/utils/api/query'
 import { CONFIG } from '@/utils/config'
 import { QueryClientProvider } from '@tanstack/react-query'
@@ -10,6 +11,8 @@ import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { PropsWithChildren, useEffect } from 'react'
+
+export { NavigationHistoryProvider }
 
 export function PolarPostHogProvider({
   children,

--- a/clients/apps/web/src/providers/navigationHistory.tsx
+++ b/clients/apps/web/src/providers/navigationHistory.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+interface NavigationHistoryContextValue {
+  currentURL: string
+  previousURL: string | null
+  withPotentialPreviousParams: (pathPrefix: string) => string
+}
+
+const NavigationHistoryContext = createContext<NavigationHistoryContextValue>({
+  currentURL: '',
+  previousURL: null,
+  withPotentialPreviousParams: (path) => path,
+})
+
+export const useNavigationHistory = () => useContext(NavigationHistoryContext)
+
+export const NavigationHistoryProvider = ({ children }: PropsWithChildren) => {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const [previousURL, setPreviousURL] = useState<string | null>(null)
+  const currentURLRef = useRef<string | null>(null)
+
+  const currentURL = useMemo(() => {
+    const searchString = searchParams.toString()
+    return searchString ? `${pathname}?${searchString}` : pathname
+  }, [pathname, searchParams])
+
+  useEffect(() => {
+    if (currentURLRef.current !== currentURL) {
+      setPreviousURL(currentURLRef.current)
+      currentURLRef.current = currentURL
+    }
+  }, [currentURL])
+
+  const withPotentialPreviousParams = useCallback(
+    (pathPrefix: string) => {
+      if (previousURL?.startsWith(pathPrefix)) {
+        const queryIndex = previousURL.indexOf('?')
+        if (queryIndex !== -1) {
+          return `${pathPrefix}${previousURL.slice(queryIndex)}`
+        }
+      }
+      return pathPrefix
+    },
+    [previousURL],
+  )
+
+  return (
+    <NavigationHistoryContext.Provider
+      value={{ currentURL, previousURL, withPotentialPreviousParams }}
+    >
+      {children}
+    </NavigationHistoryContext.Provider>
+  )
+}


### PR DESCRIPTION
## 🎯 What

This PR will add a context provider that keeps track of your current and previous page URL's. This is used to preserve any type of `?interval` date params that we set inside of `/cost` which means we can navigate back from an event and preserve the query param. As an example:

1. Go to http://127.0.0.1:3000/dashboard/foo/analytics/costs/foo
2. Update the time interval to a week
3. URL is now http://127.0.0.1:3000/dashboard/foo/analytics/costs/foo?interval=week
4. Go to an event
5. URL is now http://127.0.0.1:3000/dashboard/foo/analytics/costs/foo/bar
6. Press the back link
7. URL is now http://127.0.0.1:3000/dashboard/foo/analytics/costs/foo?interval=week