### PR TITLE
server/worker: use a HTTPX client middleware to benefit from pooling when sending webhooks

### DIFF
--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -27,6 +27,7 @@ from ._enqueue import (
     enqueue_job,
 )
 from ._health import HealthMiddleware
+from ._httpx import HTTPXMiddleware
 from ._memory import MemoryMonitorMiddleware
 from ._metrics import PrometheusMiddleware
 from ._redis import RedisMiddleware
@@ -178,6 +179,7 @@ broker.add_middleware(middleware.CurrentMessage())
 broker.add_middleware(MaxRetriesMiddleware())
 broker.add_middleware(SQLAlchemyMiddleware())
 broker.add_middleware(RedisMiddleware())
+broker.add_middleware(HTTPXMiddleware())
 broker.add_middleware(scheduler_middleware)
 broker.add_middleware(LogfireMiddleware())
 broker.add_middleware(LogContextMiddleware())
@@ -246,6 +248,7 @@ def actor[**P, R](
 __all__ = [
     "AsyncSessionMaker",
     "CronTrigger",
+    "HTTPXMiddleware",
     "JobQueueManager",
     "RedisMiddleware",
     "TaskPriority",

--- a/server/polar/worker/_httpx.py
+++ b/server/polar/worker/_httpx.py
@@ -1,0 +1,46 @@
+import dramatiq
+import httpx
+import structlog
+from dramatiq.asyncio import get_event_loop_thread
+
+from polar.logging import Logger
+
+log: Logger = structlog.get_logger()
+
+
+_httpx: httpx.AsyncClient | None = None
+
+
+async def _close_client() -> None:
+    global _httpx
+    if _httpx is not None:
+        await _httpx.aclose()
+        log.info("Closed HTTPX client")
+        _httpx = None
+
+
+class HTTPXMiddleware(dramatiq.Middleware):
+    """
+    Middleware managing the lifecycle of an HTTPX AsyncClient.
+    """
+
+    @classmethod
+    def get(cls) -> httpx.AsyncClient:
+        global _httpx
+        if _httpx is None:
+            raise RuntimeError("HTTPX not initialized")
+        return _httpx
+
+    def before_worker_boot(
+        self, broker: dramatiq.Broker, worker: dramatiq.Worker
+    ) -> None:
+        global _httpx
+        _httpx = httpx.AsyncClient()
+        log.info("Created HTTPX client")
+
+    def after_worker_shutdown(
+        self, broker: dramatiq.Broker, worker: dramatiq.Worker
+    ) -> None:
+        event_loop_thread = get_event_loop_thread()
+        assert event_loop_thread is not None
+        event_loop_thread.run_coroutine(_close_client())


### PR DESCRIPTION
- server/worker: use a HTTPX client middleware to benefit from pooling when sending webhooks