### PR TITLE
feat: add Member-based authenticators for customer portal

### DIFF
--- a/server/polar/customer_portal/auth.py
+++ b/server/polar/customer_portal/auth.py
@@ -3,9 +3,12 @@ from typing import Annotated
 from fastapi import Depends
 
 from polar.auth.dependencies import Authenticator
-from polar.auth.models import Anonymous, AuthSubject, Customer
+from polar.auth.models import Anonymous, AuthSubject, Customer, Member
 from polar.auth.scope import Scope
+from polar.exceptions import NotPermitted
+from polar.models.member import MemberRole
 
+# Customer-only authenticators (legacy, for non-migrated orgs)
 _CustomerPortalRead = Authenticator(
     required_scopes={
         Scope.customer_portal_read,
@@ -27,4 +30,72 @@ _CustomerPortalOAuthAccount = Authenticator(
 )
 CustomerPortalOAuthAccount = Annotated[
     AuthSubject[Customer | Anonymous], Depends(_CustomerPortalOAuthAccount)
+]
+
+
+# Member-only authenticators (for orgs with member_model_enabled=true)
+_CustomerPortalMemberRead = Authenticator(
+    required_scopes={
+        Scope.customer_portal_read,
+        Scope.customer_portal_write,
+    },
+    allowed_subjects={Member},
+)
+CustomerPortalMemberRead = Annotated[
+    AuthSubject[Member], Depends(_CustomerPortalMemberRead)
+]
+
+_CustomerPortalMemberWrite = Authenticator(
+    required_scopes={Scope.customer_portal_write},
+    allowed_subjects={Member},
+)
+CustomerPortalMemberWrite = Annotated[
+    AuthSubject[Member], Depends(_CustomerPortalMemberWrite)
+]
+
+
+class _RoleCheck:
+    """Dependency that checks if a Member has one of the allowed roles."""
+
+    def __init__(self, allowed_roles: set[MemberRole]) -> None:
+        self.allowed_roles = allowed_roles
+
+    async def __call__(
+        self, auth_subject: AuthSubject[Member] = Depends(_CustomerPortalMemberWrite)
+    ) -> AuthSubject[Member]:
+        if auth_subject.subject.role not in self.allowed_roles:
+            raise NotPermitted("Insufficient role for this operation")
+        return auth_subject
+
+
+# Role-based authenticators (Member-only, with role restrictions)
+CustomerPortalOwner = Annotated[
+    AuthSubject[Member],
+    Depends(_RoleCheck(allowed_roles={MemberRole.owner})),
+]
+
+CustomerPortalBillingManager = Annotated[
+    AuthSubject[Member],
+    Depends(_RoleCheck(allowed_roles={MemberRole.owner, MemberRole.billing_manager})),
+]
+
+
+# Union authenticators (accept both Customer and Member during migration)
+_CustomerPortalUnionRead = Authenticator(
+    required_scopes={
+        Scope.customer_portal_read,
+        Scope.customer_portal_write,
+    },
+    allowed_subjects={Customer, Member},
+)
+CustomerPortalUnionRead = Annotated[
+    AuthSubject[Customer | Member], Depends(_CustomerPortalUnionRead)
+]
+
+_CustomerPortalUnionWrite = Authenticator(
+    required_scopes={Scope.customer_portal_write},
+    allowed_subjects={Customer, Member},
+)
+CustomerPortalUnionWrite = Annotated[
+    AuthSubject[Customer | Member], Depends(_CustomerPortalUnionWrite)
 ]


### PR DESCRIPTION
## 📋 Summary

Phase 3 of Customer Portal Auth implementation adds Member-based authenticators to support organizations with member_model_enabled during migration.

## 🎯 What

Added 8 new authenticators and utilities to `server/polar/customer_portal/auth.py`:
- **Member-only authenticators**: `CustomerPortalMemberRead`, `CustomerPortalMemberWrite`
- **Role-based authenticators**: `CustomerPortalOwner`, `CustomerPortalBillingManager`  
- **Role check dependency**: `_RoleCheck` class validates Member roles
- **Union authenticators**: `CustomerPortalUnionRead`, `CustomerPortalUnionWrite` for accepting both Customer and Member during migration

## 🤔 Why

Organizations are being migrated to a Member-based model for seat management. These authenticators enable:
- Member-only portal endpoints for new B2B features
- Role-based access control (owner/billing_manager restrictions)
- Backward compatibility with existing Customer-based endpoints during migration

## 🔧 How

Follows existing authenticator patterns using `Authenticator(allowed_subjects, required_scopes)`. The `_RoleCheck` dependency provides role-based validation by checking `member.role` against allowed roles and raising `NotPermitted` (403) if unauthorized.

## 🧪 Testing

- ✅ Code follows style guidelines (lint passed)
- ✅ Type checking passed (no issues)
- ✅ No breaking changes to existing Customer-only authenticators