### PR TITLE
Fix delay by manually setting `eta`

### DIFF
--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -87,6 +87,7 @@ class JobQueueManager:
             )
 
             # Handle delay: convert to eta and use delayed queue
+            # See https://github.com/Bogdanp/dramatiq/blob/aa91cdfcfa6d8ad957ca0afe900266617f2661f8/dramatiq/brokers/stub.py#L107-L116
             if delay is not None and delay > 0:
                 current_millis = int(time.time() * 1000)
                 eta = current_millis + delay


### PR DESCRIPTION
The fix in #8343 didn't actually work, since `delay` isn't an option on `message_with_options` unlike on `send_with_options` in Dramatiq. Thank you @Yopi for pointing that out.

This mimics the delay implementation from `send_with_options` to properly implement the delay. This is agnostic of Redis /  RabbitMQ / …

I have tested it locally with a 30-second delay and you can see them execute one-by-one now.

