### PR TITLE
Move visibility out of product info section

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductInfoSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductInfoSection.tsx
@@ -10,11 +10,6 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { Label } from '@polar-sh/ui/components/ui/label'
-import {
-  RadioGroup,
-  RadioGroupItem,
-} from '@polar-sh/ui/components/ui/radio-group'
 import { useFormContext } from 'react-hook-form'
 import { ProductFormType } from './ProductForm'
 
@@ -74,61 +69,6 @@ export const ProductInfoSection = ({
                   {...field}
                   value={field.value || ''}
                 />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={control}
-          name="visibility"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Visibility</FormLabel>
-              <FormControl>
-                <div className="@container">
-                  <RadioGroup
-                    value={field.value ?? 'public'}
-                    onValueChange={field.onChange}
-                    className="grid-cols-1 gap-3 @md:grid-cols-2"
-                  >
-                    <Label
-                      htmlFor="visibility-public"
-                      className={`flex cursor-pointer flex-col gap-2 rounded-2xl border p-4 font-normal transition-colors ${
-                        field.value === 'public' || !field.value
-                          ? 'dark:bg-polar-800 bg-gray-50'
-                          : 'dark:border-polar-700 dark:hover:border-polar-700 dark:text-polar-500 dark:hover:bg-polar-700 dark:bg-polar-900 border-gray-100 text-gray-500 hover:border-gray-200'
-                      }`}
-                    >
-                      <div className="flex items-center gap-2.5 font-medium">
-                        <RadioGroupItem value="public" id="visibility-public" />
-                        Public
-                      </div>
-                      <p className="dark:text-polar-500 text-sm text-gray-500">
-                        Shown in the Customer Portal
-                      </p>
-                    </Label>
-                    <Label
-                      htmlFor="visibility-private"
-                      className={`flex cursor-pointer flex-col gap-2 rounded-2xl border p-4 font-normal transition-colors ${
-                        field.value === 'private'
-                          ? 'dark:bg-polar-800 bg-gray-50'
-                          : 'dark:border-polar-700 dark:hover:border-polar-700 dark:text-polar-500 dark:hover:bg-polar-700 dark:bg-polar-900 border-gray-100 text-gray-500 hover:border-gray-200'
-                      }`}
-                    >
-                      <div className="flex items-center gap-2.5 font-medium">
-                        <RadioGroupItem
-                          value="private"
-                          id="visibility-private"
-                        />
-                        Private
-                      </div>
-                      <p className="dark:text-polar-500 text-sm text-gray-500">
-                        Only purchasable via a direct checkout link
-                      </p>
-                    </Label>
-                  </RadioGroup>
-                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/clients/apps/web/src/components/Products/ProductForm/ProductMetadataSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductMetadataSection.tsx
@@ -1,5 +1,19 @@
 import { Section } from '@/components/Layout/Section'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { Label } from '@polar-sh/ui/components/ui/label'
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '@polar-sh/ui/components/ui/radio-group'
+import { useFormContext } from 'react-hook-form'
 import { ProductMetadataForm } from '../ProductMetadataForm'
+import { ProductFormType } from './ProductForm'
 
 export interface ProductMetadataSectionProps {
   className?: string
@@ -10,14 +24,68 @@ export const ProductMetadataSection = ({
   className,
   compact,
 }: ProductMetadataSectionProps) => {
+  const { control } = useFormContext<ProductFormType>()
+
   return (
     <Section
-      title="Metadata"
-      description="Optional metadata to associate with the product"
+      title="Product Configuration"
       className={className}
       compact={compact}
     >
       <ProductMetadataForm />
+
+      <FormField
+        control={control}
+        name="visibility"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Visibility</FormLabel>
+            <FormControl>
+              <div className="@container">
+                <RadioGroup
+                  value={field.value ?? 'public'}
+                  onValueChange={field.onChange}
+                  className="grid-cols-1 gap-3 @md:grid-cols-2"
+                >
+                  <Label
+                    htmlFor="visibility-public"
+                    className={`flex cursor-pointer flex-col gap-2 rounded-2xl border p-4 font-normal transition-colors ${
+                      field.value === 'public' || !field.value
+                        ? 'dark:bg-polar-800 bg-gray-50'
+                        : 'dark:border-polar-700 dark:hover:border-polar-700 dark:text-polar-500 dark:hover:bg-polar-700 dark:bg-polar-900 border-gray-100 text-gray-500 hover:border-gray-200'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2.5 font-medium">
+                      <RadioGroupItem value="public" id="visibility-public" />
+                      Public
+                    </div>
+                    <p className="dark:text-polar-500 text-sm text-gray-500">
+                      Shown in the Customer Portal
+                    </p>
+                  </Label>
+                  <Label
+                    htmlFor="visibility-private"
+                    className={`flex cursor-pointer flex-col gap-2 rounded-2xl border p-4 font-normal transition-colors ${
+                      field.value === 'private'
+                        ? 'dark:bg-polar-800 bg-gray-50'
+                        : 'dark:border-polar-700 dark:hover:border-polar-700 dark:text-polar-500 dark:hover:bg-polar-700 dark:bg-polar-900 border-gray-100 text-gray-500 hover:border-gray-200'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2.5 font-medium">
+                      <RadioGroupItem value="private" id="visibility-private" />
+                      Private
+                    </div>
+                    <p className="dark:text-polar-500 text-sm text-gray-500">
+                      Only purchasable via a direct checkout link
+                    </p>
+                  </Label>
+                </RadioGroup>
+              </div>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
     </Section>
   )
 }

--- a/clients/apps/web/src/components/Products/ProductMetadataForm.tsx
+++ b/clients/apps/web/src/components/Products/ProductMetadataForm.tsx
@@ -1,4 +1,4 @@
-import { FormField } from '@polar-sh/ui/components/ui/form'
+import { FormField, FormLabel } from '@polar-sh/ui/components/ui/form'
 
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
 import Button from '@polar-sh/ui/components/atoms/Button'
@@ -43,7 +43,24 @@ export const ProductMetadataForm = () => {
   }, [fields, trigger])
 
   return (
-    <FormItem className="flex flex-col gap-6">
+    <FormItem className="flex flex-col gap-2">
+      <div className="flex flex-row items-center justify-between">
+        <FormLabel>Metadata</FormLabel>
+        <p className="dark:text-polar-500 text-sm text-gray-500">
+          <Button
+            size="sm"
+            variant="secondary"
+            className="self-start"
+            type="button"
+            onClick={() => {
+              append({ key: '', value: '' })
+            }}
+          >
+            Add Metadata
+          </Button>
+        </p>
+      </div>
+
       {fields.length > 0 && (
         <div className="flex flex-col gap-2">
           {fields.map((field, index) => (
@@ -104,17 +121,12 @@ export const ProductMetadataForm = () => {
           ))}
         </div>
       )}
-      <Button
-        size="sm"
-        variant="secondary"
-        className="self-start"
-        type="button"
-        onClick={() => {
-          append({ key: '', value: '' })
-        }}
-      >
-        Add Metadata
-      </Button>
+
+      {fields.length === 0 && (
+        <p className="dark:text-polar-500 dark:bg-polar-800 flex h-10 items-center justify-center rounded-2xl bg-gray-50 text-center text-sm text-gray-500 italic">
+          No metadata added.
+        </p>
+      )}
     </FormItem>
   )
 }


### PR DESCRIPTION
Bit of an emergency brake PR since I forgot the `ProductInfoSection` also shows up during manual onboarding, and it's not nice there.

I'm cooking on a bigger overhaul of the product form, but this will clean up onboarding in the mean time.