### PR TITLE
server/dispute: revoke benefits/subscription when receiving dispute

### DIFF
--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -28,11 +28,15 @@ class DisputeRepository(
     model = Dispute
 
     async def get_by_payment_processor_dispute_id(
-        self, processor: PaymentProcessor, processor_id: str
+        self, processor: PaymentProcessor, processor_id: str, *, options: Options = ()
     ) -> Dispute | None:
-        statement = self.get_base_statement().where(
-            Dispute.payment_processor == processor,
-            Dispute.payment_processor_id == processor_id,
+        statement = (
+            self.get_base_statement()
+            .where(
+                Dispute.payment_processor == processor,
+                Dispute.payment_processor_id == processor_id,
+            )
+            .options(*options)
         )
         return await self.get_one_or_none(statement)
 
@@ -42,6 +46,8 @@ class DisputeRepository(
         processor_payment_id: str,
         total_amount: int,
         currency: str,
+        *,
+        options: Options = (),
     ) -> Dispute | None:
         statement = (
             self.get_base_statement()
@@ -52,17 +58,26 @@ class DisputeRepository(
                 Payment.processor == processor,
                 Payment.processor_id == processor_payment_id,
             )
+            .options(*options)
             .order_by(Dispute.created_at.asc())
             .limit(1)
         )
         return await self.get_one_or_none(statement)
 
     async def get_by_alert_processor_id(
-        self, processor: DisputeAlertProcessor, processor_id: str
+        self,
+        processor: DisputeAlertProcessor,
+        processor_id: str,
+        *,
+        options: Options = (),
     ) -> Dispute | None:
-        statement = self.get_base_statement().where(
-            Dispute.dispute_alert_processor == processor,
-            Dispute.dispute_alert_processor_id == processor_id,
+        statement = (
+            self.get_base_statement()
+            .where(
+                Dispute.dispute_alert_processor == processor,
+                Dispute.dispute_alert_processor_id == processor_id,
+            )
+            .options(*options)
         )
         return await self.get_one_or_none(statement)
 
@@ -93,7 +108,10 @@ class DisputeRepository(
         return statement
 
     def get_eager_options(self) -> Options:
-        return (joinedload(Dispute.payment),)
+        return (
+            joinedload(Dispute.payment),
+            joinedload(Dispute.order),
+        )
 
     def get_sorting_clause(self, property: DisputeSortProperty) -> SortingClause:
         match property:


### PR DESCRIPTION
Fix #8381

- server/dispute: revoke benefits/subscription when receiving dispute
