### PR TITLE
emails: Move the rest of the enqueue_email to render in worker

### DIFF
--- a/server/polar/customer_seat/sender.py
+++ b/server/polar/customer_seat/sender.py
@@ -1,9 +1,8 @@
 import structlog
 
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import SeatInvitationEmail, SeatInvitationProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.logging import Logger
 from polar.models import CustomerSeat, Organization
 
@@ -33,7 +32,7 @@ def send_seat_invitation_email(
         f"?token={seat.invitation_token}"
     )
 
-    html_content = render_email_template(
+    enqueue_email_template(
         SeatInvitationEmail(
             props=SeatInvitationProps.model_validate(
                 {
@@ -44,13 +43,9 @@ def send_seat_invitation_email(
                     "claim_url": claim_url,
                 }
             )
-        )
-    )
-
-    enqueue_email(
+        ),
         to_email_addr=customer_email,
         subject=f"You've been invited to access {product_name}",
-        html_content=html_content,
     )
 
     log.info(

--- a/server/polar/email_update/service.py
+++ b/server/polar/email_update/service.py
@@ -6,9 +6,8 @@ from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import EmailUpdateEmail, EmailUpdateProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
 from polar.kit.extensions.sqlalchemy import sql
@@ -80,18 +79,16 @@ class EmailUpdateService(ResourceServiceReader[EmailVerification]):
 
         email = email_update_record.email
         url_params = {"token": token, **extra_url_params}
-        body = render_email_template(
+        enqueue_email_template(
             EmailUpdateEmail(
                 props=EmailUpdateProps(
                     email=email,
                     token_lifetime_minutes=token_lifetime_minutes,
                     url=f"{base_url}?{urlencode(url_params)}",
                 )
-            )
-        )
-
-        enqueue_email(
-            to_email_addr=email, subject="Update your email", html_content=body
+            ),
+            to_email_addr=email,
+            subject="Update your email",
         )
 
     async def verify(self, session: AsyncSession, token: str) -> User:

--- a/server/polar/login_code/service.py
+++ b/server/polar/login_code/service.py
@@ -8,9 +8,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import LoginCodeEmail, LoginCodeProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
@@ -67,17 +66,17 @@ class LoginCodeService:
 
         email = login_code.email
         subject = "Sign in to Polar"
-        body = render_email_template(
+        enqueue_email_template(
             LoginCodeEmail(
                 props=LoginCodeProps(
                     email=email,
                     code=code,
                     code_lifetime_minutes=code_lifetime_minutes,
                 )
-            )
+            ),
+            to_email_addr=email,
+            subject=subject,
         )
-
-        enqueue_email(to_email_addr=email, subject=subject, html_content=body)
 
         if settings.is_development():
             log.info(

--- a/server/polar/oauth2/service/oauth2_client.py
+++ b/server/polar/oauth2/service/oauth2_client.py
@@ -6,9 +6,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.email.react import render_email_template
 from polar.email.schemas import OAuth2LeakedClientEmail, OAuth2LeakedClientProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
 from polar.kit.crypto import generate_token
 from polar.kit.pagination import PaginationParams, paginate
@@ -91,7 +90,7 @@ class OAuth2ClientService(ResourceServiceReader[OAuth2Client]):
 
         if client.user is not None:
             email = client.user.email
-            body = render_email_template(
+            enqueue_email_template(
                 OAuth2LeakedClientEmail(
                     props=OAuth2LeakedClientProps(
                         email=email,
@@ -100,10 +99,10 @@ class OAuth2ClientService(ResourceServiceReader[OAuth2Client]):
                         notifier=notifier,
                         url=url or "",
                     )
-                )
+                ),
+                to_email_addr=email,
+                subject=subject,
             )
-
-            enqueue_email(to_email_addr=email, subject=subject, html_content=body)
 
         log.info(
             "Revoke leaked OAuth2 client",

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -6,9 +6,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import OAuth2LeakedTokenEmail, OAuth2LeakedTokenProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
 from polar.kit.crypto import get_token_hash
 from polar.kit.services import ResourceServiceReader
@@ -100,7 +99,7 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
         oauth2_client = oauth2_token.client
 
         for recipient in recipients:
-            body = render_email_template(
+            enqueue_email_template(
                 OAuth2LeakedTokenEmail(
                     props=OAuth2LeakedTokenProps(
                         email=recipient,
@@ -108,12 +107,9 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
                         notifier=notifier,
                         url=url or "",
                     )
-                )
-            )
-            enqueue_email(
+                ),
                 to_email_addr=recipient,
                 subject="Security Notice - Your Polar Access Token has been leaked",
-                html_content=body,
             )
 
         log.info(

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -21,9 +21,8 @@ from polar.customer_portal.schemas.order import (
     CustomerOrderUpdate,
 )
 from polar.customer_session.service import customer_session as customer_session_service
-from polar.email.react import render_email_template
 from polar.email.schemas import EmailAdapter
-from polar.email.sender import Attachment, enqueue_email
+from polar.email.sender import Attachment, enqueue_email_template
 from polar.enums import PaymentProcessor, TaxProcessor
 from polar.event.service import event as event_service
 from polar.event.system import (
@@ -1478,12 +1477,11 @@ class OrderService:
                 {"remote_url": invoice.url, "filename": order.invoice_filename}
             ]
 
-        body = render_email_template(email)
-        enqueue_email(
+        enqueue_email_template(
+            email,
             **organization.email_from_reply,
             to_email_addr=customer.email,
             subject=subject,
-            html_content=body,
             attachments=attachments,
         )
 

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -8,9 +8,8 @@ from polar.account.service import account as account_service
 from polar.auth.models import is_anonymous, is_user
 from polar.auth.scope import Scope
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import OrganizationInviteEmail, OrganizationInviteProps
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import (
     NotPermitted,
     PolarRequestValidationError,
@@ -377,7 +376,7 @@ async def invite_member(
 
     # Send invitation email
     email = invite_body.email
-    body = render_email_template(
+    enqueue_email_template(
         OrganizationInviteEmail(
             props=OrganizationInviteProps(
                 email=email,
@@ -387,13 +386,9 @@ async def invite_member(
                     f"/dashboard/{organization.slug}"
                 ),
             )
-        )
-    )
-
-    enqueue_email(
+        ),
         to_email_addr=email,
         subject=f"You've been invited to {organization.name} on Polar",
-        html_content=body,
     )
 
     # Get the user organization relationship to return

--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -8,12 +8,11 @@ from sqlalchemy import UnaryExpression, asc, desc
 
 from polar.auth.models import AuthSubject, Organization, is_user
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import (
     OrganizationAccessTokenLeakedEmail,
     OrganizationAccessTokenLeakedProps,
 )
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
 from polar.integrations.loops.service import loops as loops_service
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
@@ -181,7 +180,7 @@ class OrganizationAccessTokenService:
         )
         for organization_member in organization_members:
             email = organization_member.user.email
-            body = render_email_template(
+            enqueue_email_template(
                 OrganizationAccessTokenLeakedEmail(
                     props=OrganizationAccessTokenLeakedProps(
                         email=email,
@@ -189,12 +188,9 @@ class OrganizationAccessTokenService:
                         notifier=notifier,
                         url=url or "",
                     )
-                )
-            )
-            enqueue_email(
+                ),
                 to_email_addr=email,
                 subject="Security Notice - Your Polar Organization Access Token has been leaked",
-                html_content=body,
             )
 
         log.info(

--- a/server/polar/personal_access_token/service.py
+++ b/server/polar/personal_access_token/service.py
@@ -8,12 +8,11 @@ from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.email.schemas import (
     PersonalAccessTokenLeakedEmail,
     PersonalAccessTokenLeakedProps,
 )
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
 from polar.kit.crypto import get_token_hash
 from polar.kit.pagination import PaginationParams, paginate
@@ -109,7 +108,7 @@ class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):
 
         email = personal_access_token.user.email
 
-        body = render_email_template(
+        enqueue_email_template(
             PersonalAccessTokenLeakedEmail(
                 props=PersonalAccessTokenLeakedProps(
                     email=email,
@@ -117,13 +116,9 @@ class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):
                     notifier=notifier,
                     url=url or "",
                 )
-            )
-        )
-
-        enqueue_email(
+            ),
             to_email_addr=email,
             subject="Security Notice - Your Polar Personal Access Token has been leaked",
-            html_content=body,
         )
 
         log.info(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -23,9 +23,8 @@ from polar.customer_seat.service import seat_service
 from polar.customer_session.service import customer_session as customer_session_service
 from polar.discount.repository import DiscountRedemptionRepository
 from polar.discount.service import discount as discount_service
-from polar.email.react import render_email_template
 from polar.email.schemas import EmailAdapter
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
 from polar.event.service import event as event_service
 from polar.event.system import (
@@ -2358,15 +2357,13 @@ class SubscriptionService:
             }
         )
 
-        body = render_email_template(email)
-
         subject = subject_template.format(product=product)
 
-        enqueue_email(
+        enqueue_email_template(
+            email,
             **organization.email_from_reply,
             to_email_addr=subscription.customer.email,
             subject=subject,
-            html_content=body,
         )
 
     async def _get_outdated_grants(

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -14,9 +14,8 @@ from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
 from polar.checkout.repository import CheckoutRepository
 from polar.config import settings
 from polar.customer.schemas.state import CustomerState
-from polar.email.react import render_email_template
 from polar.email.schemas import EmailAdapter
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError, ResourceNotFound
 from polar.integrations.loops.service import loops as loops_service
 from polar.kit.crypto import generate_token
@@ -389,12 +388,10 @@ class WebhookService:
                         }
                     )
 
-                    body = render_email_template(email)
-
-                    enqueue_email(
+                    enqueue_email_template(
+                        email,
                         to_email_addr=user.email,
                         subject=f"Webhook endpoint disabled for {organization.name}",
-                        html_content=body,
                     )
 
     async def count_earlier_pending_events(

--- a/server/tests/customer_seat/test_sender.py
+++ b/server/tests/customer_seat/test_sender.py
@@ -12,11 +12,7 @@ class TestSendSeatInvitationEmail:
         customer_seat_pending: CustomerSeat,
         seat_enabled_organization: Organization,
     ) -> None:
-        mock_enqueue = mocker.patch("polar.customer_seat.sender.enqueue_email")
-        mock_render = mocker.patch(
-            "polar.customer_seat.sender.render_email_template",
-            return_value="<html>Test Email</html>",
-        )
+        mock_enqueue = mocker.patch("polar.customer_seat.sender.enqueue_email_template")
 
         send_seat_invitation_email(
             customer_email="test@example.com",
@@ -26,19 +22,16 @@ class TestSendSeatInvitationEmail:
             billing_manager_email="manager@example.com",
         )
 
-        mock_render.assert_called_once()
-        call_args = mock_render.call_args
-        email = call_args[0][0]
+        mock_enqueue.assert_called_once()
+        email = mock_enqueue.call_args[0][0]
         assert isinstance(email, SeatInvitationEmail)
         assert email.props.organization.id == seat_enabled_organization.id
         assert customer_seat_pending.invitation_token is not None
         assert customer_seat_pending.invitation_token in email.props.claim_url
 
-        mock_enqueue.assert_called_once()
         enqueue_kwargs = mock_enqueue.call_args[1]
         assert enqueue_kwargs["to_email_addr"] == "test@example.com"
         assert "Test Product" in enqueue_kwargs["subject"]
-        assert enqueue_kwargs["html_content"] == "<html>Test Email</html>"
 
     def test_send_invitation_no_token(
         self,
@@ -48,7 +41,7 @@ class TestSendSeatInvitationEmail:
     ) -> None:
         customer_seat_claimed.invitation_token = None
 
-        mock_enqueue = mocker.patch("polar.customer_seat.sender.enqueue_email")
+        mock_enqueue = mocker.patch("polar.customer_seat.sender.enqueue_email_template")
         mock_log = mocker.patch("polar.customer_seat.sender.log")
 
         send_seat_invitation_email(
@@ -68,11 +61,7 @@ class TestSendSeatInvitationEmail:
         customer_seat_pending: CustomerSeat,
         seat_enabled_organization: Organization,
     ) -> None:
-        mock_render = mocker.patch(
-            "polar.customer_seat.sender.render_email_template",
-            return_value="<html>Test Email</html>",
-        )
-        mocker.patch("polar.customer_seat.sender.enqueue_email")
+        mock_enqueue = mocker.patch("polar.customer_seat.sender.enqueue_email_template")
 
         send_seat_invitation_email(
             customer_email="test@example.com",
@@ -82,7 +71,6 @@ class TestSendSeatInvitationEmail:
             billing_manager_email="manager@example.com",
         )
 
-        call_args = mock_render.call_args
-        email = call_args[0][0]
+        email = mock_enqueue.call_args[0][0]
         assert isinstance(email, SeatInvitationEmail)
         assert email.props.organization.id == seat_enabled_organization.id

--- a/server/tests/oauth2/service/test_oauth2_client.py
+++ b/server/tests/oauth2/service/test_oauth2_client.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.email.schemas import OAuth2LeakedClientEmail
 from polar.enums import TokenType
 from polar.models import OAuth2Client
 from polar.oauth2.service.oauth2_client import oauth2_client as oauth2_client_service
@@ -12,7 +13,7 @@ from polar.postgres import AsyncSession
 @pytest.fixture(autouse=True)
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
-        "polar.oauth2.service.oauth2_client.enqueue_email", autospec=True
+        "polar.oauth2.service.oauth2_client.enqueue_email_template", autospec=True
     )
 
 
@@ -73,3 +74,4 @@ class TestRevokeLeaked:
             assert updated_oauth2_client.registration_access_token != token
 
         enqueue_email_mock.assert_called_once()
+        assert isinstance(enqueue_email_mock.call_args[0][0], OAuth2LeakedClientEmail)

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.email.schemas import OAuth2LeakedTokenEmail
 from polar.enums import TokenType
 from polar.models import OAuth2Client, Organization, User, UserOrganization
 from polar.oauth2.service.oauth2_token import oauth2_token as oauth2_token_service
@@ -15,7 +16,7 @@ from ..conftest import create_oauth2_token
 @pytest.fixture(autouse=True)
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
-        "polar.oauth2.service.oauth2_token.enqueue_email", autospec=True
+        "polar.oauth2.service.oauth2_token.enqueue_email_template", autospec=True
     )
 
 
@@ -79,6 +80,7 @@ class TestRevokeLeaked:
         assert oauth2_token.refresh_token_revoked_at is not None
 
         enqueue_email_mock.assert_called_once()
+        assert isinstance(enqueue_email_mock.call_args[0][0], OAuth2LeakedTokenEmail)
 
     @pytest.mark.parametrize(
         ("token", "token_type"),
@@ -116,6 +118,7 @@ class TestRevokeLeaked:
         assert oauth2_token.refresh_token_revoked_at is not None
 
         enqueue_email_mock.assert_called_once()
+        assert isinstance(enqueue_email_mock.call_args[0][0], OAuth2LeakedTokenEmail)
 
     async def test_already_revoked(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
 from polar.checkout.eventstream import CheckoutEvent
+from polar.email.schemas import OrderConfirmationEmail
 from polar.enums import (
     InvoiceNumbering,
     PaymentProcessor,
@@ -153,7 +154,7 @@ def enqueue_job_mock(mocker: MockerFixture) -> MagicMock:
 
 @pytest.fixture
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("polar.order.service.enqueue_email", autospec=True)
+    return mocker.patch("polar.order.service.enqueue_email_template", autospec=True)
 
 
 @pytest.fixture
@@ -2151,6 +2152,7 @@ class TestSendConfirmationEmail:
 
         assert order.invoice_path is None
         enqueue_email_mock.assert_called_once()
+        assert isinstance(enqueue_email_mock.call_args[0][0], OrderConfirmationEmail)
         attachments = enqueue_email_mock.call_args[1]["attachments"]
         assert len(attachments) == 0
 
@@ -2175,6 +2177,7 @@ class TestSendConfirmationEmail:
 
         assert order.invoice_path is not None
         enqueue_email_mock.assert_called_once()
+        assert isinstance(enqueue_email_mock.call_args[0][0], OrderConfirmationEmail)
         attachments = enqueue_email_mock.call_args[1]["attachments"]
         assert len(attachments) == 1
 

--- a/server/tests/organization_access_token/test_service.py
+++ b/server/tests/organization_access_token/test_service.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.config import settings
+from polar.email.schemas import OrganizationAccessTokenLeakedEmail
 from polar.enums import TokenType
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
@@ -19,7 +20,7 @@ from tests.fixtures.database import SaveFixture
 @pytest.fixture(autouse=True)
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
-        "polar.organization_access_token.service.enqueue_email", autospec=True
+        "polar.organization_access_token.service.enqueue_email_template", autospec=True
     )
 
 
@@ -73,3 +74,6 @@ class TestRevokeLeaked:
         assert updated_organization_access_token.deleted_at is not None
 
         enqueue_email_mock.assert_called_once()
+        assert isinstance(
+            enqueue_email_mock.call_args[0][0], OrganizationAccessTokenLeakedEmail
+        )

--- a/server/tests/personal_access_token/test_service.py
+++ b/server/tests/personal_access_token/test_service.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.config import settings
+from polar.email.schemas import PersonalAccessTokenLeakedEmail
 from polar.enums import TokenType
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
@@ -19,7 +20,7 @@ from tests.fixtures.database import SaveFixture
 @pytest.fixture(autouse=True)
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
-        "polar.personal_access_token.service.enqueue_email", autospec=True
+        "polar.personal_access_token.service.enqueue_email_template", autospec=True
     )
 
 
@@ -73,3 +74,6 @@ class TestRevokeLeaked:
         assert updated_personal_access_token.deleted_at is not None
 
         enqueue_email_mock.assert_called_once()
+        assert isinstance(
+            enqueue_email_mock.call_args[0][0], PersonalAccessTokenLeakedEmail
+        )

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.util.typing import TypeAlias
 from polar.auth.models import AuthSubject
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.checkout.eventstream import CheckoutEvent
+from polar.email.schemas import SubscriptionRevokedEmail
 from polar.enums import (
     PaymentProcessor,
     SubscriptionProrationBehavior,
@@ -170,7 +171,7 @@ def enqueue_job_mock(mocker: MockerFixture) -> MagicMock:
 
 @pytest.fixture
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("polar.subscription.service.enqueue_email")
+    return mocker.patch("polar.subscription.service.enqueue_email_template")
 
 
 @pytest.fixture
@@ -1047,6 +1048,7 @@ class TestCycle:
         )
 
         enqueue_email_mock.assert_called_once()
+        assert isinstance(enqueue_email_mock.call_args[0][0], SubscriptionRevokedEmail)
         subject = enqueue_email_mock.call_args.kwargs["subject"]
         assert "ended" in subject.lower()
 


### PR DESCRIPTION
This will prevent these email sendouts from blocking the event loop.

Continues the work that was started in https://github.com/polarsource/polar/pull/9985
