### PR TITLE
Add onboarding experiment setup

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/onboarding/product/ProductPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/onboarding/product/ProductPage.tsx
@@ -8,6 +8,7 @@ import { FadeUp } from '@/components/Animated/FadeUp'
 import LogoIcon from '@/components/Brand/LogoIcon'
 import { AssistantStep } from '@/components/Onboarding/AssistantStep'
 import { ProductStep } from '@/components/Onboarding/ProductStep'
+import { useOnboardingTracking } from '@/hooks/onboarding'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import { twMerge } from 'tailwind-merge'
 
@@ -17,6 +18,7 @@ export default function ClientPage({
   isAssistantEnabled: boolean
 }) {
   const { organization, organizations } = useContext(OrganizationContext)
+  const { trackStepSkipped } = useOnboardingTracking()
   const [mode, setMode] = useState<'assistant' | 'manual'>(
     isAssistantEnabled ? 'assistant' : 'manual',
   )
@@ -96,6 +98,7 @@ export default function ClientPage({
             <Link
               href={`/dashboard/${organization.slug}`}
               className="dark:hover:text-polar-500 dark:hover:bg-polar-700 rounded-full px-2.5 py-1 transition-colors duration-100 hover:bg-gray-100 hover:text-gray-500"
+              onClick={() => trackStepSkipped('product', organization.id)}
             >
               Skip onboarding
             </Link>

--- a/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
@@ -1,10 +1,12 @@
+import { useOnboardingTracking } from '@/hooks'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { Tabs, TabsList, TabsTrigger } from '@polar-sh/ui/components/atoms/Tabs'
 import Link from 'next/link'
-import { useContext, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import slugify from 'slugify'
 import { twMerge } from 'tailwind-merge'
 import LogoIcon from '../Brand/LogoIcon'
@@ -150,6 +152,25 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
   const [packageManager, setPackageManager] = useState<PackageManager>('pnpm')
 
   const { organization } = useContext(OrganizationContext)
+  const router = useRouter()
+  const { trackStepStarted, trackStepCompleted, trackCompleted, getSession } =
+    useOnboardingTracking()
+
+  useEffect(() => {
+    const session = getSession()
+    if (session) {
+      trackStepStarted('integrate', organization.id)
+    }
+  }, [organization.id, getSession, trackStepStarted])
+
+  const handleGoToDashboard = async () => {
+    const session = getSession()
+    if (session) {
+      await trackStepCompleted('integrate', organization.id)
+      await trackCompleted(organization.id)
+    }
+    router.push(`/dashboard/${organization.slug}`)
+  }
 
   const parsedFrameworks = useMemo(() => frameworks(products), [products])
 
@@ -209,11 +230,9 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
                 <ArrowOutwardOutlined className="ml-2" fontSize="small" />
               </Button>
             </Link>
-            <Link href={`/dashboard/${organization.slug}`} className="w-full">
-              <Button size="lg" fullWidth>
-                Go to Dashboard
-              </Button>
-            </Link>
+            <Button size="lg" fullWidth onClick={handleGoToDashboard}>
+              Go to Dashboard
+            </Button>
           </div>
         </div>
       </div>

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -13,4 +13,9 @@ export const experiments = {
     variants: ['control', 'treatment'] as const,
     defaultVariant: 'control',
   },
+  onboarding_flow_v1: {
+    description: 'Test onboarding flow variations',
+    variants: ['control', 'treatment'] as const,
+    defaultVariant: 'control',
+  },
 } as const

--- a/clients/apps/web/src/hooks/index.ts
+++ b/clients/apps/web/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './auth'
 export * from './oauth-accounts'
+export * from './onboarding'
 export * from './upsell'

--- a/clients/apps/web/src/hooks/onboarding.ts
+++ b/clients/apps/web/src/hooks/onboarding.ts
@@ -1,0 +1,234 @@
+'use client'
+
+import { useExperiment } from '@/experiments/client'
+import { schemas } from '@polar-sh/client'
+import { usePostHog } from 'posthog-js/react'
+import { useCallback, useMemo } from 'react'
+
+const ONBOARDING_COOKIE_NAME = 'polar_onboarding_session'
+const SESSION_TIMEOUT_HOURS = 24
+
+export type OnboardingStep = 'org' | 'product' | 'integrate'
+export type SignupMethod = 'github' | 'google' | 'email'
+
+export const inferSignupMethod = (
+  oauthAccounts?: schemas['OAuthAccountRead'][],
+): SignupMethod => {
+  if (!oauthAccounts || oauthAccounts.length === 0) {
+    return 'email'
+  }
+
+  if (oauthAccounts.some((account) => account.platform === 'github')) {
+    return 'github'
+  }
+
+  if (oauthAccounts.some((account) => account.platform === 'google')) {
+    return 'google'
+  }
+
+  return 'email'
+}
+
+export interface OnboardingSessionState {
+  session_id: string
+  started_at: string
+  current_step: OnboardingStep
+  steps_completed: number
+  signup_method: SignupMethod
+  experiment_variant?: string | null
+}
+
+const getOnboardingSession = (): OnboardingSessionState | null => {
+  if (typeof document === 'undefined') return null
+
+  const cookieValue = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${ONBOARDING_COOKIE_NAME}=`))
+    ?.split('=')[1]
+
+  if (!cookieValue) return null
+
+  try {
+    return JSON.parse(decodeURIComponent(cookieValue))
+  } catch {
+    return null
+  }
+}
+
+const setOnboardingSession = (session: OnboardingSessionState): void => {
+  if (typeof document === 'undefined') return
+
+  const maxAge = SESSION_TIMEOUT_HOURS * 60 * 60
+  const encoded = encodeURIComponent(JSON.stringify(session))
+  document.cookie = `${ONBOARDING_COOKIE_NAME}=${encoded}; max-age=${maxAge}; path=/; SameSite=Lax`
+}
+
+const clearOnboardingSession = (): void => {
+  if (typeof document === 'undefined') return
+  document.cookie = `${ONBOARDING_COOKIE_NAME}=; max-age=0; path=/`
+}
+
+interface UseOnboardingTrackingReturn {
+  startOnboarding: (signupMethod: SignupMethod) => OnboardingSessionState | null
+  trackStepStarted: (step: OnboardingStep, organizationId?: string) => void
+  trackStepCompleted: (step: OnboardingStep, organizationId?: string) => void
+  trackStepSkipped: (step: OnboardingStep, organizationId?: string) => void
+  trackCompleted: (organizationId: string) => void
+  getSession: () => OnboardingSessionState | null
+  clearSession: () => void
+  experimentVariant: string
+}
+
+export const useOnboardingTracking = (): UseOnboardingTrackingReturn => {
+  const posthog = usePostHog()
+
+  const { variant: experimentVariant } = useExperiment('onboarding_flow_v1', {
+    trackExposure: false,
+  })
+
+  const captureEvent = useCallback(
+    (
+      event: string,
+      properties: Record<string, string | number | null | undefined>,
+    ) => {
+      posthog?.capture(event, properties)
+    },
+    [posthog],
+  )
+
+  const startOnboarding = useCallback(
+    (signupMethod: SignupMethod): OnboardingSessionState | null => {
+      const existingSession = getOnboardingSession()
+
+      if (existingSession) {
+        return existingSession
+      }
+
+      const sessionId = crypto.randomUUID()
+      const startedAt = new Date().toISOString()
+
+      posthog?.capture('$feature_flag_called', {
+        $feature_flag: 'onboarding_flow_v1',
+        $feature_flag_response: experimentVariant,
+      })
+
+      captureEvent('dashboard:onboarding:started', {
+        onboarding_session_id: sessionId,
+        signup_method: signupMethod,
+        '$feature/onboarding_flow_v1': experimentVariant,
+      })
+
+      const session: OnboardingSessionState = {
+        session_id: sessionId,
+        started_at: startedAt,
+        current_step: 'org',
+        steps_completed: 0,
+        signup_method: signupMethod,
+        experiment_variant: experimentVariant,
+      }
+
+      setOnboardingSession(session)
+      return session
+    },
+    [posthog, experimentVariant, captureEvent],
+  )
+
+  const trackStepStarted = useCallback(
+    (step: OnboardingStep, organizationId?: string): void => {
+      const session = getOnboardingSession()
+      if (!session || session.current_step === step) return
+
+      captureEvent(`dashboard:onboarding:step:${step}:started`, {
+        onboarding_session_id: session.session_id,
+        step,
+        organization_id: organizationId,
+        experiment_variant: session.experiment_variant,
+      })
+
+      setOnboardingSession({ ...session, current_step: step })
+    },
+    [captureEvent],
+  )
+
+  const trackStepCompleted = useCallback(
+    (step: OnboardingStep, organizationId?: string): void => {
+      const session = getOnboardingSession()
+      if (!session) return
+
+      captureEvent(`dashboard:onboarding:step:${step}:completed`, {
+        onboarding_session_id: session.session_id,
+        step,
+        organization_id: organizationId,
+        experiment_variant: session.experiment_variant,
+      })
+
+      setOnboardingSession({
+        ...session,
+        steps_completed: session.steps_completed + 1,
+      })
+    },
+    [captureEvent],
+  )
+
+  const trackStepSkipped = useCallback(
+    (step: OnboardingStep, organizationId?: string): void => {
+      const session = getOnboardingSession()
+      if (!session) return
+
+      captureEvent(`dashboard:onboarding:step:${step}:skipped`, {
+        onboarding_session_id: session.session_id,
+        step,
+        organization_id: organizationId,
+        experiment_variant: session.experiment_variant,
+      })
+    },
+    [captureEvent],
+  )
+
+  const trackCompleted = useCallback(
+    (organizationId: string): void => {
+      const session = getOnboardingSession()
+      if (!session) return
+
+      captureEvent('dashboard:onboarding:completed', {
+        onboarding_session_id: session.session_id,
+        organization_id: organizationId,
+        experiment_variant: session.experiment_variant,
+      })
+
+      clearOnboardingSession()
+    },
+    [captureEvent],
+  )
+
+  const getSession = useCallback((): OnboardingSessionState | null => {
+    return getOnboardingSession()
+  }, [])
+
+  const clearSession = useCallback((): void => {
+    clearOnboardingSession()
+  }, [])
+
+  return useMemo(
+    () => ({
+      startOnboarding,
+      trackStepStarted,
+      trackStepCompleted,
+      trackStepSkipped,
+      trackCompleted,
+      getSession,
+      clearSession,
+      experimentVariant,
+    }),
+    [
+      startOnboarding,
+      trackStepStarted,
+      trackStepCompleted,
+      trackStepSkipped,
+      trackCompleted,
+      getSession,
+      clearSession,
+      experimentVariant,
+    ],
+  )
+}


### PR DESCRIPTION
Add the foundation for experimentation in the onboarding flow, as well as a very simple A/B test to validate the setup. The A/B tests changes the button copy on the org creation page to either be `Continue` or `Create`.