### PR TITLE
Log customer session verification code in dev mode

### DIFF
--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -4,6 +4,7 @@ import uuid
 from dataclasses import dataclass
 from math import ceil
 
+import structlog
 from sqlalchemy import select
 
 from polar.config import settings
@@ -19,6 +20,8 @@ from polar.member.repository import MemberRepository
 from polar.models import CustomerSession, CustomerSessionCode, Organization
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession
+
+log = structlog.get_logger()
 
 
 @dataclass
@@ -200,6 +203,16 @@ class CustomerSessionService:
             subject=f"Access your {organization.name} purchases",
             html_content=body,
         )
+
+        if settings.is_development():
+            log.info(
+                "\n"
+                "╔══════════════════════════════════════════════════════════╗\n"
+                "║                                                          ║\n"
+                f"║           🔑 CUSTOMER SESSION CODE: {code}              ║\n"
+                "║                                                          ║\n"
+                "╚══════════════════════════════════════════════════════════╝"
+            )
 
     async def authenticate(
         self, session: AsyncSession, code: str


### PR DESCRIPTION
## 📋 Summary

Add structured logging for customer session verification codes during development, matching the pattern used for login codes.

## 🎯 What

Added development-mode logging to the `CustomerSessionService.send()` method that displays the verification code in a formatted box in dev logs.

## 🤔 Why

When testing the customer portal flow locally, it's helpful to see the verification code displayed in the logs (similar to how login codes are shown), making it easier to test without checking emails.

## 🔧 How

- Added `structlog` import
- Added logger instance initialization
- Added conditional dev-mode logging that displays the code in a formatted ASCII box when `settings.is_development()` is true

## 🧪 Testing

- [x] I have tested these changes locally
- [x] Code follows existing patterns (matches login code implementation)
- [x] My changes generate no new warnings

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] AI/LLM Policy: Code has been reviewed and tested