### PR TITLE
fix: allow meter name update in UI after first event ingestion

### DIFF
--- a/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
+++ b/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
@@ -37,13 +37,8 @@ export const MeterUpdateModal = ({
 
   const onSubmit = useCallback(
     async (body: schemas['MeterUpdate']) => {
-      const allowedBody: schemas['MeterUpdate'] = hasProcessedEvents
-        ? {
-            name: body.name,
-          }
-        : body
-
-      const { data: meter, error } = await updateMeter.mutateAsync(allowedBody)
+      // Let the backend validate which fields can be updated
+      const { data: meter, error } = await updateMeter.mutateAsync(body)
 
       if (error) {
         if (isValidationError(error.detail)) {
@@ -62,7 +57,7 @@ export const MeterUpdateModal = ({
 
       hide()
     },
-    [router, hasProcessedEvents, updateMeter, hide, toast, setError],
+    [router, updateMeter, hide, toast, setError],
   )
 
   if (!meter) return null


### PR DESCRIPTION
<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

Fixes [#6490](https://github.com/polarsource/polar/issues/6490) 

<!-- Brief description of what this PR does -->

## 🎯 What

The backend already allows name updates when a meter has processed events (only `filter` and `aggregation` are protected in `meter/service.py`). The bug was in the frontend: the update modal was restricting the PATCH body to `{ name }` when `hasProcessedEvents` was true.

## 🤔 Why

Users could not rename meters after events were ingested. 

## 🔧 How

<!-- Describe the approach you took to implement the changes -->

## 🧪 Testing

<!-- Check all that apply -->

- [x] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Setup: Create a meter and ingest events 
2. UI: Update meter name

## 🖼️ Screenshots/Recordings
[Screencast from 28-01-26 07:41:42 PM IST.webm](https://github.com/user-attachments/assets/868f5f9b-5c73-4ffa-8a32-43d1191da127)


## 📝 Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
