### PR TITLE
pagination: Split query into a separate count

### DIFF
--- a/server/polar/kit/pagination.py
+++ b/server/polar/kit/pagination.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Query
 from pydantic import BaseModel, GetCoreSchemaHandler
 from pydantic._internal._repr import display_as_type
 from pydantic_core import CoreSchema
-from sqlalchemy import Select, func, over
+from sqlalchemy import Select, func, select
 from sqlalchemy.sql._typing import _ColumnsClauseArgument
 
 from polar.config import settings
@@ -60,20 +60,33 @@ async def paginate(
 ) -> tuple[Sequence[Any], int]:
     page, limit = pagination
     offset = limit * (page - 1)
-    statement = statement.offset(offset).limit(limit)
 
     if count_clause is not None:
-        statement = statement.add_columns(count_clause)
-    else:
-        statement = statement.add_columns(over(func.count()))
+        paginated = statement.offset(offset).limit(limit)
+        paginated = paginated.add_columns(count_clause)
+        result = await session.execute(paginated)
+        results: list[Any] = []
+        count = 0
+        for row in result.unique().all():
+            (*queried_data, c) = row._tuple()
+            count = int(c)
+            if len(queried_data) == 1:
+                results.append(queried_data[0])
+            else:
+                results.append(queried_data)
+        return results, count
 
-    result = await session.execute(statement)
+    count_statement = select(func.count()).select_from(
+        statement.order_by(None).subquery()
+    )
+    count_result = await session.execute(count_statement)
+    count = count_result.scalar_one()
 
-    results: list[Any] = []
-    count = 0
+    paginated = statement.offset(offset).limit(limit)
+    result = await session.execute(paginated)
+    results = []
     for row in result.unique().all():
-        (*queried_data, c) = row._tuple()
-        count = int(c)
+        queried_data = row._tuple()
         if len(queried_data) == 1:
             results.append(queried_data[0])
         else:

--- a/server/polar/kit/repository/base.py
+++ b/server/polar/kit/repository/base.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, Protocol, Self
 
-from sqlalchemy import Select, UnaryExpression, asc, desc, func, over, select
+from sqlalchemy import Select, UnaryExpression, asc, desc, func, select
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql.base import ExecutableOption
@@ -106,18 +106,17 @@ class RepositoryBase[M]:
         self, statement: Select[tuple[M]], *, limit: int, page: int
     ) -> tuple[list[M], int]:
         offset = (page - 1) * limit
-        paginated_statement: Select[tuple[M, int]] = (
-            statement.add_columns(over(func.count())).limit(limit).offset(offset)
+
+        count_statement = select(func.count()).select_from(
+            statement.order_by(None).subquery()
         )
+        count_result = await self.session.execute(count_statement)
+        count = count_result.scalar_one()
+
+        paginated_statement = statement.limit(limit).offset(offset)
         # Streaming can't be applied here, since we need to call ORM's unique()
         results = await self.session.execute(paginated_statement)
-
-        items: list[M] = []
-        count = 0
-        for result in results.unique().all():
-            item, count = result._tuple()
-            items.append(item)
-
+        items = list(results.unique().scalars().all())
         return items, count
 
     def get_base_statement(self) -> Select[tuple[M]]:


### PR DESCRIPTION
Instead of doing COUNT(*) OVER(), we can do a separate COUNT query. Doing the COUNT(*) OVER() means that the limit/offset doesn't stop execution, and thus will always take a long time.