### PR TITLE
fix: Restore Playwright worker deployment in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,9 @@ jobs:
       environment: production
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
-      render-worker-service-ids: "srv-d4k6otfgi27c73cicnpg,srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
+      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0"
+      docker-digest-playwright: ${{ needs.build-playwright.outputs.digest }}
+      render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
## 📋 Summary

Fixes website scraping failure in production due to missing Chromium browser in Playwright workers.

## 🎯 What

Restored the separate Playwright worker deployment configuration for production. Worker `srv-d4k6otfgi27c73cicnpg` is now deployed with the `polar-playwright` Docker image that includes Chromium, instead of the base image.

## 🤔 Why

Commit 5d87b4b16 ("Deploy Playwright workers in parallel") accidentally merged the Playwright worker service ID back into the regular worker list. This caused it to be deployed with the base Docker image that only has the Playwright Python package but not the Chromium browser binary. The website collector for organization reviews runs on this worker and fails with: `BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell`

## 🔧 How

Removed `srv-d4k6otfgi27c73cicnpg` from `render-worker-service-ids` and added it to `render-playwright-worker-service-ids` with the `docker-digest-playwright` parameter, matching the original setup from commit 6ac0dde6b and the current working sandbox configuration.