### PR TITLE
server/migrations: fix payout status migration

### DIFF
--- a/server/migrations/versions/2026-02-19-1501_add_back_payout_status_with_trigger.py
+++ b/server/migrations/versions/2026-02-19-1501_add_back_payout_status_with_trigger.py
@@ -49,6 +49,8 @@ def upgrade() -> None:
         UPDATE payout_attempts SET id = id
         """
     )
+    op.execute("""UPDATE payouts SET status = 'pending' WHERE status IS NULL""")
+
     op.alter_column("payouts", "status", nullable=False)
 
     op.create_index(op.f("ix_payouts_status"), "payouts", ["status"], unique=False)


### PR DESCRIPTION
Fix #9632

- server/migrations: fix payout status migration
