### PR TITLE
Prevent webhook endpoints with localhost URLs

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -24,6 +24,22 @@ type CreateOrUpdate =
   | schemas['WebhookEndpointCreate']
   | schemas['WebhookEndpointUpdate']
 
+const isPrivateIP = (hostname: string): boolean => {
+  const parts = hostname.split('.')
+  if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
+    const [a, b] = parts.map(Number)
+    if (a === 10) return true
+    if (a === 172 && b >= 16 && b <= 31) return true
+    if (a === 192 && b === 168) return true
+    if (a === 169 && b === 254) return true
+    if (a === 127) return true
+    if (a === 0) return true
+    if (a === 100 && b >= 64 && b <= 127) return true
+  }
+  if (/^\[?f[cd]/i.test(hostname) || /^\[?fe80/i.test(hostname)) return true
+  return false
+}
+
 export const FieldName = () => {
   const { control } = useFormContext<CreateOrUpdate>()
 
@@ -68,9 +84,18 @@ export const FieldUrl = () => {
           }
           try {
             const url = new URL(value)
-            const localhostHosts = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]']
-            if (localhostHosts.includes(url.hostname.toLowerCase())) {
-              return 'Webhook URLs cannot point to localhost.'
+            const hostname = url.hostname.toLowerCase()
+            const localhostHosts = [
+              'localhost',
+              '127.0.0.1',
+              '0.0.0.0',
+              '[::1]',
+            ]
+            if (localhostHosts.includes(hostname)) {
+              return 'Webhook URLs cannot point to localhost or private IP addresses.'
+            }
+            if (isPrivateIP(hostname)) {
+              return 'Webhook URLs cannot point to localhost or private IP addresses.'
             }
           } catch {
             return false

--- a/server/migrations/versions/2026-03-14-1200_disable_localhost_webhook_endpoints.py
+++ b/server/migrations/versions/2026-03-14-1200_disable_localhost_webhook_endpoints.py
@@ -1,4 +1,4 @@
-"""Disable localhost webhook endpoints
+"""Disable localhost and private IP webhook endpoints
 
 Revision ID: 147643549822
 Revises: 9b73bce01fd4
@@ -30,6 +30,11 @@ def upgrade() -> None:
                 OR url ~ '^https?://127\\.0\\.0\\.1([:/]|$)'
                 OR url ~ '^https?://\\[::1\\]([:/]|$)'
                 OR url ~ '^https?://0\\.0\\.0\\.0([:/]|$)'
+                OR url ~ '^https?://10\\.[0-9]+\\.[0-9]+\\.[0-9]+([:/]|$)'
+                OR url ~ '^https?://172\\.(1[6-9]|2[0-9]|3[01])\\.[0-9]+\\.[0-9]+([:/]|$)'
+                OR url ~ '^https?://192\\.168\\.[0-9]+\\.[0-9]+([:/]|$)'
+                OR url ~ '^https?://169\\.254\\.[0-9]+\\.[0-9]+([:/]|$)'
+                OR url ~ '^https?://100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\.[0-9]+\\.[0-9]+([:/]|$)'
               )
             """
         )

--- a/server/polar/webhook/schemas.py
+++ b/server/polar/webhook/schemas.py
@@ -1,3 +1,4 @@
+import ipaddress
 from typing import Annotated
 
 from pydantic import (
@@ -15,6 +16,17 @@ from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.organization.schemas import OrganizationID
 
 LOCALHOST_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "[::1]"}
+
+
+def is_blocked_webhook_host(host: str) -> bool:
+    if host.lower() in LOCALHOST_HOSTS:
+        return True
+    clean = host.strip("[]")
+    try:
+        return not ipaddress.ip_address(clean).is_global
+    except ValueError:
+        return False
+
 
 HttpsUrl = Annotated[
     AnyUrl,
@@ -106,8 +118,10 @@ class WebhookEndpointCreate(Schema):
     @field_validator("url", mode="after")
     @classmethod
     def validate_not_localhost(cls, v: AnyUrl) -> AnyUrl:
-        if v.host and v.host.lower() in LOCALHOST_HOSTS:
-            raise ValueError("Webhook URLs cannot point to localhost.")
+        if v.host and is_blocked_webhook_host(v.host):
+            raise ValueError(
+                "Webhook URLs cannot point to localhost or private IP addresses."
+            )
         return v
 
 
@@ -142,8 +156,10 @@ class WebhookEndpointUpdate(Schema):
     @field_validator("url", mode="after")
     @classmethod
     def validate_not_localhost(cls, v: AnyUrl | None) -> AnyUrl | None:
-        if v is not None and v.host and v.host.lower() in LOCALHOST_HOSTS:
-            raise ValueError("Webhook URLs cannot point to localhost.")
+        if v is not None and v.host and is_blocked_webhook_host(v.host):
+            raise ValueError(
+                "Webhook URLs cannot point to localhost or private IP addresses."
+            )
         return v
 
 

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from collections.abc import Sequence
 from typing import Literal, cast, overload
+from urllib.parse import urlparse
 from uuid import UUID
 
 import structlog
@@ -57,7 +58,11 @@ from polar.webhook.repository import (
 from polar.worker import enqueue_job
 
 from .eventstream import publish_webhook_event
-from .schemas import LOCALHOST_HOSTS, WebhookEndpointCreate, WebhookEndpointUpdate
+from .schemas import (
+    WebhookEndpointCreate,
+    WebhookEndpointUpdate,
+    is_blocked_webhook_host,
+)
 from .webhooks import SkipEvent, UnsupportedTarget, WebhookPayloadTypeAdapter
 
 log: Logger = structlog.get_logger()
@@ -158,15 +163,14 @@ class WebhookService:
     ) -> WebhookEndpoint:
         repository = WebhookEndpointRepository.from_session(session)
 
-        # Block enabling an endpoint that has a localhost URL
         is_enabling = update_schema.enabled is True and not endpoint.enabled
-        if is_enabling and self._is_localhost_url(endpoint.url):
+        if is_enabling and self._is_blocked_url(endpoint.url):
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "enabled"),
-                        "msg": "Cannot enable a webhook endpoint with a localhost URL. Please update the URL first.",
+                        "msg": "Cannot enable a webhook endpoint with a localhost or private IP URL. Please update the URL first.",
                         "input": update_schema.enabled,
                     }
                 ]
@@ -816,12 +820,10 @@ class WebhookService:
                 break
 
     @staticmethod
-    def _is_localhost_url(url: str) -> bool:
-        from urllib.parse import urlparse
-
+    def _is_blocked_url(url: str) -> bool:
         parsed = urlparse(url)
         hostname = parsed.hostname or ""
-        return hostname.lower() in LOCALHOST_HOSTS
+        return is_blocked_webhook_host(hostname)
 
     async def _get_event_target_endpoints(
         self,


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #<!-- issue number -->

This PR prevents webhook endpoints from being created or enabled with localhost URLs, which could pose a security risk by allowing webhooks to target local development environments.

## 🎯 What

- Added validation in `WebhookEndpointCreate` and `WebhookEndpointUpdate` schemas to reject localhost URLs (localhost, 127.0.0.1, 0.0.0.0, [::1])
- Added a database migration to disable any existing webhook endpoints with localhost URLs
- Added client-side validation in the webhook form to prevent users from entering localhost URLs
- Added a helper method `_is_localhost_url()` to the webhook service for URL validation
- Added logic to prevent enabling a webhook endpoint that has a localhost URL

## 🤔 Why

Webhook endpoints pointing to localhost URLs could be exploited to send webhook events to local development environments, potentially exposing sensitive data or allowing unauthorized access. This change ensures that only production-ready URLs (HTTPS) are allowed for webhook endpoints.

## 🔧 How

1. **Backend validation**: Added `validate_not_localhost()` field validators to both `WebhookEndpointCreate` and `WebhookEndpointUpdate` schemas that check the URL's hostname against a set of localhost addresses
2. **Database migration**: Created a migration that disables all existing webhook endpoints with localhost URLs to prevent them from being used
3. **Update protection**: Added logic in `update_endpoint()` to prevent enabling an endpoint if it has a localhost URL
4. **Client-side validation**: Added validation in the webhook form to show an error message when users try to enter a localhost URL
5. **Shared constants**: Defined `LOCALHOST_HOSTS` constant in schemas.py and reused it across the service layer

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking

### Test Instructions

1. Attempt to create a webhook endpoint with URL `https://localhost:8000/webhook` - should be rejected with validation error
2. Attempt to create a webhook endpoint with URL `https://127.0.0.1:8000/webhook` - should be rejected with validation error
3. Attempt to update an existing webhook endpoint to enable it if it has a localhost URL - should be rejected with validation error
4. Verify that webhook endpoints with valid HTTPS URLs can still be created and enabled normally
5. Run the database migration and verify that any existing localhost webhook endpoints are disabled

## 📝 Additional Notes

The migration uses PostgreSQL regex patterns to identify localhost URLs in various formats. The `downgrade()` function is intentionally left empty as we don't want to re-enable disabled endpoints if this migration is rolled back.

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally

https://claude.ai/code/session_01V3mC3E2cWGVkRhgXwmEtQ1