### PR TITLE
Optimize organization avatar display with CDN resizing

### DIFF
--- a/server/emails/src/components/OrganizationHeader.tsx
+++ b/server/emails/src/components/OrganizationHeader.tsx
@@ -1,13 +1,19 @@
 import { Column, Img, Link, Row, Section, Text } from '@react-email/components'
 import type { schemas } from '../types'
 
-const S3_HOST = 'polar-public-files.s3.amazonaws.com'
-const CDN_HOST = 'uploads.polar.sh'
+const S3_TO_CDN: Record<string, string> = {
+  'polar-public-files.s3.amazonaws.com': 'uploads.polar.sh',
+  'polar-public-sandbox-files.s3.amazonaws.com': 'sandbox-uploads.polar.sh',
+}
 
 const getResizedAvatarUrl = (url: string): string => {
-  if (!url.includes(S3_HOST)) return url
-  const cdnUrl = url.replace(S3_HOST, CDN_HOST)
-  return `${cdnUrl}${cdnUrl.includes('?') ? '&' : '?'}width=64`
+  for (const [s3Host, cdnHost] of Object.entries(S3_TO_CDN)) {
+    if (url.includes(s3Host)) {
+      const cdnUrl = url.replace(s3Host, cdnHost)
+      return `${cdnUrl}${cdnUrl.includes('?') ? '&' : '?'}width=64`
+    }
+  }
+  return url
 }
 
 interface HeaderProps {


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #<!-- issue number -->

Optimizes organization avatar images in email headers by routing them through the CDN with automatic resizing to 64px width.

## 🎯 What

- Added `getResizedAvatarUrl()` utility function that transforms S3 avatar URLs to use the CDN with width parameter
- Updated `OrganizationHeader` component to use resized avatar URLs instead of raw S3 URLs
- Non-S3 URLs are passed through unchanged for compatibility

## 🤔 Why

This change improves email rendering performance by:
- Reducing image file sizes through CDN-based resizing
- Leveraging CDN caching for faster delivery
- Ensuring consistent 64px avatar display in email headers

## 🔧 How

The implementation:
1. Detects if the avatar URL is hosted on S3 (`polar-public-files.s3.amazonaws.com`)
2. Rewrites S3 URLs to use the CDN domain (`uploads.polar.sh`)
3. Appends a `width=64` query parameter for automatic resizing
4. Handles existing query parameters correctly with `&` or `?` separator

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have run linting and type checking

### Test Instructions

1. Verify organization avatars display correctly in email templates
2. Confirm S3 URLs are properly transformed to CDN URLs with width parameter
3. Ensure non-S3 URLs are not modified

## 📝 Additional Notes

This is a frontend email component change with no breaking changes. Existing functionality is preserved for non-S3 avatar URLs.

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

https://claude.ai/code/session_01Gu488bnTrramWMHQ1FSYTw