### PR TITLE
server/scripts: filter already-migrated orgs in query

### DIFF
--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -32,7 +32,7 @@ from typing import Any
 import dramatiq
 import structlog
 import typer
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from polar import tasks  # noqa: F401
 from polar.kit.db.postgres import create_async_sessionmaker
@@ -91,11 +91,24 @@ async def migrate_organizations(
     async with JobQueueManager.open(dramatiq.get_broker(), redis):
         async with sessionmaker() as session:
             # Build query for eligible organizations
+            # Exclude orgs already migrated or with seat-based pricing at the DB level
             statement = (
                 select(Organization)
                 .where(
                     Organization.deleted_at.is_(None),
                     Organization.blocked_at.is_(None),
+                    or_(
+                        Organization.feature_settings["member_model_enabled"].is_(None),
+                        Organization.feature_settings["member_model_enabled"]
+                        .as_boolean()
+                        .is_(False),
+                    ),
+                    or_(
+                        Organization.feature_settings["seat_based_pricing"].is_(None),
+                        Organization.feature_settings["seat_based_pricing"]
+                        .as_boolean()
+                        .is_(False),
+                    ),
                 )
                 .order_by(Organization.next_review_threshold.asc())
             )
@@ -123,58 +136,32 @@ async def migrate_organizations(
                 typer.echo("No eligible organizations found.")
                 return
 
-            # Separate already-migrated from eligible
-            already_migrated = [
-                org
-                for org in organizations
-                if org.feature_settings.get("member_model_enabled", False)
-            ]
-            seat_based = [
-                org
-                for org in organizations
-                if org.feature_settings.get("seat_based_pricing", False)
-                and not org.feature_settings.get("member_model_enabled", False)
-            ]
-            to_migrate = [
-                org
-                for org in organizations
-                if not org.feature_settings.get("member_model_enabled", False)
-                and not org.feature_settings.get("seat_based_pricing", False)
-            ]
-
-            typer.echo(f"Found {len(organizations)} organization(s) matching filters:")
-            typer.echo(f"  - {len(already_migrated)} already have member_model_enabled")
-            typer.echo(f"  - {len(seat_based)} skipped (seat_based_pricing enabled)")
-            typer.echo(f"  - {len(to_migrate)} to migrate")
+            typer.echo(f"Found {len(organizations)} organization(s) to migrate")
             typer.echo()
-
-            if not to_migrate:
-                typer.echo("Nothing to migrate.")
-                return
 
             # Display organizations to migrate
             typer.echo("Organizations to migrate (ordered by next_review_threshold):")
             typer.echo(f"{'Slug':<40} {'Threshold':>10} {'ID'}")
             typer.echo("-" * 90)
-            for org in to_migrate:
+            for org in organizations:
                 typer.echo(f"{org.slug:<40} {org.next_review_threshold:>10} {org.id}")
             typer.echo()
 
             if dry_run:
                 typer.echo("DRY RUN - No changes will be made.")
                 typer.echo(
-                    f"Would migrate {len(to_migrate)} organization(s) and enqueue backfill jobs."
+                    f"Would migrate {len(organizations)} organization(s) and enqueue backfill jobs."
                 )
                 return
 
             # Perform migration
-            typer.echo(f"Migrating {len(to_migrate)} organization(s)...")
+            typer.echo(f"Migrating {len(organizations)} organization(s)...")
             typer.echo()
 
             migrated_count = 0
             failed_count = 0
 
-            for org in to_migrate:
+            for org in organizations:
                 try:
                     # Enable member_model_enabled
                     org.feature_settings = {
@@ -192,7 +179,7 @@ async def migrate_organizations(
 
                     migrated_count += 1
                     typer.echo(
-                        f"  [{migrated_count}/{len(to_migrate)}] "
+                        f"  [{migrated_count}/{len(organizations)}] "
                         f"{org.slug} (threshold={org.next_review_threshold})"
                     )
 


### PR DESCRIPTION
## 📋 Summary

Move `member_model_enabled` and `seat_based_pricing` filtering from Python to the SQL WHERE clause for better performance and correctness.

## 🎯 What

- Added JSONB filtering conditions to exclude already-migrated and seat-based pricing organizations directly in the database query
- Removed redundant Python-side list comprehensions that filtered the same conditions
- Simplified output messaging since all returned organizations are eligible

## 🤔 Why

Database-level filtering reduces the number of organizations fetched and processed in memory. The `--limit` flag now correctly applies to only eligible organizations rather than filtering after the limit is applied.

## 🔧 How

Used SQLAlchemy's JSONB operators (`["key"].is_(None)` and `.as_boolean()`) to query feature_settings directly, following the same pattern established in `server/polar/organization/repository.py`.

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass