### PR TITLE
Fix HMR in checkout

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -65,7 +65,7 @@ const docsCSP = `
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['shiki'],
+  transpilePackages: ['shiki', '@polar-sh/checkout'],
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
 
   // This is required to support PostHog trailing slash API requests

--- a/clients/packages/checkout/package.json
+++ b/clients/packages/checkout/package.json
@@ -17,7 +17,7 @@
   "exports": {
     "./guards": {
       "types": "./dist/guards.d.ts",
-      "default": "./dist/guards.js"
+      "default": "./src/guards.ts"
     },
     "./embed": {
       "types": "./dist/embed.d.ts",
@@ -25,15 +25,40 @@
     },
     "./components": {
       "types": "./dist/components/index.d.ts",
-      "default": "./dist/components/index.js"
+      "default": "./src/components/index.ts"
     },
     "./hooks": {
       "types": "./dist/hooks/index.d.ts",
-      "default": "./dist/hooks/index.js"
+      "default": "./src/hooks/index.ts"
     },
     "./providers": {
       "types": "./dist/providers/index.d.ts",
-      "default": "./dist/providers/index.js"
+      "default": "./src/providers/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./guards": {
+        "types": "./dist/guards.d.ts",
+        "default": "./dist/guards.js"
+      },
+      "./embed": {
+        "types": "./dist/embed.d.ts",
+        "default": "./dist/embed.js"
+      },
+      "./components": {
+        "types": "./dist/components/index.d.ts",
+        "default": "./dist/components/index.js"
+      },
+      "./hooks": {
+        "types": "./dist/hooks/index.d.ts",
+        "default": "./dist/hooks/index.js"
+      },
+      "./providers": {
+        "types": "./dist/providers/index.d.ts",
+        "default": "./dist/providers/index.js"
+      }
     }
   },
   "devDependencies": {
@@ -45,9 +70,6 @@
     "terser": "^5.46.0",
     "tsup": "^8.5.1",
     "typescript": "latest"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "dependencies": {
     "@polar-sh/currency": "workspace:^",


### PR DESCRIPTION
Point `@polar-sh/checkout` exports to source files instead of `dist/` whuch enables HMR in development when editing checkout components. The built `/dist` exports are preserved in `publishConfig.exports` for npm publishing.