### PR TITLE
Fix code formatting in webhook delivery docs

### DIFF
--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -42,15 +42,15 @@ import { validateEvent, WebhookVerificationError } from '@polar-sh/sdk/webhooks'
 const app = express()
 
 app.post(
-'/webhook',
-express.raw({ type: 'application/json' }),
-(req: Request, res: Response) => {
-try {
-const event = validateEvent(
-req.body,
-req.headers,
-process.env['POLAR_WEBHOOK_SECRET'] ?? '',
-)
+  '/webhook',
+  express.raw({ type: 'application/json' }),
+  (req: Request, res: Response) => {
+    try {
+      const event = validateEvent(
+        req.body,
+        req.headers,
+        process.env['POLAR_WEBHOOK_SECRET'] ?? '',
+      )
 
       // Process the event
 
@@ -61,11 +61,9 @@ process.env['POLAR_WEBHOOK_SECRET'] ?? '',
       }
       throw error
     }
-
-},
+  },
 )
-
-````
+```
 
 ```python Python (Flask)
 import os
@@ -88,7 +86,7 @@ def webhook():
         return "", 202
     except WebhookVerificationError as e:
         return "", 403
-````
+```
 
 </CodeGroup>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

- Fix indentation in TypeScript Express example
- Change code block endings from 4 backticks to 3

<!-- Brief description of what this PR does -->

## 🎯 What

<!-- Describe what changes you've made -->

## 🤔 Why

<!-- Explain why this change is needed -->



## 🔧 How

<!-- Describe the approach you took to implement the changes -->

## 🧪 Testing

<!-- Check all that apply -->

- [x] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

<!-- Provide step-by-step instructions for reviewers to test your changes -->

1.
2.
3.

## 🖼️ Screenshots/Recordings

Before: 

<img width="1291" height="813" alt="Screenshot 2026-01-13 at 8 03 33 PM" src="https://github.com/user-attachments/assets/4a22d0aa-b967-495b-ae64-741106edd5da" />

After: 

<img width="1262" height="777" alt="Screenshot 2026-01-13 at 7 58 06 PM" src="https://github.com/user-attachments/assets/bef8a2c2-7014-4c9a-a391-cf6e1130323f" />


## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
