### PR TITLE
customer: Add prefix filter on external customer id

### DIFF
--- a/server/migrations/versions/2025-12-11-1504_add_text_pattern_ops_indexes_for_.py
+++ b/server/migrations/versions/2025-12-11-1504_add_text_pattern_ops_indexes_for_.py
@@ -1,0 +1,51 @@
+"""add text_pattern_ops indexes for external_id
+
+Revision ID: 26cae817076b
+Revises: 827dddaa615a
+Create Date: 2025-12-11 15:04:51.599479
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "26cae817076b"
+down_revision = "827dddaa615a"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_customers_external_id_pattern",
+            "customers",
+            ["external_id"],
+            unique=False,
+            postgresql_ops={"external_id": "text_pattern_ops"},
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_events_external_customer_id_pattern",
+            "events",
+            ["external_customer_id"],
+            unique=False,
+            postgresql_ops={"external_customer_id": "text_pattern_ops"},
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_events_external_customer_id_pattern",
+            table_name="events",
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_customers_external_id_pattern",
+            table_name="customers",
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -111,6 +111,11 @@ class Customer(MetadataMixin, RecordModel):
             unique=True,
             postgresql_nulls_not_distinct=True,
         ),
+        Index(
+            "ix_customers_external_id_pattern",
+            "external_id",
+            postgresql_ops={"external_id": "text_pattern_ops"},
+        ),
         UniqueConstraint("organization_id", "external_id"),
         UniqueConstraint("organization_id", "short_id"),
     )

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -135,6 +135,11 @@ class Event(Model, MetadataMixin):
             "customer_id",
             literal_column("ingested_at DESC"),
         ),
+        Index(
+            "ix_events_external_customer_id_pattern",
+            "external_customer_id",
+            postgresql_ops={"external_customer_id": "text_pattern_ops"},
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)


### PR DESCRIPTION
On customers and events.

Since we are not using C collation we don't get this for free with our existing indexes, so we need to have a specific text_pattern_ops index.

https://www.postgresql.org/docs/current/indexes-opclass.html