### PR TITLE
customer-meter: Increase the time a lock is held to 30s

### DIFF
--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -126,7 +126,7 @@ class CustomerMeterService:
     ) -> tuple[CustomerMeter | None, bool]:
         async with locker.lock(
             f"customer_meter:{customer.id}:{meter.id}",
-            timeout=5.0,
+            timeout=30.0,
             blocking_timeout=0.2,
         ):
             repository = CustomerMeterRepository.from_session(session)


### PR DESCRIPTION
This will allow slow queries to finish processing without contention