### PR TITLE
fe/dashboard: Portal Tooltip to prevent clipping

### DIFF
--- a/clients/packages/ui/src/components/ui/tooltip.tsx
+++ b/clients/packages/ui/src/components/ui/tooltip.tsx
@@ -17,15 +17,17 @@ const TooltipContent = ({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'bg-popover text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md',
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'bg-popover text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 )
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
Otherwise the tooltip gets clipped by overflow-hidden
<img width="294" height="137" alt="Screenshot 2026-03-02 at 18 09 01" src="https://github.com/user-attachments/assets/1f715a18-a6e3-413d-ab15-b4b823c64927" />

<img width="194" height="148" alt="Screenshot 2026-03-02 at 18 08 51" src="https://github.com/user-attachments/assets/4644f3eb-ab6c-4d6e-bd84-b23dd03243d1" />
