### PR TITLE
Experiment: Optimize checkout for Apple Pay / Google Pay

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useExperiment } from '@/experiments/client'
 import { useCheckoutConfirmedRedirect } from '@/hooks/checkout'
 import { usePostHog } from '@/hooks/posthog'
 import { useOrganizationPaymentStatus } from '@/hooks/queries/org'
@@ -53,6 +54,10 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
   const { resolvedTheme } = useTheme()
   const theme = _theme || (resolvedTheme as 'light' | 'dark')
   const posthog = usePostHog()
+
+  const { variant: walletPaymentExperiment } = useExperiment(
+    'checkout_wallet_payment',
+  )
 
   const openedTrackedRef = useRef(false)
   useEffect(() => {
@@ -226,6 +231,7 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
           themePreset={themePreset}
           disabled={shouldBlockCheckout}
           isUpdatePending={isUpdatePending}
+          walletPaymentExperiment={walletPaymentExperiment}
         />
       </ShadowBox>
     )
@@ -291,6 +297,7 @@ const Checkout = ({ embed: _embed, theme: _theme }: CheckoutProps) => {
             themePreset={themePreset}
             disabled={shouldBlockCheckout}
             isUpdatePending={isUpdatePending}
+            walletPaymentExperiment={walletPaymentExperiment}
           />
         </div>
       </ShadowBoxOnMd>

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -18,4 +18,10 @@ export const experiments = {
     variants: ['control', 'treatment'] as const,
     defaultVariant: 'control',
   },
+  checkout_wallet_payment: {
+    description:
+      'Optimized checkout for wallet payments (Apple Pay, Google Pay)',
+    variants: ['control', 'treatment'] as const,
+    defaultVariant: 'control',
+  },
 } as const

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -166,7 +166,7 @@ export const CheckoutFormProvider = ({ children }: React.PropsWithChildren) => {
             payment_method_data: {
               // Stripe requires fields to be explicitly set to null if they are not provided
               billing_details: {
-                name: data.customerName,
+                name: data.customerName || null,
                 email: data.customerEmail,
                 address: {
                   line1: data.customerBillingAddress?.line1 || null,


### PR DESCRIPTION
This PR will add some optimizations for the Apple Pay / Google Pay workflow:

1. If Apple / Google Pay is available, put that first in the payments list
2. If Apple / Google Pay is used, hide `Cardholder name` and fetch that from the Stripe token


| Control | Treatment  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-02-12 at 11 58 46" src="https://github.com/user-attachments/assets/37ad9659-524f-4392-950f-4753649b7a64" /> | <img width="1840" height="1134" alt="Screenshot 2026-02-12 at 11 59 04" src="https://github.com/user-attachments/assets/81a269a9-41ec-4695-98be-a2d8b1bf7d72" /> |

Stripe's checkout token used to get the cardholder name:

<img width="1487" height="402" alt="Screenshot 2026-02-12 at 11 09 56" src="https://github.com/user-attachments/assets/8f19b7e6-66fe-457b-b8ba-4691c8172bf7" />


