### PR TITLE
logs: Increase S3 batch size

### DIFF
--- a/server/polar/logfire.py
+++ b/server/polar/logfire.py
@@ -137,6 +137,7 @@ def configure_logfire(service_name: Literal["server", "worker"]) -> None:
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                     region_name=settings.AWS_REGION,
                 ),
+                max_export_batch_size=2048,
                 schedule_delay_millis=60_000,
             )
         )


### PR DESCRIPTION
We ideally want to have fewer PUTs to S3 to avoid racking up too high bills. Each uncompressed record is roughly 3.5KB, so going from 512->2048 is not too bloody.
