### PR TITLE
server/benefit/grant: swallow BenefitActionRequiredError on delete grant

### DIFF
--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -668,9 +668,10 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
                     "Stopping retries and marking grant as revoked"
                 ),
                 error=str(e),
-                defer_seconds=e.defer_seconds,
                 benefit_grant_id=str(grant.id),
             )
+        except BenefitActionRequiredError:
+            pass
 
         grant.set_revoked()
 


### PR DESCRIPTION
Fix #9688

- server/benefit/grant: swallow BenefitActionRequiredError on delete grant
