### PR TITLE
server: revive log correlation ID with a tracable source for tasks

### DIFF
--- a/server/polar/logging.py
+++ b/server/polar/logging.py
@@ -1,4 +1,6 @@
+import contextvars
 import logging.config
+import typing
 import uuid
 from typing import Any
 
@@ -153,5 +155,21 @@ def configure(*, logfire: bool = False) -> None:
         Production.configure(logfire=logfire)
 
 
-def generate_correlation_id() -> str:
-    return str(uuid.uuid4())
+class CorrelationID:
+    _correlation_id: typing.ClassVar[contextvars.ContextVar[str | None]] = (
+        contextvars.ContextVar("polar.correlation_id", default=None)
+    )
+
+    @classmethod
+    def set(cls) -> str:
+        correlation_id = str(uuid.uuid4())
+        cls._correlation_id.set(correlation_id)
+        return correlation_id
+
+    @classmethod
+    def get(cls) -> str | None:
+        return cls._correlation_id.get()
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._correlation_id.set(None)

--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -11,7 +11,7 @@ import dramatiq
 import structlog
 from dramatiq.common import dq_name
 
-from polar.logging import Logger
+from polar.logging import CorrelationID, Logger
 from polar.redis import Redis
 
 from ._debounce import set_debounce_key
@@ -80,11 +80,14 @@ class JobQueueManager:
             fn: dramatiq.Actor[Any, Any] = broker.get_actor(actor_name)
             redis_message_id = str(uuid.uuid4())
 
+            correlation_id = CorrelationID.get()
+
             # Build base message without delay
             message = fn.message_with_options(
                 args=args,
                 kwargs=kwargs,
                 redis_message_id=redis_message_id,
+                source_correlation_id=correlation_id,
             )
 
             # Set debounce key if any


### PR DESCRIPTION
- server: revive log correlation ID with a tracable source for tasks