### PR TITLE
feat: add customer type field code changes

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -34,8 +34,10 @@ import {
   TabsTrigger,
 } from '@polar-sh/ui/components/atoms/Tabs'
 import { formatCurrencyAndAmount } from '@polar-sh/ui/lib/money'
+import { Status } from '@polar-sh/ui/components/atoms/Status'
 import Link from 'next/link'
 import React, { useMemo } from 'react'
+import { twMerge } from 'tailwind-merge'
 import { benefitsDisplayNames } from '../Benefit/utils'
 import MetricChartBox from '../Metrics/MetricChartBox'
 import { DetailRow } from '../Shared/DetailRow'
@@ -494,6 +496,9 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
         <MembersSection
           customerId={customer.id}
           organizationId={organization.id}
+          customerType={
+            (customer as { type?: 'individual' | 'team' }).type
+          }
         />
 
         <ShadowBox className="flex flex-col gap-8">
@@ -504,6 +509,20 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
               <DetailRow label="External ID" value={customer.external_id} />
               <DetailRow label="Email" value={customer.email} />
               <DetailRow label="Name" value={customer.name} />
+              <DetailRow
+                label="Type"
+                value={
+                  <Status
+                    className={twMerge(
+                      customer.type === 'team'
+                        ? 'bg-purple-100 text-purple-600 dark:bg-purple-950 dark:text-purple-400'
+                        : 'bg-gray-100 text-gray-600 dark:bg-polar-700 dark:text-polar-400',
+                      'w-fit text-xs',
+                    )}
+                    status={customer.type === 'team' ? 'Team' : 'Individual'}
+                  />
+                }
+              />
               <DetailRow
                 label="Tax ID"
                 value={

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -26,11 +26,13 @@ const roleDisplayConfig = {
 interface MembersSectionProps {
   customerId: string
   organizationId: string
+  customerType?: 'individual' | 'team'
 }
 
 export const MembersSection = ({
   customerId,
   organizationId,
+  customerType,
 }: MembersSectionProps) => {
   const { data: organization } = useOrganization(
     organizationId,
@@ -38,9 +40,11 @@ export const MembersSection = ({
   )
   const { data: membersData, isLoading } = useMembers(customerId)
 
+  // Only show Members section for team customers when member model is enabled
   const isEnabled =
     organization?.feature_settings?.member_model_enabled &&
-    organization?.feature_settings?.seat_based_pricing_enabled
+    organization?.feature_settings?.seat_based_pricing_enabled &&
+    customerType === 'team'
 
   const members = useMemo(
     () => membersData?.pages.flatMap((page) => page.items) ?? [],

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -22,6 +22,7 @@ from polar.kit.schemas import (
     TimestampedSchema,
 )
 from polar.member import Member, OwnerCreate
+from polar.models.customer import CustomerType
 from polar.organization.schemas import OrganizationID
 from polar.tax.tax_id import TaxID
 
@@ -61,6 +62,15 @@ class CustomerCreate(MetadataInputMixin, Schema):
     name: CustomerNameInput | None = None
     billing_address: AddressInput | None = None
     tax_id: TaxID | None = None
+    type: CustomerType | None = Field(
+        default=None,
+        description=(
+            "The type of customer. "
+            "Defaults to 'individual'. "
+            "Set to 'team' for customers that can have multiple members."
+        ),
+        examples=["individual"],
+    )
     organization_id: OrganizationID | None = Field(
         default=None,
         description=(
@@ -93,6 +103,14 @@ class CustomerUpdate(CustomerUpdateBase):
         description=_external_id_description,
         examples=[_external_id_example],
     )
+    type: CustomerType | None = Field(
+        default=None,
+        description=(
+            "The customer type. "
+            "Can only be upgraded from 'individual' to 'team', never downgraded."
+        ),
+        examples=["team"],
+    )
 
 
 class CustomerUpdateExternalID(CustomerUpdateBase): ...
@@ -113,6 +131,13 @@ class CustomerBase(MetadataOutputMixin, TimestampedSchema, IDSchema):
             "the customer portal using their email address."
         ),
         examples=[True],
+    )
+    type: CustomerType = Field(
+        description=(
+            "The type of customer: 'individual' for single users, "
+            "'team' for customers with multiple members."
+        ),
+        examples=["individual"],
     )
     name: str | None = Field(description=_name_description, examples=[_name_example])
     billing_address: Address | None


### PR DESCRIPTION
## Summary

- Add `type` to API schemas for create/update/read
- Prevent downgrade from `'team'` to `'individual'`
- Auto-upgrade customer to `'team'` when assigning seats
- Limit individual customers to 1 member (the owner)
- Show Members section only for `'team'` customers in UI
- Display customer type badge in Customer Details

**Part 2 of 2**: This PR adds schemas, services, and frontend. Requires migration + model from PR #9191 to be merged first.

Closes #8942

## Test plan

- [ ] Run backend tests: `uv run task test`
- [ ] Run frontend build: `cd clients && pnpm build`
- [ ] Manual testing:
  - Create customer -> verify `type = "individual"`
  - Assign seat -> verify auto-upgrade to `"team"`
  - Try downgrade -> verify error
  - Check Members tab visibility for both types

🤖 Generated with [Claude Code](https://claude.com/claude-code)