### PR TITLE
events: Remove event closures

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -4,6 +4,9 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    UUID as SA_UUID,
+)
+from sqlalchemy import (
     ColumnElement,
     ColumnExpressionArgument,
     Numeric,
@@ -15,12 +18,13 @@ from sqlalchemy import (
     cast,
     desc,
     func,
+    literal,
     literal_column,
     or_,
     select,
     text,
 )
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
 from sqlalchemy.orm import aliased, joinedload
 
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
@@ -264,6 +268,44 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         results = await self.get_all(statement)
         order = {id: i for i, id in enumerate(ids)}
         return sorted(results, key=lambda e: order.get(e.id, 0))
+
+    async def get_ancestors_batch(
+        self, event_ids: Sequence[UUID]
+    ) -> dict[UUID, list[str]]:
+        if not event_ids:
+            return {}
+
+        anchor = select(
+            Event.id.label("event_id"),
+            Event.parent_id.label("ancestor_id"),
+            literal(1).label("depth"),
+        ).where(Event.id.in_(event_ids), Event.parent_id.is_not(None))
+
+        cte = anchor.cte("ancestor_chain", recursive=True)
+        parent = Event.__table__.alias("parent")
+        recursive = (
+            select(
+                cte.c.event_id,
+                parent.c.parent_id.label("ancestor_id"),
+                (cte.c.depth + 1).label("depth"),
+            )
+            .select_from(cte.join(parent, cte.c.ancestor_id == parent.c.id))
+            .where(parent.c.parent_id.is_not(None))
+        )
+        cte = cte.union_all(recursive)
+
+        statement = select(
+            cte.c.event_id,
+            func.array_agg(
+                aggregate_order_by(cte.c.ancestor_id, cte.c.depth.asc()),
+                type_=SA_UUID(),
+            ).label("ancestors"),
+        ).group_by(cte.c.event_id)
+
+        result = await self.session.execute(statement)
+        return {
+            row.event_id: [str(aid) for aid in row.ancestors] for row in result.all()
+        }
 
     async def get_hierarchy_stats(
         self,

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -9,10 +9,7 @@ from zoneinfo import ZoneInfo
 import logfire
 import structlog
 from opentelemetry import trace
-from sqlalchemy import (
-    or_,
-    select,
-)
+from sqlalchemy import or_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import contains_eager
 
@@ -40,7 +37,6 @@ from polar.models import (
     Customer,
     CustomerMeter,
     Event,
-    EventClosure,
     Meter,
     MeterEvent,
     Organization,
@@ -723,6 +719,9 @@ class EventService:
         processed_events: dict[uuid.UUID, dict[str, Any]] = {}
 
         with logfire.span("process_events", event_count=len(sorted_metadata)):
+            # Events needs to be sorted here primarily for the purpose of root id
+            # resolution. Hierarchical events with parent_id in the same batch should
+            # get the same root id assigned.
             for metadata in sorted_metadata:
                 index = metadata["index"]
                 event_create = ingest.events[index]
@@ -825,93 +824,16 @@ class EventService:
         )
         return event
 
-    async def populate_event_closures_batch(
+    async def _build_ancestors_batch(
         self, session: AsyncSession, event_ids: Sequence[uuid.UUID]
     ) -> Mapping[uuid.UUID, Sequence[str]]:
-        if not event_ids:
-            return {}
-
-        result = await session.execute(
-            select(Event.id, Event.parent_id).where(Event.id.in_(event_ids))
-        )
-        events_data = result.all()
-
-        events_list = [
-            {"id": event_id, "parent_id": parent_id}
-            for event_id, parent_id in events_data
-        ]
-        sorted_events = _topological_sort_events(events_list)
-
-        all_closure_entries = []
-        event_closures: dict[uuid.UUID, list[tuple[uuid.UUID, int]]] = {}
-        ancestors_by_event: dict[uuid.UUID, list[str]] = {}
-
-        for event in sorted_events:
-            event_id = event["id"]
-            parent_id = event.get("parent_id")
-
-            event_closures[event_id] = [(event_id, 0)]
-            all_closure_entries.append(
-                {
-                    "ancestor_id": event_id,
-                    "descendant_id": event_id,
-                    "depth": 0,
-                }
-            )
-
-            if parent_id is not None:
-                # Check if parent is in current batch
-                if parent_id in event_closures:
-                    # Parent is in current batch, use in-memory closures
-                    for ancestor_id, depth in event_closures[parent_id]:
-                        event_closures[event_id].append((ancestor_id, depth + 1))
-                        all_closure_entries.append(
-                            {
-                                "ancestor_id": ancestor_id,
-                                "descendant_id": event_id,
-                                "depth": depth + 1,
-                            }
-                        )
-                else:
-                    # Parent is from previous batch, query database
-                    parent_closures_result = await session.execute(
-                        select(
-                            EventClosure.ancestor_id,
-                            EventClosure.depth,
-                        ).where(EventClosure.descendant_id == parent_id)
-                    )
-
-                    for ancestor_id, depth in parent_closures_result:
-                        event_closures[event_id].append((ancestor_id, depth + 1))
-                        all_closure_entries.append(
-                            {
-                                "ancestor_id": ancestor_id,
-                                "descendant_id": event_id,
-                                "depth": depth + 1,
-                            }
-                        )
-
-            ancestors_by_event[event_id] = [
-                str(aid)
-                for aid, d in sorted(event_closures[event_id], key=lambda x: x[1])
-                if d > 0
-            ]
-
-        if all_closure_entries:
-            await session.execute(
-                insert(EventClosure)
-                .values(all_closure_entries)
-                .on_conflict_do_nothing(index_elements=["ancestor_id", "descendant_id"])
-            )
-
-        return ancestors_by_event
+        repository = EventRepository.from_session(session)
+        return await repository.get_ancestors_batch(event_ids)
 
     async def ingested(
         self, session: AsyncSession, event_ids: Sequence[uuid.UUID]
     ) -> None:
-        ancestors_by_event = await self.populate_event_closures_batch(
-            session, event_ids
-        )
+        ancestors_by_event = await self._build_ancestors_batch(session, event_ids)
         repository = EventRepository.from_session(session)
         statement = (
             repository.get_base_statement()

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -9,18 +9,15 @@ from sqlalchemy import (
     ColumnElement,
     ForeignKey,
     Index,
-    Select,
     String,
     Uuid,
     and_,
     case,
-    event,
     exists,
     extract,
     literal_column,
     or_,
     select,
-    update,
 )
 from sqlalchemy import (
     cast as sql_cast,
@@ -28,7 +25,6 @@ from sqlalchemy import (
 from sqlalchemy import (
     cast as sqla_cast,
 )
-from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     Mapped,
@@ -440,55 +436,3 @@ class EventClosure(Model):
             foreign_keys="EventClosure.descendant_id",
             lazy="raise",
         )
-
-
-# Event listener to populate closure table when events are inserted
-@event.listens_for(Event, "after_insert")
-def populate_event_closure(mapper: Any, connection: Any, target: Event) -> None:
-    """
-    Automatically populate the closure table when an event is inserted.
-    This ensures the closure table is maintained even when using session.add() directly.
-    """
-    # Insert self-reference
-    connection.execute(
-        insert(EventClosure).values(
-            ancestor_id=target.id,
-            descendant_id=target.id,
-            depth=0,
-        )
-    )
-
-    # If event has a parent, copy parent's ancestors
-    if target.parent_id is not None:
-        parent_closures: Select[Any] = select(
-            EventClosure.ancestor_id,
-            literal_column(f"'{target.id}'::uuid").label("descendant_id"),
-            (EventClosure.depth + 1).label("depth"),
-        ).where(EventClosure.descendant_id == target.parent_id)
-
-        connection.execute(
-            insert(EventClosure).from_select(
-                ["ancestor_id", "descendant_id", "depth"],
-                parent_closures,
-            )
-        )
-
-    # Set root_id if not already set
-    if target.root_id is None:
-        if target.parent_id is None:
-            # This is a root event
-            connection.execute(
-                update(Event).where(Event.id == target.id).values(root_id=target.id)
-            )
-            target.root_id = target.id
-        else:
-            # Get parent's root_id
-            result = connection.execute(
-                select(Event.root_id).where(Event.id == target.parent_id)
-            )
-            parent_root_id = result.scalar_one_or_none()
-            root_id = parent_root_id or target.parent_id
-            connection.execute(
-                update(Event).where(Event.id == target.id).values(root_id=root_id)
-            )
-            target.root_id = root_id

--- a/server/tests/event/test_ancestors.py
+++ b/server/tests/event/test_ancestors.py
@@ -1,11 +1,12 @@
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import select
 
 from polar.auth.models import AuthSubject
+from polar.event.repository import EventRepository
 from polar.event.schemas import EventCreateExternalCustomer, EventsIngest
 from polar.event.service import event as event_service
 from polar.kit.db.postgres import AsyncSession
-from polar.models import Event, EventClosure, Organization
+from polar.models import Event, Organization
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -16,11 +17,11 @@ from tests.fixtures.random_objects import (
 
 
 @pytest.mark.asyncio
-class TestClosureTable:
-    async def test_closure_table_population_root_event(
+class TestGetAncestorsBatch:
+    async def test_root_event_has_no_ancestors(
         self, save_fixture: SaveFixture, session: AsyncSession
     ) -> None:
-        """Test that closure table is populated for a root event."""
+        """Test that a root event has no ancestors."""
         organization = await create_organization(save_fixture)
 
         # Create root event
@@ -30,24 +31,16 @@ class TestClosureTable:
             name="root",
         )
 
-        # Check that root_id is set to itself
-        assert root.root_id == root.id
+        repository = EventRepository.from_session(session)
+        result = await repository.get_ancestors_batch([root.id])
 
-        # Check closure table has self-reference
-        result = await session.execute(
-            select(EventClosure).where(EventClosure.descendant_id == root.id)
-        )
-        closures = result.scalars().all()
+        # Root events should not appear in the result (no ancestors)
+        assert root.id not in result
 
-        assert len(closures) == 1
-        assert closures[0].ancestor_id == root.id
-        assert closures[0].descendant_id == root.id
-        assert closures[0].depth == 0
-
-    async def test_closure_table_population_with_parent(
+    async def test_child_has_parent_as_ancestor(
         self, save_fixture: SaveFixture, session: AsyncSession
     ) -> None:
-        """Test that closure table is populated for events with parents."""
+        """Test that a child event has its parent as ancestor."""
         organization = await create_organization(save_fixture)
 
         # Create root event
@@ -65,35 +58,16 @@ class TestClosureTable:
             parent_id=root.id,
         )
 
-        # Check that child has correct root_id
-        assert child.root_id == root.id
-        assert child.parent_id == root.id
+        repository = EventRepository.from_session(session)
+        result = await repository.get_ancestors_batch([child.id])
 
-        # Check closure table for child
-        result = await session.execute(
-            select(EventClosure).where(EventClosure.descendant_id == child.id)
-        )
-        closures = result.scalars().all()
+        # Should have 1 ancestor: the parent
+        assert result[child.id] == [str(root.id)]
 
-        # Should have 2 rows: self-reference and link to parent
-        assert len(closures) == 2
-
-        # Find the rows
-        self_ref = next((c for c in closures if c.depth == 0), None)
-        parent_link = next((c for c in closures if c.depth == 1), None)
-
-        assert self_ref is not None
-        assert self_ref.ancestor_id == child.id
-        assert self_ref.descendant_id == child.id
-
-        assert parent_link is not None
-        assert parent_link.ancestor_id == root.id
-        assert parent_link.descendant_id == child.id
-
-    async def test_closure_table_population_grandchild(
+    async def test_grandchild_ancestors_ordered_by_depth(
         self, save_fixture: SaveFixture, session: AsyncSession
     ) -> None:
-        """Test that closure table is populated correctly for deeper hierarchies."""
+        """Test that ancestors are ordered by depth for deeper hierarchies."""
         organization = await create_organization(save_fixture)
 
         # Create root -> child -> grandchild
@@ -117,35 +91,16 @@ class TestClosureTable:
             parent_id=child.id,
         )
 
-        # Check root_id propagation
-        assert root.root_id == root.id
-        assert child.root_id == root.id
-        assert grandchild.root_id == root.id
+        repository = EventRepository.from_session(session)
+        result = await repository.get_ancestors_batch([grandchild.id])
 
-        # Check closure table for grandchild
-        result = await session.execute(
-            select(EventClosure)
-            .where(EventClosure.descendant_id == grandchild.id)
-            .order_by(EventClosure.depth)
-        )
-        closures = result.scalars().all()
+        # Should have 2 ancestors: parent (depth 1), grandparent (depth 2)
+        assert result[grandchild.id] == [str(child.id), str(root.id)]
 
-        # Should have 3 rows: self (depth 0), parent (depth 1), grandparent (depth 2)
-        assert len(closures) == 3
-
-        assert closures[0].ancestor_id == grandchild.id
-        assert closures[0].depth == 0
-
-        assert closures[1].ancestor_id == child.id
-        assert closures[1].depth == 1
-
-        assert closures[2].ancestor_id == root.id
-        assert closures[2].depth == 2
-
-    async def test_child_count_calculation(
+    async def test_batch_with_multiple_events(
         self, save_fixture: SaveFixture, session: AsyncSession
     ) -> None:
-        """Test that child_count is correctly calculated from closure table."""
+        """Test that ancestors are correctly computed for a batch of events."""
         organization = await create_organization(save_fixture)
 
         # Create root with 3 children
@@ -155,29 +110,30 @@ class TestClosureTable:
             name="root",
         )
 
+        children = []
         for i in range(3):
-            await create_event(
+            child = await create_event(
                 save_fixture,
                 organization=organization,
                 name=f"child{i}",
                 parent_id=root.id,
             )
+            children.append(child)
 
-        # Count descendants from closure table (excluding self-reference)
-        result = await session.execute(
-            select(func.count())
-            .select_from(EventClosure)
-            .where(
-                EventClosure.ancestor_id == root.id,
-                EventClosure.depth > 0,
-            )
+        repository = EventRepository.from_session(session)
+        result = await repository.get_ancestors_batch(
+            [root.id] + [c.id for c in children]
         )
-        child_count = result.scalar()
 
-        assert child_count == 3
+        # Root should have no ancestors
+        assert root.id not in result
+
+        # Each child should have root as its only ancestor
+        for child in children:
+            assert result[child.id] == [str(root.id)]
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
-    async def test_closure_table_batch_ingest_out_of_order(
+    async def test_batch_ingest_out_of_order(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -185,10 +141,8 @@ class TestClosureTable:
         auth_subject: AuthSubject[Organization],
     ) -> None:
         """
-        Test that closure table is correctly populated when multiple hierarchical
+        Test that ancestors are correctly computed when multiple hierarchical
         events are ingested in a single batch, even when out of order.
-
-        Tests the topological sort in populate_event_closures_batch.
         """
         customer = await create_customer(
             save_fixture, organization=organization, external_id="test-customer-123"
@@ -204,7 +158,7 @@ class TestClosureTable:
         # grandchild1 grandchild2
         #
         # Ingest order: grandchild2, child1, grandchild1, root, child2
-        # This tests that topological sort handles out-of-order ingestion
+        # This tests that the recursive CTE handles out-of-order ingestion
 
         ingest = EventsIngest(
             events=[
@@ -245,14 +199,16 @@ class TestClosureTable:
             ]
         )
 
-        response = await event_service.ingest(session, auth_subject, ingest)
+        await event_service.ingest(session, auth_subject, ingest)
 
-        # Manually populate closure table (normally done by background worker)
+        # Build ancestors (normally done by background worker)
         id_result = await session.execute(
             select(Event.id).where(Event.organization_id == organization.id)
         )
         event_ids = [row[0] for row in id_result.all()]
-        await event_service.populate_event_closures_batch(session, event_ids)
+
+        repository = EventRepository.from_session(session)
+        ancestors = await repository.get_ancestors_batch(event_ids)
 
         # Get all events
         event_result = await session.execute(
@@ -288,52 +244,13 @@ class TestClosureTable:
         assert grandchild2.parent_id == child2.id
         assert grandchild2.root_id == root.id
 
-        # Verify closure table for root (should have 4 descendants)
-        result = await session.execute(
-            select(EventClosure)
-            .where(EventClosure.ancestor_id == root.id)
-            .order_by(EventClosure.depth, EventClosure.descendant_id)
-        )
-        root_closures = result.scalars().all()
+        # Verify ancestors for root (should have none)
+        assert root.id not in ancestors
 
-        # Root should have: self (1) + children (2) + grandchildren (2) = 5 entries
-        assert len(root_closures) == 5
+        # Verify ancestors for children (should have root)
+        assert ancestors[child1.id] == [str(root.id)]
+        assert ancestors[child2.id] == [str(root.id)]
 
-        depths = {c.descendant_id: c.depth for c in root_closures}
-        assert depths[root.id] == 0
-        assert depths[child1.id] == 1
-        assert depths[child2.id] == 1
-        assert depths[grandchild1.id] == 2
-        assert depths[grandchild2.id] == 2
-
-        # Verify closure table for child1 (should have 1 descendant)
-        result = await session.execute(
-            select(EventClosure)
-            .where(EventClosure.ancestor_id == child1.id)
-            .order_by(EventClosure.depth)
-        )
-        child1_closures = result.scalars().all()
-
-        # child1 should have: self (1) + grandchild1 (1) = 2 entries
-        assert len(child1_closures) == 2
-        assert child1_closures[0].descendant_id == child1.id
-        assert child1_closures[0].depth == 0
-        assert child1_closures[1].descendant_id == grandchild1.id
-        assert child1_closures[1].depth == 1
-
-        # Verify closure table for grandchild1 (should have all ancestors)
-        result = await session.execute(
-            select(EventClosure)
-            .where(EventClosure.descendant_id == grandchild1.id)
-            .order_by(EventClosure.depth)
-        )
-        grandchild1_closures = result.scalars().all()
-
-        # grandchild1 should have: self (1) + parent (1) + grandparent (1) = 3 entries
-        assert len(grandchild1_closures) == 3
-        assert grandchild1_closures[0].ancestor_id == grandchild1.id
-        assert grandchild1_closures[0].depth == 0
-        assert grandchild1_closures[1].ancestor_id == child1.id
-        assert grandchild1_closures[1].depth == 1
-        assert grandchild1_closures[2].ancestor_id == root.id
-        assert grandchild1_closures[2].depth == 2
+        # Verify ancestors for grandchildren (parent first, then root)
+        assert ancestors[grandchild1.id] == [str(child1.id), str(root.id)]
+        assert ancestors[grandchild2.id] == [str(child2.id), str(root.id)]

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1945,10 +1945,15 @@ async def create_event(
     external_customer_id: str | None = None,
     external_id: str | None = None,
     parent_id: uuid.UUID | None = None,
+    root_id: uuid.UUID | None = None,
     metadata: dict[str, str | int | bool | float | Any] | None = None,
     event_type: EventType | None = None,
 ) -> Event:
+    event_id = uuid.uuid4()
+    if root_id is None:
+        root_id = parent_id if parent_id is not None else event_id
     event = Event(
+        id=event_id,
         timestamp=timestamp or utc_now(),
         source=source,
         name=name,
@@ -1956,6 +1961,7 @@ async def create_event(
         external_customer_id=external_customer_id,
         external_id=external_id,
         parent_id=parent_id,
+        root_id=root_id,
         organization=organization,
         user_metadata=metadata or {},
         event_type_id=event_type.id if event_type else None,


### PR DESCRIPTION
We stop writing to event closures and simplify the ancestor list generation via postgres recursive CTEs.