### PR TITLE
Fix: raise 422 on checkout external_id/email mismatch

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -221,6 +221,15 @@ class CheckoutCustomerDeleted(CheckoutError):
         super().__init__(message, 409)
 
 
+class CheckoutCustomerExternalIdMismatch(CheckoutError):
+    def __init__(self) -> None:
+        message = (
+            "A customer with this external ID already exists "
+            "but with a different email address."
+        )
+        super().__init__(message, 422)
+
+
 CHECKOUT_CLIENT_SECRET_PREFIX = "polar_c_"
 
 
@@ -2475,6 +2484,13 @@ class CheckoutService:
             customer = await repository.get_by_email_and_organization(
                 checkout.customer_email, checkout.organization.id
             )
+            if customer is None and checkout.external_customer_id is not None:
+                existing = await repository.get_by_external_id_and_organization(
+                    checkout.external_customer_id,
+                    checkout.organization.id,
+                )
+                if existing is not None:
+                    raise CheckoutCustomerExternalIdMismatch()
             if customer is None:
                 customer = Customer(
                     external_id=checkout.external_customer_id,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -26,6 +26,7 @@ from polar.checkout.schemas import (
 from polar.checkout.service import (
     AlreadyActiveSubscriptionError,
     CheckoutCustomerDeleted,
+    CheckoutCustomerExternalIdMismatch,
     NotConfirmedCheckout,
     NotOpenCheckout,
     TrialAlreadyRedeemed,
@@ -3885,6 +3886,85 @@ class TestConfirm:
                     }
                 ),
             )
+
+    async def test_external_id_mismatch(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+        organization: Organization,
+    ) -> None:
+        await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="EXTERNAL_ID",
+            email="existing@example.com",
+        )
+
+        checkout_one_time_fixed.external_customer_id = "EXTERNAL_ID"
+        await save_fixture(checkout_one_time_fixed)
+
+        with pytest.raises(CheckoutCustomerExternalIdMismatch):
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout_one_time_fixed,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "different@example.com",
+                        "customer_billing_address": {"country": "FR"},
+                    }
+                ),
+            )
+
+    async def test_external_id_no_mismatch_same_email(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+        organization: Organization,
+    ) -> None:
+        """When the email matches an existing customer with the same external_id,
+        the checkout should proceed normally (matched by email lookup)."""
+        existing = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="EXTERNAL_ID",
+            email="same@example.com",
+        )
+
+        checkout_one_time_fixed.external_customer_id = "EXTERNAL_ID"
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.update_customer.return_value = SimpleNamespace(
+            id=existing.stripe_customer_id
+        )
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                    "customer_name": "Customer Name",
+                    "customer_email": "same@example.com",
+                    "customer_billing_address": {"country": "FR"},
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.customer is not None
+        assert checkout.customer.id == existing.id
 
     async def test_archived_price(
         self,


### PR DESCRIPTION
## Summary
- When a checkout has an `external_customer_id` matching an existing customer but with a different email, raise a `422 CheckoutCustomerExternalIdMismatch` error instead of crashing with an `IntegrityError` on the `customers_organization_id_external_id_key` unique constraint
- Adds two tests: one for the mismatch error case, one for the happy path where email matches

## Test plan
- [x] `test_external_id_mismatch` — verifies 422 is raised when external_id exists with different email
- [x] `test_external_id_no_mismatch_same_email` — verifies checkout proceeds when email matches existing customer
- [x] `test_valid_stripe_new_customer_external_id` — existing test still passes
- [x] Backend lint passes
- [x] mypy type check passes

Fixes SERVER-465

🤖 Generated with [Claude Code](https://claude.com/claude-code)