### PR TITLE
Hide benefits section for seat-based products

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
@@ -24,10 +24,6 @@ const CheckoutBenefits = ({
   })
   const expectedBenefits = checkout.product.benefits.length
 
-  const isSeatBasedProduct = checkout.product.prices.some(
-    (price) => price.amountType === 'seat_based',
-  )
-
   const customerEvents = useCustomerSSE(customerSessionToken)
   useEffect(() => {
     customerEvents.on('benefit.granted', refetch)
@@ -45,10 +41,6 @@ const CheckoutBenefits = ({
     }, maxWaitingTimeMs)
     return () => clearInterval(intervalId)
   }, [benefitGrants, expectedBenefits, maxWaitingTimeMs, refetch])
-
-  if (isSeatBasedProduct) {
-    return null
-  }
 
   return (
     <>

--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -206,13 +206,14 @@ export const CheckoutConfirmation = ({
         {status === 'succeeded' && (
           <>
             <CheckoutSeatInvitations checkout={checkout} />
-            {hasProductCheckout(checkout) && (
-              <CheckoutBenefits
-                checkout={checkout}
-                customerSessionToken={customerSessionToken}
-                maxWaitingTimeMs={maxWaitingTimeMs}
-              />
-            )}
+            {hasProductCheckout(checkout) &&
+              checkout.productPrice.amountType !== 'seat_based' && (
+                <CheckoutBenefits
+                  checkout={checkout}
+                  customerSessionToken={customerSessionToken}
+                  maxWaitingTimeMs={maxWaitingTimeMs}
+                />
+              )}
             <p className="dark:text-polar-500 text-center text-xs text-gray-500">
               This order was processed by our online reseller & Merchant of
               Record, Polar, who also handles order-related inquiries and


### PR DESCRIPTION
## Summary

Benefits are now hidden on the checkout confirmation page when the product uses seat-based pricing, since the team invitation interface replaces the benefits list for those products.

## What

Moved the seat-based product check from conditional rendering in the parent component into `CheckoutBenefits` with an early return that renders `null`.

## Why

Benefits should only display for non-seat-based products. The "Invite team members" section is shown for seat-based products and the benefits list would be redundant alongside it.

## How

Added `if (isSeatBasedProduct) return null` after all hooks but before rendering in `CheckoutBenefits`, following the same pattern as `CheckoutSeatInvitations`. Cleaned up now-unreachable guard conditions in the effect and render.

## Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass