### PR TITLE
Add Zed debugger configuration for pytest

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,26 @@
+[
+  {
+    "label": "pytest: Current Test File",
+    "adapter": "Debugpy",
+    "request": "launch",
+    "module": "pytest",
+    "args": ["$ZED_FILE", "-v"],
+    "cwd": "$ZED_WORKTREE_ROOT/server"
+  },
+  {
+    "label": "pytest: Current Test (with target)",
+    "adapter": "Debugpy",
+    "request": "launch",
+    "module": "pytest",
+    "args": ["$ZED_CUSTOM_PYTHON_TEST_TARGET", "-v"],
+    "cwd": "$ZED_WORKTREE_ROOT/server"
+  },
+  {
+    "label": "pytest: All Tests",
+    "adapter": "Debugpy",
+    "request": "launch",
+    "module": "pytest",
+    "args": ["-v"],
+    "cwd": "$ZED_WORKTREE_ROOT/server"
+  }
+]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
   "minio>=7.2.9",
   "polar-sdk==0.27.3",
   "locust>=2.20.0",
+  "debugpy>=1.8.19",
 ]
 
 [tool.taskipy.tasks]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -575,6 +575,19 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/75/9e12d4d42349b817cd545b89247696c67917aab907012ae5b64bbfea3199/debugpy-1.8.19.tar.gz", hash = "sha256:eea7e5987445ab0b5ed258093722d5ecb8bb72217c5c9b1e21f64efe23ddebdb", size = 1644590, upload-time = "2025-12-15T21:53:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b9/cbec520c3a00508327476c7fce26fbafef98f412707e511eb9d19a2ef467/debugpy-1.8.19-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:1e8c4d1bd230067bf1bbcdbd6032e5a57068638eb28b9153d008ecde288152af", size = 2537372, upload-time = "2025-12-15T21:53:57.318Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5e/cf4e4dc712a141e10d58405c58c8268554aec3c35c09cdcda7535ff13f76/debugpy-1.8.19-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:d40c016c1f538dbf1762936e3aeb43a89b965069d9f60f9e39d35d9d25e6b809", size = 4268729, upload-time = "2025-12-15T21:53:58.712Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a3/c91a087ab21f1047db328c1d3eb5d1ff0e52de9e74f9f6f6fa14cdd93d58/debugpy-1.8.19-cp314-cp314-win32.whl", hash = "sha256:0601708223fe1cd0e27c6cce67a899d92c7d68e73690211e6788a4b0e1903f5b", size = 5286388, upload-time = "2025-12-15T21:54:00.687Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b8/bfdc30b6e94f1eff09f2dc9cc1f9cd1c6cde3d996bcbd36ce2d9a4956e99/debugpy-1.8.19-cp314-cp314-win_amd64.whl", hash = "sha256:8e19a725f5d486f20e53a1dde2ab8bb2c9607c40c00a42ab646def962b41125f", size = 5327741, upload-time = "2025-12-15T21:54:02.148Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3e/e27078370414ef35fafad2c06d182110073daaeb5d3bf734b0b1eeefe452/debugpy-1.8.19-py2.py3-none-any.whl", hash = "sha256:360ffd231a780abbc414ba0f005dad409e71c78637efe8f2bd75837132a41d38", size = 5292321, upload-time = "2025-12-15T21:54:16.024Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1907,6 +1920,7 @@ dependencies = [
 dev = [
     { name = "boto3-stubs", extra = ["s3"] },
     { name = "coverage" },
+    { name = "debugpy" },
     { name = "fakeredis", extra = ["lua"] },
     { name = "freezegun" },
     { name = "locust" },
@@ -1990,6 +2004,7 @@ requires-dist = [
 dev = [
     { name = "boto3-stubs", extras = ["s3"], specifier = ">=1.38.30" },
     { name = "coverage", specifier = ">=7.6.0" },
+    { name = "debugpy", specifier = ">=1.8.19" },
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.26.1" },
     { name = "freezegun", specifier = ">=1.5.1" },
     { name = "locust", specifier = ">=2.20.0" },


### PR DESCRIPTION
## 📋 Summary

Enable debugging pytest tests directly in Zed editor using the debugpy adapter.

## 🎯 What

- Added `.zed/debug.json` with three pytest debugging configurations
- Added `debugpy` to backend dev dependencies

## 🤔 Why

Now that pytest tasks work in Zed (via `.zed/tasks.json`), developers need a way to debug tests interactively with breakpoints and variable inspection.

## 🔧 How

Three debug configurations are provided:
1. **pytest: Current Test File** - Debug the currently open test file
2. **pytest: Current Test (with target)** - Debug specific test class/method
3. **pytest: All Tests** - Debug entire test suite

Press F4 to start debugging or select from the debugger dropdown.

## 🧪 Testing

- [x] I have tested these changes locally (verified debugger can break on pytest tests)
- [x] All existing tests pass
- [x] No new tests needed (configuration change)

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation