### PR TITLE
feat: add member_id support to customer-sessions endpoint

### DIFF
--- a/server/polar/customer_session/schemas.py
+++ b/server/polar/customer_session/schemas.py
@@ -19,6 +19,15 @@ class CustomerSessionCreateBase(Schema):
             ),
         ),
     ] = None
+    external_member_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "External ID of the member to create a session for. "
+                "Alternative to `member_id`."
+            ),
+        ),
+    ] = None
     return_url: Annotated[
         HttpUrl | None,
         Field(

--- a/server/polar/customer_session/service.py
+++ b/server/polar/customer_session/service.py
@@ -106,6 +106,11 @@ class CustomerSessionService(ResourceServiceReader[CustomerSession]):
                 member_repository, customer, customer_create.member_id
             )
 
+        if customer_create.external_member_id is not None:
+            return await self._get_member_by_external_id(
+                member_repository, customer, customer_create.external_member_id
+            )
+
         customer_type = customer.type or CustomerType.individual
         if customer_type == CustomerType.team:
             raise PolarRequestValidationError(
@@ -142,6 +147,31 @@ class CustomerSessionService(ResourceServiceReader[CustomerSession]):
                 ]
             )
         # get_by_id_and_customer_id doesn't joinedload the customer,
+        # set it for response serialization
+        member.customer = customer
+        return member
+
+    async def _get_member_by_external_id(
+        self,
+        member_repository: MemberRepository,
+        customer: Customer,
+        external_member_id: str,
+    ) -> Member:
+        member = await member_repository.get_by_customer_id_and_external_id(
+            customer.id, external_member_id
+        )
+        if member is None:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "loc": ("body", "external_member_id"),
+                        "msg": "Member does not exist for this customer.",
+                        "type": "value_error",
+                        "input": external_member_id,
+                    }
+                ]
+            )
+        # get_by_customer_id_and_external_id doesn't joinedload the customer,
         # set it for response serialization
         member.customer = customer
         return member

--- a/server/tests/customer_session/test_endpoints.py
+++ b/server/tests/customer_session/test_endpoints.py
@@ -386,3 +386,72 @@ class TestCreate:
         json = response.json()
         assert json["token"].startswith(MEMBER_SESSION_TOKEN_PREFIX)
         assert json["customer_id"] == str(customer.id)
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_external_member_id(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        customer = await create_customer(
+            save_fixture, organization=organization, email="test@example.com"
+        )
+
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            name="Member",
+            role=MemberRole.member,
+            external_id="ext_member_123",
+        )
+        await save_fixture(member)
+
+        response = await client.post(
+            "/v1/customer-sessions/",
+            json={
+                "customer_id": str(customer.id),
+                "external_member_id": "ext_member_123",
+            },
+        )
+
+        assert response.status_code == 201
+        json = response.json()
+        assert json["token"].startswith(MEMBER_SESSION_TOKEN_PREFIX)
+        assert json["customer_id"] == str(customer.id)
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_external_member_id_not_found(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        customer = await create_customer(
+            save_fixture, organization=organization, email="test@example.com"
+        )
+
+        response = await client.post(
+            "/v1/customer-sessions/",
+            json={
+                "customer_id": str(customer.id),
+                "external_member_id": "nonexistent",
+            },
+        )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## 📋 Summary

Allow creating sessions for specific members by adding an optional `member_id` parameter to `POST /v1/customer-sessions/`. This enables the endpoint to work with both individual and team customers.

## 🎯 What

- Added optional `member_id` field to customer session creation schemas
- When `member_model_enabled` is true and `member_id` is provided, creates a session for that specific member
- When `member_model_enabled` is true and `member_id` is not provided:
  - For individual customers: auto-resolves the owner member
  - For team customers: returns 422 error (team customers require explicit member selection)
- When `member_model_enabled` is false, `member_id` is silently ignored

## 🤔 Why

This change unifies the customer-sessions and member-sessions endpoints by allowing customer-sessions to work with both individual and team customers. Team customers now require explicit member_id since they have multiple members.

## 🔧 How

Refactored session resolution logic into focused helper methods:
- `_get_customer()`: Looks up customer by ID or external ID
- `_resolve_member()`: Dispatches between explicit member_id, team customer error check, and owner member resolution
- `_get_member_by_id()`: Validates member exists for the customer
- `_resolve_owner_member()`: Auto-resolves or creates owner member for individual customers

## 🧪 Testing

- ✅ All existing tests pass (`uv run task test` for backend)
- ✅ Added 4 new tests covering all new behaviors
- ✅ Linting and type checking pass (`uv run task lint && uv run task lint_types`)

### Test Coverage

1. `test_member_id_creates_session_for_specific_member` - Explicit member_id creates session for that member
2. `test_member_id_not_found` - Invalid member_id returns 422
3. `test_team_customer_without_member_id` - Team customer without member_id returns 422
4. `test_team_customer_with_member_id` - Team customer with member_id succeeds