### PR TITLE
Prevent ternary in render

### DIFF
--- a/clients/apps/app/app/(authenticated)/customers/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/customers/[id]/index.tsx
@@ -176,7 +176,7 @@ export default function Index() {
           </Details>
         </Box>
 
-        {customer?.metadata && Object.keys(customer.metadata).length > 0 && (
+        {customer?.metadata && Object.keys(customer.metadata).length > 0 ? (
           <Box>
             <Details>
               {Object.entries(customer.metadata).map(([key, value]) => (
@@ -184,7 +184,7 @@ export default function Index() {
               ))}
             </Details>
           </Box>
-        )}
+        ) : null}
 
         <Box gap="spacing-16" flexDirection="column" flex={1}>
           <Box

--- a/clients/apps/app/app/(authenticated)/finance/index.tsx
+++ b/clients/apps/app/app/(authenticated)/finance/index.tsx
@@ -105,12 +105,12 @@ export default function Finance() {
       }
     >
       <Stack.Screen options={{ title: 'Finance' }} />
-      {!account?.is_payouts_enabled && (
+      {!account?.is_payouts_enabled ? (
         <Banner
           title="No Payout Account"
           description="This organization does not have a payout account connected."
         />
-      )}
+      ) : null}
       <Box
         flexDirection="column"
         gap="spacing-8"

--- a/clients/apps/app/app/(authenticated)/metrics/index.tsx
+++ b/clients/apps/app/app/(authenticated)/metrics/index.tsx
@@ -79,7 +79,7 @@ export default function Index() {
             setSelectedTimeInterval(value as keyof ReturnType<typeof timeRange>)
           }
         >
-          {organization && (
+          {organization ? (
             <TabsList>
               {Object.entries(timeRange(organization)).map(([key, value]) => {
                 return (
@@ -89,7 +89,7 @@ export default function Index() {
                 )
               })}
             </TabsList>
-          )}
+          ) : null}
         </Tabs>
       </SafeAreaView>
       {metrics.isLoading ? (

--- a/clients/apps/app/app/(authenticated)/onboarding/index.tsx
+++ b/clients/apps/app/app/(authenticated)/onboarding/index.tsx
@@ -118,7 +118,9 @@ export default function Onboarding() {
           >
             Create your organization
           </Text>
-          {errors.root && <Text color="error">{errors.root.message}</Text>}
+          {errors.root ? (
+            <Text color="error">{errors.root.message}</Text>
+          ) : null}
           <FormInput
             label="Organization Name"
             placeholder="Acme Inc."
@@ -200,13 +202,13 @@ export default function Onboarding() {
               Create Organization
             </Button>
           </Box>
-          {organizations.length > 0 && (
+          {organizations.length > 0 ? (
             <Box>
               <Button onPress={() => router.replace('/')} variant="secondary">
                 Back to Dashboard
               </Button>
             </Box>
-          )}
+          ) : null}
         </Box>
       </SafeAreaView>
     </ScrollView>

--- a/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
@@ -196,7 +196,7 @@ export default function Index() {
         />
       </Details>
 
-      {order.metadata && Object.keys(order.metadata).length > 0 && (
+      {order.metadata && Object.keys(order.metadata).length > 0 ? (
         <Box>
           <Details>
             {Object.entries(order.metadata).map(([key, value]) => (
@@ -204,7 +204,7 @@ export default function Index() {
             ))}
           </Details>
         </Box>
-      )}
+      ) : null}
     </ScrollView>
   )
 }

--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/cancel/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/cancel/index.tsx
@@ -102,18 +102,6 @@ export default function Index() {
     CANCELLATION_REASONS,
   ) as (keyof typeof CANCELLATION_REASONS)[]
 
-  let periodEndOutput: string | undefined = undefined
-
-  if (subscription?.current_period_end) {
-    periodEndOutput = new Date(
-      subscription.current_period_end,
-    ).toLocaleDateString('en-US', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    })
-  }
-
   if (!subscription) {
     return (
       <Stack.Screen
@@ -211,7 +199,7 @@ export default function Index() {
                 }}
               >
                 <Text>{getHumanCancellationReason(reason)}</Text>
-                {cancellationReason === reason && (
+                {cancellationReason === reason ? (
                   <Box>
                     <MaterialIcons
                       name="check"
@@ -219,7 +207,7 @@ export default function Index() {
                       color={theme.colors.text}
                     />
                   </Box>
-                )}
+                ) : null}
               </Touchable>
             ))}
           </Box>

--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
@@ -141,13 +141,13 @@ export default function Index() {
             }
             valueStyle={{ textTransform: 'capitalize' }}
           />
-          {subscription.status === 'canceled' && (
+          {subscription.status === 'canceled' ? (
             <DetailRow
               label="Cancellation Reason"
               value={subscription.customer_cancellation_reason}
             />
-          )}
-          {subscription.status === 'canceled' && (
+          ) : null}
+          {subscription.status === 'canceled' ? (
             <DetailRow
               label="Cancels At"
               value={
@@ -165,7 +165,7 @@ export default function Index() {
                     )
               }
             />
-          )}
+          ) : null}
           <DetailRow
             label="Recurring Interval"
             value={subscription.recurring_interval.split('_').join(' ')}
@@ -188,7 +188,7 @@ export default function Index() {
               dateStyle: 'medium',
             })}
           />
-          {subscription.ends_at && (
+          {subscription.ends_at ? (
             <DetailRow
               label="End Date"
               value={new Date(subscription.ends_at ?? '').toLocaleDateString(
@@ -198,22 +198,23 @@ export default function Index() {
                 },
               )}
             />
-          )}
+          ) : null}
         </Details>
       </Box>
 
-      {subscription.metadata &&
-        Object.keys(subscription.metadata).length > 0 && (
-          <Box>
-            <Details>
-              {Object.entries(subscription.metadata).map(([key, value]) => (
-                <DetailRow key={key} label={key} value={String(value)} />
-              ))}
-            </Details>
-          </Box>
-        )}
+      {subscription.metadata
+        ? Object.keys(subscription.metadata).length > 0 && (
+            <Box>
+              <Details>
+                {Object.entries(subscription.metadata).map(([key, value]) => (
+                  <DetailRow key={key} label={key} value={String(value)} />
+                ))}
+              </Details>
+            </Box>
+          )
+        : null}
 
-      {subscription.status === 'active' && (
+      {subscription.status === 'active' ? (
         <Box flexDirection="column" gap="spacing-8">
           <Link key={'update'} href={`/subscriptions/${id}/update`} asChild>
             <Button>Update Subscription</Button>
@@ -222,7 +223,7 @@ export default function Index() {
             <Button variant="secondary">Cancel Subscription</Button>
           </Link>
         </Box>
-      )}
+      ) : null}
 
       <Box gap="spacing-16" paddingVertical="spacing-12">
         <Box

--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/update/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/update/index.tsx
@@ -181,7 +181,7 @@ export default function Index() {
           )}
         </Box>
       </Box>
-      {selectedProduct && selectedProduct.id !== subscription.product.id && (
+      {selectedProduct && selectedProduct.id !== subscription.product.id ? (
         <Box
           backgroundColor="card"
           padding="spacing-16"
@@ -192,7 +192,7 @@ export default function Index() {
             lose access to {subscription.product.name} benefits.
           </Text>
         </Box>
-      )}
+      ) : null}
       <Button
         loading={updateSubscription.isPending}
         disabled={updateSubscription.isPending || !selectedProductId}
@@ -217,8 +217,6 @@ const ProrationBehaviorSelector = ({
 }: {
   form: UseFormReturn<schemas['SubscriptionUpdateProduct']>
 }) => {
-  const theme = useTheme()
-
   const { watch, setValue } = form
 
   const prorationBehavior = watch('proration_behavior')

--- a/clients/apps/app/components/Errors/Fallback.tsx
+++ b/clients/apps/app/components/Errors/Fallback.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 
 import { Box } from '@/components/Shared/Box'
 import PolarLogo from '@/components/Shared/PolarLogo'
-import { useTheme } from '@/design-system/useTheme'
 import { useLogout } from '@/hooks/auth'
 import { useOAuth } from '@/hooks/oauth'
 import { isValidationError, UnauthorizedResponseError } from '@polar-sh/client'
@@ -17,7 +16,6 @@ export const ErrorFallback = ({
   error,
   resetErrorBoundary,
 }: ErrorFallbackProps) => {
-  const theme = useTheme()
   const logout = useLogout()
   const { authenticate } = useOAuth()
   const permissionError =

--- a/clients/apps/app/components/Form/FormInput.tsx
+++ b/clients/apps/app/components/Form/FormInput.tsx
@@ -34,7 +34,9 @@ export const FormInput = <T extends FieldValues>({
       <Box flexDirection="column" gap="spacing-8">
         <Box flexDirection="row" gap="spacing-8" justifyContent="space-between">
           <Text color="subtext">{label}</Text>
-          {secondaryLabel && <Text color="subtext">{secondaryLabel}</Text>}
+          {secondaryLabel ? (
+            <Text color="subtext">{secondaryLabel}</Text>
+          ) : null}
         </Box>
         <Input value={field.value} onChangeText={field.onChange} {...props} />
       </Box>

--- a/clients/apps/app/components/Home/RevenueTile.tsx
+++ b/clients/apps/app/components/Home/RevenueTile.tsx
@@ -74,7 +74,7 @@ export const RevenueTile = ({ loading }: RevenueTileProps) => {
           </Box>
           <Text variant="body">30 Days</Text>
         </Box>
-        {cumulativeRevenueData.length > 0 && (
+        {cumulativeRevenueData.length > 0 ? (
           <Box flex={1} flexGrow={1} width="100%">
             <CartesianChart
               data={cumulativeRevenueData}
@@ -99,7 +99,7 @@ export const RevenueTile = ({ loading }: RevenueTileProps) => {
               )}
             </CartesianChart>
           </Box>
-        )}
+        ) : null}
         <Text
           variant="headline"
           numberOfLines={1}

--- a/clients/apps/app/components/Metrics/Chart.tsx
+++ b/clients/apps/app/components/Metrics/Chart.tsx
@@ -89,7 +89,7 @@ export const Chart = ({
       gap="spacing-12"
     >
       <Box flexDirection="row" justifyContent="space-between">
-        {title && <Text variant="subtitle">{title}</Text>}
+        {title ? <Text variant="subtitle">{title}</Text> : null}
       </Box>
 
       <Box flexDirection="row" alignItems="baseline" gap="spacing-8">
@@ -100,7 +100,7 @@ export const Chart = ({
         ) : null}
       </Box>
 
-      {chartData.length > 0 && (
+      {chartData.length > 0 ? (
         <Box style={{ width: '100%', height }}>
           <CartesianChart
             data={chartData}
@@ -132,7 +132,7 @@ export const Chart = ({
             )}
           </CartesianChart>
         </Box>
-      )}
+      ) : null}
       <Box flexDirection="row" justifyContent="space-between">
         <Text variant="caption" color="subtext">
           {format(currentPeriod.startDate, 'MMM d')}

--- a/clients/apps/app/components/Notifications/NotificationBadge.tsx
+++ b/clients/apps/app/components/Notifications/NotificationBadge.tsx
@@ -13,7 +13,7 @@ export const NotificationBadge = () => {
     <Link href="/notifications" asChild>
       <Touchable hitSlop={16} style={{ position: 'relative' }}>
         <MaterialIcons name="bolt" size={24} color={theme.colors.text} />
-        {showBadge && (
+        {showBadge ? (
           <Box
             backgroundColor="primary"
             position="absolute"
@@ -23,7 +23,7 @@ export const NotificationBadge = () => {
             height={4}
             borderRadius="border-radius-2"
           />
-        )}
+        ) : null}
       </Touchable>
     </Link>
   )

--- a/clients/apps/app/components/Orders/OrderRow.tsx
+++ b/clients/apps/app/components/Orders/OrderRow.tsx
@@ -80,7 +80,7 @@ export const OrderRow = ({
             {order?.product?.name}
           </Text>
           <Box flex={1} flexDirection="row" gap="spacing-6">
-            {showTimestamp && (
+            {showTimestamp ? (
               <>
                 <Text
                   color="subtext"
@@ -96,7 +96,7 @@ export const OrderRow = ({
                 </Text>
                 {loading ? null : <Text color="subtext">•</Text>}
               </>
-            )}
+            ) : null}
             <Text
               numberOfLines={1}
               style={{ flexShrink: 1, flexWrap: 'wrap' }}

--- a/clients/apps/app/components/Products/ProductRow.tsx
+++ b/clients/apps/app/components/Products/ProductRow.tsx
@@ -1,11 +1,10 @@
 import { Box } from '@/components/Shared/Box'
 import { Image } from '@/components/Shared/Image/Image'
 import { useTheme } from '@/design-system/useTheme'
-import { OrganizationContext } from '@/providers/OrganizationProvider'
 import MaterialIcons from '@expo/vector-icons/MaterialIcons'
 import { schemas } from '@polar-sh/client'
 import { Link } from 'expo-router'
-import React, { useContext } from 'react'
+import React from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { Pill } from '../Shared/Pill'
 import { Text } from '../Shared/Text'
@@ -19,7 +18,6 @@ export interface ProductRowProps {
 
 export const ProductRow = ({ product, style }: ProductRowProps) => {
   const theme = useTheme()
-  const { organization } = useContext(OrganizationContext)
 
   return (
     <Link
@@ -82,7 +80,7 @@ export const ProductRow = ({ product, style }: ProductRowProps) => {
             >
               {product.name}
             </Text>
-            {product.is_archived && <Pill color="red">Archived</Pill>}
+            {product.is_archived ? <Pill color="red">Archived</Pill> : null}
           </Box>
           <ProductPriceLabel product={product} />
         </Box>

--- a/clients/apps/app/components/Settings/SettingsList.tsx
+++ b/clients/apps/app/components/Settings/SettingsList.tsx
@@ -69,11 +69,11 @@ const StaticSettingsItem = ({
     >
       <Box flexDirection="column" gap="spacing-2" maxWidth="80%">
         <Text variant="body">{title}</Text>
-        {description && (
+        {description ? (
           <Text variant="bodySmall" color="subtext">
             {description}
           </Text>
-        )}
+        ) : null}
       </Box>
       <Box flexDirection="row" alignItems="center" gap="spacing-12">
         {children}
@@ -112,11 +112,11 @@ const TouchableSettingsItem = ({
       >
         <Box flexDirection="column" gap="spacing-2" maxWidth="70%">
           <Text variant="body">{title}</Text>
-          {description && (
+          {description ? (
             <Text variant="bodySmall" color="subtext">
               {description}
             </Text>
-          )}
+          ) : null}
         </Box>
         <Box flexDirection="row" alignItems="center" gap="spacing-12">
           {children}

--- a/clients/apps/app/components/Shared/Avatar.tsx
+++ b/clients/apps/app/components/Shared/Avatar.tsx
@@ -71,7 +71,7 @@ export const Avatar = ({
       position="relative"
       overflow="hidden"
     >
-      {showInitials && (
+      {showInitials ? (
         <Box
           style={{
             width: size,
@@ -85,8 +85,8 @@ export const Avatar = ({
         >
           <Text style={{ fontSize: size / 3 }}>{initials}</Text>
         </Box>
-      )}
-      {image && (
+      ) : null}
+      {image ? (
         <Box position="absolute" style={{ inset: 0 }}>
           <Image
             style={{
@@ -102,7 +102,7 @@ export const Avatar = ({
             source={{ uri: image }}
           />
         </Box>
-      )}
+      ) : null}
     </Box>
   )
 }

--- a/clients/apps/app/components/Shared/Button.tsx
+++ b/clients/apps/app/components/Shared/Button.tsx
@@ -81,15 +81,15 @@ export const Button = ({
         backgroundColor={backgroundColor}
         width={fullWidth ? '100%' : undefined}
       >
-        {loading && (
+        {loading ? (
           <Box marginRight="spacing-8">
             <ActivityIndicator
               size="small"
               color={theme.colors[textColorToken]}
             />
           </Box>
-        )}
-        {icon && !loading && <Box marginRight="spacing-4">{icon}</Box>}
+        ) : null}
+        {icon && !loading ? <Box marginRight="spacing-4">{icon}</Box> : null}
         <Text variant={sizeStyle.textVariant} color={textColorToken}>
           {children}
         </Text>

--- a/clients/apps/app/components/Shared/Checkbox.tsx
+++ b/clients/apps/app/components/Shared/Checkbox.tsx
@@ -31,14 +31,14 @@ export const Checkbox = ({ label, checked, onChange }: CheckboxProps) => {
         borderWidth={1}
         borderColor="border"
       >
-        {checked && (
+        {checked ? (
           <Box
             width={12}
             height={12}
             borderRadius="border-radius-full"
             backgroundColor="monochromeInverted"
           />
-        )}
+        ) : null}
       </Box>
       <Text color={checked ? 'text' : 'subtext'}>{label}</Text>
     </Touchable>

--- a/clients/apps/app/components/Shared/Details.tsx
+++ b/clients/apps/app/components/Shared/Details.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@/components/Shared/Box'
-import { useTheme } from '@/design-system/useTheme'
 import { StyleProp, TextStyle, ViewStyle } from 'react-native'
 import { Text } from './Text'
 
@@ -34,8 +33,6 @@ export const DetailRow = ({
   value?: React.ReactNode
   valueStyle?: StyleProp<TextStyle>
 }) => {
-  const theme = useTheme()
-
   return (
     <Box flexDirection="row" justifyContent="space-between" gap="spacing-8">
       <Text color="subtext" style={labelStyle}>

--- a/clients/apps/app/components/Shared/Image/Image.tsx
+++ b/clients/apps/app/components/Shared/Image/Image.tsx
@@ -34,7 +34,7 @@ export const Image = ({ onLoad, onLayout, style, ...props }: ImageProps) => {
         onLayout={handleLayout}
         onLoad={handleLoad}
       />
-      {showWarning && (
+      {showWarning ? (
         <Box
           position="absolute"
           backgroundColor="error"
@@ -53,7 +53,7 @@ export const Image = ({ onLoad, onLayout, style, ...props }: ImageProps) => {
               : `${100 - Math.round((sizeWarning.actual / sizeWarning.target) * 100)}% too small`}
           </Text>
         </Box>
-      )}
+      ) : null}
     </>
   )
 }

--- a/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
+++ b/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
@@ -113,7 +113,7 @@ export const SubscriptionRow = ({
               loading={loading}
               product={subscription?.product}
             />
-            {showCustomer && (
+            {showCustomer ? (
               <>
                 <Text
                   style={{ flexShrink: 1, display: loading ? 'none' : 'flex' }}
@@ -131,7 +131,7 @@ export const SubscriptionRow = ({
                   {subscription?.customer.email}
                 </Text>
               </>
-            )}
+            ) : null}
           </Box>
         </Box>
       </Touchable>

--- a/clients/apps/app/eslint-rules/no-jsx-logical-and.js
+++ b/clients/apps/app/eslint-rules/no-jsx-logical-and.js
@@ -1,0 +1,43 @@
+/**
+ * ESLint rule to prevent usage of && operator for conditional rendering in JSX.
+ * Use ternary expressions instead: {condition ? <Component /> : null}
+ */
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow && operator for conditional rendering in JSX. Use ternary expressions instead.',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noLogicalAnd:
+        'Do not use && for conditional rendering, this can crash the app. Use a ternary expression instead: {condition ? <Component /> : null}',
+    },
+  },
+
+  create(context) {
+    return {
+      LogicalExpression(node) {
+        if (node.operator !== '&&') {
+          return
+        }
+
+        const isInJSXExpression = node.parent.type === 'JSXExpressionContainer'
+
+        const rightIsJSX =
+          node.right.type === 'JSXElement' || node.right.type === 'JSXFragment'
+
+        if (isInJSXExpression && rightIsJSX) {
+          context.report({
+            node,
+            messageId: 'noLogicalAnd',
+          })
+        }
+      },
+    }
+  },
+}

--- a/clients/apps/app/eslint-rules/no-jsx-logical-and.test.js
+++ b/clients/apps/app/eslint-rules/no-jsx-logical-and.test.js
@@ -1,0 +1,116 @@
+const { RuleTester } = require('eslint')
+const rule = require('./no-jsx-logical-and')
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('no-jsx-logical-and', rule, {
+  valid: [
+    {
+      code: `
+        const Component = () => (
+          <div>{isVisible ? <Text>Hello</Text> : null}</div>
+        );
+      `,
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>{count > 0 ? <Text>Items</Text> : null}</div>
+        );
+      `,
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>{isLoading ? <Spinner /> : <Content />}</div>
+        );
+      `,
+    },
+    {
+      code: `
+        // && outside of JSX is fine
+        const result = foo && bar;
+      `,
+    },
+    {
+      code: `
+        // && with non-JSX right side in JSX is fine
+        const Component = () => (
+          <div>{foo && "text"}</div>
+        );
+      `,
+    },
+    {
+      code: `
+        // Nested ternaries are fine
+        const Component = () => (
+          <div>{a ? (b ? <X /> : null) : null}</div>
+        );
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `
+        const Component = () => (
+          <div>{isVisible && <Text>Hello</Text>}</div>
+        );
+      `,
+      errors: [{ messageId: 'noLogicalAnd' }],
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>{count && <Text>Items</Text>}</div>
+        );
+      `,
+      errors: [{ messageId: 'noLogicalAnd' }],
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>{user?.name && <Profile />}</div>
+        );
+      `,
+      errors: [{ messageId: 'noLogicalAnd' }],
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>{items.length > 0 && <List />}</div>
+        );
+      `,
+      errors: [{ messageId: 'noLogicalAnd' }],
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>{isVisible && <><Text>A</Text><Text>B</Text></>}</div>
+        );
+      `,
+      errors: [{ messageId: 'noLogicalAnd' }],
+    },
+    {
+      code: `
+        const Component = () => (
+          <div>
+            {foo && <A />}
+            {bar && <B />}
+          </div>
+        );
+      `,
+      errors: [{ messageId: 'noLogicalAnd' }, { messageId: 'noLogicalAnd' }],
+    },
+  ],
+})

--- a/clients/apps/app/eslint.config.js
+++ b/clients/apps/app/eslint.config.js
@@ -7,6 +7,7 @@ const noStyleSheetCreateRule = require('./eslint-rules/no-stylesheet-create')
 const noImageRule = require('./eslint-rules/no-image')
 const noFlatListRule = require('./eslint-rules/no-flatlist')
 const noTouchableRule = require('./eslint-rules/no-touchable')
+const noJsxLogicalAndRule = require('./eslint-rules/no-jsx-logical-and')
 
 module.exports = defineConfig([
   expoConfig,
@@ -23,6 +24,7 @@ module.exports = defineConfig([
           'no-image': noImageRule,
           'no-flatlist': noFlatListRule,
           'no-touchable': noTouchableRule,
+          'no-jsx-logical-and': noJsxLogicalAndRule,
         },
       },
     },
@@ -33,6 +35,7 @@ module.exports = defineConfig([
       '@polar/no-image': 'error',
       '@polar/no-flatlist': 'error',
       '@polar/no-touchable': 'error',
+      '@polar/no-jsx-logical-and': 'error',
     },
   },
 ])


### PR DESCRIPTION
## 📋 Summary

In React Native, the `&&` pattern can crash your app when conditionally rendering components, e.g:

```
{count && <Text>You have {count} products</Text>}
```

If count is 0, JavaScript evaluates 0 && <Text>... as 0 (falsy short-circuit). React Native then tries to render 0 as a raw value, which throws:

```
Error: Text strings must be rendered within a <Text> component.
```

This PR fixes that by adding an ESLint rule that prevents this pattern:

```
❌ {count && <Text>You have {count} products</Text>}
✅ {count ? <Text>You have {count} products</Text> : null}
```