### PR TITLE
fix: block subscription cycles for denied organizations

### DIFF
--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import Customer, Organization, Subscription
+from polar.models.organization import OrganizationStatus
 from polar.postgres import create_sync_engine
 
 log: Logger = structlog.get_logger()
@@ -118,6 +119,7 @@ class SubscriptionJobStore(BaseJobStore):
                 Customer.is_deleted.is_(False),
                 Organization.is_deleted.is_(False),
                 Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.DENIED,
                 Subscription.scheduler_locked_at.is_(None),
                 Subscription.active.is_(True),
                 Subscription.current_period_end.is_not(None),


### PR DESCRIPTION
## 📋 Summary

Prevent denied organizations from having subscriptions cycled and generating paid orders. This addresses the issue where denied orgs could circumvent payment restrictions by creating subscriptions with free trial periods that later transitioned to paid cycles.

## 🎯 What

Added a filter in the subscription scheduler to exclude organizations with `DENIED` status from being scheduled for subscription cycling.

## 🤔 Why

- Denied organizations cannot create new subscriptions (checkout blocks them)
- However, existing subscriptions continued cycling and generating paid orders
- This allowed denied orgs like amit-malka to have "free first month" subscriptions that later became paid
- The scheduler is the primary gate for subscription cycles, so filtering here prevents the entire order creation pipeline

## 🔧 How

Modified `SubscriptionJobStore._get_base_statement()` to add `Organization.status != OrganizationStatus.DENIED` condition to the WHERE clause, alongside the existing `blocked_at.is_(None)` check.

## 🧪 Testing

- [x] All existing tests pass (`uv run task test` for backend)
- [x] Code follows style guidelines (ruff check, mypy)
- [x] No new warnings

## 📝 Additional Notes

This is a focused fix that prevents denied organizations' subscriptions from being scheduled for cycling. The change is minimal (2 lines) and follows the existing pattern of filtering blocked organizations.