### PR TITLE
fix: API SLO dashboard endpoint selection and method filtering

### DIFF
--- a/server/monitoring/grafana/dashboards/api-slo.json
+++ b/server/monitoring/grafana/dashboards/api-slo.json
@@ -1239,7 +1239,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - (sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", status_code=~\"5..\"}[5m])) or vector(0)) / sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\"}[5m])))",
+          "expr": "100 * (1 - (sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\", status_code=~\"5..\"}[5m])) or vector(0)) / sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\"}[5m])))",
           "legendFormat": "Availability",
           "refId": "A"
         }
@@ -1328,7 +1328,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(polar_http_request_duration_seconds_bucket{env=\"$env\", endpoint=~\"$endpoint\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(polar_http_request_duration_seconds_bucket{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -1337,7 +1337,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(polar_http_request_duration_seconds_bucket{env=\"$env\", endpoint=~\"$endpoint\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(polar_http_request_duration_seconds_bucket{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -1346,7 +1346,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(polar_http_request_duration_seconds_bucket{env=\"$env\", endpoint=~\"$endpoint\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(polar_http_request_duration_seconds_bucket{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -1435,7 +1435,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\"}[5m])) by (method)",
+          "expr": "sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\"}[5m])) by (method)",
           "legendFormat": "{{method}}",
           "refId": "A"
         }
@@ -1555,7 +1555,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\"}[5m])) by (status_code)",
+          "expr": "sum(rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\"}[5m])) by (status_code)",
           "legendFormat": "{{status_code}}",
           "refId": "A"
         }


### PR DESCRIPTION
## 📋 Summary

Fixes endpoint detail filtering in the API SLO dashboard by adding proper method variable handling and filtering.

## 🎯 What

- Added `allValue=".*"` to the method variable to ensure regex expansion works correctly when "All" is selected
- Added `method=~"$method"` filter to all Endpoint Detail panels so they respect the method selection

## 🤔 Why

The endpoint variable dropdown was broken when "All" was selected for methods because Grafana's `$__all` special value doesn't expand correctly in `label_values()` queries. Additionally, the Endpoint Detail panels were showing data for all methods regardless of which method was selected in the filter.

## 🔧 How

Modified the API SLO dashboard JSON to:
1. Add `allValue=".*"` to the method variable definition (line ~1813)
2. Update 6 prometheus queries in the Endpoint Detail panels to include `method=~"$method"` filter

## 🧪 Testing

- Tested locally by validating JSON syntax
- Changes are configuration only (no code changes)
- Verify in Grafana: select a specific method, confirm Endpoint Detail panels only show data for that method
- Select "All" methods to verify all data appears and endpoint dropdown populates correctly