### PR TITLE
fix: exclude already answered appeals from bulk review script

### DIFF
--- a/server/scripts/bulk_appeal_review.py
+++ b/server/scripts/bulk_appeal_review.py
@@ -83,7 +83,7 @@ async def get_appeal_threads(plain: Plain) -> list[dict[str, str]]:
         kwargs: dict[str, Any] = dict(
             filters=ThreadsFilter(
                 label_type_ids=[APPEAL_LABEL_TYPE_ID],
-                statuses=[ThreadStatus.TODO, ThreadStatus.SNOOZED],
+                statuses=[ThreadStatus.TODO],
             ),
             first=50,
         )
@@ -141,8 +141,10 @@ async def is_thread_answered(plain_token: str, thread_id: str) -> bool:
         node = edge.get("node", {})
         actor = node.get("actor", {})
         entry = node.get("entry", {})
-        # Staff replied via chat or email
-        if actor.get("__typename") == "UserActor" and entry.get("__typename") in (
+        # Staff or bot replied via chat or email
+        if actor.get("__typename") in ("UserActor", "MachineUserActor") and entry.get(
+            "__typename"
+        ) in (
             "ChatEntry",
             "EmailEntry",
         ):


### PR DESCRIPTION
## Summary

Prevents the bulk appeal review script from re-processing appeals that have already been answered by the bot.

## What

- Removed `ThreadStatus.SNOOZED` from thread filtering to skip already-processed appeals
- Enhanced `is_thread_answered()` to detect bot replies (`MachineUserActor`) in addition to staff replies

## Why

The bot answers appeal emails and snoozes the threads. However, the script was still picking up these snoozed threads and attempting to re-process them, as shown in the provided example.

## How

1. Filter for only `TODO` threads (snoozed threads are skipped)
2. Check timeline for both `UserActor` (staff) and `MachineUserActor` (bot) replies as indicators that a thread has been answered