### PR TITLE
feat: wire all code paths to record review decisions

### DIFF
--- a/server/tests/organization_review/test_repository.py
+++ b/server/tests/organization_review/test_repository.py
@@ -5,6 +5,7 @@ import pytest
 
 from polar.models.organization import Organization
 from polar.models.organization_agent_review import OrganizationAgentReview
+from polar.models.user import User
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -190,3 +191,453 @@ class TestGetLatestAgentReview:
         assert latest is not None
         assert latest.model_used == "model-b"
         assert latest.report["review_type"] == "setup_complete"
+
+
+@pytest.mark.asyncio
+class TestRecordHumanDecision:
+    async def test_derives_context_from_agent_review(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """review_context is derived from the agent review's review_type."""
+        repo = OrganizationReviewRepository.from_session(session)
+        await repo.save_agent_review(
+            organization_id=organization.id,
+            review_type="submission",
+            report={"report": {"verdict": "APPROVE", "overall_risk_score": 12.0}},
+            model_used="test-model",
+            reviewed_at=datetime.now(UTC),
+        )
+        await session.flush()
+
+        decision = await repo.record_human_decision(
+            organization_id=organization.id,
+            reviewer_id=user.id,
+            decision="APPROVE",
+            reason="Looks good",
+        )
+        await session.flush()
+
+        assert decision.actor_type == "human"
+        assert decision.decision == "APPROVE"
+        assert decision.review_context == "submission"
+        assert decision.agreement == "AGREE"
+        assert decision.verdict == "APPROVE"
+        assert decision.risk_score == 12.0
+        assert decision.reason == "Looks good"
+        assert decision.is_current is True
+
+    async def test_with_agent_review_override(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """Human overrides AI DENY verdict to APPROVE."""
+        repo = OrganizationReviewRepository.from_session(session)
+        await repo.save_agent_review(
+            organization_id=organization.id,
+            review_type="threshold",
+            report={"report": {"verdict": "DENY", "overall_risk_score": 78.0}},
+            model_used="test-model",
+            reviewed_at=datetime.now(UTC),
+        )
+        await session.flush()
+
+        decision = await repo.record_human_decision(
+            organization_id=organization.id,
+            reviewer_id=user.id,
+            decision="APPROVE",
+            reason="False positive",
+        )
+        await session.flush()
+
+        assert decision.review_context == "threshold"
+        assert decision.agreement == "OVERRIDE_TO_APPROVE"
+        assert decision.verdict == "DENY"
+        assert decision.risk_score == 78.0
+
+    async def test_explicit_context_overrides_agent_review(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """Explicit review_context takes precedence over agent review."""
+        repo = OrganizationReviewRepository.from_session(session)
+        await repo.save_agent_review(
+            organization_id=organization.id,
+            review_type="submission",
+            report={"report": {"verdict": "DENY", "overall_risk_score": 80.0}},
+            model_used="test-model",
+            reviewed_at=datetime.now(UTC),
+        )
+        await session.flush()
+
+        decision = await repo.record_human_decision(
+            organization_id=organization.id,
+            reviewer_id=user.id,
+            decision="APPROVE",
+            review_context="appeal",
+        )
+        await session.flush()
+
+        assert decision.review_context == "appeal"
+
+    async def test_without_agent_review(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """Falls back to 'manual' when no agent review exists."""
+        repo = OrganizationReviewRepository.from_session(session)
+        decision = await repo.record_human_decision(
+            organization_id=organization.id,
+            reviewer_id=user.id,
+            decision="APPROVE",
+        )
+        await session.flush()
+
+        assert decision.actor_type == "human"
+        assert decision.decision == "APPROVE"
+        assert decision.review_context == "manual"
+        assert decision.agent_review_id is None
+        assert decision.verdict is None
+        assert decision.agreement is None
+        assert decision.risk_score is None
+        assert decision.is_current is True
+
+    async def test_deactivates_previous_decision(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """New human decision deactivates the previous one."""
+        repo = OrganizationReviewRepository.from_session(session)
+        first = await repo.record_human_decision(
+            organization_id=organization.id,
+            reviewer_id=user.id,
+            decision="DENY",
+        )
+        await session.flush()
+
+        second = await repo.record_human_decision(
+            organization_id=organization.id,
+            reviewer_id=user.id,
+            decision="APPROVE",
+            review_context="appeal",
+        )
+        await session.flush()
+
+        await session.refresh(first)
+        assert first.is_current is False
+        assert second.is_current is True
+
+
+@pytest.mark.asyncio
+class TestSaveReviewDecision:
+    async def test_agent_decision(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        decision = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="agent",
+            decision="APPROVE",
+            review_context="threshold",
+            verdict="APPROVE",
+            risk_score=15.0,
+        )
+        await session.flush()
+
+        assert decision.organization_id == organization.id
+        assert decision.actor_type == "agent"
+        assert decision.decision == "APPROVE"
+        assert decision.review_context == "threshold"
+        assert decision.verdict == "APPROVE"
+        assert decision.risk_score == 15.0
+        assert decision.reviewer_id is None
+        assert decision.is_current is True
+
+    async def test_human_decision(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+
+        # Create an agent review first
+        agent_review = await repo.save_agent_review(
+            organization_id=organization.id,
+            review_type="submission",
+            report={"report": {"verdict": "DENY", "overall_risk_score": 85.0}},
+            model_used="test-model",
+            reviewed_at=datetime.now(UTC),
+        )
+        await session.flush()
+
+        decision = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="human",
+            decision="APPROVE",
+            review_context="manual",
+            agent_review_id=agent_review.id,
+            reviewer_id=user.id,
+            verdict="DENY",
+            agreement="OVERRIDE_TO_APPROVE",
+            risk_score=85.0,
+            reason="Verified legitimate business",
+        )
+        await session.flush()
+
+        assert decision.organization_id == organization.id
+        assert decision.actor_type == "human"
+        assert decision.decision == "APPROVE"
+        assert decision.reviewer_id == user.id
+        assert decision.agent_review_id == agent_review.id
+        assert decision.verdict == "DENY"
+        assert decision.agreement == "OVERRIDE_TO_APPROVE"
+        assert decision.reason == "Verified legitimate business"
+        assert decision.is_current is True
+
+    async def test_dual_write_old_columns(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """Verify old columns are populated for backward compat."""
+        repo = OrganizationReviewRepository.from_session(session)
+        decision = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="human",
+            decision="DENY",
+            review_context="manual",
+            reviewer_id=user.id,
+            verdict="APPROVE",
+            reason="Suspicious activity",
+        )
+        await session.flush()
+
+        # Old columns should be populated via dual-write
+        assert decision.ai_verdict == "APPROVE"  # maps from verdict
+        assert decision.human_verdict == "DENY"  # maps from decision
+        assert decision.override_reason == "Suspicious activity"  # maps from reason
+        assert decision.reviewed_at is not None
+
+    async def test_is_current_defaults_to_true(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        decision = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="agent",
+            decision="ESCALATE",
+            review_context="setup_complete",
+        )
+        await session.flush()
+
+        assert decision.is_current is True
+
+
+@pytest.mark.asyncio
+class TestGetCurrentDecision:
+    async def test_returns_decision_when_exists(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="agent",
+            decision="APPROVE",
+            review_context="threshold",
+        )
+        await session.flush()
+
+        current = await repo.get_current_decision(organization.id)
+        assert current is not None
+        assert current.decision == "APPROVE"
+
+    async def test_returns_none_when_no_decision(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        current = await repo.get_current_decision(organization.id)
+        assert current is None
+
+    async def test_returns_none_for_non_current(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="agent",
+            decision="APPROVE",
+            review_context="threshold",
+            is_current=False,
+        )
+        await session.flush()
+
+        current = await repo.get_current_decision(organization.id)
+        assert current is None
+
+
+@pytest.mark.asyncio
+class TestDeactivateCurrentDecisions:
+    async def test_deactivates_existing_current(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        decision = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="agent",
+            decision="APPROVE",
+            review_context="threshold",
+        )
+        await session.flush()
+        assert decision.is_current is True
+
+        await repo.deactivate_current_decisions(organization.id)
+        # Need to expire cached attributes to see the DB change
+        await session.refresh(decision)
+        assert decision.is_current is False
+
+    async def test_noop_when_no_current(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        # Should not raise
+        await repo.deactivate_current_decisions(organization.id)
+
+    async def test_new_decision_after_deactivation(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+
+        # First decision
+        first = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="agent",
+            decision="APPROVE",
+            review_context="threshold",
+        )
+        await session.flush()
+
+        # Deactivate, then create new decision
+        await repo.deactivate_current_decisions(organization.id)
+        second = await repo.save_review_decision(
+            organization_id=organization.id,
+            actor_type="human",
+            decision="DENY",
+            review_context="manual",
+        )
+        await session.flush()
+
+        await session.refresh(first)
+        assert first.is_current is False
+        assert second.is_current is True
+
+        # get_current_decision should return the new one
+        current = await repo.get_current_decision(organization.id)
+        assert current is not None
+        assert current.id == second.id
+
+
+@pytest.mark.asyncio
+class TestRecordAgentDecision:
+    async def test_creates_decision_with_correct_fields(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        agent_review = await repo.save_agent_review(
+            organization_id=organization.id,
+            review_type="threshold",
+            report={"report": {"verdict": "APPROVE", "overall_risk_score": 10.0}},
+            model_used="test-model",
+            reviewed_at=datetime.now(UTC),
+        )
+        await session.flush()
+
+        decision = await repo.record_agent_decision(
+            organization_id=organization.id,
+            agent_review_id=agent_review.id,
+            decision="APPROVE",
+            review_context="threshold",
+            verdict="APPROVE",
+            risk_score=10.0,
+        )
+        await session.flush()
+
+        assert decision.actor_type == "agent"
+        assert decision.decision == "APPROVE"
+        assert decision.review_context == "threshold"
+        assert decision.verdict == "APPROVE"
+        assert decision.risk_score == 10.0
+        assert decision.agent_review_id == agent_review.id
+        assert decision.is_current is True
+
+    async def test_deactivates_previous_decision(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        agent_review = await repo.save_agent_review(
+            organization_id=organization.id,
+            review_type="threshold",
+            report={"report": {"verdict": "APPROVE", "overall_risk_score": 10.0}},
+            model_used="test-model",
+            reviewed_at=datetime.now(UTC),
+        )
+        await session.flush()
+
+        first = await repo.record_agent_decision(
+            organization_id=organization.id,
+            agent_review_id=agent_review.id,
+            decision="APPROVE",
+            review_context="threshold",
+            verdict="APPROVE",
+        )
+        await session.flush()
+
+        second = await repo.record_agent_decision(
+            organization_id=organization.id,
+            agent_review_id=agent_review.id,
+            decision="DENY",
+            review_context="submission",
+            verdict="DENY",
+        )
+        await session.flush()
+
+        await session.refresh(first)
+        assert first.is_current is False
+        assert second.is_current is True


### PR DESCRIPTION
## Summary
- Replaces `_record_review_feedback()` with `record_human_decision()` and `record_agent_decision()` on the repository
- Every status-changing decision now writes to `organization_review_feedback`: V2 backoffice (approve, deny, approve_denied, unblock_approve), V1 backoffice (approve, deny, approve_appeal, deny_appeal), agent tasks (auto-approve, auto-deny, escalate)
- `review_context` is auto-derived from the last agent review's `review_type`, with explicit override for appeals and fallback to "manual"
- Agreement between AI verdict and human decision is computed automatically
- Dual-writes old columns for backward compat during the expand-modify-contract migration
- Fixes: silent drop when no agent review existed, unblock_approve missing decision recording

**Depends on #9794** (schema expansion)

## Test plan
- [ ] `uv run task lint && uv run task lint_types` pass
- [ ] `POLAR_ENV=testing uv run pytest tests/organization_review/test_repository.py -v` — 25 tests pass
- [ ] Approve org in V2 backoffice → decision row with correct `review_context` derived from agent review
- [ ] Deny org in V2 backoffice → decision row with `OVERRIDE_TO_DENY` agreement when AI said APPROVE
- [ ] Approve denied org → decision row (no longer silently dropped when no agent review)
- [ ] Unblock+approve → decision row created (was missing before)
- [ ] V1 approve/deny/appeal actions → decision rows created
- [ ] Agent auto-approve (threshold) → decision row with `actor_type=agent`
- [ ] Agent auto-deny (submission) → decision row with `actor_type=agent`
- [ ] Agent escalate (setup_complete) → decision row with `decision=ESCALATE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)