### PR TITLE
Preserve en-US locale when checkout localization is disabled

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2217,6 +2217,14 @@ class CheckoutService:
         ).items():
             setattr(checkout, attr, value)
 
+        # `None` locale would opt in to browser-based language detection.
+        # If people haven't opted in to this yet, we hardcode the default locale
+        # to `en-US` to keep the current behavior
+        if not checkout.organization.feature_settings.get(
+            "checkout_localization_enabled", False
+        ):
+            checkout.locale = "en-US"
+
         # Reset is_business_customer if payment form is no longer required
         # This handles the case where a 100% discount is applied and the
         # billing address section disappears from the frontend


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #<!-- issue number -->

This PR ensures that checkouts maintain the `en-US` locale by default when the checkout localization feature is not enabled, preventing unintended browser-based language detection.

## 🎯 What

Added a check in the `_update_checkout` method to explicitly set the checkout locale to `en-US` when the `checkout_localization_enabled` feature flag is disabled on the organization.

## 🤔 Why

The code introduces support for browser-based language detection via `None` locale values. However, to maintain backward compatibility and preserve current behavior for organizations that haven't opted into this feature, we need to explicitly set the locale to `en-US` when the feature is disabled.

## 🔧 How

After updating checkout attributes, we check the organization's feature settings for `checkout_localization_enabled`. If this feature is not enabled (defaults to `False`), we hardcode the checkout locale to `en-US` to maintain the existing behavior.

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

This change affects the checkout update flow. Verify that:
1. Checkouts for organizations without the `checkout_localization_enabled` feature flag maintain `en-US` locale
2. Checkouts for organizations with the feature enabled can use `None` locale for browser-based detection
3. Existing checkout functionality remains unaffected

## 📝 Additional Notes

This is a defensive change to ensure backward compatibility as the localization feature is rolled out. The logic is straightforward and follows the existing pattern of feature flag checks in the codebase.

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")

https://claude.ai/code/session_01VJeYap8H7cuypz3cBPZPrg