### PR TITLE
terraform: increase S3 presigned URL TTL from 10 to 60 minutes

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -215,7 +215,7 @@ module "production" {
   aws_s3_config = {
     region                        = "us-east-2"
     signature_version             = "v4"
-    files_presign_ttl             = "600"
+    files_presign_ttl             = "3600"
     files_public_bucket_name      = "polar-public-files"
     customer_invoices_bucket_name = "polar-customer-invoices"
     payout_invoices_bucket_name   = "polar-payout-invoices"

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -140,7 +140,7 @@ module "sandbox" {
   aws_s3_config = {
     region                        = "us-east-2"
     signature_version             = "v4"
-    files_presign_ttl             = "600"
+    files_presign_ttl             = "3600"
     files_public_bucket_name      = "polar-public-sandbox-files"
     customer_invoices_bucket_name = "polar-sandbox-customer-invoices"
     payout_invoices_bucket_name   = "polar-sandbox-payout-invoices"


### PR DESCRIPTION
<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

**Related Issue**: Fixes #8848

Issue https://github.com/polarsource/polar/issues/8745 changed the default `S3_FILES_PRESIGN_TTL` in the server config [file](https://github.com/polarsource/polar/blob/main/server/polar/config.py#L280) to 3600s from 600s to allow a longer time for large files to upload. Terraform is overwriting this config. This PR updates the Terraform variables to 3600 to match the code defaults.

## 🎯 What

Changing Terraform variables.

## 🤔 Why

Changing the `S3_FILES_PRESIGN_TTL` variable from 600 to 3600 in `polar/server/config.py` ([PR](https://github.com/polarsource/polar/pull/8782)) was not a sufficient change. Since environment variables take precedence over code defaults, the actual runtime value was 600 seconds.  When testing, 10 minutes was not enough time for me or my peers when uploading files of 2.9gb and 7.9gb via the pre-signed URL on various WiFi connections.

## 🔧 How

 Updated `files_presign_ttl` from "600" to "3600" in:
  - terraform/sandbox/render.tf:143
  - terraform/production/render.tf:218
 
This sets the `POLAR_S3_FILES_PRESIGN_TTL` environment variable in `terraform/modules/render_service/main.tf`  to 3600 seconds (60 minutes),.

Previously, Terraform was setting this environment variable to 600, which overrode the 3600 default in `server/polar/config.py` via `settings.S3_FILES_PRESIGN_TTL`. With this change the environment varible matches the intended behaviour, and `downloadable`, `product_media`, and `organization_avatars` in `server/polar/file/s3.py` will have pre-signed URLs lasting 1 hour as expected.

Note: `server/polar/integrations/aws/s3/service.py` has a hardcoded function parameter default of `presign_ttl: int = 600`. Since Terraform environment variables don't affect Python function parameter defaults, the invoice functions `create_order_invoice()`, `get_order_invoice_url()`,  `create_payout_invoice()`, `get_payout_invoice_url()` will still have a 10 minute expiration time, unless that code is updated to explicitly use `settings.S3_FILES_PRESIGN_TTL`

## 🧪 Testing
A maintainer with Terraform Cloud access will need to apply these changes by running terraform apply in both the terraform/sandbox and terraform/production directories
  
- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

 - A maintainer with Terraform access needs to review the pull request
 - Run `terraform plan` to verify the changes
 - Run `terraform apply` to deploy the changes to sandbox/production

## 🖼️ Screenshots/Recordings

<!-- Include screenshots or recordings if your changes affect the UI -->
<!-- You can drag and drop images directly into this text area -->

## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
