### PR TITLE
fix(refund): use quoted forward references for TYPE_CHECKING imports

### DIFF
--- a/server/polar/models/refund.py
+++ b/server/polar/models/refund.py
@@ -240,7 +240,7 @@ class Refund(MetadataMixin, RecordModel):
 
     @classmethod
     def from_stripe(
-        cls, stripe_refund: stripe_lib.Refund, order: Order, payment: Payment
+        cls, stripe_refund: stripe_lib.Refund, order: "Order", payment: "Payment"
     ) -> Self:
         amount, tax_amount = order.calculate_refunded_tax_from_total(
             stripe_refund.amount


### PR DESCRIPTION
The Order and Payment types are imported under TYPE_CHECKING but were used without quotes in the from_stripe method signature, causing a NameError at runtime during module import.

This prevented database migrations and server startup.

fixes #8736 