### PR TITLE
fix: handle legacy agent report JSONB validation

### DIFF
--- a/server/polar/organization_review/report.py
+++ b/server/polar/organization_review/report.py
@@ -52,8 +52,9 @@ class AgentReportV1(Schema):
 
     version: Literal[1] = 1
 
-    review_type: str = Field(
-        description="Review trigger context: submission, setup_complete, threshold, manual"
+    review_type: str | None = Field(
+        default=None,
+        description="Review trigger context: submission, setup_complete, threshold, manual",
     )
 
     report: ReviewAgentReport = Field(description="The core AI analysis output")

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -259,7 +259,7 @@ class OrganizationReviewRepository(
             risk_score = parsed.report.overall_risk_score
 
             if review_context is None:
-                derived_context = parsed.review_type
+                derived_context = parsed.review_type or "manual"
 
         await self.deactivate_current_decisions(organization_id)
         return await self.save_review_decision(

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -215,10 +215,10 @@ class WebsiteData(Schema):
 class DataSnapshot(Schema):
     """All collected data for the AI analyzer."""
 
-    context: ReviewContext
+    context: ReviewContext | None = None
     organization: OrganizationData
     products: ProductsData
-    identity: IdentityData
+    identity: IdentityData = Field(default_factory=IdentityData)
     account: AccountData
     metrics: PaymentMetrics
     history: HistoryData
@@ -262,6 +262,7 @@ class DimensionAssessment(Schema):
 class ReviewVerdict(StrEnum):
     APPROVE = "APPROVE"
     DENY = "DENY"
+    NEEDS_HUMAN_REVIEW = "NEEDS_HUMAN_REVIEW"
 
 
 class ReviewAgentReport(Schema):


### PR DESCRIPTION
## Summary
- Fix `ValidationError` when viewing organization details in the backoffice for orgs with legacy agent review data (Fixes SERVER-44Z)
- Add `NEEDS_HUMAN_REVIEW` to `ReviewVerdict` enum — the UI already renders it but the schema rejected it
- Make `AgentReportV1.review_type`, `DataSnapshot.context`, and `DataSnapshot.identity` optional with sensible defaults for legacy rows that predate these fields
- Add `or "manual"` fallback in repository when deriving review context from a potentially-None `review_type`

## Test plan
- [ ] Verify backoffice org detail page loads for organizations with legacy agent reviews (the ones currently erroring)
- [ ] Verify backoffice org detail page still works for organizations with current-format agent reviews
- [ ] Verify new agent reviews are still created correctly (write path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)