### PR TITLE
subscription: Send canceled webhook again when canceled

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1918,7 +1918,7 @@ class SubscriptionService:
         if became_past_due:
             await self._on_subscription_past_due(session, subscription)
 
-        if became_canceled:
+        if became_canceled or (became_revoked and previous_is_canceled):
             await self._on_subscription_canceled(
                 session, subscription, revoked=became_revoked
             )


### PR DESCRIPTION
When a subscription is set to be canceled, and then is forcefully canceled immediately, we send a new webhook and create a new canceled event.
