### PR TITLE
feat: add email column to customer_seats table

### DIFF
--- a/server/migrations/versions/2026-01-08_add_email_to_customer_seats.py
+++ b/server/migrations/versions/2026-01-08_add_email_to_customer_seats.py
@@ -1,0 +1,28 @@
+"""add_email_to_customer_seats
+
+Revision ID: 8a7b9c0d1e2f
+Revises: daafaba9088a
+Create Date: 2026-01-08 09:20:32.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "8a7b9c0d1e2f"
+down_revision = "daafaba9088a"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "customer_seats", sa.Column("email", sa.String(length=320), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("customer_seats", "email")

--- a/server/polar/models/customer_seat.py
+++ b/server/polar/models/customer_seat.py
@@ -84,6 +84,8 @@ class CustomerSeat(RecordModel):
         index=True,
     )
 
+    email: Mapped[str | None] = mapped_column(String(320), nullable=True, default=None)
+
     invitation_token: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None, index=True
     )


### PR DESCRIPTION
## Summary

Add `email` column to the `customer_seats` table to store the seat member's email directly on the seat.

This is a prerequisite for the member model feature (#8789) where seats reference billing customers rather than individual seat member customers. The email column allows storing the seat member's email independently of any Customer entity.

## Changes

- Add nullable `email` column (VARCHAR 320) to `customer_seats` table

## Test Plan

- [x] Migration applies cleanly
- [x] Migration rolls back cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)