### PR TITLE
worker/health: Add maximum webhook age for undelivered check

### DIFF
--- a/server/polar/webhook/repository.py
+++ b/server/polar/webhook/repository.py
@@ -30,7 +30,7 @@ class WebhookEventRepository(
     model = WebhookEvent
 
     async def get_all_undelivered(
-        self, older_than: datetime | None = None
+        self, older_than: datetime | None = None, newer_than: datetime | None = None
     ) -> Sequence[WebhookEvent]:
         statement = (
             self.get_base_statement()
@@ -47,6 +47,8 @@ class WebhookEventRepository(
         )
         if older_than is not None:
             statement = statement.where(WebhookEvent.created_at < older_than)
+        if newer_than is not None:
+            statement = statement.where(WebhookEvent.created_at > newer_than)
         return await self.get_all(statement)
 
     async def get_recent_by_endpoint(

--- a/server/polar/worker/_health.py
+++ b/server/polar/worker/_health.py
@@ -50,6 +50,7 @@ async def health(request: Request) -> JSONResponse:
 
 
 UNDELIVERED_WEBHOOKS_MINIMUM_AGE = timedelta(minutes=5)
+UNDELIVERED_WEBHOOKS_MAXIMUM_AGE = timedelta(hours=6)
 UNDELIVERED_WEBHOOKS_ALERT_THRESHOLD = 10
 
 UNHANDLED_EXTERNAL_EVENTS_MINIMUM_AGE = timedelta(minutes=5)
@@ -61,7 +62,8 @@ async def webhooks(request: Request) -> JSONResponse:
     async with async_sessionmaker() as session:
         repository = WebhookEventRepository(session)
         undelivered_webhooks = await repository.get_all_undelivered(
-            older_than=utc_now() - UNDELIVERED_WEBHOOKS_MINIMUM_AGE
+            older_than=utc_now() - UNDELIVERED_WEBHOOKS_MINIMUM_AGE,
+            newer_than=utc_now() - UNDELIVERED_WEBHOOKS_MAXIMUM_AGE,
         )
         if len(undelivered_webhooks) > UNDELIVERED_WEBHOOKS_ALERT_THRESHOLD:
             return JSONResponse(


### PR DESCRIPTION
To avoid having to scan the entire table to figure out if there's a problem.
