### PR TITLE
Clarify subscription uncanceled webhook documentation

### DIFF
--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -910,7 +910,11 @@ class WebhookSubscriptionCanceledPayload(WebhookSubscriptionUpdatedPayloadBase):
 
 class WebhookSubscriptionUncanceledPayload(WebhookSubscriptionUpdatedPayloadBase):
     """
-    Sent when a subscription is uncanceled.
+    Sent when a customer revokes a pending cancellation.
+
+    When a customer cancels with "at period end", they retain access until the
+    subscription would renew. During this time, they can change their mind and
+    undo the cancellation. This event is triggered when they do so.
 
     **Discord & Slack support:** Full
     """


### PR DESCRIPTION
Explain that "uncanceling" refers to when a customer revokes a pending "cancel at period end" cancellation before the subscription actually ends.