### PR TITLE
Make `minimum_amount` of $0.50 explicit

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -108,7 +108,8 @@ export const ProductPriceCustomItem: React.FC<ProductPriceCustomItemProps> = ({
         control={control}
         name={`prices.${index}.minimum_amount`}
         rules={{
-          min: { value: 50, message: 'Price must be greater than $0.5' },
+          required: 'This field is required',
+          min: { value: 50, message: 'Price must be greater than $0.50' },
         }}
         render={({ field }) => {
           return (
@@ -668,6 +669,7 @@ const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
         replace({
           amount_type: 'custom',
           price_currency: 'usd',
+          minimum_amount: 50,
         })
       } else if (amountType === 'free') {
         replace({

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -17291,7 +17291,7 @@ export interface components {
        * Minimum Amount
        * @description The minimum amount the customer can pay.
        */
-      minimum_amount: number | null
+      minimum_amount: number
       /**
        * Maximum Amount
        * @description The maximum amount the customer can pay.
@@ -21609,7 +21609,7 @@ export interface components {
        * Minimum Amount
        * @description The minimum amount the customer can pay.
        */
-      minimum_amount: number | null
+      minimum_amount: number
       /**
        * Maximum Amount
        * @description The maximum amount the customer can pay.
@@ -21640,8 +21640,9 @@ export interface components {
       /**
        * Minimum Amount
        * @description The minimum amount the customer can pay.
+       * @default 50
        */
-      minimum_amount?: number | null
+      minimum_amount: number
       /**
        * Maximum Amount
        * @description The maximum amount the customer can pay.

--- a/server/migrations/versions/2026-01-20_backfill_custom_price_minimum_amount.py
+++ b/server/migrations/versions/2026-01-20_backfill_custom_price_minimum_amount.py
@@ -1,0 +1,36 @@
+"""Backfill minimum_amount for custom prices
+
+Revision ID: 597080a0dd14
+Revises: 6145195fc43a
+Create Date: 2026-01-20
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "597080a0dd14"
+down_revision = "6145195fc43a"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Backfill minimum_amount=50 for existing custom prices that have NULL
+    # This makes the API non-nullable while keeping the DB column nullable
+    # (due to polymorphism - other price types don't use this field)
+    op.execute(
+        """
+        UPDATE product_prices
+        SET minimum_amount = 50
+        WHERE amount_type = 'custom' AND minimum_amount IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    # No downgrade needed - NULL and 50 have the same effective behavior
+    # in the legacy code, so we don't need to revert the data
+    pass

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -141,8 +141,10 @@ class ProductPriceCustomCreate(ProductPriceCreateBase):
 
     amount_type: Literal[ProductPriceAmountType.custom]
     price_currency: PriceCurrency = "usd"
-    minimum_amount: PriceAmount | None = Field(
-        default=None, ge=50, description="The minimum amount the customer can pay."
+    minimum_amount: int = Field(
+        default=MINIMUM_PRICE_AMOUNT,
+        ge=MINIMUM_PRICE_AMOUNT,
+        description=("The minimum amount the customer can pay."),
     )
     maximum_amount: PriceAmount | None = Field(
         default=None,
@@ -520,8 +522,8 @@ class ProductPriceFixedBase(ProductPriceBase):
 class ProductPriceCustomBase(ProductPriceBase):
     amount_type: Literal[ProductPriceAmountType.custom]
     price_currency: str = Field(description="The currency.")
-    minimum_amount: int | None = Field(
-        description="The minimum amount the customer can pay."
+    minimum_amount: int = Field(
+        description=("The minimum amount the customer can pay.")
     )
     maximum_amount: int | None = Field(
         description="The maximum amount the customer can pay."
@@ -529,6 +531,11 @@ class ProductPriceCustomBase(ProductPriceBase):
     preset_amount: int | None = Field(
         description="The initial amount shown to the customer."
     )
+
+    @field_validator("minimum_amount", mode="before")
+    @classmethod
+    def set_minimum_amount_default(cls, v: int | None) -> int:
+        return v if v is not None else MINIMUM_PRICE_AMOUNT
 
 
 class ProductPriceFreeBase(ProductPriceBase):


### PR DESCRIPTION
Cherry-picks part of #9041 that's enforcing minimum amount to be set on PWYW price configurations, with a minimum of $0.50.

This will also backfill all `null` values for `minimum_amount` to $0.50 for consistency.

In #9041, we will then drop the minimum to $0.00 to accept free, but enforce the $0.50 minimum for payments.