### PR TITLE
event-types: Default tinybird shadow to true

### DIFF
--- a/server/polar/event_type/service.py
+++ b/server/polar/event_type/service.py
@@ -78,7 +78,7 @@ class EventTypeService:
         if org is None:
             return db_results, db_count
 
-        tinybird_shadow = org.feature_settings.get("tinybird_compare", False)
+        tinybird_shadow = org.feature_settings.get("tinybird_compare", True)
         tinybird_read = org.feature_settings.get("tinybird_read", False)
 
         try:
@@ -148,7 +148,7 @@ class EventTypeService:
             return None
 
         if org.feature_settings.get("tinybird_read", False) or org.feature_settings.get(
-            "tinybird_compare", False
+            "tinybird_compare", True
         ):
             return org
 

--- a/server/tests/event_type/test_service.py
+++ b/server/tests/event_type/test_service.py
@@ -62,7 +62,10 @@ class TestListWithStatsDualRead:
         save_fixture: SaveFixture,
     ) -> None:
         mocker.patch("polar.event_type.service.settings.TINYBIRD_EVENTS_READ", True)
-        organization.feature_settings = {"tinybird_read": False}
+        organization.feature_settings = {
+            "tinybird_read": False,
+            "tinybird_compare": False,
+        }
         await save_fixture(organization)
 
         event_type = await create_event_type(


### PR DESCRIPTION
If Tinybeard read is enabled in the service,
then we will always shadow-log unless
we have turned it off for the org.