### PR TITLE
fix: resolve CSP violations in copy buttons

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -17,6 +17,7 @@ from ...components import (
     status_badge,
     tab_nav,
 )
+from ...components._clipboard_button import clipboard_button
 
 
 class OrganizationDetailView:
@@ -312,13 +313,8 @@ class OrganizationDetailView:
                                 classes="font-mono text-xs bg-base-200 px-2 py-1 rounded flex-1"
                             ):
                                 text(self.org.slug)
-                            with button(
-                                variant="secondary",
-                                size="sm",
-                                ghost=True,
-                                onclick=f"navigator.clipboard.writeText('{self.org.slug}'); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 1000)",
-                            ):
-                                text("Copy")
+                            with clipboard_button(self.org.slug):
+                                pass
 
                     # ID (copyable)
                     with tag.div():
@@ -329,13 +325,8 @@ class OrganizationDetailView:
                                 classes="font-mono text-xs bg-base-200 px-2 py-1 rounded flex-1 break-all"
                             ):
                                 text(str(self.org.id))
-                            with button(
-                                variant="secondary",
-                                size="sm",
-                                ghost=True,
-                                onclick=f"navigator.clipboard.writeText('{self.org.id}'); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 1000)",
-                            ):
-                                text("Copy")
+                            with clipboard_button(str(self.org.id)):
+                                pass
 
                     # Created
                     with tag.div():

--- a/server/polar/backoffice/organizations_v2/views/sections/review_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/review_section.py
@@ -354,11 +354,6 @@ class ReviewSection:
         )
         template_text = "\n".join(template_lines)
 
-        # Escape for JS
-        escaped = (
-            template_text.replace("\\", "\\\\").replace("`", "\\`").replace("$", "\\$")
-        )
-
         with card(bordered=True):
             with tag.h2(classes="text-lg font-bold mb-4"):
                 text("Review Reply Template")
@@ -370,7 +365,8 @@ class ReviewSection:
 
             with tag.button(
                 classes="btn btn-sm btn-outline",
-                onclick=f"navigator.clipboard.writeText(`{escaped}`); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy to Clipboard', 1000)",
+                **{"data-copy-text": template_text},
+                _="on click call navigator.clipboard.writeText(my.dataset.copyText) then put 'Copied!' into me then wait 1s then put 'Copy to Clipboard' into me",
             ):
                 text("Copy to Clipboard")
 


### PR DESCRIPTION
## 📋 Summary

Fixes CSP (Content Security Policy) violations in Safari when clicking copy buttons on the organizations-v2 pages. The error "Refused to execute a script for an inline event handler because 'unsafe-inline' does not appear in the script-src directive" was blocking copy functionality.

## 🎯 What

Replaced three inline `onclick` handlers with CSP-compliant alternatives:
- Slug and Organization ID copy buttons now use the existing `clipboard_button` component (Hyperscript-based)
- Reply template copy button uses Hyperscript with a `data-attribute` to support multi-line text

## 🤔 Why

The backoffice CSP explicitly sets `script-src 'self'` (no `unsafe-inline`) for security. Inline event handlers violate this policy and fail in Safari. The codebase already had a CSP-compliant solution available through the `clipboard_button` component.

## 🔧 How

- Imported and used the existing `clipboard_button` component for single-line text (slug, org ID)
- Replaced multi-line copy with Hyperscript (`_=` attribute) and `data-copy-text` attribute for the reply template
- Removed unnecessary JS escaping logic since Hyperscript handles the text directly

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] Code follows project style guidelines
- [x] No new warnings generated

**Test Instructions**: Navigate to the organizations-v2 detail page in the backoffice, verify copy buttons work in Safari for slug, org ID, and reply template fields.

## 📝 Additional Notes

This is a security hardening fix that maintains all existing functionality while complying with the CSP configuration.