### PR TITLE
server/backoffice: require override reason when no AI agreement

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -736,9 +736,7 @@ async def approve_dialog(
         return HXRedirectResponse(
             request,
             str(
-                request.url_for(
-                    "organizations:detail", organization_id=organization_id
-                )
+                request.url_for("organizations:detail", organization_id=organization_id)
             ),
             303,
         )

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -35,9 +35,7 @@ def _get_logfire_url(organization_id: UUID) -> str:
 class OrganizationDetailView:
     """Render the organization detail view with horizontal section tabs."""
 
-    def __init__(
-        self, organization: Organization, ai_verdict: str = ""
-    ):
+    def __init__(self, organization: Organization, ai_verdict: str = ""):
         self.org = organization
         self.ai_verdict = ai_verdict
 


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Mandatory override reason when AI and human decisions don't match across all backoffice review dialogs.

## 🎯 What

Modified 4 backoffice dialog endpoints to require an override reason when a human reviewer's decision contradicts the AI recommendation. The changes ensure audit-trail completeness when there's disagreement with the AI verdict.

## 🤔 Why

Overrides without explanations make it hard to audit why a human disagreed with the AI. Making the reason mandatory ensures decision transparency and accountability.

## 🔧 How

- **Move agent_review fetch before POST check** — so it's available for both validation and form rendering
- **Compute is_override** — by comparing human decision against AI verdict
- **Server-side validation** — reject form submission if override without reason, re-render with error
- **Contextual UI** — label changes based on agreement state, HTML `required` attribute when overriding, error alert on validation failure
- **Add missing field** — `unblock_approve_dialog` previously had no reason field; now added with same pattern

## 🧪 Testing

- [x] All existing tests pass (`uv run pytest tests/backoffice/ -x -q` — 7 passed)
- [x] Code syntax verified
- [x] Tested locally

### Test Instructions

1. Navigate to organization review dialogs (approve, deny, approve-denied, unblock-approve)
2. When AI verdict differs from your action, verify reason textarea is marked required
3. Attempt to submit without reason — should show error and re-render form
4. Submit with reason — should succeed
5. When AI verdict matches action, reason remains optional

## 📝 Additional Notes

All 4 endpoints follow the same pattern for consistency. The `is_override` logic is specific to each endpoint's decision type.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] All tests pass locally
- [x] I have tested the changes locally