### PR TITLE
Split subscription cycled & trial converted email

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -40,6 +40,11 @@ const customerEmails: {
     description: 'Sent when a subscription automatically renews',
   },
   {
+    key: 'subscription_cycled_after_trial',
+    title: 'Trial converted',
+    description: 'Sent when a trial ends and the subscription becomes paid',
+  },
+  {
     key: 'subscription_updated',
     title: 'Subscription updated',
     description:

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -21025,6 +21025,8 @@ export interface components {
       subscription_confirmation: boolean
       /** Subscription Cycled */
       subscription_cycled: boolean
+      /** Subscription Cycled After Trial */
+      subscription_cycled_after_trial: boolean
       /** Subscription Past Due */
       subscription_past_due: boolean
       /** Subscription Revoked */

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -18,6 +18,7 @@ import { SeatInvitation } from './seat_invitation'
 import { SubscriptionCancellation } from './subscription_cancellation'
 import { SubscriptionConfirmation } from './subscription_confirmation'
 import { SubscriptionCycled } from './subscription_cycled'
+import { SubscriptionCycledAfterTrial } from './subscription_cycled_after_trial'
 import { SubscriptionPastDue } from './subscription_past_due'
 import { SubscriptionRevoked } from './subscription_revoked'
 import { SubscriptionUncanceled } from './subscription_uncanceled'
@@ -41,6 +42,7 @@ const TEMPLATES: Record<string, React.FC<any>> = {
   subscription_cancellation: SubscriptionCancellation,
   subscription_confirmation: SubscriptionConfirmation,
   subscription_cycled: SubscriptionCycled,
+  subscription_cycled_after_trial: SubscriptionCycledAfterTrial,
   subscription_past_due: SubscriptionPastDue,
   subscription_revoked: SubscriptionRevoked,
   subscription_uncanceled: SubscriptionUncanceled,

--- a/server/emails/src/emails/subscription_cycled_after_trial.tsx
+++ b/server/emails/src/emails/subscription_cycled_after_trial.tsx
@@ -1,0 +1,73 @@
+import {
+  Heading,
+  Hr,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import BodyText from '../components/BodyText'
+import Button from '../components/Button'
+import FooterCustomer from '../components/FooterCustomer'
+import OrderSummary from '../components/OrderSummary'
+import WrapperOrganization from '../components/WrapperOrganization'
+import { order, organization, product } from '../preview'
+import type { schemas } from '../types'
+
+export function SubscriptionCycledAfterTrial({
+  email,
+  organization,
+  product,
+  subscription,
+  order,
+  url,
+}: schemas['SubscriptionCycledAfterTrialProps']) {
+  return (
+    <WrapperOrganization organization={organization}>
+      <Preview>
+        Your trial for {product.name} has ended — your subscription is now
+        active
+      </Preview>
+      <Section>
+        <Heading as="h1" className="text-xl font-bold text-gray-900">
+          Your trial has ended
+        </Heading>
+        <BodyText>
+          Your trial for <span className="font-bold">{product.name}</span> has
+          ended and your subscription is now active.
+        </BodyText>
+      </Section>
+      <Section className="my-8 text-center">
+        <Button href={url}>Manage my subscription</Button>
+      </Section>
+      <Hr />
+      <OrderSummary order={order} />
+      <Section className="mt-6 border-t border-gray-200 pt-4 pb-4">
+        <Text className="m-0 text-xs text-gray-600">
+          If you're having trouble with the button above, copy & paste the URL
+          below into your web browser.
+        </Text>
+        <Text className="mt-2 mb-0 text-xs">
+          <Link href={url} className="break-all text-blue-600 underline">
+            {url}
+          </Link>
+        </Text>
+      </Section>
+      <FooterCustomer organization={organization} email={email} />
+    </WrapperOrganization>
+  )
+}
+
+SubscriptionCycledAfterTrial.PreviewProps = {
+  email: 'john@example.com',
+  organization,
+  product,
+  subscription: {
+    id: '12345',
+    status: 'active',
+  },
+  order,
+  url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
+}
+
+export default SubscriptionCycledAfterTrial

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -34,6 +34,7 @@ class EmailTemplate(StrEnum):
     subscription_cancellation = "subscription_cancellation"
     subscription_confirmation = "subscription_confirmation"
     subscription_cycled = "subscription_cycled"
+    subscription_cycled_after_trial = "subscription_cycled_after_trial"
     subscription_past_due = "subscription_past_due"
     subscription_revoked = "subscription_revoked"
     subscription_uncanceled = "subscription_uncanceled"
@@ -248,6 +249,17 @@ class SubscriptionCycledEmail(BaseModel):
     props: SubscriptionCycledProps
 
 
+class SubscriptionCycledAfterTrialProps(SubscriptionPropsBase):
+    order: OrderEmail
+
+
+class SubscriptionCycledAfterTrialEmail(BaseModel):
+    template: Literal[EmailTemplate.subscription_cycled_after_trial] = (
+        EmailTemplate.subscription_cycled_after_trial
+    )
+    props: SubscriptionCycledAfterTrialProps
+
+
 class SubscriptionPastDueProps(SubscriptionPropsBase):
     payment_url: str | None = None
 
@@ -360,6 +372,7 @@ Email = Annotated[
     | SubscriptionCancellationEmail
     | SubscriptionConfirmationEmail
     | SubscriptionCycledEmail
+    | SubscriptionCycledAfterTrialEmail
     | SubscriptionPastDueEmail
     | SubscriptionRevokedEmail
     | SubscriptionUncanceledEmail

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1341,6 +1341,7 @@ class OrderService:
             "order_confirmation",
             "subscription_confirmation",
             "subscription_cycled",
+            "subscription_cycled_after_trial",
             "subscription_updated",
         ]
         subject_template: str
@@ -1365,12 +1366,18 @@ class OrderService:
                     "id": "{subscription}",
                     "email": "{email}",
                 }
-            case (
-                OrderBillingReasonInternal.subscription_cycle
-                | OrderBillingReasonInternal.subscription_cycle_after_trial
-            ):
+            case OrderBillingReasonInternal.subscription_cycle:
                 template_name = "subscription_cycled"
                 subject_template = "Your {description} subscription has been renewed"
+                url_path_template = "/{organization}/portal"
+                url_params = {
+                    "customer_session_token": "{token}",
+                    "id": "{subscription}",
+                    "email": "{email}",
+                }
+            case OrderBillingReasonInternal.subscription_cycle_after_trial:
+                template_name = "subscription_cycled_after_trial"
+                subject_template = "Your {description} subscription is now active"
                 url_path_template = "/{organization}/portal"
                 url_params = {
                     "customer_session_token": "{token}",


### PR DESCRIPTION
I believe the subscription cycle email should have different copy when it's a trial conversion. My first attempt was going to be sending the billing reason to the template so that we could split the copy there, but I think this is the proper split.

Includes a data migration so that people that have opted out of subscription cycle emails don't get suddenly opted in for trial conversion emails.