### PR TITLE
feat: add MANUAL review context for comprehensive backoffice org analysis

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -665,7 +665,11 @@ async def run_review_agent(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    enqueue_job("organization_review.run_agent", organization_id=organization.id)
+    enqueue_job(
+        "organization_review.run_agent",
+        organization_id=organization.id,
+        context="manual",
+    )
 
     return HXRedirectResponse(
         request,

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -103,8 +103,8 @@ async def _collect_data(
     else:
         products_data = ProductsData()
 
-    # Payment metrics — only for THRESHOLD (no payments exist at submission or setup)
-    if context == ReviewContext.THRESHOLD:
+    # Payment metrics — collected for THRESHOLD and MANUAL reviews
+    if context in (ReviewContext.THRESHOLD, ReviewContext.MANUAL):
         total, succeeded, amount = await review_repository.get_payment_stats(
             organization.id
         )

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -13,6 +13,7 @@ class ReviewContext(StrEnum):
     SUBMISSION = "submission"  # First review at details submission time
     SETUP_COMPLETE = "setup_complete"  # Review when all setup steps are done
     THRESHOLD = "threshold"  # Following reviews when payment threshold hit
+    MANUAL = "manual"  # Full manual review triggered from backoffice
 
 
 # --- Collector output schemas ---


### PR DESCRIPTION
## 📋 Summary

Introduces a dedicated `MANUAL` review context for the backoffice "Run Agent" button, replacing the generic `THRESHOLD` default.

## 🎯 What

- Adds `ReviewContext.MANUAL` to the review context enum
- Backoffice "Run Agent" now enqueues with `context="manual"` instead of the THRESHOLD default
- MANUAL context collects **all available data**: payments (if any), Stripe identity verification, account signals, products, website, and history
- Adds `MANUAL_PREAMBLE` — comprehensive AI instructions covering all 5 dimensions with detailed Stripe fraud signal guidance (combining insights from both SETUP_COMPLETE and THRESHOLD contexts)

## 🤔 Why

The backoffice "Run Agent" previously defaulted to `THRESHOLD` context which had no specific AI preamble, relying only on the generic system prompt. MANUAL context gives the human reviewer a truly comprehensive analysis with explicit guidance on Stripe signals, financial risk thresholds, identity cross-referencing, and policy compliance — without triggering any automated status changes.

## 🔧 How

- `schemas.py`: Added `MANUAL = "manual"` to `ReviewContext`
- `agent.py`: Payment metrics now collected for both `THRESHOLD` and `MANUAL` contexts
- `analyzer.py`: Added `MANUAL_PREAMBLE` with full analysis instructions; mapped in the context→instructions dict
- `endpoints.py`: Passes `context="manual"` when enqueuing the review job

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Navigate to a backoffice org detail page
2. Click "Run Agent" — verify job is enqueued with `context=manual`
3. Check the agent report covers all dimensions including Stripe signals and payment metrics

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings