### PR TITLE
fix: correct breadcrumb order in backoffice layout

### DIFF
--- a/server/polar/backoffice/components/_layout.py
+++ b/server/polar/backoffice/components/_layout.py
@@ -15,15 +15,13 @@ def content(
 ) -> Generator[None]:
     with tag.div(classes="breadcrumbs text-sm"):
         with tag.ul():
-            for title, href in reversed(
-                [
-                    *breadcrumbs,
-                    (
-                        "Polar Backoffice",
-                        str(request.url_for("index")),
-                    ),
-                ]
-            ):
+            for title, href in [
+                (
+                    "Polar Backoffice",
+                    str(request.url_for("index")),
+                ),
+                *breadcrumbs,
+            ]:
                 with tag.li():
                     with tag.a(href=href):
                         text(title)


### PR DESCRIPTION
## 📋 Summary

Fixes breadcrumb ordering in the backoffice organization detail pages. Previously, breadcrumbs were displayed in reverse order.

## 🎯 What

Fixed the breadcrumb rendering logic in `_layout.py` to display breadcrumbs in the correct hierarchical order.

## 🤔 Why

The breadcrumb component was appending "Polar Backoffice" at the end and then reversing the entire list, which flipped the order of intermediate breadcrumbs. Now breadcrumbs display correctly as "Polar Backoffice > Organizations > [Item]" instead of "Polar Backoffice > [Item] > Organizations".

## 🔧 How

- Prepended "Polar Backoffice" to the beginning of the breadcrumbs list
- Removed the `reversed()` call on the breadcrumb list iteration

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Navigate to Polar Backoffice
2. Go to Organizations section
3. Click on any organization (e.g., Voidpet)
4. Verify breadcrumb shows "Polar Backoffice > Organizations > [Organization Name]"

## 📝 Additional Notes

This is a minor UI fix affecting only the backoffice component breadcrumb rendering logic.