### PR TITLE
refactor: inline backfill in migration script

### DIFF
--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -209,9 +209,7 @@ async def migrate_organizations(
                     session
                 ).get_by_id(org.id)
                 assert organization is not None
-                grants_linked = await _backfill_benefit_grants(
-                    session, organization
-                )
+                grants_linked = await _backfill_benefit_grants(session, organization)
 
             # Step D: Soft-delete orphaned seat-holder customers
             async with sessionmaker() as session:


### PR DESCRIPTION
## 📋 Summary

Modifies the organization migration script to execute backfill steps directly instead of enqueueing async tasks, avoiding task queue limitations for large-scale migrations.

## 🎯 What

- Removed dependency on `dramatiq` task queue and `JobQueueManager`
- Imported the 4 backfill helper functions directly from `polar.organization.tasks`
- Script now runs all migration steps inline: enable feature flag, create owner members, migrate seats, link benefit grants, cleanup orphaned customers

## 🤔 Why

Async task queues can become a bottleneck for large-scale organization migrations. Running backfill steps directly in the script ensures reliable, sequential execution without queueing delays or task limits.

## 🔧 How

Each organization is processed sequentially with the same 4-step backfill approach, but executed directly with independent database sessions per step to preserve idempotency. Progress is tracked and reported with per-organization statistics.

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)