### PR TITLE
refund: Handle null stripe reason

### DIFF
--- a/server/polar/models/refund.py
+++ b/server/polar/models/refund.py
@@ -248,7 +248,7 @@ class Refund(MetadataMixin, RecordModel):
 
         failure_reason = getattr(stripe_refund, "failure_reason", None)
         failure_reason = RefundFailureReason.from_stripe(failure_reason)
-        stripe_reason = stripe_refund.reason
+        stripe_reason = stripe_refund.reason if stripe_refund.reason else "other"
         reason = RefundReason.from_stripe(stripe_refund.reason)
 
         status = RefundStatus.pending


### PR DESCRIPTION
It got disappeared in an refactor, but since we don't allow null processor_reason we need a default value when Stripe does not assign it.