### PR TITLE
multi-currency: Use babel instead of countryinfo

### DIFF
--- a/server/polar/kit/currency.py
+++ b/server/polar/kit/currency.py
@@ -1,9 +1,8 @@
 from decimal import Decimal
 from enum import StrEnum
-from typing import cast
 
 from babel.numbers import format_currency as _format_currency
-from countryinfo import CountryInfo
+from babel.numbers import get_territory_currencies
 
 
 class PresentmentCurrency(StrEnum):
@@ -29,17 +28,15 @@ def get_presentment_currency(country: str) -> PresentmentCurrency | None:
         The presentment currency or None if no supported currency is found.
     """
     try:
-        countryinfo = CountryInfo(country)
-        currencies = cast(list[str], countryinfo.currencies())
-    except KeyError:
+        currencies = get_territory_currencies(country)
+    except Exception:
         return None
-    else:
-        for currency in currencies:
-            try:
-                return PresentmentCurrency(currency.lower())
-            except ValueError:
-                continue
-        return None
+    for currency in currencies:
+        try:
+            return PresentmentCurrency(currency.lower())
+        except ValueError:
+            continue
+    return None
 
 
 _ZERO_DECIMAL_CURRENCIES: set[str] = {

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
   "asgi-ratelimit>=0.10.0",
   "aiocsv>=1.4.0",
   "alembic-utils>=0.8.8",
-  "countryinfo>=0.1.2",
   "clickhouse-connect>=0.8.0",
   "playwright>=1.50.0",
   "trafilatura>=2.0.0",

--- a/server/tests/kit/test_currency.py
+++ b/server/tests/kit/test_currency.py
@@ -10,6 +10,7 @@ from polar.kit.currency import get_presentment_currency
         pytest.param("GB", "gbp", id="supported country GB"),
         pytest.param("FR", "eur", id="supported country FR"),
         pytest.param("SE", "sek", id="supported country SE"),
+        pytest.param("AX", "eur", id="supported territory AX"),
         pytest.param("CN", None, id="unsupported country"),
         pytest.param("KK", None, id="invalid country code"),
     ],

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -474,14 +474,6 @@ wheels = [
 ]
 
 [[package]]
-name = "countryinfo"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/16/9fa55d43ae8ee969b75b3977d45f6640bb6c0e52d9912af11593e112a3cc/countryinfo-0.1.2-py3-none-any.whl", hash = "sha256:fd518b3fd8899f6520518320ac17b67bf410c7db5044c61cb191f802bb85c34d", size = 602240, upload-time = "2020-06-01T15:00:09.025Z" },
-]
-
-[[package]]
 name = "courlan"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2055,7 +2047,6 @@ dependencies = [
     { name = "babel" },
     { name = "boto3" },
     { name = "clickhouse-connect" },
-    { name = "countryinfo" },
     { name = "cryptography" },
     { name = "dramatiq", extra = ["redis", "watch"] },
     { name = "email-validator" },
@@ -2143,7 +2134,6 @@ requires-dist = [
     { name = "babel", specifier = ">=2.16.0" },
     { name = "boto3", specifier = ">=1.38.30" },
     { name = "clickhouse-connect", specifier = ">=0.8.0" },
-    { name = "countryinfo", specifier = ">=0.1.2" },
     { name = "cryptography", specifier = ">=43.0.1" },
     { name = "dramatiq", extras = ["redis", "watch"], git = "https://github.com/frankie567/dramatiq?rev=memory-leak-asyncio-ter" },
     { name = "email-validator", specifier = ">=2.1.0.post1" },


### PR DESCRIPTION
It seems like countryinfo has some problems publishing the latest version, and the version that's published doesn't include certain territories (among them Åland).

Since we already have babel as a dependency, we can get the currency information from there.
