### PR TITLE
fix: display correct Charges/Payouts enabled status in backoffice

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/account_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/account_section.py
@@ -136,11 +136,7 @@ class AccountSection:
 
                             with tag.div(classes="grid grid-cols-2 gap-3"):
                                 # Charges enabled
-                                charges_enabled = (
-                                    account.is_charges_enabled
-                                    if hasattr(account, "charges_enabled")
-                                    else False
-                                )
+                                charges_enabled = account.is_charges_enabled
                                 with tag.div(classes="flex items-center gap-2"):
                                     icon = "Yes" if charges_enabled else "No"
                                     color = (
@@ -153,11 +149,7 @@ class AccountSection:
                                     text("Charges Enabled")
 
                                 # Payouts enabled
-                                payouts_enabled = (
-                                    account.is_payouts_enabled
-                                    if hasattr(account, "payouts_enabled")
-                                    else False
-                                )
+                                payouts_enabled = account.is_payouts_enabled
                                 with tag.div(classes="flex items-center gap-2"):
                                     icon = "Yes" if payouts_enabled else "No"
                                     color = (


### PR DESCRIPTION
## 📋 Summary

Fixes incorrect display of account charge and payout status in the backoffice Payment Account section.

## 🎯 What

The "Charges Enabled" and "Payouts Enabled" badges were always showing "No" regardless of the actual account status.

## 🤔 Why

The code checked `hasattr(account, "charges_enabled")` but the actual attribute name is `is_charges_enabled` (with the `is_` prefix). This caused the hasattr check to always return False, falling through to the default False value.

## 🔧 How

Removed the unnecessary hasattr guards and directly use the account properties. Since `is_charges_enabled` and `is_payouts_enabled` are non-nullable Boolean columns on the Account model, they're always present.