### PR TITLE
Debounce customer_state.changed webhook with dedicated actor

### DIFF
--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -700,11 +700,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         assert loaded is not None
         loaded.previous_properties = previous_grant_properties
         await webhook_service.send(session, benefit.organization, event_type, loaded)
-        enqueue_job(
-            "customer.webhook",
-            WebhookEventType.customer_state_changed,
-            grant.customer_id,
-        )
+        enqueue_job("customer.state_changed_webhook", grant.customer_id)
 
 
 benefit_grant = BenefitGrantService(BenefitGrant)

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -82,6 +82,13 @@ class Settings(BaseSettings):
     CUSTOMER_METER_UPDATE_DEBOUNCE_MIN_THRESHOLD: timedelta = timedelta(seconds=15)
     CUSTOMER_METER_UPDATE_DEBOUNCE_MAX_THRESHOLD: timedelta = timedelta(minutes=180)
 
+    CUSTOMER_STATE_CHANGED_WEBHOOK_DEBOUNCE_MIN_THRESHOLD: timedelta = timedelta(
+        seconds=1
+    )
+    CUSTOMER_STATE_CHANGED_WEBHOOK_DEBOUNCE_MAX_THRESHOLD: timedelta = timedelta(
+        seconds=5
+    )
+
     SECRET: str = "super secret jwt secret"
     JWKS: JWKSFile = Field(default="./.jwks.json")
     CURRENT_JWK_KID: str = "polar_dev"

--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -26,7 +26,6 @@ from polar.meter.aggregation import (
 from polar.meter.repository import MeterRepository
 from polar.models import Customer, CustomerMeter, Event, Meter, MeterEvent
 from polar.models.event import EventSource
-from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
 from polar.worker import enqueue_job
 
@@ -110,9 +109,7 @@ class CustomerMeterService:
             updated = updated or meter_updated
 
         if updated:
-            enqueue_job(
-                "customer.webhook", WebhookEventType.customer_state_changed, customer.id
-            )
+            enqueue_job("customer.state_changed_webhook", customer.id)
 
     async def update_customer_meter(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -823,11 +823,7 @@ class SubscriptionService:
         if subscription.active:
             await self._on_subscription_activated(session, subscription, False)
 
-        enqueue_job(
-            "customer.webhook",
-            WebhookEventType.customer_state_changed,
-            subscription.customer_id,
-        )
+        enqueue_job("customer.state_changed_webhook", subscription.customer_id)
 
     @contextlib.asynccontextmanager
     async def lock(
@@ -1927,11 +1923,7 @@ class SubscriptionService:
                 session, subscription, past_due=became_past_due
             )
 
-        enqueue_job(
-            "customer.webhook",
-            WebhookEventType.customer_state_changed,
-            subscription.customer_id,
-        )
+        enqueue_job("customer.state_changed_webhook", subscription.customer_id)
 
     async def _on_subscription_updated(
         self,

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -1031,10 +1031,14 @@ class TestWebhook:
         customer: Customer,
     ) -> None:
         send_mock = mocker.patch("polar.webhook.service.webhook.send")
+        enqueue_mock = mocker.patch("polar.customer.service.enqueue_job")
 
         await customer_service.webhook(session, redis, event_type, customer)
 
-        assert send_mock.call_count == 2
+        assert send_mock.call_count == 1
+        enqueue_mock.assert_called_once_with(
+            "customer.state_changed_webhook", customer.id
+        )
 
     async def test_state_changed_event(
         self,


### PR DESCRIPTION
The customer_state_changed webhook was fired from multiple places
(subscription changes, benefit grants, meter updates, customer CRUD)
without any deduplication. During operations like subscription creation
that also trigger benefit grants, this caused multiple redundant webhooks
for the same customer in rapid succession.

Introduces a dedicated `customer.state_changed_webhook` actor with
debounce support (1s min / 5s max threshold), keyed per customer_id.
All call sites now enqueue through this actor instead of the generic
`customer.webhook` actor, ensuring only one state_changed webhook fires
per customer within the debounce window.

https://claude.ai/code/session_01Sxo8K6q1kNPVyKE5zzBHG1