### PR TITLE
feat: add daily cron job for bulk appeal review

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -320,9 +320,12 @@ resource "render_cron_job" "cron" {
     }
   }
 
+  # Cron jobs don't support Render secret_files, so we pass JWKS as an env var
+  # and write it to a temp file in the start command.
   env_vars = {
     SERVICE_NAME                 = { value = each.key }
     POLAR_DATABASE_POOL_SIZE     = { value = each.value.database_pool_size }
+    POLAR_JWKS_CONTENT           = { value = var.backend_secrets.jwks }
     POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
     POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
     POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -214,7 +214,7 @@ module "production" {
   cron_jobs = {
     "bulk-appeal-review" = {
       schedule      = "0 8 * * *" # 8:00 UTC = 9:00 CET
-      start_command = "uv run python -m scripts.bulk_appeal_review --execute --limit 0"
+      start_command = "printenv POLAR_JWKS_CONTENT > /tmp/jwks.json && POLAR_JWKS=/tmp/jwks.json uv run python -m scripts.bulk_appeal_review --execute --limit 0"
     }
   }
 


### PR DESCRIPTION
## Summary

Add a Render cron job that automatically reviews organization appeals daily at 8:00 UTC (9:00 CET).

## What

- New `render_cron_job` resource in the Render service module supporting configurable cron jobs
- Daily `bulk-appeal-review` cron job in production that runs `bulk_appeal_review.py --execute --limit 0`
- Cron jobs inherit all necessary environment variables and database/Redis access via env group links
- Fixed JWKS handling for cron jobs (write env var to temp file since cron jobs don't support Render secret_files)

## Why

The bulk appeal review script is a long-running process that shouldn't be interrupted by deploys. Render's cron job service guarantees single-run execution and deploy-safe behavior, making it ideal for this use case.

## How

Extended the `render_service` module to accept a `cron_jobs` variable (map of schedule + command). Added `render_cron_job` resource with automatic fallback to API service Docker image. Cron jobs are included in `all_service_ids` so they inherit all env groups (database, Redis, OpenAI API key, Plain token, etc.). JWKS content is passed as `POLAR_JWKS_CONTENT` env var and written to `/tmp/jwks.json` in the start command since Render cron jobs don't support secret file mounting.

## Testing

Terraform changes only — no new backend tests needed. After applying:
1. Verify the cron job appears in the Render dashboard
2. Monitor first run at 8:00 UTC
3. Check logs and database for successful appeal processing

🤖 Generated with Claude Code