### PR TITLE
Filter license keys by customer ID

### DIFF
--- a/server/polar/license_key/endpoints.py
+++ b/server/polar/license_key/endpoints.py
@@ -2,6 +2,7 @@ from fastapi import Depends, Query
 from pydantic import UUID4
 
 from polar.benefit.schemas import BenefitID
+from polar.customer.schemas.customer import CustomerID
 from polar.exceptions import ResourceNotFound
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.pagination import ListResource, PaginationParamsQuery
@@ -50,6 +51,9 @@ async def list(
     benefit_id: MultipleQueryFilter[BenefitID] | None = Query(
         None, title="BenefitID Filter", description="Filter by benefit ID."
     ),
+    customer_id: MultipleQueryFilter[CustomerID] | None = Query(
+        None, title="CustomerID Filter", description="Filter by customer ID."
+    ),
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[LicenseKeyRead]:
     """Get license keys connected to the given organization & filters."""
@@ -58,6 +62,7 @@ async def list(
         auth_subject,
         organization_id=organization_id,
         benefit_id=benefit_id,
+        customer_id=customer_id,
         pagination=pagination,
     )
 

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -44,6 +44,7 @@ class LicenseKeyService:
         pagination: PaginationParams,
         organization_id: Sequence[UUID] | None = None,
         benefit_id: Sequence[UUID] | None = None,
+        customer_id: Sequence[UUID] | None = None,
     ) -> tuple[Sequence[LicenseKey], int]:
         repository = LicenseKeyRepository.from_session(session)
         statement = (
@@ -57,6 +58,9 @@ class LicenseKeyService:
 
         if benefit_id is not None:
             statement = statement.where(LicenseKey.benefit_id.in_(benefit_id))
+
+        if customer_id is not None:
+            statement = statement.where(LicenseKey.customer_id.in_(customer_id))
 
         return await repository.paginate(
             statement, limit=pagination.limit, page=pagination.page


### PR DESCRIPTION
Allow merchants to filter license keys by customer ID, enabling them to view all license keys for a specific customer.