### PR TITLE
feat: add AI Verdict label to organization review badges

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -200,8 +200,11 @@ class OverviewSection(ChecklistMixin):
                 else:
                     badge_class = "badge-neutral"
                     display_verdict = verdict
-                with tag.div(classes=f"badge {badge_class} badge-lg font-semibold"):
-                    text(display_verdict)
+                with tag.div(classes="flex items-center gap-1"):
+                    with tag.span(classes="text-sm text-base-content/60"):
+                        text("AI Verdict:")
+                    with tag.div(classes=f"badge {badge_class} badge-sm"):
+                        text(display_verdict)
 
                 risk_level = review_report.overall_risk_level.value
                 risk_badge_class = RISK_LEVEL_BADGE.get(risk_level, "badge-ghost")

--- a/server/polar/backoffice/organizations_v2/views/sections/review_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/review_section.py
@@ -100,8 +100,11 @@ class ReviewSection(ChecklistMixin):
                 else:
                     badge_class = VERDICT_BADGE.get(verdict, "badge-ghost")
                     display_verdict = verdict
-                with tag.div(classes=f"badge {badge_class} badge-lg"):
-                    text(display_verdict)
+                with tag.div(classes="flex items-center gap-1"):
+                    with tag.span(classes="text-sm font-medium"):
+                        text("AI Verdict:")
+                    with tag.div(classes=f"badge {badge_class} badge-sm"):
+                        text(display_verdict)
 
                 risk_level = review_report.overall_risk_level.value
                 risk_badge_class = RISK_LEVEL_BADGE.get(risk_level, "badge-ghost")


### PR DESCRIPTION
## 📋 Summary

Adds "AI Verdict:" label prefix to the verdict badges in the backoffice organization review sections to clarify that these are AI-generated recommendations. Also reduces badge size to `badge-sm` for visual consistency with the AI Risk badge.

## 🎯 What

- Added "AI Verdict:" label prefix in OverviewSection and ReviewSection
- Changed verdict badge size from `badge-lg` to `badge-sm`
- Applied consistent styling with the AI Risk badge

## 🤔 Why

To improve clarity in the backoffice UI by explicitly labeling AI suggestions and maintaining consistent visual hierarchy between verdict and risk badges.

## 🧪 Testing

- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- Changes affect only backoffice HTML rendering, manually verified