### PR TITLE
Add composite (organization_id, source, id) index to events

### DIFF
--- a/server/migrations/versions/2025-12-26-1000_add_events_composite_index.py
+++ b/server/migrations/versions/2025-12-26-1000_add_events_composite_index.py
@@ -1,0 +1,32 @@
+"""Add composite index on events (organization_id, source, id)
+
+Revision ID: 8c4a2b3d5e6f
+Revises: 916e176efd47
+Create Date: 2025-12-26 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "8c4a2b3d5e6f"
+down_revision = "916e176efd47"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_events_organization_id_source_id",
+            "events",
+            ["organization_id", "source", "id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_organization_id_source_id", table_name="events")

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -140,6 +140,12 @@ class Event(Model, MetadataMixin):
             "external_customer_id",
             postgresql_ops={"external_customer_id": "text_pattern_ops"},
         ),
+        Index(
+            "ix_events_organization_id_source_id",
+            "organization_id",
+            "source",
+            "id",
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)


### PR DESCRIPTION
Should allow us to hit an index in `subscription.update_meters`.

It could theoretically replace the indexes on `organization_id` (since that can just use this composite index) and on `source` (since `get_readable_statement` will always filter on `organization_id` first too).