### PR TITLE
refactor: remove future_annual_revenue from organization_review

### DIFF
--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -290,8 +290,6 @@ class ReviewAnalyzer:
             parts.append(f"Intended Use: {org.intended_use}")
         if org.customer_acquisition:
             parts.append(f"Customer Acquisition: {', '.join(org.customer_acquisition)}")
-        if org.future_annual_revenue is not None:
-            parts.append(f"Expected Annual Revenue: ${org.future_annual_revenue:,}")
         if org.switching_from:
             parts.append(f"Switching From: {org.switching_from}")
         if org.socials:

--- a/server/polar/organization_review/collectors/organization.py
+++ b/server/polar/organization_review/collectors/organization.py
@@ -14,7 +14,6 @@ def collect_organization_data(organization: Organization) -> OrganizationData:
         product_description=details.get("product_description"),
         intended_use=details.get("intended_use"),
         customer_acquisition=details.get("customer_acquisition", []),
-        future_annual_revenue=details.get("future_annual_revenue"),
         switching_from=details.get("switching_from"),
         previous_annual_revenue=details.get("previous_annual_revenue"),
         socials=[

--- a/server/polar/organization_review/eval/task.py
+++ b/server/polar/organization_review/eval/task.py
@@ -39,7 +39,6 @@ def build_snapshot(review_input: ReviewInput) -> DataSnapshot:
         product_description=details.get("product_description"),
         intended_use=details.get("intended_use"),
         customer_acquisition=details.get("customer_acquisition", []),
-        future_annual_revenue=details.get("future_annual_revenue"),
         switching_from=details.get("switching_from"),
         previous_annual_revenue=details.get("previous_annual_revenue"),
         socials=review_input.socials,

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -73,7 +73,6 @@ class OrganizationData(Schema):
     product_description: str | None = None
     intended_use: str | None = None
     customer_acquisition: list[str] = Field(default_factory=list)
-    future_annual_revenue: int | None = None
     switching_from: str | None = None
     previous_annual_revenue: int | None = None
     socials: list[dict[str, str]] = Field(default_factory=list)


### PR DESCRIPTION
## Summary

Remove the `future_annual_revenue` field from the organization review module as it's redundant with existing revenue fields.

## What

Removed `future_annual_revenue` from:
- `OrganizationData` schema definition
- Organization data collector
- Review analyzer prompt context
- Eval task snapshot builder

## Why

This field is redundant and simplifies the data collection and analysis pipeline for organization reviews.

## Testing

- ✅ All linting checks passed (`uv run task lint`)
- ✅ All type checks passed (`uv run task lint_types`)