### PR TITLE
fix: replace caplog with log mock in dunning order tests

### DIFF
--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2971,10 +2971,11 @@ class TestProcessDunningOrder:
         save_fixture: SaveFixture,
         customer: Customer,
         product: Product,
-        caplog: pytest.LogCaptureFixture,
+        mocker: MockerFixture,
     ) -> None:
         """Test that process_dunning_order logs warning for orders without subscription"""
         # Given
+        log_mock = mocker.patch("polar.order.service.log")
         order = await create_order(
             save_fixture,
             product=product,
@@ -2986,7 +2987,10 @@ class TestProcessDunningOrder:
         await order_service.process_dunning_order(session, order)
 
         # Then
-        assert "Order has no subscription, skipping dunning" in caplog.text
+        log_mock.warning.assert_called_once_with(
+            "Order has no subscription, skipping dunning",
+            order_id=order.id,
+        )
 
     async def test_process_dunning_order_cancelled_subscription(
         self,
@@ -3029,10 +3033,11 @@ class TestProcessDunningOrder:
         customer: Customer,
         product: Product,
         subscription: Subscription,
-        caplog: pytest.LogCaptureFixture,
+        mocker: MockerFixture,
     ) -> None:
         """Test that process_dunning_order logs warning for subscriptions without payment method"""
         # Given
+        log_mock = mocker.patch("polar.order.service.log")
         order = await create_order(
             save_fixture,
             product=product,
@@ -3048,8 +3053,10 @@ class TestProcessDunningOrder:
 
         # Then
         enqueue_job_mock.assert_not_called()
-        assert (
-            "Order subscription has no payment method, record a failure" in caplog.text
+        log_mock.warning.assert_called_once_with(
+            "Order subscription has no payment method, record a failure",
+            order_id=order.id,
+            subscription_id=subscription.id,
         )
 
     async def test_process_dunning_order_soft_deleted_payment_method(
@@ -3060,10 +3067,11 @@ class TestProcessDunningOrder:
         customer: Customer,
         product: Product,
         subscription: Subscription,
-        caplog: pytest.LogCaptureFixture,
+        mocker: MockerFixture,
     ) -> None:
         """Test that process_dunning_order logs warning for subscriptions with a soft deleted payment method"""
         # Given
+        log_mock = mocker.patch("polar.order.service.log")
         order = await create_order(
             save_fixture,
             product=product,
@@ -3083,8 +3091,10 @@ class TestProcessDunningOrder:
 
         # Then
         enqueue_job_mock.assert_not_called()
-        assert (
-            "Order subscription has no payment method, record a failure" in caplog.text
+        log_mock.warning.assert_called_once_with(
+            "Order subscription has no payment method, record a failure",
+            order_id=order.id,
+            subscription_id=subscription.id,
         )
 
     async def test_process_dunning_order_success(

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -137,9 +137,10 @@ class TestProcessDunningOrder:
         save_fixture: SaveFixture,
         product: Product,
         organization: Organization,
-        caplog: pytest.LogCaptureFixture,
+        mocker: MockerFixture,
     ) -> None:
         # Given
+        log_mock = mocker.patch("polar.order.service.log")
         customer = await create_customer(save_fixture, organization=organization)
         order = await create_order(
             save_fixture,
@@ -152,7 +153,10 @@ class TestProcessDunningOrder:
         await process_dunning_order(order.id)
 
         # Then
-        assert "Order has no subscription, skipping dunning" in caplog.text
+        log_mock.warning.assert_called_once_with(
+            "Order has no subscription, skipping dunning",
+            order_id=order.id,
+        )
 
     async def test_cancelled_subscription_order_cleared_from_dunning(
         self,
@@ -194,9 +198,10 @@ class TestProcessDunningOrder:
         save_fixture: SaveFixture,
         product: Product,
         organization: Organization,
-        caplog: pytest.LogCaptureFixture,
+        mocker: MockerFixture,
     ) -> None:
         # Given
+        log_mock = mocker.patch("polar.order.service.log")
         customer = await create_customer(save_fixture, organization=organization)
         subscription = await create_subscription(
             save_fixture,
@@ -220,8 +225,10 @@ class TestProcessDunningOrder:
         await process_dunning_order(order.id)
 
         # Then
-        assert (
-            "Order subscription has no payment method, record a failure" in caplog.text
+        log_mock.warning.assert_called_once_with(
+            "Order subscription has no payment method, record a failure",
+            order_id=order.id,
+            subscription_id=subscription.id,
         )
 
     async def test_valid_order_triggers_payment_retry(


### PR DESCRIPTION
## Summary

- Fixes 5 failing tests in `TestProcessDunningOrder` across `test_service.py` and `test_tasks.py`
- Root cause: `structlog.get_logger()` returns the root logger which has `propagate=False` in the logging config, so pytest's `caplog` fixture never captures the output
- Replaces `caplog.text` assertions with `mocker.patch("polar.order.service.log")` + `log_mock.warning.assert_called_once_with(...)`, matching the existing codebase pattern (e.g. `test_checkout_service.py`, `test_sender.py`)

## Test plan

- [x] All 12 tests in `TestProcessDunningOrder` pass (both files)
- [x] Lint passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)