### PR TITLE
Migrate events metrics to use Events hypertable

### DIFF
--- a/server/polar/kit/time_queries.py
+++ b/server/polar/kit/time_queries.py
@@ -28,6 +28,11 @@ class TimeInterval(StrEnum):
     ) -> Function[datetime]:
         return func.date_trunc(self.value, column)
 
+    def sql_time_bucket(
+        self, column: SQLColumnExpression[datetime] | datetime
+    ) -> Function[datetime]:
+        return func.time_bucket(self.sql_interval(), column)
+
 
 def get_timestamp_series_cte(
     start_timestamp: datetime, end_timestamp: datetime, interval: TimeInterval

--- a/server/polar/metrics/metrics.py
+++ b/server/polar/metrics/metrics.py
@@ -22,7 +22,7 @@ from polar.enums import SubscriptionRecurringInterval
 from polar.kit.time_queries import TimeInterval
 from polar.models import Checkout, Order, Subscription
 from polar.models.checkout import CheckoutStatus
-from polar.models.event import Event
+from polar.models.event_hyper import EventHyper
 from polar.models.subscription import CustomerCancellationReason
 
 from .queries import MetricQuery
@@ -790,8 +790,8 @@ class CostsMetric(SQLMetric):
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
         return func.sum(
-            Event.user_metadata["_cost"]["amount"].as_numeric(17, 12)
-        ).filter(Event.user_metadata["_cost"].is_not(None))
+            EventHyper.user_metadata["_cost"]["amount"].as_numeric(17, 12)
+        ).filter(EventHyper.user_metadata["_cost"].is_not(None))
 
     @classmethod
     def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
@@ -809,8 +809,8 @@ class CumulativeCostsMetric(SQLMetric):
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
         return func.sum(
-            Event.user_metadata["_cost"]["amount"].as_numeric(17, 12)
-        ).filter(Event.user_metadata["_cost"].is_not(None))
+            EventHyper.user_metadata["_cost"]["amount"].as_numeric(17, 12)
+        ).filter(EventHyper.user_metadata["_cost"].is_not(None))
 
     @classmethod
     def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
@@ -877,12 +877,14 @@ class CostPerUserMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[float]:
-        total_customers = func.count(func.distinct(Event.customer_id)) + func.count(
-            func.distinct(Event.external_customer_id)
-        )
+        total_customers = func.count(
+            func.distinct(EventHyper.customer_id)
+        ) + func.count(func.distinct(EventHyper.external_customer_id))
 
         total_costs = func.sum(
-            func.coalesce(Event.user_metadata["_cost"]["amount"].as_numeric(17, 12), 0)
+            func.coalesce(
+                EventHyper.user_metadata["_cost"]["amount"].as_numeric(17, 12), 0
+            )
         )
 
         return type_coerce(
@@ -1015,8 +1017,8 @@ class ActiveUserMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
-        return func.count(func.distinct(Event.customer_id)) + func.count(
-            func.distinct(Event.external_customer_id)
+        return func.count(func.distinct(EventHyper.customer_id)) + func.count(
+            func.distinct(EventHyper.external_customer_id)
         )
 
     @classmethod

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -630,7 +630,7 @@ def get_events_metrics_cte(
     start_timestamp, end_timestamp = bounds
     timestamp_column: ColumnElement[datetime] = timestamp_series.c.timestamp
 
-    day_column = interval.sql_date_trunc(EventHyper.timestamp)
+    day_column = interval.sql_time_bucket(EventHyper.timestamp)
 
     statement = (
         select(

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -33,6 +33,7 @@ from polar.models import (
     DiscountProduct,
     Dispute,
     Event,
+    EventHyper,
     EventType,
     IssueReward,
     LegacyRecurringProductPriceCustom,
@@ -1746,8 +1747,11 @@ async def create_event(
     metadata: dict[str, str | int | bool | float | Any] | None = None,
     event_type: EventType | None = None,
 ) -> Event:
+    ts = timestamp or utc_now()
+    event_id = uuid.uuid4()
     event = Event(
-        timestamp=timestamp or utc_now(),
+        id=event_id,
+        timestamp=ts,
         source=source,
         name=name,
         customer_id=customer.id if customer else None,
@@ -1759,6 +1763,23 @@ async def create_event(
         event_type_id=event_type.id if event_type else None,
     )
     await save_fixture(event)
+
+    event_hyper = EventHyper(
+        id=event_id,
+        timestamp=ts,
+        ingested_at=utc_now(),
+        source=source,
+        name=name,
+        customer_id=customer.id if customer else None,
+        external_customer_id=external_customer_id,
+        external_id=external_id,
+        parent_id=parent_id,
+        organization_id=organization.id,
+        user_metadata=metadata or {},
+        event_type_id=event_type.id if event_type else None,
+    )
+    await save_fixture(event_hyper)
+
     return event
 
 


### PR DESCRIPTION
We revert the x lateral queries as we gain more performance from doing the single grouped query again against the timescaledb hypertable.