### PR TITLE
Add `checkout_localization_enabled` feature flag

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -8991,8 +8991,8 @@ export interface components {
        * @description Whether customers can update their subscriptions from the customer portal.
        */
       allow_customer_updates: boolean
-      /** Localization Enabled */
-      readonly localization_enabled: boolean
+      /** Default Locale */
+      readonly default_locale: string
     }
     /**
      * BenefitType
@@ -10328,8 +10328,8 @@ export interface components {
        * @description Whether customers can update their subscriptions from the customer portal.
        */
       allow_customer_updates: boolean
-      /** Localization Enabled */
-      readonly localization_enabled: boolean
+      /** Default Locale */
+      readonly default_locale: string
     }
     /**
      * CheckoutPriceCreate
@@ -14228,8 +14228,8 @@ export interface components {
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
       /** @description Feature flags for the customer portal. */
       organization_features?: components['schemas']['CustomerOrganizationFeatureSettings']
-      /** Localization Enabled */
-      readonly localization_enabled: boolean
+      /** Default Locale */
+      readonly default_locale: string
     }
     /**
      * CustomerOrganizationData

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -316,10 +316,14 @@ class OrganizationPublicBase(OrganizationBase):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def localization_enabled(self) -> bool:
+    def default_locale(self) -> str:
         if self.feature_settings is None:
-            return False
-        return bool(self.feature_settings.checkout_localization_enabled)
+            return "en-US"
+
+        if self.feature_settings.checkout_localization_enabled:
+            return "auto"
+
+        return "en-US"
 
 
 class Organization(OrganizationBase):


### PR DESCRIPTION
Add `checkout_localization_enabled` as a feature flag on the organization, but also expose it publicly as a computed property because we need to access it from the `/checkouts/client/:clientSecret` endpoint, and organization feature settings get stripped there.