### PR TITLE
feat: add Logfire logs action to organizations_v2 detail view

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -27,7 +27,9 @@ def _get_logfire_url(organization_id: UUID) -> str:
         "q": f"attributes->>'subject_id' = '{organization_id}'",
         "last": "30d",
     }
-    return f"https://logfire-us.pydantic.dev/polar/polar?{urllib.parse.urlencode(params)}"
+    return (
+        f"https://logfire-us.pydantic.dev/polar/polar?{urllib.parse.urlencode(params)}"
+    )
 
 
 class OrganizationDetailView:


### PR DESCRIPTION
## 📋 Summary

Adds "View API Logs in Logfire" external link to the organizations_v2 detail view, grouping it with the existing "Search in Plain" action for better UX. Also fixes dropdown menu interactivity issues.

## 🎯 What

- Added "View API Logs in Logfire" link in the top-right dropdown menu
- Grouped both external tool links (Plain + Logfire) together
- Visually separated external tools from destructive actions with a divider
- Fixed DaisyUI dropdown interactivity by adding required `tabindex="0"` attributes
- Increased menu width to `w-56` and added `z-10` for proper rendering

## 🤔 Why

Enables admins to quickly investigate API logs for organizations without leaving the backoffice, improving the support workflow when reviewing organization details.

## 🔧 How

- Added `_get_logfire_url()` helper that filters logs by organization ID over 30 days, matching existing patterns in `_setup_verdict.py`
- Added new menu item with external link following the same pattern as "Search in Plain"
- Fixed dropdown with DaisyUI requirements (tabindex and z-index)

## 🧪 Testing

Manual testing in the backoffice organizations_v2 detail page:
1. Click the "⋮" button in the top-right header
2. Verify dropdown menu opens with "Search in Plain" and "View API Logs in Logfire" grouped together
3. Verify a visual divider separates these from "Delete Organization"
4. Click "View API Logs in Logfire" and verify it opens Logfire with the correct organization filter