### PR TITLE
Add support for experiments

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -129,6 +129,23 @@ const nextConfig = {
     ],
   },
 
+  async rewrites() {
+    return [
+      {
+        source: '/ingest/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/ingest/:path*',
+        destination: 'https://us.i.posthog.com/:path*',
+      },
+      {
+        source: '/ingest/decide',
+        destination: 'https://us.i.posthog.com/decide',
+      },
+    ]
+  },
+
   async redirects() {
     return [
       // dashboard.polar.sh redirections

--- a/clients/apps/web/src/app/layout.tsx
+++ b/clients/apps/web/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import '../styles/globals.css'
 
 import SandboxBanner from '@/components/Sandbox/SandboxBanner'
+import { getExperimentNames } from '@/experiments'
+import { ExperimentProvider } from '@/experiments/ExperimentProvider'
+import { getExperiments } from '@/experiments/server'
 import { UserContextProvider } from '@/providers/auth'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { CONFIG } from '@/utils/config'
@@ -101,6 +104,8 @@ export default async function RootLayout({
     }
   }
 
+  const experimentVariants = await getExperiments(getExperimentNames())
+
   return (
     <html
       lang="en"
@@ -141,21 +146,23 @@ export default async function RootLayout({
           textRendering: 'optimizeLegibility',
         }}
       >
-        <UserContextProvider
-          user={authenticatedUser}
-          userOrganizations={userOrganizations}
-        >
-          <PolarPostHogProvider>
-            <PolarQueryClientProvider>
-              <PolarNuqsProvider>
-                <NavigationHistoryProvider>
-                  <SandboxBanner />
-                  {children}
-                </NavigationHistoryProvider>
-              </PolarNuqsProvider>
-            </PolarQueryClientProvider>
-          </PolarPostHogProvider>
-        </UserContextProvider>
+        <ExperimentProvider experiments={experimentVariants}>
+          <UserContextProvider
+            user={authenticatedUser}
+            userOrganizations={userOrganizations}
+          >
+            <PolarPostHogProvider>
+              <PolarQueryClientProvider>
+                <PolarNuqsProvider>
+                  <NavigationHistoryProvider>
+                    <SandboxBanner />
+                    {children}
+                  </NavigationHistoryProvider>
+                </PolarNuqsProvider>
+              </PolarQueryClientProvider>
+            </PolarPostHogProvider>
+          </UserContextProvider>
+        </ExperimentProvider>
       </body>
     </html>
   )

--- a/clients/apps/web/src/app/providers.tsx
+++ b/clients/apps/web/src/app/providers.tsx
@@ -29,7 +29,6 @@ export function PolarPostHogProvider({
       api_host: '/ingest',
       defaults: '2025-05-24', // this enables automatic pageview tracking
       persistence: cookieConsentGiven() === 'yes' ? 'localStorage' : 'memory',
-      advanced_disable_feature_flags: true,
     })
   }, [])
 

--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -28,7 +28,7 @@ import { getThemePreset } from '@polar-sh/ui/hooks/theming'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CheckoutCard } from './CheckoutCard'
 import CheckoutProductInfo from './CheckoutProductInfo'
 
@@ -54,6 +54,7 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
   const posthog = usePostHog()
 
   const themePreset = getThemePreset(checkout.organization.slug, theme)
+  const hasTrackedOpen = useRef(false)
 
   // Check organization payment readiness (account verification only for checkout)
   const { data: paymentStatus } = useOrganizationPaymentStatus(
@@ -68,6 +69,8 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
 
   // Track checkout page open
   useEffect(() => {
+    if (hasTrackedOpen.current) return
+    hasTrackedOpen.current = true
     posthog.capture('storefront:subscriptions:checkout:open', {
       organization_slug: checkout.organization.slug,
       product_id: checkout.productId,

--- a/clients/apps/web/src/experiments/Experiment.tsx
+++ b/clients/apps/web/src/experiments/Experiment.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { type ReactNode, createContext, useContext } from 'react'
+import { useExperiment } from './client'
+import type { ExperimentName } from './index'
+
+interface ExperimentContextValue {
+  variant: string
+  isControl: boolean
+  isTreatment: boolean
+}
+
+const ExperimentContext = createContext<ExperimentContextValue | null>(null)
+
+function useExperimentComponentContext() {
+  const context = useContext(ExperimentContext)
+  if (!context) {
+    throw new Error(
+      'Experiment.Control/Treatment must be used within an Experiment component',
+    )
+  }
+  return context
+}
+
+interface ExperimentProps<T extends ExperimentName> {
+  name: T
+  children: ReactNode
+}
+
+function Experiment<T extends ExperimentName>({
+  name,
+  children,
+}: ExperimentProps<T>) {
+  const experimentResult = useExperiment(name)
+
+  return (
+    <ExperimentContext.Provider value={experimentResult}>
+      {children}
+    </ExperimentContext.Provider>
+  )
+}
+
+interface VariantProps {
+  children: ReactNode
+}
+
+function Control({ children }: VariantProps) {
+  const { isControl } = useExperimentComponentContext()
+  return isControl ? <>{children}</> : null
+}
+
+function Treatment({ children }: VariantProps) {
+  const { isTreatment } = useExperimentComponentContext()
+  return isTreatment ? <>{children}</> : null
+}
+
+interface VariantMatchProps {
+  match: string
+  children: ReactNode
+}
+
+function Variant({ match, children }: VariantMatchProps) {
+  const { variant } = useExperimentComponentContext()
+  return variant === match ? <>{children}</> : null
+}
+
+Experiment.Control = Control
+Experiment.Treatment = Treatment
+Experiment.Variant = Variant
+
+export { Experiment }

--- a/clients/apps/web/src/experiments/ExperimentProvider.tsx
+++ b/clients/apps/web/src/experiments/ExperimentProvider.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { createContext, useContext, type ReactNode } from 'react'
+import type { ExperimentName, ExperimentVariant } from './index'
+
+type ExperimentVariants = {
+  [K in ExperimentName]?: ExperimentVariant<K>
+}
+
+const ExperimentContext = createContext<ExperimentVariants>({})
+
+interface ExperimentProviderProps {
+  children: ReactNode
+  experiments: ExperimentVariants
+}
+
+export function ExperimentProvider({
+  children,
+  experiments,
+}: ExperimentProviderProps) {
+  return (
+    <ExperimentContext.Provider value={experiments}>
+      {children}
+    </ExperimentContext.Provider>
+  )
+}
+
+export function useExperimentContext() {
+  return useContext(ExperimentContext)
+}

--- a/clients/apps/web/src/experiments/client.ts
+++ b/clients/apps/web/src/experiments/client.ts
@@ -1,0 +1,49 @@
+'use client'
+
+import { usePostHog } from 'posthog-js/react'
+import { useEffect, useMemo, useRef } from 'react'
+import { useExperimentContext } from './ExperimentProvider'
+import {
+  type ExperimentName,
+  type ExperimentResult,
+  getDefaultVariant,
+} from './index'
+
+export interface UseExperimentOptions {
+  trackExposure?: boolean
+}
+
+export function useExperiment<T extends ExperimentName>(
+  experimentName: T,
+  options?: UseExperimentOptions,
+): ExperimentResult<T> {
+  const { trackExposure = true } = options ?? {}
+  const posthog = usePostHog()
+  const hasTracked = useRef(false)
+  const experiments = useExperimentContext()
+
+  const variant =
+    experiments[experimentName] ?? getDefaultVariant(experimentName)
+
+  useEffect(() => {
+    if (!trackExposure || hasTracked.current) {
+      return
+    }
+
+    hasTracked.current = true
+
+    posthog.capture('$feature_flag_called', {
+      $feature_flag: experimentName,
+      $feature_flag_response: variant,
+    })
+  }, [experimentName, variant, trackExposure, posthog])
+
+  return useMemo(
+    () => ({
+      variant,
+      isControl: variant === 'control',
+      isTreatment: variant === 'treatment',
+    }),
+    [variant],
+  )
+}

--- a/clients/apps/web/src/experiments/distinct-id.ts
+++ b/clients/apps/web/src/experiments/distinct-id.ts
@@ -1,0 +1,28 @@
+import { nanoid } from 'nanoid'
+import { cookies } from 'next/headers'
+
+const DISTINCT_ID_COOKIE = 'polar_distinct_id'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+
+export async function getDistinctId(): Promise<string> {
+  const cookieStore = await cookies()
+  const existingId = cookieStore.get(DISTINCT_ID_COOKIE)?.value
+
+  if (existingId) {
+    return existingId
+  }
+
+  const newId = `anon_${nanoid()}`
+
+  return newId
+}
+
+export async function getExistingDistinctId(): Promise<string | undefined> {
+  const cookieStore = await cookies()
+  return cookieStore.get(DISTINCT_ID_COOKIE)?.value
+}
+
+export const distinctIdCookieConfig = {
+  name: DISTINCT_ID_COOKIE,
+  maxAge: COOKIE_MAX_AGE,
+}

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -1,0 +1,16 @@
+/**
+ * All active experiments
+ *
+ * To add a new experiment:
+ * 1. Create a new experiment in PostHog
+ * 2. Add it here with variants and default
+ * 3. Use useExperiment() or <Experiment> in your components
+ *
+ */
+export const experiments = {
+  'placeholder-experiment': {
+    description: 'Placeholder description',
+    variants: ['control', 'treatment'] as const,
+    defaultVariant: 'control',
+  },
+} as const

--- a/clients/apps/web/src/experiments/index.ts
+++ b/clients/apps/web/src/experiments/index.ts
@@ -1,0 +1,35 @@
+import { experiments } from './experiments'
+
+export { experiments }
+
+export interface ExperimentDefinition<V extends readonly string[]> {
+  description: string
+  variants: V
+  defaultVariant: V[number]
+}
+
+export type ExperimentRegistry = Record<
+  string,
+  ExperimentDefinition<readonly string[]>
+>
+
+export type ExperimentName = keyof typeof experiments
+
+export type ExperimentVariant<T extends ExperimentName> =
+  (typeof experiments)[T]['variants'][number]
+
+export type ExperimentResult<T extends ExperimentName> = {
+  variant: ExperimentVariant<T>
+  isControl: boolean
+  isTreatment: boolean
+}
+
+export function getDefaultVariant<T extends ExperimentName>(
+  experimentName: T,
+): ExperimentVariant<T> {
+  return experiments[experimentName].defaultVariant as ExperimentVariant<T>
+}
+
+export function getExperimentNames(): ExperimentName[] {
+  return Object.keys(experiments) as ExperimentName[]
+}

--- a/clients/apps/web/src/experiments/posthog-server.ts
+++ b/clients/apps/web/src/experiments/posthog-server.ts
@@ -1,0 +1,28 @@
+import { PostHog } from 'posthog-node'
+
+let posthogClient: PostHog | null = null
+
+export function getPostHogServer(): PostHog | null {
+  const token = process.env.NEXT_PUBLIC_POSTHOG_TOKEN
+
+  if (!token) {
+    return null
+  }
+
+  if (!posthogClient) {
+    posthogClient = new PostHog(token, {
+      host: 'https://us.i.posthog.com',
+      flushAt: 1,
+      flushInterval: 0,
+    })
+  }
+
+  return posthogClient
+}
+
+export async function shutdownPostHog(): Promise<void> {
+  if (posthogClient) {
+    await posthogClient.shutdown()
+    posthogClient = null
+  }
+}

--- a/clients/apps/web/src/experiments/server.ts
+++ b/clients/apps/web/src/experiments/server.ts
@@ -1,0 +1,64 @@
+import { getDistinctId } from '@/experiments/distinct-id'
+import { getPostHogServer } from '@/experiments/posthog-server'
+import {
+  type ExperimentName,
+  type ExperimentVariant,
+  experiments,
+  getDefaultVariant,
+} from './index'
+
+export interface GetExperimentOptions {
+  distinctId?: string
+}
+
+export async function getExperiment<T extends ExperimentName>(
+  experimentName: T,
+  options?: GetExperimentOptions,
+): Promise<ExperimentVariant<T>> {
+  const posthog = getPostHogServer()
+
+  if (!posthog) {
+    return getDefaultVariant(experimentName)
+  }
+
+  const distinctId = options?.distinctId ?? (await getDistinctId())
+  const experiment = experiments[experimentName]
+
+  try {
+    const flagValue = await posthog.getFeatureFlag(experimentName, distinctId, {
+      sendFeatureFlagEvents: false,
+    })
+
+    if (typeof flagValue === 'string') {
+      const validVariants = experiment.variants as readonly string[]
+      if (validVariants.includes(flagValue)) {
+        return flagValue as ExperimentVariant<T>
+      }
+    }
+
+    if (typeof flagValue === 'boolean') {
+      return (flagValue ? 'treatment' : 'control') as ExperimentVariant<T>
+    }
+
+    return getDefaultVariant(experimentName)
+  } catch (error) {
+    console.error(`Error fetching experiment ${experimentName}:`, error)
+    return getDefaultVariant(experimentName)
+  }
+}
+
+export async function getExperiments<T extends ExperimentName>(
+  experimentNames: T[],
+  options?: GetExperimentOptions,
+): Promise<Record<T, ExperimentVariant<T>>> {
+  const distinctId = options?.distinctId ?? (await getDistinctId())
+
+  const results = await Promise.all(
+    experimentNames.map(async (name) => {
+      const variant = await getExperiment(name, { distinctId })
+      return [name, variant] as const
+    }),
+  )
+
+  return Object.fromEntries(results) as Record<T, ExperimentVariant<T>>
+}

--- a/clients/apps/web/src/hooks/posthog.ts
+++ b/clients/apps/web/src/hooks/posthog.ts
@@ -50,6 +50,7 @@ type Verb =
   | 'done'
   | 'open'
   | 'close'
+  | 'complete'
 
 export type EventName = `${Surface}:${Category}:${Noun}:${Verb}`
 


### PR DESCRIPTION
## 📋 Summary

This PR will add the ability to run experiments both on the dashboard and checkout.

### Usage

### 1. Define experiment in PostHog
Go to the PostHog dashboard and create a new experiment, take note of the experiment handle.

### 2. Add the experiment

Add it to `src/experiments/experiments.ts`:

```tsx
  export const experiments = {
    'my-experiment': {
      description: 'Test new feature',
      variants: ['control', 'treatment'] as const,
      defaultVariant: 'control',
    },
  } as const
```

### 3. Implement the experiment

There's two ways to check for the experiment group:

#### Client side

```tsx
const { isControl, isTreatment, variant } = useExperiment('my-experiment')
return isControl ? <OldVersion /> : <NewVersion />
```

or

```tsx
<Experiment name="my-experiment">
  <Experiment.Control>
    <OldVersion />
  </Experiment.Control>
  <Experiment.Treatment>
    <NewVersion />
  </Experiment.Treatment>
</Experiment>
```

#### Server side

```tsx
// page.tsx (server component)
import { getExperiment } from '@/experiments/server'

export default async function Page() {
  const variant = await getExperiment('my-experiment')
  return <MyComponent variant={variant} />
}

interface Props {
  variant: ExperimentVariant<'my-experiment'>
}

export function MyComponent({ variant }: Props) {
  const isControl = variant === 'control'
  return isControl ? <A /> : <B />
}
```