### PR TITLE
order-items: Add order id index on order items

### DIFF
--- a/server/migrations/versions/2025-12-11-1051_add_index_to_order_items_order_id.py
+++ b/server/migrations/versions/2025-12-11-1051_add_index_to_order_items_order_id.py
@@ -1,0 +1,32 @@
+"""add index to order_items.order_id
+
+Revision ID: aa7611c80a41
+Revises: cb7c757fe36e
+Create Date: 2025-12-11 10:51:08.709436
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "aa7611c80a41"
+down_revision = "cb7c757fe36e"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_order_items_order_id"),
+            "order_items",
+            ["order_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_order_items_order_id"), table_name="order_items")

--- a/server/polar/models/order_item.py
+++ b/server/polar/models/order_item.py
@@ -31,7 +31,7 @@ class OrderItem(RecordModel):
     tax_amount: Mapped[int] = mapped_column(Integer, nullable=False)
     proration: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     order_id: Mapped[UUID] = mapped_column(
-        Uuid, ForeignKey("orders.id", ondelete="cascade")
+        Uuid, ForeignKey("orders.id", ondelete="cascade"), index=True
     )
     product_price_id: Mapped[UUID | None] = mapped_column(
         Uuid, ForeignKey("product_prices.id", ondelete="restrict"), nullable=True


### PR DESCRIPTION
To speed up the order -> order_item relationship
given the fact that we are eagerly loading them.
