### PR TITLE
Skip seat-based pricing orgs in migration

### DIFF
--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -129,14 +129,22 @@ async def migrate_organizations(
                 for org in organizations
                 if org.feature_settings.get("member_model_enabled", False)
             ]
+            seat_based = [
+                org
+                for org in organizations
+                if org.feature_settings.get("seat_based_pricing", False)
+                and not org.feature_settings.get("member_model_enabled", False)
+            ]
             to_migrate = [
                 org
                 for org in organizations
                 if not org.feature_settings.get("member_model_enabled", False)
+                and not org.feature_settings.get("seat_based_pricing", False)
             ]
 
             typer.echo(f"Found {len(organizations)} organization(s) matching filters:")
             typer.echo(f"  - {len(already_migrated)} already have member_model_enabled")
+            typer.echo(f"  - {len(seat_based)} skipped (seat_based_pricing enabled)")
             typer.echo(f"  - {len(to_migrate)} to migrate")
             typer.echo()
 


### PR DESCRIPTION
## Summary

Exclude organizations with the `seat_based_pricing` feature flag enabled from the member model migration script.

## What

Added filtering to ignore organizations where `seat_based_pricing` is enabled when determining which organizations to migrate to the member model.

## Why

Organizations using seat-based pricing require special handling and should not be included in the standard member model migration.

## How

- Separate out organizations with `seat_based_pricing` enabled into a `seat_based` list
- Exclude these from the `to_migrate` list
- Report the count of skipped organizations in the migration output