### PR TITLE
Fix meter reset on subscription_update orders

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -731,10 +731,12 @@ class OrderService:
                 )
 
             # Reset the associated meters, if any
+            # Note: subscription_update is intentionally excluded - meter credits from
+            # benefit grants should persist within a billing cycle. Subscription updates
+            # are for prorations, not new billing periods.
             if billing_reason in {
                 OrderBillingReasonInternal.subscription_cycle,
                 OrderBillingReasonInternal.subscription_cycle_after_trial,
-                OrderBillingReasonInternal.subscription_update,
             }:
                 await subscription_service.reset_meters(session, subscription)
 


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes meter credit loss during subscription updates (seat billing issue)

## 🎯 What

Removed `subscription_update` from the list of billing reasons that trigger meter resets in the OrderService. Added a regression test to ensure meters are not reset on subscription_update orders.

## 🤔 Why

When `subscription_update` orders were created, meters were being reset mid-cycle. The `reset_meters()` function only re-applies rollover credits, not benefit-based credits (like included Team Seats). This caused customers to lose their meter credits for billing purposes, even though their benefit grants were still active and the dashboard showed correct values.

**Timeline of the bug:**
1. Cycle starts → meter.credited (10 units from benefits)
2. API call triggers subscription_update → meter.reset (credits lost)
3. Usage event (8 units) occurs
4. Cycle billing: 8 consumed - 0 credited = 8 billable ($120)
5. Should have been: 8 consumed - 10 credited = 0 billable ($0)

## 🔧 How

- Modified `OrderService.create_subscription_order()` to only reset meters on new billing cycles (`subscription_cycle`, `subscription_cycle_after_trial`)
- Added explanatory comment about why `subscription_update` is excluded
- Refactored the existing test to be more explicit about `subscription_cycle` behavior
- Added regression test specifically for `subscription_update` to document expected behavior

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend)
- [x] I have added new tests for new functionality (regression test for subscription_update)

### Test Instructions

1. Create a subscription with a metered product that has benefit-based meter credits
2. Trigger a subscription update mid-cycle (e.g., via API PATCH)
3. Verify no `meter.reset` event is created
4. Verify meter credits persist and are correctly applied in billing

## 📝 Additional Notes

**Edge case consideration (per François):** When `proration_behavior == invoice`, immediate invoicing occurs and meters arguably should reset (since we bill pending entries). However:
- The current `reset_meters()` doesn't re-apply benefit credits after reset
- A proper fix would need `reset_meters()` to also create `meter.credited` events for active benefit grants
- This simpler fix (not resetting on subscription_update) is the safer conservative approach

If the team prefers, a more comprehensive fix would be to modify `reset_meters()` to re-grant benefit credits, then keep meter reset on `subscription_update` for the immediate invoice case.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: Changes have been tested and verified locally