### PR TITLE
Tweak retries on low priority queue

### DIFF
--- a/server/polar/auth/tasks.py
+++ b/server/polar/auth/tasks.py
@@ -12,6 +12,7 @@ log: Logger = structlog.get_logger()
     actor_name="auth.delete_expired",
     cron_trigger=CronTrigger(hour=0, minute=0),
     priority=TaskPriority.LOW,
+    max_retries=0,
 )
 async def auth_delete_expired() -> None:
     async with AsyncSessionMaker() as session:

--- a/server/polar/customer_session/tasks.py
+++ b/server/polar/customer_session/tasks.py
@@ -7,6 +7,7 @@ from .service import customer_session as customer_session_service
     actor_name="customer_session.delete_expired",
     cron_trigger=CronTrigger(hour=0, minute=0),
     priority=TaskPriority.LOW,
+    max_retries=0,
 )
 async def customer_session_delete_expired() -> None:
     async with AsyncSessionMaker() as session:

--- a/server/polar/email_update/tasks.py
+++ b/server/polar/email_update/tasks.py
@@ -13,6 +13,7 @@ log: Logger = structlog.get_logger()
     actor_name="email_update.delete_expired_record",
     cron_trigger=CronTrigger(hour=0, minute=0),
     priority=TaskPriority.LOW,
+    max_retries=0,
 )
 async def email_update_delete_expired_record() -> None:
     async with AsyncSessionMaker() as session:

--- a/server/polar/external_event/tasks.py
+++ b/server/polar/external_event/tasks.py
@@ -12,6 +12,7 @@ from .repository import ExternalEventRepository
     actor_name="external_event.prune",
     priority=TaskPriority.LOW,
     cron_trigger=CronTrigger(hour=0, minute=0),
+    max_retries=0,
 )
 async def external_event_prune() -> None:
     async with AsyncSessionMaker() as session:

--- a/server/polar/organization_access_token/tasks.py
+++ b/server/polar/organization_access_token/tasks.py
@@ -9,7 +9,7 @@ from .repository import OrganizationAccessTokenRepository
 @actor(
     actor_name="organization_access_token.record_usage",
     priority=TaskPriority.LOW,
-    max_retries=3,
+    max_retries=1,
     min_backoff=5_000,
 )
 async def record_usage(

--- a/server/polar/personal_access_token/tasks.py
+++ b/server/polar/personal_access_token/tasks.py
@@ -6,7 +6,12 @@ from polar.worker import AsyncSessionMaker, TaskPriority, actor
 from .service import personal_access_token as personal_access_token_service
 
 
-@actor(actor_name="personal_access_token.record_usage", priority=TaskPriority.LOW)
+@actor(
+    actor_name="personal_access_token.record_usage",
+    priority=TaskPriority.LOW,
+    max_retries=1,
+    min_backoff=5_000,
+)
 async def record_usage(
     personal_access_token_id: uuid.UUID, last_used_at: float
 ) -> None:


### PR DESCRIPTION
- Limit record_usage tasks (org/personal access tokens) to 1 retry with 5s backoff
- Disable retries for cron tasks that will run again on next schedule: auth.delete_expired, email_update.delete_expired_record, external_event.prune, customer_session.delete_expired