### PR TITLE
observability: Export logfire gauges to prometheus

### DIFF
--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -48,6 +48,7 @@ def create_async_engine(
     *,
     dsn: str,
     application_name: str | None = None,
+    pool_logging_name: str | None = None,
     pool_size: int | None = None,
     pool_recycle: int | None = None,
     command_timeout: float | None = None,
@@ -65,6 +66,7 @@ def create_async_engine(
         connect_args=connect_args,
         pool_size=pool_size,
         pool_recycle=pool_recycle,
+        pool_logging_name=pool_logging_name,
         json_serializer=json_serializer,
     )
 
@@ -73,6 +75,7 @@ def create_sync_engine(
     *,
     dsn: str,
     application_name: str | None = None,
+    pool_logging_name: str | None = None,
     pool_size: int | None = None,
     pool_recycle: int | None = None,
     command_timeout: float | None = None,
@@ -89,6 +92,7 @@ def create_sync_engine(
         connect_args=connect_args,
         pool_size=pool_size,
         pool_recycle=pool_recycle,
+        pool_logging_name=pool_logging_name,
     )
 
 

--- a/server/polar/logfire.py
+++ b/server/polar/logfire.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 from polar.config import settings
 from polar.kit.db.postgres import Engine
+from polar.observability.otel_prometheus import PrometheusMeterProvider
 
 Matcher = Callable[[str, "Attributes | None"], bool]
 
@@ -107,8 +108,11 @@ def instrument_fastapi(app: FastAPI) -> None:
     logfire.instrument_fastapi(app, capture_headers=True)
 
 
+_meter_provider = PrometheusMeterProvider()
+
+
 def instrument_sqlalchemy(engines: Sequence[Engine]) -> None:
-    logfire.instrument_sqlalchemy(engines=engines)
+    logfire.instrument_sqlalchemy(engines=engines, meter_provider=_meter_provider)
 
 
 __all__ = [

--- a/server/polar/observability/otel_prometheus.py
+++ b/server/polar/observability/otel_prometheus.py
@@ -1,0 +1,170 @@
+"""
+Simple OpenTelemetry MeterProvider that bridges to prometheus_client.
+
+Supports multiprocess mode via prometheus_client's PROMETHEUS_MULTIPROC_DIR.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from opentelemetry.metrics import (
+    CallbackT,
+    Counter,
+    Histogram,
+    Meter,
+    MeterProvider,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
+from opentelemetry.metrics import _Gauge as Gauge
+from prometheus_client import Gauge as PromGauge
+
+import polar.observability.metrics  # noqa: F401  # Sets PROMETHEUS_MULTIPROC_DIR
+
+if TYPE_CHECKING:
+    from opentelemetry.context import Context
+
+type Attributes = (
+    Mapping[
+        str,
+        str
+        | bool
+        | int
+        | float
+        | Sequence[str]
+        | Sequence[bool]
+        | Sequence[int]
+        | Sequence[float],
+    ]
+    | None
+)
+
+
+class PrometheusUpDownCounter(UpDownCounter):
+    def __init__(self, name: str, unit: str, description: str) -> None:
+        prom_name = name.replace(".", "_")
+        self._gauge = PromGauge(
+            prom_name,
+            description,
+            ["service", "state"],
+            multiprocess_mode="livesum",
+        )
+
+    def add(
+        self,
+        amount: int | float,
+        attributes: Attributes = None,
+        context: "Context | None" = None,
+    ) -> None:
+        labels = self._extract_labels(attributes)
+        self._gauge.labels(**labels).inc(amount)
+
+    def _extract_labels(self, attributes: Attributes) -> dict[str, str]:
+        if not attributes:
+            return {"service": "unknown", "state": "unknown"}
+        return {
+            "service": str(attributes.get("pool.name", "unknown")),
+            "state": str(attributes.get("state", "unknown")),
+        }
+
+
+class PrometheusMeter(Meter):
+    def __init__(self, name: str, version: str | None, schema_url: str | None) -> None:
+        self._name = name
+        self._version = version
+        self._schema_url = schema_url
+        self._instruments: dict[str, Any] = {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str | None:
+        return self._version
+
+    @property
+    def schema_url(self) -> str | None:
+        return self._schema_url
+
+    def create_up_down_counter(
+        self,
+        name: str,
+        unit: str = "",
+        description: str = "",
+    ) -> UpDownCounter:
+        if name not in self._instruments:
+            self._instruments[name] = PrometheusUpDownCounter(name, unit, description)
+        return self._instruments[name]
+
+    def create_counter(
+        self,
+        name: str,
+        unit: str = "",
+        description: str = "",
+    ) -> Counter:
+        raise NotImplementedError
+
+    def create_histogram(
+        self,
+        name: str,
+        unit: str = "",
+        description: str = "",
+        *,
+        explicit_bucket_boundaries_advisory: Sequence[float] | None = None,
+    ) -> Histogram:
+        raise NotImplementedError
+
+    def create_gauge(
+        self,
+        name: str,
+        unit: str = "",
+        description: str = "",
+    ) -> Gauge:
+        raise NotImplementedError
+
+    def create_observable_counter(
+        self,
+        name: str,
+        callbacks: Sequence[CallbackT] | None = None,
+        unit: str = "",
+        description: str = "",
+    ) -> ObservableCounter:
+        raise NotImplementedError
+
+    def create_observable_up_down_counter(
+        self,
+        name: str,
+        callbacks: Sequence[CallbackT] | None = None,
+        unit: str = "",
+        description: str = "",
+    ) -> ObservableUpDownCounter:
+        raise NotImplementedError
+
+    def create_observable_gauge(
+        self,
+        name: str,
+        callbacks: Sequence[CallbackT] | None = None,
+        unit: str = "",
+        description: str = "",
+    ) -> ObservableGauge:
+        raise NotImplementedError
+
+
+class PrometheusMeterProvider(MeterProvider):
+    def __init__(self) -> None:
+        self._meters: dict[str, PrometheusMeter] = {}
+
+    def get_meter(
+        self,
+        name: str,
+        version: str | None = None,
+        schema_url: str | None = None,
+        attributes: Attributes = None,
+    ) -> Meter:
+        key = f"{name}:{version}:{schema_url}"
+        if key not in self._meters:
+            self._meters[key] = PrometheusMeter(name, version, schema_url)
+        return self._meters[key]

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -20,10 +20,13 @@ from polar.kit.db.postgres import create_sync_engine as _create_sync_engine
 type ProcessName = Literal["app", "worker", "scheduler", "script"]
 
 
-def create_async_engine(process_name: ProcessName) -> AsyncEngine:
+def create_async_engine(
+    process_name: ProcessName, *, pool_logging_name: str | None = None
+) -> AsyncEngine:
     return _create_async_engine(
         dsn=str(settings.get_postgres_dsn("asyncpg")),
         application_name=f"{settings.ENV.value}.{process_name}",
+        pool_logging_name=pool_logging_name or process_name,
         debug=settings.SQLALCHEMY_DEBUG,
         pool_size=settings.DATABASE_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
@@ -35,6 +38,7 @@ def create_async_read_engine(process_name: ProcessName) -> AsyncEngine:
     return _create_async_engine(
         dsn=str(settings.get_postgres_read_dsn("asyncpg")),
         application_name=f"{settings.ENV.value}.{process_name}",
+        pool_logging_name=f"{process_name}_read",
         debug=settings.SQLALCHEMY_DEBUG,
         pool_size=settings.DATABASE_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
@@ -46,6 +50,7 @@ def create_sync_engine(process_name: ProcessName) -> Engine:
     return _create_sync_engine(
         dsn=str(settings.get_postgres_dsn("psycopg2")),
         application_name=f"{settings.ENV.value}.{process_name}",
+        pool_logging_name=f"{process_name}_sync",
         debug=settings.SQLALCHEMY_DEBUG,
         pool_size=settings.DATABASE_SYNC_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,

--- a/server/polar/worker/_sqlalchemy.py
+++ b/server/polar/worker/_sqlalchemy.py
@@ -1,4 +1,5 @@
 import contextlib
+import sys
 from collections.abc import AsyncIterator
 
 import dramatiq
@@ -12,6 +13,17 @@ from polar.logging import Logger
 from polar.postgres import AsyncEngine, AsyncSession, create_async_engine
 
 log: Logger = structlog.get_logger()
+
+
+def _get_worker_pool_name() -> str:
+    """Get pool name from --queues CLI arg, e.g. 'worker-webhooks' or 'worker-high_priority'."""
+    try:
+        idx = sys.argv.index("--queues")
+        queues = sys.argv[idx + 1].split(",")
+        return f"worker-{'-'.join(sorted(queues))}"
+    except (ValueError, IndexError):
+        return "worker"
+
 
 _sqlalchemy_engine: AsyncEngine | None = None
 _sqlalchemy_async_sessionmaker: AsyncSessionMakerType | None = None
@@ -41,10 +53,11 @@ class SQLAlchemyMiddleware(dramatiq.Middleware):
         self, broker: dramatiq.Broker, worker: dramatiq.Worker
     ) -> None:
         global _sqlalchemy_engine, _sqlalchemy_async_sessionmaker
-        _sqlalchemy_engine = create_async_engine("worker")
+        pool_name = _get_worker_pool_name()
+        _sqlalchemy_engine = create_async_engine("worker", pool_logging_name=pool_name)
         _sqlalchemy_async_sessionmaker = create_async_sessionmaker(_sqlalchemy_engine)
         instrument_sqlalchemy([_sqlalchemy_engine.sync_engine])
-        log.info("Created database engine")
+        log.info("Created database engine", pool_name=pool_name)
 
     def after_worker_shutdown(
         self, broker: dramatiq.Broker, worker: dramatiq.Worker


### PR DESCRIPTION
This adds a Prometheus metrics exporter that we can pass to `logfire.instrument_sqlalchemy`. This will expose the db connection pool informatoin per service (idle / active).