### PR TITLE
Remove 'rule' from payment status constants

### DIFF
--- a/server/polar/models/payment.py
+++ b/server/polar/models/payment.py
@@ -40,7 +40,6 @@ UNRECOVERABLE_DECLINE_CODES: set[str] = {
     "stolen_card",
     "stop_payment_order",
     "highest_risk_level",
-    "rule",
     "elevated_risk_level",
     "blocklist",
 }


### PR DESCRIPTION
We have some `hourly` rate limits in Radar, so we need to retry these payments.
