### PR TITLE
Fix discount expiration when applied to existing subscriptions

### DIFF
--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -453,3 +453,7 @@ def _discount_set(
     initiator: Event,
 ) -> None:
     target.update_amount_and_currency(target.subscription_product_prices, value)
+    # Reset discount_applied_at when discount changes so the new discount's
+    # expiration will be tracked from its first use in a billing cycle
+    if value != oldvalue:
+        target.discount_applied_at = None

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1045,6 +1045,13 @@ async def create_subscription(
         seats=seats,
         past_due_at=past_due_at,
     )
+
+    # For non-trial subscriptions with a discount, set discount_applied_at to simulate
+    # the behavior of create_or_update_from_checkout where the discount is applied
+    # to the first payment at checkout time. Set this explicitly after constructor
+    # to ensure it's not cleared by the discount "set" event listener.
+    if discount is not None and trial_start is None:
+        subscription.discount_applied_at = current_period_start
     await save_fixture(subscription)
 
     return subscription


### PR DESCRIPTION
Use the new `discount_applied_at` field to properly track when a discount was first applied to a billing cycle, rather than using started_at.

This fixes issues where:
- Discounts applied to existing subscriptions expired immediately (because started_at was in the past)
- Repeating discounts during trial periods expired too early (the discount should only count months where it was actually applied)

Changes:
- Update is_repetition_expired to use discount_applied_at instead of started_at, simplifying the trial_ended logic
- Set discount_applied_at when creating subscription from checkout
- Set discount_applied_at on first use during billing cycle
- Reset discount_applied_at when discount changes
- Update fixtures to match new behavior
- Add test for repeating discounts with trial periods

Cherry-picked from #8780 