### PR TITLE
Add PostHog to worker

### DIFF
--- a/server/polar/worker/run.py
+++ b/server/polar/worker/run.py
@@ -1,11 +1,13 @@
 from polar import tasks
 from polar.logfire import configure_logfire
 from polar.logging import configure as configure_logging
+from polar.posthog import configure_posthog
 from polar.sentry import configure_sentry
 from polar.worker import broker
 
 configure_sentry()
 configure_logfire("worker")
 configure_logging(logfire=True)
+configure_posthog()
 
 __all__ = ["broker", "tasks"]


### PR DESCRIPTION
In https://github.com/polarsource/polar/pull/9071 I moved the `storefront:subscriptions:checkout:open` and `storefront:subscriptions:checkout:complete` from the client to the server for more reliable data.

After shipping however I noticed that we are sending `checkout:open` like normal, but we are not sending any `checkout:complete` events at all from here: https://github.com/polarsource/polar/blob/main/server/polar/checkout/service.py#L1285-L1294

This is because PostHog is not configured in our worker.