### PR TITLE
Fix approve custom amounts for thresholds in backoffice v2

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -631,7 +631,16 @@ async def approve_denied_dialog(
         )
 
     with modal("Approve Denied Organization", open=True):
-        with tag.div(classes="flex flex-col gap-4"):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations-v2:approve_denied_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
             with tag.p(classes="font-semibold"):
                 text("Approve this previously denied organization")
 
@@ -662,17 +671,8 @@ async def approve_denied_dialog(
                 with tag.form(method="dialog"):
                     with button(ghost=True):
                         text("Cancel")
-                with tag.form(
-                    hx_post=str(
-                        request.url_for(
-                            "organizations-v2:approve_denied_dialog",
-                            organization_id=organization_id,
-                        )
-                    ),
-                    hx_target="#modal",
-                ):
-                    with button(variant="primary"):
-                        text("Approve Organization")
+                with button(variant="primary", type="submit"):
+                    text("Approve Organization")
 
     return None
 
@@ -720,7 +720,16 @@ async def unblock_approve_dialog(
         )
 
     with modal("Unblock & Approve Organization", open=True):
-        with tag.div(classes="flex flex-col gap-4"):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations-v2:unblock_approve_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
             with tag.p(classes="font-semibold"):
                 text("Unblock and approve this organization")
 
@@ -751,17 +760,8 @@ async def unblock_approve_dialog(
                 with tag.form(method="dialog"):
                     with button(ghost=True):
                         text("Cancel")
-                with tag.form(
-                    hx_post=str(
-                        request.url_for(
-                            "organizations-v2:unblock_approve_dialog",
-                            organization_id=organization_id,
-                        )
-                    ),
-                    hx_target="#modal",
-                ):
-                    with button(variant="primary"):
-                        text("Unblock & Approve")
+                with button(variant="primary", type="submit"):
+                    text("Unblock & Approve")
 
     return None
 


### PR DESCRIPTION
## Summary

Fixes the approve custom amounts functionality in backoffice v2 dialogs.

## What

The `approve_denied_dialog` and `unblock_approve_dialog` endpoints had a form submission bug where the threshold input field was outside the form element, preventing the custom amount value from being submitted.

## Why

When users tried to approve organizations with custom thresholds, the form would submit without the threshold value, causing the approval to use default values instead of the user-specified amount.

## How

Restructured the modal dialogs to wrap the entire form content (including the threshold input) in a single `<form>` element with the appropriate `hx_post` handler, ensuring all form fields are included in the submission.

## Testing

- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)
- All checks pass
- Changes follow the same pattern used in other form dialogs