### PR TITLE
feat(discounts): add sortable Created column in Discounts Table

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/DiscountsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/DiscountsPage.tsx
@@ -22,6 +22,7 @@ import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import Search from '@mui/icons-material/Search'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
+import  FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import {
   DataTable,
   DataTableColumnDef,
@@ -232,6 +233,20 @@ const ClientPage: React.FC<ClientPageProps> = ({
           <>
             {redemptions}
             {discount.max_redemptions ? `/${discount.max_redemptions}` : ''}
+          </>
+        )
+      },
+    },
+    {
+      accessorKey: 'created_at',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Created At" />
+      ),
+      cell: ({ row: { original: discount } }) => {
+        return (
+          <>
+           <FormattedDateTime datetime={discount.created_at} resolution="day" />
           </>
         )
       },


### PR DESCRIPTION
### **📋 Summary**

Fixes #8177 
Adds a sortable Created column to the Discounts table.

### **🎯 What**

Added “Created” column

Displayed created_at using <FormattedDateTime />

Enabled client-side sorting via accessorKey: "created_at."

 ### **🤔 Why**

Makes it easier for users to find the newest discount codes.

### **🧪 Testing**

 Tested locally

 Sorting works in both directions

 UI matches existing table patterns

🖼️ Video

https://github.com/user-attachments/assets/7b218db8-b189-4009-adc9-2847eb127785

