### PR TITLE
Add Playwright to Docker image for low priority worker

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -19,8 +19,9 @@ on:
         type: string
       render-worker-service-ids:
         description: "Comma-separated list of Render worker service IDs"
-        required: true
+        required: false
         type: string
+        default: ""
       has-migrations:
         description: "Whether this deployment includes database migrations"
         required: false
@@ -36,6 +37,16 @@ on:
         required: false
         type: boolean
         default: false
+      docker-digest-playwright:
+        description: "Playwright Docker image digest to deploy"
+        required: false
+        type: string
+        default: ""
+      render-playwright-worker-service-ids:
+        description: "Comma-separated list of Render playwright worker service IDs"
+        required: false
+        type: string
+        default: ""
     secrets:
       RENDER_API_TOKEN:
         required: true
@@ -101,7 +112,9 @@ jobs:
             ${{ inputs.docker-digest }} \
             ${{ inputs.has-migrations }} \
             "${{ inputs.render-api-service-id }}" \
-            "${{ inputs.render-worker-service-ids }}"
+            "${{ inputs.render-worker-service-ids }}" \
+            "${{ inputs.docker-digest-playwright }}" \
+            "${{ inputs.render-playwright-worker-service-ids }}"
         env:
           RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,16 +104,55 @@ jobs:
           secrets: |
             IPINFO_ACCESS_TOKEN=${{ secrets.IPINFO_ACCESS_TOKEN }}
 
+  build-playwright:
+    name: "Build Playwright Docker Image 🎭"
+    needs: [build]
+    if: needs.build.result == 'success'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/polarsource/polar-playwright
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+      - uses: docker/build-push-action@v6
+        id: push
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          context: ./server
+          file: ./server/Dockerfile.playwright
+          platforms: linux/amd64
+          build-args: |
+            BASE_IMAGE=ghcr.io/polarsource/polar@${{ needs.build.outputs.digest }}
+
   deploy-sandbox:
     name: "Deploy to Sandbox 🧪"
-    needs: [changes, build]
-    if: always() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    needs: [changes, build, build-playwright]
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-playwright.result == 'success' || needs.build-playwright.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: sandbox
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-crkocgbtq21c73ddsdbg"
-      render-worker-service-ids: "srv-d089jj7diees73934kgg"
+      render-worker-service-ids: ""
+      docker-digest-playwright: ${{ needs.build-playwright.outputs.digest }}
+      render-playwright-worker-service-ids: "srv-d089jj7diees73934kgg"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
@@ -127,14 +166,16 @@ jobs:
 
   deploy-production:
     name: "Deploy to Production 🚀"
-    needs: [changes, build, deploy-sandbox]
-    if: always() && !failure() && !cancelled() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    needs: [changes, build, build-playwright, deploy-sandbox]
+    if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-playwright.result == 'success' || needs.build-playwright.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: production
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
-      render-worker-service-ids: "srv-d4k6otfgi27c73cicnpg,srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
+      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
+      docker-digest-playwright: ${{ needs.build-playwright.outputs.digest }}
+      render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}

--- a/server/Dockerfile.playwright
+++ b/server/Dockerfile.playwright
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN uv run playwright install --with-deps chromium

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
   "alembic-utils>=0.8.8",
   "countryinfo>=0.1.2",
   "clickhouse-connect>=0.8.0",
+  "playwright>=1.50.0",
 ]
 
 [dependency-groups]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1895,6 +1895,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1934,6 +1953,7 @@ dependencies = [
     { name = "logfire", extra = ["fastapi", "httpx", "redis", "sqlalchemy"] },
     { name = "makefun" },
     { name = "plain-client" },
+    { name = "playwright" },
     { name = "posthog" },
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
@@ -2019,6 +2039,7 @@ requires-dist = [
     { name = "logfire", extras = ["fastapi", "httpx", "sqlalchemy", "redis"], specifier = ">=2.6.0" },
     { name = "makefun", specifier = ">=1.15.6" },
     { name = "plain-client", specifier = ">=0.0.3" },
+    { name = "playwright", specifier = ">=1.50.0" },
     { name = "posthog", specifier = ">=3.6.0" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.5" },
@@ -2331,6 +2352,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730, upload-time = "2025-03-17T18:53:14.532Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Create a separate `polar-playwright` Docker image extending the base with Chromium for the low_priority worker to use for web scraping. This keeps other worker images small.

## What

- Added `playwright>=1.50.0` dependency
- Created `server/Dockerfile.playwright` extending base image with Chromium
- New `build-playwright` CI job builds and pushes `polar-playwright` image to GHCR
- Deploy jobs updated to deploy playwright workers with the separate image
- Enhanced deploy script to handle multiple image types and validate build results

## Why

The low_priority worker needs Playwright/Chromium to scrape organization websites. Rather than bundling 500MB of browser dependencies in all worker images, we create a specialized image deployed only to workers that need it.

## How

- `build-playwright` job runs after `build` succeeds, extending the base image digest with Chromium
- Deployment workflow passes playwright digest and worker IDs separately to the deploy script
- Deploy script now accepts image parameter to `deploy_servers` function, supporting both polar and polar-playwright images
- Build result validation prevents failed builds from deploying

## Testing

- Verified workflow conditions correctly check build results
- Validated shell script parameter handling for empty worker arrays
- Confirmed Docker image metadata tags follow existing patterns
- All workflow syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)