### PR TITLE
Fix expired tokens displaying as still active

### DIFF
--- a/clients/apps/web/src/components/Settings/AccessTokenSettings.tsx
+++ b/clients/apps/web/src/components/Settings/AccessTokenSettings.tsx
@@ -51,13 +51,23 @@ const AccessToken = (props: schemas['PersonalAccessToken']) => {
             <h3 className="text-md">{props.comment}</h3>
             <p className="dark:text-polar-400 text-sm text-gray-500">
               {props.expires_at ? (
-                <>
-                  Expires on{' '}
-                  <FormattedDateTime
-                    datetime={props.expires_at}
-                    dateStyle="long"
-                  />
-                </>
+                new Date(props.expires_at) < new Date() ? (
+                  <span className="text-red-500 dark:text-red-400">
+                    Expired on{' '}
+                    <FormattedDateTime
+                      datetime={props.expires_at}
+                      dateStyle="long"
+                    />
+                  </span>
+                ) : (
+                  <>
+                    Expires on{' '}
+                    <FormattedDateTime
+                      datetime={props.expires_at}
+                      dateStyle="long"
+                    />
+                  </>
+                )
               ) : (
                 <span className="text-red-500 dark:text-red-400">
                   Never expires

--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -360,13 +360,23 @@ const AccessTokenItem = ({
             {!minimal && (
               <p className="dark:text-polar-400 text-sm text-gray-500">
                 {token.expires_at ? (
-                  <>
-                    Expires on{' '}
-                    <FormattedDateTime
-                      datetime={token.expires_at}
-                      dateStyle="long"
-                    />
-                  </>
+                  new Date(token.expires_at) < new Date() ? (
+                    <span className="text-red-500 dark:text-red-400">
+                      Expired on{' '}
+                      <FormattedDateTime
+                        datetime={token.expires_at}
+                        dateStyle="long"
+                      />
+                    </span>
+                  ) : (
+                    <>
+                      Expires on{' '}
+                      <FormattedDateTime
+                        datetime={token.expires_at}
+                        dateStyle="long"
+                      />
+                    </>
+                  )
                 ) : (
                   <span className="text-red-500 dark:text-red-400">
                     Never expires


### PR DESCRIPTION
Tokens past their expiration date now show "Expired on" in red text instead of "Expires on" in the default muted color. Applied to both organization and personal access token settings.
