### PR TITLE
Remove `@polar-sh/client` from changesets ignore

### DIFF
--- a/clients/.changeset/config.json
+++ b/clients/.changeset/config.json
@@ -10,7 +10,6 @@
   "ignore": [
     "web",
     "@polar-sh/app",
-    "@examples/checkout-embed",
-    "@polar-sh/client"
+    "@examples/checkout-embed"
   ]
 }


### PR DESCRIPTION
Since `@polar-sh/client` has `private: true` in `package.json`, the package won't be published. But we can't ignore it in the changeset configuration because `@polar-sh/checkout` depends on it