### PR TITLE
docs: Add database migration commands to server guide

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -11,6 +11,10 @@ uv run task test         # Run tests with coverage
 uv run task test_fast    # Faster parallel tests
 uv run task lint         # Auto-fix linting
 uv run task lint_types   # Type checking with mypy
+
+# Database migrations
+uv run alembic revision --autogenerate -m "description"  # Create migration
+uv run alembic upgrade head                              # Apply migrations
 ```
 
 ## Module Structure


### PR DESCRIPTION
## 📋 Summary

Adds alembic database migration commands to the Quick Commands section in `server/CLAUDE.md` for developer reference.

## 🎯 What

Added two commonly-used alembic commands to the server development guide:
- Creating migrations: `uv run alembic revision --autogenerate -m "description"`
- Applying migrations: `uv run alembic upgrade head`

## 🤔 Why

Developers frequently need to create and apply database migrations during backend development. Having these commands documented in the Quick Commands section makes them easily discoverable.

## 🧪 Testing

- [x] I have performed a self-review of my code
- [x] I have updated the relevant documentation