### PR TITLE
server/checkout: fix error when trying to detect trial abuse with non-card payment method

### DIFF
--- a/server/polar/integrations/stripe/utils.py
+++ b/server/polar/integrations/stripe/utils.py
@@ -12,6 +12,7 @@ def get_expandable_id(expandable: ExpandableField[StripeObject]) -> str:
 
 
 def get_fingerprint(payment_method: stripe_lib.PaymentMethod) -> str | None:
-    if payment_method.card is not None:
-        return payment_method.card.fingerprint
+    card: stripe_lib.PaymentMethod.Card | None = getattr(payment_method, "card", None)
+    if card is not None:
+        return getattr(card, "fingerprint", None)
     return None


### PR DESCRIPTION
Fix #8812

- server/checkout: fix error when trying to detect trial abuse with non-card payment method
