### PR TITLE
server/models: add MeterEvent model and migration

### DIFF
--- a/server/migrations/versions/2026-01-07-2343_add_meter_events_table.py
+++ b/server/migrations/versions/2026-01-07-2343_add_meter_events_table.py
@@ -1,0 +1,95 @@
+"""add meter_events table
+
+Revision ID: 081d3553f2ed
+Revises: 24bb42b493d7
+Create Date: 2026-01-07 10:42:17.345848
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "081d3553f2ed"
+down_revision = "24bb42b493d7"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "meter_events",
+        sa.Column("meter_id", sa.Uuid(), nullable=False),
+        sa.Column("event_id", sa.Uuid(), nullable=False),
+        sa.Column("customer_id", sa.Uuid(), nullable=True),
+        sa.Column("external_customer_id", sa.String(), nullable=True),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("ingested_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("timestamp", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["customer_id"],
+            ["customers.id"],
+            name=op.f("meter_events_customer_id_fkey"),
+            ondelete="set null",
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["events.id"],
+            name=op.f("meter_events_event_id_fkey"),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["meter_id"],
+            ["meters.id"],
+            name=op.f("meter_events_meter_id_fkey"),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            name=op.f("meter_events_organization_id_fkey"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("meter_id", "event_id", name=op.f("meter_events_pkey")),
+    )
+
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_meter_events_meter_customer_ingested",
+            "meter_events",
+            ["meter_id", "customer_id", "ingested_at"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_meter_events_meter_external_customer_ingested",
+            "meter_events",
+            ["meter_id", "external_customer_id", "ingested_at"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_meter_events_meter_ingested",
+            "meter_events",
+            ["meter_id", "ingested_at", "event_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_meter_events_meter_ingested",
+        table_name="meter_events",
+    )
+    op.drop_index(
+        "ix_meter_events_meter_external_customer_ingested",
+        table_name="meter_events",
+    )
+    op.drop_index(
+        "ix_meter_events_meter_customer_ingested",
+        table_name="meter_events",
+    )
+    op.drop_table("meter_events")

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -34,6 +34,7 @@ from .license_key_activation import LicenseKeyActivation
 from .login_code import LoginCode
 from .member import Member, MemberRole
 from .meter import Meter
+from .meter_event import MeterEvent
 from .notification import Notification
 from .notification_recipient import NotificationRecipient
 from .oauth2_authorization_code import OAuth2AuthorizationCode
@@ -123,6 +124,7 @@ __all__ = [
     "Member",
     "MemberRole",
     "Meter",
+    "MeterEvent",
     "Model",
     "Notification",
     "NotificationRecipient",

--- a/server/polar/models/meter_event.py
+++ b/server/polar/models/meter_event.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from polar.kit.db.models import Model
+
+
+class MeterEvent(Model):
+    __tablename__ = "meter_events"
+    __table_args__ = (
+        Index("ix_meter_events_meter_ingested", "meter_id", "ingested_at", "event_id"),
+        Index(
+            "ix_meter_events_meter_customer_ingested",
+            "meter_id",
+            "customer_id",
+            "ingested_at",
+        ),
+        Index(
+            "ix_meter_events_meter_external_customer_ingested",
+            "meter_id",
+            "external_customer_id",
+            "ingested_at",
+        ),
+    )
+
+    meter_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("meters.id", ondelete="cascade"), primary_key=True
+    )
+    event_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("events.id", ondelete="cascade"), primary_key=True
+    )
+    customer_id: Mapped[UUID | None] = mapped_column(
+        Uuid, ForeignKey("customers.id", ondelete="set null"), nullable=True
+    )
+    external_customer_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    organization_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("organizations.id", ondelete="cascade"), nullable=False
+    )
+    ingested_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    timestamp: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )


### PR DESCRIPTION
Add a new `meter_events` junction table that pre-computes which events match each meter. This eliminates expensive JSONB filter evaluation at query time for meter billing.

Split out from https://github.com/polarsource/polar/pull/8790