### PR TITLE
fix: compile backoffice in conductor-run script

### DIFF
--- a/dev/conductor-run
+++ b/dev/conductor-run
@@ -26,6 +26,10 @@ if [[ ! -f "server/.env" ]]; then
     ./dev/setup-environment
 fi
 
+# Build backoffice
+echo "Building backoffice..."
+(cd server && uv run task backoffice)
+
 # Start all services in detached mode
 ./dev/docker-dev -i "$INSTANCE" -d
 


### PR DESCRIPTION
## Summary

Ensure backoffice is built before starting development services in conductor.

## What

Added `uv run task backoffice` to the conductor-run script to compile the backoffice before launching Docker services.

## Why

The backoffice needs to be compiled for the development environment to function properly.

## Testing

- Tested locally with conductor run