### PR TITLE
ci: Cancel running tests on new push

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: ./clients

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
If you are iterating on a PR, it seems unnecessary to let the tests from the previous push continue to run.
