### PR TITLE
sdk/overlays: remove timezone enum parameter from /v1/meters/{id}/quantities

### DIFF
--- a/sdk/overlays/timezone_enum.yml
+++ b/sdk/overlays/timezone_enum.yml
@@ -5,3 +5,5 @@ info:
 actions:
   - target: "$.paths['/v1/metrics/'].get.parameters[?(@.name=='timezone')].schema.enum"
     remove: true
+  - target: "$.paths['/v1/meters/{id}/quantities'].get.parameters[?(@.name=='timezone')].schema.enum"
+    remove: true


### PR DESCRIPTION
- sdk/overlays: remove timezone enum parameter from /v1/meters/{id}/quantities