### PR TITLE
Revert "Avoid queue pile-ups on processing customers (#8893)"

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -76,7 +76,6 @@ class Settings(BaseSettings):
 
     CUSTOMER_METER_UPDATE_DEBOUNCE_MIN_THRESHOLD: timedelta = timedelta(seconds=5)
     CUSTOMER_METER_UPDATE_DEBOUNCE_MAX_THRESHOLD: timedelta = timedelta(minutes=15)
-    CUSTOMER_METER_UPDATE_PROCESSING_TIMEOUT: timedelta = timedelta(seconds=60)
 
     # TimescaleDB Migration - dual-write to events_hyper table
     EVENTS_DUAL_WRITE_ENABLED: bool = False

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -1,10 +1,9 @@
 import contextlib
 from collections.abc import AsyncGenerator, Iterable, Sequence
-from datetime import datetime
-from typing import Any, cast
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import CursorResult, Select, func, or_, select, update
+from sqlalchemy import Select, func, select, update
 from sqlalchemy import inspect as orm_inspect
 from sqlalchemy.orm import InstanceState
 
@@ -158,49 +157,6 @@ class CustomerRepository(
             .values(meters_updated_at=utc_now())
         )
         await self.session.execute(statement)
-
-    async def clear_meters_processing(
-        self, customer: Customer, meters_dirtied_at: datetime | None = None
-    ) -> None:
-        """
-        Clear the meters processing state after task completion.
-
-        If meters_dirtied_at is provided, only clear meters_dirtied_at if it
-        hasn't been updated since processing started (i.e., no new events came in).
-        """
-        if meters_dirtied_at is not None:
-            # Try to clear both meters_processing_since and meters_dirtied_at
-            # but only if meters_dirtied_at hasn't been updated during processing
-            statement = (
-                update(Customer)
-                .where(
-                    Customer.id == customer.id,
-                    or_(
-                        Customer.meters_dirtied_at.is_(None),
-                        Customer.meters_dirtied_at <= meters_dirtied_at,
-                    ),
-                )
-                .values(meters_processing_since=None, meters_dirtied_at=None)
-            )
-            # https://github.com/sqlalchemy/sqlalchemy/commit/67f62aac5b49b6d048ca39019e5bd123d3c9cfb2
-            result = cast(CursorResult[Customer], await self.session.execute(statement))
-
-            # If no rows were updated, meters_dirtied_at was updated during processing
-            # Just clear meters_processing_since
-            if result.rowcount == 0:
-                statement = (
-                    update(Customer)
-                    .where(Customer.id == customer.id)
-                    .values(meters_processing_since=None)
-                )
-                await self.session.execute(statement)
-        else:
-            statement = (
-                update(Customer)
-                .where(Customer.id == customer.id)
-                .values(meters_processing_since=None)
-            )
-            await self.session.execute(statement)
 
     async def get_by_id_and_organization(
         self, id: UUID, organization_id: UUID

--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -121,7 +121,6 @@ class CustomerMeterService:
 
         customer_repository = CustomerRepository.from_session(session)
         await customer_repository.set_meters_updated_at((customer,))
-        await customer_repository.clear_meters_processing(customer, meters_dirtied_at)
 
     async def update_customer_meter(
         self,


### PR DESCRIPTION
This reverts commit 0da8dd6dfd9ea585ce948f98b44adb8ee45d6c31.

---

I don't know why but it appears to never clear `meters_processing_since` in prod.