### PR TITLE
fix: count distinct orders for refund rate instead of refund records

### DIFF
--- a/server/polar/backoffice/organizations/analytics.py
+++ b/server/polar/backoffice/organizations/analytics.py
@@ -72,10 +72,10 @@ class PaymentAnalyticsService:
         return count, total_amount, risk_scores
 
     async def get_refund_stats(self, organization_id: UUID4) -> tuple[int, int]:
-        """Get refund count and total amount in USD cents for organization."""
+        """Get count of orders with refunds and total refund amount in USD cents."""
         result = await self.session.execute(
             select(
-                func.count(Refund.id),
+                func.count(func.distinct(Refund.order_id)),
                 func.coalesce(-func.sum(Transaction.amount), 0),
             )
             .join(Order, Refund.order_id == Order.id)

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -611,7 +611,7 @@ class ReviewAnalyzer:
             if metrics.p90_risk_score is not None:
                 parts.append(f"P90 Risk Score: {metrics.p90_risk_score}")
             parts.append(
-                f"Refunds: {metrics.refund_count} (${metrics.refund_amount_cents / 100:,.2f})"
+                f"Refunded Orders: {metrics.refund_count} (${metrics.refund_amount_cents / 100:,.2f})"
             )
             if metrics.succeeded_payments > 0:
                 refund_rate = metrics.refund_count / metrics.succeeded_payments * 100

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -166,9 +166,9 @@ class OrganizationReviewRepository(
         return p50, p90
 
     async def get_refund_stats(self, organization_id: UUID) -> tuple[int, int]:
-        """Returns (refund_count, refund_amount_cents)."""
+        """Returns (refunded_orders_count, refund_amount_cents)."""
         statement = select(
-            func.count(Refund.id),
+            func.count(func.distinct(Refund.order_id)),
             func.coalesce(func.sum(Refund.amount), 0),
         ).where(
             Refund.organization_id == organization_id,

--- a/server/tests/backoffice/test_analytics.py
+++ b/server/tests/backoffice/test_analytics.py
@@ -128,6 +128,111 @@ class TestGetRefundStats:
         assert count == 1
         assert refund_amount == 1000  # USD, not 900 EUR
 
+    async def test_multiple_refunds_on_same_order_counts_as_one(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+    ) -> None:
+        """
+        When an order has multiple refunds (e.g. partial + remainder),
+        the count should reflect one refunded order, not the number of
+        refund records. The total amount should still sum all refunds.
+        """
+        org = await create_organization(save_fixture)
+        customer = await create_customer(
+            save_fixture, organization=org, stripe_customer_id="STRIPE_CUST_SPLIT"
+        )
+        order = await create_order(save_fixture, customer=customer)
+        payment = await create_payment(
+            save_fixture,
+            org,
+            amount=1100,
+            currency="usd",
+            status=PaymentStatus.succeeded,
+        )
+        # First partial refund
+        refund1 = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=999,
+            currency="usd",
+            processor_id="STRIPE_REFUND_1",
+        )
+        await create_refund_transaction(save_fixture, amount=-999, refund=refund1)
+        # Second refund (remainder) on the same order
+        refund2 = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=101,
+            currency="usd",
+            processor_id="STRIPE_REFUND_2",
+        )
+        await create_refund_transaction(save_fixture, amount=-101, refund=refund2)
+
+        service = PaymentAnalyticsService(session)
+        count, refund_amount = await service.get_refund_stats(org.id)
+
+        assert count == 1  # One order, not two refund records
+        assert refund_amount == 1100  # Total amount across both refunds
+
+    async def test_refunds_on_different_orders_counted_separately(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+    ) -> None:
+        """
+        Refunds on different orders should each be counted.
+        """
+        org = await create_organization(save_fixture)
+        customer = await create_customer(
+            save_fixture, organization=org, stripe_customer_id="STRIPE_CUST_MULTI"
+        )
+        order1 = await create_order(save_fixture, customer=customer)
+        payment1 = await create_payment(
+            save_fixture,
+            org,
+            amount=500,
+            currency="usd",
+            status=PaymentStatus.succeeded,
+            processor_id="STRIPE_PAY_1",
+        )
+        refund1 = await create_refund(
+            save_fixture,
+            order1,
+            payment1,
+            amount=500,
+            currency="usd",
+            processor_id="STRIPE_REFUND_A",
+        )
+        await create_refund_transaction(save_fixture, amount=-500, refund=refund1)
+
+        order2 = await create_order(save_fixture, customer=customer)
+        payment2 = await create_payment(
+            save_fixture,
+            org,
+            amount=300,
+            currency="usd",
+            status=PaymentStatus.succeeded,
+            processor_id="STRIPE_PAY_2",
+        )
+        refund2 = await create_refund(
+            save_fixture,
+            order2,
+            payment2,
+            amount=300,
+            currency="usd",
+            processor_id="STRIPE_REFUND_B",
+        )
+        await create_refund_transaction(save_fixture, amount=-300, refund=refund2)
+
+        service = PaymentAnalyticsService(session)
+        count, refund_amount = await service.get_refund_stats(org.id)
+
+        assert count == 2  # Two distinct orders
+        assert refund_amount == 800
+
     async def test_no_refunds(
         self,
         session: AsyncSession,

--- a/server/tests/organization_review/test_repository.py
+++ b/server/tests/organization_review/test_repository.py
@@ -30,7 +30,12 @@ from polar.organization_review.schemas import (
 )
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_payment
+from tests.fixtures.random_objects import (
+    create_customer,
+    create_order,
+    create_payment,
+    create_refund,
+)
 
 
 def _make_typed_report(
@@ -817,3 +822,118 @@ class TestGetRiskScorePercentiles:
         # [1,1,1,1,1,1,1,1,1,100]: p50=1, p90=int(10.9)=10
         assert p50 == 1
         assert p90 == 10
+
+
+@pytest.mark.asyncio
+class TestGetRefundStats:
+    async def test_multiple_refunds_on_same_order_counts_as_one(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """
+        Split refunds (partial + remainder) on the same order should count
+        as one refunded order, not inflate the refund rate.
+        """
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            stripe_customer_id="STRIPE_CUST_SPLIT_REVIEW",
+        )
+        order = await create_order(save_fixture, customer=customer)
+        payment = await create_payment(
+            save_fixture,
+            organization,
+            amount=1100,
+            currency="usd",
+            status=PaymentStatus.succeeded,
+        )
+        # Partial refund
+        await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=999,
+            currency="usd",
+            processor_id="STRIPE_REFUND_SPLIT_1",
+        )
+        # Remainder refund on the same order
+        await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=101,
+            currency="usd",
+            processor_id="STRIPE_REFUND_SPLIT_2",
+        )
+
+        repo = OrganizationReviewRepository.from_session(session)
+        count, refund_amount = await repo.get_refund_stats(organization.id)
+
+        assert count == 1  # One order, not two refund records
+        assert refund_amount == 1100  # Total amount across both refunds
+
+    async def test_refunds_on_different_orders_counted_separately(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Refunds on different orders should each be counted."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            stripe_customer_id="STRIPE_CUST_MULTI_REVIEW",
+        )
+        order1 = await create_order(save_fixture, customer=customer)
+        payment1 = await create_payment(
+            save_fixture,
+            organization,
+            amount=500,
+            currency="usd",
+            status=PaymentStatus.succeeded,
+            processor_id="STRIPE_PAY_REVIEW_1",
+        )
+        await create_refund(
+            save_fixture,
+            order1,
+            payment1,
+            amount=500,
+            currency="usd",
+            processor_id="STRIPE_REFUND_REVIEW_A",
+        )
+
+        order2 = await create_order(save_fixture, customer=customer)
+        payment2 = await create_payment(
+            save_fixture,
+            organization,
+            amount=300,
+            currency="usd",
+            status=PaymentStatus.succeeded,
+            processor_id="STRIPE_PAY_REVIEW_2",
+        )
+        await create_refund(
+            save_fixture,
+            order2,
+            payment2,
+            amount=300,
+            currency="usd",
+            processor_id="STRIPE_REFUND_REVIEW_B",
+        )
+
+        repo = OrganizationReviewRepository.from_session(session)
+        count, refund_amount = await repo.get_refund_stats(organization.id)
+
+        assert count == 2  # Two distinct orders
+        assert refund_amount == 800
+
+    async def test_no_refunds(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        count, refund_amount = await repo.get_refund_stats(organization.id)
+        assert count == 0
+        assert refund_amount == 0


### PR DESCRIPTION
## Summary
- Refund rate was calculated as `refund_records_count / payment_count`, which inflated the rate when an order had split refunds (e.g. partial + remainder). A single order refunded in two parts showed 200% instead of 100%.
- Changed to `count(distinct(order_id)) / payment_count` in both backoffice analytics and organization review repository queries.
- Added tests to prevent regression: split refunds on same order count as 1, refunds on different orders count separately.

## Test plan
- [ ] Verify `test_multiple_refunds_on_same_order_counts_as_one` passes in both test files
- [ ] Verify `test_refunds_on_different_orders_counted_separately` passes in both test files
- [ ] Verify existing refund stats tests still pass
- [ ] Check backoffice org review page shows correct refund rate for orgs with split refunds

🤖 Generated with [Claude Code](https://claude.com/claude-code)