### PR TITLE
ops: Specify a custom Polar SERVICE_NAME for services

### DIFF
--- a/server/polar/logfire.py
+++ b/server/polar/logfire.py
@@ -117,7 +117,9 @@ def _scrubbing_callback(match: logfire.ScrubMatch) -> Any | None:
 
 
 def configure_logfire(service_name: Literal["server", "worker"]) -> None:
-    resolved_service_name = os.environ.get("RENDER_SERVICE_NAME", service_name)
+    resolved_service_name = os.environ.get(
+        "SERVICE_NAME", os.environ.get("RENDER_SERVICE_NAME", service_name)
+    )
 
     logfire.configure(
         send_to_logfire="if-token-present",

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -246,6 +246,7 @@ resource "render_web_service" "api" {
   custom_domains = var.api_service_config.custom_domains
 
   env_vars = {
+    SERVICE_NAME                 = { value = "api${local.env_suffix}" }
     WEB_CONCURRENCY              = { value = var.api_service_config.web_concurrency }
     FORWARDED_ALLOW_IPS          = { value = var.api_service_config.forwarded_allow_ips }
     POLAR_ALLOWED_HOSTS          = { value = var.api_service_config.allowed_hosts }
@@ -301,6 +302,7 @@ resource "render_web_service" "worker" {
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null
 
   env_vars = {
+    SERVICE_NAME                 = { value = each.key }
     dramatiq_prom_port           = { value = each.value.dramatiq_prom_port }
     POLAR_DATABASE_POOL_SIZE     = { value = each.value.database_pool_size }
     POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }


### PR DESCRIPTION
Since our RENDER_SERVICE_NAME has got arbitrary suffixes for some of the serviecs (most likely due to naming conflicts when they were created) the name is not ideal. This allows us to add override it with something a bit more like we want.