### PR TITLE
events: Add events hypertable

### DIFF
--- a/server/migrations/env.py
+++ b/server/migrations/env.py
@@ -14,6 +14,9 @@ def include_object(object, name, type_, reflected, compare_to):
     # Exclude TimescaleDB - Docker image handles creation, migration is backup
     if isinstance(object, PGExtension) and object.signature == "timescaledb":
         return False
+    # Exclude TimescaleDB auto-created index on hypertable partitioning column
+    if type_ == "index" and name == "events_hyper_ingested_at_idx":
+        return False
     return True
 
 

--- a/server/migrations/versions/2025-12-15-1356_create_events_hyper_shadow_hypertable.py
+++ b/server/migrations/versions/2025-12-15-1356_create_events_hyper_shadow_hypertable.py
@@ -1,0 +1,99 @@
+"""create_events_hyper_shadow_hypertable
+
+Revision ID: 03f24e6aa030
+Revises: b3887f09f522
+Create Date: 2025-12-15 11:00:03.649717
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "03f24e6aa030"
+down_revision = "b3887f09f522"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Create shadow table with same structure (no FKs to events)
+    op.execute("""
+        CREATE TABLE events_hyper (
+            id UUID NOT NULL,
+            ingested_at TIMESTAMP WITH TIME ZONE NOT NULL,
+            timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+            name VARCHAR(128) NOT NULL,
+            source VARCHAR NOT NULL,
+            customer_id UUID REFERENCES customers(id),
+            external_customer_id VARCHAR,
+            external_id VARCHAR,
+            parent_id UUID,
+            root_id UUID,
+            organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+            event_type_id UUID REFERENCES event_types(id),
+            user_metadata JSONB NOT NULL,
+            PRIMARY KEY (id, ingested_at)
+        )
+    """)
+
+    # Convert to hypertable with 1-week chunks
+    op.execute("""
+        SELECT create_hypertable(
+            'events_hyper',
+            'ingested_at',
+            chunk_time_interval => INTERVAL '1 week'
+        )
+    """)
+
+    # Create partial unique index (must include partitioning column for TimescaleDB)
+    op.execute("""
+        CREATE UNIQUE INDEX ix_events_hyper_external_id
+        ON events_hyper (external_id, ingested_at)
+        WHERE external_id IS NOT NULL
+    """)
+
+    # Create single-column indexes matching original table
+    op.execute("CREATE INDEX ix_events_hyper_id ON events_hyper (id)")
+    op.execute("CREATE INDEX ix_events_hyper_timestamp ON events_hyper (timestamp)")
+    op.execute("CREATE INDEX ix_events_hyper_name ON events_hyper (name)")
+    op.execute("CREATE INDEX ix_events_hyper_source ON events_hyper (source)")
+    op.execute("CREATE INDEX ix_events_hyper_customer_id ON events_hyper (customer_id)")
+    op.execute(
+        "CREATE INDEX ix_events_hyper_external_customer_id ON events_hyper (external_customer_id)"
+    )
+    op.execute("CREATE INDEX ix_events_hyper_parent_id ON events_hyper (parent_id)")
+    op.execute("CREATE INDEX ix_events_hyper_root_id ON events_hyper (root_id)")
+    op.execute(
+        "CREATE INDEX ix_events_hyper_organization_id ON events_hyper (organization_id)"
+    )
+    op.execute(
+        "CREATE INDEX ix_events_hyper_event_type_id ON events_hyper (event_type_id)"
+    )
+
+    # Create composite indexes
+    op.execute("""
+        CREATE INDEX ix_events_hyper_org_timestamp_id
+        ON events_hyper (organization_id, timestamp DESC, id);
+    """)
+
+    op.execute("""
+        CREATE INDEX ix_events_hyper_org_external_id_ingested
+        ON events_hyper (organization_id, external_customer_id, ingested_at DESC);
+    """)
+
+    op.execute("""
+        CREATE INDEX ix_events_hyper_org_customer_id_ingested
+        ON events_hyper (organization_id, customer_id, ingested_at DESC);
+    """)
+
+    op.execute("""
+        CREATE INDEX ix_events_hyper_external_customer_pattern
+        ON events_hyper USING btree (external_customer_id text_pattern_ops);
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS events_hyper CASCADE")

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -84,6 +84,9 @@ class Settings(BaseSettings):
     CUSTOMER_METER_UPDATE_DEBOUNCE_MIN_THRESHOLD: timedelta = timedelta(seconds=5)
     CUSTOMER_METER_UPDATE_DEBOUNCE_MAX_THRESHOLD: timedelta = timedelta(minutes=15)
 
+    # TimescaleDB Migration - dual-write to events_hyper table
+    EVENTS_DUAL_WRITE_ENABLED: bool = False
+
     SECRET: str = "super secret jwt secret"
     JWKS: JWKSFile = Field(default="./.jwks.json")
     CURRENT_JWK_KID: str = "polar_dev"

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -22,6 +22,7 @@ from .dispute import Dispute
 from .downloadable import Downloadable
 from .email_verification import EmailVerification
 from .event import Event, EventClosure
+from .event_hyper import EventHyper
 from .event_type import EventType
 from .external_event import ExternalEvent
 from .file import File
@@ -107,6 +108,7 @@ __all__ = [
     "EmailVerification",
     "Event",
     "EventClosure",
+    "EventHyper",
     "EventType",
     "ExternalEvent",
     "File",

--- a/server/polar/models/event_hyper.py
+++ b/server/polar/models/event_hyper.py
@@ -1,0 +1,93 @@
+import datetime
+from uuid import UUID
+
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, String, Uuid, literal_column
+from sqlalchemy.orm import Mapped, mapped_column
+
+from polar.kit.db.models import Model
+from polar.kit.metadata import MetadataMixin
+from polar.kit.utils import generate_uuid, utc_now
+
+from .event import EventSource
+
+
+class EventHyper(Model, MetadataMixin):
+    """
+    Shadow model for the events_hyper hypertable.
+    Used during the dual-write migration period.
+    """
+
+    __tablename__ = "events_hyper"
+    __table_args__ = (
+        Index(
+            "ix_events_hyper_external_id",
+            "external_id",
+            "ingested_at",
+            unique=True,
+            postgresql_where=literal_column("external_id IS NOT NULL"),
+        ),
+        Index("ix_events_hyper_id", "id"),
+        Index(
+            "ix_events_hyper_org_timestamp_id",
+            "organization_id",
+            literal_column("timestamp DESC"),
+            "id",
+        ),
+        Index(
+            "ix_events_hyper_org_external_id_ingested",
+            "organization_id",
+            "external_customer_id",
+            literal_column("ingested_at DESC"),
+        ),
+        Index(
+            "ix_events_hyper_org_customer_id_ingested",
+            "organization_id",
+            "customer_id",
+            literal_column("ingested_at DESC"),
+        ),
+        Index(
+            "ix_events_hyper_external_customer_pattern",
+            "external_customer_id",
+            postgresql_ops={"external_customer_id": "text_pattern_ops"},
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
+    ingested_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=utc_now,
+        primary_key=True,
+    )
+    timestamp: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=utc_now, index=True
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    source: Mapped[EventSource] = mapped_column(
+        String, nullable=False, default=EventSource.system, index=True
+    )
+
+    customer_id: Mapped[UUID | None] = mapped_column(
+        Uuid, ForeignKey("customers.id"), nullable=True, index=True
+    )
+
+    external_customer_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+
+    external_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    parent_id: Mapped[UUID | None] = mapped_column(Uuid, nullable=True, index=True)
+
+    root_id: Mapped[UUID | None] = mapped_column(Uuid, nullable=True, index=True)
+
+    organization_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("organizations.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
+
+    event_type_id: Mapped[UUID | None] = mapped_column(
+        Uuid, ForeignKey("event_types.id"), nullable=True, index=True
+    )

--- a/server/scripts/backfill_events_hyper.py
+++ b/server/scripts/backfill_events_hyper.py
@@ -1,0 +1,288 @@
+import asyncio
+import logging.config
+from datetime import UTC, datetime
+from functools import wraps
+from typing import Any
+
+import structlog
+import typer
+from rich.progress import Progress
+from sqlalchemy import func, select, text
+
+from polar.config import settings
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import Event
+
+cli = typer.Typer()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+async def run_backfill(
+    batch_size: int = 100_000,
+    cutoff_date: datetime | None = None,
+    session: AsyncSession | None = None,
+    delay_seconds: float = 1.0,
+) -> None:
+    """
+    Backfill events_hyper table from events table.
+
+    This script copies events from the original events table to the events_hyper
+    hypertable in batches, ordered by ingested_at.
+    """
+    engine = None
+    own_session = False
+
+    if cutoff_date is None:
+        cutoff_date = datetime.now(UTC)
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    try:
+        total_events_result = await session.execute(
+            select(func.count())
+            .select_from(Event)
+            .where(Event.ingested_at < cutoff_date)
+        )
+        total_events = total_events_result.scalar_one()
+
+        if total_events == 0:
+            typer.echo("No events to backfill")
+            if engine is not None:
+                await engine.dispose()
+            raise typer.Exit(0)
+
+        typer.echo(f"Found {total_events} events to backfill (before {cutoff_date})")
+
+        already_copied_result = await session.execute(
+            text(
+                "SELECT COUNT(*) FROM events_hyper WHERE ingested_at < :cutoff"
+            ).bindparams(cutoff=cutoff_date)
+        )
+        already_copied = already_copied_result.scalar_one()
+        typer.echo(f"Already copied: {already_copied} events")
+
+        remaining = total_events - already_copied
+        if remaining <= 0:
+            typer.echo("All events already backfilled!")
+            if engine is not None:
+                await engine.dispose()
+            raise typer.Exit(0)
+
+        typer.echo(f"Remaining to copy: {remaining} events")
+
+        with Progress() as progress:
+            task = progress.add_task(
+                "[cyan]Backfilling events_hyper...", total=remaining
+            )
+
+            total_inserted = 0
+            last_ingested_at = None
+
+            while True:
+                # Use raw SQL for the INSERT ... SELECT to handle NOT EXISTS efficiently
+                if last_ingested_at is None:
+                    query = text("""
+                        INSERT INTO events_hyper (
+                            id, ingested_at, timestamp, name, source,
+                            customer_id, external_customer_id, external_id,
+                            parent_id, root_id, organization_id, event_type_id,
+                            user_metadata
+                        )
+                        SELECT
+                            e.id, e.ingested_at, e.timestamp, e.name, e.source,
+                            e.customer_id, e.external_customer_id, e.external_id,
+                            e.parent_id, e.root_id, e.organization_id, e.event_type_id,
+                            e.user_metadata
+                        FROM events e
+                        WHERE e.ingested_at < :cutoff
+                          AND NOT EXISTS (
+                              SELECT 1 FROM events_hyper eh
+                              WHERE eh.id = e.id AND eh.ingested_at = e.ingested_at
+                          )
+                        ORDER BY e.ingested_at
+                        LIMIT :batch_size
+                        RETURNING ingested_at
+                    """).bindparams(cutoff=cutoff_date, batch_size=batch_size)
+                else:
+                    query = text("""
+                        INSERT INTO events_hyper (
+                            id, ingested_at, timestamp, name, source,
+                            customer_id, external_customer_id, external_id,
+                            parent_id, root_id, organization_id, event_type_id,
+                            user_metadata
+                        )
+                        SELECT
+                            e.id, e.ingested_at, e.timestamp, e.name, e.source,
+                            e.customer_id, e.external_customer_id, e.external_id,
+                            e.parent_id, e.root_id, e.organization_id, e.event_type_id,
+                            e.user_metadata
+                        FROM events e
+                        WHERE e.ingested_at < :cutoff
+                          AND e.ingested_at >= :last_ingested_at
+                          AND NOT EXISTS (
+                              SELECT 1 FROM events_hyper eh
+                              WHERE eh.id = e.id AND eh.ingested_at = e.ingested_at
+                          )
+                        ORDER BY e.ingested_at
+                        LIMIT :batch_size
+                        RETURNING ingested_at
+                    """).bindparams(
+                        cutoff=cutoff_date,
+                        batch_size=batch_size,
+                        last_ingested_at=last_ingested_at,
+                    )
+
+                result = await session.execute(query)
+                rows = result.fetchall()
+                inserted = len(rows)
+
+                await session.commit()
+
+                if inserted == 0:
+                    break
+
+                total_inserted += inserted
+                progress.update(task, advance=inserted)
+
+                if rows:
+                    last_ingested_at = rows[-1][0]
+
+                typer.echo(
+                    f"Inserted {inserted} rows (total: {total_inserted}, "
+                    f"last: {last_ingested_at})"
+                )
+
+                if inserted < batch_size:
+                    break
+
+                # Throttle to avoid overwhelming the database
+                await asyncio.sleep(delay_seconds)
+
+        # ID-based verification
+        typer.echo("\n--- Verification ---\n")
+
+        # Count events in source
+        events_count_result = await session.execute(
+            select(func.count())
+            .select_from(Event)
+            .where(Event.ingested_at < cutoff_date)
+        )
+        events_count = events_count_result.scalar_one()
+
+        # Count events in target
+        hyper_count_result = await session.execute(
+            text(
+                "SELECT COUNT(*) FROM events_hyper WHERE ingested_at < :cutoff"
+            ).bindparams(cutoff=cutoff_date)
+        )
+        hyper_count = hyper_count_result.scalar_one()
+
+        typer.echo(f"Inserted this run: {total_inserted}")
+        typer.echo(f"Events table count (before cutoff): {events_count}")
+        typer.echo(f"Events_hyper table count (before cutoff): {hyper_count}")
+
+        # Find missing IDs (in events but not in events_hyper)
+        missing_result = await session.execute(
+            text("""
+                SELECT COUNT(*) FROM events e
+                WHERE e.ingested_at < :cutoff
+                  AND NOT EXISTS (
+                      SELECT 1 FROM events_hyper eh
+                      WHERE eh.id = e.id
+                  )
+            """).bindparams(cutoff=cutoff_date)
+        )
+        missing_count = missing_result.scalar_one()
+
+        # Find extra IDs (in events_hyper but not in events)
+        extra_result = await session.execute(
+            text("""
+                SELECT COUNT(*) FROM events_hyper eh
+                WHERE eh.ingested_at < :cutoff
+                  AND NOT EXISTS (
+                      SELECT 1 FROM events e
+                      WHERE e.id = eh.id
+                  )
+            """).bindparams(cutoff=cutoff_date)
+        )
+        extra_count = extra_result.scalar_one()
+
+        typer.echo(f"Missing from events_hyper: {missing_count}")
+        typer.echo(f"Extra in events_hyper: {extra_count}")
+
+        if missing_count == 0 and extra_count == 0:
+            typer.echo("\n✅ ID verification passed! All IDs match.")
+        else:
+            if missing_count > 0:
+                typer.echo(f"\n⚠️ {missing_count} events missing - run again")
+            if extra_count > 0:
+                typer.echo(
+                    f"\n❌ {extra_count} extra events in hyper table - investigate"
+                )
+
+        typer.echo("\n---\n")
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+def drop_all(*args: Any, **kwargs: Any) -> Any:
+    raise structlog.DropEvent
+
+
+@cli.command()
+@typer_async
+async def backfill_events_hyper(
+    batch_size: int = typer.Option(
+        100_000, help="Number of events to process per batch"
+    ),
+    cutoff_date: datetime = typer.Option(
+        None,
+        help="Only backfill events before this date (ISO format). Defaults to now.",
+    ),
+    delay_seconds: float = typer.Option(1.0, help="Seconds to wait between batches"),
+) -> None:
+    """
+    Backfill events_hyper hypertable from events table.
+
+    This should be run after enabling dual-write to copy historical events.
+    """
+    structlog.configure(processors=[drop_all])
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": True,
+        }
+    )
+
+    await run_backfill(
+        batch_size=batch_size,
+        cutoff_date=cutoff_date,
+        delay_seconds=delay_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
We create a shadow copy of the events table, that we make into a timescaledb
hypertable. We will double write to both events table for a period of time
until we are ready to drop the old events table.

Initially we let the hypertable be bucketed by week, this can be changed going forward if
the event volumes pick up.

The `events_hyper` table is a 1:1 copy of the `events` table, except the foreign key references since that is not supported by timescaledb.