### PR TITLE
fix: soft-delete members when customer is deleted

### DIFF
--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -94,6 +94,23 @@ class BenefitGrantRepository(
         )
         return await self.get_all(statement)
 
+    async def list_granted_by_member(
+        self,
+        member_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Sequence[BenefitGrant]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                BenefitGrant.member_id == member_id,
+                BenefitGrant.is_granted.is_(True),
+                BenefitGrant.is_deleted.is_(False),
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     async def list_granted_by_benefit_and_customer(
         self,
         benefit: Benefit,

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -614,6 +614,14 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         for grant in grants:
             enqueue_job("benefit.delete_grant", benefit_grant_id=grant.id)
 
+    async def enqueue_member_grant_deletions(
+        self, session: AsyncSession, member_id: UUID
+    ) -> None:
+        repository = BenefitGrantRepository.from_session(session)
+        grants = await repository.list_granted_by_member(member_id)
+        for grant in grants:
+            enqueue_job("benefit.delete_grant", benefit_grant_id=grant.id)
+
     async def enqueue_customer_grant_deletions(
         self, session: AsyncSession, customer: Customer
     ) -> None:

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -410,6 +410,8 @@ class CustomerService:
         enqueue_job("subscription.cancel_customer", customer_id=customer.id)
         enqueue_job("benefit.revoke_customer", customer_id=customer.id)
 
+        await member_service.delete_by_customer(session, customer.id)
+
         if anonymize:
             # Anonymize also sets deleted_at
             return await self.anonymize(session, customer)

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -137,6 +137,57 @@ class MemberService:
 
         return deleted_member
 
+    async def delete_by_customer(
+        self,
+        session: AsyncSession,
+        customer_id: UUID,
+    ) -> Sequence[Member]:
+        """
+        Soft-delete all members for a customer.
+
+        Unlike delete(), this skips the owner guard since the entire
+        customer is being removed.
+        """
+        from polar.benefit.grant.service import (
+            benefit_grant as benefit_grant_service,
+        )
+
+        repository = MemberRepository.from_session(session)
+        members = await repository.list_by_customer(session, customer_id)
+
+        if not members:
+            return []
+
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(
+            members[0].organization_id
+        )
+
+        deleted: list[Member] = []
+        for member in members:
+            enqueue_job("customer_seat.revoke_seats_for_member", member_id=member.id)
+            await benefit_grant_service.enqueue_member_grant_deletions(
+                session, member.id
+            )
+            deleted_member = await repository.soft_delete(member)
+            log.info(
+                "member.delete.success",
+                member_id=member.id,
+                customer_id=member.customer_id,
+                organization_id=member.organization_id,
+            )
+
+            if organization:
+                await webhook_service.send(
+                    session,
+                    organization,
+                    WebhookEventType.member_deleted,
+                    deleted_member,
+                )
+            deleted.append(deleted_member)
+
+        return deleted
+
     async def create_owner_member(
         self,
         session: AsyncSession,

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -20,7 +20,7 @@ from polar.redis import Redis
 from polar.tax.tax_id import TaxIDFormat
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_customer
+from tests.fixtures.random_objects import create_customer, create_member
 
 
 @pytest.mark.asyncio
@@ -836,6 +836,143 @@ class TestDelete:
                 external_id=recycled.external_id,
                 user_metadata=recycled.user_metadata,
             )
+
+    async def test_delete_soft_deletes_members(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Deleting a customer should soft-delete its members."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="member-cleanup@example.com",
+        )
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+
+        assert member.deleted_at is None
+        await customer_service.delete(session, customer)
+        await session.flush()
+
+        repository = MemberRepository.from_session(session)
+        active_members = await repository.list_by_customer(session, customer.id)
+        assert len(active_members) == 0
+
+    async def test_delete_prevents_duplicate_members_on_recreate(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """
+        Reproducer for the duplicate member bug:
+        1. Create customer → member auto-created
+        2. Delete customer → member should be deleted too
+        3. Create new customer with same email → new member created
+        4. Only ONE active member should exist for this email+org
+        """
+        customer1 = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="duplicate-test@example.com",
+        )
+        member1 = await create_member(
+            save_fixture,
+            customer=customer1,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+
+        await customer_service.delete(session, customer1)
+        await session.flush()
+
+        customer2 = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="duplicate-test@example.com",
+        )
+        member2 = await create_member(
+            save_fixture,
+            customer=customer2,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+
+        repository = MemberRepository.from_session(session)
+        active_members = await repository.list_by_email_and_organization(
+            session, "duplicate-test@example.com", organization.id
+        )
+        assert len(active_members) == 1
+        assert active_members[0].id == member2.id
+        assert active_members[0].customer_id == customer2.id
+
+    async def test_delete_with_anonymize_soft_deletes_members(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Deleting with anonymize=True should also soft-delete members."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="anon-member@example.com",
+            name="Anon Member User",
+        )
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+
+        assert member.deleted_at is None
+        await customer_service.delete(session, customer, anonymize=True)
+        await session.flush()
+
+        repository = MemberRepository.from_session(session)
+        active_members = await repository.list_by_customer(session, customer.id)
+        assert len(active_members) == 0
+
+    async def test_delete_with_multiple_members(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Deleting a customer should soft-delete all its members."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="multi-member@example.com",
+        )
+        member_owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="multi-member@example.com",
+        )
+        member_regular = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.member,
+            email="team-member@example.com",
+        )
+
+        await customer_service.delete(session, customer)
+        await session.flush()
+
+        repository = MemberRepository.from_session(session)
+        active_members = await repository.list_by_customer(session, customer.id)
+        assert len(active_members) == 0
 
 
 @pytest.mark.asyncio

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -674,3 +674,123 @@ class TestDelete:
             await member_service.delete(session, owner)
 
         assert "only owner" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+class TestDeleteByCustomer:
+    async def test_enqueues_seat_revocation_for_each_member(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock: MagicMock = mocker.patch("polar.member.service.enqueue_job")
+
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+        owner = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="owner@example.com",
+            name="Owner",
+            role=MemberRole.owner,
+        )
+        await save_fixture(owner)
+        regular = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="regular@example.com",
+            name="Regular",
+            role=MemberRole.member,
+        )
+        await save_fixture(regular)
+
+        deleted = await member_service.delete_by_customer(session, customer.id)
+
+        assert len(deleted) == 2
+        assert all(m.deleted_at is not None for m in deleted)
+
+        seat_revocation_calls = [
+            c
+            for c in enqueue_job_mock.call_args_list
+            if c.args[0] == "customer_seat.revoke_seats_for_member"
+        ]
+        assert len(seat_revocation_calls) == 2
+        revoked_member_ids = {c.kwargs["member_id"] for c in seat_revocation_calls}
+        assert revoked_member_ids == {owner.id, regular.id}
+
+    async def test_enqueues_benefit_grant_deletions_for_each_member(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_member_mock: MagicMock = mocker.patch(
+            "polar.benefit.grant.service.BenefitGrantService"
+            ".enqueue_member_grant_deletions"
+        )
+
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+        owner = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="owner@example.com",
+            name="Owner",
+            role=MemberRole.owner,
+        )
+        await save_fixture(owner)
+
+        await member_service.delete_by_customer(session, customer.id)
+
+        enqueue_member_mock.assert_called_once_with(session, owner.id)
+
+    async def test_skips_owner_guard(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """delete_by_customer should delete the only owner without raising."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+        owner = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="owner@example.com",
+            name="Owner",
+            role=MemberRole.owner,
+        )
+        await save_fixture(owner)
+
+        deleted = await member_service.delete_by_customer(session, customer.id)
+
+        assert len(deleted) == 1
+        assert deleted[0].deleted_at is not None
+
+    async def test_no_members_returns_empty(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+
+        deleted = await member_service.delete_by_customer(session, customer.id)
+
+        assert deleted == []


### PR DESCRIPTION
## Summary
- When a customer is deleted, all associated members are now soft-deleted
- Previously, deleting a customer left orphaned members behind, causing duplicate members when the same email was re-created as a new customer
- Discovered via production case where `angelosdaniil@gmail.com` had two active members in org `wiring-planner1`

## Test plan
- [x] `test_delete_soft_deletes_members` — verifies members are cleaned up on customer delete
- [x] `test_delete_prevents_duplicate_members_on_recreate` — reproduces the exact production bug
- [x] `test_delete_with_anonymize_soft_deletes_members` — covers the anonymize path
- [x] `test_delete_with_multiple_members` — covers team customers with multiple members
- [x] All 7 `TestDelete` tests pass
- [x] Lint passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)