### PR TITLE
Make business dashboard thresholds scale-adaptive

### DIFF
--- a/server/monitoring/grafana/dashboards/business.json
+++ b/server/monitoring/grafana/dashboards/business.json
@@ -13,7 +13,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current checkout creation rate (checkouts per minute)",
+      "description": "Checkout creation rate compared to 7-day average. 1.0 = matching baseline, <0.8 or >1.2 = significant deviation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -29,15 +29,23 @@
               },
               {
                 "color": "yellow",
-                "value": 0.1
+                "value": 0.5
               },
               {
                 "color": "green",
-                "value": 1
+                "value": 0.8
+              },
+              {
+                "color": "yellow",
+                "value": 1.2
+              },
+              {
+                "color": "red",
+                "value": 1.5
               }
             ]
           },
-          "unit": "cpm"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -68,12 +76,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(polar_checkout_created_total{env=\"$env\"}[5m])) * 60",
+          "expr": "(sum(rate(polar_checkout_created_total{env=\"$env\"}[5m])) * 60) / clamp_min(avg_over_time((sum(rate(polar_checkout_created_total{env=\"$env\"}[5m])) * 60)[7d:1h]), 0.001)",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Checkout Creation Rate",
+      "title": "Checkout Creation vs Baseline",
       "type": "stat"
     },
     {
@@ -81,7 +89,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current checkout success rate (succeeded per minute)",
+      "description": "Checkout success rate compared to 7-day average. 1.0 = matching baseline, <0.8 or >1.2 = significant deviation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -97,15 +105,23 @@
               },
               {
                 "color": "yellow",
-                "value": 0.1
+                "value": 0.5
               },
               {
                 "color": "green",
-                "value": 1
+                "value": 0.8
+              },
+              {
+                "color": "yellow",
+                "value": 1.2
+              },
+              {
+                "color": "red",
+                "value": 1.5
               }
             ]
           },
-          "unit": "cpm"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -136,12 +152,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(polar_checkout_succeeded_total{env=\"$env\"}[5m])) * 60",
+          "expr": "(sum(rate(polar_checkout_succeeded_total{env=\"$env\"}[5m])) * 60) / clamp_min(avg_over_time((sum(rate(polar_checkout_succeeded_total{env=\"$env\"}[5m])) * 60)[7d:1h]), 0.001)",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Checkout Success Rate",
+      "title": "Checkout Success vs Baseline",
       "type": "stat"
     },
     {
@@ -149,7 +165,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Percentage of checkouts that succeed (succeeded / created)",
+      "description": "Conversion rate compared to 7-day average. 1.0 = matching baseline, <0.8 or >1.2 = significant deviation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -165,15 +181,23 @@
               },
               {
                 "color": "yellow",
-                "value": 50
+                "value": 0.5
               },
               {
                 "color": "green",
-                "value": 80
+                "value": 0.8
+              },
+              {
+                "color": "yellow",
+                "value": 1.2
+              },
+              {
+                "color": "red",
+                "value": 1.5
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -204,12 +228,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (sum(rate(polar_checkout_succeeded_total{env=\"$env\"}[1h])) / clamp_min(sum(rate(polar_checkout_created_total{env=\"$env\"}[1h])), 0.001))",
+          "expr": "(sum(rate(polar_checkout_succeeded_total{env=\"$env\"}[1h])) / clamp_min(sum(rate(polar_checkout_created_total{env=\"$env\"}[1h])), 0.001)) / clamp_min(avg_over_time((sum(rate(polar_checkout_succeeded_total{env=\"$env\"}[1h])) / clamp_min(sum(rate(polar_checkout_created_total{env=\"$env\"}[1h])), 0.001))[7d:1h]), 0.001)",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Conversion Rate (1h)",
+      "title": "Conversion vs Baseline",
       "type": "stat"
     },
     {
@@ -522,7 +546,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -532,16 +556,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
                 "color": "green",
-                "value": 80
+                "value": null
               }
             ]
           },
@@ -713,7 +729,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -935,7 +951,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Anomaly Detection (for Grafana ML, expand to configure)",
+      "title": "Rate Deviation Analysis",
       "type": "row"
     }
   ],


### PR DESCRIPTION
## 📋 Summary

Converts the business metrics dashboard from hardcoded absolute thresholds to dynamic ratio-based thresholds that compare current values against 7-day averages. This makes the dashboard automatically adapt as checkout volume scales.

## 🎯 What

- Updated three stat panels to show "vs Baseline" ratio metrics instead of absolute rates
- Changed thresholds to ratio-based ranges: green 0.8-1.2, yellow 0.5-0.8/1.2-1.5, red <0.5 or >1.5
- Uncollapsed and repositioned the "Rate Deviation Analysis" section to be more prominent
- Removed threshold coloring from the conversion rate time series panel
- Removed obsolete test cases that tested functionality removed in commit 6251ded25

## 🤔 Why

The hardcoded thresholds (e.g., 0.1 cpm for yellow, 1 cpm for green) don't scale with business growth. A ratio-based approach where 1.0 always means "matching the 7-day baseline" is more robust and adaptive.

## 🔧 How

Each stat panel now includes a PromQL query that calculates the current value divided by the 7-day rolling average. Thresholds are applied to the ratio rather than absolute values. This approach scales automatically regardless of actual traffic volume.

## 🧪 Testing

- [x] JSON syntax validation
- [x] Test file syntax validation  
- [x] Removed tests that tested removed functionality