### PR TITLE
events: Ignore events hypertable migration/model mismatch

### DIFF
--- a/server/migrations/env.py
+++ b/server/migrations/env.py
@@ -14,6 +14,10 @@ def include_object(object, name, type_, reflected, compare_to):
     # Exclude TimescaleDB - Docker image handles creation, migration is backup
     if isinstance(object, PGExtension) and object.signature == "timescaledb":
         return False
+    # Exclude tables/indexes marked with skip_autogenerate
+    if type_ in ("table", "index") and hasattr(object, "info"):
+        if object.info.get("skip_autogenerate"):
+            return False
     # Exclude TimescaleDB auto-created index on hypertable partitioning column
     if type_ == "index" and name == "events_hyper_ingested_at_idx":
         return False

--- a/server/polar/models/event_hyper.py
+++ b/server/polar/models/event_hyper.py
@@ -55,6 +55,7 @@ class EventHyper(Model, MetadataMixin):
             "external_customer_id",
             postgresql_ops={"external_customer_id": "text_pattern_ops"},
         ),
+        {"info": {"skip_autogenerate": True}},
     )
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)


### PR DESCRIPTION
Prerequisite to be able to drop it.