### PR TITLE
fix: SLO metrics refresh and dashboard window

### DIFF
--- a/server/monitoring/grafana/dashboards/api-slo.json
+++ b/server/monitoring/grafana/dashboards/api-slo.json
@@ -68,7 +68,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - ((count(\n  (\n    histogram_quantile(0.99, sum by (endpoint, method, le) (\n      rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n    )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))\n  )\n  or\n  (\n    (100 * (1 - (\n      sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n      or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n    ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n    < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d]))\n  )\n) or vector(0)) / count(max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d])))))",
+          "expr": "100 * (1 - ((count(\n  (\n    histogram_quantile(0.99, sum by (endpoint, method, le) (\n      rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n    )) > on(endpoint, method) group_left() max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[1h]))\n  )\n  or\n  (\n    (100 * (1 - (\n      sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n      or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n    ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n    < on(endpoint, method) group_left() max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[1h]))\n  )\n) or vector(0)) / count(max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[1h])))))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -395,7 +395,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(\n  histogram_quantile(0.99, sum by (endpoint, method, le) (\n    rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n  )) > on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))\n)",
+          "expr": "(\n  histogram_quantile(0.99, sum by (endpoint, method, le) (\n    rate(polar_http_request_duration_seconds_bucket{env=\"$env\"}[$__range])\n  )) > on(endpoint, method) group_left() max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[1h]))\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -406,7 +406,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))",
+          "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[1h]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -417,7 +417,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(\n  (100 * (1 - (\n    sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n    or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n  ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n  < on(endpoint, method) max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d]))\n)",
+          "expr": "(\n  (100 * (1 - (\n    sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[$__range]))\n    or (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range])) * 0)\n  ) / sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[$__range]))))\n  < on(endpoint, method) group_left() max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[1h]))\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -428,7 +428,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d]))",
+          "expr": "max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[1h]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1008,7 +1008,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))",
+              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[1h]))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -1019,7 +1019,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[30d]))",
+              "expr": "max by (endpoint, method) (last_over_time(polar_slo_p99_target_seconds{env=\"$env\"}[1h]))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -1765,7 +1765,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "(\n  (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[1h])) or vector(0))\n  /\n  ((1 - max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[30d])) / 100) * sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[1h])))\n)",
+              "expr": "(\n  (sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\", status_code=~\"5..\"}[1h])) or vector(0))\n  /\n  ((1 - max by (endpoint, method) (last_over_time(polar_slo_availability_target{env=\"$env\"}[1h])) / 100) * sum by (endpoint, method) (rate(polar_http_request_total{env=\"$env\"}[1h])))\n)",
               "legendFormat": "{{method}} {{endpoint}} (1h)",
               "refId": "A"
             }

--- a/server/polar/observability/slo.py
+++ b/server/polar/observability/slo.py
@@ -9,13 +9,18 @@ as Prometheus metrics. This enables:
 3. Scalable SLO management (add endpoint = add to list, deploy, done)
 
 Usage:
-    Call init_slo_metrics() once on application startup to populate
-    the target metrics.
+    Call start_slo_metrics() on application startup and stop_slo_metrics()
+    on shutdown. Metrics are refreshed every 5 minutes.
 """
 
+import threading
+
+import structlog
 from prometheus_client import Gauge
 
-# SLO target metrics - set once on startup, used for dynamic comparisons
+log = structlog.get_logger()
+
+# SLO target metrics - refreshed periodically for dynamic comparisons
 # These metrics allow dashboard queries and alerts to use group_left joins
 # to compare actual values against per-endpoint targets.
 
@@ -58,13 +63,62 @@ CRITICAL_ENDPOINTS: list[tuple[str, str, float, float]] = [
     ("/v1/checkouts/{id}", "GET", 0.3, 99.95),
 ]
 
+_refresh_thread: threading.Thread | None = None
+_shutdown_event: threading.Event | None = None
 
-def init_slo_metrics() -> None:
+SLO_REFRESH_INTERVAL_SECONDS = 300  # 5 minutes
+
+
+def start_slo_metrics() -> None:
+    """Initialize SLO metrics and start background refresh thread."""
+    global _refresh_thread, _shutdown_event
+
+    # Initialize metrics immediately
+    _set_slo_metrics()
+
+    # Start periodic refresh if not already running
+    if _refresh_thread is not None:
+        return
+
+    _shutdown_event = threading.Event()
+    _refresh_thread = threading.Thread(
+        target=_run_refresh_loop,
+        args=(_shutdown_event,),
+        daemon=True,
+    )
+    _refresh_thread.start()
+    log.info("slo_metrics_started", refresh_interval=SLO_REFRESH_INTERVAL_SECONDS)
+
+
+def stop_slo_metrics() -> None:
+    """Stop the SLO metrics refresh thread."""
+    global _refresh_thread, _shutdown_event
+
+    if _shutdown_event is not None:
+        _shutdown_event.set()
+
+    if _refresh_thread is not None:
+        _refresh_thread.join(timeout=5.0)
+        _refresh_thread = None
+        _shutdown_event = None
+
+    log.info("slo_metrics_stopped")
+
+
+def _run_refresh_loop(shutdown_event: threading.Event) -> None:
+    """Background loop that refreshes SLO metrics periodically."""
+    while not shutdown_event.is_set():
+        shutdown_event.wait(SLO_REFRESH_INTERVAL_SECONDS)
+        if not shutdown_event.is_set():
+            try:
+                _set_slo_metrics()
+            except Exception:
+                log.exception("slo_metrics_refresh_error")
+
+
+def _set_slo_metrics() -> None:
     """
-    Initialize SLO target metrics with configured values.
-
-    Call this once on application startup. The metrics are then available
-    for Prometheus queries that compare actual values against targets.
+    Set SLO target metrics with configured values.
 
     Example PromQL using these metrics:
         # Check if p99 exceeds target for any critical endpoint:


### PR DESCRIPTION
## 📋 Summary

Fixes dashboard showing stale SLO target values by adding periodic metric refresh and shortening the lookback window.

## 🎯 What

- Added background thread to refresh SLO target metrics every 5 minutes
- Updated dashboard queries to use 1h lookback window instead of 30d
- Added `group_left()` to join operations for proper deduplication with multiple pod instances

## 🤔 Why

SLO target metrics were only emitted once at startup, causing old values to persist for 30 days. Multiple pod instances each emit the same metrics with different PIDs. The `max` aggregation in dashboard queries picked the highest value, showing outdated targets (e.g., 500ms instead of current 300ms for `GET /v1/checkouts/{id}`).

## 🔧 How

- `slo.py`: Added `start_slo_metrics()` and `stop_slo_metrics()` functions with background thread pattern matching `remote_write.py`
- `app.py`: Integrated lifecycle management in FastAPI lifespan handler
- `api-slo.json`: Changed `[30d]` to `[1h]` lookback, added `group_left()` to joins for proper deduplication

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend)
- [ ] I have run linting and type checking

## 📝 Additional Notes

With 5-minute refresh intervals and 1h lookback window, the dashboard provides 12 samples of buffer while ensuring SLO target changes appear within minutes of deployment.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>