### PR TITLE
fix: use admin email in backoffice Plain search

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -426,8 +426,14 @@ async def get_organization_detail(
     if agent_review and agent_review.report:
         ai_verdict = agent_review.report.get("report", {}).get("verdict", "")
 
+    # Fetch admin user email for Plain search
+    admin_user = await repository.get_admin_user(session, organization)
+    admin_email = admin_user.email if admin_user else None
+
     # Create views
-    detail_view = OrganizationDetailView(organization, ai_verdict=ai_verdict)
+    detail_view = OrganizationDetailView(
+        organization, ai_verdict=ai_verdict, admin_email=admin_email
+    )
 
     # Fetch analytics data for overview section
     setup_data = None

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -35,9 +35,15 @@ def _get_logfire_url(organization_id: UUID) -> str:
 class OrganizationDetailView:
     """Render the organization detail view with horizontal section tabs."""
 
-    def __init__(self, organization: Organization, ai_verdict: str = ""):
+    def __init__(
+        self,
+        organization: Organization,
+        ai_verdict: str = "",
+        admin_email: str | None = None,
+    ):
         self.org = organization
         self.ai_verdict = ai_verdict
+        self.admin_email = admin_email
 
     @contextlib.contextmanager
     def section_tabs(
@@ -452,7 +458,7 @@ class OrganizationDetailView:
                                 text("Run Review Agent")
                         with tag.li():
                             with tag.a(
-                                href=f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={self.org.email or self.org.slug}",
+                                href=f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={self.admin_email or self.org.slug}",
                                 target="_blank",
                             ):
                                 text("Search in Plain")


### PR DESCRIPTION
## 📋 Summary

Fixes the "Search in Plain" feature in the backoffice v2 to use the admin user's email instead of the organization's contact email.

## 🎯 What

- Modified `OrganizationDetailView` to accept and store the admin user's email
- Updated the "Search in Plain" link to use `admin_email` instead of `org.email`
- Fetched the admin user in the detail endpoint before creating the view

## 🤔 Why

The organization's contact email (support email) was being used for Plain search instead of the admin user's email. This caused searches to look in the wrong account. The classic backoffice uses the admin email, so the v2 should too.

## 🔧 How

- Added `admin_email` parameter to `OrganizationDetailView.__init__()`
- Used `OrganizationRepository.get_admin_user()` to fetch the admin user in the endpoint
- Updated the Plain search URL to prefer `admin_email` with fallback to `org.slug`

## 🧪 Testing

- [x] Linting and type checking passed (`uv run task lint && uv run task lint_types`)

### Test Instructions

1. Navigate to an organization detail view in the backoffice v2
2. Click "Search in Plain" in the dropdown menu
3. Verify it searches by the admin user's email instead of the organization's contact email