### PR TITLE
Assign appeal review threads to a random support agent

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -309,6 +309,9 @@ class PlainService:
                     customer_identifier=customer_identifier,
                     title=f"Organization Appeal - {organization.slug}",
                     label_type_ids=["lt_01K3QWYTDV7RSS7MM2RC584X41"],
+                    assigned_to=CreateThreadAssignedToInput(
+                        user_id=random.choice(SUPPORT_AGENT_IDS)
+                    ),
                     components=[
                         ComponentInput(
                             component_text=ComponentTextInput(


### PR DESCRIPTION
Apply the same random agent assignment used for initial account reviews to `create_appeal_review_thread`, using `random.choice(SUPPORT_AGENT_IDS)`.

https://claude.ai/code/session_013PZdSUQZKtagRCUnStrt8Q

