### PR TITLE
Fix discount rendering on checkout

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -58,8 +58,8 @@ const DetailRow = ({
     <div
       className={`flex flex-row items-start justify-between gap-x-8 ${emphasis ? 'font-medium' : 'dark:text-polar-500 text-gray-500'}`}
     >
-      <span>{title}</span>
-      {children}
+      <span className="min-w-0 truncate">{title}</span>
+      <span className="shrink-0">{children}</span>
     </div>
   )
 }
@@ -788,7 +788,7 @@ const BaseCheckoutForm = ({
                     {checkout.discount && (
                       <>
                         <DetailRow
-                          title={`${checkout.discount.name} (${getDiscountDisplay(checkout.discount)})`}
+                          title={`${checkout.discount.name}${checkout.discount.type === 'percentage' ? ` (${getDiscountDisplay(checkout.discount)})` : ''}`}
                         >
                           {formatCurrency('standard')(
                             -checkout.discountAmount,


### PR DESCRIPTION
Some tweaks to how we render discounts on the checkout:

* Percentage amount, no change
* Fixed amount: Remove double values, e.g `Discount name (-$50)   -$50` becomes `Discount name   -$50`
* Long discount names: We'll truncate these to prevent breaking into two lines

| Percentage (no change) | Fixed (remove double values) | Long discount name |
|--------|--------|--------|
| <img width="412" height="386" alt="Screenshot 2026-02-06 at 12 55 10" src="https://github.com/user-attachments/assets/d2e3c75a-225c-4e16-97c7-cfe23e4d4b7a" /> | <img width="414" height="380" alt="Screenshot 2026-02-06 at 12 55 31" src="https://github.com/user-attachments/assets/7542f432-062b-4e83-add6-dfbe26b71d36" /> | <img width="321" height="389" alt="Screenshot 2026-02-06 at 12 57 01" src="https://github.com/user-attachments/assets/9b351d52-24aa-488e-b9e9-fcec460a24b1" /> |