### PR TITLE
fix: add threads and discord to social platforms

### DIFF
--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -137,6 +137,8 @@ class OrganizationSocialPlatforms(StrEnum):
     youtube = "youtube"
     tiktok = "tiktok"
     linkedin = "linkedin"
+    threads = "threads"
+    discord = "discord"
     other = "other"
 
 
@@ -148,6 +150,8 @@ PLATFORM_DOMAINS = {
     "youtube": ["youtube.com", "youtu.be"],
     "tiktok": ["tiktok.com"],
     "linkedin": ["linkedin.com"],
+    "threads": ["threads.net"],
+    "discord": ["discord.gg", "discord.com"],
 }
 
 


### PR DESCRIPTION
## Summary
- Add `threads` and `discord` to `OrganizationSocialPlatforms` enum and `PLATFORM_DOMAINS` dict in `server/polar/organization/schemas.py`
- The backoffice already supports these platforms, but the public schema was missing them, causing `KeyError: 'threads'` crashes in the `organization.reviewed` background task

## Test plan
- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes
- [ ] Verify an organization with threads/discord social links can be serialized without errors

Fixes SERVER-44H

🤖 Generated with [Claude Code](https://claude.com/claude-code)