### PR TITLE
metrics: Fallback to global exchange rate

### DIFF
--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -313,8 +313,48 @@ def get_active_subscriptions_cte(
         .group_by(fx_day, fx_currency)
     )
 
+    global_fx_day = func.date_trunc("day", Transaction.created_at)
+    global_fx_daily = cte(
+        select(
+            global_fx_day.label("day"),
+            fx_currency.label("presentment_currency"),
+            func.avg(fx_value).label("avg_exchange_rate"),
+        )
+        .select_from(Transaction)
+        .where(
+            Transaction.type == TransactionType.payment,
+            Transaction.presentment_currency.is_not(None),
+            Transaction.created_at >= start_timestamp,
+            Transaction.created_at <= end_timestamp,
+        )
+        .group_by(global_fx_day, fx_currency)
+    )
+
+    closest_global_fx_rate = (
+        select(global_fx_daily.c.avg_exchange_rate)
+        .where(
+            global_fx_daily.c.presentment_currency == func.lower(Subscription.currency),
+        )
+        .order_by(
+            func.abs(
+                func.extract(
+                    "epoch",
+                    global_fx_daily.c.day - timestamp_column,
+                )
+            )
+        )
+        .limit(1)
+        .correlate(Subscription, timestamp_series)
+        .scalar_subquery()
+    )
+
     converted_amount = func.round(
-        Subscription.amount * func.coalesce(bucketed_fx.c.avg_exchange_rate, 1)
+        Subscription.amount
+        * func.coalesce(
+            bucketed_fx.c.avg_exchange_rate,
+            closest_global_fx_rate,
+            1,
+        )
     )
     monthly_amount = case(
         (


### PR DESCRIPTION
If an organization doesn't have a lot of orders, or is newly created, there might not be an exchange rate to use that's close in time. In that case lets look at the global exchange rates and use the closest in time.

Contrary to the reverted commit, this uses an intermediary CTE for aggregation instead of doing the subquery for every row.
