### PR TITLE
Fix environment setup and pnpm race conditions

### DIFF
--- a/dev/conductor-run
+++ b/dev/conductor-run
@@ -20,6 +20,12 @@ INSTANCE=$(( (CONDUCTOR_PORT - 55000) / 10 ))
 
 cd "$ROOT_DIR"
 
+# Generate environment files if needed
+if [[ ! -f "server/.env" ]]; then
+    echo "Generating environment files..."
+    ./dev/setup-environment
+fi
+
 # Start all services in detached mode
 ./dev/docker-dev -i "$INSTANCE" -d
 

--- a/dev/docker/scripts/startup.sh
+++ b/dev/docker/scripts/startup.sh
@@ -18,11 +18,11 @@ else
     echo "Python dependencies up to date"
 fi
 
-# Build email templates for this architecture
+# Build email templates for this architecture (API only to avoid race conditions)
 # The binary must be built for the container's architecture (Linux), not host (macOS)
 ARCH=$(uname -m)
 EMAIL_MARKER="emails/bin/.built-${ARCH}"
-if [[ ! -f "$EMAIL_MARKER" ]]; then
+if [[ "${1:-api}" == "api" ]] && [[ ! -f "$EMAIL_MARKER" ]]; then
     echo "Building email templates for ${ARCH}..."
     cd emails
     # Clean previous builds (may be from different architecture)
@@ -39,6 +39,12 @@ if [[ ! -f "$EMAIL_MARKER" ]]; then
     touch "bin/.built-${ARCH}"
     cd ..
     echo "Email templates built for ${ARCH}"
+elif [[ "${1:-api}" == "worker" ]] && [[ ! -f "$EMAIL_MARKER" ]]; then
+    echo "Waiting for API to build email templates..."
+    while [[ ! -f "$EMAIL_MARKER" ]]; do
+        sleep 2
+    done
+    echo "Email templates ready"
 else
     echo "Email templates already built for ${ARCH}"
 fi


### PR DESCRIPTION
## Summary

Fixes startup failures when `.env` doesn't exist and eliminates pnpm store corruption errors.

## What

- Add automatic `.env` file generation to `conductor-run` when missing
- Prevent concurrent pnpm installs by having only API build email templates
- Worker service now waits for API to complete email template build

## Why

The `conductor-run` script would fail with "env file not found" error. Additionally, when both API and worker containers start simultaneously, they both try to run `pnpm install` in the emails directory, causing race conditions that corrupt the pnpm store.

## How

1. Added environment file check in `conductor-run` that runs `setup-environment` if `.env` doesn't exist
2. Modified `startup.sh` to only build email templates in the API container (`if [[ "${1:-api}" == "api" ]]`)
3. Added wait logic in worker container that polls for the `EMAIL_MARKER` file before proceeding

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have run linting and type checking

Test instructions:
1. Clean up Docker containers: `./dev/docker-dev -i 0 down`
2. Remove pnpm store volume: `docker volume rm polar-dev-0_pnpm_store` 
3. Start fresh: `./dev/docker-dev -i 0 -d`
4. Check logs: `./dev/docker-dev -i 0 logs api` and `./dev/docker-dev -i 0 logs worker`
5. Verify no pnpm store errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)