### PR TITLE
fe/file-upload: Handle errors gracefully

### DIFF
--- a/clients/apps/web/src/components/Benefit/Downloadables/BenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/Downloadables/BenefitForm.tsx
@@ -2,10 +2,11 @@
 
 import { FileObject, useFileUpload } from '@/components/FileUpload'
 import { FileRead } from '@/components/FileUpload/Upload'
+import { toast } from '@/components/Toast/use-toast'
 import { useFiles } from '@/hooks/queries/files'
 import FileUploadIcon from '@mui/icons-material/FileUploadOutlined'
 import { schemas } from '@polar-sh/client'
-import { ReactElement, useEffect, useRef, useState } from 'react'
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 import { FileList } from './FileList'
@@ -108,6 +109,13 @@ const DownloadablesForm = ({
     })
   }
 
+  const onFileUploadError = useCallback((fileName: string, error: Error) => {
+    toast({
+      title: 'Upload Failed',
+      description: `Failed to upload ${fileName}. Please try again.`,
+    })
+  }, [])
+
   const {
     files,
     setFiles,
@@ -120,6 +128,7 @@ const DownloadablesForm = ({
     organization,
     service: 'downloadable',
     onFilesUpdated,
+    onFileUploadError,
     initialFiles,
   })
 

--- a/clients/apps/web/src/components/FileUpload/Upload.test.ts
+++ b/clients/apps/web/src/components/FileUpload/Upload.test.ts
@@ -1,0 +1,323 @@
+import { schemas } from '@polar-sh/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Upload } from './Upload'
+
+vi.mock('@/utils/client', () => ({
+  api: {
+    POST: vi.fn(),
+  },
+}))
+
+vi.mock('hash-wasm', () => ({
+  createSHA256: vi.fn(),
+}))
+
+const { api } = await import('@/utils/client')
+
+const mockOrganization = {
+  id: 'org-123',
+  name: 'Test Org',
+} as schemas['Organization']
+
+const mockFileUpload: schemas['FileUpload'] = {
+  id: 'file-123',
+  organization_id: 'org-123',
+  name: 'test.zip',
+  path: 'downloadable/org-123/file-123/test.zip',
+  mime_type: 'application/zip',
+  size: 100,
+  size_readable: '100 B',
+  is_uploaded: false,
+  service: 'downloadable',
+  storage_version: null,
+  checksum_etag: null,
+  checksum_sha256_base64: null,
+  checksum_sha256_hex: null,
+  last_modified_at: null,
+  version: null,
+  upload: {
+    id: 'upload-123',
+    path: 'downloadable/org-123/file-123/test.zip',
+    parts: [
+      {
+        number: 1,
+        chunk_start: 0,
+        chunk_end: 100,
+        checksum_sha256_base64: 'abc123',
+        url: 'https://s3.example.com/upload?part=1',
+        expires_at: '2024-01-01T00:10:00Z',
+        headers: { 'x-amz-checksum-sha256': 'abc123' },
+      },
+    ],
+  },
+}
+
+const mockFileRead = {
+  ...mockFileUpload,
+  is_uploaded: true,
+  checksum_sha256_base64: 'abc123',
+  checksum_sha256_hex: 'abc123hex',
+  last_modified_at: '2024-01-01T00:00:00Z',
+  storage_version: 'v1',
+  version: null,
+}
+
+function createTestFile(size = 100) {
+  return new File([new ArrayBuffer(size)], 'test.zip', {
+    type: 'application/zip',
+  })
+}
+
+function createUpload(
+  overrides: Partial<ConstructorParameters<typeof Upload>[0]> = {},
+) {
+  return new Upload({
+    organization: mockOrganization,
+    service: 'downloadable',
+    file: createTestFile(),
+    onFileProcessing: vi.fn(),
+    onFileCreate: vi.fn(),
+    onFileUploadProgress: vi.fn(),
+    onFileUploaded: vi.fn(),
+    onFileUploadError: vi.fn(),
+    ...overrides,
+  })
+}
+
+function mockXHR(options: { status?: number; etag?: string | null } = {}) {
+  const { status = 200, etag = '"abc123"' } = options
+
+  vi.stubGlobal(
+    'XMLHttpRequest',
+    vi.fn().mockImplementation(() => ({
+      open: vi.fn(),
+      send: vi.fn().mockImplementation(function (this: any) {
+        if (this.upload?.onprogress) {
+          this.upload.onprogress({ lengthComputable: true, loaded: 50 })
+        }
+        this.readyState = 4
+        this.status = status
+        this.statusText = status === 200 ? 'OK' : 'Error'
+        this.onreadystatechange?.()
+      }),
+      setRequestHeader: vi.fn(),
+      getResponseHeader: vi.fn().mockImplementation((header: string) => {
+        if (header === 'ETag') return etag
+        return null
+      }),
+      readyState: 0,
+      status: 0,
+      statusText: '',
+      onreadystatechange: null as any,
+      upload: { onprogress: null as any },
+    })),
+  )
+}
+
+describe('Upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  describe('run - error handling', () => {
+    it('should complete a successful upload end-to-end', async () => {
+      const onFileProcessing = vi.fn()
+      const onFileCreate = vi.fn()
+      const onFileUploaded = vi.fn()
+      const onFileUploadError = vi.fn()
+
+      const upload = createUpload({
+        onFileProcessing,
+        onFileCreate,
+        onFileUploaded,
+        onFileUploadError,
+      })
+
+      vi.spyOn(upload, 'create').mockResolvedValue({
+        data: mockFileUpload,
+        error: undefined,
+        response: new Response(),
+      } as any)
+
+      mockXHR()
+
+      vi.mocked(api.POST).mockResolvedValueOnce({
+        data: mockFileRead,
+        error: undefined,
+        response: new Response(),
+      } as any)
+
+      await upload.run()
+
+      expect(onFileProcessing).toHaveBeenCalledOnce()
+      expect(onFileCreate).toHaveBeenCalledOnce()
+      expect(onFileUploaded).toHaveBeenCalledWith(mockFileRead)
+      expect(onFileUploadError).not.toHaveBeenCalled()
+    })
+
+    it('should call onFileUploadError with tempId when file creation fails', async () => {
+      const onFileProcessing = vi.fn()
+      const onFileCreate = vi.fn()
+      const onFileUploaded = vi.fn()
+      const onFileUploadError = vi.fn()
+
+      const upload = createUpload({
+        onFileProcessing,
+        onFileCreate,
+        onFileUploaded,
+        onFileUploadError,
+      })
+
+      vi.spyOn(upload, 'create').mockResolvedValue({
+        data: undefined,
+        error: { detail: 'Bad request' },
+        response: new Response(null, { status: 422 }),
+      } as any)
+
+      await upload.run()
+
+      expect(onFileProcessing).toHaveBeenCalledOnce()
+      expect(onFileCreate).not.toHaveBeenCalled()
+      expect(onFileUploaded).not.toHaveBeenCalled()
+      expect(onFileUploadError).toHaveBeenCalledOnce()
+      expect(onFileUploadError).toHaveBeenCalledWith(
+        upload.tempId,
+        expect.any(Error),
+      )
+    })
+
+    it('should call onFileUploadError with file id when S3 returns 403', async () => {
+      const onFileCreate = vi.fn()
+      const onFileUploaded = vi.fn()
+      const onFileUploadError = vi.fn()
+
+      const upload = createUpload({
+        onFileCreate,
+        onFileUploaded,
+        onFileUploadError,
+      })
+
+      vi.spyOn(upload, 'create').mockResolvedValue({
+        data: mockFileUpload,
+        error: undefined,
+        response: new Response(),
+      } as any)
+
+      mockXHR({ status: 403 })
+
+      await upload.run()
+
+      expect(onFileCreate).toHaveBeenCalledOnce()
+      expect(onFileUploaded).not.toHaveBeenCalled()
+      expect(onFileUploadError).toHaveBeenCalledOnce()
+      expect(onFileUploadError).toHaveBeenCalledWith(
+        'file-123',
+        expect.objectContaining({
+          message: expect.stringContaining('Failed to upload part'),
+        }),
+      )
+    })
+
+    it('should call onFileUploadError when XHR returns status 0 (network error)', async () => {
+      const onFileUploaded = vi.fn()
+      const onFileUploadError = vi.fn()
+
+      const upload = createUpload({ onFileUploaded, onFileUploadError })
+
+      vi.spyOn(upload, 'create').mockResolvedValue({
+        data: mockFileUpload,
+        error: undefined,
+        response: new Response(),
+      } as any)
+
+      mockXHR({ status: 0 })
+
+      await upload.run()
+
+      expect(onFileUploaded).not.toHaveBeenCalled()
+      expect(onFileUploadError).toHaveBeenCalledOnce()
+      expect(onFileUploadError).toHaveBeenCalledWith(
+        'file-123',
+        expect.objectContaining({
+          message: expect.stringContaining('Failed to upload part'),
+        }),
+      )
+    })
+
+    it('should call onFileUploadError when complete endpoint returns error', async () => {
+      const onFileUploaded = vi.fn()
+      const onFileUploadError = vi.fn()
+
+      const upload = createUpload({ onFileUploaded, onFileUploadError })
+
+      vi.spyOn(upload, 'create').mockResolvedValue({
+        data: mockFileUpload,
+        error: undefined,
+        response: new Response(),
+      } as any)
+
+      mockXHR()
+
+      vi.mocked(api.POST).mockResolvedValueOnce({
+        data: undefined,
+        error: { detail: 'NoSuchUpload' },
+        response: new Response(null, { status: 500 }),
+      } as any)
+
+      await upload.run()
+
+      expect(onFileUploaded).not.toHaveBeenCalled()
+      expect(onFileUploadError).toHaveBeenCalledOnce()
+      expect(onFileUploadError).toHaveBeenCalledWith(
+        'file-123',
+        expect.objectContaining({
+          message: expect.stringContaining('Failed to complete file upload'),
+        }),
+      )
+    })
+  })
+
+  describe('upload (single part XHR)', () => {
+    it('should resolve with completed part on success', async () => {
+      mockXHR({ status: 200, etag: '"etag-value"' })
+
+      const upload = createUpload()
+      const part = mockFileUpload.upload.parts[0]
+
+      const result = await upload.upload({ part, onProgress: vi.fn() })
+
+      expect(result).toEqual({
+        number: 1,
+        checksum_etag: '"etag-value"',
+        checksum_sha256_base64: 'abc123',
+      })
+    })
+
+    it('should reject when S3 returns non-200 status', async () => {
+      mockXHR({ status: 403 })
+
+      const upload = createUpload()
+      const part = mockFileUpload.upload.parts[0]
+
+      await expect(
+        upload.upload({ part, onProgress: vi.fn() }),
+      ).rejects.toThrow('Failed to upload part: HTTP 403')
+    })
+
+    it('should reject when ETag is missing from response', async () => {
+      mockXHR({ status: 200, etag: null })
+
+      const upload = createUpload()
+      const part = mockFileUpload.upload.parts[0]
+
+      await expect(
+        upload.upload({ part, onProgress: vi.fn() }),
+      ).rejects.toThrow('ETag not found in response')
+    })
+  })
+})

--- a/clients/apps/web/src/components/FileUpload/Upload.ts
+++ b/clients/apps/web/src/components/FileUpload/Upload.ts
@@ -17,6 +17,7 @@ interface UploadProperties {
   onFileCreate: (tempId: string, response: schemas['FileUpload']) => void
   onFileUploadProgress: (file: schemas['FileUpload'], uploaded: number) => void
   onFileUploaded: (response: FileRead) => void
+  onFileUploadError: (fileId: string, error: Error) => void
 }
 
 export class Upload {
@@ -28,6 +29,7 @@ export class Upload {
   onFileCreate: (tempId: string, response: schemas['FileUpload']) => void
   onFileUploadProgress: (file: schemas['FileUpload'], uploaded: number) => void
   onFileUploaded: (response: FileRead) => void
+  onFileUploadError: (fileId: string, error: Error) => void
 
   constructor({
     organization,
@@ -37,6 +39,7 @@ export class Upload {
     onFileCreate,
     onFileUploadProgress,
     onFileUploaded,
+    onFileUploadError,
   }: UploadProperties) {
     this.organization = organization
     this.service = service
@@ -46,6 +49,7 @@ export class Upload {
     this.onFileCreate = onFileCreate
     this.onFileUploadProgress = onFileUploadProgress
     this.onFileUploaded = onFileUploaded
+    this.onFileUploadError = onFileUploadError
   }
 
   async getSha256Base64(buffer: ArrayBuffer) {
@@ -206,7 +210,7 @@ export class Upload {
     })
 
     if (error) {
-      return
+      throw new Error('Failed to complete file upload')
     }
 
     this.onFileUploaded(data)
@@ -215,21 +219,27 @@ export class Upload {
   async run() {
     this.onFileProcessing(this.tempId, this.file)
 
-    const { data: createFileResponse, error } = await this.create()
-    if (error) {
-      return
+    let fileId = this.tempId
+    try {
+      const { data: createFileResponse, error } = await this.create()
+      if (error) {
+        throw new Error('Failed to create file upload')
+      }
+
+      fileId = createFileResponse.id
+      this.onFileCreate(this.tempId, createFileResponse)
+
+      const uploadedParts = await this.uploadMultiparts({
+        parts: createFileResponse.upload.parts,
+        onProgress: (uploaded: number) => {
+          this.onFileUploadProgress(createFileResponse, uploaded)
+        },
+      })
+
+      await this.complete(createFileResponse, uploadedParts)
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error('Upload failed')
+      this.onFileUploadError(fileId, error)
     }
-    const upload = createFileResponse.upload
-
-    this.onFileCreate(this.tempId, createFileResponse)
-
-    const uploadedParts = await this.uploadMultiparts({
-      parts: upload.parts,
-      onProgress: (uploaded: number) => {
-        this.onFileUploadProgress(createFileResponse, uploaded)
-      },
-    })
-
-    await this.complete(createFileResponse, uploadedParts)
   }
 }

--- a/clients/apps/web/src/components/FileUpload/index.ts
+++ b/clients/apps/web/src/components/FileUpload/index.ts
@@ -39,6 +39,7 @@ interface FileUploadProps<T extends FileRead | schemas['FileUpload']> {
   initialFiles: FileRead[]
   onFilesUpdated: (files: FileObject<T>[]) => void
   onFilesRejected?: (rejections: FileRejection[]) => void
+  onFileUploadError?: (fileName: string, error: Error) => void
 }
 
 export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
@@ -48,6 +49,7 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
   organization,
   onFilesUpdated,
   onFilesRejected,
+  onFileUploadError,
   initialFiles = [],
 }: FileUploadProps<T>) => {
   const [files, setFilesState] = useState<FileObject<T>[]>(
@@ -131,6 +133,14 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
     })
   }
 
+  const onFileError = (fileId: string, error: Error) => {
+    removeFile(fileId)
+    if (onFileUploadError) {
+      const file = files.find((f) => f.id === fileId)
+      onFileUploadError(file?.name ?? 'Unknown file', error)
+    }
+  }
+
   const onDrop = (acceptedFiles: File[], fileRejections: FileRejection[]) => {
     for (const file of acceptedFiles) {
       const upload = new Upload({
@@ -141,6 +151,7 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
         onFileCreate,
         onFileUploadProgress,
         onFileUploaded,
+        onFileUploadError: onFileError,
       })
       upload.run()
     }

--- a/clients/apps/web/src/components/Products/CreateProductPage.tsx
+++ b/clients/apps/web/src/components/Products/CreateProductPage.tsx
@@ -35,6 +35,7 @@ const reuploadMedia = async (
       onFileUploadProgress: () => {},
       onFileUploaded: (response) =>
         resolve(response as schemas['ProductMediaFileRead']),
+      onFileUploadError: (_fileId, error) => reject(error),
     })
     upload.run().catch(reject)
   })

--- a/clients/apps/web/src/hooks/queries/files.ts
+++ b/clients/apps/web/src/hooks/queries/files.ts
@@ -43,6 +43,7 @@ export const useFiles = (
         }
       }),
     retry: defaultRetry,
+    enabled: fileIds.length > 0,
   })
 
 export const usePatchFile = (


### PR DESCRIPTION
Act on errors, raise a toast and remove broken files instead of leaving the user stuck. 