### PR TITLE
fix: update Plain API timeline query to use current schema

### DIFF
--- a/server/scripts/appeal_review.py
+++ b/server/scripts/appeal_review.py
@@ -908,18 +908,27 @@ def _create_agent(model_name: str) -> Agent[AppealAgentDeps, AppealReviewResult]
         query ThreadTimeline($threadId: ID!) {
           thread(threadId: $threadId) {
             title
-            timelineEntries(first: 50) {
+            timeline(first: 50) {
               edges {
                 node {
-                  ... on ChatEntry {
-                    text
-                    customerActor { customer { fullName email { email } } }
-                    userActor { user { fullName } }
+                  actor {
+                    __typename
+                    ... on UserActor {
+                      user { fullName }
+                    }
+                    ... on CustomerActor {
+                      customer { fullName email { email } }
+                    }
                   }
-                  ... on EmailEntry {
-                    text
-                    from { name email }
-                    to { name email }
+                  entry {
+                    ... on ChatEntry {
+                      text
+                    }
+                    ... on EmailEntry {
+                      text
+                      from { name email }
+                      to { name email }
+                    }
                   }
                 }
               }
@@ -949,26 +958,29 @@ def _create_agent(model_name: str) -> Agent[AppealAgentDeps, AppealReviewResult]
 
         parts = [f"Thread: {thread_data.get('title', 'Untitled')}"]
 
-        entries = thread_data.get("timelineEntries", {}).get("edges", [])
+        entries = thread_data.get("timeline", {}).get("edges", [])
         if not entries:
             parts.append("No messages in this thread.")
         else:
             for edge in entries:
                 node = edge.get("node", {})
-                text = node.get("text", "")
+                entry = node.get("entry", {})
+                text = entry.get("text", "")
                 if not text:
                     continue
 
-                # Determine sender
+                # Determine sender from the actor on the timeline entry
+                actor = node.get("actor", {})
+                actor_type = actor.get("__typename", "")
                 sender = "Unknown"
-                if "customerActor" in node and node["customerActor"]:
-                    cust = node["customerActor"].get("customer", {})
+                if actor_type == "CustomerActor":
+                    cust = actor.get("customer", {})
                     sender = cust.get("fullName") or "Customer"
-                elif "userActor" in node and node["userActor"]:
-                    user = node["userActor"].get("user", {})
+                elif actor_type == "UserActor":
+                    user = actor.get("user", {})
                     sender = user.get("fullName") or "Agent"
-                elif "from" in node and node["from"]:
-                    sender = node["from"].get("name") or node["from"].get("email", "")
+                elif entry.get("from"):
+                    sender = entry["from"].get("name") or entry["from"].get("email", "")
 
                 parts.append(f"\n[{sender}]: {text[:1000]}")
 

--- a/server/scripts/bulk_appeal_review.py
+++ b/server/scripts/bulk_appeal_review.py
@@ -57,14 +57,14 @@ SLUG_PATTERN = re.compile(r"Organization Appeal - (\S+)")
 TIMELINE_QUERY = """
 query ThreadTimeline($threadId: ID!) {
   thread(threadId: $threadId) {
-    timelineEntries(first: 50) {
+    timeline(first: 50) {
       edges {
         node {
-          ... on ChatEntry {
-            userActor { user { fullName } }
+          actor {
+            __typename
           }
-          ... on EmailEntry {
-            from { email }
+          entry {
+            __typename
           }
         }
       }
@@ -136,14 +136,16 @@ async def is_thread_answered(plain_token: str, thread_id: str) -> bool:
     if not thread_data:
         return True
 
-    entries = thread_data.get("timelineEntries", {}).get("edges", [])
+    entries = thread_data.get("timeline", {}).get("edges", [])
     for edge in entries:
         node = edge.get("node", {})
-        # Staff replied via chat
-        if node.get("userActor"):
-            return True
-        # Outbound email sent
-        if "from" in node and node["from"]:
+        actor = node.get("actor", {})
+        entry = node.get("entry", {})
+        # Staff replied via chat or email
+        if actor.get("__typename") == "UserActor" and entry.get("__typename") in (
+            "ChatEntry",
+            "EmailEntry",
+        ):
             return True
 
     return False


### PR DESCRIPTION
## Summary

Fixes the bulk appeal review script failure where all threads were incorrectly marked as answered, preventing any appeals from being processed.

## What

Updated GraphQL queries in `bulk_appeal_review.py` and `appeal_review.py` to use the current Plain API schema:
- Changed `timelineEntries` field to `timeline`
- Restructured to access entry types under `node.entry` instead of directly on `node`
- Updated actor access to use `node.actor` with `__typename` discriminator

## Why

The Plain API schema was updated, renaming the `timelineEntries` field to `timeline` and restructuring the response. The old queries returned 400 (schema validation errors), causing the scripts to incorrectly treat all threads as answered and skip processing them entirely.

## How

Updated both GraphQL query definitions and their response parsers to work with the new schema structure where actors and entry types are properly nested.

✅ Lint and type checking: passed