### PR TITLE
fix: Repair broken warning block rendering in order.created webhook docs

### DIFF
--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -399,7 +399,8 @@ class WebhookOrderCreatedPayload(WebhookOrderPayloadBase):
     * A subscription is renewed. In this case, `billing_reason` is set to `subscription_cycle`.
     * A subscription is upgraded or downgraded with an immediate proration invoice. In this case, `billing_reason` is set to `subscription_update`.
 
-    <Warning>The order might not be paid yet, so the `status` field might be `pending`.</Warning>
+    > [!WARNING]
+    > The order might not be paid yet, so the `status` field might be `pending`.
 
     **Discord & Slack support:** Full
     """


### PR DESCRIPTION
## Description
This PR fixes a rendering issue in the `order.created` webhook documentation where a warning block was displaying as raw text (`<Warning>...</Warning>`) instead of a formatted alert box.

The issue was caused by the use of a custom React component syntax inside the Python docstring, which the documentation generator did not parse correctly.

## Fix
I have replaced the `<Warning>` tags with standard GitHub Flavored Markdown (GFM) alert syntax:
`> [!WARNING]`

This ensures the warning renders correctly in:
- The generated API reference (Next.js frontend).
- The backend's Swagger UI documentation.

## Related Issue
Fixes #8095

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified the fix locally