### PR TITLE
rate-limit: Call the middleware twice (before and after auth)

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -172,6 +172,7 @@ def create_app() -> FastAPI:
     if not settings.is_testing():
         app.add_middleware(rate_limit.get_middleware)
         app.add_middleware(AuthSubjectMiddleware)
+        app.add_middleware(rate_limit.get_middleware)
         app.add_middleware(FlushEnqueuedWorkerJobsMiddleware)
         app.add_middleware(AsyncSessionMiddleware)
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")


### PR DESCRIPTION
This will rate limit all requests by IP address, and if they authenticate we will also rate limit them by the auth subject.

If they fail authentication we abort the middleware execution order.