### PR TITLE
feat: Script to post action-required comments on Plain review threads

### DIFF
--- a/server/scripts/comment_review_actions.py
+++ b/server/scripts/comment_review_actions.py
@@ -78,7 +78,9 @@ async def get_review_threads(
     created_at_filter: DatetimeFilter | None = None
     if older_than_days is not None:
         cutoff = datetime.now(UTC) - timedelta(days=older_than_days)
-        cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%S.") + f"{cutoff.microsecond // 1000:03d}Z"
+        cutoff_str = (
+            cutoff.strftime("%Y-%m-%dT%H:%M:%S.") + f"{cutoff.microsecond // 1000:03d}Z"
+        )
         created_at_filter = DatetimeFilter(before=cutoff_str)
         log.info(
             "Filtering threads older than",


### PR DESCRIPTION
## 📋 Summary

Adds a new script that automatically posts friendly, personalized action-required comments on Plain review threads for organizations in initial review.

## 🎯 What

New script `server/scripts/comment_review_actions.py` that:
- Paginates Plain threads with the "Initial Account Review" label
- Extracts org slugs from thread preview text via regex
- Checks the database for org issues: missing website, missing social links, unverified admin identity, non-refunded test orders
- Posts adapted numbered comments with specific instructions for each issue

## 🤔 Why

Automates the review process by posting contextual reminders to orgs about what they need to fix before approval, following a friendly template with direct guidance.

## 🔧 How

Follows the same pattern as `create_review_tickets.py`: async script with `--execute` flag (dry-run default), structlog for logging, and DB session management. Uses Plain GraphQL API to paginate threads and post replies via `reply_to_thread`. Issues are checked via SQL queries against org, user, and order tables. Comment text is adapted per org (e.g., numbering adjusts based on which issues apply).

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (\`uv run task test\` for backend)

### Test Instructions

1. \`cd server && uv run python -m scripts.comment_review_actions --limit 1\` — Dry-run, check logs
2. \`uv run python -m scripts.comment_review_actions --limit 0\` — Dry-run, all threads
3. \`uv run python -m scripts.comment_review_actions --execute --limit 1\` — Post one comment, verify in Plain UI

## 📝 Additional Notes

Comment message template is friendly and adaptive: always includes discount code request, conditionally includes website/socials/refund instructions based on org's specific issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)