### PR TITLE
Fix SLO dashboard showing old targets and mixed methods

### DIFF
--- a/server/monitoring/grafana/dashboards/api-slo.json
+++ b/server/monitoring/grafana/dashboards/api-slo.json
@@ -68,7 +68,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - ((count(\n  (\n    histogram_quantile(0.99, sum by (endpoint, method, le) (\n      rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n    )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))\n  )\n  or\n  (\n    (100 * (1 - (\n      sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n      or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n    ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n    < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d]))\n  )\n) or vector(0)) / count(max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d])))))",
+          "expr": "100 * (1 - ((count(\n  (\n    histogram_quantile(0.99, sum by (endpoint, method, le) (\n      rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n    )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))\n  )\n  or\n  (\n    (100 * (1 - (\n      sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n      or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n    ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n    < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d]))\n  )\n) or vector(0)) / count(max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d])))))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -395,7 +395,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(\n  histogram_quantile(0.99, sum by (endpoint, method, le) (\n    rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n  )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))\n)",
+          "expr": "(\n  histogram_quantile(0.99, sum by (endpoint, method, le) (\n    rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n  )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -406,7 +406,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))",
+          "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -417,7 +417,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(\n  (100 * (1 - (\n    sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n    or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n  ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n  < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d]))\n)",
+          "expr": "(\n  (100 * (1 - (\n    sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n    or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n  ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n  < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d]))\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -428,7 +428,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d]))",
+          "expr": "max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -438,40 +438,61 @@
       "title": "Breaching SLOs (Critical Endpoints)",
       "transformations": [
         {
-          "id": "joinByField",
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
           "options": {
-            "byField": "endpoint",
-            "mode": "outer"
+            "fields": {
+              "endpoint": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "method": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "Value #P99Breach": {
+                "aggregations": ["lastNotNull"],
+                "operation": "aggregate"
+              },
+              "Value #P99Target": {
+                "aggregations": ["lastNotNull"],
+                "operation": "aggregate"
+              },
+              "Value #AvailBreach": {
+                "aggregations": ["lastNotNull"],
+                "operation": "aggregate"
+              },
+              "Value #AvailTarget": {
+                "aggregations": ["lastNotNull"],
+                "operation": "aggregate"
+              }
+            }
           }
         },
         {
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "method 2": true,
-              "method 3": true,
-              "method 4": true
+              "Time": true
             },
             "indexByName": {
               "endpoint": 0,
-              "method 1": 1,
-              "Value #P99Breach": 2,
-              "Value #P99Target": 3,
-              "Value #AvailBreach": 4,
-              "Value #AvailTarget": 5
+              "method": 1,
+              "Value #P99Breach (lastNotNull)": 2,
+              "Value #P99Target (lastNotNull)": 3,
+              "Value #AvailBreach (lastNotNull)": 4,
+              "Value #AvailTarget (lastNotNull)": 5
             },
             "renameByName": {
               "endpoint": "Endpoint",
-              "method 1": "Method",
-              "Value #P99Breach": "Current P99",
-              "Value #P99Target": "Target P99",
-              "Value #AvailBreach": "Current Avail",
-              "Value #AvailTarget": "Target Avail"
+              "method": "Method",
+              "Value #P99Breach (lastNotNull)": "Current P99",
+              "Value #P99Target (lastNotNull)": "Target P99",
+              "Value #AvailBreach (lastNotNull)": "Current Avail",
+              "Value #AvailTarget (lastNotNull)": "Target Avail"
             }
           }
         },
@@ -987,7 +1008,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))",
+              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -998,7 +1019,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds[30d]))",
+              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -1744,7 +1765,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "(\n  (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[1h])) or vector(0))\n  /\n  ((1 - max by (endpoint, method) (last_over_time(polar_slo_availability_target[30d])) / 100) * sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[1h])))\n)",
+              "expr": "(\n  (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[1h])) or vector(0))\n  /\n  ((1 - max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d])) / 100) * sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[1h])))\n)",
               "legendFormat": "{{method}} {{endpoint}} (1h)",
               "refId": "A"
             }


### PR DESCRIPTION
## Summary

Fixed two issues in the API SLO dashboard where target values were displayed incorrectly.

## What

1. **Breaching SLOs table**: Different HTTP methods on the same endpoint were showing mixed target values (e.g., PATCH showing GET's target)
   - Replaced `joinByField` (endpoint only) with `merge` + `groupBy` (endpoint AND method)

2. **All Endpoints Health table**: Showed old P99 targets from before the Jan 9th update (e.g., 8s instead of 5s)
   - Added `{env="$env"}` filter to SLO target queries to isolate each environment and prevent cross-environment duplicate series

## Why

The dashboard queries were either not properly grouping by method or not filtering to the selected environment, causing incorrect target comparisons and stale data display.

## How

- Updated Grafana transformations to group by both endpoint and method
- Added environment filter to all SLO target metric queries in PromQL expressions
- Maintained `max by (endpoint, method)` aggregation for handling multiple pod instances within an environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)