### PR TITLE
Explicit Currency Symbol on Checkout

### DIFF
--- a/clients/packages/checkout/src/utils/money.ts
+++ b/clients/packages/checkout/src/utils/money.ts
@@ -7,6 +7,7 @@ export const formatCurrencyNumber = (
   const currencyNumberFormat = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency,
+    currencyDisplay: 'code',
     minimumFractionDigits,
     maximumFractionDigits,
   })


### PR DESCRIPTION
Due to us narrowing down to a simple symbol (like '$' when dealing with dollars) on checkouts, some customers (canadians, australians, and other people using variants of the dollar) gets a very poor experience.

Some customers think they're charged in their native currency, while in fact it's always USD.

This fix explicitly shows `USD 123.45` whenever we render currencies.