### PR TITLE
tf: Read the remote state for Render service image

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -213,18 +213,10 @@ resource "render_web_service" "api" {
 
   runtime_source = {
     image = {
-      image_url              = "ghcr.io/polarsource/polar"
-      tag                    = "latest"
+      image_url              = split("@", var.api_service_config.image_url)[0]
       registry_credential_id = var.registry_credential_id
+      digest                 = var.api_service_config.image_digest
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      runtime_source.image.image_url,
-      runtime_source.image.digest,
-      runtime_source.image.tag,
-    ]
   }
 
   autoscaling = var.environment == "production" ? {
@@ -280,23 +272,11 @@ resource "render_web_service" "worker" {
   num_instances     = each.value.num_instances
 
   runtime_source = {
-    image = each.value.digest != null ? {
-      image_url              = each.value.image_url
+    image = {
+      image_url              = split("@", each.value.image_url)[0]
       registry_credential_id = var.registry_credential_id
-      digest                 = each.value.digest
-      } : {
-      image_url              = each.value.image_url
-      registry_credential_id = var.registry_credential_id
-      tag                    = each.value.tag
+      digest                 = each.value.image_digest
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      runtime_source.image.image_url,
-      runtime_source.image.tag,
-      runtime_source.image.digest,
-    ]
   }
 
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null

--- a/terraform/modules/render_service/outputs.tf
+++ b/terraform/modules/render_service/outputs.tf
@@ -12,3 +12,8 @@ output "worker_urls" {
   description = "Map of worker names to their URLs"
   value       = { for name, worker in render_web_service.worker : name => worker.url }
 }
+
+output "worker_ids" {
+  description = "Map of worker names to their IDs"
+  value       = { for name, worker in render_web_service.worker : name => worker.id }
+}

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -20,6 +20,7 @@ variable "registry_credential_id" {
   sensitive   = true
 }
 
+
 # Variables for configuring the services and workers
 variable "api_service_config" {
   description = "API service configuration"
@@ -27,6 +28,8 @@ variable "api_service_config" {
     allowed_hosts          = string # "[\"polar.sh\", \"backoffice.polar.sh\"]"
     cors_origins           = string # "[\"https://polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = list(object({ name = string }))
+    image_url              = optional(string, "ghcr.io/polarsource/polar")
+    image_digest           = string
     web_concurrency        = optional(string, "2")
     forwarded_allow_ips    = optional(string, "*")
     database_pool_size     = optional(string, "20")
@@ -41,23 +44,14 @@ variable "workers" {
   description = "Map of worker configurations"
   type = map(object({
     start_command      = string
-    image_url          = optional(string, "ghcr.io/polarsource/polar")
-    digest             = optional(string)
-    tag                = optional(string)
+    image_url          = string
+    image_digest       = string
     custom_domains     = optional(list(object({ name = string })), [])
     dramatiq_prom_port = optional(string, "10000")
     plan               = optional(string, "pro")
     num_instances      = optional(number, 1)
     database_pool_size = optional(string, "5")
   }))
-
-  validation {
-    condition = alltrue([
-      for name, worker in var.workers :
-      (worker.digest != null) != (worker.tag != null)
-    ])
-    error_message = "Each worker must specify exactly one of 'digest' or 'tag', not both or neither."
-  }
 }
 
 variable "postgres_config" {


### PR DESCRIPTION
Since we are running into an issue where the digest tracked in Terraform is not the same as the remote state, we get an error that we cant update it.

Ignoring changes to these fields didn't make a difference since the Render terraform provider is passing the entire object to Render.

The solution here is to bring in the services as a data source and get the current image digest for them. This will prevent terraform from accidentally rolling back a deploy, and hopefully also prevent the issue we were seeing.

This does, however, introduce a race condition in wich we need to have the services set up to be able to read them in a data resource. The solution is simply to comment out the data blocks the first time we run this, on initial setup.
