### PR TITLE
fix(backoffice): unify Organization Review card layout

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -89,7 +89,11 @@ class OverviewSection:
                         with tag.div(classes="flex items-center gap-3"):
                             if review.validated_at:
                                 with tag.span(classes="text-xs text-base-content/60"):
-                                    text(review.validated_at.strftime("%Y-%m-%d %H:%M UTC"))
+                                    text(
+                                        review.validated_at.strftime(
+                                            "%Y-%m-%d %H:%M UTC"
+                                        )
+                                    )
                             with button(
                                 variant="primary",
                                 size="sm",
@@ -168,7 +172,13 @@ class OverviewSection:
                             with tag.pre(
                                 classes="text-xs bg-base-200 p-4 rounded mt-2 overflow-x-auto max-h-96 overflow-y-auto"
                             ):
-                                text(json.dumps(review.organization_details_snapshot, indent=2, default=str))
+                                text(
+                                    json.dumps(
+                                        review.organization_details_snapshot,
+                                        indent=2,
+                                        default=str,
+                                    )
+                                )
                 else:
                     with tag.div(classes="flex items-center justify-between mb-4"):
                         with tag.h2(classes="text-lg font-bold"):


### PR DESCRIPTION
## 📋 Summary

Fixes inconsistent UI in the backoffice Organization Review card, which showed two completely different layouts depending on whether data came from `OrganizationReview` (legacy) or `OrganizationAgentReview`.

## 🎯 What

Rewrites the fallback path in `OverviewSection.organization_review_card` (when no agent review exists) to match the agent review layout.

## 🤔 Why

The same card showed different formats — one with a large bold risk score, bulleted violated sections list, and "Assessment" label in a grey box; the other with a timestamp header, inline comma-separated sections, and a summary paragraph. This was confusing for reviewers.

## 🔧 How

- Added `validated_at` timestamp to the header (matching agent review's `reviewed_at`)
- Matched risk score display (`Risk: X/100` in consistent sizing)
- Changed violated sections from a bulleted `<ul>` to inline comma-separated text
- Changed assessment reason from a labelled grey box to a plain paragraph
- Added model info footer and collapsible org details snapshot
- Unified appeal information styling

## 🧪 Testing

- [ ] I have tested these changes locally

### Test Instructions

1. Open backoffice and find an organization with an `OrganizationReview` but no `OrganizationAgentReview`
2. The card should now look visually consistent with organizations that have an agent review
3. Verify the "Run Agent" button still works

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code