### PR TITLE
feat: add review context badge to organization review card

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -65,6 +65,23 @@ class OverviewSection:
     # Top-left: Organization Review card
     # ------------------------------------------------------------------
 
+    _REVIEW_CONTEXT_LABELS: dict[str, str] = {
+        "submission": "Submission",
+        "setup_complete": "Setup Complete",
+        "threshold": "Threshold",
+        "manual": "Manual",
+    }
+
+    def _render_review_context_badge(self, review_type: str | None) -> None:
+        """Render a small badge showing the review trigger context."""
+        if not review_type:
+            return
+        label = self._REVIEW_CONTEXT_LABELS.get(
+            review_type, review_type.replace("_", " ").title()
+        )
+        with tag.div(classes="badge badge-ghost badge-sm badge-outline gap-1"):
+            text(label)
+
     @contextlib.contextmanager
     def organization_review_card(self, request: Request) -> Generator[None]:
         """Merged agent report + org.review fallback card."""
@@ -200,11 +217,14 @@ class OverviewSection:
             # --- Agent report present ---
             report = self.agent_report.get("report", {})
             usage = self.agent_report.get("usage", {})
+            review_type = self.agent_report.get("review_type")
 
             # Header with timestamp and re-run button
             with tag.div(classes="flex items-center justify-between mb-4"):
-                with tag.h2(classes="text-lg font-bold"):
-                    text("Organization Review")
+                with tag.div(classes="flex items-center gap-2"):
+                    with tag.h2(classes="text-lg font-bold"):
+                        text("Organization Review")
+                    self._render_review_context_badge(review_type)
                 with tag.div(classes="flex items-center gap-3"):
                     if self.agent_reviewed_at:
                         with tag.span(classes="text-xs text-base-content/60"):


### PR DESCRIPTION
## 📋 Summary

Add a subtle badge next to the "Organization Review" title in the backoffice organization detail page that displays the review trigger context.

## 🎯 What

- Added `_render_review_context_badge()` method to render a small outline badge showing the review context
- Display the context (submission, setup_complete, threshold, or manual) inline with the card title
- Uses existing `review_type` data already stored in the agent report JSONB

## 🤔 Why

Reviewers need quick visibility into why and when a review was triggered. The context is critical for understanding the review's scope and timing but was previously hidden in the data.

## 🔧 How

- Added a mapping of review_type values to user-friendly labels
- Render context badge from `agent_report.get("review_type")` alongside the title
- Used neutral `badge-ghost badge-outline` styling for consistent integration

## 🧪 Testing

- [x] I have run linting and type checking (ruff check and mypy both pass)
- Code follows existing backoffice patterns (tagflow rendering, DaisyUI components)
- No new queries or backend changes required—data already exists

## 🖼️ Screenshots/Recordings

The badge displays like: `Organization Review [Submission]` with timestamp and Re-run button on the right.