### PR TITLE
Use correct aggregation function for quantities total

### DIFF
--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -346,7 +346,7 @@ class MeterService:
         # Note: avg and unique require special handling that's not implemented here -
         # avg would need weighted averages, unique would need to avoid double counting.
         if meter.aggregation.is_summable():
-            total_agg_func = func.sum
+            total_agg_func = AggregationFunction.sum.get_sql_function
         else:
             total_agg_func = meter.aggregation.func.get_sql_function
 

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import timedelta
 from decimal import Decimal
+from typing import Literal
 from unittest.mock import AsyncMock
 
 import pytest
@@ -431,9 +432,7 @@ class TestGetQuantities:
             # For min: total should be min across all days with data (NULLs from empty days are ignored)
             # Day 1: min(10, 20) = 10, Day 2: NULL (no events), Day 3: min(15, 5) = 5
             # Total: min(10, NULL, 5) = 5 (SQL MIN ignores NULLs)
-            pytest.param(
-                AggregationFunction.min, [10, 0, 5], 5, id="min aggregation"
-            ),
+            pytest.param(AggregationFunction.min, [10, 0, 5], 5, id="min aggregation"),
             # For sum: total should be sum across all days (this is summable, so sum is correct)
             pytest.param(
                 AggregationFunction.sum, [30, 0, 20], 50, id="sum aggregation"
@@ -442,7 +441,12 @@ class TestGetQuantities:
     )
     async def test_interval_non_summable_aggregation(
         self,
-        aggregation_func: AggregationFunction,
+        aggregation_func: Literal[
+            AggregationFunction.sum,
+            AggregationFunction.max,
+            AggregationFunction.min,
+            AggregationFunction.avg,
+        ],
         expected_daily_quantities: list[int],
         expected_total: int,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary
Fixes a regression in the `/v1/meters/{id}/quantities` API endpoint where the total field was incorrectly calculated for meters with non-summable aggregations (MAX, MIN).

## Bug
Users reported seeing incorrect values in the total field:

> When I look in the UI, the events show total_enabled_servers: 1. However, when reading from the API with a 30 day lookback, I see almost every org showing 29/30/31.

> For meters with max aggregation, the quantities.total value returns the sum of all values (not max across all values).

## Root Cause

**This is a regression** introduced in commit 668ea64 (Dec 18, 2025) titled "meter: Speed up query by avoiding large cartesian join".

### Before the regression

The original code correctly used the meter's aggregation function for the total:

```python
func.coalesce(
    meter.aggregation.get_sql_column(Event).filter(
        interval.sql_date_trunc(Event.timestamp) >= interval.sql_date_trunc(start_timestamp),
        interval.sql_date_trunc(Event.timestamp) <= interval.sql_date_trunc(end_timestamp),
    ),
    0,
).label("total"),
```

### After the regression

_Commit 668ea64_

The performance optimization refactored the query to use pre-computed daily aggregates, but hardcoded func.sum() for the total:

```python
func.coalesce(
    func.sum(daily_metrics.c.quantity).over(order_by=timestamp_column),
    0,
).label("total"),
```

This works correctly for summable aggregations (count, sum) but is incorrect for non-summable ones (max, min, avg, unique).

## Fix

The fix determines the appropriate SQL window function based on whether the meter's aggregation is summable:

```python
if meter.aggregation.is_summable():
    total_agg_func = func.sum
else:
    total_agg_func = meter.aggregation.func.get_sql_function
```

This is still broken for average & unique aggregation meters.