### PR TITLE
server/kit/anonymization: use a valid TLD for anonymized email domain

### DIFF
--- a/server/migrations/versions/2026-02-12-0839_update_anonymized_email_domain.py
+++ b/server/migrations/versions/2026-02-12-0839_update_anonymized_email_domain.py
@@ -1,0 +1,39 @@
+"""Update anonymized email domain
+
+Revision ID: b7a3d4baf848
+Revises: eee9c7fb3595
+Create Date: 2026-02-12 08:39:07.218529
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b7a3d4baf848"
+down_revision = "eee9c7fb3595"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE users
+        SET email = REPLACE(email, '@anonymized.invalid', '@anonymized.polar.sh')
+        WHERE email LIKE '%@anonymized.invalid'
+        """
+    )
+    op.execute(
+        """
+        UPDATE customers
+        SET email = REPLACE(email, '@anonymized.invalid', '@anonymized.polar.sh')
+        WHERE email LIKE '%@anonymized.invalid'
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/server/polar/kit/anonymization.py
+++ b/server/polar/kit/anonymization.py
@@ -7,7 +7,7 @@ def anonymize_for_deletion(value: str) -> str:
     return ret.hexdigest()
 
 
-ANONYMIZED_EMAIL_DOMAIN = "anonymized.invalid"
+ANONYMIZED_EMAIL_DOMAIN = "anonymized.polar.sh"
 
 
 def anonymize_email_for_deletion(email: str) -> str:

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -1029,7 +1029,7 @@ class TestDeleteCustomerWithAnonymize:
         assert deleted is not None
 
         # Email should be hashed
-        assert deleted.email.endswith("@anonymized.invalid")
+        assert deleted.email.endswith("@anonymized.polar.sh")
         assert deleted.email_verified is False
 
         # Name should be hashed (64-char hex string from SHA-256)
@@ -1067,7 +1067,7 @@ class TestDeleteCustomerWithAnonymize:
         assert deleted is not None
 
         # Email should be hashed
-        assert deleted.email.endswith("@anonymized.invalid")
+        assert deleted.email.endswith("@anonymized.polar.sh")
 
         # Name should be PRESERVED for businesses
         assert deleted.name == "Acme Corp"
@@ -1170,7 +1170,7 @@ class TestDeleteCustomerExternalWithAnonymize:
         assert deleted is not None
 
         # Email should be hashed
-        assert deleted.email.endswith("@anonymized.invalid")
+        assert deleted.email.endswith("@anonymized.polar.sh")
 
         # External ID should be preserved
         assert deleted.external_id == "ext-anon-123"

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -773,7 +773,7 @@ class TestDelete:
         )
         deleted = await customer_service.delete(session, customer, anonymize=True)
         assert deleted.deleted_at is not None
-        assert deleted.email.endswith("@anonymized.invalid")
+        assert deleted.email.endswith("@anonymized.polar.sh")
         assert deleted.name is not None
         assert deleted.name != "Delete Anon User"
         assert len(deleted.name) == 64  # SHA-256 hex
@@ -825,7 +825,7 @@ class TestAnonymize:
         anonymized = await customer_service.anonymize(session, customer)
 
         # Email should be hashed
-        assert anonymized.email.endswith("@anonymized.invalid")
+        assert anonymized.email.endswith("@anonymized.polar.sh")
         assert anonymized.email != "individual@example.com"
         assert anonymized.email_verified is False
 
@@ -860,7 +860,7 @@ class TestAnonymize:
         anonymized = await customer_service.anonymize(session, customer)
 
         # Email should be hashed
-        assert anonymized.email.endswith("@anonymized.invalid")
+        assert anonymized.email.endswith("@anonymized.polar.sh")
         assert anonymized.email_verified is False
 
         # Name should be PRESERVED for businesses
@@ -1008,7 +1008,7 @@ class TestAnonymize:
         # Should still be able to anonymize
         anonymized = await customer_service.anonymize(session, customer)
 
-        assert anonymized.email.endswith("@anonymized.invalid")
+        assert anonymized.email.endswith("@anonymized.polar.sh")
         assert anonymized.deleted_at is not None
 
 

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -101,7 +101,7 @@ class TestRequestDeletion:
         assert result.blocked_reasons == []
         assert user.deleted_at is not None
         assert user.email != original_email
-        assert user.email.endswith("@anonymized.invalid")
+        assert user.email.endswith("@anonymized.polar.sh")
 
     async def test_blocked_with_active_organization(
         self,
@@ -137,7 +137,7 @@ class TestRequestDeletion:
 
         assert result.deleted is True
         assert user.email != original_email
-        assert user.email.endswith("@anonymized.invalid")
+        assert user.email.endswith("@anonymized.polar.sh")
         assert user.avatar_url is None
         assert user.meta == {}
         assert user.deleted_at is not None


### PR DESCRIPTION
- server/kit/anonymization: use a valid TLD for anonymized email domain