### PR TITLE
fix(docs): replace invalid MCP server name with hyphenated version

### DIFF
--- a/docs/integrate/mcp.mdx
+++ b/docs/integrate/mcp.mdx
@@ -154,7 +154,7 @@ claude mcp add --transport http "Polar" "https://mcp.polar.sh/mcp/polar-mcp"
 For sandbox:
 
 ```
-claude mcp add --transport http "Polar Sandbox" "https://mcp.polar.sh/mcp/polar-sandbox"
+claude mcp add --transport http "Polar-Sandbox" "https://mcp.polar.sh/mcp/polar-sandbox"
 ```
 
 ### ChatGPT


### PR DESCRIPTION
## 📋 Summary
**Related Issue**: N/A (minor documentation fix)

Fix invalid MCP server name in docs that contains a space.

## 🎯 What

Changed `"Polar Sandbox"` to `"Polar-Sandbox"` in `docs/integrate/mcp.mdx`.

## 🤔 Why

The Claude CLI does not allow spaces in MCP server names. Running the current command returns:
> "Invalid name Polar Sandbox. Names can only contain letters, numbers, hyphens, and underscores."

## 🔧 How

Replaced the space with a hyphen in the server name string.

## 🧪 Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Run `claude mcp add --transport http "Polar Sandbox" "https://mcp.polar.sh/mcp/polar-sandbox"` — fails
2. Run `claude mcp add --transport http "Polar-Sandbox" "https://mcp.polar.sh/mcp/polar-sandbox"` — succeeds

## 🖼️ Screenshots/Recordings

N/A

## 📝 Additional Notes

Minor documentation fix — no issue required per CONTRIBUTING.md.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")