### PR TITLE
feat: add customer type field migration

### DIFF
--- a/server/migrations/versions/2026-01-26_add_customer_type_field.py
+++ b/server/migrations/versions/2026-01-26_add_customer_type_field.py
@@ -1,0 +1,39 @@
+"""Add customer type field
+
+Revision ID: 0d22a3046589
+Revises: 7a8b9c0d1e2f
+Create Date: 2026-01-26
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0d22a3046589"
+down_revision = "7a8b9c0d1e2f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Add type column as nullable
+    op.add_column(
+        "customers",
+        sa.Column("type", sa.String(), nullable=True),
+    )
+
+    # Set all existing customers to 'individual' by default
+    op.execute("UPDATE customers SET type = 'individual' WHERE type IS NULL")
+
+    # Make the column non-nullable
+    op.alter_column(
+        "customers",
+        "type",
+        existing_type=sa.String(),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("customers", "type")

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -57,6 +57,11 @@ def short_id_to_base26(short_id: int) -> str:
     return result.rjust(8, "A")
 
 
+class CustomerType(StrEnum):
+    individual = "individual"
+    team = "team"
+
+
 class CustomerOAuthPlatform(StrEnum):
     github = "github"
     discord = "discord"
@@ -137,6 +142,11 @@ class Customer(MetadataMixin, RecordModel):
     )
     email: Mapped[str] = mapped_column(String(320), nullable=False)
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    type: Mapped[CustomerType] = mapped_column(
+        String, nullable=False, default=CustomerType.individual
+    )
+
     stripe_customer_id: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None, unique=False
     )


### PR DESCRIPTION
## Summary

- Add database migration for `type` column on `customers` table
- Add `CustomerType` enum and `type` field to Customer model
- All existing customers default to `'individual'`
- Values: `'individual'` or `'team'`

**Part 1 of 2**: This PR adds migration + model. Schemas, services, and frontend changes will follow in a separate PR.

**Note**: Existing customers with seat-based subscriptions will be upgraded to `'team'` in a future migration.

## Test plan

- [ ] Run migration locally: `uv run alembic upgrade head`
- [ ] Run `uv run alembic check` (should pass)
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)