### PR TITLE
balance-event: Set correct fee on order balance event

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1468,40 +1468,6 @@ class OrderService:
         payment_transaction.payment_customer = order.customer
         session.add(payment_transaction)
 
-        try:
-            assert payment_transaction.presentment_amount is not None
-            assert payment_transaction.presentment_currency is not None
-
-            metadata: BalanceOrderMetadata = {
-                "transaction_id": str(payment_transaction.id),
-                "order_id": str(order.id),
-                "amount": payment_transaction.amount,
-                "currency": payment_transaction.currency,
-                "presentment_amount": payment_transaction.presentment_amount,
-                "presentment_currency": payment_transaction.presentment_currency,
-                "tax_amount": order.tax_amount,
-                "fee": 0,
-            }
-            if order.tax_rate is not None:
-                if order.tax_rate["country"] is not None:
-                    metadata["tax_country"] = order.tax_rate["country"]
-                if order.tax_rate["state"] is not None:
-                    metadata["tax_state"] = order.tax_rate["state"]
-            if order.subscription_id is not None:
-                metadata["subscription_id"] = str(order.subscription_id)
-            if order.product_id is not None:
-                metadata["product_id"] = str(order.product_id)
-
-            balance_order_event = build_system_event(
-                SystemEvent.balance_order,
-                customer=order.customer,
-                organization=organization,
-                metadata=metadata,
-            )
-            await event_service.create_event(session, balance_order_event)
-        except Exception as e:
-            log.error("Could not save balance.order transaction", error=str(e))
-
         # Prepare an held balance
         # It'll be used if the account is not created yet
         held_balance = HeldBalance(
@@ -1556,6 +1522,57 @@ class OrderService:
         )
         order.platform_fee_currency = platform_fee_transactions[0][0].currency
         session.add(order)
+
+        await self._create_balance_order_event(
+            session,
+            payment_transaction=payment_transaction,
+            order=order,
+            organization=organization,
+            fee=order.platform_fee_amount,
+        )
+
+    async def _create_balance_order_event(
+        self,
+        session: AsyncSession,
+        *,
+        payment_transaction: Transaction,
+        order: Order,
+        organization: Organization,
+        fee: int,
+    ) -> None:
+        try:
+            assert payment_transaction.presentment_amount is not None
+            assert payment_transaction.presentment_currency is not None
+
+            metadata: BalanceOrderMetadata = {
+                "transaction_id": str(payment_transaction.id),
+                "order_id": str(order.id),
+                "amount": payment_transaction.amount,
+                "currency": payment_transaction.currency,
+                "presentment_amount": payment_transaction.presentment_amount,
+                "presentment_currency": payment_transaction.presentment_currency,
+                "tax_amount": order.tax_amount,
+                "fee": fee,
+            }
+            if order.tax_rate is not None:
+                if order.tax_rate["country"] is not None:
+                    metadata["tax_country"] = order.tax_rate["country"]
+                if order.tax_rate["state"] is not None:
+                    metadata["tax_state"] = order.tax_rate["state"]
+            if order.subscription_id is not None:
+                metadata["subscription_id"] = str(order.subscription_id)
+            if order.product_id is not None:
+                metadata["product_id"] = str(order.product_id)
+
+            balance_order_event = build_system_event(
+                SystemEvent.balance_order,
+                customer=order.customer,
+                organization=organization,
+                metadata=metadata,
+            )
+            await event_service.create_event(session, balance_order_event)
+        except Exception as e:
+            log.error("Could not save balance.order event", error=str(e))
 
     async def send_webhook(
         self,


### PR DESCRIPTION
Create the `balance.order` event when we have the fees instead of setting it to 0.