### PR TITLE
backoffice: Dont short circuit payment statistics

### DIFF
--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -191,16 +191,6 @@ async def get_payment_statistics(
 
     # Get account ID for the organization
     account_id = await analytics_service.get_organization_account_id(organization_id)
-    if not account_id:
-        return PaymentStatistics(
-            payment_count=0,
-            p50_risk=0,
-            p90_risk=0,
-            refunds_count=0,
-            transfer_sum=0,
-            refunds_amount=0,
-            total_payment_amount=0,
-        )
 
     # Get payment statistics
     (


### PR DESCRIPTION
To ensure that v1 and v2 are showing the same numbers.