### PR TITLE
chore: add seat-based organization seed data

### DIFF
--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -631,7 +631,7 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
         organization.details = org_data.get("details", {})  # type: ignore
         organization.details_submitted_at = utc_now()
         organization.status = org_data.get("status", OrganizationStatus.CREATED)
-        organization.feature_settings = org_data.get("feature_settings", {})  # type: ignore
+        organization.feature_settings = org_data.get("feature_settings", {})
         session.add(organization)
 
         # Create OrganizationReview with PASS verdict for ACTIVE organizations


### PR DESCRIPTION
## 📋 Summary

This PR adds two new test organizations to the seed data to support development and testing of seat-based billing features.

## 🎯 What

Added **SeatBased Members Corp** and **SeatBased Only Corp** organizations with:
- Seat-based products with tiered pricing (/seat and /seat)
- Customers with purchased (5 seats) and allocated (2 seats) subscriptions
- Members entity for the first org, Customer records for seat holders in the second org
- Proper feature flags enabling seat-based pricing

## 🤔 Why

This enables testing of two billing models:
1. **With Members Model**: Organization with `member_model_enabled=True` using Members entity to track seat allocations
2. **Without Members Model**: Organization with `member_model_enabled=False` using individual Customer records for seat holders

## 🔧 How

- Extended seed data TypedDicts to support seat-based customers and feature settings
- Added logic to create seat-based products with tiered pricing
- For member-enabled orgs: creates Members and links them to CustomerSeats
- For non-member orgs: creates individual Customer records for each seat holder
- Changed user creation to use `get_by_email_or_create` to allow multiple orgs per user

## 🧪 Testing

- [ ] I have tested these changes locally with `uv run task seeds_load`
- The seed data creates organizations with proper relationships and feature flags