### PR TITLE
ci: Clean up lambda deploy

### DIFF
--- a/.github/workflows/deploy_image_resizer.yml
+++ b/.github/workflows/deploy_image_resizer.yml
@@ -52,26 +52,3 @@ jobs:
         run: |
           aws s3 cp lambda/image-resizer/package.zip \
             s3://polar-lambda-artifacts/image-resizer/package.zip
-
-      - name: Update Lambda functions
-        run: |
-          for func in polar-sandbox-image-resizer polar-image-resizer; do
-            if ! aws lambda get-function --function-name "$func" --region us-east-1 > /dev/null 2>&1; then
-              echo "Skipping $func (not found)"
-              continue
-            fi
-
-            aws lambda update-function-code \
-              --function-name "$func" \
-              --s3-bucket polar-lambda-artifacts \
-              --s3-key image-resizer/package.zip \
-              --region us-east-1
-
-            aws lambda wait function-updated \
-              --function-name "$func" \
-              --region us-east-1
-
-            aws lambda publish-version \
-              --function-name "$func" \
-              --region us-east-1
-          done

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -312,20 +312,6 @@ resource "aws_iam_policy" "lambda_artifacts_upload" {
           "s3:PutObject"
         ]
         Resource = "${aws_s3_bucket.lambda_artifacts.arn}/*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "lambda:GetFunction",
-          "lambda:UpdateFunctionCode",
-          "lambda:PublishVersion"
-        ]
-        Resource = [
-          "arn:aws:lambda:us-east-1:*:function:polar-image-resizer",
-          "arn:aws:lambda:us-east-1:*:function:polar-image-resizer:*",
-          "arn:aws:lambda:us-east-1:*:function:polar-sandbox-image-resizer",
-          "arn:aws:lambda:us-east-1:*:function:polar-sandbox-image-resizer:*"
-        ]
       }
     ]
   })


### PR DESCRIPTION
Since its set to autopublish we dont need to cut a new version from GitHub actions