### PR TITLE
revert: Restore image_url to Terraform ignore_changes

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -214,6 +214,7 @@ resource "render_web_service" "api" {
 
   lifecycle {
     ignore_changes = [
+      runtime_source.image.image_url,
       runtime_source.image.digest,
       runtime_source.image.tag,
     ]
@@ -284,6 +285,7 @@ resource "render_web_service" "worker" {
 
   lifecycle {
     ignore_changes = [
+      runtime_source.image.image_url,
       runtime_source.image.tag,
       runtime_source.image.digest,
     ]


### PR DESCRIPTION
## Summary

Reverts the `ignore_changes` portion of #9537. Removing `image_url` from `ignore_changes` caused Terraform to try to re-validate all services' images, failing with "unable to fetch image with provided input".

## What

Restores `runtime_source.image.image_url` to the `lifecycle.ignore_changes` block on both the API and worker service resources.

## Why

The sandbox worker's image URL will be updated directly via the Render dashboard instead. With `ignore_changes`, Terraform won't try to revert the manual change.