### PR TITLE
fix: prevent agent auto-approval when org is manually put under review

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -830,6 +830,17 @@ class OrganizationService:
         organization.status_updated_at = datetime.now(UTC)
         await self._sync_account_status(session, organization)
         session.add(organization)
+
+        # Record a human ESCALATE decision so the agent knows not to auto-act
+        review_repository = AgentReviewRepository.from_session(session)
+        await review_repository.deactivate_current_decisions(organization.id)
+        await review_repository.save_review_decision(
+            organization_id=organization.id,
+            actor_type="human",
+            decision="ESCALATE",
+            review_context="manual",
+        )
+
         if enqueue_review:
             enqueue_job("organization.under_review", organization_id=organization.id)
         return organization

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -114,6 +114,27 @@ async def run_review_agent(
         # For THRESHOLD context with auto-approve eligibility:
         # delegate decision to the service layer
         if review_context == ReviewContext.THRESHOLD and auto_approve_eligible:
+            # If a human manually set this org under review, skip auto-action
+            current_decision = await review_repository.get_current_decision(
+                organization_id
+            )
+            if (
+                current_decision is not None
+                and current_decision.actor_type == "human"
+                and current_decision.review_context == "manual"
+            ):
+                auto_approve_eligible = False
+                log.info(
+                    "organization_review.threshold.manual_review_override",
+                    organization_id=str(organization_id),
+                    slug=organization.slug,
+                    verdict=report.verdict.value,
+                )
+                await plain_service.create_organization_review_thread(
+                    session, organization
+                )
+
+        if review_context == ReviewContext.THRESHOLD and auto_approve_eligible:
             auto_approved = await organization_service.handle_ongoing_review_verdict(
                 session, organization, report.verdict
             )


### PR DESCRIPTION
## 📋 Summary

When an organization is manually set to ongoing review via the backoffice, the automated review agent should not take any action regardless of its verdict.

## 🎯 What

- Record a human ESCALATE feedback entry when an org is manually put under review
- Check for this feedback before auto-approving in the review agent task
- If a manual review is detected, skip auto-action and create a Plain thread for human review

## 🤔 Why

Previously, when an org was manually set to ongoing review, if the review agent ran (either from the old backoffice path with `enqueue_review=True` or from a threshold check), it could still auto-approve and increase thresholds. This violated the expectation that manual reviews should require explicit human decision-making.

## 🔧 How

Uses the existing `OrganizationReviewFeedback` table to persist a "manual review" signal without adding new schema. When `set_organization_under_review` is called, it records a human ESCALATE feedback. The `run_review_agent` task then checks for this before auto-approving in the threshold context.

## 🧪 Testing

- [x] All existing tests pass
- [x] Lint and type checking pass (`uv run task lint && uv run task lint_types`)

### Test Instructions

1. Manually set an org to ongoing review via backoffice
2. Trigger or let a threshold cause the agent to run
3. Verify the agent does not auto-approve and instead creates a Plain thread
4. Verify a human reviewer must explicitly approve/deny

## 📝 Additional Notes

This solution uses existing infrastructure (`OrganizationReviewFeedback` table) and requires no database migrations or schema changes.