### PR TITLE
balance-events: Ensure that the transaction ID is persisted

### DIFF
--- a/server/polar/transaction/service/refund.py
+++ b/server/polar/transaction/service/refund.py
@@ -224,6 +224,7 @@ class RefundTransactionService(BaseTransactionService):
             order_id=payment_transaction.order_id,
         )
         session.add(refund_reversal_transaction)
+        await session.flush()
 
         try:
             customer = payment_transaction.payment_customer


### PR DESCRIPTION
Before using it in event, otherwise we get None as the transaction ID of the balance.refund_reversal event
