### PR TITLE
feat: expand AI review dimensions by default in organizations backoffice

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from datetime import datetime
 
 from fastapi import Request
-from tagflow import tag, text
+from tagflow import attr, tag, text
 
 from polar.models import Organization
 from polar.organization_review.report import AnyAgentReport
@@ -239,6 +239,7 @@ class OverviewSection(ChecklistMixin):
             # Per-dimension breakdown (collapsible)
             if review_report.dimensions:
                 with tag.details(classes="mb-4"):
+                    attr("open", True)
                     with tag.summary(
                         classes="text-sm font-bold cursor-pointer hover:text-base-content"
                     ):


### PR DESCRIPTION
## 📋 Summary

Expands the AI review dimension breakdown sections by default in the organizations backoffice, improving visibility of dimension assessments.

## 🎯 What

- Added `open` attribute to `<details>` elements in overview and reviews sections
- Dimension breakdowns now display expanded on page load instead of requiring user interaction

## 🤔 Why

AI review dimensions contain important assessment data (risk levels, findings, recommendations). Making them expanded by default improves discoverability and reduces friction for backoffice users reviewing organizations.

## 🔧 How

Used tagflow's `attr("open", True)` pattern (consistent with existing codebase usage) to set the `open` HTML attribute on two `<details>` elements:
- `overview_section.py`: Dimension Breakdown section
- `reviews_section.py`: Full report details section (containing dimension breakdowns)

## 🧪 Testing

- [x] All existing tests pass (`uv run task test` for backend)
- [x] Lint and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] Changes tested in browser - dimensions now display expanded by default