### PR TITLE
Extract name from Stripe's confirmation token

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1057,6 +1057,31 @@ class CheckoutService:
         ):
             raise PaymentNotReady()
 
+        # For wallet payments (Apple Pay, Google Pay), we hide the customer name field
+        # for better UX and instead extract the name from Stripe's confirmation token.
+        if (
+            checkout.payment_processor == PaymentProcessor.stripe
+            and checkout_confirm.confirmation_token_id is not None
+            and checkout.customer_name is None
+        ):
+            try:
+                confirmation_token = await stripe_service.get_confirmation_token(
+                    checkout_confirm.confirmation_token_id
+                )
+                if (
+                    confirmation_token.payment_method_preview is not None
+                    and confirmation_token.payment_method_preview.billing_details
+                    is not None
+                ):
+                    wallet_name = (
+                        confirmation_token.payment_method_preview.billing_details.name
+                    )
+                    if wallet_name:
+                        checkout.customer_name = wallet_name
+                        session.add(checkout)
+            except stripe_lib.StripeError:
+                pass
+
         required_fields = self._get_required_confirm_fields(checkout)
         for required_field in required_fields:
             if (

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -274,6 +274,16 @@ class StripeService:
             id, stripe_account=stripe_account, expand=expand or []
         )
 
+    async def get_confirmation_token(
+        self,
+        id: str,
+        *,
+        expand: list[str] | None = None,
+    ) -> stripe_lib.ConfirmationToken:
+        return await stripe_lib.ConfirmationToken.retrieve_async(
+            id, expand=expand or []
+        )
+
     async def create_payout(
         self,
         *,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3802,10 +3802,17 @@ class TestConfirm:
         self,
         payload: dict[str, str],
         missing_fields: set[tuple[str, ...]],
+        stripe_service_mock: MagicMock,
         session: AsyncSession,
         auth_subject: AuthSubject[Anonymous],
         checkout_one_time_fixed: Checkout,
     ) -> None:
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = MagicMock()
+        confirmation_token.payment_method_preview.billing_details.name = None
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+
         with pytest.raises(PolarRequestValidationError) as e:
             await checkout_service.confirm(
                 session,
@@ -4883,6 +4890,192 @@ class TestConfirm:
 
         assert confirmed_checkout.status == CheckoutStatus.confirmed
         stripe_service_mock.create_payment_intent.assert_called_once()
+
+    async def test_wallet_payment_extracts_name_from_confirmation_token(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        """
+        Test that when customer_name is not provided (wallet payment like Apple Pay),
+        the name is extracted from the Stripe confirmation token.
+        """
+        await save_fixture(checkout_one_time_fixed)
+
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = MagicMock()
+        confirmation_token.payment_method_preview.billing_details.name = (
+            "John Appleseed"
+        )
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                    "customer_email": "beppe@example.com",
+                    "customer_billing_address": {
+                        "line1": "Some Street",
+                        "postal_code": "12345",
+                        "city": "New York",
+                        "state": "US-NY",
+                        "country": "US",
+                    },
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.customer_name == "John Appleseed"
+        stripe_service_mock.get_confirmation_token.assert_called_once_with(
+            "CONFIRMATION_TOKEN_ID"
+        )
+
+    async def test_wallet_payment_uses_provided_name_over_token(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        """
+        Test that when customer_name IS provided, it takes precedence over
+        the name in the confirmation token (backwards compatibility).
+        """
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                    "customer_name": "Provided Name",
+                    "customer_email": "beppe@example.com",
+                    "customer_billing_address": {
+                        "line1": "Some Street",
+                        "postal_code": "12345",
+                        "city": "New York",
+                        "state": "US-NY",
+                        "country": "US",
+                    },
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.customer_name == "Provided Name"
+        stripe_service_mock.get_confirmation_token.assert_not_called()
+
+    async def test_wallet_payment_fails_validation_on_stripe_error(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        """
+        Checkout fails validation if fetching the confirmation token fails
+        and customer_name is not provided.
+        """
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.get_confirmation_token.side_effect = stripe_lib.StripeError(
+            "API Error"
+        )
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout_one_time_fixed,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_email": "beppe@example.com",
+                        "customer_billing_address": {
+                            "line1": "Some Street",
+                            "postal_code": "12345",
+                            "city": "New York",
+                            "state": "US-NY",
+                            "country": "US",
+                        },
+                    }
+                ),
+            )
+
+        assert any(
+            error["loc"] == ("body", "customer_name")
+            for error in exc_info.value.errors()
+        )
+
+    async def test_wallet_payment_fails_validation_on_missing_billing_details(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        """
+        Checkout fails validation when confirmation token has no billing details
+        and customer_name is not provided.
+        """
+        await save_fixture(checkout_one_time_fixed)
+
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = None
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout_one_time_fixed,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_email": "beppe@example.com",
+                        "customer_billing_address": {
+                            "line1": "Some Street",
+                            "postal_code": "12345",
+                            "city": "New York",
+                            "state": "US-NY",
+                            "country": "US",
+                        },
+                    }
+                ),
+            )
+
+        assert any(
+            error["loc"] == ("body", "customer_name")
+            for error in exc_info.value.errors()
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As a part of simplifying the checkout flow this PR will add backend support for fetching the user name from Stripe's confirmation token when using Apple/Google Pay.

Here's how it works today:

1. The user chooses Apple/Google Pay as a payment service
2. They enter the cardholder name
3. They make the purchase

With this PR (and frontend changes in the `feature/apple-pay-optimization` branch) the flow will instead be:

1. The user chooses Apple/Google Pay as a payment service
2. They make the purchase
3. We fetch the cardholder from Stripe's checkout token

<img width="1616" height="976" alt="Screenshot 2026-02-05 at 15 29 53" src="https://github.com/user-attachments/assets/4c2930de-677a-4fc7-a1cf-148e8cdd4d01" />
