### PR TITLE
Fix product switcher showing prices in default currency instead of de…

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
@@ -14,7 +14,7 @@ import {
 } from '@polar-sh/ui/components/ui/radio-group'
 import { ThemingPresetProps } from '@polar-sh/ui/hooks/theming'
 import { cn } from '@polar-sh/ui/lib/utils'
-import { Fragment, useCallback } from 'react'
+import { Fragment, useCallback, useMemo } from 'react'
 import type { ProductCheckoutPublic } from '../guards'
 import { hasLegacyRecurringPrices } from '../utils/product'
 import { capitalize, decapitalize } from '../utils/string'
@@ -42,8 +42,24 @@ const CheckoutProductSwitcher = ({
     product: selectedProduct,
     productPrice: selectedPrice,
     products,
-    prices,
+    prices: allPrices,
+    currency,
   } = checkout
+
+  // Filter prices to only show ones matching the checkout's detected currency.
+  // Products with presentment currencies may have prices in multiple currencies,
+  // but the switcher should only display prices in the checkout's currency.
+  const prices = useMemo(() => {
+    const filtered: typeof allPrices = {}
+    for (const [productId, productPrices] of Object.entries(allPrices)) {
+      const currencyPrices = productPrices.filter(
+        (p) => p.priceCurrency === currency,
+      )
+      filtered[productId] =
+        currencyPrices.length > 0 ? currencyPrices : productPrices
+    }
+    return filtered
+  }, [allPrices, currency])
 
   const selectProduct = useCallback(
     (value: string) => {
@@ -60,7 +76,7 @@ const CheckoutProductSwitcher = ({
         }
       }
     },
-    [update, products],
+    [update, products, prices],
   )
 
   if (


### PR DESCRIPTION
…tected currency

The product switcher was displaying prices using the first price in the array for each product, which follows database ordering (by amount_type, then created_at) regardless of currency. For products with multiple presentment currencies, this meant showing the default currency price instead of the checkout's detected currency.

Filter the prices by checkout.currency in the CheckoutProductSwitcher component before rendering, so prices are shown in the correct detected presentment currency.

https://claude.ai/code/session_01Fyuv9bUAeQB4GrqHNiBsmE
