### PR TITLE
Disable SQLAlchemy debug logging and fix Conductor instance isolation

### DIFF
--- a/dev/conductor-run
+++ b/dev/conductor-run
@@ -14,9 +14,10 @@ else
     ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 fi
 
-# Calculate instance from CONDUCTOR_PORT (default to 0)
+# Calculate instance from CONDUCTOR_PORT
+# Always add 1 to avoid clashing with server/docker-compose.yml (instance 0)
 CONDUCTOR_PORT="${CONDUCTOR_PORT:-55000}"
-INSTANCE=$(( (CONDUCTOR_PORT - 55000) / 10 ))
+INSTANCE=$(( (CONDUCTOR_PORT - 55000) / 10 + 1 ))
 
 cd "$ROOT_DIR"
 

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -15,7 +15,7 @@ x-common-backend-env: &common-backend-env
   POLAR_ENV: development
   POLAR_LOG_LEVEL: DEBUG
   POLAR_TESTING: "0"
-  POLAR_SQLALCHEMY_DEBUG: "1"
+  POLAR_SQLALCHEMY_DEBUG: "0"
   POLAR_POSTHOG_DEBUG: "1"
   # Database - uses service name for container networking
   POLAR_POSTGRES_USER: ${POLAR_POSTGRES_USER:-polar}


### PR DESCRIPTION
## Summary

Improve development experience by disabling noisy SQLAlchemy debug logging and ensure Conductor workspaces don't clash with the default docker-compose setup.

## What

- Disable `POLAR_SQLALCHEMY_DEBUG` in dev docker-compose to reduce noise
- Update Conductor runner to always add +1 to instance number, preventing clash with instance 0 (the default)

## Why

SQLAlchemy debug logging is very verbose and doesn't add value in development. Conductor instances need isolation from the default server/docker-compose.yml which uses ports 8000/3000/9001 (instance 0).

## How

- Changed `POLAR_SQLALCHEMY_DEBUG` from "1" to "0" in docker-compose.dev.yml
- Modified dev/conductor-run to calculate instance as `(CONDUCTOR_PORT - 55000) / 10 + 1` instead of `/10`, ensuring minimum instance 1

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>