### PR TITLE
server/webhook: switch back task name to webhook_event.send

### DIFF
--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -273,7 +273,7 @@ class WebhookService:
         if event is None:
             raise ResourceNotFound()
 
-        enqueue_job("webhook_event.send.v2", webhook_event_id=event.id, redeliver=True)
+        enqueue_job("webhook_event.send", webhook_event_id=event.id, redeliver=True)
 
     async def on_event_success(self, session: AsyncSession, id: UUID) -> None:
         """
@@ -725,7 +725,7 @@ class WebhookService:
                 session.add(event_type)
                 events.append(event_type)
                 await session.flush()
-                enqueue_job("webhook_event.send.v2", webhook_event_id=event_type.id)
+                enqueue_job("webhook_event.send", webhook_event_id=event_type.id)
             except UnsupportedTarget as e:
                 # Log the error but do not raise to not fail the whole request
                 log.error(e.message)

--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -33,7 +33,7 @@ log: Logger = structlog.get_logger()
 @actor(
     actor_name="webhook_event.send",
     max_retries=settings.WEBHOOK_MAX_RETRIES,
-    priority=TaskPriority.MEDIUM,
+    queue_name=TaskQueue.WEBHOOKS,
 )
 async def webhook_event_send(webhook_event_id: UUID, redeliver: bool = False) -> None:
     async with AsyncSessionMaker() as session:

--- a/server/scripts/webhook_trigger.py
+++ b/server/scripts/webhook_trigger.py
@@ -83,9 +83,7 @@ async def webhook_trigger(newer_than: datetime) -> None:
                 task = progress.add_task("[green]Processing...", total=count)
                 async for event in events:
                     event_id = event._tuple()[0]
-                    manager.enqueue_job(
-                        "webhook_event.send.v2", webhook_event_id=event_id
-                    )
+                    manager.enqueue_job("webhook_event.send", webhook_event_id=event_id)
                     progress.advance(task)
 
 

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -56,7 +56,7 @@ async def test_webhook_send(
     assert event.webhook_endpoint == endpoint
 
     enqueue_job_mock.assert_called_once_with(
-        "webhook_event.send.v2", webhook_event_id=event.id
+        "webhook_event.send", webhook_event_id=event.id
     )
 
 


### PR DESCRIPTION
- server/webhook: switch back task name to webhook_event.send