### PR TITLE
Fix Docker web container OOM kills

### DIFF
--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -195,8 +195,8 @@ services:
       dockerfile: dev/docker/Dockerfile.web.dev
     env_file: *common-env-file
     environment:
-      # Node memory limit to prevent OOM
-      NODE_OPTIONS: "--max-old-space-size=3072"
+      # Node memory limit to prevent OOM (keep well below container limit to leave room for native memory)
+      NODE_OPTIONS: "--max-old-space-size=2560"
       # NEXT_PUBLIC_* are for browser requests (via host machine)
       NEXT_PUBLIC_API_URL: http://localhost:${API_PORT:-8000}
       NEXT_PUBLIC_FRONTEND_BASE_URL: http://localhost:${WEB_PORT:-3000}
@@ -222,7 +222,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 6G
 
   # ============================================
   # Optional Services (use --profile flag)

--- a/dev/docker/scripts/startup-web.sh
+++ b/dev/docker/scripts/startup-web.sh
@@ -43,8 +43,8 @@ case "${1:-dev}" in
         echo "Starting Next.js development server..."
         echo "Web will be available at http://localhost:3000"
         echo ""
-        echo "NOTE: Next.js with Turbopack requires significant memory (~4GB)."
-        echo "If the container crashes, increase Docker Desktop memory to 10GB+."
+        echo "NOTE: Next.js with Turbopack requires significant memory (~6GB)."
+        echo "If the container crashes, increase Docker Desktop memory to 12GB+."
         echo ""
         cd apps/web
         exec pnpm next dev --port 3000 --hostname 0.0.0.0


### PR DESCRIPTION
## 📋 Summary

Fixes OOM kills of the Next.js web container by rebalancing memory allocation between the Node.js heap and native memory.

## 🎯 What

- Increased container memory limit from 4GB to 6GB
- Reduced Node heap limit from 3072MB to 2560MB
- Updated startup messages to reflect new requirements

## 🤔 Why

The previous configuration allocated 3GB of the 4GB container limit to the Node heap, leaving only 1GB for native memory (SWC compiler, file watchers, buffers, etc.). This caused frequent OOM kills during Next.js development. The new config maintains the V8 heap at 2.5GB but gives proper headroom for native memory operations.

## ✅ Testing

- Developers can test by running `docker compose -f dev/docker/docker-compose.dev.yml up web` and verifying the container no longer crashes during development
- The startup message now correctly reports the new memory requirements