### PR TITLE
subscription: We overwrite canceled_at on revocation of subscriptions

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1724,7 +1724,8 @@ class SubscriptionService:
         previous_is_canceled = subscription.canceled
 
         now = utc_now()
-        subscription.canceled_at = now
+        if subscription.canceled_at is None:
+            subscription.canceled_at = now
 
         if customer_reason:
             subscription.customer_cancellation_reason = customer_reason


### PR DESCRIPTION
This makes the canceled_at be inconsistent with the cancelation event. Since the subscription wasn't actually canceled when it was revoked, it makes more sense to _not_ overwrite the value, if it is already set.
