### PR TITLE
Use last_over_time for SLO targets

### DIFF
--- a/server/monitoring/grafana/dashboards/api-slo.json
+++ b/server/monitoring/grafana/dashboards/api-slo.json
@@ -68,7 +68,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - ((count(\n  (\n    histogram_quantile(0.99, sum by (endpoint, method, le) (\n      rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n    )) > on(endpoint, method) max by (endpoint, method) (polar_slo_p99_target_seconds)\n  )\n  or\n  (\n    (100 * (1 - (\n      sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n      or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n    ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n    < on(endpoint, method) max by (endpoint, method) (polar_slo_availability_target)\n  )\n) or vector(0)) / count(max by (endpoint, method) (polar_slo_p99_target_seconds))))",
+          "expr": "100 * (1 - ((count(\n  (\n    histogram_quantile(0.99, sum by (endpoint, method, le) (\n      rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n    )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))\n  )\n  or\n  (\n    (100 * (1 - (\n      sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n      or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n    ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n    < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d]))\n  )\n) or vector(0)) / count(max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d])))))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -395,7 +395,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(\n  histogram_quantile(0.99, sum by (endpoint, method, le) (\n    rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n  )) > on(endpoint, method) max by (endpoint, method) (polar_slo_p99_target_seconds)\n)",
+          "expr": "(\n  histogram_quantile(0.99, sum by (endpoint, method, le) (\n    rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n  )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -406,7 +406,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (endpoint, method) (polar_slo_p99_target_seconds)",
+          "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -417,7 +417,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(\n  (100 * (1 - (\n    sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n    or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n  ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n  < on(endpoint, method) max by (endpoint, method) (polar_slo_availability_target)\n)",
+          "expr": "(\n  (100 * (1 - (\n    sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n    or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n  ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n  < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d]))\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -428,7 +428,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (endpoint, method) (polar_slo_availability_target)",
+          "expr": "max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -987,7 +987,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max by (endpoint, method) (polar_slo_p99_target_seconds)",
+              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -998,7 +998,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max by (endpoint, method) (polar_slo_p99_target_seconds)",
+              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -1744,7 +1744,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "(\n  (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[1h])) or vector(0))\n  /\n  ((1 - max by (endpoint, method) (polar_slo_availability_target) / 100) * sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[1h])))\n)",
+              "expr": "(\n  (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[1h])) or vector(0))\n  /\n  ((1 - max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d])) / 100) * sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[1h])))\n)",
               "legendFormat": "{{method}} {{endpoint}} (1h)",
               "refId": "A"
             }


### PR DESCRIPTION
## Summary

Updates the API SLO dashboard to use `last_over_time` instead of `max` for fetching SLO target values. This ensures correct behavior when SLO metrics are only pushed during deploys.

## What

Replaced all SLO target queries with `last_over_time(...[30d])` wrapped in `max by (endpoint, method)` aggregation. This captures the most recent pushed value within the last 30 days while deduplicating across instances.

## Why

The `max` aggregation could miss recent SLO values if there are stale series from old instances. Since these metrics are only pushed at deploy time, `last_over_time` is more appropriate to get the most recently deployed configuration.

## How

Used `last_over_time` with a 30-day lookback window to accommodate infrequent deployments, and wrapped with `max by (endpoint, method)` to handle multiple instances and avoid duplicate series errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)