### PR TITLE
refactor: defer Docker startup from setup to run for Conductor

### DIFF
--- a/dev/conductor-setup
+++ b/dev/conductor-setup
@@ -23,22 +23,6 @@ if [[ ! -f "server/.env" ]] || [[ ! -f "clients/apps/web/.env.local" ]]; then
     ./dev/setup-environment
 fi
 
-# Start infrastructure services
-echo "Starting infrastructure services..."
-./dev/docker-dev -i "$INSTANCE" -d db redis minio minio-setup
-
-# Wait for services to be ready
-echo "Waiting for services to be ready..."
-sleep 10
-
-# Start API to run migrations (startup.sh handles migrations automatically)
-echo "Starting API service (this will run migrations)..."
-./dev/docker-dev -i "$INSTANCE" -d api
-
-# Wait for API to be ready
-echo "Waiting for API to be ready..."
-sleep 15
-
 echo ""
 echo "============================================"
 echo "  Setup complete for instance $INSTANCE"


### PR DESCRIPTION
## 📋 Summary

Moves Docker service initialization from `conductor-setup` to `conductor-run`. This allows setup to complete quickly by only generating environment files, with Docker services starting only when the developer clicks run.

## 🎯 What

Removed Docker startup logic (db, redis, minio, api) from `conductor-setup` script. The setup now only generates environment files if needed.

## 🤔 Why

Faster setup phase - developers don't have to wait for Docker to start during initial setup. Docker services are deferred until they explicitly click "Run".

## 🔧 How

Removed lines 26-40 from `dev/conductor-setup` that started infrastructure services and waited for them to be ready. The `conductor-run` script already starts all services, so no changes needed there.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] Setup completes without starting Docker
- [x] Run command starts Docker services normally