### PR TITLE
server/dispute: fix object not being properly flushed before refund creation

### DIFF
--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -81,6 +81,7 @@ class DisputeService:
             dispute.status = DisputeStatus.prevented
             balance_transaction = get_dispute_balance_transaction(stripe_dispute)
             assert balance_transaction is not None
+            await session.flush()
             await refund_service.create_from_dispute(
                 session, dispute, balance_transaction.id
             )


### PR DESCRIPTION
Fix #8323

- server/dispute: fix object not being properly flushed before refund creation
