### PR TITLE
fix: don't set org to initial_review in setup_complete handler

### DIFF
--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -180,15 +180,12 @@ async def run_review_agent(
                     verdict=report.verdict.value,
                 )
 
-        # For SETUP_COMPLETE context: hold payouts and create Plain thread on denial
+        # For SETUP_COMPLETE context: log the flagged verdict.
+        # Do NOT set the org to INITIAL_REVIEW here — that must only happen
+        # when check_review_threshold fires (on the first sale), so the
+        # organization_under_review task creates the Plain thread.
         if review_context == ReviewContext.SETUP_COMPLETE:
             if report.verdict == ReviewVerdict.DENY:
-                organization.status = OrganizationStatus.INITIAL_REVIEW
-                organization.status_updated_at = datetime.now(UTC)
-                session.add(organization)
-
-                await organization_service._sync_account_status(session, organization)
-
                 await review_repository.record_agent_decision(
                     organization_id=organization_id,
                     agent_review_id=agent_review.id,


### PR DESCRIPTION
## Summary

- The SETUP_COMPLETE DENY handler was prematurely setting the organization status to `initial_review`, which prevented `check_review_threshold` from firing when a sale came in (it early-returns if `is_under_review` is already true)
- This meant `organization_under_review` was never triggered, so no Plain thread was created for human review
- Orgs like `dezzani-rolando` and `fontofweb` got stuck in `initial_review` with no Plain ticket

## Test plan

- [ ] Verify that after a SETUP_COMPLETE DENY, the org status remains unchanged (e.g. `created`)
- [ ] Verify that when a sale comes in after SETUP_COMPLETE DENY, `check_review_threshold` fires and creates the Plain thread via `organization_under_review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)