### PR TITLE
Block seat-based product creation when feature flag is disabled

### DIFF
--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -52,6 +52,7 @@ from .schemas import (
     ProductCreate,
     ProductPriceCreate,
     ProductPriceMeteredCreateBase,
+    ProductPriceSeatBasedCreate,
     ProductUpdate,
 )
 from .sorting import ProductSortProperty
@@ -534,6 +535,19 @@ class ProductService:
                 price = model_class(
                     product=product, source=source, **price_schema.model_dump()
                 )
+                if isinstance(price_schema, ProductPriceSeatBasedCreate):
+                    if not organization.feature_settings.get(
+                        "seat_based_pricing_enabled", False
+                    ):
+                        errors.append(
+                            {
+                                "type": "value_error",
+                                "loc": (*error_prefix, index),
+                                "msg": "Seat-based pricing is not enabled for this organization.",
+                                "input": price_schema,
+                            }
+                        )
+                        continue
                 if is_metered_price(price) and isinstance(
                     price_schema, ProductPriceMeteredCreateBase
                 ):


### PR DESCRIPTION
## 📋 Summary

Adds a feature flag check to prevent organizations from creating seat-based products when the `seat_based_pricing_enabled` feature flag is disabled.

## 🎯 What

- Added validation in `get_validated_prices()` to check `organization.feature_settings.get("seat_based_pricing_enabled", False)` when a `ProductPriceSeatBasedCreate` price is encountered
- If the flag is disabled, the price is rejected with a validation error
- Both `create` and `update` product operations are protected by this check

## 🤔 Why

Organizations could previously create seat-based products even when they didn't have the feature enabled, leading to products they couldn't actually use.

## 🔧 How

The check is placed in `get_validated_prices()` after price model creation but before metered pricing validation, following the existing pattern for pricing validation.

## 🧪 Testing

- Added `test_seat_based_price_feature_disabled`: Verifies that creating a product with seat-based pricing raises `PolarRequestValidationError` when the feature is disabled
- Added `test_seat_based_price_feature_enabled`: Verifies that creation succeeds when the feature is enabled
- Both tests use simple single-tier seat pricing configurations