### PR TITLE
customer-meter: dont activate all meters unless needed

### DIFF
--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -145,7 +145,9 @@ class CustomerMeterService:
             )
 
             if customer_meter is None:
-                activated_at = utc_now()
+                activated_at = (
+                    utc_now() if (last_event is not None or activate_meter) else None
+                )
                 customer_meter = await repository.create(
                     CustomerMeter(
                         customer=customer, meter=meter, activated_at=activated_at

--- a/server/tests/customer_meter/test_service.py
+++ b/server/tests/customer_meter/test_service.py
@@ -176,7 +176,6 @@ async def events_for_external_customer(
 
 @pytest.mark.asyncio
 class TestUpdateCustomerMeter:
-    @pytest.mark.skip
     async def test_no_matching_event_not_existing_customer_meter(
         self, session: AsyncSession, locker: Locker, customer: Customer, meter: Meter
     ) -> None:


### PR DESCRIPTION
We only want to activate meters that:
- Have events
- Are part of a benefit
