### PR TITLE
ci: Add action to verify migrations are in made in different PR

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   changes:
@@ -15,15 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       server: ${{ steps.filter.outputs.server }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+      server_files: ${{ steps.filter.outputs.server_files }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          list-files: json
           filters: |
             server:
               - 'server/**'
               - '.github/workflows/test_server.yaml'
+            migrations:
+              - 'server/migrations/versions/**'
 
   linters:
     name: "Server: Linters 📝"
@@ -64,6 +70,87 @@ jobs:
       - name: 🛟 Type Check Server (mypy)
         working-directory: ./server
         run: uv run task lint_types
+
+  migration-check:
+    name: "Server: Migration Check 📚"
+    needs: changes
+    if: needs.changes.outputs.migrations == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for disallowed files
+        id: check
+        env:
+          SERVER_FILES: ${{ needs.changes.outputs.server_files }}
+        run: |
+          DISALLOWED=""
+          for file in $(echo "$SERVER_FILES" | jq -r '.[]'); do
+            # Allow: migrations, models, and the workflow file itself
+            if [[ "$file" == server/migrations/* ]]; then
+              continue
+            fi
+            if [[ "$file" == server/polar/models/* ]]; then
+              continue
+            fi
+            if [[ "$file" == .github/* ]]; then
+              continue
+            fi
+            DISALLOWED="$DISALLOWED$file\n"
+          done
+
+          if [ -n "$DISALLOWED" ]; then
+            echo "has_disallowed=true" >> $GITHUB_OUTPUT
+            FILES_LIST=$(echo -e "$DISALLOWED" | sed '/^$/d' | sed 's/^/- `/' | sed 's/$/`/')
+            echo "files_list<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILES_LIST" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "has_disallowed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v4
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: "<!-- __MIGRATION_CHECK -->"
+
+      - name: Create or update failure comment
+        if: steps.check.outputs.has_disallowed == 'true'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- __MIGRATION_CHECK -->
+            ## ⚠️ Migration Isolation Check Failed
+
+            This PR contains database migrations along with other code changes. To ensure safe deployments, please split this into separate PRs,
+            or verify that your changes will not break. Keep in mind that the API is deployed before the workers.
+
+            1. **Migration PR**: Only model changes and the migration file
+            2. **Code PR**: All other changes (can be merged after migration PR)
+
+            ### Files that should be in a separate PR:
+            ${{ steps.check.outputs.files_list }}
+
+            ### Why?
+            Migrations are deployed separately and run before code changes. Mixing them can cause deployment issues if the new code depends on the migration.
+
+      - name: Delete resolved comment
+        if: steps.check.outputs.has_disallowed == 'false' && steps.fc.outputs.comment-id != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }}
+            })
+
+      - name: Fail check
+        if: steps.check.outputs.has_disallowed == 'true'
+        run: exit 1
 
   test:
     name: "Server: Tests 🐍"


### PR DESCRIPTION
Today we stagger our deployments when they contain migrations, so we deploy the API first (which will trigger the migration) and when it is completed we deploy the workers.

When adding code (columns, tables, etc) the migration will run before any of the code is run using it. This can be fine, but it can also be dangerous if something goes wrong during the migration.

When removing code, the old workers will continue the run while the migration is being run to delete resources (columns, tables, etc). This causes some disturbances. 

The idea behind this action is to prompt the developer if this is what they want to do, or if they should split their change into two PRs. By splitting the change into two we ensure that we decouple database migrations and code changes. 

It adds some friction in the PR step, but removes a lot of noise and unnecessary stress during the deployment.