### PR TITLE
Re-upload images on duplicated product creation

### DIFF
--- a/clients/apps/web/src/utils/product.ts
+++ b/clients/apps/web/src/utils/product.ts
@@ -116,7 +116,7 @@ export const productToCreateForm = (
   return {
     ...productBase,
     name: `Copy of ${product.name}`,
-    full_medias: product.medias,
+    full_medias: product.medias.map((media) => ({ ...media })),
     prices: product.prices.map((price) => {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       const {


### PR DESCRIPTION
## 📋 Summary

When duplicating a product we currently have the following bug:

1. Create **Product A** with an image
2. Duplicate **Product A**, creating **Product B**
3. Delete the image from **Product B**
4. The image from **Product A** is also deleted

This is because we are just passing the reference to the image to **Product B**, thus deleting the image in one of the product means deleting it for all products.

This PR fixes that by re-uploading the image when duplicating a product