### PR TITLE
dev docker: Allow storing persistent instance number

### DIFF
--- a/dev/docker/.env.docker.template
+++ b/dev/docker/.env.docker.template
@@ -4,6 +4,10 @@
 # All variables have sensible defaults. Only uncomment and modify
 # values if you need to customize the development environment.
 
+# Instance number for port isolation (0 = default ports, no offset)
+# Set via: dev docker set-instance <number>
+# POLAR_DOCKER_INSTANCE=
+
 # Database credentials (defaults work out of the box)
 # POLAR_POSTGRES_USER=polar
 # POLAR_POSTGRES_PWD=polar


### PR DESCRIPTION
## 📋 Summary

Adds support for storing a default Docker instance number in `.env.docker`, allowing it to persist across Conductor sessions, terminal restarts, and other tools. Instance 0 enables default ports (no offset).

## 🎯 What

- Read `POLAR_DOCKER_INSTANCE` from `.env.docker` as highest priority source
- Add `dev docker set-instance <number>` command to store instance number
- Add `dev docker clear-instance` command to revert to auto-detection
- Show "Using stored instance X (from .env.docker)" when loaded from file
- Add `POLAR_DOCKER_INSTANCE` to `.env.docker.template` with documentation

## 🤔 Why

Currently, the dev docker instance number is auto-detected from either `CONDUCTOR_PORT` or a workspace path hash. This makes it difficult to explicitly store a preference (e.g., "I always want instance 0 for the main Polar folder"). The stored instance file allows developers to explicitly pin an instance, which will be respected across tool switches and terminal sessions.

## 🔧 How

Priority order for instance detection:
1. `POLAR_DOCKER_INSTANCE` in `.env.docker` (new, highest priority)
2. `CONDUCTOR_PORT` env var
3. Workspace path hash (fallback)

The implementation adds three utility functions to read/write/clear the instance number, and modifies `_detect_instance()` to return a tuple `(instance, source)` for better visibility.

## 🧪 Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking

### Test Instructions

1. `dev docker set-instance 0` → stores instance 0
2. `dev docker up` → prints "Using stored instance 0 (from .env.docker)"
3. `dev docker clear-instance` → removes stored instance
4. `dev docker -i 5 up` → explicit flag still overrides stored instance

## 📝 Additional Notes

This is a dev tooling enhancement that doesn't affect production code. The `.env.docker` file is already gitignored, so this doesn't introduce any version control concerns.