### PR TITLE
Add tax ID validation for customer creation and updates

### DIFF
--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -63,7 +63,7 @@ class CustomerCreate(MetadataInputMixin, Schema):
     )
     name: CustomerNameInput | None = None
     billing_address: AddressInput | None = None
-    tax_id: TaxID | None = None
+    tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
     locale: Locale | None = None
     type: CustomerType | None = Field(
         default=None,
@@ -97,7 +97,7 @@ class CustomerUpdateBase(MetadataInputMixin, Schema):
     )
     name: CustomerNameInput | None = None
     billing_address: AddressInput | None = None
-    tax_id: TaxID | None = None
+    tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
     locale: Locale | None = None
 
 

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -28,6 +28,7 @@ from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.redis import Redis
 from polar.subscription.repository import SubscriptionRepository
+from polar.tax.tax_id import InvalidTaxID, validate_tax_id
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
 
@@ -157,13 +158,45 @@ class CustomerService:
         if errors:
             raise PolarRequestValidationError(errors)
 
+        validated_tax_id = None
+        if customer_create.tax_id is not None:
+            if customer_create.billing_address is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "missing",
+                            "loc": ("body", "billing_address"),
+                            "msg": "Country is required to validate tax ID.",
+                            "input": None,
+                        }
+                    ]
+                )
+            try:
+                validated_tax_id = validate_tax_id(
+                    customer_create.tax_id,
+                    customer_create.billing_address.country,
+                )
+            except InvalidTaxID as e:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "invalid",
+                            "loc": ("body", "tax_id"),
+                            "msg": "Invalid tax ID.",
+                            "input": customer_create.tax_id,
+                        }
+                    ]
+                ) from e
+
         try:
             async with repository.create_context(
                 Customer(
                     organization=organization,
                     **customer_create.model_dump(
-                        exclude={"organization_id", "owner"}, by_alias=True
+                        exclude={"organization_id", "owner", "tax_id"},
+                        by_alias=True,
                     ),
+                    tax_id=validated_tax_id,
                 )
             ) as customer:
                 owner_email = (
@@ -307,11 +340,47 @@ class CustomerService:
         if errors:
             raise PolarRequestValidationError(errors)
 
+        # Validate tax_id
+        tax_id = customer_update.tax_id or (
+            customer.tax_id[0] if customer.tax_id else None
+        )
+        if tax_id is not None:
+            billing_address = (
+                customer_update.billing_address
+                if "billing_address" in customer_update.model_fields_set
+                and customer_update.billing_address is not None
+                else customer.billing_address
+            )
+            if billing_address is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "missing",
+                            "loc": ("body", "billing_address"),
+                            "msg": "Country is required to validate tax ID.",
+                            "input": None,
+                        }
+                    ]
+                )
+            try:
+                customer.tax_id = validate_tax_id(tax_id, billing_address.country)
+            except InvalidTaxID as e:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "invalid",
+                            "loc": ("body", "tax_id"),
+                            "msg": "Invalid tax ID.",
+                            "input": customer_update.tax_id,
+                        }
+                    ]
+                ) from e
+
         try:
             return await repository.update(
                 customer,
                 update_dict=customer_update.model_dump(
-                    exclude={"email"}, exclude_unset=True, by_alias=True
+                    exclude={"email", "tax_id"}, exclude_unset=True, by_alias=True
                 ),
             )
         except IntegrityError as e:

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -359,6 +359,83 @@ class TestCreate:
             )
         assert exc_info.value.errors()[0]["loc"] == ("body", "external_id")
 
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"), AuthSubjectFixture(subject="organization")
+    )
+    async def test_tax_id_without_billing_address(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Creating a customer with tax_id but no billing_address should fail."""
+        payload: dict[str, Any] = {
+            "email": "taxid-no-address@example.com",
+            "tax_id": "FR61954506077",
+        }
+        if is_user(auth_subject):
+            payload["organization_id"] = str(organization.id)
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await customer_service.create(
+                session, CustomerCreate.model_validate(payload), auth_subject
+            )
+        assert exc_info.value.errors()[0]["loc"] == ("body", "billing_address")
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"), AuthSubjectFixture(subject="organization")
+    )
+    async def test_invalid_tax_id(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Creating a customer with an invalid tax_id should fail."""
+        payload: dict[str, Any] = {
+            "email": "invalid-taxid@example.com",
+            "tax_id": "INVALID",
+            "billing_address": {"country": "FR"},
+        }
+        if is_user(auth_subject):
+            payload["organization_id"] = str(organization.id)
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await customer_service.create(
+                session, CustomerCreate.model_validate(payload), auth_subject
+            )
+        assert exc_info.value.errors()[0]["loc"] == ("body", "tax_id")
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"), AuthSubjectFixture(subject="organization")
+    )
+    async def test_valid_tax_id(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Creating a customer with a valid tax_id should validate and store it as a tuple."""
+        payload: dict[str, Any] = {
+            "email": "valid-taxid@example.com",
+            "tax_id": "FR61954506077",
+            "billing_address": {"country": "FR"},
+        }
+        if is_user(auth_subject):
+            payload["organization_id"] = str(organization.id)
+
+        customer = await customer_service.create(
+            session, CustomerCreate.model_validate(payload), auth_subject
+        )
+        await session.flush()
+
+        assert customer.tax_id is not None
+        assert customer.tax_id[0] == "FR61954506077"
+        assert customer.tax_id[1] == TaxIDFormat.eu_vat
+
 
 @pytest.mark.asyncio
 class TestUpdate:
@@ -586,6 +663,90 @@ class TestUpdate:
         await session.flush()
 
         assert updated_customer.type == CustomerType.team
+
+    async def test_tax_id_without_billing_address(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        """Updating a customer with tax_id but no billing_address should fail."""
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await customer_service.update(
+                session,
+                customer,
+                CustomerUpdate(tax_id="FR61954506077"),
+            )
+        assert exc_info.value.errors()[0]["loc"] == ("body", "billing_address")
+
+    async def test_invalid_tax_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Updating a customer with an invalid tax_id should fail."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="invalid-taxid-update@example.com",
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await customer_service.update(
+                session,
+                customer,
+                CustomerUpdate(tax_id="INVALID"),
+            )
+        assert exc_info.value.errors()[0]["loc"] == ("body", "tax_id")
+
+    async def test_valid_tax_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Updating a customer with a valid tax_id should validate and store it as a tuple."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="valid-taxid-update@example.com",
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        updated_customer = await customer_service.update(
+            session,
+            customer,
+            CustomerUpdate(tax_id="FR61954506077"),
+        )
+        await session.flush()
+
+        assert updated_customer.tax_id is not None
+        assert updated_customer.tax_id[0] == "FR61954506077"
+        assert updated_customer.tax_id[1] == TaxIDFormat.eu_vat
+
+    async def test_billing_address_change_revalidates_tax_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Changing billing_address should re-validate existing tax_id against new country."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="revalidate-taxid@example.com",
+            billing_address=Address(country=CountryAlpha2("FR")),
+            tax_id=("FR61954506077", TaxIDFormat.eu_vat),
+        )
+        # Changing country to US should fail because FR VAT is not valid in US
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await customer_service.update(
+                session,
+                customer,
+                CustomerUpdate(
+                    billing_address=AddressInput(country=CountryAlpha2Input("US"))
+                ),
+            )
+        assert exc_info.value.errors()[0]["loc"] == ("body", "tax_id")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📋 Summary

Implements tax ID validation for customers, ensuring tax IDs are validated against the customer's billing address country and stored as tuples containing both the ID and its format.

## 🎯 What

- Added tax ID validation using the `validate_tax_id` function from `polar.tax.tax_id`
- Changed `tax_id` field type from `TaxID` to `str` in `CustomerCreate` and `CustomerUpdateBase` schemas
- Tax IDs are now validated and stored as tuples `(tax_id_string, TaxIDFormat)` in the database
- Added validation rules:
  - Tax ID requires a billing address with a country to validate against
  - Tax ID format must be valid for the specified country
  - When billing address changes, existing tax ID is re-validated against the new country

## 🤔 Why

Tax ID validation is essential for compliance and accurate tax handling. By validating at creation/update time and storing the format, the system can:
- Prevent invalid tax IDs from being stored
- Ensure tax IDs are appropriate for their billing country
- Maintain data integrity when customer location changes

## 🔧 How

1. **In `customer_service.create()`**: Added validation logic that:
   - Checks billing address exists when tax_id is provided
   - Calls `validate_tax_id()` to validate format and country compatibility
   - Stores the returned tuple (tax_id, format) instead of raw string
   - Raises `PolarRequestValidationError` with appropriate error messages on validation failure

2. **In `customer_service.update()`**: Added similar validation that:
   - Handles both new tax_id values and re-validation of existing ones
   - Uses updated billing address if provided, otherwise uses current address
   - Re-validates existing tax_id when billing address changes
   - Excludes `tax_id` from the standard update dict to apply validated tuple

3. **In schemas**: Changed `tax_id` field from `TaxID` type to `Annotated[str | None, EmptyStrToNoneValidator]` to accept raw string input that gets validated in the service layer

## 🧪 Testing

Added comprehensive test coverage:
- `test_tax_id_without_billing_address`: Validates that tax_id requires billing_address
- `test_invalid_tax_id`: Validates that invalid tax IDs are rejected
- `test_valid_tax_id`: Validates that valid tax IDs are accepted and stored as tuples
- `test_billing_address_change_revalidates_tax_id`: Validates that changing billing address re-validates existing tax_id

All tests cover both user and organization auth subjects for create operations, and update operations with various scenarios.

https://claude.ai/code/session_01WKoA2TmWLwi9Kph6ZdCHu6