### PR TITLE
tests: 100% forever discount skips payment intent setup

### DIFF
--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -5057,7 +5057,7 @@ class TestConfirm:
 
         # Verify preconditions
         assert checkout.is_payment_required is False
-        assert checkout.is_payment_setup_required is True
+        assert checkout.is_payment_setup_required is False
         assert checkout.discount is not None
         assert checkout.discount.duration == DiscountDuration.forever
 


### PR DESCRIPTION
Based on #9766 / d99dd36 we no longer require payment setup if you have a 100% forever discount
