### PR TITLE
fe/checkout: Build before running tests

### DIFF
--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -51,7 +51,9 @@
     "MCP_OAUTH2_CLIENT_SECRET"
   ],
   "tasks": {
-    "test": {},
+    "test": {
+      "dependsOn": ["^build"]
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]


### PR DESCRIPTION
Since we now have checkout tests, they are breaking since there is a race condition on the ui package build and the tests running.
