### PR TITLE
Fix distinct id

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -54,13 +54,21 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
   const { resolvedTheme } = useTheme()
   const theme = _theme || (resolvedTheme as 'light' | 'dark')
   const posthog = usePostHog()
+
+  // Skip experiment tracking for embeds due to third-party cookie limitations
+  const experimentOptions = { trackExposure: !embed }
   const { isTreatment: isFormFirstLayout } = useExperiment(
     'checkout_form_first',
+    experimentOptions,
   )
   const { isTreatment: isSubscribeNow } = useExperiment(
     'checkout_button_subscribe',
+    experimentOptions,
   )
-  const { isTreatment: isPayNow } = useExperiment('checkout_button_pay')
+  const { isTreatment: isPayNow } = useExperiment(
+    'checkout_button_pay',
+    experimentOptions,
+  )
 
   const themePreset = getThemePreset(checkout.organization.slug, theme)
 

--- a/clients/apps/web/src/experiments/distinct-id.ts
+++ b/clients/apps/web/src/experiments/distinct-id.ts
@@ -1,23 +1,32 @@
 import { nanoid } from 'nanoid'
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 
 const DISTINCT_ID_COOKIE = 'polar_distinct_id'
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 
 export async function getDistinctId(): Promise<string> {
-  const cookieStore = await cookies()
-  const existingId = cookieStore.get(DISTINCT_ID_COOKIE)?.value
-
-  if (existingId) {
-    return existingId
+  const headerStore = await headers()
+  const headerDistinctId = headerStore.get('x-polar-distinct-id')
+  if (headerDistinctId) {
+    return headerDistinctId
   }
 
-  const newId = `anon_${nanoid()}`
+  const cookieStore = await cookies()
+  const cookieDistinctId = cookieStore.get(DISTINCT_ID_COOKIE)?.value
+  if (cookieDistinctId) {
+    return cookieDistinctId
+  }
 
-  return newId
+  return `anon_fallback_${nanoid()}`
 }
 
 export async function getExistingDistinctId(): Promise<string | undefined> {
+  const headerStore = await headers()
+  const headerDistinctId = headerStore.get('x-polar-distinct-id')
+  if (headerDistinctId) {
+    return headerDistinctId
+  }
+
   const cookieStore = await cookies()
   return cookieStore.get(DISTINCT_ID_COOKIE)?.value
 }


### PR DESCRIPTION
This PR fixes some inconsistencies on how we set `distinct_id` (used for A/B tests).  On first visit, middleware and getDistinctId() both generated different IDs because:

- Middleware sets cookie in response
- getDistinctId() reads from request (cookie not there yet)

This PR fixes that by using the same distinct_id is now used for:
- Server-side /opened call
- PostHog bootstrap
- Experiment exposure events
- checkout:complete events