### PR TITLE
fix: auto-detect social link platform from URL

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -71,15 +71,20 @@ const SwitchingFromOptions = {
   other: 'Other',
 }
 
-const SOCIAL_PLATFORM_DOMAINS = {
+const SOCIAL_PLATFORM_DOMAINS: Record<string, string> = {
   'x.com': 'x',
   'twitter.com': 'x',
   'instagram.com': 'instagram',
   'facebook.com': 'facebook',
+  'fb.com': 'facebook',
   'youtube.com': 'youtube',
-  'linkedin.com': 'linkedin',
   'youtu.be': 'youtube',
+  'linkedin.com': 'linkedin',
   'github.com': 'github',
+  'threads.net': 'threads',
+  'tiktok.com': 'tiktok',
+  'discord.gg': 'discord',
+  'discord.com': 'discord',
 }
 
 interface OrganizationSocialLinksProps {
@@ -146,7 +151,10 @@ const OrganizationSocialLinks = ({
     let newPlatform: schemas['OrganizationSocialPlatforms'] = 'other'
     try {
       const url = new URL(value)
-      const hostname = url.hostname as keyof typeof SOCIAL_PLATFORM_DOMAINS
+      let hostname = url.hostname
+      if (hostname.startsWith('www.')) {
+        hostname = hostname.slice(4)
+      }
       newPlatform = (SOCIAL_PLATFORM_DOMAINS[hostname] ??
         'other') as schemas['OrganizationSocialPlatforms']
     } catch {}


### PR DESCRIPTION
## Summary

- **Fixes SERVER-44K**: `organization_reviewed` task crashed with `ValidationError` when a social link had a mismatched platform/URL (e.g. `platform=threads` with `url=https://x.com/...`)
- Backend `OrganizationSocialLink` validator now auto-detects the platform from the URL hostname instead of rejecting mismatches, falling back to `other` for unrecognized domains
- Frontend `SOCIAL_PLATFORM_DOMAINS` mapping extended with missing platforms (threads, tiktok, discord, fb.com) and now strips `www.` prefixes

## Test plan

- [ ] Enter a threads.net URL in social links — should auto-detect as "threads" with correct icon
- [ ] Enter a tiktok.com URL — should auto-detect as "tiktok"
- [ ] Enter a discord.gg URL — should auto-detect as "discord"
- [ ] Enter a www.x.com URL — should auto-detect as "x" (www stripped)
- [ ] Enter an unknown domain URL — should default to "other"
- [ ] Verify `organization_reviewed` task no longer crashes with mismatched social data in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)