### PR TITLE
fix: Add workspace ID to Plain search URL in organizations_v2

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -397,7 +397,7 @@ class OrganizationDetailView:
                     ):
                         with tag.li():
                             with tag.a(
-                                href=f"https://app.plain.com/search?q={self.org.email or self.org.slug}",
+                                href=f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={self.org.email or self.org.slug}",
                                 target="_blank",
                             ):
                                 text("Search in Plain")


### PR DESCRIPTION
## 📋 Summary

Fixes the Plain search URL in the organizations_v2 detail view which was missing the workspace ID path segment.

## 🎯 What

Updated the Plain search link URL from `https://app.plain.com/search?q=...` to `https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q=...` to include the workspace ID in the path.

## 🤔 Why

The missing workspace ID was causing the search link to route to an incorrect Plain URL, whereas the v1 implementation includes the proper workspace ID.

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass