### PR TITLE
Fix lock error handling for PostgreSQL FOR UPDATE NOWAIT

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -8,7 +8,7 @@ import structlog
 from pydantic import UUID4
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy import func, select
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import Anonymous, AuthSubject
@@ -1690,7 +1690,7 @@ class CheckoutService:
                 nowait=True,
                 options=repository.get_eager_options(),
             )
-        except OperationalError as e:
+        except DBAPIError as e:
             if "could not obtain lock" in str(e):
                 raise CheckoutLocked(checkout_id) from e
             raise

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import structlog
 from sqlalchemy import Select, UnaryExpression, asc, delete, desc, func, or_, select
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, is_organization, is_user
@@ -401,7 +401,7 @@ class DiscountService(ResourceServiceReader[Discount]):
         # Acquire FOR UPDATE lock (we're already inside checkout's transaction)
         try:
             await repository.get_by_id_for_update(discount.id, nowait=True)
-        except OperationalError as e:
+        except DBAPIError as e:
             if "could not obtain lock" in str(e):
                 raise DiscountNotRedeemableError(discount) from e
             raise


### PR DESCRIPTION
## 📋 Summary

SQLAlchemy's asyncpg dialect maps `LockNotAvailableError` to `DBAPIError`, not `OperationalError`. The code was catching the wrong exception type, causing lock errors to propagate as unhandled exceptions.

## 🎯 What

Changed exception handling in checkout and discount services from `OperationalError` to `DBAPIError` to properly catch PostgreSQL row lock contention errors.

## 🤔 Why

The commit that introduced PostgreSQL `FOR UPDATE NOWAIT` locking was catching `OperationalError`, but SQLAlchemy's asyncpg dialect maps the lock error to `DBAPIError`. This caused lock contention errors to be unhandled.

## 🔧 How

Updated the exception handlers in `_lock_checkout_update()` and `redeem_discount()` to catch `DBAPIError` instead of `OperationalError`. Since `OperationalError` is a subclass of `DBAPIError`, this also handles any other operational errors.