### PR TITLE
Fix Playwright deployment to sandbox

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,8 +174,6 @@ jobs:
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
       render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
-      docker-digest-playwright: ${{ needs.build-playwright.outputs.digest }}
-      render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -273,11 +273,11 @@ resource "render_web_service" "worker" {
 
   runtime_source = {
     image = each.value.digest != null ? {
-      image_url              = "ghcr.io/polarsource/polar"
+      image_url              = each.value.image_url
       registry_credential_id = var.registry_credential_id
       digest                 = each.value.digest
       } : {
-      image_url              = "ghcr.io/polarsource/polar"
+      image_url              = each.value.image_url
       registry_credential_id = var.registry_credential_id
       tag                    = each.value.tag
     }

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -41,6 +41,7 @@ variable "workers" {
   description = "Map of worker configurations"
   type = map(object({
     start_command      = string
+    image_url          = optional(string, "ghcr.io/polarsource/polar")
     digest             = optional(string)
     tag                = optional(string)
     custom_domains     = optional(list(object({ name = string })), [])

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -91,6 +91,7 @@ module "sandbox" {
   workers = {
     worker-sandbox = {
       start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority"
+      image_url          = "ghcr.io/polarsource/polar-playwright"
       tag                = "latest"
       dramatiq_prom_port = "10000"
     }


### PR DESCRIPTION
## Summary

Fixes the Render deployment error: `only the image tag or digest can be updated when creating a deploy`. This occurred because the sandbox worker was configured with the base polar image but the deploy script attempted to push the polar-playwright image (different image URL).

## What

- Added optional `image_url` field to worker Terraform config (defaults to base polar image for backwards compatibility)
- Set sandbox `worker-sandbox` to use `ghcr.io/polarsource/polar-playwright` image
- Removed playwright deployment parameters from production deploy job (sandbox only for now)
- Updated worker Terraform resource to use per-worker `image_url` instead of hardcoded base image

## Why

Render's API only permits updating the tag or digest of an image URL—not the image URL itself. To deploy a different image to a service, the service's image URL must first be configured in Terraform. This change allows individual workers to specify their own image URL while maintaining backwards compatibility for existing workers.

## How

Workers can now optionally specify `image_url` in Terraform. The sandbox worker is configured to use the playwright image. Production workers continue using the base image (default).

**Important**: The Terraform sandbox config must be applied before this PR is deployed to update the Render service image URL.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>