### PR TITLE
Add docker cleanup on archive for Conductor workspaces

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "$CONDUCTOR_ROOT_PATH/dev/conductor-setup",
+    "run": "$CONDUCTOR_ROOT_PATH/dev/conductor-run",
+    "archive": "$CONDUCTOR_ROOT_PATH/dev/conductor-archive"
+  }
+}

--- a/dev/conductor-archive
+++ b/dev/conductor-archive
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Cleanup Polar development environment when Conductor archives workspace
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONDUCTOR_PORT="${CONDUCTOR_PORT:-55000}"
+INSTANCE=$(( (CONDUCTOR_PORT - 55000) / 10 ))
+
+"$SCRIPT_DIR/docker-dev" -i "$INSTANCE" cleanup

--- a/dev/docker-dev
+++ b/dev/docker-dev
@@ -68,6 +68,7 @@ Actions:
   restart   Restart services
   build     Build or rebuild services
   shell     Open a shell in a service container
+  cleanup   Stop services and remove all volumes (fresh start)
 
 Services:
   api       Backend API server
@@ -131,7 +132,7 @@ while [[ $# -gt 0 ]]; do
             print_usage
             exit 0
             ;;
-        up|down|logs|ps|restart|build|shell)
+        up|down|logs|ps|restart|build|shell|cleanup)
             ACTION="$1"
             shift
             ;;
@@ -299,6 +300,13 @@ case $ACTION in
         print_info "Opening shell in $SERVICE container..."
         # shellcheck disable=SC2086
         $COMPOSE_CMD exec "$SERVICE" /bin/bash
+        ;;
+
+    cleanup)
+        check_docker
+        print_info "Cleaning up Polar development environment (instance $INSTANCE)..."
+        $COMPOSE_CMD down -v --remove-orphans
+        print_success "Environment cleaned up (containers and volumes removed)"
         ;;
 
     *)


### PR DESCRIPTION
## 📋 Summary

Adds automatic Docker container and volume cleanup when a Conductor workspace is archived, ensuring a fresh start when the workspace is reopened.

## 🎯 What

- Added `cleanup` action to `docker-dev` script that removes containers and volumes
- Created `conductor-archive` wrapper script to run cleanup when workspace is archived
- Updated `conductor.json` with archive script reference

## 🤔 Why

When workspaces are archived, Docker containers and volumes persist, consuming disk space and potentially causing issues when the workspace is reopened. This automates cleanup for a fresh state on next launch.

## 🔧 How

Uses `docker compose down -v --remove-orphans` to stop and remove all containers and named volumes for the workspace instance.