### PR TITLE
fix: add authorization check to get_seat()

### DIFF
--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -596,7 +596,8 @@ class SeatService:
     ) -> CustomerSeat | None:
         repository = CustomerSeatRepository.from_session(session)
 
-        seat = await repository.get_by_id(
+        seat = await repository.get_by_id_and_auth_subject(
+            auth_subject,
             seat_id,
             options=repository.get_eager_options(),
         )
@@ -611,12 +612,6 @@ class SeatService:
             organization_id = seat.order.organization.id
         else:
             return None
-
-        if isinstance(auth_subject.subject, Organization):
-            if organization_id != auth_subject.subject.id:
-                return None
-        elif isinstance(auth_subject.subject, User):
-            pass
 
         await self.check_seat_feature_enabled(session, organization_id)
         return seat


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Pre-existing authorization bypass identified during code review

Fixes a critical authorization bypass in the `get_seat()` method that allowed any authenticated user to view any seat by ID, regardless of organization membership.

## 🎯 What

- Replaced manual authorization logic in `get_seat()` with `repository.get_by_id_and_auth_subject()`
- Removed broken `elif isinstance(auth_subject.subject, User): pass` clause
- Updated tests: `test_get_seat_as_user` now requires org membership, added `test_get_seat_as_user_not_member` to verify denial

## 🤔 Why

The original code had an empty `pass` clause for User subjects, skipping any membership check. Users could access seats they didn't own via organization membership validation. The repository already had a proper auth-aware method.

## 🔧 How

Used existing `get_by_id_and_auth_subject()` which filters via `get_readable_statement()` that checks `UserOrganization` membership for User subjects, ensuring only org members can access seats.

## 🧪 Testing

- [x] All 6 existing tests pass (`TestGetSeat` class)
- [x] Added new test `test_get_seat_as_user_not_member` verifying unauthorized access is denied
- [x] Updated `test_get_seat_as_user` to require `user_organization_seat_enabled` fixture