### PR TITLE
Add Toast

### DIFF
--- a/clients/apps/app/app/(authenticated)/_layout.tsx
+++ b/clients/apps/app/app/(authenticated)/_layout.tsx
@@ -7,6 +7,7 @@ import { PolarOrganizationProvider } from '@/providers/OrganizationProvider'
 import { PolarClientProvider } from '@/providers/PolarClientProvider'
 import { PolarQueryClientProvider } from '@/providers/PolarQueryClientProvider'
 import { useSession } from '@/providers/SessionProvider'
+import { ToastProvider } from '@/providers/ToastProvider'
 import { UserProvider } from '@/providers/UserProvider'
 import { DarkTheme, ThemeProvider } from '@react-navigation/native'
 import { useQueryClient } from '@tanstack/react-query'
@@ -66,7 +67,9 @@ export default function Providers() {
             <DeepLinkProvider>
               <NotificationsProvider>
                 <PolarOrganizationProvider>
-                  <RootLayout />
+                  <ToastProvider>
+                    <RootLayout />
+                  </ToastProvider>
                 </PolarOrganizationProvider>
               </NotificationsProvider>
             </DeepLinkProvider>

--- a/clients/apps/app/app/(authenticated)/catalogue/checkout-links/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/catalogue/checkout-links/[id]/index.tsx
@@ -20,6 +20,7 @@ import {
 import { useInfiniteDiscounts } from '@/hooks/polar/discounts'
 import { useInfiniteProducts } from '@/hooks/polar/products'
 import { OrganizationContext } from '@/providers/OrganizationProvider'
+import { useToast } from '@/providers/ToastProvider'
 import { Stack, useLocalSearchParams } from 'expo-router'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
@@ -43,6 +44,7 @@ export default function CheckoutLinkDetails() {
   const { id } = useLocalSearchParams()
   const theme = useTheme()
   const { organization } = useContext(OrganizationContext)
+  const toast = useToast()
 
   const {
     data: checkoutLink,
@@ -108,7 +110,6 @@ export default function CheckoutLinkDetails() {
     { key: string; value: string }[]
   >([])
   const [showAddMetadataSheet, setShowAddMetadataSheet] = useState(false)
-  const [showSaved, setShowSaved] = useState(false)
 
   useEffect(() => {
     if (checkoutLink) {
@@ -155,17 +156,18 @@ export default function CheckoutLinkDetails() {
             {} as Record<string, string>,
           ),
         })
-        setShowSaved(true)
-        setTimeout(() => setShowSaved(false), 2000)
-      } catch (error) {
+
+        toast.showInfo('Saved!')
+      } catch {
         Alert.alert('Error', 'Failed to update checkout link')
       }
     },
     [
-      updateCheckoutLink,
       selectedProductIds,
+      updateCheckoutLink,
       selectedDiscountId,
       metadataFields,
+      toast,
     ],
   )
 
@@ -299,7 +301,7 @@ export default function CheckoutLinkDetails() {
             }}
             loading={updateCheckoutLink.isPending}
           >
-            {showSaved ? 'Saved!' : 'Save'}
+            Save
           </Button>
         </ScrollView>
       </KeyboardAvoidingView>

--- a/clients/apps/app/app/(authenticated)/catalogue/products/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/catalogue/products/[id]/index.tsx
@@ -17,6 +17,7 @@ import { useMetrics } from '@/hooks/polar/metrics'
 import { useOrders } from '@/hooks/polar/orders'
 import { useProduct, useProductUpdate } from '@/hooks/polar/products'
 import { OrganizationContext } from '@/providers/OrganizationProvider'
+import { useToast } from '@/providers/ToastProvider'
 import { formatCurrencyAndAmount } from '@/utils/money'
 import { schemas } from '@polar-sh/client'
 import { Stack, useLocalSearchParams } from 'expo-router'
@@ -37,6 +38,7 @@ export default function Index() {
   const { id } = useLocalSearchParams()
   const theme = useTheme()
   const { organization } = useContext(OrganizationContext)
+  const toast = useToast()
 
   const {
     data: product,
@@ -121,6 +123,8 @@ export default function Index() {
           value,
         })),
       })
+
+      toast.showInfo('Saved!')
     },
     [reset, updateProduct],
   )

--- a/clients/apps/app/components/CheckoutLinks/Details/LinkEmbedSection.tsx
+++ b/clients/apps/app/components/CheckoutLinks/Details/LinkEmbedSection.tsx
@@ -2,10 +2,10 @@ import { Box } from '@/components/Shared/Box'
 import { Text } from '@/components/Shared/Text'
 import { Touchable } from '@/components/Shared/Touchable'
 import { useTheme } from '@/design-system/useTheme'
+import { useToast } from '@/providers/ToastProvider'
 import MaterialIcons from '@expo/vector-icons/MaterialIcons'
 import * as Clipboard from 'expo-clipboard'
 import { useCallback } from 'react'
-import { Alert } from 'react-native'
 
 interface LinkEmbedSectionProps {
   url: string
@@ -13,11 +13,12 @@ interface LinkEmbedSectionProps {
 
 export const LinkEmbedSection = ({ url }: LinkEmbedSectionProps) => {
   const theme = useTheme()
+  const toast = useToast()
 
   const handleCopyLink = useCallback(async () => {
     await Clipboard.setStringAsync(url)
-    Alert.alert('Copied', 'Checkout link copied to clipboard')
-  }, [url])
+    toast.showInfo('Copied to clipboard')
+  }, [url, toast])
 
   return (
     <Box flexDirection="column" gap="spacing-12">

--- a/clients/apps/app/components/Shared/Toast.tsx
+++ b/clients/apps/app/components/Shared/Toast.tsx
@@ -1,0 +1,191 @@
+import { ColorToken } from '@/design-system/theme'
+import { useTheme } from '@/design-system/useTheme'
+import MaterialIcons from '@expo/vector-icons/MaterialIcons'
+import * as Haptics from 'expo-haptics'
+import { useCallback, useEffect } from 'react'
+import { Pressable } from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import Animated, {
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Box } from './Box'
+import { Text } from './Text'
+
+export type ToastType = 'info' | 'success' | 'error' | 'warning'
+
+interface ToastProps {
+  message: string
+  type: ToastType
+  persistent: boolean
+  visible: boolean
+  onDismiss: () => void
+  bottomOffset?: number
+}
+
+const SWIPE_THRESHOLD = 50
+
+const springConfig = {
+  damping: 60,
+  stiffness: 600,
+}
+
+interface TypeConfig {
+  backgroundColor: string
+  iconColor: string
+  textColorKey: ColorToken
+}
+
+const getTypeConfig = (
+  type: ToastType,
+  colors: ReturnType<typeof useTheme>['colors'],
+): TypeConfig => {
+  switch (type) {
+    case 'success':
+      return {
+        backgroundColor: colors.statusGreen,
+        iconColor: colors.monochrome,
+        textColorKey: 'monochrome',
+      }
+    case 'error':
+      return {
+        backgroundColor: colors.statusRed,
+        iconColor: colors.monochrome,
+        textColorKey: 'monochrome',
+      }
+    case 'warning':
+      return {
+        backgroundColor: colors.statusYellow,
+        iconColor: colors.monochrome,
+        textColorKey: 'monochrome',
+      }
+    case 'info':
+    default:
+      return {
+        backgroundColor: colors.primary,
+        iconColor: colors.text,
+        textColorKey: 'text',
+      }
+  }
+}
+
+export const Toast = ({
+  message,
+  type,
+  persistent,
+  visible,
+  onDismiss,
+  bottomOffset = 0,
+}: ToastProps) => {
+  const theme = useTheme()
+  const insets = useSafeAreaInsets()
+  const typeConfig = getTypeConfig(type, theme.colors)
+
+  const translateY = useSharedValue(100)
+  const opacity = useSharedValue(0)
+  const gestureTranslateY = useSharedValue(0)
+
+  const triggerHaptic = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+  }, [])
+
+  useEffect(() => {
+    if (visible) {
+      translateY.value = withSpring(0, springConfig)
+      opacity.value = withTiming(1, { duration: 200 })
+    } else {
+      translateY.value = withSpring(100, springConfig)
+      opacity.value = withTiming(0, { duration: 150 })
+    }
+  }, [visible, translateY, opacity])
+
+  const dismiss = useCallback(() => {
+    triggerHaptic()
+    onDismiss()
+  }, [onDismiss, triggerHaptic])
+
+  const panGesture = Gesture.Pan()
+    .onUpdate((e) => {
+      if (e.translationY > 0) {
+        gestureTranslateY.value = e.translationY
+      }
+    })
+    .onEnd((e) => {
+      if (e.translationY > SWIPE_THRESHOLD || e.velocityY > 500) {
+        runOnJS(dismiss)()
+      }
+      gestureTranslateY.value = withSpring(0, springConfig)
+    })
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const totalTranslateY = translateY.value + gestureTranslateY.value
+    const gestureOpacity = interpolate(
+      gestureTranslateY.value,
+      [0, SWIPE_THRESHOLD],
+      [1, 0.5],
+    )
+
+    return {
+      transform: [{ translateY: totalTranslateY }],
+      opacity: opacity.value * gestureOpacity,
+    }
+  })
+
+  return (
+    <GestureDetector gesture={panGesture}>
+      <Animated.View
+        style={[
+          {
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: bottomOffset + insets.bottom + theme.spacing['spacing-16'],
+            alignItems: 'center',
+            zIndex: 9999,
+          },
+          animatedStyle,
+        ]}
+      >
+        <Box
+          flexDirection="row"
+          alignItems="center"
+          paddingHorizontal="spacing-32"
+          paddingVertical="spacing-12"
+          borderRadius="border-radius-999"
+          gap="spacing-12"
+          style={{
+            maxWidth: '90%',
+            backgroundColor: typeConfig.backgroundColor,
+            shadowColor: theme.colors.monochrome,
+            shadowOffset: { width: 0, height: theme.dimension['dimension-4'] },
+            shadowOpacity: 0.3,
+            shadowRadius: theme.spacing['spacing-8'],
+            elevation: 8,
+          }}
+        >
+          <Text
+            variant="body"
+            color={typeConfig.textColorKey}
+            numberOfLines={2}
+          >
+            {message}
+          </Text>
+          {persistent ? (
+            <Pressable onPress={dismiss} hitSlop={8}>
+              <MaterialIcons
+                name="close"
+                size={20}
+                color={theme.colors[typeConfig.textColorKey]}
+              />
+            </Pressable>
+          ) : null}
+        </Box>
+      </Animated.View>
+    </GestureDetector>
+  )
+}

--- a/clients/apps/app/providers/ToastProvider.tsx
+++ b/clients/apps/app/providers/ToastProvider.tsx
@@ -1,0 +1,145 @@
+import { Toast, ToastType } from '@/components/Shared/Toast'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+
+const AUTO_DISMISS_DURATION = 2000
+const BOTTOM_OFFSET = 30
+
+interface ToastOptions {
+  persistent?: boolean
+}
+
+interface ToastState {
+  id: number
+  message: string
+  type: ToastType
+  persistent: boolean
+}
+
+interface ToastContextValue {
+  showInfo: (message: string, options?: ToastOptions) => void
+  showSuccess: (message: string, options?: ToastOptions) => void
+  showError: (message: string, options?: ToastOptions) => void
+  showWarning: (message: string, options?: ToastOptions) => void
+  dismiss: () => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export const useToast = (): ToastContextValue => {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}
+
+interface ToastProviderProps {
+  children: React.ReactNode
+}
+
+export const ToastProvider = ({ children }: ToastProviderProps) => {
+  const [toast, setToast] = useState<ToastState | null>(null)
+  const [visible, setVisible] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const idCounter = useRef(0)
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    clearTimer()
+    setVisible(false)
+    setTimeout(() => {
+      setToast(null)
+    }, 200)
+  }, [clearTimer])
+
+  const showToast = useCallback(
+    (message: string, type: ToastType, options?: ToastOptions) => {
+      clearTimer()
+
+      const persistent = options?.persistent ?? false
+      const id = ++idCounter.current
+
+      setToast({ id, message, type, persistent })
+      setVisible(true)
+
+      if (!persistent) {
+        timeoutRef.current = setTimeout(() => {
+          dismiss()
+        }, AUTO_DISMISS_DURATION)
+      }
+    },
+    [clearTimer, dismiss],
+  )
+
+  const showInfo = useCallback(
+    (message: string, options?: ToastOptions) => {
+      showToast(message, 'info', options)
+    },
+    [showToast],
+  )
+
+  const showSuccess = useCallback(
+    (message: string, options?: ToastOptions) => {
+      showToast(message, 'success', options)
+    },
+    [showToast],
+  )
+
+  const showError = useCallback(
+    (message: string, options?: ToastOptions) => {
+      showToast(message, 'error', options)
+    },
+    [showToast],
+  )
+
+  const showWarning = useCallback(
+    (message: string, options?: ToastOptions) => {
+      showToast(message, 'warning', options)
+    },
+    [showToast],
+  )
+
+  useEffect(() => {
+    return () => {
+      clearTimer()
+    }
+  }, [clearTimer])
+
+  const contextValue: ToastContextValue = {
+    showInfo,
+    showSuccess,
+    showError,
+    showWarning,
+    dismiss,
+  }
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      {toast && (
+        <Toast
+          key={toast.id}
+          message={toast.message}
+          type={toast.type}
+          persistent={toast.persistent}
+          visible={visible}
+          onDismiss={dismiss}
+          bottomOffset={BOTTOM_OFFSET}
+        />
+      )}
+    </ToastContext.Provider>
+  )
+}


### PR DESCRIPTION
## 📋 Summary

Add a new `useToast()` hook with a few different presets (info, error, success etc.)

<img width="325" align="right" alt="" src="https://github.com/user-attachments/assets/c94d8ae0-219f-462b-bd61-827e7e86acd7" />
