### PR TITLE
fix: auto-generate server/.env in dev docker up

### DIFF
--- a/dev/cli/cli.py
+++ b/dev/cli/cli.py
@@ -4,6 +4,7 @@
 # dependencies = [
 #     "typer>=0.12.0",
 #     "rich>=13.0.0",
+#     "python-dotenv>=1.0.0",
 # ]
 # ///
 """


### PR DESCRIPTION
## Summary

Fixes the `dev docker up` command failing in fresh environments where `server/.env` doesn't yet exist.

## What

Added automatic generation of `server/.env` from the template when running `dev docker up`, with support for applying central secrets from `~/.config/polar/secrets.env` when available.

## Why

The Docker dev environment requires `server/.env` to exist (referenced as `env_file` in docker-compose.dev.yml), but in new worktrees or fresh environments, this file isn't created automatically. Users had to run `dev setup-environment` first, which is an extra step not needed for isolated Docker environments.

## How

- Added `_ensure_server_env()` function in `docker.py` that generates `server/.env` from template on first run
- Applies central secrets (Stripe, GitHub credentials) when available, mirroring `dev setup-environment` behavior
- Maps backend secrets to frontend env vars (`NEXT_PUBLIC_STRIPE_KEY`, `NEXT_PUBLIC_GITHUB_APP_NAMESPACE`)
- Added `python-dotenv` to CLI inline dependencies for env file parsing

## Testing

- `dev docker up` now succeeds in fresh environments without requiring `dev setup-environment` first
- Central secrets are properly applied when available

---
🤖 Generated with Claude Code