### PR TITLE
Hide usage section when organization has no active meters

### DIFF
--- a/server/polar/customer_portal/endpoints/organization.py
+++ b/server/polar/customer_portal/endpoints/organization.py
@@ -37,6 +37,18 @@ async def get(
     if organization is None:
         raise ResourceNotFound()
 
-    return CustomerOrganizationData.model_validate(
+    has_meters = await customer_organization_service.has_active_meters(
+        session, organization.id
+    )
+
+    data = CustomerOrganizationData.model_validate(
         {"organization": organization, "products": organization.products}
     )
+
+    if not has_meters:
+        data.organization.customer_portal_settings = {
+            **data.organization.customer_portal_settings,
+            "usage": {"show": False},
+        }
+
+    return data

--- a/server/polar/customer_portal/service/organization.py
+++ b/server/polar/customer_portal/service/organization.py
@@ -1,12 +1,27 @@
-from sqlalchemy import select
+from uuid import UUID
+
+from sqlalchemy import exists, select
 from sqlalchemy.orm import selectinload
 
 from polar.kit.services import ResourceServiceReader
 from polar.models import Organization, Product, ProductVisibility
+from polar.models.meter import Meter
 from polar.postgres import AsyncSession
 
 
 class CustomerOrganizationService(ResourceServiceReader[Organization]):
+    async def has_active_meters(
+        self, session: AsyncSession, organization_id: UUID
+    ) -> bool:
+        statement = select(
+            exists().where(
+                Meter.organization_id == organization_id,
+                Meter.archived_at.is_(None),
+            )
+        )
+        result = await session.execute(statement)
+        return result.scalar_one()
+
     async def get_by_slug(
         self, session: AsyncSession, slug: str
     ) -> Organization | None:


### PR DESCRIPTION
## 📋 Summary

Conditionally hide the usage section in the customer portal when an organization has no active meters.

## 🎯 What

- Added `has_active_meters()` method to `CustomerOrganizationService` to check if an organization has any non-archived meters
- Modified the organization endpoint to check for active meters and conditionally disable the usage section in customer portal settings when none exist

## 🤔 Why

Organizations without active meters should not display the usage section in the customer portal, as there would be no usage data to show. This improves the user experience by hiding irrelevant UI elements.

## 🔧 How

1. Added a new `has_active_meters()` async method that queries for the existence of non-archived meters for a given organization using SQLAlchemy's `exists()` function
2. In the organization endpoint's `get()` handler, call this method and conditionally set `usage.show` to `False` in the customer portal settings when no active meters are found
3. The check is performed after validating the organization exists but before returning the response

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests for new functionality

## 📝 Additional Notes

The implementation uses SQLAlchemy's efficient `exists()` subquery pattern to avoid loading full meter records when we only need to check for their existence.

https://claude.ai/code/session_01J9EoAS59wvDp2FkVAZfV4G