### PR TITLE
server/sentry: explicitly set default integrations, disable stdlib integration

### DIFF
--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -1,10 +1,17 @@
+import logging
 import os
 
 import sentry_sdk
 from dramatiq import get_broker
+from sentry_sdk.integrations.argv import ArgvIntegration
+from sentry_sdk.integrations.atexit import AtexitIntegration
+from sentry_sdk.integrations.dedupe import DedupeIntegration
 from sentry_sdk.integrations.dramatiq import DramatiqIntegration as _DramatiqIntegration
 from sentry_sdk.integrations.dramatiq import SentryMiddleware
+from sentry_sdk.integrations.excepthook import ExcepthookIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.modules import ModulesIntegration
 
 from polar.auth.models import AuthSubject, Subject, is_user
 from polar.config import settings
@@ -35,11 +42,20 @@ def configure_sentry() -> None:
         release=os.environ.get("RELEASE_VERSION", "development"),
         server_name=os.environ.get("RENDER_INSTANCE_ID", "localhost"),
         environment=settings.ENV,
-        integrations=[
-            FastApiIntegration(transaction_style="endpoint"),
-            # DramatiqIntegration(),
-        ],
+        default_integrations=False,
         auto_enabling_integrations=False,
+        integrations=[
+            AtexitIntegration(),
+            ExcepthookIntegration(),
+            DedupeIntegration(),
+            ModulesIntegration(),
+            ArgvIntegration(),
+            LoggingIntegration(
+                level=logging.INFO,  # Capture info and above as breadcrumbs
+                event_level=None,
+            ),
+            FastApiIntegration(transaction_style="endpoint"),
+        ],
     )
 
 


### PR DESCRIPTION
- server/sentry: explicitly set default integrations, disable stdlib integration