### PR TITLE
feat/backend: separate subscription.past_due from revoked

### DIFF
--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -69,7 +69,7 @@ class SubscriptionStatus(StrEnum):
 
     @classmethod
     def revoked_statuses(cls) -> set[Self]:
-        return {cls.past_due, cls.canceled, cls.unpaid}  # type: ignore
+        return {cls.canceled, cls.unpaid}  # type: ignore
 
     @classmethod
     def billable_statuses(cls) -> set[Self]:

--- a/server/polar/models/webhook_endpoint.py
+++ b/server/polar/models/webhook_endpoint.py
@@ -32,6 +32,7 @@ class WebhookEventType(StrEnum):
     subscription_canceled = "subscription.canceled"
     subscription_uncanceled = "subscription.uncanceled"
     subscription_revoked = "subscription.revoked"
+    subscription_past_due = "subscription.past_due"
     refund_created = "refund.created"
     refund_updated = "refund.updated"
     product_created = "product.created"

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -558,6 +558,15 @@ class WebhookService:
         self,
         session: AsyncSession,
         target: Organization,
+        event: Literal[WebhookEventType.subscription_past_due],
+        data: Subscription,
+    ) -> list[WebhookEvent]: ...
+
+    @overload
+    async def send(
+        self,
+        session: AsyncSession,
+        target: Organization,
         event: Literal[WebhookEventType.refund_created],
         data: Refund,
     ) -> list[WebhookEvent]: ...


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #8325

This PR fixes the incorrect semantic of the `subscription.revoked` webhook, which was being sent when a subscription entered `past_due` status. This conflates temporary payment failures with terminal subscription states.

## 🎯 What

- Removed `past_due` from `revoked_statuses()` - now only returns `{canceled, unpaid}`
- Added new `subscription.past_due` webhook event for payment failures
- Updated `_on_subscription_past_due()` to send the new webhook
- Updated webhook payloads with Discord/Slack support for the new event
- Fixed `InactiveSubscription` exception to return 403 status code

## 🤔 Why

The `subscription.revoked` webhook should only fire when a subscription reaches a terminal state (canceled or permanently unpaid after retries). When a subscription enters `past_due` due to payment failure, this is a recoverable state - the customer can update their payment method and restore the subscription. Benefits are temporarily suspended, not permanently revoked. The new `subscription.past_due` webhook allows developers to properly distinguish between these two semantic states.

## 🔧 How

- Modified `SubscriptionStatus.revoked_statuses()` to exclude `past_due`
- Added `subscription_past_due` to `WebhookEventType` enum and related webhook infrastructure
- Created `WebhookSubscriptionPastDuePayload` with Discord/Slack formatting
- Updated webhook service overloads for type safety
- Fixed test compatibility issues

## 🧪 Testing

- [x] All existing tests pass (2305 passed, 6 failed → all fixed)
- [x] Type checking passes
- [x] Linting passes
- [x] Benefit revocation logic still works correctly with grace periods

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] All tests pass locally
- [x] Type checking passes with `uv run task lint_types`
- [x] Tested webhook event generation
- [x] Verified benefit revocation grace period still works

## 📝 Breaking Changes

This is a **breaking semantic change** for webhook consumers:
- Previously: `subscription.revoked` fired for both `past_due` and terminal states
- After: `subscription.revoked` only fires for `canceled`/`unpaid`; new `subscription.past_due` fires for payment failures

Developers who relied on `subscription.revoked` for `past_due` subscriptions will need to subscribe to the new `subscription.past_due` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)