### PR TITLE
server/worker: place AsyncIOMiddleware at the bottom to flush exception traceback after Sentry/loggers

### DIFF
--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -142,9 +142,6 @@ class LogfireMiddleware(dramatiq.Middleware):
         if logfire_stack is not None:
             logfire_stack.close()
 
-        # THEORY: force flush logfire events after each task to avoid memory bursts
-        logfire.force_flush()
-
     def after_skip_message(
         self, broker: dramatiq.Broker, message: dramatiq.Message[Any]
     ) -> None:


### PR DESCRIPTION

- Revert "server/worker: flush logfire after each task to avoid memory bursts"
- server/worker: place AsyncIOMiddleware at the bottom to flush exception traceback after Sentry/loggers
  