### PR TITLE
tinybird: Add cron job for tinybird reconcilation

### DIFF
--- a/server/polar/integrations/tinybird/tasks.py
+++ b/server/polar/integrations/tinybird/tasks.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+from apscheduler.triggers.cron import CronTrigger
+
+from polar.kit.utils import utc_now
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+from .service import reconcile_events
+
+
+@actor(
+    actor_name="tinybird.reconcile_events",
+    cron_trigger=CronTrigger(minute=0),
+    priority=TaskPriority.LOW,
+)
+async def reconcile_events_task() -> None:
+    async with AsyncSessionMaker() as session:
+        end = utc_now() - timedelta(minutes=5)
+        start = end - timedelta(minutes=60)
+        await reconcile_events(session, start, end)

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -14,6 +14,7 @@ from polar.external_event import tasks as external_event
 from polar.integrations.chargeback_stop import tasks as chargeback_stop
 from polar.integrations.loops import tasks as loops
 from polar.integrations.stripe import tasks as stripe
+from polar.integrations.tinybird import tasks as tinybird
 from polar.meter import tasks as meter
 from polar.notifications import tasks as notifications
 from polar.order import tasks as order
@@ -53,6 +54,7 @@ __all__ = [
     "processor_transaction",
     "stripe",
     "subscription",
+    "tinybird",
     "transaction",
     "user",
     "webhook",


### PR DESCRIPTION
It's a bit unclear if:
1. We need this
2. We should do this

But it seems like we have experienced a slight discrepancy between PG and Tinybird. This will both run and reconcile the problem, but also log it so that we can verify if the problem grows or if it is a problem at all. Can be considered both belt and suspenders.