### PR TITLE
server/customer: prevent resetting customer address to null from API

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -210,6 +210,20 @@ class CustomerService:
             customer.email = customer_update.email
             customer.email_verified = False
 
+        # Prevent setting billing address to null
+        if (
+            "billing_address" in customer_update.model_fields_set
+            and customer_update.billing_address is None
+        ):
+            errors.append(
+                {
+                    "type": "value_error",
+                    "loc": ("body", "billing_address"),
+                    "msg": "Customer billing address cannot be reset to null once set.",
+                    "input": customer_update.billing_address,
+                }
+            )
+
         # Validate external_id changes (only for CustomerUpdate schema)
         if (
             isinstance(customer_update, CustomerUpdate)

--- a/server/polar/customer_portal/service/customer.py
+++ b/server/polar/customer_portal/service/customer.py
@@ -50,9 +50,20 @@ class CustomerService:
         if customer_update.billing_name is not None:
             customer.billing_name = customer_update.billing_name
 
-        customer.billing_address = (
-            customer_update.billing_address or customer.billing_address
-        )
+        if "billing_address" in customer_update.model_fields_set:
+            if customer_update.billing_address is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "missing",
+                            "loc": ("body", "billing_address"),
+                            "msg": "Customer billing address cannot be reset to null once set.",
+                            "input": customer_update.billing_address,
+                        }
+                    ]
+                )
+            else:
+                customer.billing_address = customer_update.billing_address
 
         tax_id = customer_update.tax_id or (
             customer.tax_id[0] if customer.tax_id else None

--- a/server/tests/customer_portal/service/test_customer.py
+++ b/server/tests/customer_portal/service/test_customer.py
@@ -87,6 +87,23 @@ class TestUpdate:
                 ),
             )
 
+    async def test_explicit_null_billing_address(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await customer_service.update(
+                session, customer, CustomerPortalCustomerUpdate(billing_address=None)
+            )
+        assert customer.billing_address is not None
+
     async def test_billing_name_update(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
- server/customer: prevent resetting customer address to null from API