### PR TITLE
server/checkout: validate uniqueness of product ID when creating checkout

### DIFF
--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -11,6 +11,7 @@ from pydantic import (
     IPvAnyAddress,
     Tag,
     computed_field,
+    field_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
 
@@ -302,6 +303,14 @@ class CheckoutProductsCreate(CheckoutCreateBase):
         ),
         min_length=1,
     )
+
+    @field_validator("products")
+    @classmethod
+    def products_must_be_unique(cls, v: list[UUID4]) -> list[UUID4]:
+        if len(v) != len(set(v)):
+            raise ValueError("Product IDs must be unique.")
+        return v
+
     prices: dict[UUID4, ProductPriceCreateList] | None = Field(
         default=None,
         description=(

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -288,6 +288,24 @@ class TestCreateCheckout:
         assert response.status_code == 201
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
+    async def test_duplicate_products(
+        self,
+        api_prefix: str,
+        client: AsyncClient,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            f"{api_prefix}/",
+            json={
+                "payment_processor": "stripe",
+                "products": [str(product.id), str(product.id)],
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
     @pytest.mark.parametrize(
         "customer_billing_address",
         [


### PR DESCRIPTION
Fix #9918

- server/checkout: validate uniqueness of product ID when creating checkout
