### PR TITLE
Contract organization_review_feedback: drop legacy columns

### DIFF
--- a/server/migrations/versions/2026-02-27-1200_contract_organization_review_feedback.py
+++ b/server/migrations/versions/2026-02-27-1200_contract_organization_review_feedback.py
@@ -1,0 +1,68 @@
+"""Contract organization_review_feedback: drop legacy columns
+
+Revision ID: a7b3c9d2e1f0
+Revises: 9807b1404905
+Create Date: 2026-02-27 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "a7b3c9d2e1f0"
+down_revision = "9807b1404905"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Drop legacy columns that have been replaced by new ones:
+    #   ai_verdict    -> verdict
+    #   human_verdict -> decision (when actor_type='human')
+    #   agreement     -> derivable from verdict + decision
+    #   override_reason -> reason
+    #   reviewed_at   -> created_at (from RecordModel base)
+    op.drop_column("organization_review_feedback", "ai_verdict")
+    op.drop_column("organization_review_feedback", "human_verdict")
+    op.drop_column("organization_review_feedback", "agreement")
+    op.drop_column("organization_review_feedback", "override_reason")
+    op.drop_column("organization_review_feedback", "reviewed_at")
+
+
+def downgrade() -> None:
+    # Re-add legacy columns as nullable (they were made nullable in the expand phase)
+    op.add_column(
+        "organization_review_feedback",
+        sa.Column("reviewed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "organization_review_feedback",
+        sa.Column("override_reason", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "organization_review_feedback",
+        sa.Column("agreement", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "organization_review_feedback",
+        sa.Column("human_verdict", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "organization_review_feedback",
+        sa.Column("ai_verdict", sa.String(), nullable=True),
+    )
+
+    # Backfill legacy columns from new columns
+    op.execute(
+        sa.text("""
+            UPDATE organization_review_feedback
+            SET
+                ai_verdict = verdict,
+                human_verdict = CASE WHEN actor_type = 'human' THEN decision ELSE NULL END,
+                override_reason = reason,
+                reviewed_at = created_at
+        """)
+    )

--- a/server/polar/models/organization_review_feedback.py
+++ b/server/polar/models/organization_review_feedback.py
@@ -1,10 +1,8 @@
-from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import (
-    TIMESTAMP,
     Boolean,
     Float,
     ForeignKey,
@@ -27,24 +25,6 @@ if TYPE_CHECKING:
 class OrganizationReviewFeedback(RecordModel):
     """Captures review decisions for organizations — both AI agent and human reviewer."""
 
-    # --- Existing enums (kept for backward compat during expand phase) ---
-
-    class AIVerdict(StrEnum):
-        APPROVE = "APPROVE"
-        DENY = "DENY"
-        NEEDS_HUMAN_REVIEW = "NEEDS_HUMAN_REVIEW"
-
-    class HumanVerdict(StrEnum):
-        APPROVE = "APPROVE"
-        DENY = "DENY"
-
-    class Agreement(StrEnum):
-        AGREE = "AGREE"
-        OVERRIDE_TO_APPROVE = "OVERRIDE_TO_APPROVE"
-        OVERRIDE_TO_DENY = "OVERRIDE_TO_DENY"
-
-    # --- New enums ---
-
     class ActorType(StrEnum):
         AGENT = "agent"
         HUMAN = "human"
@@ -65,7 +45,7 @@ class OrganizationReviewFeedback(RecordModel):
         ),
     )
 
-    # --- Existing columns (now nullable for agent decisions) ---
+    # --- FK columns (nullable — not all decisions have both) ---
 
     agent_review_id: Mapped[UUID | None] = mapped_column(
         Uuid,
@@ -81,19 +61,7 @@ class OrganizationReviewFeedback(RecordModel):
         index=True,
     )
 
-    ai_verdict: Mapped[str | None] = mapped_column(String, nullable=True)
-    human_verdict: Mapped[str | None] = mapped_column(String, nullable=True)
-    agreement: Mapped[str | None] = mapped_column(String, nullable=True)
-
-    override_reason: Mapped[str | None] = mapped_column(
-        Text, nullable=True, default=None
-    )
-
-    reviewed_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=True
-    )
-
-    # --- New columns ---
+    # --- Decision columns ---
 
     organization_id: Mapped[UUID | None] = mapped_column(
         Uuid,


### PR DESCRIPTION
## Summary
- Add alembic migration to drop 5 legacy columns from `organization_review_feedback`: `ai_verdict`, `human_verdict`, `agreement`, `override_reason`, `reviewed_at`
- Remove old enums (`AIVerdict`, `HumanVerdict`, `Agreement`) and column definitions from the model
- Update tests to drop old column assertions and the dual-write test

**Depends on:** #9882 (dual-write removal must be deployed first)

This is part 2 of the contract phase. The migration and model change are in the same PR to keep CI's migration check happy. Merge only after #9882 is deployed so no running code references the dropped columns.

## Test plan
- [ ] `alembic upgrade head` runs without errors
- [ ] `alembic downgrade -1` successfully re-creates columns and backfills
- [ ] Existing `test_repository.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)