### PR TITLE
Fix: Payment retry issues in customer portal

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/OrderPaymentRetry.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/OrderPaymentRetry.tsx
@@ -48,6 +48,7 @@ export const OrderPaymentRetry = ({
   const [showRetryButton, setShowRetryButton] = useState(false)
 
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const hasInitiatedPaymentRef = useRef(false)
 
   const cleanupPolling = () => {
     if (pollingIntervalRef.current) {
@@ -62,6 +63,7 @@ export const OrderPaymentRetry = ({
     setHasSubmitted(false)
     setPaymentComplete(false)
     setShowRetryButton(false)
+    hasInitiatedPaymentRef.current = false
     cleanupPolling()
   }
 
@@ -354,18 +356,19 @@ export const OrderPaymentRetry = ({
   }, [])
 
   // Auto-trigger payment for saved payment methods
+  // Use ref for synchronous guard to prevent double-calls in React Strict Mode
   useEffect(() => {
-    if (paymentMethodId && !hasSubmitted && !isProcessing && !isPolling) {
+    if (
+      paymentMethodId &&
+      !hasInitiatedPaymentRef.current &&
+      !isProcessing &&
+      !isPolling
+    ) {
+      hasInitiatedPaymentRef.current = true
       setHasSubmitted(true)
       handleSavedPaymentMethod()
     }
-  }, [
-    paymentMethodId,
-    hasSubmitted,
-    isProcessing,
-    isPolling,
-    handleSavedPaymentMethod,
-  ])
+  }, [paymentMethodId, isProcessing, isPolling, handleSavedPaymentMethod])
 
   return (
     <div className="space-y-4">

--- a/server/polar/integrations/stripe/payment.py
+++ b/server/polar/integrations/stripe/payment.py
@@ -195,7 +195,15 @@ async def handle_failure(
         await checkout_service.handle_failure(session, checkout, payment=payment)
 
     if order is not None:
-        await order_service.handle_payment_failure(session, order)
+        # Check if this is a manual retry - skip dunning progression if so
+        skip_dunning = (
+            hasattr(object, "metadata")
+            and object.metadata is not None
+            and object.metadata.get("manual_retry") == "true"
+        )
+        await order_service.handle_payment_failure(
+            session, order, skip_dunning=skip_dunning
+        )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Fixes three critical issues with the "Retry Payment" flow in the customer portal:

1. **3DS Modal Display**: 3DS authentication now displays as a popup/modal instead of redirecting to another page
2. **Retry Persistence**: Canceling 3DS no longer prevents future retry attempts
3. **Dunning Management**: Manual retry cancellations no longer progress the dunning state machine

## Changes

- Pass Stripe instance to OrderPaymentRetry component for saved payment methods
- Remove `return_url` and add `allow_redirects: "never"` for popup 3DS mode
- Add `manual_retry` metadata flag and skip dunning progression on manual retry cancellation
- Prevent double API calls by using useRef guard in React Strict Mode

## Testing

- Test 3DS with card `4000002500003155` (requires 3DS verification)
- Cancel 3DS popup and verify "Retry Payment" button still appears
- Complete retry successfully after canceling

🤖 Generated with Claude Code