### PR TITLE
docs: add documentation requirements to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,28 @@ If you need to ensure that data is flushed to the database, to run constraints o
 - Use existing fixtures and avoid redundant setup
 - Mock external services appropriately
 
+### Documentation
+
+Documentation lives in `docs/` and uses Mintlify. Some documentation is auto-generated, some requires manual updates.
+
+**Auto-generated (no action needed):**
+- API endpoint documentation (generated from OpenAPI/FastAPI routes)
+- Webhook event schemas (generated from `WebhookEventType` enum and Pydantic schemas)
+
+**Manual updates required for:**
+- New features or significant feature changes → `docs/features/`
+- New integration guides or SDK adapters → `docs/guides/` or `docs/integrate/`
+- Customer-facing behavior changes → `docs/changelog/recent.mdx`
+
+**When to update documentation:**
+- Adding a new public API endpoint with novel functionality
+- Adding a new webhook event type (add to `WebhookEventType` enum - docs auto-generate)
+- Changing business behavior that affects how customers use Polar
+- Adding new customer-facing features or configuration options
+- Deprecating or removing functionality
+
+**Claude Code reminder:** When working on public-facing changes, consider whether documentation updates are needed and add a todo item like "Update docs for [feature]" if appropriate. Use judgment based on the scope and customer impact of the change.
+
 ### Load Testing
 
 Polar includes a comprehensive load testing infrastructure for validating payment processing performance and capacity:


### PR DESCRIPTION
## 📋 Summary

This PR adds guidance to CLAUDE.md on when and where to update documentation, helping Claude Code and developers avoid forgetting documentation updates for customer-facing changes.

## 🎯 What

Added a new **Documentation** subsection under Development Guidelines that clarifies:
- Which documentation is auto-generated (API endpoints, webhook schemas)
- Which requires manual updates (features, guides, changelog)
- Specific triggers for when documentation should be updated
- Locations for manual documentation updates

## 🤔 Why

Currently there's no clear guidance in CLAUDE.md about documentation requirements. This causes documentation to sometimes be forgotten when implementing public-facing features, webhooks, or API changes. The new section helps Claude Code track documentation tasks alongside feature implementation.

## 🔧 How

Leverages Claude Code's todo feature - when working on public-facing changes, the guidance reminds to consider adding a "Update docs for X" todo item. The section clearly distinguishes auto-generated docs (no action needed) from manual updates.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] All tests pass locally (documentation update only)