### PR TITLE
Skip renewal emails for completely free subscriptions

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -79,7 +79,6 @@ from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.product.guard import (
     is_custom_price,
-    is_free_price,
     is_seat_price,
     is_static_price,
 )
@@ -1484,7 +1483,7 @@ class OrderService:
             subscription = order.subscription
             if subscription is not None:
                 is_free_product_price = all(
-                    is_free_price(spp.product_price)
+                    spp.product_price.is_free
                     for spp in subscription.subscription_product_prices
                 )
                 if is_free_product_price:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2216,6 +2216,11 @@ class SubscriptionService:
     async def send_renewal_reminder_email(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:
+        if all(
+            spp.product_price.is_free
+            for spp in subscription.subscription_product_prices
+        ):
+            return
         if subscription.current_period_end is None:
             return
         renewal_date = subscription.current_period_end.strftime("%m/%d/%Y")
@@ -2230,6 +2235,11 @@ class SubscriptionService:
     async def send_trial_conversion_reminder_email(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:
+        if all(
+            spp.product_price.is_free
+            for spp in subscription.subscription_product_prices
+        ):
+            return
         if subscription.trial_end is None:
             return
         conversion_date = subscription.trial_end.strftime("%m/%d/%Y")


### PR DESCRIPTION
Fixes #9287

Sending subscription renewals for free subscriptions is confusing for customers, especially if they've been 'invisibly' put on a free plan over API for easier entitlement management. Hiding it for everyone feels better than adding yet another toggle in the settings, in my opinion.

I decided to keep the `subscription_create` email for free subscriptions, customers may rely on that email to get access to their benefits. I think that's still a bit of a weird use case for the 'invisible free plan over API' use case, but then for now these merchants would have to disable the `subscription_create` email altogether, and implement their own communication. A fair trade-off, for now, I think.