### PR TITLE
Add versioning to organization agent review reports

### DIFF
--- a/server/migrations/versions/2026-02-26-1200_stamp_agent_review_report_version.py
+++ b/server/migrations/versions/2026-02-26-1200_stamp_agent_review_report_version.py
@@ -1,0 +1,41 @@
+"""Stamp version=1 on existing organization_agent_reviews.report JSONB
+
+Revision ID: a7f3e1c20b94
+Revises: 1f3638dfb58f
+Create Date: 2026-02-26 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "a7f3e1c20b94"
+down_revision = "1f3638dfb58f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Stamp all existing rows that don't already have a version key.
+    # Uses jsonb_set to add {"version": 1} to the report column.
+    op.execute(
+        sa.text("""
+            UPDATE organization_agent_reviews
+            SET report = jsonb_set(report, '{version}', '1'::jsonb)
+            WHERE NOT (report ? 'version')
+        """)
+    )
+
+
+def downgrade() -> None:
+    # Remove the version key from all reports that have version=1.
+    op.execute(
+        sa.text("""
+            UPDATE organization_agent_reviews
+            SET report = report - 'version'
+            WHERE report->>'version' = '1'
+        """)
+    )

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -1381,9 +1381,9 @@ async def get(
             # Fetch the AI verdict to determine if this is an override
             agent_review = await review_repo.get_latest_agent_review(id)
             ai_verdict: str | None = None
-            if agent_review and agent_review.report:
-                report = agent_review.report.get("report", {})
-                ai_verdict = report.get("verdict")
+            if agent_review:
+                parsed = agent_review.parsed_report
+                ai_verdict = parsed.report.verdict.value
 
             reason = getattr(account_status, "reason", None)
             reason = reason.strip() if reason else None

--- a/server/polar/models/organization_agent_review.py
+++ b/server/polar/models/organization_agent_review.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import RecordModel
+from polar.organization_review.report import AnyAgentReport
 
 if TYPE_CHECKING:
     from polar.models.organization import Organization
@@ -33,6 +34,17 @@ class OrganizationAgentReview(RecordModel):
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:
         return relationship("Organization", lazy="raise")
+
+    @property
+    def parsed_report(self) -> AnyAgentReport:
+        """Deserialize the raw JSONB into a versioned, typed report schema.
+
+        The result is *not* cached — call once and bind to a local variable
+        if you need it multiple times in the same scope.
+        """
+        from polar.organization_review.report import parse_agent_report
+
+        return parse_agent_report(self.report)
 
     def __repr__(self) -> str:
         return (

--- a/server/polar/organization_review/report.py
+++ b/server/polar/organization_review/report.py
@@ -1,0 +1,123 @@
+"""Versioned, type-safe schemas for OrganizationAgentReview.report JSONB.
+
+Every report stored in the ``organization_agent_reviews.report`` column MUST
+carry a ``version`` integer so that readers can deserialize it into the correct
+Pydantic model.  Legacy rows written before versioning was introduced are
+treated as V1.
+
+Adding a new version
+--------------------
+1. Define ``AgentReportV2(Schema)`` with ``version: Literal[2] = 2``.
+2. Add it to the ``AnyAgentReport`` union.
+3. Handle it in ``parse_agent_report``.
+4. Update ``LATEST_VERSION`` and ``LatestAgentReport``.
+"""
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from polar.kit.schemas import Schema
+
+from .schemas import (
+    AgentReviewResult,
+    DataSnapshot,
+    ReviewAgentReport,
+    UsageInfo,
+)
+
+__all__ = [
+    "LATEST_VERSION",
+    "AgentReportV1",
+    "AnyAgentReport",
+    "LatestAgentReport",
+    "build_agent_report",
+    "parse_agent_report",
+]
+
+# ---------------------------------------------------------------------------
+# Version 1
+# ---------------------------------------------------------------------------
+
+LATEST_VERSION: Literal[1] = 1
+
+
+class AgentReportV1(Schema):
+    """Version 1 of the persisted agent review report.
+
+    Matches the structure that was written to JSONB before versioning was added,
+    plus an explicit ``version`` field.  Fields mirror ``AgentReviewResult`` with
+    the addition of ``review_type`` (injected at save time).
+    """
+
+    version: Literal[1] = 1
+
+    review_type: str = Field(
+        description="Review trigger context: submission, setup_complete, threshold, manual"
+    )
+
+    report: ReviewAgentReport = Field(description="The core AI analysis output")
+    data_snapshot: DataSnapshot = Field(
+        description="All collected data that was fed to the analyzer"
+    )
+    model_used: str = Field(description="AI model identifier")
+    duration_seconds: float = Field(
+        default=0.0, description="Wall-clock time for the review"
+    )
+    usage: UsageInfo = Field(default_factory=UsageInfo)
+    timed_out: bool = False
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Union of all versions
+# ---------------------------------------------------------------------------
+
+AnyAgentReport = AgentReportV1  # Union[AgentReportV1, AgentReportV2, ...] in the future
+LatestAgentReport = AgentReportV1
+
+
+# ---------------------------------------------------------------------------
+# Parse (read path)
+# ---------------------------------------------------------------------------
+
+
+def parse_agent_report(data: dict[str, Any]) -> AnyAgentReport:
+    """Deserialize a raw JSONB dict into a versioned report schema.
+
+    Legacy rows without a ``version`` key are treated as V1.
+
+    Raises ``ValueError`` for unknown versions and ``ValidationError`` for
+    data that doesn't match the expected schema.
+    """
+    version = data.get("version")
+    if version is None or version == 1:
+        return AgentReportV1.model_validate(data)
+
+    raise ValueError(f"Unknown agent report version: {version}")
+
+
+# ---------------------------------------------------------------------------
+# Build (write path)
+# ---------------------------------------------------------------------------
+
+
+def build_agent_report(
+    result: AgentReviewResult,
+    review_type: str,
+) -> AgentReportV1:
+    """Construct a ``LatestAgentReport`` from an ``AgentReviewResult``.
+
+    This is the single place where we build the report dict that gets persisted.
+    """
+    return AgentReportV1(
+        version=LATEST_VERSION,
+        review_type=review_type,
+        report=result.report,
+        data_snapshot=result.data_snapshot,
+        model_used=result.model_used,
+        duration_seconds=result.duration_seconds,
+        usage=result.usage,
+        timed_out=result.timed_out,
+        error=result.error,
+    )

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -18,6 +18,7 @@ from polar.organization.service import organization as organization_service
 from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
 from .agent import run_organization_review
+from .report import build_agent_report
 from .repository import OrganizationReviewRepository
 from .schemas import ReviewContext, ReviewVerdict
 
@@ -103,11 +104,10 @@ async def run_review_agent(
 
         # Persist agent report to its own table (both contexts)
         review_repository = OrganizationReviewRepository.from_session(session)
+        typed_report = build_agent_report(result, review_type=review_context.value)
         agent_review = await review_repository.save_agent_review(
             organization_id=organization_id,
-            review_type=review_context.value,
-            report=result.model_dump(mode="json"),
-            model_used=result.model_used,
+            report=typed_report,
             reviewed_at=datetime.now(UTC),
         )
 

--- a/server/tests/organization_review/test_report.py
+++ b/server/tests/organization_review/test_report.py
@@ -1,0 +1,271 @@
+"""Tests for the versioned agent report module."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from polar.organization_review.report import (
+    LATEST_VERSION,
+    AgentReportV1,
+    build_agent_report,
+    parse_agent_report,
+)
+from polar.organization_review.schemas import (
+    AccountData,
+    AgentReviewResult,
+    DataSnapshot,
+    DimensionAssessment,
+    HistoryData,
+    IdentityData,
+    OrganizationData,
+    PaymentMetrics,
+    ProductsData,
+    ReviewAgentReport,
+    ReviewContext,
+    ReviewDimension,
+    ReviewVerdict,
+    UsageInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_review_report() -> ReviewAgentReport:
+    return ReviewAgentReport(
+        verdict=ReviewVerdict.APPROVE,
+        overall_risk_score=15.0,
+        summary="Low risk organization",
+        violated_sections=[],
+        dimensions=[
+            DimensionAssessment(
+                dimension=ReviewDimension.POLICY_COMPLIANCE,
+                score=10.0,
+                confidence=0.9,
+                findings=["All policies met"],
+                recommendation="Approve",
+            ),
+        ],
+        recommended_action="Approve without conditions",
+    )
+
+
+def _make_data_snapshot() -> DataSnapshot:
+    return DataSnapshot(
+        context=ReviewContext.SUBMISSION,
+        organization=OrganizationData(name="Test Org", slug="test-org"),
+        products=ProductsData(),
+        identity=IdentityData(),
+        account=AccountData(),
+        metrics=PaymentMetrics(),
+        history=HistoryData(),
+        collected_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _make_agent_review_result() -> AgentReviewResult:
+    return AgentReviewResult(
+        report=_make_review_report(),
+        data_snapshot=_make_data_snapshot(),
+        model_used="gpt-4o-mini",
+        duration_seconds=2.5,
+        usage=UsageInfo(input_tokens=100, output_tokens=50, total_tokens=150),
+    )
+
+
+def _make_v1_report_dict(
+    *,
+    version: int | None = 1,
+    review_type: str = "submission",
+) -> dict[str, Any]:
+    """Build a raw dict matching the V1 JSONB shape."""
+    result = _make_agent_review_result()
+    d = result.model_dump(mode="json")
+    d["review_type"] = review_type
+    if version is not None:
+        d["version"] = version
+    return d
+
+
+# ---------------------------------------------------------------------------
+# parse_agent_report
+# ---------------------------------------------------------------------------
+
+
+class TestParseAgentReport:
+    def test_parses_v1_with_explicit_version(self) -> None:
+        data = _make_v1_report_dict(version=1)
+        parsed = parse_agent_report(data)
+
+        assert isinstance(parsed, AgentReportV1)
+        assert parsed.version == 1
+        assert parsed.review_type == "submission"
+        assert parsed.report.verdict == ReviewVerdict.APPROVE
+        assert parsed.report.overall_risk_score == 15.0
+        assert parsed.model_used == "gpt-4o-mini"
+        assert parsed.duration_seconds == 2.5
+
+    def test_parses_legacy_without_version(self) -> None:
+        """Legacy rows don't have a version field — should be treated as V1."""
+        data = _make_v1_report_dict(version=None)
+        assert "version" not in data
+
+        parsed = parse_agent_report(data)
+        assert isinstance(parsed, AgentReportV1)
+        assert parsed.version == 1
+
+    def test_preserves_dimensions(self) -> None:
+        data = _make_v1_report_dict()
+        parsed = parse_agent_report(data)
+
+        assert len(parsed.report.dimensions) == 1
+        dim = parsed.report.dimensions[0]
+        assert dim.dimension == ReviewDimension.POLICY_COMPLIANCE
+        assert dim.score == 10.0
+        assert dim.confidence == 0.9
+
+    def test_preserves_usage(self) -> None:
+        data = _make_v1_report_dict()
+        parsed = parse_agent_report(data)
+
+        assert parsed.usage.input_tokens == 100
+        assert parsed.usage.output_tokens == 50
+        assert parsed.usage.total_tokens == 150
+
+    def test_preserves_data_snapshot(self) -> None:
+        data = _make_v1_report_dict()
+        parsed = parse_agent_report(data)
+
+        assert parsed.data_snapshot.context == ReviewContext.SUBMISSION
+        assert parsed.data_snapshot.organization.name == "Test Org"
+        assert parsed.data_snapshot.organization.slug == "test-org"
+
+    def test_unknown_version_raises(self) -> None:
+        data = _make_v1_report_dict()
+        data["version"] = 999
+
+        with pytest.raises(ValueError, match="Unknown agent report version: 999"):
+            parse_agent_report(data)
+
+    def test_invalid_data_raises_validation_error(self) -> None:
+        """Missing required fields should raise a Pydantic ValidationError."""
+        with pytest.raises(ValidationError):
+            parse_agent_report({"version": 1, "review_type": "manual"})
+
+    def test_roundtrip_through_model_dump(self) -> None:
+        """parse(report.model_dump()) should equal the original."""
+        original = AgentReportV1(
+            review_type="threshold",
+            report=_make_review_report(),
+            data_snapshot=_make_data_snapshot(),
+            model_used="gpt-4o",
+            duration_seconds=3.0,
+        )
+        dumped = original.model_dump(mode="json")
+        restored = parse_agent_report(dumped)
+
+        assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# build_agent_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAgentReport:
+    def test_builds_latest_version(self) -> None:
+        result = _make_agent_review_result()
+        report = build_agent_report(result, review_type="submission")
+
+        assert isinstance(report, AgentReportV1)
+        assert report.version == LATEST_VERSION
+        assert report.review_type == "submission"
+
+    def test_copies_all_fields(self) -> None:
+        result = _make_agent_review_result()
+        report = build_agent_report(result, review_type="threshold")
+
+        assert report.report == result.report
+        assert report.data_snapshot == result.data_snapshot
+        assert report.model_used == result.model_used
+        assert report.duration_seconds == result.duration_seconds
+        assert report.usage == result.usage
+        assert report.timed_out == result.timed_out
+        assert report.error == result.error
+
+    def test_serializes_to_valid_json(self) -> None:
+        result = _make_agent_review_result()
+        report = build_agent_report(result, review_type="manual")
+        data = report.model_dump(mode="json")
+
+        # Should contain version key
+        assert data["version"] == 1
+        assert data["review_type"] == "manual"
+        # Should be parseable back
+        parsed = parse_agent_report(data)
+        assert parsed == report
+
+    def test_with_error_and_timeout(self) -> None:
+        result = _make_agent_review_result()
+        result.timed_out = True
+        result.error = "Agent timed out"
+
+        report = build_agent_report(result, review_type="submission")
+        assert report.timed_out is True
+        assert report.error == "Agent timed out"
+
+
+# ---------------------------------------------------------------------------
+# AgentReportV1 schema
+# ---------------------------------------------------------------------------
+
+
+class TestAgentReportV1:
+    def test_version_defaults_to_1(self) -> None:
+        report = AgentReportV1(
+            review_type="manual",
+            report=_make_review_report(),
+            data_snapshot=_make_data_snapshot(),
+            model_used="test",
+            duration_seconds=1.0,
+        )
+        assert report.version == 1
+
+    def test_version_is_literal_1(self) -> None:
+        """Cannot set version to anything other than 1."""
+        with pytest.raises(ValidationError):
+            AgentReportV1(
+                version=2,  # type: ignore[arg-type]
+                review_type="manual",
+                report=_make_review_report(),
+                data_snapshot=_make_data_snapshot(),
+                model_used="test",
+                duration_seconds=1.0,
+            )
+
+    def test_duration_defaults_to_zero(self) -> None:
+        report = AgentReportV1(
+            review_type="manual",
+            report=_make_review_report(),
+            data_snapshot=_make_data_snapshot(),
+            model_used="test",
+        )
+        assert report.duration_seconds == 0.0
+
+    def test_deny_verdict(self) -> None:
+        review_report = _make_review_report()
+        review_report.verdict = ReviewVerdict.DENY
+        review_report.overall_risk_score = 85.0
+
+        report = AgentReportV1(
+            review_type="submission",
+            report=review_report,
+            data_snapshot=_make_data_snapshot(),
+            model_used="gpt-4o",
+            duration_seconds=5.0,
+        )
+        assert report.report.verdict == ReviewVerdict.DENY
+        assert report.report.overall_risk_score == 85.0


### PR DESCRIPTION
## 📋 Summary

Introduces versioning and type-safe schemas for the `organization_agent_reviews.report` JSONB column. This enables safe evolution of the report structure over time and provides compile-time type safety throughout the codebase.

## 🎯 What

- **New module** `polar/organization_review/report.py`: Defines versioned report schemas (`AgentReportV1`) with `parse_agent_report()` and `build_agent_report()` functions for serialization/deserialization
- **Schema updates**: All report data now flows through typed Pydantic models instead of raw dicts
- **Repository changes**: `save_agent_review()` now accepts a typed `AnyAgentReport` instead of separate `review_type`, `report`, and `model_used` parameters
- **Model property**: Added `parsed_report` property to `OrganizationAgentReview` for convenient deserialization
- **Backoffice updates**: Replaced dict access patterns with typed attribute access in review display components
- **Migration**: Stamps `version=1` on all existing reports to support legacy data

## 🤔 Why

The previous approach stored reports as untyped dicts, making it:
- Difficult to evolve the schema safely (no validation at write time)
- Error-prone in consumers (dict key typos, missing null checks)
- Hard to track what fields are required vs. optional

Versioning enables:
- Safe schema evolution (add `AgentReportV2` without breaking existing code)
- Type safety throughout the codebase (IDE autocomplete, type checking)
- Backward compatibility (legacy rows without version are treated as V1)
- Clear contract between producers and consumers

## 🔧 How

1. **Versioning layer**: `AgentReportV1` is a Pydantic schema with `version: Literal[1]` that mirrors the existing JSONB structure plus an explicit version field
2. **Parse path**: `parse_agent_report()` reads the version field (defaulting to 1 for legacy rows) and deserializes into the appropriate schema
3. **Build path**: `build_agent_report()` is the single place where reports are constructed, ensuring all required fields are present
4. **Backward compatibility**: Legacy rows without a version field are automatically treated as V1; the migration stamps existing rows with `version=1`
5. **Consumer updates**: Backoffice views now receive typed `AnyAgentReport` objects and access fields via attributes instead of dict keys

## 🧪 Testing

- Added comprehensive test suite in `server/tests/organization_review/test_report.py` covering:
  - Parsing V1 reports with and without explicit version field
  - Roundtrip serialization/deserialization
  - Schema validation and error handling
  - Field preservation across all report components
- Updated `test_repository.py` to use typed reports and verify `parsed_report` property
- All existing tests pass with the new typed approach

## 📝 Additional Notes

- The `LATEST_VERSION` constant is set to 1; future versions can be added by defining `AgentReportV2`, adding it to the `AnyAgentReport` union, and updating `parse_agent_report()`
- The migration is safe for production: it only adds a version field to existing rows, doesn't modify any other data
- All backoffice components now have compile-time type safety when accessing report fields

https://claude.ai/code/session_01F2M8ggXkWBwKY4wW1zZA84