### PR TITLE
feat: add timebound inside _build_latest_event_statement

### DIFF
--- a/server/polar/customer_meter/scheduler.py
+++ b/server/polar/customer_meter/scheduler.py
@@ -17,9 +17,11 @@ from polar.models import Customer
 from polar.postgres import create_sync_engine
 
 
-def enqueue_update_customer(customer_id: uuid.UUID) -> None:
+def enqueue_update_customer(
+    customer_id: uuid.UUID, meters_dirtied_at: datetime.datetime | None = None
+) -> None:
     actor = dramatiq.get_broker().get_actor("customer_meter.update_customer")
-    actor.send(customer_id=customer_id)
+    actor.send(customer_id=customer_id, meters_dirtied_at=meters_dirtied_at)
 
 
 ORG_ID = "b3caa8b6-a64b-4c7c-94ad-03f70cc06841"
@@ -132,7 +134,7 @@ class CustomerMeterJobStore(BaseJobStore):
                     "trigger": trigger,
                     "executor": self.executor,
                     "func": enqueue_update_customer,
-                    "args": (customer_id,),
+                    "args": (customer_id, meters_dirtied_at),
                     "kwargs": {},
                     "id": f"customers:meter_update:{customer_id}",
                     "name": None,

--- a/server/polar/customer_meter/tasks.py
+++ b/server/polar/customer_meter/tasks.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 from opentelemetry import trace
 
@@ -26,7 +27,9 @@ class CustomerDoesNotExist(CustomerMeterTaskError):
     max_retries=1,
     min_backoff=30_000,
 )
-async def update_customer(customer_id: uuid.UUID) -> None:
+async def update_customer(
+    customer_id: uuid.UUID, meters_dirtied_at: datetime | None = None
+) -> None:
     async with AsyncSessionMaker() as session:
         repository = CustomerRepository.from_session(session)
         customer = await repository.get_by_id(customer_id)
@@ -39,4 +42,6 @@ async def update_customer(customer_id: uuid.UUID) -> None:
         redis = RedisMiddleware.get()
         locker = Locker(redis)
 
-        await customer_meter_service.update_customer(session, locker, customer)
+        await customer_meter_service.update_customer(
+            session, locker, customer, meters_dirtied_at
+        )


### PR DESCRIPTION
For `_get_latest_current_window_event` and the early exit case, this should be much faster