### PR TITLE
fix: include low-priority worker in production deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,7 +173,7 @@ jobs:
       environment: production
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
-      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
+      render-worker-service-ids: "srv-d4k6otfgi27c73cicnpg,srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
## 📋 Summary

Fixes the missing low-priority worker from the production deployment pipeline.

## 🎯 What

Added the low-priority worker service ID (`srv-d4k6otfgi27c73cicnpg`) to the production deployment configuration in `.github/workflows/deploy.yml`.

## 🤔 Why

The low-priority worker was not being deployed by CI/CD, causing it to remain on an outdated code version. This prevented the `organization_review.run_agent` task from being registered, resulting in `ActorNotFound` errors when the review agent button was clicked in the backoffice.

## 🔧 How

Updated the `render-worker-service-ids` list in the production deployment job to include the low-priority worker service ID at the beginning of the comma-separated list.

## 🧪 Testing

- [x] Change is minimal and follows the existing pattern (same format as other worker IDs)
- [x] No new code logic, only configuration update
- [x] All 5 production workers are now included in deployments: scheduler, worker (low-priority), worker-medium-priority, worker-high-priority, worker-webhook

## 📝 Additional Notes

Once this PR is merged and deployed, the low-priority worker will receive code updates and the organization review agent will function correctly.