### PR TITLE
meter: Allow summing distinct counts per day

### DIFF
--- a/server/polar/meter/aggregation.py
+++ b/server/polar/meter/aggregation.py
@@ -61,6 +61,9 @@ class CountAggregation(BaseModel):
         """
         return True
 
+    def get_running_total_sql_function(self) -> AggregationFunction:
+        return AggregationFunction.sum
+
     def matches(self, event: Event) -> bool:
         return True
 
@@ -105,6 +108,11 @@ class PropertyAggregation(BaseModel):
         """
         return self.func == AggregationFunction.sum
 
+    def get_running_total_sql_function(self) -> AggregationFunction:
+        if self.is_summable():
+            return AggregationFunction.sum
+        return self.func
+
     def matches(self, event: Event) -> bool:
         if self.property in ("name", "source", "timestamp"):
             return True
@@ -130,6 +138,9 @@ class UniqueAggregation(BaseModel):
         could appear in multiple groups).
         """
         return False
+
+    def get_running_total_sql_function(self) -> AggregationFunction:
+        return AggregationFunction.sum
 
     def matches(self, event: Event) -> bool:
         return True

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -342,16 +342,9 @@ class MeterService:
         day_column = interval.sql_date_trunc(Event.timestamp)
         truncated_timestamp = interval.sql_date_trunc(timestamp_column)
 
-        # Determine the appropriate SQL function for the running total calculation.
-        # For summable aggregations (count, sum), we can sum the daily values.
-        # For non-summable aggregations (max, min), we must use the same aggregation
-        # function to get the correct total (e.g., max of daily maxes = overall max).
-        # Note: avg and unique require special handling that's not implemented here -
-        # avg would need weighted averages, unique would need to avoid double counting.
-        if meter.aggregation.is_summable():
-            total_agg_func = AggregationFunction.sum.get_sql_function
-        else:
-            total_agg_func = meter.aggregation.func.get_sql_function
+        total_agg_func = (
+            meter.aggregation.get_running_total_sql_function().get_sql_function
+        )
 
         if customer_aggregation_function is not None:
             daily_metrics = cte(


### PR DESCRIPTION
Fix #9185

Since DISTINCT is not implemented for window functions, we need to handle the unique function for daily windows.

  - is_summable() → "can I sum this across customer/price groups?" (used in billing_entry and customer_meter)
  - get_running_total_sql_function() → "what SQL function accumulates daily values over time in a window?" (used in meter/service.py)
