### PR TITLE
custom-fields: Dont allow larger or smaller numbers than int32

### DIFF
--- a/server/tests/custom_field/test_data.py
+++ b/server/tests/custom_field/test_data.py
@@ -60,6 +60,9 @@ async def custom_field_data_schema(
     (
         pytest.param({"text1": "abc", "number1": "abc"}, id="invalid number"),
         pytest.param({"text1": "abc", "number1": -1}, id="invalid number constraint"),
+        pytest.param(
+            {"text1": "abc", "number1": 2**32}, id="invalid number constraint"
+        ),
         pytest.param({"text1": "abc", "select1": "c"}, id="invalid select"),
         pytest.param({"number1": 123, "select1": "c"}, id="missing required"),
     ),


### PR DESCRIPTION
Zod validates that a number is a valid int according to JS, which can turn into a problem if someone enters a too large number and Zod validates the response.

We could allow up to `2**53-1` instead of `2**31-1`, but this should be fine.