### PR TITLE
benefits: Revoke benefits immediately on product change

### DIFF
--- a/server/polar/benefit/tasks.py
+++ b/server/polar/benefit/tasks.py
@@ -69,6 +69,7 @@ async def enqueue_benefits_grants(
     customer_id: uuid.UUID,
     product_id: uuid.UUID,
     member_id: uuid.UUID | None = None,
+    skip_outdated_revokes: bool = False,
     **scope: Unpack[BenefitGrantScopeArgs],
 ) -> None:
     async with AsyncSessionMaker() as session:
@@ -89,7 +90,13 @@ async def enqueue_benefits_grants(
         resolved_scope = await resolve_scope(session, scope)
 
         await benefit_grant_service.enqueue_benefits_grants(
-            session, task, customer, product, member_id=member_id, **resolved_scope
+            session,
+            task,
+            customer,
+            product,
+            member_id=member_id,
+            skip_outdated_revokes=skip_outdated_revokes,
+            **resolved_scope,
         )
 
 

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -99,6 +99,7 @@ from polar.product.price_set import NoPricesForCurrencies, PriceSet
 from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.schemas import ProductPriceCreateList
 from polar.product.service import product as product_service
+from polar.redis import Redis
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import TaxCalculationError, TaxCode, get_tax_service
@@ -1226,6 +1227,7 @@ class CheckoutService:
     async def handle_success(
         self,
         session: AsyncSession,
+        redis: Redis,
         checkout: Checkout,
         payment: Payment | None = None,
         payment_method: PaymentMethod | None = None,
@@ -1247,7 +1249,7 @@ class CheckoutService:
                 subscription,
                 created,
             ) = await subscription_service.create_or_update_from_checkout(
-                session, checkout, payment_method
+                session, redis, checkout, payment_method
             )
             await order_service.create_from_checkout_subscription(
                 session,

--- a/server/polar/checkout/tasks.py
+++ b/server/polar/checkout/tasks.py
@@ -5,6 +5,7 @@ from polar.models.checkout import CheckoutStatus
 from polar.worker import (
     AsyncSessionMaker,
     CronTrigger,
+    RedisMiddleware,
     TaskPriority,
     actor,
     enqueue_job,
@@ -33,7 +34,7 @@ async def handle_free_success(checkout_id: uuid.UUID) -> None:
         )
         if checkout is None:
             raise CheckoutDoesNotExist(checkout_id)
-        await checkout_service.handle_success(session, checkout)
+        await checkout_service.handle_success(session, RedisMiddleware.get(), checkout)
 
 
 @actor(

--- a/server/polar/integrations/stripe/payment.py
+++ b/server/polar/integrations/stripe/payment.py
@@ -19,6 +19,7 @@ from polar.order.service import order as order_service
 from polar.payment.service import payment as payment_service
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.postgres import AsyncSession
+from polar.redis import Redis
 from polar.wallet.repository import WalletRepository, WalletTransactionRepository
 
 
@@ -118,7 +119,9 @@ async def resolve_order(
 
 
 async def handle_success(
-    session: AsyncSession, object: stripe_lib.Charge | stripe_lib.SetupIntent
+    session: AsyncSession,
+    redis: Redis,
+    object: stripe_lib.Charge | stripe_lib.SetupIntent,
 ) -> None:
     checkout = await resolve_checkout(session, object)
     wallet, wallet_transaction = await resolve_wallet(session, object)
@@ -149,6 +152,7 @@ async def handle_success(
 
         await checkout_service.handle_success(
             session,
+            redis,
             checkout,
             payment=payment,
             payment_method=payment_method,

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -42,6 +42,7 @@ from polar.models.order import OrderStatus
 from polar.models.subscription import CustomerCancellationReason
 from polar.order.service import order as order_service
 from polar.postgres import AsyncSession
+from polar.redis import Redis
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -1710,6 +1711,7 @@ class TestSystemEvents:
     async def test_subscription_created(
         self,
         session: AsyncSession,
+        redis: Redis,
         save_fixture: SaveFixture,
         product: Product,
         customer: Customer,
@@ -1723,7 +1725,7 @@ class TestSystemEvents:
         )
 
         subscription, _ = await subscription_service.create_or_update_from_checkout(
-            session, checkout
+            session, redis, checkout
         )
 
         event_repository = EventRepository.from_session(session)


### PR DESCRIPTION
Fix #9410

Today we have an issue where a meter reset will happen, and benefit revocation and benefit grants will happen after the fact. This means that someone might lose credits if they are granted 100 credits today, the meter resets, they receive 1000 credits and get the 100 credits removed. This means that they end up with 900 credits.

If we instead revoke the benefits, reset the meters and then grant the benefits they will end up with the 1000 credits as expected.

The change here is that the benefit revocation happens synchronously instead of in a task. The ideal would be to chain tasks together, or order them, but it's not possible today.
