### PR TITLE
logs: Increase S3 partioning to be per hour

### DIFF
--- a/server/polar/observability/s3_span_exporter.py
+++ b/server/polar/observability/s3_span_exporter.py
@@ -47,7 +47,8 @@ class S3SpanExporter(SpanExporter):
         key = (
             f"spans/{self.service_name}"
             f"/dt={now.strftime('%Y-%m-%d')}"
-            f"/{now.strftime('%H%M%S')}_{uuid.uuid4().hex}.jsonl.gz"
+            f"/hour={now.strftime('%H')}"
+            f"/{now.strftime('%M%S')}_{uuid.uuid4().hex}.jsonl.gz"
         )
 
         try:

--- a/terraform/modules/athena_spans/main.tf
+++ b/terraform/modules/athena_spans/main.tf
@@ -56,7 +56,10 @@ resource "aws_glue_catalog_table" "spans" {
     "projection.dt.type"           = "date"
     "projection.dt.range"          = "2025-01-01,NOW"
     "projection.dt.format"         = "yyyy-MM-dd"
-    "storage.location.template"    = "s3://${var.logs_bucket_name}/spans/$${service_name}/dt=$${dt}"
+    "projection.hour.type"         = "integer"
+    "projection.hour.range"        = "0,23"
+    "projection.hour.digits"       = "2"
+    "storage.location.template"    = "s3://${var.logs_bucket_name}/spans/$${service_name}/dt=$${dt}/hour=$${hour}"
   }
 
   partition_keys {
@@ -67,6 +70,11 @@ resource "aws_glue_catalog_table" "spans" {
   partition_keys {
     name = "dt"
     type = "string"
+  }
+
+  partition_keys {
+    name = "hour"
+    type = "int"
   }
 
   storage_descriptor {


### PR DESCRIPTION
This will make it slightly cheaper to scan through small amounts of data