### PR TITLE
docs: Add subscription.past_due webhook event

### DIFF
--- a/docs/integrate/webhooks/events.mdx
+++ b/docs/integrate/webhooks/events.mdx
@@ -101,14 +101,23 @@ In order to properly implement logic for handling subscriptions, you should look
   ></Card>
 
   <Card
+    title="subscription.past_due"
+    icon="link"
+    href="/api-reference/webhooks/subscription.past_due"
+    horizontal
+  >
+    Fired when a subscription payment has failed. The customer can recover by updating their payment method.
+  </Card>
+
+  <Card
     title="subscription.updated"
     icon="link"
     href="/api-reference/webhooks/subscription.updated"
     horizontal
   >
     Use this event if you want to handle cancellations, un-cancellations, etc. The
-    updated event is a catch-all event for `subscription.active` ,
-    `subscription.canceled`, `subscription.uncanceled` and `subscription.revoked`.
+    updated event is a catch-all event for `subscription.active`,
+    `subscription.canceled`, `subscription.uncanceled`, `subscription.past_due` and `subscription.revoked`.
   </Card>
 
   <Card


### PR DESCRIPTION
## Summary

Documents the new `subscription.past_due` webhook event introduced in #8325. This event fires when a subscription payment fails, allowing customers to recover by updating their payment method.

## What

- Added `subscription.past_due` event card to the webhook events reference page
- Updated `subscription.updated` description to include it in the catch-all events list

## Why

The commit separated past due events from revoked states to better distinguish recoverable payment failures from terminal subscription states. The documentation needed to be updated to reflect this new event.

## How

Added the event card following the existing pattern and updated the catch-all event description with proper formatting.