### PR TITLE
Handle empty strings in organization socials form

### DIFF
--- a/server/polar/backoffice/organizations/forms.py
+++ b/server/polar/backoffice/organizations/forms.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from annotated_types import Ge
 from fastapi import UploadFile
@@ -7,6 +7,7 @@ from pydantic import (
     Field,
     StringConstraints,
     TypeAdapter,
+    model_validator,
 )
 
 from polar.kit.schemas import HttpUrlToStr
@@ -144,6 +145,14 @@ class UpdateOrganizationInternalNotesForm(forms.BaseForm):
 
 class UpdateOrganizationSocialsForm(forms.BaseForm):
     """Form for editing organization social media links."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def empty_strings_to_none(cls, data: dict[str, Any]) -> dict[str, Any]:
+        for key, value in data.items():
+            if isinstance(value, str) and value.strip() == "":
+                data[key] = None
+        return data
 
     youtube_url: Annotated[
         HttpUrlToStr | None,


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #<!-- issue number -->

Adds validation to the `UpdateOrganizationSocialsForm` to convert empty strings to `None` values before processing.

## 🎯 What

Added a `@model_validator` to `UpdateOrganizationSocialsForm` that converts empty or whitespace-only strings to `None` for all form fields. This ensures consistent handling of empty social media URL inputs.

## 🤔 Why

When users clear social media URL fields in the organization settings, empty strings should be treated as `None` (no value) rather than invalid URLs. This validator normalizes the input data before validation, preventing validation errors on intentionally cleared fields.

## 🔧 How

- Added `model_validator` import from `pydantic`
- Added `Any` type import for type hints
- Implemented `empty_strings_to_none` validator with `mode="before"` to process raw input data before Pydantic validation
- The validator iterates through all form fields and converts empty/whitespace strings to `None`

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Navigate to organization settings
2. Clear one or more social media URL fields (leave them empty)
3. Submit the form
4. Verify the form accepts empty fields without validation errors
5. Verify the cleared fields are saved as `None` in the database

## 📝 Additional Notes

This change uses Pydantic's `mode="before"` validator to normalize input at the earliest stage, ensuring empty strings are converted to `None` before any field-level validation occurs.

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally

https://claude.ai/code/session_01ERh9FAEPBUJeWfnSCLnQWj