### PR TITLE
metrics: Migrate CheckoutConversion meta metric

### DIFF
--- a/server/polar/metrics/metrics.py
+++ b/server/polar/metrics/metrics.py
@@ -9,13 +9,11 @@ if TYPE_CHECKING:
 
 from sqlalchemy import (
     ColumnElement,
-    Float,
     Integer,
     SQLColumnExpression,
     case,
     func,
     or_,
-    type_coerce,
 )
 
 from polar.enums import SubscriptionRecurringInterval
@@ -280,26 +278,17 @@ class SucceededCheckoutsMetric(SQLMetric):
         return cumulative_sum(periods, cls.slug)
 
 
-class CheckoutsConversionMetric(SQLMetric):
+class CheckoutsConversionMetric(MetaMetric):
     slug = "checkouts_conversion"
     display_name = "Checkouts Conversion Rate"
     type = MetricType.percentage
-    query = MetricQuery.checkouts
+    dependencies: ClassVar[list[str]] = ["checkouts", "succeeded_checkouts"]
 
     @classmethod
-    def get_sql_expression(
-        cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
-    ) -> ColumnElement[float]:
-        return type_coerce(
-            case(
-                (func.count(Checkout.id) == 0, 0),
-                else_=func.count(Checkout.id).filter(
-                    Checkout.status == CheckoutStatus.succeeded
-                )
-                / func.count(Checkout.id),
-            ),
-            Float,
-        )
+    def compute_from_period(cls, period: "MetricsPeriod") -> float:
+        checkouts = period.checkouts or 0
+        succeeded = period.succeeded_checkouts or 0
+        return succeeded / checkouts if checkouts > 0 else 0.0
 
     @classmethod
     def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> float:
@@ -860,11 +849,11 @@ METRICS_POSTGRES: list[type[SQLMetric]] = [
     AverageRevenuePerUserMetric,
     CheckoutsMetric,
     SucceededCheckoutsMetric,
-    CheckoutsConversionMetric,
     ChurnedSubscriptionsMetric,
 ]
 
 METRICS_POST_COMPUTE: list[type[MetaMetric]] = [
+    CheckoutsConversionMetric,
     ChurnRateMetric,
     LTVMetric,
     GrossMarginMetric,

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -209,11 +209,11 @@ class MetricsService:
                 period_dict[meta_metric.slug] = meta_metric.compute_from_period(period)
 
             if metrics is not None:
-                requested = set(metrics)
+                all_resolved = pg_slugs | tb_slugs | meta_slugs
                 period_dict = {
                     k: v
                     for k, v in period_dict.items()
-                    if k == "timestamp" or k in requested
+                    if k == "timestamp" or k in all_resolved
                 }
 
             periods.append(MetricsPeriod.model_validate(period_dict))
@@ -221,6 +221,19 @@ class MetricsService:
         totals: dict[str, int | float] = {}
         for metric in filtered_all_metrics:
             totals[metric.slug] = metric.get_cumulative(periods)
+
+        if metrics is not None:
+            requested = set(metrics)
+            periods = [
+                MetricsPeriod.model_validate(
+                    {
+                        k: v
+                        for k, v in p.model_dump().items()
+                        if k == "timestamp" or k in requested
+                    }
+                )
+                for p in periods
+            ]
 
         return MetricsResponse.model_validate(
             {

--- a/server/tests/metrics/test_service.py
+++ b/server/tests/metrics/test_service.py
@@ -22,6 +22,7 @@ from polar.models import (
     User,
     UserOrganization,
 )
+from polar.models.checkout import CheckoutStatus
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.event import EventSource
 from polar.models.order import OrderStatus
@@ -2868,8 +2869,6 @@ class TestCheckoutMetrics:
         If 2 checkouts are opened and 1 succeeds, conversion should be 50%,
         NOT based on total created checkouts.
         """
-        from polar.models.checkout import CheckoutStatus
-
         product = await create_product(
             save_fixture,
             organization=organization,
@@ -2927,6 +2926,62 @@ class TestCheckoutMetrics:
 
         # Conversion should be 50% (1/2), not ~20% (1/5)
         assert metrics.totals.checkouts_conversion == 0.5
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"), AuthSubjectFixture(subject="organization")
+    )
+    async def test_checkouts_conversion_cumulative_without_sibling_metrics(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        """
+        Test that requesting only checkouts_conversion (without checkouts
+        or succeeded_checkouts) still computes a correct cumulative total.
+        """
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+        )
+
+        for _ in range(2):
+            await create_checkout(
+                save_fixture,
+                products=[product],
+                created_at=datetime(2024, 1, 15, 9, 0, tzinfo=UTC),
+                analytics_metadata={},
+            )
+
+        await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.succeeded,
+            created_at=datetime(2024, 1, 15, 10, 0, tzinfo=UTC),
+            analytics_metadata={},
+        )
+
+        metrics = await metrics_service.get_metrics(
+            session,
+            auth_subject,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.month,
+            metrics=["checkouts_conversion"],
+        )
+
+        assert metrics.totals.checkouts_conversion is not None
+        assert metrics.totals.checkouts_conversion > 0
+        assert abs(metrics.totals.checkouts_conversion - 1 / 3) < 0.01
+
+        jan = metrics.periods[0]
+        assert jan.checkouts is None
+        assert jan.succeeded_checkouts is None
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"), AuthSubjectFixture(subject="organization")


### PR DESCRIPTION
Since the cumulative calculation has dependencies on other metrics, it seemed easier to make the entire metric a meta metric since we resolve the dependencies for those metrics already.
