### PR TITLE
events: Add net_amount to balance.order

### DIFF
--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -359,6 +359,7 @@ class BalanceOrderMetadata(TypedDict):
     product_id: NotRequired[str]
     subscription_id: NotRequired[str]
     amount: int
+    net_amount: NotRequired[int]
     currency: str
     presentment_amount: int
     presentment_currency: str

--- a/server/polar/held_balance/service.py
+++ b/server/polar/held_balance/service.py
@@ -133,6 +133,7 @@ class HeldBalanceService(ResourceServiceReader[HeldBalance]):
                 "transaction_id": str(payment_transaction.id),
                 "order_id": str(order.id),
                 "amount": payment_transaction.amount,
+                "net_amount": order.net_amount,
                 "currency": payment_transaction.currency,
                 "presentment_amount": payment_transaction.presentment_amount,
                 "presentment_currency": payment_transaction.presentment_currency,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1596,6 +1596,7 @@ class OrderService:
                 "transaction_id": str(payment_transaction.id),
                 "order_id": str(order.id),
                 "amount": payment_transaction.amount,
+                "net_amount": order.net_amount,
                 "currency": payment_transaction.currency,
                 "presentment_amount": payment_transaction.presentment_amount,
                 "presentment_currency": payment_transaction.presentment_currency,


### PR DESCRIPTION
To get the amount which is without Stripe fees (that we typically use for MRR metrics)