### PR TITLE
backoffice: Add clickable team member links to user detail pages

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -51,7 +51,16 @@ class TeamSection:
 
                                     with tag.div():
                                         with tag.div(classes="font-semibold"):
-                                            text(member.user.email or "Unknown")
+                                            with tag.a(
+                                                href=str(
+                                                    request.url_for(
+                                                        "users:get",
+                                                        id=member.user_id,
+                                                    )
+                                                ),
+                                                classes="hover:text-primary hover:underline",
+                                            ):
+                                                text(member.user.email or "Unknown")
                                         with tag.div(
                                             classes="text-sm text-base-content/60"
                                         ):


### PR DESCRIPTION
## 📋 Summary

Restores the ability to click on team member emails in the backoffice to view their detailed user information, matching the v1 functionality.

## 🎯 What

Added clickable links to team member emails in the organization team section. Clicking a member's email now navigates to their user detail page at `/backoffice/users/{user_id}`.

## 🤔 Why

Admins need quick access to detailed user information (ID, email, organizations, OAuth accounts, etc.) from the team management interface.

## 🔧 How

Wrapped the member email text in an `<a>` tag that links to the `users:get` route with hover effects (primary text color and underline).

## 🧪 Testing

- [x] Verified the link generates the correct URL format
- [x] Tested link styling with hover state