### PR TITLE
Add organization_review_feedback model and migration

### DIFF
--- a/server/migrations/versions/2026-02-24-1200_add_organization_review_feedback.py
+++ b/server/migrations/versions/2026-02-24-1200_add_organization_review_feedback.py
@@ -1,0 +1,86 @@
+"""Add organization_review_feedback table
+
+Revision ID: d91eff4975e1
+Revises: 138febbc19df
+Create Date: 2026-02-24 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "d91eff4975e1"
+down_revision = "138febbc19df"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organization_review_feedback",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("modified_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("agent_review_id", sa.Uuid(), nullable=False),
+        sa.Column("reviewer_id", sa.Uuid(), nullable=False),
+        sa.Column("ai_verdict", sa.String(), nullable=False),
+        sa.Column("human_verdict", sa.String(), nullable=False),
+        sa.Column("agreement", sa.String(), nullable=False),
+        sa.Column("override_reason", sa.Text(), nullable=True),
+        sa.Column("reviewed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["agent_review_id"],
+            ["organization_agent_reviews.id"],
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["reviewer_id"],
+            ["users.id"],
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_organization_review_feedback_created_at"),
+        "organization_review_feedback",
+        ["created_at"],
+    )
+    op.create_index(
+        op.f("ix_organization_review_feedback_deleted_at"),
+        "organization_review_feedback",
+        ["deleted_at"],
+    )
+    op.create_index(
+        op.f("ix_organization_review_feedback_agent_review_id"),
+        "organization_review_feedback",
+        ["agent_review_id"],
+    )
+    op.create_index(
+        op.f("ix_organization_review_feedback_reviewer_id"),
+        "organization_review_feedback",
+        ["reviewer_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_organization_review_feedback_reviewer_id"),
+        table_name="organization_review_feedback",
+    )
+    op.drop_index(
+        op.f("ix_organization_review_feedback_agent_review_id"),
+        table_name="organization_review_feedback",
+    )
+    op.drop_index(
+        op.f("ix_organization_review_feedback_deleted_at"),
+        table_name="organization_review_feedback",
+    )
+    op.drop_index(
+        op.f("ix_organization_review_feedback_created_at"),
+        table_name="organization_review_feedback",
+    )
+    op.drop_table("organization_review_feedback")

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -47,6 +47,7 @@ from .organization import Organization
 from .organization_access_token import OrganizationAccessToken
 from .organization_agent_review import OrganizationAgentReview
 from .organization_review import OrganizationReview
+from .organization_review_feedback import OrganizationReviewFeedback
 from .payment import Payment
 from .payment_method import PaymentMethod
 from .payout import Payout
@@ -141,6 +142,7 @@ __all__ = [
     "OrganizationAccessToken",
     "OrganizationAgentReview",
     "OrganizationReview",
+    "OrganizationReviewFeedback",
     "Payment",
     "PaymentMethod",
     "Payout",

--- a/server/polar/models/organization_review_feedback.py
+++ b/server/polar/models/organization_review_feedback.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import TIMESTAMP, ForeignKey, String, Text, Uuid
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+
+from polar.kit.db.models import RecordModel
+
+if TYPE_CHECKING:
+    from polar.models.organization_agent_review import OrganizationAgentReview
+    from polar.models.user import User
+
+
+class OrganizationReviewFeedback(RecordModel):
+    """Captures the relationship between an AI review verdict and a human reviewer's decision."""
+
+    class AIVerdict(StrEnum):
+        APPROVE = "APPROVE"
+        DENY = "DENY"
+        NEEDS_HUMAN_REVIEW = "NEEDS_HUMAN_REVIEW"
+
+    class HumanVerdict(StrEnum):
+        APPROVE = "APPROVE"
+        DENY = "DENY"
+
+    class Agreement(StrEnum):
+        AGREE = "AGREE"
+        OVERRIDE_TO_APPROVE = "OVERRIDE_TO_APPROVE"
+        OVERRIDE_TO_DENY = "OVERRIDE_TO_DENY"
+
+    __tablename__ = "organization_review_feedback"
+
+    agent_review_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("organization_agent_reviews.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
+
+    reviewer_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("users.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
+
+    ai_verdict: Mapped[AIVerdict] = mapped_column(String, nullable=False)
+    human_verdict: Mapped[HumanVerdict] = mapped_column(String, nullable=False)
+    agreement: Mapped[Agreement] = mapped_column(String, nullable=False)
+
+    override_reason: Mapped[str | None] = mapped_column(
+        Text, nullable=True, default=None
+    )
+
+    reviewed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+
+    @declared_attr
+    def agent_review(cls) -> Mapped["OrganizationAgentReview"]:
+        return relationship("OrganizationAgentReview", lazy="raise")
+
+    @declared_attr
+    def reviewer(cls) -> Mapped["User"]:
+        return relationship("User", lazy="raise")
+
+    def __repr__(self) -> str:
+        return (
+            f"OrganizationReviewFeedback(id={self.id}, "
+            f"agent_review_id={self.agent_review_id}, "
+            f"agreement={self.agreement})"
+        )


### PR DESCRIPTION
## Summary
- Adds `organization_review_feedback` table to capture structured agree/disagree signals between AI review verdicts and human reviewer decisions
- Creates `OrganizationReviewFeedback` SQLAlchemy model with enums for `AIVerdict` (APPROVE/DENY/NEEDS_HUMAN_REVIEW), `HumanVerdict` (APPROVE/DENY), and `Agreement` (AGREE/OVERRIDE_TO_APPROVE/OVERRIDE_TO_DENY)
- Includes Alembic migration with proper indexes on `agent_review_id`, `reviewer_id`, `created_at`, and `deleted_at`

## Why
This is the foundation for RLHF — recording the relationship between AI recommendations and human decisions. Human reviewers already make decisions after seeing AI reports; this table captures that signal for future model improvement.

## Test plan
- [ ] Run `alembic upgrade head` to verify migration applies cleanly
- [ ] Run `alembic downgrade -1` to verify rollback works
- [ ] Verify model imports correctly via `from polar.models import OrganizationReviewFeedback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)