### PR TITLE
feat: add Import Orders and Domain Allowlist to backoffice v2

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -449,6 +449,28 @@ class OrganizationDetailView:
                                 target="_blank",
                             ):
                                 text("View API Logs in Logfire")
+                        with tag.li():
+                            with tag.a(
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:import_orders",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Import Orders")
+                        with tag.li():
+                            with tag.a(
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:add_payment_method_domain",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Add Domain to Allowlist")
                         with tag.li(classes="border-t border-base-200 mt-1 pt-1"):
                             with tag.a(
                                 hx_get=str(


### PR DESCRIPTION
## Summary

Port two missing features from backoffice v1 to the new v2 interface.

## What

- **Import Orders**: Enable CSV-based order importing with real-time progress via SSE
- **Add Domain to Allowlist**: Allow admins to add custom domains to Apple Pay/Google Pay allowlist via Stripe

Both features are now accessible from the organization detail page dropdown menu.

## How

Reused existing forms (`OrganizationOrdersImportForm`, `AddPaymentMethodDomainForm`) and business logic (`orders_import_sse`, `stripe_service.create_payment_method_domain`) from v1, adapting parameter names and route naming conventions for v2 consistency.

## Testing

- [x] Lint checks pass (`uv run task lint`)
- [x] Type checks pass (`uv run task lint_types`)
- Code follows project style guidelines