### PR TITLE
Add bun package manager option to SDK adapter docs

### DIFF
--- a/docs/integrate/sdk/adapters/astro.mdx
+++ b/docs/integrate/sdk/adapters/astro.mdx
@@ -28,6 +28,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/astro
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/astro
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout

--- a/docs/integrate/sdk/adapters/better-auth.mdx
+++ b/docs/integrate/sdk/adapters/better-auth.mdx
@@ -41,6 +41,11 @@ Install the required Better Auth and Polar packages using the following command:
     pnpm add better-auth @polar-sh/better-auth @polar-sh/sdk
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add better-auth @polar-sh/better-auth @polar-sh/sdk
+    ```
+  </Tab>
 </Tabs>
 
 ## Integrate Polar with BetterAuth

--- a/docs/integrate/sdk/adapters/elysia.mdx
+++ b/docs/integrate/sdk/adapters/elysia.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/elysia
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/elysia
+    ```
+  </Tab>
 </Tabs>
 
 ### Checkout

--- a/docs/integrate/sdk/adapters/express.mdx
+++ b/docs/integrate/sdk/adapters/express.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/express
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/express
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout

--- a/docs/integrate/sdk/adapters/fastify.mdx
+++ b/docs/integrate/sdk/adapters/fastify.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/fastify
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/fastify
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout

--- a/docs/integrate/sdk/adapters/hono.mdx
+++ b/docs/integrate/sdk/adapters/hono.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/hono
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/hono
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout

--- a/docs/integrate/sdk/adapters/nextjs.mdx
+++ b/docs/integrate/sdk/adapters/nextjs.mdx
@@ -29,6 +29,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/nextjs
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/nextjs
+    ```
+  </Tab>
 </Tabs>
 
 

--- a/docs/integrate/sdk/adapters/nuxt.mdx
+++ b/docs/integrate/sdk/adapters/nuxt.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/nuxt
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/nuxt
+    ```
+  </Tab>
 </Tabs>
 
 ### Register the module

--- a/docs/integrate/sdk/adapters/remix.mdx
+++ b/docs/integrate/sdk/adapters/remix.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/remix
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/remix
+    ```
+  </Tab>
 </Tabs>
 
 

--- a/docs/integrate/sdk/adapters/supabase.mdx
+++ b/docs/integrate/sdk/adapters/supabase.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/supabase
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/supabase
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout

--- a/docs/integrate/sdk/adapters/sveltekit.mdx
+++ b/docs/integrate/sdk/adapters/sveltekit.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/sveltekit
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/sveltekit
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout

--- a/docs/integrate/sdk/adapters/tanstack-start.mdx
+++ b/docs/integrate/sdk/adapters/tanstack-start.mdx
@@ -27,6 +27,11 @@ Install the required Polar packages using the following command:
     pnpm add zod @polar-sh/tanstack-start
     ```
   </Tab>
+  <Tab title="bun">
+    ```bash Terminal
+    bun add zod @polar-sh/tanstack-start
+    ```
+  </Tab>
 </Tabs>
 
 ## Checkout


### PR DESCRIPTION
Adds bun as an installation option alongside npm, yarn, and pnpm in all SDK adapter documentation pages.

**Files updated:**
- astro.mdx
- better-auth.mdx
- elysia.mdx
- express.mdx
- fastify.mdx
- hono.mdx
- nextjs.mdx
- nuxt.mdx
- remix.mdx
- supabase.mdx
- sveltekit.mdx
- tanstack-start.mdx

<img width="1134" height="416" alt="image" src="https://github.com/user-attachments/assets/36cc939b-e026-49e7-856c-a9173b7f02df" />

