### PR TITLE
Add known-good integration domains whitelist for org reviews

### DIFF
--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -7,6 +7,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 
 from polar.config import settings
 
+from .known_domains import known_domains_for_prompt, match_known_domain
 from .policy import fetch_policy_content
 from .schemas import DataSnapshot, ReviewAgentReport, ReviewContext, UsageInfo
 from .thresholds import thresholds_for_prompt
@@ -240,7 +241,7 @@ Return only APPROVE or DENY.
 """
 
 
-THRESHOLD_PREAMBLE = """\
+THRESHOLD_PREAMBLE = f"""\
 This is a THRESHOLD review triggered when a payment threshold is hit. \
 Perform a comprehensive analysis across ALL five dimensions. \
 If website content is not available, flag this as a red flag.
@@ -253,7 +254,12 @@ organization's website. Mismatched or suspicious domains are yellow flags.
 mean the customer pays but receives nothing tangible — a red flag if there are no webhooks \
 or API keys configured.
 - **API & Webhook integration**: Having API keys or webhook endpoints is a positive signal. \
-Webhook domains should match the organization's website or known services.
+Webhook domains should match the organization's website or known services. \
+Domains marked '(known service)' in the webhook domain list are legitimate third-party \
+integration platforms and should NOT be flagged as suspicious mismatches.
+
+Known integration platform domains:
+{known_domains_for_prompt()}
 
 Return only APPROVE or DENY.
 """
@@ -303,10 +309,26 @@ organization's website. Mismatched or suspicious domains are yellow flags.
 mean the customer pays but receives nothing tangible — a red flag if there are no webhooks \
 or API keys configured.
 - **API & Webhook integration**: Having API keys or webhook endpoints is a positive signal. \
-Webhook domains should match the organization's website or known services.
+Webhook domains should match the organization's website or known services. \
+Domains marked '(known service)' in the webhook domain list are legitimate third-party \
+integration platforms and should NOT be flagged as suspicious mismatches.
+
+Known integration platform domains:
+{known_domains_for_prompt()}
 
 Return only APPROVE or DENY.
 """
+
+
+def _annotate_domains(domains: list[str]) -> str:
+    """Join domain names, tagging known service domains for the AI agent."""
+    parts = []
+    for d in domains:
+        if match_known_domain(d) is not None:
+            parts.append(f"{d} (known service)")
+        else:
+            parts.append(d)
+    return ", ".join(parts)
 
 
 class ReviewAnalyzer:
@@ -466,7 +488,7 @@ class ReviewAnalyzer:
                 for url in setup.integration.webhook_urls:
                     parts.append(f"  - {url}")
                 parts.append(
-                    f"Webhook Domains: {', '.join(setup.integration.webhook_domains)}"
+                    f"Webhook Domains: {_annotate_domains(setup.integration.webhook_domains)}"
                 )
             else:
                 parts.append("No webhook endpoints configured.")
@@ -648,12 +670,12 @@ class ReviewAnalyzer:
         return "\n".join(parts)
 
 
-def _timeout_report() -> ReviewAgentReport:
+def _fallback_report(summary: str, finding: str, action: str) -> ReviewAgentReport:
     from .schemas import DimensionAssessment, ReviewDimension, ReviewVerdict, RiskLevel
 
     return ReviewAgentReport(
         verdict=ReviewVerdict.DENY,
-        summary="Analysis timed out. Denied for human review.",
+        summary=summary,
         merchant_summary="Error occurred during analysis. Please contact support for assistance.",
         violated_sections=[],
         dimensions=[
@@ -661,34 +683,29 @@ def _timeout_report() -> ReviewAgentReport:
                 dimension=ReviewDimension.POLICY_COMPLIANCE,
                 risk_level=RiskLevel.MEDIUM,
                 confidence=0.0,
-                findings=["Analysis timed out"],
+                findings=[finding],
                 recommendation="Human review required",
             )
         ],
         overall_risk_level=RiskLevel.MEDIUM,
-        recommended_action="Human review required due to timeout.",
+        recommended_action=action,
+    )
+
+
+def _timeout_report() -> ReviewAgentReport:
+    return _fallback_report(
+        "Analysis timed out. Denied for human review.",
+        "Analysis timed out",
+        "Human review required due to timeout.",
     )
 
 
 def _error_report(error: str) -> ReviewAgentReport:
-    from .schemas import DimensionAssessment, ReviewDimension, ReviewVerdict, RiskLevel
-
-    return ReviewAgentReport(
-        verdict=ReviewVerdict.DENY,
-        summary=f"Analysis failed with error: {error[:200]}. Denied for human review.",
-        merchant_summary="Error occurred during analysis. Please contact support for assistance.",
-        violated_sections=[],
-        dimensions=[
-            DimensionAssessment(
-                dimension=ReviewDimension.POLICY_COMPLIANCE,
-                risk_level=RiskLevel.MEDIUM,
-                confidence=0.0,
-                findings=[f"Analysis error: {error[:200]}"],
-                recommendation="Human review required",
-            )
-        ],
-        overall_risk_level=RiskLevel.MEDIUM,
-        recommended_action="Human review required due to analysis error.",
+    msg = error[:200]
+    return _fallback_report(
+        f"Analysis failed with error: {msg}. Denied for human review.",
+        f"Analysis error: {msg}",
+        "Human review required due to analysis error.",
     )
 
 

--- a/server/polar/organization_review/collectors/setup.py
+++ b/server/polar/organization_review/collectors/setup.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 from polar.models.checkout_link import CheckoutLink
 from polar.models.webhook_endpoint import WebhookEndpoint
 
+from ..known_domains import match_known_domain
 from ..schemas import (
     CheckoutLinkBenefitData,
     CheckoutLinksData,
@@ -21,6 +22,18 @@ def _extract_domain(url: str) -> str | None:
         return None
 
 
+def _unique_domains(urls: list[str]) -> list[str]:
+    """Extract and deduplicate domains from a list of URLs, preserving order."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for url in urls:
+        domain = _extract_domain(url)
+        if domain and domain not in seen:
+            seen.add(domain)
+            result.append(domain)
+    return result
+
+
 def collect_setup_data(
     checkout_links: list[CheckoutLink],
     checkout_return_urls: list[str],
@@ -35,31 +48,15 @@ def collect_setup_data(
             seen_urls.add(link.success_url)
             unique_urls.append(link.success_url)
 
-    url_domains = []
-    seen_domains: set[str] = set()
-    for url in unique_urls:
-        domain = _extract_domain(url)
-        if domain and domain not in seen_domains:
-            seen_domains.add(domain)
-            url_domains.append(domain)
-
     success_url_data = CheckoutSuccessUrlData(
         unique_urls=unique_urls,
-        domains=url_domains,
+        domains=_unique_domains(unique_urls),
     )
 
     # Checkout return URLs (from the checkouts table, API-created)
-    return_url_domains: list[str] = []
-    seen_return_domains: set[str] = set()
-    for url in checkout_return_urls:
-        domain = _extract_domain(url)
-        if domain and domain not in seen_return_domains:
-            seen_return_domains.add(domain)
-            return_url_domains.append(domain)
-
     return_url_data = CheckoutReturnUrlData(
         unique_urls=checkout_return_urls,
-        domains=return_url_domains,
+        domains=_unique_domains(checkout_return_urls),
     )
 
     # Checkout links with benefit info
@@ -93,18 +90,15 @@ def collect_setup_data(
 
     # Integration data
     webhook_urls = [ep.url for ep in webhook_endpoints]
-    webhook_domains: list[str] = []
-    seen_wh_domains: set[str] = set()
-    for url in webhook_urls:
-        domain = _extract_domain(url)
-        if domain and domain not in seen_wh_domains:
-            seen_wh_domains.add(domain)
-            webhook_domains.append(domain)
+    webhook_domains = _unique_domains(webhook_urls)
 
     integration_data = IntegrationData(
         api_key_count=api_key_count,
         webhook_urls=webhook_urls,
         webhook_domains=webhook_domains,
+        webhook_known_service_domains=[
+            d for d in webhook_domains if match_known_domain(d) is not None
+        ],
     )
 
     return SetupData(

--- a/server/polar/organization_review/known_domains.py
+++ b/server/polar/organization_review/known_domains.py
@@ -1,0 +1,76 @@
+"""Known-good integration platform domains for organization reviews.
+
+Used by the AI review agent to avoid false-positive flags on legitimate
+third-party webhook and checkout URL domains.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class KnownDomain:
+    """A known-good integration platform domain."""
+
+    pattern: str
+    name: str
+    category: str
+
+    def matches(self, domain: str) -> bool:
+        """Check if *domain* matches this pattern.
+
+        Exact patterns match literally; wildcard patterns (``*.example.com``)
+        match any subdomain of ``example.com`` via suffix check on
+        ``.example.com``.  The bare root (``example.com``) is **not** matched
+        by a wildcard pattern — only actual subdomains qualify.
+        """
+        if self.pattern.startswith("*."):
+            suffix = self.pattern[1:]  # e.g. ".supabase.co"
+            return domain.endswith(suffix) and domain != suffix.lstrip(".")
+        return domain == self.pattern
+
+
+# -- Domain whitelist (single source of truth) --
+
+KNOWN_DOMAINS: list[KnownDomain] = [
+    # Analytics
+    KnownDomain("datafa.st", "Datafast", "analytics"),
+    # Messaging
+    KnownDomain("discord.com", "Discord", "messaging"),
+    KnownDomain("discordapp.com", "Discord", "messaging"),
+    KnownDomain("hooks.slack.com", "Slack", "messaging"),
+    # Affiliate
+    KnownDomain("affonso.io", "Affonso", "affiliate"),
+    # Automation
+    KnownDomain("hooks.zapier.com", "Zapier", "automation"),
+    KnownDomain("*.make.com", "Make.com", "automation"),
+    KnownDomain("webhook.ottokit.com", "OttoKit", "automation"),
+    KnownDomain("hkdk.events", "Hookdeck", "automation"),
+    KnownDomain("play.svix.com", "Svix", "automation"),
+    KnownDomain("script.google.com", "Google Apps Script", "automation"),
+    # Integration
+    KnownDomain("nifty.codes", "Nifty Codes", "integration"),
+    # CRM
+    KnownDomain("services.leadconnectorhq.com", "GoHighLevel", "crm"),
+    # Backend
+    KnownDomain("*.supabase.co", "Supabase", "backend"),
+    KnownDomain("*.convex.site", "Convex", "backend"),
+    KnownDomain("*.convex.cloud", "Convex", "backend"),
+]
+
+
+def match_known_domain(domain: str) -> KnownDomain | None:
+    """Return the first matching :class:`KnownDomain`, or ``None``."""
+    for kd in KNOWN_DOMAINS:
+        if kd.matches(domain):
+            return kd
+    return None
+
+
+def known_domains_for_prompt() -> str:
+    """Format the whitelist as a block for inclusion in AI prompts."""
+    lines: list[str] = []
+    for kd in KNOWN_DOMAINS:
+        lines.append(f"- {kd.pattern} ({kd.name}, {kd.category})")
+    return "\n".join(lines)

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -177,6 +177,7 @@ class IntegrationData(Schema):
     api_key_count: int = 0
     webhook_urls: list[str] = Field(default_factory=list)
     webhook_domains: list[str] = Field(default_factory=list)
+    webhook_known_service_domains: list[str] = Field(default_factory=list)
 
 
 class SetupData(Schema):

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -204,6 +204,38 @@ class TestCollectSetupDataIntegration:
         assert result.integration.webhook_domains == []
 
 
+class TestCollectSetupDataKnownDomains:
+    def test_webhook_known_domains(self) -> None:
+        ep1 = _build_webhook_endpoint(url="https://myapp.com/webhook")
+        ep2 = _build_webhook_endpoint(url="https://discord.com/api/webhooks/123")
+        ep3 = _build_webhook_endpoint(url="https://hooks.zapier.com/hook/abc")
+
+        result = collect_setup_data([], [], 0, [ep1, ep2, ep3])
+
+        assert set(result.integration.webhook_known_service_domains) == {
+            "discord.com",
+            "hooks.zapier.com",
+        }
+
+    def test_webhook_wildcard_known_domains(self) -> None:
+        ep = _build_webhook_endpoint(
+            url="https://myproject.supabase.co/functions/v1/hook"
+        )
+
+        result = collect_setup_data([], [], 0, [ep])
+
+        assert result.integration.webhook_known_service_domains == [
+            "myproject.supabase.co"
+        ]
+
+    def test_empty_when_all_custom(self) -> None:
+        ep = _build_webhook_endpoint(url="https://mystore.com/webhook")
+
+        result = collect_setup_data([], [], 0, [ep])
+
+        assert result.integration.webhook_known_service_domains == []
+
+
 class TestCollectSetupDataCombined:
     def test_full_setup(self) -> None:
         """Integration test with all data populated."""

--- a/server/tests/organization_review/test_known_domains.py
+++ b/server/tests/organization_review/test_known_domains.py
@@ -1,0 +1,66 @@
+from polar.organization_review.known_domains import (
+    KNOWN_DOMAINS,
+    KnownDomain,
+    known_domains_for_prompt,
+    match_known_domain,
+)
+
+
+class TestKnownDomainMatches:
+    def test_exact_match(self) -> None:
+        kd = KnownDomain("discord.com", "Discord", "messaging")
+        assert kd.matches("discord.com") is True
+
+    def test_exact_no_match(self) -> None:
+        kd = KnownDomain("discord.com", "Discord", "messaging")
+        assert kd.matches("other.com") is False
+
+    def test_wildcard_match(self) -> None:
+        kd = KnownDomain("*.supabase.co", "Supabase", "backend")
+        assert kd.matches("abcdef.supabase.co") is True
+
+    def test_wildcard_no_match_bare_root(self) -> None:
+        """The bare root should NOT match a wildcard pattern."""
+        kd = KnownDomain("*.supabase.co", "Supabase", "backend")
+        assert kd.matches("supabase.co") is False
+
+    def test_wildcard_no_match_different_domain(self) -> None:
+        kd = KnownDomain("*.supabase.co", "Supabase", "backend")
+        assert kd.matches("evil.com") is False
+
+    def test_wildcard_safety_no_suffix_trick(self) -> None:
+        """Ensure evil-supabase.co does NOT match *.supabase.co."""
+        kd = KnownDomain("*.supabase.co", "Supabase", "backend")
+        assert kd.matches("evil-supabase.co") is False
+
+    def test_exact_pattern_not_wildcard(self) -> None:
+        kd = KnownDomain("hooks.slack.com", "Slack", "messaging")
+        assert kd.matches("hooks.slack.com") is True
+        assert kd.matches("evil.hooks.slack.com") is False
+
+
+class TestMatchKnownDomain:
+    def test_returns_matching_entry(self) -> None:
+        result = match_known_domain("discord.com")
+        assert result is not None
+        assert result.name == "Discord"
+
+    def test_returns_none_for_unknown(self) -> None:
+        assert match_known_domain("unknown-domain.example.com") is None
+
+    def test_wildcard_returns_entry(self) -> None:
+        result = match_known_domain("myproject.supabase.co")
+        assert result is not None
+        assert result.name == "Supabase"
+
+
+class TestKnownDomainsForPrompt:
+    def test_non_empty(self) -> None:
+        result = known_domains_for_prompt()
+        assert len(result) > 0
+
+    def test_contains_all_entries(self) -> None:
+        result = known_domains_for_prompt()
+        for kd in KNOWN_DOMAINS:
+            assert kd.pattern in result
+            assert kd.name in result


### PR DESCRIPTION
## Summary
- Adds a maintainable whitelist of known-good integration platform domains (Discord, Zapier, Supabase, Slack, etc.) to prevent the AI review agent from flagging legitimate third-party webhook endpoints as suspicious domain mismatches
- Webhook domains matching the whitelist are annotated as `(known service)` in the AI prompt, and the full reference list is included in the preamble
- Adds `webhook_known_service_domains` field to `IntegrationData` schema for structured tracking

## Test plan
- [ ] Verify `uv run pytest server/tests/organization_review/ -v` passes
- [ ] Verify `uv run task lint_types` passes (confirmed locally)
- [ ] Verify `uv run task lint` passes (confirmed locally)
- [ ] Manually trigger a review for an org with known-service webhooks (e.g. Discord, Zapier) and confirm they are not flagged as suspicious

🤖 Generated with [Claude Code](https://claude.com/claude-code)