### PR TITLE
Fix approve buttons on organization detail page

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -549,7 +549,14 @@ async def approve_organization(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    # Use provided threshold or default to $250 in cents (max as per requirement)
+    # Check form data for threshold in dollars (from custom approve input)
+    if threshold is None:
+        form_data = await request.form()
+        raw_dollars = form_data.get("threshold_dollars")
+        if raw_dollars:
+            threshold = int(float(str(raw_dollars)) * 100)
+
+    # Use provided threshold or default to $250 in cents
     next_review_threshold = threshold if threshold else 25000
 
     # Approve the organization

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -199,39 +199,31 @@ class OrganizationDetailView:
                                 text("Deny")
 
                     elif self.org.is_under_review:
-                        # Quick approve with doubled threshold
-                        # Use current threshold (in cents) or $250 default, then double it
-                        current_threshold = self.org.next_review_threshold or 25000
-                        next_threshold = current_threshold * 2
-                        next_threshold_display = f"${next_threshold / 100:,.0f}"
+                        # Quick approve with $250 default threshold
+                        approve_url = str(
+                            request.url_for(
+                                "organizations-v2:approve",
+                                organization_id=self.org.id,
+                            )
+                        )
 
                         with tag.div(classes="w-full"):
                             with button(
                                 variant="secondary",
                                 size="sm",
                                 outline=True,
-                                hx_post=str(
-                                    request.url_for(
-                                        "organizations-v2:approve",
-                                        organization_id=self.org.id,
-                                    )
-                                )
-                                + f"?threshold={next_threshold}",
-                                hx_confirm=f"Approve this organization with {next_threshold_display} threshold?",
+                                hx_post=approve_url + "?threshold=25000",
+                                hx_confirm="Approve this organization with $250 threshold?",
                             ):
-                                text(f"Approve ({next_threshold_display})")
+                                text("Approve ($250)")
 
                         # Custom approve with input
-                        approve_url = str(
-                            request.url_for(
-                                "organizations-v2:approve", organization_id=self.org.id
-                            )
-                        )
                         with tag.div(classes="flex gap-2"):
                             with tag.input(
                                 type="number",
+                                name="threshold_dollars",
                                 id="custom-threshold",
-                                placeholder="Custom amount",
+                                placeholder="Custom $ amount",
                                 classes="input input-bordered input-sm flex-1",
                             ):
                                 pass
@@ -239,7 +231,9 @@ class OrganizationDetailView:
                                 variant="secondary",
                                 size="sm",
                                 outline=True,
-                                onclick=f"const amount = document.getElementById('custom-threshold').value; if(amount && confirm('Approve with $' + amount + ' threshold?')) {{ htmx.ajax('POST', '{approve_url}?threshold=' + (amount * 100), {{target: 'body'}}); }}",
+                                hx_post=approve_url,
+                                hx_include="#custom-threshold",
+                                hx_confirm="Approve with custom threshold?",
                             ):
                                 text("✓")
 


### PR DESCRIPTION
## Summary

Fixed two issues with the approve buttons on the organization detail page:

1. **Default Approve button** - Was showing $500 instead of $250 because it doubled the current threshold. Now uses a fixed $250 threshold, matching the list view behavior.

2. **Custom Approve button** - Was blocked by Content Security Policy due to inline `onclick` JavaScript. Now uses pure HTMX attributes (`hx-post` + `hx-include`) for CSP compliance.

## Changes

- **detail_view.py**: Removed threshold doubling logic, replaced inline onclick with HTMX attributes
- **endpoints.py**: Added form data fallback to read `threshold_dollars` when query param not provided

Both buttons now work correctly and comply with CSP restrictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)