### PR TITLE
payout: Bake in all fees into the payout fees

### DIFF
--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -240,17 +240,22 @@ class PayoutService:
             raise InsufficientBalance(account, balance_amount)
 
         try:
-            payout_fees = await platform_fee_transaction_service.get_payout_fees(
+            (
+                payout_fees,
+                existing_fees_amount,
+            ) = await platform_fee_transaction_service.get_payout_fees(
                 session, account=account, balance_amount=balance_amount
             )
         except PayoutAmountTooLow as e:
             raise InsufficientBalance(account, balance_amount) from e
 
+        new_fees_amount = sum(fee for _, fee in payout_fees)
+        total_fees_amount = new_fees_amount + existing_fees_amount
         return PayoutEstimate(
             account_id=account.id,
             gross_amount=balance_amount,
-            fees_amount=sum(fee for _, fee in payout_fees),
-            net_amount=balance_amount - sum(fee for _, fee in payout_fees),
+            fees_amount=total_fees_amount,
+            net_amount=balance_amount - new_fees_amount,
         )
 
     async def create(
@@ -278,6 +283,7 @@ class PayoutService:
                 (
                     balance_amount_after_fees,
                     payout_fees_balances,
+                    total_fees_amount,
                 ) = await platform_fee_transaction_service.create_payout_fees_balances(
                     session, account=account, balance_amount=balance_amount
                 )
@@ -290,7 +296,7 @@ class PayoutService:
                     processor=account.account_type,
                     currency="usd",  # FIXME: Main Polar currency
                     amount=balance_amount_after_fees,
-                    fees_amount=balance_amount - balance_amount_after_fees,
+                    fees_amount=total_fees_amount,
                     account_currency=account.currency,
                     account_amount=balance_amount_after_fees,
                     account=account,

--- a/server/polar/transaction/repository.py
+++ b/server/polar/transaction/repository.py
@@ -11,7 +11,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionMixin,
 )
 from polar.models import Order, Payment, Transaction
-from polar.models.transaction import TransactionType
+from polar.models.transaction import PlatformFeeType, TransactionType
 
 
 class TransactionRepository(
@@ -81,6 +81,23 @@ class BalanceTransactionRepository(TransactionRepository):
                 selectinload(Transaction.balance_reversal_transactions),
                 selectinload(Transaction.payment_transaction),
             )
+        )
+        return await self.get_all(statement)
+
+    _PAYOUT_FEE_TYPES = {
+        PlatformFeeType.account,
+        PlatformFeeType.payout,
+        PlatformFeeType.cross_border_transfer,
+    }
+
+    async def get_unpaid_payout_fees_by_account(
+        self, account_id: UUID
+    ) -> Sequence[Transaction]:
+        statement = self.get_base_statement().where(
+            Transaction.type == TransactionType.balance,
+            Transaction.account_id == account_id,
+            Transaction.payout_transaction_id.is_(None),
+            Transaction.platform_fee_type.in_(self._PAYOUT_FEE_TYPES),
         )
         return await self.get_all(statement)
 

--- a/server/polar/transaction/service/platform_fee.py
+++ b/server/polar/transaction/service/platform_fee.py
@@ -19,6 +19,7 @@ from polar.transaction.fees.stripe import (
     get_stripe_subscription_fee,
 )
 
+from ..repository import BalanceTransactionRepository
 from .balance import balance_transaction as balance_transaction_service
 from .base import BaseTransactionService, BaseTransactionServiceError
 
@@ -71,12 +72,22 @@ class PlatformFeeTransactionService(BaseTransactionService):
 
     async def get_payout_fees(
         self, session: AsyncSession, *, account: Account, balance_amount: int
-    ) -> list[tuple[PlatformFeeType, int]]:
+    ) -> tuple[list[tuple[PlatformFeeType, int]], int]:
         if not account.processor_fees_applicable:
-            return []
+            return [], 0
 
         if account.account_type != AccountType.stripe:
-            return []
+            return [], 0
+
+        balance_transaction_repository = BalanceTransactionRepository.from_session(
+            session
+        )
+        existing_unpaid_fees = (
+            await balance_transaction_repository.get_unpaid_payout_fees_by_account(
+                account.id
+            )
+        )
+        existing_fees_amount = abs(sum(t.amount for t in existing_unpaid_fees))
 
         payout_fees: list[tuple[PlatformFeeType, int]] = []
 
@@ -101,16 +112,17 @@ class PlatformFeeTransactionService(BaseTransactionService):
         if payout_fee_amount > 0:
             payout_fees.append((PlatformFeeType.payout, payout_fee_amount))
 
-        return payout_fees
+        return payout_fees, existing_fees_amount
 
     async def create_payout_fees_balances(
         self, session: AsyncSession, *, account: Account, balance_amount: int
-    ) -> tuple[int, list[tuple[Transaction, Transaction]]]:
-        payout_fees = await self.get_payout_fees(
+    ) -> tuple[int, list[tuple[Transaction, Transaction]], int]:
+        payout_fees, existing_fees_amount = await self.get_payout_fees(
             session, account=account, balance_amount=balance_amount
         )
 
         payout_fees_balances: list[tuple[Transaction, Transaction]] = []
+        new_fees_amount = 0
         for payout_fee_type, fee_amount in payout_fees:
             fee_balances = await balance_transaction_service.create_balance(
                 session,
@@ -121,8 +133,10 @@ class PlatformFeeTransactionService(BaseTransactionService):
             )
             payout_fees_balances.append(fee_balances)
             balance_amount -= fee_amount
+            new_fees_amount += fee_amount
 
-        return balance_amount, payout_fees_balances
+        total_fees_amount = new_fees_amount + existing_fees_amount
+        return balance_amount, payout_fees_balances, total_fees_amount
 
     async def _create_payment_fees(
         self,

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -236,7 +236,7 @@ class TestEstimate:
         """Test that regular currencies return net_amount unchanged."""
         mocker.patch(
             "polar.payout.service.platform_fee_transaction_service.get_payout_fees",
-            return_value=[],
+            return_value=([], 0),
         )
 
         account = await create_account(save_fixture, organization, user, currency="usd")

--- a/server/tests/transaction/service/test_payout.py
+++ b/server/tests/transaction/service/test_payout.py
@@ -31,6 +31,7 @@ async def create_payout(
     (
         balance_amount_after_fees,
         payout_fees_balances,
+        _,
     ) = await platform_fee_transaction_service.create_payout_fees_balances(
         session, account=account, balance_amount=balance_amount
     )

--- a/server/tests/transaction/service/test_platform_fee.py
+++ b/server/tests/transaction/service/test_platform_fee.py
@@ -496,6 +496,7 @@ class TestCreatePayoutFeesBalances:
         (
             balance_amount,
             payout_fees_balances,
+            _,
         ) = await platform_fee_transaction_service.create_payout_fees_balances(
             session, account=account, balance_amount=10000
         )
@@ -523,6 +524,7 @@ class TestCreatePayoutFeesBalances:
         (
             balance_amount,
             payout_fees_balances,
+            _,
         ) = await platform_fee_transaction_service.create_payout_fees_balances(
             session, account=account, balance_amount=10000
         )
@@ -571,6 +573,7 @@ class TestCreatePayoutFeesBalances:
         (
             balance_amount,
             payout_fees_balances,
+            _,
         ) = await platform_fee_transaction_service.create_payout_fees_balances(
             session, account=account_processor_fees, balance_amount=10000
         )
@@ -615,6 +618,7 @@ class TestCreatePayoutFeesBalances:
         (
             balance_amount,
             payout_fees_balances,
+            _,
         ) = await platform_fee_transaction_service.create_payout_fees_balances(
             session, account=account_processor_fees, balance_amount=10000
         )
@@ -649,6 +653,7 @@ class TestCreatePayoutFeesBalances:
         (
             balance_amount,
             payout_fees_balances,
+            _,
         ) = await platform_fee_transaction_service.create_payout_fees_balances(
             session, account=account, balance_amount=10000
         )


### PR DESCRIPTION
If you do a payout, cancelation / reversal of it and a new payout we need to include the fees of the payout that didn't happen into the second payout.

Otherwise we fail the validation when generating the invoice.
