### PR TITLE
Add OrganizationAgentReview model and migration

### DIFF
--- a/server/migrations/versions/2026-02-13-1200_add_agent_report_to_org_reviews.py
+++ b/server/migrations/versions/2026-02-13-1200_add_agent_report_to_org_reviews.py
@@ -1,0 +1,86 @@
+"""Create organization_agent_reviews table
+
+Revision ID: a1c2d3e4f567
+Revises: b7a3d4baf848
+Create Date: 2026-02-13 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "a1c2d3e4f567"
+down_revision = "b7a3d4baf848"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organization_agent_reviews",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("report", sa.dialects.postgresql.JSONB(), nullable=False),
+        sa.Column("model_used", sa.String(), nullable=False),
+        sa.Column(
+            "reviewed_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            name=op.f("organization_agent_reviews_organization_id_fkey"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("organization_agent_reviews_pkey")),
+    )
+    op.create_index(
+        op.f("ix_organization_agent_reviews_created_at"),
+        "organization_agent_reviews",
+        ["created_at"],
+    )
+    op.create_index(
+        op.f("ix_organization_agent_reviews_deleted_at"),
+        "organization_agent_reviews",
+        ["deleted_at"],
+    )
+    op.create_index(
+        op.f("ix_organization_agent_reviews_organization_id"),
+        "organization_agent_reviews",
+        ["organization_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_organization_agent_reviews_organization_id"),
+        table_name="organization_agent_reviews",
+    )
+    op.drop_index(
+        op.f("ix_organization_agent_reviews_deleted_at"),
+        table_name="organization_agent_reviews",
+    )
+    op.drop_index(
+        op.f("ix_organization_agent_reviews_created_at"),
+        table_name="organization_agent_reviews",
+    )
+    op.drop_table("organization_agent_reviews")

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -45,6 +45,7 @@ from .order import Order
 from .order_item import OrderItem
 from .organization import Organization
 from .organization_access_token import OrganizationAccessToken
+from .organization_agent_review import OrganizationAgentReview
 from .organization_review import OrganizationReview
 from .payment import Payment
 from .payment_method import PaymentMethod
@@ -137,6 +138,7 @@ __all__ = [
     "OrderItem",
     "Organization",
     "OrganizationAccessToken",
+    "OrganizationAgentReview",
     "OrganizationReview",
     "Payment",
     "PaymentMethod",

--- a/server/polar/models/organization_agent_review.py
+++ b/server/polar/models/organization_agent_review.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import TIMESTAMP, ForeignKey, String, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+
+from polar.kit.db.models import RecordModel
+
+if TYPE_CHECKING:
+    from polar.models.organization import Organization
+
+
+class OrganizationAgentReview(RecordModel):
+    """Stores the result of running the AI review agent on an organization."""
+
+    __tablename__ = "organization_agent_reviews"
+
+    organization_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("organizations.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
+
+    report: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    model_used: Mapped[str] = mapped_column(String, nullable=False)
+    reviewed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+
+    @declared_attr
+    def organization(cls) -> Mapped["Organization"]:
+        return relationship("Organization", lazy="raise")
+
+    def __repr__(self) -> str:
+        return (
+            f"OrganizationAgentReview(id={self.id}, "
+            f"organization_id={self.organization_id})"
+        )


### PR DESCRIPTION
## Summary

Adds a new `OrganizationAgentReview` model and database migration to store AI review agent results.

## What

- New `OrganizationAgentReview` model (`organization_agent_reviews` table)
- Migration creating the table with JSONB `report` column, `model_used`, `reviewed_at`
- FK to organizations with cascade delete, indexed on `organization_id`
- Registered in `models/__init__.py`

## Why

Need a dedicated table to persist agent review runs, separate from the existing `OrganizationReview` (initial screening) model. Supports multiple runs per org and keeps agent data isolated from customer-facing paths.

## How

Standard RecordModel with JSONB storage for the full serialized `AgentReviewResult`.

## Testing

- [ ] Run migration: `uv run alembic upgrade head`
- [ ] Verify table created with correct columns and indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)