### PR TITLE
feat: add backoffice build step to dev setup

### DIFF
--- a/dev/cli/up_steps/12_build_backoffice.py
+++ b/dev/cli/up_steps/12_build_backoffice.py
@@ -1,0 +1,41 @@
+"""Build backoffice CSS and JS assets."""
+
+from shared import (
+    Context,
+    SERVER_DIR,
+    console,
+    run_command,
+    step_status,
+)
+
+NAME = "Building backoffice assets"
+
+BACKOFFICE_DIR = SERVER_DIR / "polar" / "backoffice"
+
+
+def check_backoffice_built() -> bool:
+    """Check if backoffice assets are already built."""
+    return (
+        (BACKOFFICE_DIR / "static" / "styles.css").exists()
+        and (BACKOFFICE_DIR / "static" / "scripts.js").exists()
+    )
+
+
+def run(ctx: Context) -> bool:
+    """Build backoffice CSS and JS assets."""
+    if check_backoffice_built() and not ctx.clean:
+        step_status(True, "Backoffice assets", "already built")
+        return True
+
+    with console.status("[bold]Building backoffice assets...[/bold]"):
+        result = run_command(
+            ["uv", "run", "task", "backoffice"], cwd=SERVER_DIR, capture=True
+        )
+        if result and result.returncode == 0:
+            step_status(True, "Backoffice assets", "built")
+            return True
+        else:
+            step_status(False, "Backoffice assets", "build failed")
+            if result and result.stderr:
+                console.print(f"[dim]{result.stderr[:500]}[/dim]")
+            return False


### PR DESCRIPTION
## 📋 Summary

Adds a new step to the `dev up` workflow to automatically compile backoffice CSS and JS assets during environment setup.

## 🎯 What

Added `dev/cli/up_steps/12_build_backoffice.py`, a new development setup step that runs `uv run task backoffice` to build Tailwind CSS and esbuild bundles for the backoffice.

## 🤔 Why

The backoffice assets need to be compiled during `dev up` so that Tailwind and DaisyUI can detect all component classes from the codebase. Running `uv run task api` alone doesn't build these assets, causing style and component issues in the backoffice UI.

## 🔧 How

- Created a new step file following the existing pattern (01_*.py through 11_*.py)
- Step runs `uv run task backoffice` which installs deps and builds CSS/JS
- Includes a check to skip rebuild if assets already exist (unless `--clean` is passed)
- Placed as the final step (step 12) after database migrations

## 🧪 Testing

- [x] All existing tests pass
- [x] Code follows project style guidelines
- [x] Tested locally with `dev up`