### PR TITLE
feat: add Phase 0B prepare command for gradual member model migration

### DIFF
--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -31,27 +31,40 @@ Usage:
         uv run python -m scripts.migrate_organizations_members repair --no-dry-run --limit 1000 --offset 0
         uv run python -m scripts.migrate_organizations_members repair --no-dry-run --limit 1000 --offset 1000
         uv run python -m scripts.migrate_organizations_members repair --no-dry-run --limit 1000 --offset 2000
+
+    Prepare seat-based orgs for member model (Phase 0B, non-destructive):
+        uv run python -m scripts.migrate_organizations_members prepare
+        uv run python -m scripts.migrate_organizations_members prepare --slug my-org --no-dry-run
+        uv run python -m scripts.migrate_organizations_members prepare --limit 10 --no-dry-run
 """
 
 import asyncio
 import logging.config
+import uuid
 from functools import wraps
 from typing import Any
 
 import structlog
 import typer
 from sqlalchemy import func, or_, select
+from sqlalchemy.orm import joinedload
 
+from polar.customer.repository import CustomerRepository
 from polar.kit.db.postgres import create_async_sessionmaker
-from polar.models import Organization
+from polar.member.repository import MemberRepository
+from polar.models import Customer, CustomerSeat, Organization
+from polar.models.benefit_grant import BenefitGrant
+from polar.models.customer_seat import SeatStatus
+from polar.models.member import Member
 from polar.organization.repository import OrganizationRepository
 from polar.organization.tasks import (
     _backfill_benefit_grants,
     _backfill_owner_members,
     _backfill_seats,
     _cleanup_orphaned_seat_customers,
+    _get_or_create_member_for_backfill,
 )
-from polar.postgres import create_async_engine
+from polar.postgres import AsyncSession, create_async_engine
 
 cli = typer.Typer()
 
@@ -428,6 +441,395 @@ async def repair(
     typer.echo("Repair complete:")
     typer.echo(f"  - Repaired: {repaired_count}")
     typer.echo(f"  - Already OK: {skipped_count}")
+    typer.echo(f"  - Failed: {failed_count}")
+
+
+_PREPARE_BATCH_SIZE = 100
+
+
+async def _prepare_seats(
+    session: AsyncSession,
+    organization: Organization,
+) -> int:
+    """Populate member_id and email on active seats.
+
+    Unlike _backfill_seats(), this does NOT change seat.customer_id
+    or set customer.type = team. It only adds member references
+    so merchants can start reading them during Phase 1.
+    """
+    from polar.models import Order, Product, Subscription
+
+    member_repository = MemberRepository.from_session(session)
+    customer_repo = CustomerRepository.from_session(session)
+
+    # Lazy cache of customer_id → owner member
+    owner_members_map: dict[uuid.UUID, Member] = {}
+
+    async def _get_owner_member(customer_id: uuid.UUID) -> Member | None:
+        if customer_id not in owner_members_map:
+            owner = await member_repository.get_owner_by_customer_id(
+                session, customer_id
+            )
+            if owner is not None:
+                owner_members_map[customer_id] = owner
+        return owner_members_map.get(customer_id)
+
+    sub_seats_stmt = (
+        select(CustomerSeat)
+        .join(Subscription, CustomerSeat.subscription_id == Subscription.id)
+        .join(Product, Subscription.product_id == Product.id)
+        .options(
+            joinedload(CustomerSeat.subscription),
+        )
+        .where(
+            Product.organization_id == organization.id,
+            CustomerSeat.status != SeatStatus.revoked,
+            CustomerSeat.subscription_id.is_not(None),
+            CustomerSeat.member_id.is_(None),
+        )
+        .order_by(CustomerSeat.id)
+    )
+    order_seats_stmt = (
+        select(CustomerSeat)
+        .join(Order, CustomerSeat.order_id == Order.id)
+        .join(Product, Order.product_id == Product.id)
+        .options(
+            joinedload(CustomerSeat.order),
+        )
+        .where(
+            Product.organization_id == organization.id,
+            CustomerSeat.status != SeatStatus.revoked,
+            CustomerSeat.order_id.is_not(None),
+            CustomerSeat.member_id.is_(None),
+        )
+        .order_by(CustomerSeat.id)
+    )
+
+    seats_found = 0
+    count = 0
+
+    for base_stmt in [sub_seats_stmt, order_seats_stmt]:
+        offset = 0
+        while True:
+            batch_stmt = base_stmt.limit(_PREPARE_BATCH_SIZE).offset(offset)
+            result = await session.execute(batch_stmt)
+            seats = list(result.scalars().unique().all())
+            if not seats:
+                break
+            seats_found += len(seats)
+            offset += _PREPARE_BATCH_SIZE
+
+            for seat in seats:
+                if seat.subscription_id is not None and seat.subscription is not None:
+                    billing_customer_id = seat.subscription.customer_id
+                elif seat.order_id is not None and seat.order is not None:
+                    billing_customer_id = seat.order.customer_id
+                else:
+                    continue
+                old_seat_customer_id = seat.customer_id
+
+                if old_seat_customer_id == billing_customer_id:
+                    # Billing manager's own seat → use their owner member
+                    owner_member = await _get_owner_member(billing_customer_id)
+                    if owner_member is None:
+                        continue
+                    seat.member_id = owner_member.id
+                    seat.email = owner_member.email
+                elif old_seat_customer_id is not None:
+                    # Someone else holds this seat → create member under billing customer
+                    seat_holder = await customer_repo.get_by_id(old_seat_customer_id)
+                    email = seat_holder.email if seat_holder else seat.email
+                    if not email:
+                        continue
+                    member = await _get_or_create_member_for_backfill(
+                        session,
+                        member_repository,
+                        billing_customer_id,
+                        organization.id,
+                        email,
+                    )
+                    seat.member_id = member.id
+                    seat.email = email
+                    if seat_holder and seat_holder._oauth_accounts:
+                        member._oauth_accounts = {**seat_holder._oauth_accounts}
+                elif seat.email:
+                    # No customer assigned yet (pending invite) → create member
+                    member = await _get_or_create_member_for_backfill(
+                        session,
+                        member_repository,
+                        billing_customer_id,
+                        organization.id,
+                        seat.email,
+                    )
+                    seat.member_id = member.id
+                # NOTE: Unlike _backfill_seats(), we do NOT change seat.customer_id
+
+                count += 1
+
+            await session.flush()
+
+    return count
+
+
+async def _prepare_benefit_grants(
+    session: AsyncSession,
+    organization: Organization,
+) -> int:
+    """Populate member_id on benefit grants.
+
+    Unlike _backfill_benefit_grants(), this does NOT change grant.customer_id
+    or transfer license keys/downloadables. It only links grants to members
+    so merchants can read grant.member in API responses and webhooks.
+
+    Since seat.customer_id is unchanged (prepare didn't rewrite it), we can
+    match seats by customer_id + subscription/order to find the right member.
+    """
+    from polar.models import Order, Subscription
+
+    member_repository = MemberRepository.from_session(session)
+
+    # Find grants without member_id for this organization's customers
+    statement = (
+        select(BenefitGrant)
+        .join(Customer, BenefitGrant.customer_id == Customer.id)
+        .where(
+            Customer.organization_id == organization.id,
+            BenefitGrant.member_id.is_(None),
+            BenefitGrant.is_deleted.is_(False),
+        )
+    )
+    results = await session.stream_scalars(
+        statement,
+        execution_options={"yield_per": _PREPARE_BATCH_SIZE},
+    )
+
+    # Lazy caches
+    owner_members_map: dict[uuid.UUID, Member] = {}
+    billing_customer_cache: dict[uuid.UUID, uuid.UUID] = {}
+
+    async def _get_billing_customer_id(grant: BenefitGrant) -> uuid.UUID | None:
+        scope_id = grant.subscription_id or grant.order_id
+        if scope_id is None:
+            return None
+        if scope_id in billing_customer_cache:
+            return billing_customer_cache[scope_id]
+        if grant.subscription_id is not None:
+            cid = await session.scalar(
+                select(Subscription.customer_id).where(
+                    Subscription.id == grant.subscription_id
+                )
+            )
+        else:
+            cid = await session.scalar(
+                select(Order.customer_id).where(Order.id == grant.order_id)
+            )
+        if cid is not None:
+            billing_customer_cache[scope_id] = cid
+        return cid
+
+    grants_found = 0
+    count = 0
+    skipped_conflicts = 0
+    try:
+        async for grant in results:
+            grants_found += 1
+
+            billing_customer_id = await _get_billing_customer_id(grant)
+
+            # Find the correct member for this grant.
+            # Since seat.customer_id is still the original holder's ID,
+            # we can match by customer_id + subscription/order.
+            target_member_id: uuid.UUID | None = None
+
+            if grant.subscription_id is not None:
+                seat_member_id = await session.scalar(
+                    select(CustomerSeat.member_id).where(
+                        CustomerSeat.subscription_id == grant.subscription_id,
+                        CustomerSeat.customer_id == grant.customer_id,
+                        CustomerSeat.member_id.is_not(None),
+                        CustomerSeat.status != SeatStatus.revoked,
+                    )
+                )
+                if seat_member_id is not None:
+                    target_member_id = seat_member_id
+            elif grant.order_id is not None:
+                seat_member_id = await session.scalar(
+                    select(CustomerSeat.member_id).where(
+                        CustomerSeat.order_id == grant.order_id,
+                        CustomerSeat.customer_id == grant.customer_id,
+                        CustomerSeat.member_id.is_not(None),
+                        CustomerSeat.status != SeatStatus.revoked,
+                    )
+                )
+                if seat_member_id is not None:
+                    target_member_id = seat_member_id
+
+            # Fallback to owner member
+            if target_member_id is None:
+                if grant.customer_id not in owner_members_map:
+                    owner = await member_repository.get_owner_by_customer_id(
+                        session, grant.customer_id
+                    )
+                    if owner is not None:
+                        owner_members_map[grant.customer_id] = owner
+                owner = owner_members_map.get(grant.customer_id)
+                if owner is not None:
+                    target_member_id = owner.id
+
+            if target_member_id is not None:
+                # Check for conflict with benefit_grants_smb_key constraint
+                existing_id = await session.scalar(
+                    select(BenefitGrant.id).where(
+                        BenefitGrant.subscription_id == grant.subscription_id,
+                        BenefitGrant.member_id == target_member_id,
+                        BenefitGrant.benefit_id == grant.benefit_id,
+                        BenefitGrant.id != grant.id,
+                        BenefitGrant.is_deleted.is_(False),
+                    )
+                )
+                if existing_id is not None:
+                    skipped_conflicts += 1
+                else:
+                    grant.member_id = target_member_id
+                    count += 1
+
+            if (count + skipped_conflicts) > 0 and (
+                count + skipped_conflicts
+            ) % _PREPARE_BATCH_SIZE == 0:
+                await session.flush()
+    finally:
+        await results.close()
+
+    await session.flush()
+
+    return count
+
+
+@cli.command()
+@typer_async
+async def prepare(
+    dry_run: bool = typer.Option(
+        True, help="If True, only show what would be done without making changes"
+    ),
+    slug: str | None = typer.Option(None, help="Prepare a single organization by slug"),
+    limit: int | None = typer.Option(
+        None, help="Maximum number of organizations to prepare"
+    ),
+) -> None:
+    """Prepare seat-based orgs for member model migration (Phase 0B).
+
+    Non-destructive: populates member_id/email on seats and grants without
+    changing customer_id, deleting customers, or flipping any flags.
+
+    Targets orgs with seat_based_pricing_enabled=True and member_model_enabled=False.
+    """
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    async with sessionmaker() as session:
+        statement = (
+            select(Organization)
+            .where(
+                Organization.deleted_at.is_(None),
+                Organization.blocked_at.is_(None),
+                Organization.feature_settings["seat_based_pricing_enabled"]
+                .as_boolean()
+                .is_(True),
+                or_(
+                    Organization.feature_settings["member_model_enabled"].is_(None),
+                    Organization.feature_settings["member_model_enabled"]
+                    .as_boolean()
+                    .is_(False),
+                ),
+            )
+            .order_by(Organization.slug.asc())
+        )
+
+        if slug is not None:
+            statement = statement.where(Organization.slug == slug)
+
+        if limit is not None:
+            statement = statement.limit(limit)
+
+        result = await session.execute(statement)
+        organizations = list(result.scalars().all())
+
+    if not organizations:
+        typer.echo("No eligible organizations found.")
+        return
+
+    typer.echo(f"Found {len(organizations)} organization(s) to prepare")
+    typer.echo()
+
+    typer.echo("Organizations to prepare:")
+    typer.echo(f"{'Slug':<40} {'ID'}")
+    typer.echo("-" * 80)
+    for org in organizations:
+        typer.echo(f"{org.slug:<40} {org.id}")
+    typer.echo()
+
+    if dry_run:
+        typer.echo("DRY RUN - No changes will be made.")
+        typer.echo(f"Would prepare {len(organizations)} organization(s).")
+        return
+
+    typer.echo(f"Preparing {len(organizations)} organization(s)...")
+    typer.echo()
+
+    prepared_count = 0
+    failed_count = 0
+
+    for org in organizations:
+        try:
+            # Step A: Create owner members for all customers without one
+            async with sessionmaker() as session:
+                organization = await OrganizationRepository.from_session(
+                    session
+                ).get_by_id(org.id)
+                assert organization is not None
+                owner_members_created = await _backfill_owner_members(
+                    session, organization
+                )
+                await session.commit()
+
+            # Step B: Prepare seats (set member_id and email, don't change customer_id)
+            async with sessionmaker() as session:
+                organization = await OrganizationRepository.from_session(
+                    session
+                ).get_by_id(org.id)
+                assert organization is not None
+                seats_prepared = await _prepare_seats(session, organization)
+                await session.commit()
+
+            # Step C: Prepare grants (set member_id, don't change customer_id)
+            async with sessionmaker() as session:
+                organization = await OrganizationRepository.from_session(
+                    session
+                ).get_by_id(org.id)
+                assert organization is not None
+                grants_linked = await _prepare_benefit_grants(session, organization)
+                await session.commit()
+
+            # NO Step D — no customer deletion
+
+            prepared_count += 1
+            typer.echo(
+                f"  [{prepared_count}/{len(organizations)}] "
+                f"{org.slug} "
+                f"owners={owner_members_created} seats={seats_prepared} "
+                f"grants={grants_linked}"
+            )
+
+        except Exception as e:
+            failed_count += 1
+            typer.echo(
+                f"  FAILED: {org.slug} - {e}",
+                err=True,
+            )
+
+    typer.echo()
+    typer.echo("Preparation complete:")
+    typer.echo(f"  - Prepared: {prepared_count}")
     typer.echo(f"  - Failed: {failed_count}")
 
 


### PR DESCRIPTION
## Summary

Add a non-destructive `prepare` command to the migration script that enables gradual, zero-downtime migration from seat-based to member model without flipping feature flags.

## What

- Added `prepare` command to `migrate_organizations_members.py` script
- Implemented `_prepare_seats()` helper that populates `seat.member_id` and `seat.email` without changing `seat.customer_id` or customer type
- Implemented `_prepare_benefit_grants()` helper that populates `grant.member_id` without changing `grant.customer_id` or transferring benefit records
- Both helpers skip conflicts with the `benefit_grants_smb_key` unique constraint
- Script runs all steps inline with explicit per-step transactions, mirroring the destructive backfill pattern

## Why

Phase 0B enables merchants to start reading member references in seats and grants during Phase 1 while still operating in legacy mode. This allows testing against new behavior before flipping the `member_model_enabled` flag in Phase 2, enabling truly gradual, zero-downtime migration.

## How

- Targets orgs with `seat_based_pricing_enabled=True` and `member_model_enabled=False`
- Runs Step A (create owner members), Step B (prepare seats), and Step C (prepare grants) inline
- Each step is idempotent and skips already-processed rows
- No Step D (customer deletion) to keep the approach non-destructive

## Testing

- ✅ Lint passes (`uv run task lint`)
- ✅ Type checking passes (`uv run task lint_types`)
- Usage: `uv run python -m scripts.migrate_organizations_members prepare --no-dry-run`