### PR TITLE
Allow editing null billing addresses from customer portal

### DIFF
--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -337,7 +337,10 @@ const DownloadInvoice = ({
                     render={({ field }) => (
                       <>
                         <CountryStatePicker
-                          disabled={true}
+                          disabled={
+                            !!order.billing_address?.state ||
+                            order.is_invoice_generated
+                          }
                           autoComplete="billing address-level1"
                           country={country}
                           value={field.value || ''}
@@ -359,7 +362,10 @@ const DownloadInvoice = ({
                     render={({ field }) => (
                       <>
                         <CountryPicker
-                          disabled={true}
+                          disabled={
+                            !!order.billing_address?.country ||
+                            order.is_invoice_generated
+                          }
                           autoComplete="billing country"
                           value={field.value || undefined}
                           onChange={field.onChange}


### PR DESCRIPTION
Not sure how some orders end up in this state, but at least this allows customers to self-serve resolve.