### PR TITLE
server/refund: fix revert tax transaction when refund amount exceeds original amount

### DIFF
--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -628,7 +628,7 @@ class RefundService(ResourceServiceReader[Refund]):
                 and order.tax_transaction_processor_id
                 and order.tax_amount > 0
             ):
-                if refund.total_amount == order.total_amount:
+                if refund.total_amount >= order.total_amount:
                     tax_transaction_processor = (
                         await stripe_service.revert_tax_transaction(
                             order.tax_transaction_processor_id,


### PR DESCRIPTION
Fix #8348

- server/refund: fix revert tax transaction when refund amount exceeds original amount
