### PR TITLE
Disable failing webhooks faster

### DIFF
--- a/server/polar/webhook/repository.py
+++ b/server/polar/webhook/repository.py
@@ -72,6 +72,21 @@ class WebhookEventRepository(
         )
         return await self.get_all(statement)
 
+    async def get_pending_by_endpoint(
+        self, endpoint_id: UUID
+    ) -> Sequence[WebhookEvent]:
+        """
+        Get all pending events for an endpoint.
+
+        Returns events where succeeded is NULL (still being retried).
+        """
+        statement = self.get_base_statement().where(
+            WebhookEvent.webhook_endpoint_id == endpoint_id,
+            WebhookEvent.succeeded.is_(None),
+            WebhookEvent.skipped.is_(False),
+        )
+        return await self.get_all(statement)
+
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization]
     ) -> Select[tuple[WebhookEvent]]:

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -301,6 +301,21 @@ class WebhookService:
                 endpoint, update_dict={"enabled": False}, flush=True
             )
 
+            # Mark all pending events as skipped
+            pending_events = await webhook_event_repository.get_pending_by_endpoint(
+                endpoint.id
+            )
+            for pending_event in pending_events:
+                pending_event.skipped = True
+                session.add(pending_event)
+
+            if pending_events:
+                log.info(
+                    "Marked pending events as skipped",
+                    webhook_endpoint_id=endpoint.id,
+                    count=len(pending_events),
+                )
+
             # Send email to all organization members
             organization_id = endpoint.organization_id
             user_organizations = await user_organization_service.list_by_org(

--- a/server/tests/webhooks/test_tasks.py
+++ b/server/tests/webhooks/test_tasks.py
@@ -202,3 +202,46 @@ class TestOnEventFailed:
         # Check that the endpoint is disabled (pending events should not block this)
         await session.refresh(webhook_endpoint_organization)
         assert webhook_endpoint_organization.enabled is False
+
+    async def test_marks_pending_events_as_skipped_when_disabled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        webhook_endpoint_organization: WebhookEndpoint,
+    ) -> None:
+        # Create threshold number of failed events
+        events = []
+        for i in range(settings.WEBHOOK_FAILURE_THRESHOLD):
+            event = WebhookEvent(
+                webhook_endpoint_id=webhook_endpoint_organization.id,
+                type=WebhookEventType.customer_created,
+                payload='{"foo":"bar"}',
+                succeeded=False,
+            )
+            await save_fixture(event)
+            events.append(event)
+
+        # Add some pending events (succeeded=None)
+        pending_events = []
+        for i in range(3):
+            pending_event = WebhookEvent(
+                webhook_endpoint_id=webhook_endpoint_organization.id,
+                type=WebhookEventType.customer_created,
+                payload='{"foo":"bar"}',
+                succeeded=None,
+                skipped=False,
+            )
+            await save_fixture(pending_event)
+            pending_events.append(pending_event)
+
+        # Trigger the failure handler
+        await webhook_service.on_event_failed(session, events[-1].id)
+
+        # Check that the endpoint is disabled
+        await session.refresh(webhook_endpoint_organization)
+        assert webhook_endpoint_organization.enabled is False
+
+        # Check that pending events are now marked as skipped
+        for pending_event in pending_events:
+            await session.refresh(pending_event)
+            assert pending_event.skipped is True


### PR DESCRIPTION
In main, we don't exclude pending webhook events (`succeeded is None`) from the check on consecutive failures, which makes it so that in burst of webhook triggers, some webhooks collect up to 400-500 events and a multiple of that in delivery attempts before there's a long enough pause that the 10 latest events are all effectively failed without any new ones in a pending state.

This fixes it by looking at the 10 latest completed events (succeeded or failed) which I think is correct behavior and was an initial oversight in implementing the auto-disable. We also mark pending webhooks as skipped to make sure they won't be (re-)tried. 