### PR TITLE
fix: fall back to document issuing country for identity verification

### DIFF
--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -198,13 +198,22 @@ class UserService:
         try:
             vs = await stripe_service.get_verification_session(
                 user.identity_verification_id,
-                expand=["verified_outputs"],
+                expand=["verified_outputs", "last_verification_report"],
             )
+            # Try verified address country first
             verified_outputs = getattr(vs, "verified_outputs", None)
             if verified_outputs:
                 address = getattr(verified_outputs, "address", None)
-                if address:
+                if address and address.country:
                     return address.country
+            # Fall back to document issuing country from the verification report
+            report = getattr(vs, "last_verification_report", None)
+            if report:
+                document = getattr(report, "document", None)
+                if document:
+                    issuing_country = getattr(document, "issuing_country", None)
+                    if issuing_country:
+                        return issuing_country
         except stripe_lib.StripeError:
             log.warning(
                 "get_identity_verified_country.fetch_failed",


### PR DESCRIPTION
## Summary
- Fix identity country not showing in backoffice team view for passport-based verifications
- The previous code only checked `verified_outputs.address.country`, which is only populated when address verification is enabled in the Stripe Identity session
- Now falls back to `last_verification_report.document.issuing_country` (the document's issuing country) when no verified address is available

## Test plan
- [ ] Verify the backoffice team view now shows "NG" for the organization at `10adc40f-e247-40ce-aea5-c3df7df5b26a`
- [ ] Confirm passport-based verifications show the document issuing country
- [ ] Confirm address-based verifications still show the address country (takes priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)