### PR TITLE
emails: Add alternative flow to enqueue email with template

### DIFF
--- a/server/emails/README.md
+++ b/server/emails/README.md
@@ -44,7 +44,7 @@ Don't hesitate to reuse existing schemas for common types like `Organization`, `
 3. Create a new TSX file in the `src/emails` directory with the name of the email template, as snake case, e.g. `customer_greetings.tsx`.
 4. Implement the email template using the `react-email` components.
 
-## How to render it from the Python server?
+## How to send it from the Python server?
 
 First, you'll need to build the email templates:
 
@@ -52,19 +52,31 @@ First, you'll need to build the email templates:
 uv run task emails
 ```
 
-Then, use the `render_email_template` function:
+Then, use `enqueue_email_template` to send the email via the background worker. This serializes the template data and enqueues a job — rendering happens in the worker, keeping the API request fast.
+
+```python
+from polar.email.schemas import CustomerGreetingsEmail, CustomerGreetingsProps
+from polar.email.sender import enqueue_email_template
+
+enqueue_email_template(
+    CustomerGreetingsEmail(
+        props=CustomerGreetingsProps.model_validate({
+            "email": "john@example.com",
+            "organization": organization,
+            "url": "https://example.com/welcome",
+        })
+    ),
+    to_email_addr="john@example.com",
+    subject="Welcome!",
+)
+```
+
+If you need to render synchronously (e.g. in scripts or workers that already run outside the event loop), you can use `render_email_template` directly:
 
 ```python
 from polar.email.react import render_email_template
-from polar.email.schemas import CustomerGreetingsEmail, CustomerGreetingsProps
 
-body = render_email_template(CustomerGreetingsEmail(
-    props=CustomerGreetingsProps.model_validate({
-        "email": "john@example.com",
-        "organization": organization,
-        "url": "https://example.com/welcome",
-    })
-))
+body = render_email_template(email)
 ```
 
 ## How does it work?

--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -12,9 +12,8 @@ from polar.customer_portal.repository.customer_session_code import (
     CustomerSessionCodeRepository,
 )
 from polar.customer_session.service import customer_session as customer_session_service
-from polar.email.react import render_email_template
 from polar.email.schemas import CustomerSessionCodeEmail, CustomerSessionCodeProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
@@ -204,7 +203,7 @@ class CustomerSessionService:
         delta = customer_session_code.expires_at - utc_now()
         code_lifetime_minutes = int(ceil(delta.seconds / 60))
 
-        body = render_email_template(
+        enqueue_email_template(
             CustomerSessionCodeEmail(
                 props=CustomerSessionCodeProps.model_validate(
                     {
@@ -217,14 +216,10 @@ class CustomerSessionService:
                         ),
                     }
                 )
-            )
-        )
-
-        enqueue_email(
+            ),
             **organization.email_from_reply,
             to_email_addr=customer.email,
             subject=f"Access your {organization.name} purchases",
-            html_content=body,
         )
 
         if settings.is_development():

--- a/server/polar/email/react.py
+++ b/server/polar/email/react.py
@@ -17,14 +17,11 @@ def _transform_avatar_urls_for_email(props_json: str) -> str:
     )
 
 
-def render_email_template(email: "Email") -> str:
-    props_json = email.props.model_dump_json()
-    props_json = _transform_avatar_urls_for_email(props_json)
-
+def render_from_json(template: str, props_json: str) -> str:
     process = subprocess.Popen(
         [
             settings.EMAIL_RENDERER_BINARY_PATH,
-            email.template,
+            template,
             props_json,
         ],
         stdout=subprocess.PIPE,
@@ -36,4 +33,13 @@ def render_email_template(email: "Email") -> str:
     return stdout.decode("utf-8")
 
 
-__all__ = ["render_email_template"]
+def serialize_email_props(email: "Email") -> str:
+    props_json = email.props.model_dump_json()
+    return _transform_avatar_urls_for_email(props_json)
+
+
+def render_email_template(email: "Email") -> str:
+    return render_from_json(email.template, serialize_email_props(email))
+
+
+__all__ = ["render_email_template", "render_from_json", "serialize_email_props"]

--- a/server/polar/email/sender.py
+++ b/server/polar/email/sender.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import httpx
 import structlog
@@ -11,6 +11,11 @@ from polar.config import settings
 from polar.exceptions import PolarError
 from polar.logging import Logger
 from polar.worker import enqueue_job
+
+from .react import serialize_email_props
+
+if TYPE_CHECKING:
+    from .schemas import Email
 
 log: Logger = structlog.get_logger()
 
@@ -168,6 +173,34 @@ def enqueue_email(
         to_email_addr=to_email_addr,
         subject=subject,
         html_content=html_content,
+        from_name=from_name,
+        from_email_addr=from_email_addr,
+        email_headers=email_headers,
+        reply_to_name=reply_to_name,
+        reply_to_email_addr=reply_to_email_addr,
+        attachments=attachments,
+    )
+
+
+def enqueue_email_template(
+    email: "Email",
+    *,
+    to_email_addr: str,
+    subject: str,
+    from_name: str = DEFAULT_FROM_NAME,
+    from_email_addr: str = DEFAULT_FROM_EMAIL_ADDRESS,
+    email_headers: dict[str, str] | None = None,
+    reply_to_name: str | None = DEFAULT_REPLY_TO_NAME,
+    reply_to_email_addr: str | None = DEFAULT_REPLY_TO_EMAIL_ADDRESS,
+    attachments: Iterable[Attachment] | None = None,
+) -> None:
+    enqueue_job(
+        "email.send",
+        to_email_addr=to_email_addr,
+        subject=subject,
+        html_content=None,
+        template=email.template,
+        props_json=serialize_email_props(email),
         from_name=from_name,
         from_email_addr=from_email_addr,
         email_headers=email_headers,

--- a/server/polar/email/tasks.py
+++ b/server/polar/email/tasks.py
@@ -1,5 +1,6 @@
 from polar.worker import TaskPriority, actor
 
+from .react import render_from_json
 from .sender import Attachment, email_sender
 
 
@@ -7,14 +8,21 @@ from .sender import Attachment, email_sender
 async def email_send(
     to_email_addr: str,
     subject: str,
-    html_content: str,
+    html_content: str | None,
     from_name: str,
     from_email_addr: str,
     email_headers: dict[str, str] | None,
     reply_to_name: str | None,
     reply_to_email_addr: str | None,
+    template: str | None = None,
+    props_json: str | None = None,
     attachments: list[Attachment] | None = None,
 ) -> None:
+    if html_content is None:
+        assert template is not None
+        assert props_json is not None
+        html_content = render_from_json(template, props_json)
+
     await email_sender.send(
         to_email_addr=to_email_addr,
         subject=subject,


### PR DESCRIPTION
Start with one call-site, but the ambition is to move all render calls to the workers and out from the API layer. Since we are enqueuing the email task anyway, it's better to let the worker handle the rendering, to keep our API latencies low.
