### PR TITLE
server/order: allow an order to be over-refunded internally

### DIFF
--- a/server/polar/transaction/service/refund.py
+++ b/server/polar/transaction/service/refund.py
@@ -70,7 +70,7 @@ class RefundTransactionService(BaseTransactionService):
             )
             settlement_amount = balance_transaction.amount
             settlement_currency = balance_transaction.currency
-            exchange_rate = balance_transaction.exchange_rate or 1.0
+            exchange_rate = -settlement_amount / (refund.amount + refund.tax_amount)
             settlement_tax_amount = -polar_round(refund.tax_amount * exchange_rate)
         else:
             raise NotImplementedError()

--- a/server/tests/models/test_order.py
+++ b/server/tests/models/test_order.py
@@ -23,6 +23,9 @@ from tests.fixtures.random_objects import create_order
         pytest.param(
             1000, 250, -500, 750, 500, 250, id="full refund with negative balance"
         ),
+        pytest.param(
+            1000, 250, 0, 1300, 1040, 260, id="refund exceeding original amount"
+        ),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix #8344

- server/order: allow an order to be over-refunded internally
