### PR TITLE
try/catch checkForUpdateAsync()

### DIFF
--- a/clients/apps/app/app/(authenticated)/home/index.tsx
+++ b/clients/apps/app/app/(authenticated)/home/index.tsx
@@ -100,13 +100,17 @@ export default function Index() {
     )
   }, [isRefetchingOrders, isRefetchingSubscriptions, isRefetchingCustomers])
 
-  const refresh = useCallback(() => {
-    Promise.all([
+  const refresh = useCallback(async () => {
+    await Promise.all([
       refetchOrders(),
       refetchCustomers(),
       refetchSubscriptions(),
-      checkForUpdateAsync(),
     ])
+    try {
+      await checkForUpdateAsync()
+    } catch {
+      // checkForUpdateAsync is not supported on simulator/emulator
+    }
   }, [refetchOrders, refetchCustomers, refetchSubscriptions])
 
   const { expoPushToken } = useNotifications()

--- a/clients/apps/app/components/Orders/OrderRow.tsx
+++ b/clients/apps/app/components/Orders/OrderRow.tsx
@@ -55,7 +55,7 @@ export const OrderRow = ({
             <Image
               source={{ uri: product?.medias?.[0]?.public_url }}
               style={{ width: '100%', height: '100%' }}
-              resizeMode="cover"
+              contentFit="cover"
             />
           ) : (
             <Box

--- a/clients/apps/app/components/Products/ProductRow.tsx
+++ b/clients/apps/app/components/Products/ProductRow.tsx
@@ -46,7 +46,7 @@ export const ProductRow = ({ product, style }: ProductRowProps) => {
             <Image
               source={{ uri: product?.medias?.[0]?.public_url }}
               style={{ width: '100%', height: '100%' }}
-              resizeMode="cover"
+              contentFit="cover"
             />
           ) : (
             <Box


### PR DESCRIPTION
## 📋 Summary

Simulators/emulators doesn't support `checkForUpdateAsync()`, so every time we do a pull-to-refresh on home it will throw an error which is annoying.