### PR TITLE
balance-events: Handle held balance and refund reversal

### DIFF
--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -673,6 +673,15 @@ def build_system_event(
 ) -> Event: ...
 
 
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.balance_refund_reversal],
+    customer: Customer,
+    organization: Organization,
+    metadata: BalanceRefundMetadata,
+) -> Event: ...
+
+
 def build_system_event(
     name: SystemEvent,
     customer: Customer,


### PR DESCRIPTION
- Create the missing balance.refund_reversal event on refund reversal
- Handle to exclude held balance events in the backfill script