### PR TITLE
Configurable checkout session expiration

### DIFF
--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Annotated, Any, Literal
 
 from annotated_types import Ge, Le, MaxLen, MinLen
@@ -52,6 +52,7 @@ from polar.kit.trial import (
     TrialConfigurationOutputMixin,
     TrialInterval,
 )
+from polar.kit.utils import utc_now
 from polar.models.checkout import (
     CheckoutBillingAddressFields,
     CheckoutCustomerBillingAddressFields,
@@ -173,6 +174,14 @@ _customer_metadata_description = METADATA_DESCRIPTION.format(
         "that'll be copied to the created customer."
     )
 )
+CHECKOUT_EXPIRES_AT_MIN = timedelta(minutes=30)
+CHECKOUT_EXPIRES_AT_MAX = timedelta(hours=24)
+_expires_at_description = (
+    "Optional expiration date and time for the checkout session. "
+    "Must be between 30 minutes and 24 hours from now. "
+    "If not provided, defaults to 24 hours."
+)
+
 CheckoutCurrency = Annotated[
     PresentmentCurrency,
     Field(
@@ -253,6 +262,23 @@ class CheckoutCreateBase(
     return_url: ReturnURL = None
     embed_origin: EmbedOrigin = None
     locale: Locale | None = None
+    expires_at: datetime | None = Field(
+        default=None, description=_expires_at_description
+    )
+
+    @field_validator("expires_at")
+    @classmethod
+    def validate_expires_at(cls, v: datetime | None) -> datetime | None:
+        if v is None:
+            return v
+        now = utc_now()
+        min_expires = now + CHECKOUT_EXPIRES_AT_MIN
+        max_expires = now + CHECKOUT_EXPIRES_AT_MAX
+        if v < min_expires:
+            raise ValueError("Expiration must be at least 30 minutes from now.")
+        if v > max_expires:
+            raise ValueError("Expiration must be at most 24 hours from now.")
+        return v
 
 
 class CheckoutPriceCreate(CheckoutCreateBase):

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -520,10 +520,14 @@ class CheckoutService:
                     "customer_tax_id",
                     "subscription_id",
                     "custom_field_data",
+                    "expires_at",
                 },
                 by_alias=True,
             ),
         )
+
+        if checkout_create.expires_at is not None:
+            checkout.expires_at = checkout_create.expires_at
 
         if checkout.customer is not None:
             prefill_attributes = (

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -147,7 +147,7 @@ class Settings(BaseSettings):
     EMAIL_VERIFICATION_TTL_SECONDS: int = 60 * 30  # 30 minutes
 
     # Checkout
-    CHECKOUT_TTL_SECONDS: int = 60 * 60  # 1 hour
+    CHECKOUT_TTL_SECONDS: int = 60 * 60 * 24  # 24 hours
     IP_GEOLOCATION_DATABASE_DIRECTORY_PATH: DirectoryPath = Path(__file__).parent.parent
     IP_GEOLOCATION_DATABASE_NAME: str = "ip-geolocation.mmdb"
 


### PR DESCRIPTION
Change the default checkout session expiration from 1 hour to 24 hours. Add an optional `expires_at` parameter to the checkout creation API that allows callers to set a custom expiration between 30 minutes and 24 hours from now. When not provided, the default 24-hour TTL applies.

https://claude.ai/code/session_01FdHRE18ckHwqaFjrAHRJZ9