### PR TITLE
Limit retries on `organization_access_token.record_usage` task

### DIFF
--- a/server/polar/organization_access_token/tasks.py
+++ b/server/polar/organization_access_token/tasks.py
@@ -6,7 +6,12 @@ from polar.worker import AsyncSessionMaker, TaskPriority, actor
 from .repository import OrganizationAccessTokenRepository
 
 
-@actor(actor_name="organization_access_token.record_usage", priority=TaskPriority.LOW)
+@actor(
+    actor_name="organization_access_token.record_usage",
+    priority=TaskPriority.LOW,
+    max_retries=3,
+    min_backoff=5_000,
+)
 async def record_usage(
     organization_access_token_id: uuid.UUID, last_used_at: float
 ) -> None:


### PR DESCRIPTION
Reduce `max_retries` from 20 to 3 and increase `min_backoff` from 2s to 5s for the record_usage task since it's a non-critical timestamp update.