### PR TITLE
tf/prod: Split scheduler and worker into separate instances

### DIFF
--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -43,3 +43,7 @@ def start() -> None:
 
 
 __all__ = ["tasks", "start"]
+
+
+if __name__ == "__main__":
+    start()

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -138,6 +138,13 @@ module "production" {
   }
 
   workers = {
+    "scheduler" = {
+      start_command      = "uv run python -m polar.worker.scheduler"
+      plan               = "starter"
+      tag                = "latest"
+      dramatiq_prom_port = "10000"
+      num_instances      = 1
+    }
     "worker" = {
       start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority"
       tag                = "latest"
@@ -151,7 +158,7 @@ module "production" {
       dramatiq_prom_port = "10001"
     }
     "worker-high-priority" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues high_priority -f polar.worker.scheduler:start"
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues high_priority"
       tag                = "latest"
       dramatiq_prom_port = "10001"
     }


### PR DESCRIPTION
Fix #8334
