### PR TITLE
Add "Committed Subscriptions" metric

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/components/metrics-config.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/components/metrics-config.ts
@@ -21,6 +21,7 @@ export const SUBSCRIPTION_METRICS: (keyof schemas['Metrics'])[] = [
   'committed_monthly_recurring_revenue',
   'active_subscriptions',
   'new_subscriptions',
+  'committed_subscriptions',
   'renewed_subscriptions',
   'average_revenue_per_user',
   'ltv',
@@ -32,6 +33,8 @@ export const CANCELLATION_CHART_METRICS: (keyof schemas['Metrics'])[] = [
   'canceled_subscriptions',
   'churned_subscriptions',
   'churn_rate',
+  'active_subscriptions',
+  'committed_subscriptions',
 ]
 
 export const CANCELLATION_METRICS: (keyof schemas['Metrics'])[] = [

--- a/clients/apps/web/src/utils/metrics.ts
+++ b/clients/apps/web/src/utils/metrics.ts
@@ -235,6 +235,7 @@ export const ALL_METRICS: {
     display_name: 'Renewed Subscriptions Net Revenue',
   },
   { slug: 'active_subscriptions', display_name: 'Active Subscriptions' },
+  { slug: 'committed_subscriptions', display_name: 'Committed Subscriptions' },
   {
     slug: 'monthly_recurring_revenue',
     display_name: 'Monthly Recurring Revenue',

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -17526,6 +17526,8 @@ export interface components {
       renewed_subscriptions_net_revenue?: number | null
       /** Active Subscriptions */
       active_subscriptions?: number | null
+      /** Committed Subscriptions */
+      committed_subscriptions?: number | null
       /** Monthly Recurring Revenue */
       monthly_recurring_revenue?: number | null
       /** Committed Monthly Recurring Revenue */
@@ -17596,6 +17598,7 @@ export interface components {
       renewed_subscriptions_revenue?: components['schemas']['Metric'] | null
       renewed_subscriptions_net_revenue?: components['schemas']['Metric'] | null
       active_subscriptions?: components['schemas']['Metric'] | null
+      committed_subscriptions?: components['schemas']['Metric'] | null
       monthly_recurring_revenue?: components['schemas']['Metric'] | null
       committed_monthly_recurring_revenue?:
         | components['schemas']['Metric']
@@ -17738,6 +17741,8 @@ export interface components {
       renewed_subscriptions_net_revenue?: number | null
       /** Active Subscriptions */
       active_subscriptions?: number | null
+      /** Committed Subscriptions */
+      committed_subscriptions?: number | null
       /** Monthly Recurring Revenue */
       monthly_recurring_revenue?: number | null
       /** Committed Monthly Recurring Revenue */


### PR DESCRIPTION
I thought it was possible to calculate this from active - canceled subscriptions, but that isn't actually true: canceled includes immediately churned + churn at period end, but immediately churned will no longer be part of active subscriptions, so the math is off.

If we show _Committed Revenue_ it makes sense to also show this.