### PR TITLE
fix: update backoffice internal links to organizations_v2

### DIFF
--- a/server/polar/backoffice/benefits/endpoints.py
+++ b/server/polar/backoffice/benefits/endpoints.py
@@ -44,7 +44,7 @@ class OrganizationColumn(datatable.DatatableAttrColumn[Benefit, BenefitSortPrope
     def __init__(self) -> None:
         super().__init__("organization.name", "Organization")
         self.href_getter = lambda r, i: str(
-            r.url_for("organizations-classic:get", id=i.organization_id)
+            r.url_for("organizations:detail", organization_id=i.organization_id)
         )
 
 

--- a/server/polar/backoffice/customers/components.py
+++ b/server/polar/backoffice/customers/components.py
@@ -21,7 +21,7 @@ class OrganizationColumn(datatable.DatatableAttrColumn[Customer, CustomerSortPro
     def __init__(self) -> None:
         super().__init__("organization.name", "Organization")
         self.href_getter = lambda r, i: str(
-            r.url_for("organizations-classic:get", id=i.organization_id)
+            r.url_for("organizations:detail", organization_id=i.organization_id)
         )
 
 

--- a/server/polar/backoffice/customers/endpoints.py
+++ b/server/polar/backoffice/customers/endpoints.py
@@ -213,8 +213,8 @@ async def get(
                                 "Name",
                                 href_getter=lambda r, i: str(
                                     r.url_for(
-                                        "organizations-classic:get",
-                                        id=i.organization_id,
+                                        "organizations:detail",
+                                        organization_id=i.organization_id,
                                     )
                                 ),
                             ),

--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -387,8 +387,8 @@ async def get(
                                 "Organization",
                                 href_getter=lambda r, i: str(
                                     r.url_for(
-                                        "organizations-classic:get",
-                                        id=i.organization.id,
+                                        "organizations:detail",
+                                        organization_id=i.organization.id,
                                     )
                                 ),
                             ),

--- a/server/polar/backoffice/products/endpoints.py
+++ b/server/polar/backoffice/products/endpoints.py
@@ -68,7 +68,7 @@ class OrganizationColumn(datatable.DatatableAttrColumn[Product, ProductSortPrope
     def __init__(self) -> None:
         super().__init__("organization.name", "Organization")
         self.href_getter = lambda r, i: str(
-            r.url_for("organizations-classic:get", id=i.organization_id)
+            r.url_for("organizations:detail", organization_id=i.organization_id)
         )
 
 
@@ -227,8 +227,8 @@ async def get(
                                 "Name",
                                 href_getter=lambda r, i: str(
                                     r.url_for(
-                                        "organizations-classic:get",
-                                        id=i.organization_id,
+                                        "organizations:detail",
+                                        organization_id=i.organization_id,
                                     )
                                 ),
                             ),

--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -57,7 +57,7 @@ class OrganizationColumn(
     def __init__(self) -> None:
         super().__init__("product.organization.name", "Organization")
         self.href_getter = lambda r, i: str(
-            r.url_for("organizations-classic:get", id=i.product.organization_id)
+            r.url_for("organizations:detail", organization_id=i.product.organization_id)
         )
 
 
@@ -318,8 +318,8 @@ async def get(
                                 "Organization",
                                 href_getter=lambda r, i: str(
                                     r.url_for(
-                                        "organizations-classic:get",
-                                        id=i.product.organization_id,
+                                        "organizations:detail",
+                                        organization_id=i.product.organization_id,
                                     )
                                 ),
                             ),

--- a/server/polar/backoffice/users/endpoints.py
+++ b/server/polar/backoffice/users/endpoints.py
@@ -277,7 +277,9 @@ async def get(
                     "organization.id",
                     "ID",
                     external_href=lambda r, i: str(
-                        r.url_for("organizations-classic:get", id=i.organization_id)
+                        r.url_for(
+                            "organizations:detail", organization_id=i.organization_id
+                        )
                     ),
                     clipboard=True,
                 ),

--- a/server/polar/backoffice/webhooks/endpoints.py
+++ b/server/polar/backoffice/webhooks/endpoints.py
@@ -91,7 +91,9 @@ async def list(
                     "organization.name",
                     "Organization",
                     external_href=lambda r, i: str(
-                        r.url_for("organizations-classic:get", id=i.organization_id)
+                        r.url_for(
+                            "organizations:detail", organization_id=i.organization_id
+                        )
                     ),
                 ),
             ).render(request, items):
@@ -186,8 +188,8 @@ async def get(
                                 "Name",
                                 href_getter=lambda r, i: str(
                                     r.url_for(
-                                        "organizations-classic:get",
-                                        id=i.organization_id,
+                                        "organizations:detail",
+                                        organization_id=i.organization_id,
                                     )
                                 ),
                             ),


### PR DESCRIPTION
## Summary

Update all internal links in backoffice modules to point to the organizations_v2 view instead of the classic view.

## What

Changed route references from `organizations-classic:get` (with `id=` parameter) to `organizations:detail` (with `organization_id=` parameter) across 8 files.

## Why

The organizations_v2 interface is the primary modern organization management view. Cross-module links should direct users to v2 instead of the legacy classic view.

## How

Updated URL generation calls in datatable column definitions and detail view href getters across webhooks, benefits, products, subscriptions, orders, customers, and users modules.