### PR TITLE
feat: display identity verification status and country in team view

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -64,6 +64,7 @@ from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import ReviewAgentReport
 from polar.postgres import AsyncSession, get_db_session
 from polar.transaction.service.transaction import transaction as transaction_service
+from polar.user.service import user as user_service
 from polar.worker import enqueue_job
 
 from ..components import button, modal
@@ -611,7 +612,14 @@ async def get_organization_detail(
             elif section == "team":
                 # Get admin user for the organization
                 admin_user = await repository.get_admin_user(session, organization)
-                team_section = TeamSection(organization, admin_user)
+                identity_country = None
+                if admin_user:
+                    identity_country = await user_service.get_identity_verified_country(
+                        admin_user
+                    )
+                team_section = TeamSection(
+                    organization, admin_user, identity_country=identity_country
+                )
                 with team_section.render(request):
                     pass
             elif section == "account":

--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -4,9 +4,10 @@ import contextlib
 from collections.abc import Generator
 
 from fastapi import Request
-from tagflow import tag, text
+from tagflow import classes, tag, text
 
 from polar.models import Organization, User
+from polar.models.user import IdentityVerificationStatus
 
 from ....components import action_bar, button, card
 
@@ -14,9 +15,15 @@ from ....components import action_bar, button, card
 class TeamSection:
     """Render the team section with member management."""
 
-    def __init__(self, organization: Organization, admin_user: User | None = None):
+    def __init__(
+        self,
+        organization: Organization,
+        admin_user: User | None = None,
+        identity_country: str | None = None,
+    ):
         self.org = organization
         self.admin_user = admin_user
+        self.identity_country = identity_country
 
     @contextlib.contextmanager
     def render(self, request: Request) -> Generator[None]:
@@ -50,17 +57,39 @@ class TeamSection:
                                             )
 
                                     with tag.div():
-                                        with tag.div(classes="font-semibold"):
-                                            with tag.a(
-                                                href=str(
-                                                    request.url_for(
-                                                        "users:get",
-                                                        id=member.user_id,
-                                                    )
-                                                ),
-                                                classes="hover:text-primary hover:underline",
+                                        with tag.div(classes="flex items-center gap-2"):
+                                            with tag.span(classes="font-semibold"):
+                                                with tag.a(
+                                                    href=str(
+                                                        request.url_for(
+                                                            "users:get",
+                                                            id=member.user_id,
+                                                        )
+                                                    ),
+                                                    classes="hover:text-primary hover:underline",
+                                                ):
+                                                    text(member.user.email or "Unknown")
+                                            status = (
+                                                member.user.identity_verification_status
+                                            )
+                                            if (
+                                                status
+                                                != IdentityVerificationStatus.unverified
                                             ):
-                                                text(member.user.email or "Unknown")
+                                                with tag.div(classes="badge badge-sm"):
+                                                    if (
+                                                        status
+                                                        == IdentityVerificationStatus.failed
+                                                    ):
+                                                        classes("badge-warning")
+                                                    else:
+                                                        classes("badge-neutral")
+                                                    text(status.get_display_name())
+                                            if self.identity_country:
+                                                with tag.span(
+                                                    classes="text-sm text-base-content/60"
+                                                ):
+                                                    text(self.identity_country)
                                         with tag.div(
                                             classes="text-sm text-base-content/60"
                                         ):

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -192,6 +192,26 @@ class UserService:
             },
         )
 
+    async def get_identity_verified_country(self, user: User) -> str | None:
+        if user.identity_verification_id is None:
+            return None
+        try:
+            vs = await stripe_service.get_verification_session(
+                user.identity_verification_id,
+                expand=["verified_outputs"],
+            )
+            verified_outputs = getattr(vs, "verified_outputs", None)
+            if verified_outputs:
+                address = getattr(verified_outputs, "address", None)
+                if address:
+                    return address.country
+        except stripe_lib.StripeError:
+            log.warning(
+                "get_identity_verified_country.fetch_failed",
+                identity_verification_id=user.identity_verification_id,
+            )
+        return None
+
     async def delete_identity_verification(
         self, session: AsyncSession, user: User
     ) -> User:


### PR DESCRIPTION
## Summary

Display identity verification status and verified country in the team members list of the backoffice organization view.

## What

- Added identity verification status badge next to each team member's email
- Display verified country from Stripe identity verification session
- Badge uses neutral styling for verified/pending states, warning for failed

## Why

Admin users can now see at a glance which team members have verified their identity and from which country, improving transparency in the team management interface.

## How

- Created `UserService.get_identity_verified_country()` to fetch verified country from Stripe
- Updated `TeamSection` to accept and display identity_country parameter
- Endpoint calls the service to get country data and passes it to the view

## Testing

- Ran `uv run task lint` - all checks passed
- Ran `uv run task lint_types` - no type errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)