### PR TITLE
Add offset pagination to repair migration command

### DIFF
--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -324,9 +324,9 @@ async def repair(
                 .as_boolean()
                 .is_(True),
                 or_(
-                    Organization.feature_settings[
-                        "seat_based_pricing_enabled"
-                    ].is_(None),
+                    Organization.feature_settings["seat_based_pricing_enabled"].is_(
+                        None
+                    ),
                     Organization.feature_settings["seat_based_pricing_enabled"]
                     .as_boolean()
                     .is_(False),


### PR DESCRIPTION
## 📋 Summary

Adds offset-based pagination to the `repair` command for batch processing large numbers of organizations (60k+) safely.

## 🎯 What

- Added `--offset` option to the `repair` command to enable processing organizations in configurable batches
- Added deterministic ordering with `Organization.id` as a tiebreaker to ensure stable pagination across multiple runs
- Added total count display showing progress across batches (e.g., "Found 1000 organization(s) to repair (offset=0, total=60000)")

## 🤔 Why

Processing 60k organizations in a single command risks timeout and memory issues. With offset pagination, the operation can be split across multiple CLI invocations (batches of 1000 at a time), making it safer and more observable.

## 🔧 How

- Extended the `repair` command's query with `.offset(offset)` clause
- Added `next_review_threshold ASC, id ASC` ordering to guarantee deterministic results
- Queries total count (unaffected by limit/offset) for visibility into overall progress
- Updated docstring with batch execution examples

## 🧪 Testing

The repair operation is safe to test because:
- All backfill steps are idempotent (skip items already migrated)
- Can be run with `--dry-run` (default) to preview changes
- Failed organizations don't block subsequent batches