### PR TITLE
backoffice: Improve organization review clarity

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -140,9 +140,7 @@ class OverviewSection:
                         with tag.div(
                             classes="mt-4 p-3 border-l-4 border-base-300 bg-base-200/50 rounded"
                         ):
-                            with tag.div(
-                                classes="flex items-center gap-2 mb-2"
-                            ):
+                            with tag.div(classes="flex items-center gap-2 mb-2"):
                                 with tag.span(classes="font-semibold"):
                                     text("Appeal Submitted")
                                 if review.appeal_reviewed_at:


### PR DESCRIPTION
## 📋 Summary

Improves the clarity and usability of the organization review display in the backoffice.

## 🎯 What

Enhanced the fallback organization review display (when no agent report exists) with:
- Color-coded verdict badges (green for PASS, red for FAIL, yellow for UNCERTAIN)
- Proper risk score formatting showing "X/100" 
- Violated sections now displayed as a bulleted list instead of inline badges to prevent text overflow
- Explicit "Assessment" and "Appeal Submitted" labels for better scannability
- Improved appeal status display with inline status badges

## 🤔 Why

The original fallback view had poor visual hierarchy and text overflow issues. Violated sections rendered as tiny inline badges that overlapped when the policy section names were long, making the page difficult to read. Adding section labels and using proper list formatting improves clarity.

## 🧪 Testing

- [ ] I have tested these changes locally

Test by viewing an organization with a review verdict in the backoffice admin UI.