### PR TITLE
Catch all validation errors from the BE when creating checkout links

### DIFF
--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkForm.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkForm.tsx
@@ -5,7 +5,10 @@ import {
   useSelectedProducts,
   useUpdateCheckoutLink,
 } from '@/hooks/queries'
-import { setValidationErrors } from '@/utils/api/errors'
+import {
+  normalizeValidationErrors,
+  setValidationErrors,
+} from '@/utils/api/errors'
 import { getDiscountDisplay } from '@/utils/discount'
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
 import { isValidationError, schemas } from '@polar-sh/client'
@@ -128,16 +131,21 @@ export const CheckoutLinkForm = ({
 
   const handleValidationError = useCallback(
     (data: CheckoutLinkCreateForm, errors: schemas['ValidationError'][]) => {
-      const discriminators = ['CheckoutLinkCreateProducts']
+      const discriminators = [
+        'CheckoutLinkCreateProducts',
+        'RequestValidationError',
+      ]
+
+      const normalizedErrors = normalizeValidationErrors(errors)
       const filteredErrors = checkoutLink
-        ? errors
-        : errors.filter((error) =>
+        ? normalizedErrors
+        : normalizedErrors.filter((error) =>
             discriminators.includes(error.loc[1] as string),
           )
       setValidationErrors(filteredErrors, setError, 1, discriminators)
       filteredErrors.forEach((error) => {
         let loc = error.loc.slice(1)
-        if (discriminators.includes(loc[0] as string)) {
+        if (loc.length > 0 && discriminators.includes(loc[0] as string)) {
           loc = loc.slice(1)
         }
         if (loc[0] === 'metadata') {
@@ -429,7 +437,7 @@ export const CheckoutLinkForm = ({
                     control={control}
                     name={`metadata.${index}.key`}
                     render={({ field }) => (
-                      <>
+                      <div className="flex flex-1 flex-col gap-y-1">
                         <FormControl>
                           <Input
                             {...field}
@@ -438,14 +446,14 @@ export const CheckoutLinkForm = ({
                           />
                         </FormControl>
                         <FormMessage />
-                      </>
+                      </div>
                     )}
                   />
                   <FormField
                     control={control}
                     name={`metadata.${index}.value`}
                     render={({ field }) => (
-                      <>
+                      <div className="flex flex-1 flex-col gap-y-1">
                         <FormControl>
                           <Input
                             {...field}
@@ -454,7 +462,7 @@ export const CheckoutLinkForm = ({
                           />
                         </FormControl>
                         <FormMessage />
-                      </>
+                      </div>
                     )}
                   />
                   <Button

--- a/clients/apps/web/src/utils/api/errors.ts
+++ b/clients/apps/web/src/utils/api/errors.ts
@@ -151,3 +151,20 @@ export const apiErrorToast = (
     return
   }
 }
+
+export const normalizeValidationErrors = (
+  errors: schemas['ValidationError'][],
+): schemas['ValidationError'][] =>
+  errors.map((error) => ({
+    ...error,
+    loc: error.loc.map((segment) => {
+      const s = String(segment)
+      if (s.startsWith('function-after[') || s.startsWith('function-before[')) {
+        const lastComma = s.lastIndexOf(',')
+        if (lastComma !== -1) {
+          return s.slice(lastComma + 1, -1).trim()
+        }
+      }
+      return segment
+    }),
+  }))


### PR DESCRIPTION
Currently you won't receive e.g a invalid link error when creating a checkout link, this PR fixes that by normalizing `function-after[...]` loc paths so errors are correctly mapped to their fields.

<img width="513" height="152" alt="Screenshot 2026-01-30 at 11 17 30" src="https://github.com/user-attachments/assets/ec74ffe6-c2b4-4c63-bfc5-c3787be79a89" />

It also fixes a UI issue where the meta section collapses on error:

<img width="511" height="232" alt="Screenshot 2026-01-30 at 12 24 43" src="https://github.com/user-attachments/assets/5ee5baa9-adde-4853-8542-223bff482a87" />

