### PR TITLE
email: Migrate the rest of the emails to template worker

### DIFF
--- a/server/polar/notifications/notification.py
+++ b/server/polar/notifications/notification.py
@@ -1,16 +1,18 @@
 from abc import abstractmethod
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 import pycountry
 from pydantic import UUID4, BaseModel, Discriminator, computed_field
 
 from polar.config import settings
-from polar.email.react import render_email_template
 from polar.kit.currency import format_currency
 from polar.kit.schemas import Schema
 from polar.models.order import OrderBillingReasonInternal
+
+if TYPE_CHECKING:
+    from polar.email.schemas import Email
 
 
 class NotificationType(StrEnum):
@@ -30,16 +32,14 @@ class NotificationPayloadBase(BaseModel):
     def template_name(cls) -> str:
         pass
 
-    def render(self) -> tuple[str, str]:
+    def to_email(self) -> Email:
         from polar.email.schemas import EmailAdapter
 
-        return self.subject(), render_email_template(
-            EmailAdapter.validate_python(
-                {
-                    "template": self.template_name(),
-                    "props": self,
-                }
-            )
+        return EmailAdapter.validate_python(
+            {
+                "template": self.template_name(),
+                "props": self,
+            }
         )
 
 

--- a/server/polar/notifications/tasks/email.py
+++ b/server/polar/notifications/tasks/email.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import structlog
 
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.notifications.service import notifications
 from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
@@ -18,8 +18,9 @@ async def notifications_send(notification_id: UUID) -> None:
             return
 
         notification_type = notifications.parse_payload(notif)
-        (subject, body) = notification_type.render()
 
-        enqueue_email(
-            to_email_addr=notif.user.email, subject=subject, html_content=body
+        enqueue_email_template(
+            notification_type.to_email(),
+            to_email_addr=notif.user.email,
+            subject=notification_type.subject(),
         )

--- a/server/polar/notifications/tasks/push.py
+++ b/server/polar/notifications/tasks/push.py
@@ -93,7 +93,7 @@ async def notifications_push(notification_id: UUID) -> None:
                 continue
 
             notification_type = notifications.parse_payload(notif)
-            [subject, _] = notification_type.render()
+            subject = notification_type.subject()
 
             try:
                 send_push_message(

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -6,12 +6,11 @@ from sqlalchemy.orm import joinedload
 
 from polar.account.repository import AccountRepository
 from polar.customer.repository import CustomerRepository
-from polar.email.react import render_email_template
 from polar.email.schemas import (
     OrganizationReviewedEmail,
     OrganizationReviewedProps,
 )
-from polar.email.sender import enqueue_email
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarTaskError
 from polar.held_balance.service import held_balance as held_balance_service
 from polar.integrations.plain.service import plain as plain_service
@@ -144,10 +143,10 @@ async def organization_reviewed(
                         {"email": admin_user.email, "organization": organization}
                     )
                 )
-                enqueue_email(
+                enqueue_email_template(
+                    email,
                     to_email_addr=admin_user.email,
                     subject="Your organization review is complete",
-                    html_content=render_email_template(email),
                 )
 
 

--- a/server/tests/notifications/test_email.py
+++ b/server/tests/notifications/test_email.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+from polar.email.react import render_email_template
 from polar.models.order import OrderBillingReasonInternal
 from polar.notifications.notification import (
     MaintainerAccountCreditsGrantedNotificationPayload,
@@ -13,8 +14,9 @@ from polar.notifications.notification import (
 )
 
 
-async def check_diff(email: tuple[str, str]) -> None:
-    (subject, body) = email
+async def check_diff(notification: NotificationPayloadBase) -> None:
+    subject = notification.subject()
+    body = render_email_template(notification.to_email())
     expected = f"{subject}\n<hr>\n{body}"
 
     # Run with `POLAR_TEST_RECORD=1 pytest` to produce new golden files :-)
@@ -45,7 +47,7 @@ async def test_MaintainerNewPaidSubscriptionNotification() -> None:
         subscription_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     )
 
-    await check_diff(n.render())
+    await check_diff(n)
 
 
 @pytest.mark.asyncio
@@ -66,7 +68,7 @@ async def test_MaintainerNewProductSaleNotification() -> None:
         billing_reason=OrderBillingReasonInternal.purchase,
     )
 
-    await check_diff(n.render())
+    await check_diff(n)
 
 
 @pytest.mark.asyncio
@@ -76,7 +78,7 @@ async def test_MaintainerCreateAccountNotificationPayload() -> None:
         url="https://example.com/url",
     )
 
-    await check_diff(n.render())
+    await check_diff(n)
 
 
 @pytest.mark.asyncio
@@ -86,7 +88,7 @@ async def test_MaintainerAccountCreditsGrantedNotification() -> None:
         amount=5000,
     )
 
-    await check_diff(n.render())
+    await check_diff(n)
 
 
 @pytest.mark.asyncio
@@ -124,7 +126,8 @@ async def test_MaintainerAccountCreditsGrantedNotification() -> None:
     ],
 )
 async def test_injection_payloads(payload: NotificationPayloadBase) -> None:
-    subject, body = payload.render()
+    subject = payload.subject()
+    body = render_email_template(payload.to_email())
     assert str(123456 * 9) not in subject
     assert str(123456 * 9) not in body
 
@@ -151,6 +154,7 @@ async def test_MaintainerNewProductSaleNotification_backwards_compatibility() ->
     assert n.order_date is None
     assert n.billing_reason is None
 
-    subject, body = n.render()
+    subject = n.subject()
+    body = render_email_template(n.to_email())
     assert "Old Product" in body
     assert "$10.00" in subject

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.email.schemas import OrganizationReviewedEmail
 from polar.held_balance.service import HeldBalanceService
 from polar.held_balance.service import held_balance as held_balance_service
 from polar.kit.db.postgres import AsyncSession
@@ -19,8 +20,10 @@ from tests.fixtures.database import SaveFixture
 
 
 @pytest.fixture(autouse=True)
-def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("polar.organization.tasks.enqueue_email", autospec=True)
+def enqueue_email_template_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch(
+        "polar.organization.tasks.enqueue_email_template", autospec=True
+    )
 
 
 @pytest.mark.asyncio
@@ -111,7 +114,7 @@ class TestOrganizationReviewed:
     async def test_existing_organization(
         self,
         mocker: MockerFixture,
-        enqueue_email_mock: MagicMock,
+        enqueue_email_template_mock: MagicMock,
         session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
@@ -136,13 +139,15 @@ class TestOrganizationReviewed:
 
         await organization_reviewed(organization.id, initial_review=True)
 
-        enqueue_email_mock.assert_called_once()
+        enqueue_email_template_mock.assert_called_once()
+        email_arg = enqueue_email_template_mock.call_args[0][0]
+        assert isinstance(email_arg, OrganizationReviewedEmail)
         get_admin_user_mock.assert_called_once()
 
     async def test_existing_organization_with_account(
         self,
         mocker: MockerFixture,
-        enqueue_email_mock: MagicMock,
+        enqueue_email_template_mock: MagicMock,
         session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
@@ -170,5 +175,7 @@ class TestOrganizationReviewed:
         await organization_reviewed(organization.id, initial_review=True)
 
         release_account_mock.assert_called_once()
-        enqueue_email_mock.assert_called_once()
+        enqueue_email_template_mock.assert_called_once()
+        email_arg = enqueue_email_template_mock.call_args[0][0]
+        assert isinstance(email_arg, OrganizationReviewedEmail)
         get_admin_user_mock.assert_called_once()


### PR DESCRIPTION
Follow up from
- #9985 
- #9990 

Migrate the rest of the emails to pass in the template to the worker. This will jive better with new `email_log`