### PR TITLE
Reduce `event.ingested` retries

### DIFF
--- a/server/polar/event/tasks.py
+++ b/server/polar/event/tasks.py
@@ -6,7 +6,12 @@ from polar.worker import AsyncSessionMaker, TaskPriority, actor
 from .service import event as event_service
 
 
-@actor(actor_name="event.ingested", priority=TaskPriority.LOW)
+@actor(
+    actor_name="event.ingested",
+    priority=TaskPriority.LOW,
+    max_retries=5,
+    min_backoff=30_000,
+)
 async def event_ingested(event_ids: Sequence[uuid.UUID]) -> None:
     async with AsyncSessionMaker() as session:
         await event_service.ingested(session, event_ids)


### PR DESCRIPTION
Reduce `max_retries` from 20 (default) to 5 and increase `min_backoff` from 2s to 30s to prevent queue pile-ups in production.