### PR TITLE
Add discount_applied_at column to subscriptions

### DIFF
--- a/server/migrations/versions/2026-01-06-1200_add_discount_applied_at_to_subscriptions.py
+++ b/server/migrations/versions/2026-01-06-1200_add_discount_applied_at_to_subscriptions.py
@@ -1,0 +1,51 @@
+"""Add discount_applied_at to subscriptions
+
+Revision ID: ea11a3dc85a2
+Revises: 3c48bf325744
+Create Date: 2026-01-06 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "ea11a3dc85a2"
+down_revision = "3c48bf325744"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subscriptions",
+        sa.Column("discount_applied_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+    # Backfill discount_applied_at for existing subscriptions with discounts
+    # by finding the first order that used the discount
+    op.execute(
+        """
+        UPDATE subscriptions s
+        SET discount_applied_at = o.created_at
+        FROM (
+            SELECT DISTINCT ON (o.subscription_id, o.discount_id)
+                o.subscription_id,
+                o.discount_id,
+                o.created_at
+            FROM orders o
+            WHERE o.subscription_id IS NOT NULL
+              AND o.discount_id IS NOT NULL
+              AND o.deleted_at IS NULL
+            ORDER BY o.subscription_id, o.discount_id, o.created_at ASC
+        ) o
+        WHERE s.id = o.subscription_id
+          AND s.discount_id = o.discount_id
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subscriptions", "discount_applied_at")

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -213,6 +213,11 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         Uuid, ForeignKey("discounts.id", ondelete="set null"), nullable=True
     )
 
+    discount_applied_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, default=None
+    )
+    """Timestamp when the discount was first applied to a billing cycle."""
+
     @declared_attr
     def discount(cls) -> Mapped["Discount | None"]:
         return relationship("Discount", lazy="joined")


### PR DESCRIPTION
Add a new column to track when a discount was first applied to a billing cycle. This will be used to properly calculate discount expiration for repeating and once-off discounts.

Includes data backfill migration that sets `discount_applied_at` based on the first order that used the discount.

Cherry-picked migration from #8780