### PR TITLE
fix: Remove image_url from Terraform ignore_changes

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -214,7 +214,6 @@ resource "render_web_service" "api" {
 
   lifecycle {
     ignore_changes = [
-      runtime_source.image.image_url,
       runtime_source.image.digest,
       runtime_source.image.tag,
     ]
@@ -285,7 +284,6 @@ resource "render_web_service" "worker" {
 
   lifecycle {
     ignore_changes = [
-      runtime_source.image.image_url,
       runtime_source.image.tag,
       runtime_source.image.digest,
     ]


### PR DESCRIPTION
## Summary

Follow-up to #9536. The `lifecycle.ignore_changes` block on worker services included `runtime_source.image.image_url`, which prevented Terraform from updating the image URL on existing Render services. This caused the playwright image URL change to be silently ignored ("No changes" in Terraform plan).

## What

Removed `runtime_source.image.image_url` from `ignore_changes` in both the API and worker service lifecycle blocks.

## Why

Only `tag` and `digest` need to be ignored (they change via deploy API calls). The `image_url` should be fully managed by Terraform so that changes like switching a worker to the playwright image actually get applied.

## How

After merging, re-run `terraform plan` on the sandbox workspace — it should now show a change to update `worker-sandbox`'s image URL from `ghcr.io/polarsource/polar` to `ghcr.io/polarsource/polar-playwright`. Apply it, and subsequent deploys will work.