### PR TITLE
Fix V1→V2 agent report migration crash on null review_type

### DIFF
--- a/server/polar/organization_review/report.py
+++ b/server/polar/organization_review/report.py
@@ -192,7 +192,7 @@ def _migrate_v1_to_v2(v1: AgentReportV1) -> AgentReportV2:
     """Migrate a V1 report to V2 with type-safe conversion."""
     return AgentReportV2(
         report=_migrate_report(v1.report),
-        review_type=v1.review_type,  # type: ignore[arg-type]
+        review_type=v1.review_type or "unknown",
         data_snapshot=v1.data_snapshot,
         model_used=v1.model_used,
         duration_seconds=v1.duration_seconds,

--- a/server/tests/organization_review/test_report.py
+++ b/server/tests/organization_review/test_report.py
@@ -386,6 +386,14 @@ class TestV1ToV2Migration:
         assert isinstance(parsed, AgentReportV2)
         assert parsed.version == 2
 
+    def test_v1_with_null_review_type_defaults_to_unknown(self) -> None:
+        """V1 data with review_type=None should migrate to 'unknown'."""
+        data = _make_v1_report_dict(version=1)
+        data["review_type"] = None
+        parsed = parse_agent_report(data)
+        assert isinstance(parsed, AgentReportV2)
+        assert parsed.review_type == "unknown"
+
     def test_migration_preserves_all_fields(self) -> None:
         data = _make_v1_report_dict(version=1, review_type="threshold")
         parsed = parse_agent_report(data)


### PR DESCRIPTION
## Summary
- V1 agent reports can have `review_type=None`, but `AgentReportV2` requires a non-null string
- The `_migrate_v1_to_v2` function passed `None` through, causing a `ValidationError` on the backoffice organization detail page
- Falls back to `"unknown"` during migration, which is safe since `review_type` is only used for display/informational purposes

Fixes SERVER-455

## Test plan
- [x] Added `test_v1_with_null_review_type_defaults_to_unknown` covering the exact production scenario
- [x] Lint passes
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)