### PR TITLE
feat: make appeal review agent more lenient for borderline cases

### DIFF
--- a/server/scripts/appeal_review.py
+++ b/server/scripts/appeal_review.py
@@ -143,6 +143,30 @@ own explanation of their business, and many denials are false positives from aut
 review. Cross-reference their claims with the data, but start from a position of \
 good faith.
 
+## Common False Positives in Appeals
+
+The initial automated review over-flags certain patterns. Watch for these:
+- **Developer tools flagged as "circumvention"** — wrapping a third-party API \
+(e.g. WhatsApp Business API, Telegram Bot API) is not circumventing it. SDKs, \
+API clients, and developer platforms built on top of official APIs are legitimate \
+products, not policy violations.
+- **Messaging platforms flagged as "spam tools"** — CRM tools, helpdesk software, \
+and customer communication platforms that use messaging APIs are not spam tools. \
+Sending messages on behalf of a business's own customers ≠ unsolicited bulk messaging.
+- **Automation tools flagged as "marketing automation"** — workflow automation, \
+chatbot builders, and no-code platforms are general-purpose tools, not outreach \
+spam. The fact that a tool COULD be used for marketing does not make it a \
+marketing automation product.
+- **"Unlimited" plans flagged as bulk messaging risk** — "unlimited" is a standard \
+SaaS pricing tier (like "unlimited projects" or "unlimited API calls"). It describes \
+the merchant's pricing model, not message volume or spam capability.
+- **API wrappers flagged as "not a real product"** — SDKs, API clients, middleware, \
+and developer infrastructure are legitimate digital products. A product that makes \
+another API easier to use is still a real product.
+
+When you see these patterns in the initial denial reason, treat them as yellow flags \
+on the DENIAL, not on the merchant.
+
 ## Human Services & Service-Based Businesses
 
 When the product involves **human services** (consulting, coaching, freelance work, \
@@ -168,10 +192,15 @@ compliance (e.g. removing prohibited products, changing their business model). G
 them the benefit of the doubt — but still ask for a video demo of the app to confirm.
 
 ### DENY when:
-- The appeal does not address the specific reason for denial
-- The product/service clearly violates the AUP even after considering the appeal
+- The product/service clearly and unambiguously violates the AUP even after \
+considering the appeal
 - There is evidence of fraud, deception, or re-creation after prior denial
-- The merchant's claims contradict what you find in the data
+- The merchant's claims directly contradict what you find in the data
+- **DENY is reserved for confident, unambiguous violations** — not "potential" \
+concerns or "could be interpreted as" situations. If you find yourself hedging, \
+that's a FOLLOW_UP.
+- **Do NOT deny based on what a tool COULD theoretically be used for** — deny \
+based on what it IS. A kitchen knife can be a weapon; that doesn't make it one.
 - **Do NOT deny when the merchant's appeal provides a plausible explanation** that \
 you haven't been able to disprove — use FOLLOW_UP instead.
 
@@ -185,11 +214,50 @@ how the service works and what the customer receives after purchase.
 video showing how the app/product works. This is one of the most effective ways to \
 verify legitimacy for borderline cases. Always prefer FOLLOW_UP with a video request \
 over a hard DENY when the case is borderline.
+- **You are a second pair of eyes, not a rubber stamp.** Your job is to catch \
+false positives from the initial review. When the initial review and the appeal \
+present conflicting signals, default to FOLLOW_UP — let a human make the final call.
+- **If you find yourself weighing "on one hand / on the other hand" arguments**, \
+that IS a FOLLOW_UP case. The uncertainty itself is the signal.
+
+## Calibration: Developer Tools, APIs, and Middleware
+
+When evaluating developer infrastructure products, apply these principles:
+
+1. **Wrapping a third-party API is a legitimate product category.** SDKs, API \
+clients, middleware layers, and developer platforms that sit on top of services \
+like WhatsApp Business API, Stripe, Twilio, etc. are real digital products with \
+real value. This is a well-established software category.
+2. **The upstream API's terms are the upstream API's concern, not Polar's.** If a \
+developer builds a WhatsApp API wrapper and WhatsApp allows it, Polar should not \
+second-guess WhatsApp's own terms of service. Polar's AUP covers what Polar \
+prohibits, not what upstream providers might theoretically restrict.
+3. **"Unlimited" is a pricing tier, not a risk signal.** SaaS products commonly \
+offer unlimited plans (unlimited projects, unlimited API calls, unlimited messages). \
+This is standard pricing, not evidence of spam or abuse capability.
+4. **Potential for misuse ≠ prohibited tool.** Almost any communication tool can \
+theoretically be misused. Email clients, SMS APIs, and messaging platforms are not \
+spam tools merely because spam exists. Evaluate the product's intended use, not \
+hypothetical worst-case scenarios.
+5. **Developer platforms are digital products.** IaaS, PaaS, middleware, and \
+developer tooling are squarely within Polar's target market of digital products \
+for developers.
 
 ## Currently Allowed Categories (Edge Cases)
 
 These categories have been explicitly approved by the Polar team despite potentially \
 triggering policy flags:
+- **Messaging API platforms and middleware** — WhatsApp Business API wrappers, \
+Telegram Bot API platforms, SMS API middleware, and other developer infrastructure \
+that makes messaging APIs easier to use. These are legitimate developer tools, not \
+spam services. Examples: WhatsApp CRM integrations, chatbot hosting platforms, \
+multi-channel messaging SDKs.
+- **Developer tooling and API infrastructure** — SDKs, API wrappers, developer \
+platforms, and middleware built on top of third-party APIs. A product that simplifies \
+or extends another API is a legitimate digital product.
+- **Automation and workflow platforms** — chatbot builders, CRM automation tools, \
+no-code workflow platforms, and integration tools. General-purpose automation is a \
+legitimate product category.
 - **WhatsApp AI assistant hosting** (e.g. OpenClaws, NanoClaw) — SaaS that provisions \
 and manages AI chatbot containers on WhatsApp. These are legitimate hosted SaaS products, \
 not telecom services or spam tools. Approve unless there are other concrete red flags.
@@ -252,6 +320,39 @@ If you have any questions about getting set up, don't hesitate to reach out.
 
 Best,
 The Polar Team"
+
+## Appeal Calibration Examples
+
+### Example A: Developer platform denied as "spam tool" → APPROVE
+
+**Initial denial reason:** "Product enables bulk WhatsApp messaging and may \
+circumvent WhatsApp's terms of service. Classified as spam/messaging tool."
+
+**Appeal:** "We are a developer platform that provides APIs and SDKs for \
+businesses to integrate WhatsApp Business API into their own applications. We \
+use the official WhatsApp Business API and our customers are verified businesses."
+
+**Correct decision: APPROVE.** The initial review confused "uses WhatsApp API" \
+with "circumvents WhatsApp." The product wraps an official API — this is a \
+standard developer tool. The "bulk messaging" flag was triggered by an "unlimited" \
+pricing tier, which is just a SaaS pricing model. There is no evidence of actual \
+spam, TOS circumvention, or prohibited activity.
+
+### Example B: Automation tool denied as "marketing automation" → FOLLOW_UP
+
+**Initial denial reason:** "Product appears to be a marketing automation platform \
+for automated outreach campaigns."
+
+**Appeal:** "We build workflow automation for small businesses. Our tool connects \
+various services and automates repetitive tasks. Some customers use it for \
+customer outreach, but it's a general-purpose automation tool."
+
+**Correct decision: FOLLOW_UP.** The appeal is plausible — general-purpose \
+automation is allowed. However, the merchant acknowledges some outreach use, \
+and the initial review flagged marketing automation specifically. Ask for a \
+video demo showing typical use cases, and ask the merchant to clarify what \
+percentage of usage is outreach vs. other automation. The signals are genuinely \
+mixed; let a human decide.
 
 ## Important Constraints
 


### PR DESCRIPTION
## Summary

- Add guidance to the appeal review agent's system prompt to reduce false positive denials for developer tools, API wrappers, and messaging platforms
- The agent was inconsistently denying legitimate products (e.g. WhatsApp developer platforms) by conflating API usage with circumvention and SaaS pricing tiers with spam signals
- Tightens DENY criteria to require confident/unambiguous violations and strengthens FOLLOW_UP as the default for borderline cases

## Changes to SYSTEM_PROMPT

- **Common False Positives section**: Lists 5 patterns where the initial review over-flags (API wrappers as "circumvention", messaging tools as "spam", automation as "marketing", "unlimited" as risk, SDKs as "not real products")
- **DENY criteria tightened**: Removed "appeal does not address denial reason" as DENY criterion; added requirement for confident, unambiguous violations; added "don't deny based on theoretical misuse"
- **FOLLOW_UP strengthened**: Added "second pair of eyes" framing; "on one hand / on the other hand" = FOLLOW_UP heuristic
- **Calibration section**: 5 principled guidelines for evaluating developer infrastructure products
- **Expanded Allowed Categories**: Added messaging API platforms, developer tooling, and automation/workflow platforms
- **Few-shot examples**: WhatsApp developer platform → APPROVE; automation tool with mixed signals → FOLLOW_UP

## Test plan

- [x] Python syntax check passes
- [x] `ruff check` passes
- [ ] Manual testing with borderline appeal cases to verify more consistent outcomes


🤖 Generated with [Claude Code](https://claude.com/claude-code)