### PR TITLE
Prevent billing address changes on VAT invoices

### DIFF
--- a/clients/packages/ui/src/components/atoms/CountryPicker.tsx
+++ b/clients/packages/ui/src/components/atoms/CountryPicker.tsx
@@ -41,7 +41,12 @@ const CountryPicker = ({
 }) => {
   const countryMap = getCountryList(allowedCountries as TCountryCode[])
   return (
-    <Select onValueChange={onChange} value={value} autoComplete={autoComplete} disabled={disabled}>
+    <Select
+      onValueChange={onChange}
+      value={value}
+      autoComplete={autoComplete}
+      disabled={disabled}
+    >
       <SelectTrigger className={className} disabled={disabled}>
         <SelectValue
           placeholder="Country"

--- a/server/polar/customer_portal/endpoints/order.py
+++ b/server/polar/customer_portal/endpoints/order.py
@@ -12,7 +12,6 @@ from polar.models.product import ProductBillingType
 from polar.openapi import APITag
 from polar.order.schemas import OrderID
 from polar.order.service import (
-    InvoiceBillingAddressUpdateError,
     MissingInvoiceBillingDetails,
     NotPaidOrder,
     PaymentAlreadyInProgress,
@@ -114,13 +113,7 @@ async def get(
     "/{id}",
     summary="Update Order",
     response_model=CustomerOrder,
-    responses={
-        404: OrderNotFound,
-        422: {
-            "description": "Cannot update billing address country/state after order is paid.",
-            "model": InvoiceBillingAddressUpdateError.schema(),
-        },
-    },
+    responses={404: OrderNotFound},
 )
 async def update(
     id: OrderID,

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -26,11 +26,7 @@ from polar.routing import APIRouter
 from . import auth, sorting
 from .schemas import Order as OrderSchema
 from .schemas import OrderID, OrderInvoice, OrderNotFound, OrderUpdate
-from .service import (
-    InvoiceBillingAddressUpdateError,
-    MissingInvoiceBillingDetails,
-    NotPaidOrder,
-)
+from .service import MissingInvoiceBillingDetails, NotPaidOrder
 from .service import order as order_service
 
 router = APIRouter(prefix="/orders", tags=["orders", APITag.public, APITag.mcp])
@@ -177,13 +173,7 @@ async def get(
     "/{id}",
     summary="Update Order",
     response_model=OrderSchema,
-    responses={
-        404: OrderNotFound,
-        422: {
-            "description": "Cannot update billing address country/state after order is paid.",
-            "model": InvoiceBillingAddressUpdateError.schema(),
-        },
-    },
+    responses={404: OrderNotFound},
 )
 async def update(
     id: OrderID,


### PR DESCRIPTION
VAT is calculated based on the billing address at order creation time. Changing the country/state after an order has been paid would result in an inconsistent invoice where the address doesn't match the VAT charged.