### PR TITLE
metrics/tinybird: Handle null cancelation reason as other

### DIFF
--- a/server/tinybird/pipes/subscription_state_mv.pipe
+++ b/server/tinybird/pipes/subscription_state_mv.pipe
@@ -29,7 +29,9 @@ SQL >
         ) AS canceled_at,
         argMaxState(
             CASE
-                WHEN e.name = 'subscription.canceled' THEN e.customer_cancellation_reason ELSE NULL
+                WHEN e.name = 'subscription.canceled'
+                THEN COALESCE(e.customer_cancellation_reason, '')
+                ELSE NULL
             END,
             (
                 CASE WHEN e.name = 'subscription.canceled' THEN toUInt8(1) ELSE toUInt8(0) END,


### PR DESCRIPTION
When someone cancels and re-cancels with a null reason we don't count it correctly in Tinybird