### PR TITLE
Fix discount success message showing null

### DIFF
--- a/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
@@ -52,7 +52,7 @@ const CreateDiscountModalContent = ({
       }
       toast({
         title: 'Discount Created',
-        description: `Discount ${discount.code} was created successfully`,
+        description: `Discount ${discount.name} was created successfully`,
       })
       onDiscountCreated(discount)
     },

--- a/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
@@ -53,7 +53,7 @@ const UpdateDiscountModalContent = ({
       }
       toast({
         title: 'Discount Updated',
-        description: `Discount ${discount.code} was updated successfully`,
+        description: `Discount ${discount.name} was updated successfully`,
       })
       onDiscountUpdated(discount)
     },


### PR DESCRIPTION
The success toast messages for creating and updating discounts incorrectly used discount.code which can be null. Changed to use discount.name which is always present.
