### PR TITLE
tinybird: Handle data denormalization

### DIFF
--- a/server/polar/integrations/tinybird/service.py
+++ b/server/polar/integrations/tinybird/service.py
@@ -1,11 +1,14 @@
 import json
 from collections.abc import Sequence
+from functools import partial
+from typing import Any
 
 import structlog
 
 from polar.config import settings
 from polar.logging import Logger
 from polar.models import Event
+from polar.models.event import EventSource
 
 from .client import client
 from .schemas import TinybirdEvent
@@ -15,10 +18,17 @@ log: Logger = structlog.get_logger()
 DATASOURCE_EVENTS = "events_by_ingested_at"
 
 
+def _pop_system_metadata(m: dict[str, Any], is_system: bool, key: str) -> Any:
+    return m.pop(key, None) if is_system else None
+
+
 def _event_to_tinybird(event: Event) -> TinybirdEvent:
     m = dict(event.user_metadata or {})
     cost = m.pop("_cost", None) or {}
     llm = m.pop("_llm", None) or {}
+
+    is_system = event.source == EventSource.system
+    pop = partial(_pop_system_metadata, m, is_system)
 
     return TinybirdEvent(
         id=str(event.id),
@@ -33,53 +43,53 @@ def _event_to_tinybird(event: Event) -> TinybirdEvent:
         parent_id=str(event.parent_id) if event.parent_id else None,
         root_id=str(event.root_id) if event.root_id else None,
         event_type_id=str(event.event_type_id) if event.event_type_id else None,
-        meter_id=m.pop("meter_id", None),
-        units=m.pop("units", None),
-        rollover=m.pop("rollover", None),
-        product_id=m.pop("product_id", None),
-        subscription_id=m.pop("subscription_id", None),
-        order_id=m.pop("order_id", None),
-        benefit_id=m.pop("benefit_id", None),
-        benefit_grant_id=m.pop("benefit_grant_id", None),
-        checkout_id=m.pop("checkout_id", None),
-        transaction_id=m.pop("transaction_id", None),
-        refund_id=m.pop("refund_id", None),
-        dispute_id=m.pop("dispute_id", None),
-        discount_id=m.pop("discount_id", None),
-        amount=m.pop("amount", None),
-        currency=m.pop("currency", None),
-        net_amount=m.pop("net_amount", None),
-        tax_amount=m.pop("tax_amount", None),
-        discount_amount=m.pop("discount_amount", None),
-        applied_balance_amount=m.pop("applied_balance_amount", None),
-        platform_fee=m.pop("platform_fee", None),
-        fee=m.pop("fee", None),
-        refunded_amount=m.pop("refunded_amount", None),
-        refundable_amount=m.pop("refundable_amount", None),
-        presentment_amount=m.pop("presentment_amount", None),
-        presentment_currency=m.pop("presentment_currency", None),
-        recurring_interval=m.pop("recurring_interval", None),
-        recurring_interval_count=m.pop("recurring_interval_count", None),
-        old_product_id=m.pop("old_product_id", None),
-        new_product_id=m.pop("new_product_id", None),
-        old_seats=m.pop("old_seats", None),
-        new_seats=m.pop("new_seats", None),
-        started_at=m.pop("started_at", None),
-        canceled_at=m.pop("canceled_at", None),
-        ends_at=m.pop("ends_at", None),
-        old_period_end=m.pop("old_period_end", None),
-        new_period_end=m.pop("new_period_end", None),
-        cancel_at_period_end=m.pop("cancel_at_period_end", None),
-        customer_cancellation_reason=m.pop("customer_cancellation_reason", None),
-        customer_cancellation_comment=m.pop("customer_cancellation_comment", None),
-        proration_behavior=m.pop("proration_behavior", None),
-        benefit_type=m.pop("benefit_type", None),
-        billing_type=m.pop("billing_type", None),
-        checkout_status=m.pop("checkout_status", None),
-        customer_email=m.pop("customer_email", None),
-        customer_name=m.pop("customer_name", None),
-        tax_state=m.pop("tax_state", None),
-        tax_country=m.pop("tax_country", None),
+        meter_id=pop("meter_id"),
+        units=pop("units"),
+        rollover=pop("rollover"),
+        product_id=pop("product_id"),
+        subscription_id=pop("subscription_id"),
+        order_id=pop("order_id"),
+        benefit_id=pop("benefit_id"),
+        benefit_grant_id=pop("benefit_grant_id"),
+        checkout_id=pop("checkout_id"),
+        transaction_id=pop("transaction_id"),
+        refund_id=pop("refund_id"),
+        dispute_id=pop("dispute_id"),
+        discount_id=pop("discount_id"),
+        amount=pop("amount"),
+        currency=pop("currency"),
+        net_amount=pop("net_amount"),
+        tax_amount=pop("tax_amount"),
+        discount_amount=pop("discount_amount"),
+        applied_balance_amount=pop("applied_balance_amount"),
+        platform_fee=pop("platform_fee"),
+        fee=pop("fee"),
+        refunded_amount=pop("refunded_amount"),
+        refundable_amount=pop("refundable_amount"),
+        presentment_amount=pop("presentment_amount"),
+        presentment_currency=pop("presentment_currency"),
+        recurring_interval=pop("recurring_interval"),
+        recurring_interval_count=pop("recurring_interval_count"),
+        old_product_id=pop("old_product_id"),
+        new_product_id=pop("new_product_id"),
+        old_seats=pop("old_seats"),
+        new_seats=pop("new_seats"),
+        started_at=pop("started_at"),
+        canceled_at=pop("canceled_at"),
+        ends_at=pop("ends_at"),
+        old_period_end=pop("old_period_end"),
+        new_period_end=pop("new_period_end"),
+        cancel_at_period_end=pop("cancel_at_period_end"),
+        customer_cancellation_reason=pop("customer_cancellation_reason"),
+        customer_cancellation_comment=pop("customer_cancellation_comment"),
+        proration_behavior=pop("proration_behavior"),
+        benefit_type=pop("benefit_type"),
+        billing_type=pop("billing_type"),
+        checkout_status=pop("checkout_status"),
+        customer_email=pop("customer_email"),
+        customer_name=pop("customer_name"),
+        tax_state=pop("tax_state"),
+        tax_country=pop("tax_country"),
         cost_amount=cost.get("amount"),
         cost_currency=cost.get("currency"),
         llm_vendor=llm.get("vendor"),


### PR DESCRIPTION
We dont want to extract values from the user_metadata from user events, only for the system events. Otherwise we can't guarantee the data type of the fields.
