### PR TITLE
tf: Lifecycle since the Slack variable is managed in the UI

### DIFF
--- a/terraform/global/main.tf
+++ b/terraform/global/main.tf
@@ -176,6 +176,10 @@ resource "tfe_variable" "slo_report_slack_channel" {
   description     = "Slack channel ID for SLO weekly reports"
   sensitive       = false
   variable_set_id = tfe_variable_set.global.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "tfe_variable" "cloudflare_api_token" {


### PR DESCRIPTION
The other variables are marked as sensitive so they dont get overwritten by a new run, whereas this one will always reset back to "" when the state is applied.
