### PR TITLE
server/worker: pop debounce_enqueue_timestamp from message, to make sure it doesn't leak around

### DIFF
--- a/server/polar/worker/_debounce.py
+++ b/server/polar/worker/_debounce.py
@@ -142,7 +142,7 @@ class DebounceMiddleware(dramatiq.Middleware):
         if debounce_key is None:
             return
 
-        enqueue_timestamp: int | None = message.options.get(
+        enqueue_timestamp: int | None = message.options.pop(
             "debounce_enqueue_timestamp"
         )
         if enqueue_timestamp is not None:


### PR DESCRIPTION
- server/worker: pop debounce_enqueue_timestamp from message, to make sure it doesn't leak around