### PR TITLE
fix: exclude DONE threads from account review ticket checks

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -30,6 +30,7 @@ from plain_client import (
     EmailAddressInput,
     Plain,
     ThreadsFilter,
+    ThreadStatus,
     UpsertCustomerIdentifierInput,
     UpsertCustomerInput,
     UpsertCustomerOnCreateInput,
@@ -1414,7 +1415,10 @@ class PlainService:
             if not user:
                 log.warning("User not found", email=customer_email)
                 return False
-            filters = ThreadsFilter(customer_ids=[user.id])
+            filters = ThreadsFilter(
+                customer_ids=[user.id],
+                statuses=[ThreadStatus.TODO, ThreadStatus.SNOOZED],
+            )
             threads = await plain.threads(filters=filters)
             nr_threads = 0
             for edge in threads.edges:


### PR DESCRIPTION
## 📋 Summary

Fixes account review tickets not being created for organizations with previously resolved review threads.

## 🎯 What

Modified `check_thread_exists()` in the Plain integration to filter threads by status, excluding resolved (DONE) threads from the search. Now only checks for active TODO and SNOOZED threads.

## 🤔 Why

The batch script `create_review_tickets.py` was incorrectly skipping organizations that had old resolved review threads. It would find the DONE thread via fuzzy matching on "Account Review" and assume a ticket already existed, preventing creation of new "Ongoing Account Review" tickets for organizations needing re-review.

## 🔧 How

Added `ThreadStatus` import and updated the `ThreadsFilter` to explicitly filter for `[ThreadStatus.TODO, ThreadStatus.SNOOZED]`, matching the function's docstring which stated it "only considers threads that are not done/closed."

## 🧪 Testing

- This fixes the logic bug where DONE threads were being incorrectly included in existence checks
- The script can now be safely re-run to create missing tickets for affected organizations