### PR TITLE
Alert on unsaved changes

### DIFF
--- a/clients/apps/web/src/hooks/editor.ts
+++ b/clients/apps/web/src/hooks/editor.ts
@@ -1,22 +1,85 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-export const useAlertIfUnsaved = (isEdited: boolean) => {
-  // close tab handling
-  const onBeforeUnload = useCallback(
-    (event: BeforeUnloadEvent) => {
-      if (isEdited) {
-        event.preventDefault()
-        event.returnValue = 'You have unsaved changes. Close this page?'
-      }
-    },
-    [isEdited],
-  )
+const UNSAVED_CHANGES_MESSAGE =
+  'You have unsaved changes. Are you sure you want to leave?'
+
+type NavigationType = 'push' | 'replace' | 'reload' | 'traverse'
+
+interface NavigateEvent {
+  canIntercept: boolean
+  hashChange: boolean
+  navigationType: NavigationType
+  preventDefault: () => void
+}
+
+export const useAlertIfUnsaved = () => {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+  const hasUnsavedChangesRef = useRef(hasUnsavedChanges)
 
   useEffect(() => {
+    hasUnsavedChangesRef.current = hasUnsavedChanges
+  }, [hasUnsavedChanges])
+
+  useEffect(() => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (hasUnsavedChangesRef.current) {
+        event.preventDefault()
+        event.returnValue = UNSAVED_CHANGES_MESSAGE
+      }
+    }
+
+    const onLinkClick = (event: MouseEvent) => {
+      if (!hasUnsavedChangesRef.current) return
+
+      const target = event.target as HTMLElement
+      const anchor = target.closest('a')
+
+      if (!anchor) return
+      if (anchor.target === '_blank') return
+      if (anchor.hasAttribute('download')) return
+
+      const href = anchor.getAttribute('href')
+      if (!href || href.startsWith('#') || href.startsWith('mailto:')) return
+
+      const confirmed = window.confirm(UNSAVED_CHANGES_MESSAGE)
+      if (!confirmed) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+    }
+
     window.addEventListener('beforeunload', onBeforeUnload)
+    document.addEventListener('click', onLinkClick, true)
+
+    const onNavigate = (event: NavigateEvent) => {
+      if (!hasUnsavedChangesRef.current) return
+      if (!event.canIntercept) return
+      if (event.hashChange) return
+      if (event.navigationType !== 'traverse') return
+
+      const confirmed = window.confirm(UNSAVED_CHANGES_MESSAGE)
+      if (!confirmed) {
+        event.preventDefault()
+      }
+    }
+
+    const navigation = 'navigation' in window ? window.navigation : null
+    navigation?.addEventListener(
+      'navigate',
+      onNavigate as unknown as EventListener,
+    )
 
     return () => {
       window.removeEventListener('beforeunload', onBeforeUnload)
+      document.removeEventListener('click', onLinkClick, true)
+      navigation?.removeEventListener(
+        'navigate',
+        onNavigate as unknown as EventListener,
+      )
     }
-  }, [onBeforeUnload])
+  }, [])
+
+  return useCallback((value: boolean) => {
+    setHasUnsavedChanges(value)
+  }, [])
 }


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #8406

## 🎯 What

To avoid accidental data loss when editing a product this PR will add an alert if you have unsaved changes on the product page.

It took a bit of fiddling around to handle these three cases:

- Browser reload
- Browser back button
- Navigating in the Next.js environment (clicking in the sidebar etc.)

which is why I had to make quite a lot of changes to the `useUnsavedChanges` hook.
