### PR TITLE
feat: Make appeal review agent interactive by default

### DIFF
--- a/server/scripts/appeal_review.py
+++ b/server/scripts/appeal_review.py
@@ -1012,9 +1012,9 @@ def main() -> None:
         help="Skip Plain thread lookups",
     )
     parser.add_argument(
-        "--interactive", "-i",
+        "--no-interactive",
         action="store_true",
-        help="Chat with the agent after the initial review to refine the recommendation",
+        help="Disable interactive mode (exit after initial review instead of chatting)",
     )
     args = parser.parse_args()
 
@@ -1034,7 +1034,7 @@ def main() -> None:
                 plain_api_key=args.plain_api_key,
                 skip_website=args.skip_website,
                 skip_plain=args.skip_plain,
-                interactive=args.interactive,
+                interactive=not args.no_interactive,
             )
         )
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- Interactive chat mode is now the default — after the initial review, the reviewer gets a `You>` prompt to provide feedback and refine the recommendation
- Use `--no-interactive` for single-shot behavior
- Updated decision guidance: give benefit of the doubt when merchants are willing to make changes, prefer asking for a video demo over hard denials for borderline cases

## Test plan
- [ ] Run `uv run python -m scripts.appeal_review <slug>` — verify it enters interactive mode after the review
- [ ] Run with `--no-interactive` — verify it exits after the review
- [ ] `uv run ruff check scripts/appeal_review.py` passes
- [ ] `uv run mypy scripts/appeal_review.py --ignore-missing-imports` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)