### PR TITLE
fix: handle soft-deleted customers in benefit revoke member resolution

### DIFF
--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -92,6 +92,8 @@ async def resolve_member(
     organization: Organization,
     member_id: UUID | None,
     is_seat_based: bool,
+    *,
+    include_deleted: bool = False,
 ) -> Member | None:
     member_model_enabled = organization.feature_settings.get(
         "member_model_enabled", False
@@ -120,7 +122,9 @@ async def resolve_member(
     if is_seat_based:
         raise MemberIdRequired()
 
-    member = await member_repository.get_owner_by_customer_id(session, customer_id)
+    member = await member_repository.get_owner_by_customer_id(
+        session, customer_id, include_deleted=include_deleted
+    )
     if member is None:
         # Auto-create owner member (graceful fallback during migration)
         customer_repository = CustomerRepository.from_session(session)

--- a/server/polar/benefit/tasks.py
+++ b/server/polar/benefit/tasks.py
@@ -234,6 +234,7 @@ async def benefit_revoke(
             organization=benefit.organization,
             member_id=member_id,
             is_seat_based=is_seat_based,
+            include_deleted=True,
         )
 
         try:

--- a/server/polar/member/repository.py
+++ b/server/polar/member/repository.py
@@ -114,6 +114,8 @@ class MemberRepository(
         self,
         session: AsyncReadSession,
         customer_id: UUID,
+        *,
+        include_deleted: bool = False,
     ) -> Member | None:
         """Get the owner member for a customer."""
         statement = (
@@ -121,10 +123,11 @@ class MemberRepository(
             .where(
                 Member.customer_id == customer_id,
                 Member.role == MemberRole.owner,
-                Member.is_deleted.is_(False),
             )
             .options(joinedload(Member.customer).joinedload(Customer.organization))
         )
+        if not include_deleted:
+            statement = statement.where(Member.is_deleted.is_(False))
         result = await session.execute(statement)
         return result.unique().scalar_one_or_none()
 

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -285,6 +285,79 @@ class TestResolveMember:
                 is_seat_based=False,
             )
 
+    async def test_b2c_deleted_owner_not_found_without_include_deleted(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+    ) -> None:
+        """B2C: Soft-deleted owner member is not found without include_deleted."""
+        organization = await create_organization(
+            save_fixture, feature_settings={"member_model_enabled": True}
+        )
+        customer = await create_customer(save_fixture, organization=organization)
+
+        owner_member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email=customer.email,
+            name="Owner",
+            role=MemberRole.owner,
+        )
+        owner_member.set_deleted_at()
+        await save_fixture(owner_member)
+
+        # Without include_deleted, the deleted owner is invisible
+        # and auto-create is attempted (but customer still exists so it succeeds)
+        result = await resolve_member(
+            session,
+            customer_id=customer.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=False,
+        )
+
+        assert result is not None
+        assert result.id != owner_member.id  # New member, not the deleted one
+
+    async def test_b2c_deleted_owner_found_with_include_deleted(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+    ) -> None:
+        """B2C: Soft-deleted owner member is found with include_deleted=True.
+        This is the benefit.revoke path for deleted customers."""
+        organization = await create_organization(
+            save_fixture, feature_settings={"member_model_enabled": True}
+        )
+        customer = await create_customer(save_fixture, organization=organization)
+
+        owner_member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email=customer.email,
+            name="Owner",
+            role=MemberRole.owner,
+        )
+        owner_member.set_deleted_at()
+        await save_fixture(owner_member)
+
+        # Soft-delete the customer too (matches the real scenario)
+        customer.set_deleted_at()
+        await save_fixture(customer)
+
+        result = await resolve_member(
+            session,
+            customer_id=customer.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=False,
+            include_deleted=True,
+        )
+
+        assert result is not None
+        assert result.id == owner_member.id
+        assert result.is_deleted
+
     async def test_nonexistent_member_id_b2b_raises_error(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

- Fix `CustomerDoesntHaveOwnerMember` error (SERVER-461) during `benefit.revoke` for deleted customers
- Root cause: `customer_service.delete()` soft-deletes all members **synchronously**, then enqueues `subscription.cancel_customer` which eventually triggers `benefit.revoke` **asynchronously** — by that time the owner member is already soft-deleted but `resolve_member()` filtered it out with `Member.is_deleted.is_(False)`
- Add `include_deleted` param to `get_owner_by_customer_id()` and `resolve_member()`, pass `True` from `benefit_revoke` to find the existing soft-deleted owner member

## Test plan

- [x] Added test: soft-deleted owner member is skipped without `include_deleted` (default behavior)
- [x] Added test: soft-deleted owner member is found with `include_deleted=True` (revoke path)
- [x] All 13 tests in `test_scope.py` pass
- [x] Backend lint + type check pass

Fixes SERVER-461

🤖 Generated with [Claude Code](https://claude.com/claude-code)