### PR TITLE
Standardize checkout currency format

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -423,16 +423,19 @@ const Checkout = ({
                     </div>
                   </div>
                   <span className="text-3xl font-medium">
-                    {checkout.productPrice.amountType === 'seat_based' ? (
-                      formatCurrency('compact', locale)(
-                        checkout.netAmount || 0,
-                        checkout.productPrice.priceCurrency,
+                    {checkout.discount ||
+                    checkout.productPrice.amountType === 'seat_based' ? (
+                      formatCurrency('standard', locale)(
+                        checkout.totalAmount ?? checkout.netAmount ?? 0,
+                        checkout.currency ??
+                          checkout.productPrice.priceCurrency,
                       )
                     ) : (
                       <ProductPriceLabel
                         product={checkout.product}
                         price={checkout.productPrice}
                         locale={locale}
+                        mode="standard"
                       />
                     )}
                   </span>

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
@@ -180,7 +180,7 @@ const CheckoutProductSwitcher = ({
                 currency={item.price.priceCurrency}
                 interval={item.product.recurringInterval}
                 intervalCount={item.product.recurringIntervalCount}
-                mode="compact"
+                mode="standard"
                 locale={locale}
               />
             ) : (
@@ -188,6 +188,7 @@ const CheckoutProductSwitcher = ({
                 product={item.product}
                 price={item.price}
                 locale={locale}
+                mode="standard"
               />
             )}
           </span>

--- a/clients/packages/checkout/src/components/ProductPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/ProductPriceLabel.tsx
@@ -14,12 +14,14 @@ interface ProductPriceLabelProps {
   product: CheckoutProduct
   price: ProductPrice | LegacyRecurringProductPrice
   locale?: AcceptedLocale
+  mode?: 'compact' | 'standard'
 }
 
 const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
   product,
   price,
   locale = DEFAULT_LOCALE,
+  mode = 'compact',
 }) => {
   const t = useTranslations(locale)
 
@@ -34,7 +36,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
             : product.recurringInterval
         }
         intervalCount={product.recurringIntervalCount}
-        mode="compact"
+        mode={mode}
         locale={locale}
       />
     )
@@ -58,7 +60,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
         currency={price.priceCurrency}
         interval={product.recurringInterval}
         intervalCount={product.recurringIntervalCount}
-        mode="compact"
+        mode={mode}
         locale={locale}
       />
     )


### PR DESCRIPTION
* Large price is now formatted properly (`$19` vs `A$19`)
* Large price now show the actual total with discount included

<img width="500" height="588" alt="Screenshot 2026-03-02 at 11 18 15" src="https://github.com/user-attachments/assets/50ee2267-457e-42dc-828b-73e64c52c175" />
