### PR TITLE
server/order: recalculate tax if original calculation expired when handling payment order

### DIFF
--- a/server/polar/tax/calculation/__init__.py
+++ b/server/polar/tax/calculation/__init__.py
@@ -11,6 +11,7 @@ from polar.observability import TAX_CALCULATION_TOTAL
 
 from ..tax_id import TaxID
 from .base import (
+    CalculationExpiredError,
     InvalidTaxIDError,
     TaxabilityReason,
     TaxCalculation,
@@ -137,6 +138,7 @@ class TaxCalculationService:
 tax_calculation = TaxCalculationService()
 
 __all__ = [
+    "CalculationExpiredError",
     "InvalidTaxIDError",
     "TaxCalculation",
     "TaxCalculationLogicalError",

--- a/server/polar/tax/calculation/base.py
+++ b/server/polar/tax/calculation/base.py
@@ -42,6 +42,12 @@ class TaxRecordError(TaxError):
         super().__init__(message)
 
 
+class CalculationExpiredError(TaxError):
+    def __init__(self) -> None:
+        message = "The tax calculation has expired and cannot be recorded."
+        super().__init__(message)
+
+
 class TaxCode(StrEnum):
     general_electronically_supplied_services = (
         "general_electronically_supplied_services"

--- a/server/polar/tax/calculation/numeral.py
+++ b/server/polar/tax/calculation/numeral.py
@@ -10,6 +10,7 @@ from polar.logging import Logger
 
 from ..tax_id import TaxID
 from .base import (
+    CalculationExpiredError,
     InvalidTaxIDError,
     TaxabilityReason,
     TaxCalculation,
@@ -258,6 +259,10 @@ class NumeralTaxService(TaxServiceProtocol):
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
+            error_json = e.response.json()
+            error_code = error_json.get("error", {}).get("error_code")
+            if error_code == "calculation_expired":
+                raise CalculationExpiredError() from e
             log.warning("Numeral tax record error: %s", e.response.text)
             raise TaxRecordError() from e
 


### PR DESCRIPTION
Fix #9620

- server/order: recalculate tax if original calculation expired when handling payment order
