### PR TITLE
tinybird: Default to waiting for completion

### DIFF
--- a/server/polar/integrations/tinybird/client.py
+++ b/server/polar/integrations/tinybird/client.py
@@ -200,7 +200,7 @@ class TinybirdClient:
             return result.get("data", [])
 
     async def ingest(
-        self, datasource: str, events: list[TinybirdEvent], *, wait: bool = False
+        self, datasource: str, events: list[TinybirdEvent], *, wait: bool = True
     ) -> None:
         if not events:
             return


### PR DESCRIPTION
Since we are relying on our events, we need to ensure that they are saved.

With wait=false, the request returns a 202 response. This means the data has been processed by the ingestion pipeline and will be sent to the database eventually, but the write has not yet been acknowledged by ClickHouse.
With wait=true, the request waits until the database acknowledges the write and returns 200 only once the data has been successfully inserted.

If something fails after the 202 response (for example while writing to the database), the client has no visibility of that failure. With wait=true, the request would instead return an error, which would allow the event.ingested (or other callers) to be retried.