### PR TITLE
Backfill member_id on license keys and downloadables

### DIFF
--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -47,11 +47,12 @@ import asyncio
 import logging.config
 import uuid
 from functools import wraps
-from typing import Any
+from typing import Any, cast
 
 import structlog
 import typer
 from sqlalchemy import String, func, or_, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import aliased, joinedload
 
 from polar.customer.repository import CustomerRepository
@@ -1126,13 +1127,16 @@ async def _backfill_license_keys(session: AsyncSession) -> int:
         .subquery()
     )
 
-    result = await session.execute(
-        update(LicenseKey)
-        .where(
-            LicenseKey.member_id.is_(None),
-            LicenseKey.id.cast(String) == lk_subq.c.lk_id,
-        )
-        .values(member_id=lk_subq.c.member_id)
+    result = cast(
+        CursorResult[Any],
+        await session.execute(
+            update(LicenseKey)
+            .where(
+                LicenseKey.member_id.is_(None),
+                LicenseKey.id.cast(String) == lk_subq.c.lk_id,
+            )
+            .values(member_id=lk_subq.c.member_id)
+        ),
     )
     return result.rowcount
 
@@ -1163,14 +1167,17 @@ async def _backfill_downloadables(session: AsyncSession) -> int:
         .subquery()
     )
 
-    result = await session.execute(
-        update(Downloadable)
-        .where(
-            Downloadable.member_id.is_(None),
-            Downloadable.customer_id == dl_subq.c.customer_id,
-            Downloadable.benefit_id == dl_subq.c.benefit_id,
-        )
-        .values(member_id=dl_subq.c.member_id)
+    result = cast(
+        CursorResult[Any],
+        await session.execute(
+            update(Downloadable)
+            .where(
+                Downloadable.member_id.is_(None),
+                Downloadable.customer_id == dl_subq.c.customer_id,
+                Downloadable.benefit_id == dl_subq.c.benefit_id,
+            )
+            .values(member_id=dl_subq.c.member_id)
+        ),
     )
     return result.rowcount
 

--- a/server/tests/organization/test_backfill_benefit_records.py
+++ b/server/tests/organization/test_backfill_benefit_records.py
@@ -1,13 +1,11 @@
 import uuid
 
 import pytest
-from sqlalchemy import select
 
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.utils import utc_now
 from polar.models.benefit import BenefitType
-from polar.models.benefit_grant import BenefitGrant
 from polar.models.downloadable import Downloadable, DownloadableStatus
 from polar.models.file import File, FileServiceTypes
 from polar.models.license_key import LicenseKey


### PR DESCRIPTION
## Summary

- The member model migration set `member_id` on `benefit_grants` but missed updating the related `license_keys` and `downloadables` rows
- This caused licenses to not appear in the customer portal for users logging in as members (e.g. `99alex@gmail.com`)
- Adds a `backfill-benefit-records` command to the migration script with two bulk UPDATE queries:
  - **License keys**: matched 1:1 via grant `properties->>'license_key_id'` (safe, exact join)
  - **Downloadables**: matched via `(customer_id, benefit_id)` with `DISTINCT ON` to pick the most recently granted grant

## Usage

```bash
# Dry run (shows counts)
uv run python -m scripts.migrate_organizations_members backfill-benefit-records

# Execute
uv run python -m scripts.migrate_organizations_members backfill-benefit-records --no-dry-run
```

## Test plan

- [x] 13 tests covering both license keys and downloadables backfill
- [x] Verifies correct member_id assignment from grants
- [x] Verifies already-linked records are skipped
- [x] Verifies grants without member_id are ignored
- [x] Verifies deleted grants are ignored
- [x] Verifies idempotency (second run updates 0)
- [x] Verifies multiple records are all backfilled
- [x] Verifies DISTINCT ON picks the most recent grant
- [x] Verifies cross-organization isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)