### PR TITLE
fix: revert reverse invoice iframe to S3 URL

### DIFF
--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -99,7 +99,7 @@ A modal will open, allowing you to:
 ### Sample Reverse Invoice
 
 <iframe
-  src="/assets/features/finance/payouts/sample-reverse-invoice.pdf"
+  src="https://polar-public-assets.s3.us-east-2.amazonaws.com/sample-reverse-invoice.pdf"
   width="100%"
   height="600px"
 ></iframe>


### PR DESCRIPTION
## 📋 Summary

Mintlify doesn't serve local PDFs as static assets and its Content Security Policy blocks iframe loading from the docs domain. Reverts the iframe `src` back to the S3 URL.

## 🎯 What

- Reverted the iframe source in `docs/features/finance/payouts.mdx` from local asset path back to the S3 URL

## 🤔 Why

The local asset path caused a 404 and CSP `frame-ancestors` violation on the deployed docs site.