### PR TITLE
server/subscription: when updating seats, never invoice immediately if the subscription is trialing

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1286,7 +1286,10 @@ class SubscriptionService:
             previous_is_canceled=previous_is_canceled,
         )
 
-        if proration_behavior == SubscriptionProrationBehavior.invoice:
+        if (
+            proration_behavior == SubscriptionProrationBehavior.invoice
+            and not subscription.trialing
+        ):
             # Invoice and attempt to pay immediately
             await self._create_subscription_update_order(session, subscription)
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3003,8 +3003,16 @@ class TestUpdateSeats:
         with pytest.raises(NotASeatBasedSubscription):
             await subscription_service.update_seats(session, subscription, seats=10)
 
+    @pytest.mark.parametrize(
+        "proration_behavior",
+        [
+            SubscriptionProrationBehavior.prorate,
+            SubscriptionProrationBehavior.invoice,
+        ],
+    )
     async def test_trialing_subscription(
         self,
+        proration_behavior: SubscriptionProrationBehavior,
         session: AsyncSession,
         save_fixture: SaveFixture,
         customer: Customer,
@@ -3030,7 +3038,7 @@ class TestUpdateSeats:
 
         # When: Update seats during trial
         updated = await subscription_service.update_seats(
-            session, subscription, seats=10
+            session, subscription, seats=10, proration_behavior=proration_behavior
         )
         await session.flush()
 


### PR DESCRIPTION
Fix #10105

- server/subscription: when updating seats, never invoice immediately if the subscription is trialing
