### PR TITLE
Trigger AI agent review when organization enters review status

### DIFF
--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -23,7 +23,7 @@ from polar.models.customer_seat import SeatStatus
 from polar.models.member import Member, MemberRole
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
-from polar.worker import AsyncSessionMaker, TaskPriority, actor
+from polar.worker import AsyncSessionMaker, TaskPriority, actor, enqueue_job
 
 from .repository import OrganizationRepository
 
@@ -104,6 +104,8 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
             raise OrganizationDoesNotExist(organization_id)
 
         await plain_service.create_organization_review_thread(session, organization)
+
+        enqueue_job("organization_review.run_agent", organization_id=organization_id)
 
         # We used to send an email manually too for initial reviews,
         # but we rely on Plain to do that now.


### PR DESCRIPTION
## 📋 Summary

Automatically triggers the AI agent code review when an organization transitions to review status (INITIAL_REVIEW or ONGOING_REVIEW), so reviewers have the agent's report ready when they access the Plain ticket.

## 🎯 What

Added `enqueue_job("organization_review.run_agent", organization_id=organization_id)` to the `organization_under_review` task after Plain thread creation, and imported `enqueue_job` from `polar.worker`.

## 🤔 Why

Currently the AI agent review is only triggered manually from the backoffice UI. Organizations that transition to review status automatically (via threshold check) or manually (via backoffice) now get the AI review started immediately, eliminating the extra step for reviewers.

## 🔧 How

Modified `server/polar/organization/tasks.py` to enqueue the AI agent review job as part of the `organization_under_review` task. This single change covers both trigger paths: automatic threshold transitions and manual backoffice actions.

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)