### PR TITLE
Revert "Implement spreading for `meter.billing_entries` (#8687)"

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -63,6 +63,14 @@ class Settings(BaseSettings):
     WORKER_MIN_BACKOFF_MILLISECONDS: int = 2_000
     WORKER_PROMETHEUS_DIR: Path = Path(tempfile.gettempdir()) / "prometheus_multiproc"
 
+    # Bulk jobs spread settings (for staggering large batch job enqueueing)
+    BULK_JOBS_SPREAD_THRESHOLD: int = 50  # Only spread if count exceeds this
+    BULK_JOBS_SPREAD_TARGET_DELAY_MS: int = 200  # Target delay between jobs
+    BULK_JOBS_SPREAD_MIN_DELAY_MS: int = (
+        50  # Minimum delay (floor for very large batches)
+    )
+    BULK_JOBS_SPREAD_MAX_MS: int = 300_000  # Maximum total spread time (5 minutes)
+
     # Prometheus Remote Write (for pushing metrics to Prometheus or Grafana Cloud)
     PROMETHEUS_REMOTE_WRITE_URL: str | None = None
     PROMETHEUS_REMOTE_WRITE_USERNAME: str | None = None

--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -21,11 +21,10 @@ from polar.observability import metrics as _prometheus_metrics
 
 from ._encoder import JSONEncoder
 from ._enqueue import (
-    BulkJobDelayCalculator,
     JobQueueManager,
+    calculate_bulk_job_delay,
     enqueue_events,
     enqueue_job,
-    make_bulk_job_delay_calculator,
 )
 from ._health import HealthMiddleware
 from ._httpx import HTTPXMiddleware
@@ -248,7 +247,6 @@ def actor[**P, R](
 
 __all__ = [
     "AsyncSessionMaker",
-    "BulkJobDelayCalculator",
     "CronTrigger",
     "HTTPXMiddleware",
     "JobQueueManager",
@@ -256,10 +254,10 @@ __all__ = [
     "TaskPriority",
     "TaskQueue",
     "actor",
+    "calculate_bulk_job_delay",
     "can_retry",
     "enqueue_events",
     "enqueue_job",
     "get_retries",
-    "make_bulk_job_delay_calculator",
     "scheduler_middleware",
 ]

--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -4,13 +4,14 @@ import itertools
 import time
 import uuid
 from collections import defaultdict
-from collections.abc import AsyncIterator, Callable, Iterable, Mapping
+from collections.abc import AsyncIterator, Iterable, Mapping
 from typing import Any, Self
 
 import dramatiq
 import structlog
 from dramatiq.common import dq_name
 
+from polar.config import settings
 from polar.logging import Logger
 from polar.redis import Redis
 
@@ -196,76 +197,44 @@ def enqueue_events(*event_ids: uuid.UUID) -> None:
     job_queue_manager.enqueue_events(*event_ids)
 
 
-type BulkJobDelayCalculator = Callable[[int], int | None]
-
-
-def make_bulk_job_delay_calculator(
-    total_count: int,
-    *,
-    target_delay_ms: int = 200,
-    min_delay_ms: int = 50,
-    max_spread_ms: int = 300_000,
-    allow_spill: bool = True,
-) -> BulkJobDelayCalculator:
-    """Create a delay calculator for bulk job spreading.
+def calculate_bulk_job_delay(index: int, total_count: int) -> int | None:
+    """Calculate delay in milliseconds for bulk job spreading.
 
     When enqueueing many jobs at once (e.g., granting benefits to all customers
-    of a product), this function returns a calculator that computes the appropriate
-    delay for each job to spread them out over time and prevent queue saturation.
+    of a product), this function calculates the appropriate delay for each job
+    to spread them out over time and prevent queue saturation.
 
     The delay logic:
-    1. If count * target_delay <= max_spread: use target_delay (200ms)
-    2. If calculated delay >= min_delay: compress to fit in max_spread
-    3. If calculated delay < min_delay:
-       - allow_spill=True: use min_delay, accepting that total time exceeds max_spread
-       - allow_spill=False: batch items together to stay within max_spread
+    1. If count <= threshold: no delay
+    2. If count * target_delay <= max_spread: use target_delay (200ms)
+    3. If calculated delay >= min_delay: compress to fit in max_spread
+    4. If calculated delay < min_delay: use min_delay (50ms floor)
+
+    For very large batches (>6000 items), we accept exceeding max_spread
+    rather than using sub-50ms delays which would be meaningless.
 
     Args:
+        index: The 0-based index of the current item in the batch.
         total_count: The total number of items in the batch.
-        target_delay_ms: Target delay between jobs in milliseconds (default: 200).
-        min_delay_ms: Minimum delay floor in milliseconds (default: 50).
-        max_spread_ms: Maximum total spread time in milliseconds (default: 300,000 = 5 minutes).
-        allow_spill: If True, respects min_delay even if total time exceeds max_spread.
-            If False, batches items together to stay within max_spread (default: True).
 
     Returns:
-        A function that takes an index and returns the delay in milliseconds,
-        or None if no delay is needed (first item).
+        The delay in milliseconds, or None if no delay is needed
+        (below threshold or first item).
     """
+    if total_count <= settings.BULK_JOBS_SPREAD_THRESHOLD:
+        return None
+    if index == 0:
+        return None
 
-    def linear_calculator(delay_per_item: int) -> BulkJobDelayCalculator:
-        def calculate_delay(index: int) -> int | None:
-            delay = index * delay_per_item
-            return delay or None
-
-        return calculate_delay
+    target_delay_ms = settings.BULK_JOBS_SPREAD_TARGET_DELAY_MS
+    min_delay_ms = settings.BULK_JOBS_SPREAD_MIN_DELAY_MS
+    max_spread_ms = settings.BULK_JOBS_SPREAD_MAX_MS
 
     if total_count * target_delay_ms <= max_spread_ms:
-        return linear_calculator(target_delay_ms)
+        # Use target delay - we fit within max spread
+        delay_per_item = target_delay_ms
+    else:
+        # Compress to fit, but enforce minimum floor
+        delay_per_item = max(min_delay_ms, int(max_spread_ms / total_count))
 
-    compressed_delay = max_spread_ms // total_count
-
-    if compressed_delay >= min_delay_ms:
-        return linear_calculator(compressed_delay)
-
-    if allow_spill:
-        return linear_calculator(min_delay_ms)
-
-    # Batch items to stay within max_spread, using all available slots
-    # Extra items go to earlier batches: 17 items / 5 slots = 4-4-3-3-3
-    num_slots = (max_spread_ms // min_delay_ms) + 1  # +1 for the zero-delay slot
-    base_slot_size = total_count // num_slots
-    spill_slot_size = base_slot_size + 1
-
-    num_spill_slots = total_count % num_slots
-    spill_slot_switch_index = num_spill_slots * spill_slot_size
-
-    def calculate_delay_batched(index: int) -> int | None:
-        if index < spill_slot_switch_index:
-            slot = index // spill_slot_size
-        else:
-            slot = num_spill_slots + (index - spill_slot_switch_index) // base_slot_size
-        delay = slot * min_delay_ms
-        return delay or None
-
-    return calculate_delay_batched
+    return int(index * delay_per_item)


### PR DESCRIPTION
This reverts commit 1cbdf2fffd2040d6f2822ab9f8fd434ce21501f5.

There's a bug in production that I didn't have in development.