### PR TITLE
dev: use workspace path in conductor-run script

### DIFF
--- a/dev/conductor-run
+++ b/dev/conductor-run
@@ -6,8 +6,13 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+# Use CONDUCTOR_WORKSPACE_PATH if available, otherwise fall back to script location
+if [[ -n "${CONDUCTOR_WORKSPACE_PATH:-}" ]]; then
+    ROOT_DIR="$CONDUCTOR_WORKSPACE_PATH"
+else
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+fi
 
 # Calculate instance from CONDUCTOR_PORT (default to 0)
 CONDUCTOR_PORT="${CONDUCTOR_PORT:-55000}"


### PR DESCRIPTION
## 📋 Summary

This PR ensures that when running Conductor, the script uses the workspace path instead of the repository root.

## 🎯 What

Modified the `conductor-run` script to prioritize the `CONDUCTOR_WORKSPACE_PATH` environment variable when available, allowing Conductor to properly use workspace-specific code changes.

## 🤔 Why

When developing with Conductor workspaces, code changes made in the workspace were not being picked up by the running API because the script was using the main repository path instead of the workspace path.

## 🔧 How

The script now checks for the `CONDUCTOR_WORKSPACE_PATH` environment variable first, and falls back to the original location-based path derivation if not available. This maintains backward compatibility while supporting Conductor's workspace isolation.

## 🧪 Testing

- Tested locally with Conductor workspace
- No functional changes to existing behavior when running outside Conductor