### PR TITLE
dramatiq: Prevent zombie processes on shutdown

### DIFF
--- a/server/polar/worker/_asyncio.py
+++ b/server/polar/worker/_asyncio.py
@@ -1,0 +1,47 @@
+import asyncio
+
+import dramatiq
+import structlog
+from dramatiq.asyncio import get_event_loop_thread
+from dramatiq.middleware.asyncio import AsyncIO
+
+from polar.logging import Logger
+
+log: Logger = structlog.get_logger()
+
+
+async def _cancel_pending_tasks() -> None:
+    current = asyncio.current_task()
+    tasks = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if not tasks:
+        return
+    log.info("Cancelling pending asyncio tasks", count=len(tasks))
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+class GracefulAsyncIOMiddleware(AsyncIO):
+    """Extends dramatiq's AsyncIO middleware to cancel pending tasks before
+    stopping the event loop during shutdown.
+
+    Without this, worker threads stuck in run_coroutine() become zombies
+    after the event loop is stopped — their futures never resolve and they
+    spin until TimeLimit fires (up to 60 seconds), blocking process exit.
+    """
+
+    def after_worker_shutdown(
+        self, broker: dramatiq.Broker, worker: dramatiq.Worker
+    ) -> None:
+        event_loop_thread = get_event_loop_thread()
+        if event_loop_thread is None:
+            return
+
+        if event_loop_thread.loop.is_running():
+            event_loop_thread.run_coroutine(_cancel_pending_tasks())
+
+        super().after_worker_shutdown(broker, worker)

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -21,6 +21,7 @@ from polar.logfire import instrument_httpx
 from polar.logging import CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
 
+from ._asyncio import GracefulAsyncIOMiddleware
 from ._debounce import DebounceMiddleware
 from ._encoder import JSONEncoder
 from ._health import HealthMiddleware
@@ -186,7 +187,7 @@ def get_broker() -> dramatiq.Broker:
     middleware_list = [
         # Infrastructure & async support
         middleware.ShutdownNotifications(),
-        middleware.AsyncIO(),
+        GracefulAsyncIOMiddleware(),
         # Results backend for pipeline/group support
         Results(backend=result_backend, result_ttl=60_000),
         # Group completion callbacks for orchestrating task sequences

--- a/server/tests/worker/test_asyncio.py
+++ b/server/tests/worker/test_asyncio.py
@@ -1,0 +1,165 @@
+import asyncio
+import ctypes
+import threading
+import time
+from collections.abc import Iterator
+
+import dramatiq
+import pytest
+from dramatiq import Worker
+from dramatiq.asyncio import EventLoopThread, set_event_loop_thread
+from dramatiq.brokers.stub import StubBroker
+from dramatiq.threading import Interrupt
+
+from polar.worker._asyncio import GracefulAsyncIOMiddleware
+
+
+class FakeTimeLimitExceeded(Interrupt):
+    pass
+
+
+def raise_in_thread(thread: threading.Thread, exc_type: type[BaseException]) -> None:
+    ret = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_ulong(thread.ident),  # type: ignore[arg-type]
+        ctypes.py_object(exc_type),
+    )
+    if ret == 0:
+        raise ValueError("Thread not found")
+
+
+@pytest.fixture
+def event_loop_thread() -> Iterator[EventLoopThread]:
+    elt = EventLoopThread(
+        dramatiq.logging.get_logger(__name__), interrupt_check_ival=0.1
+    )
+    elt.start(timeout=1.0)
+    set_event_loop_thread(elt)
+    yield elt
+    if elt.loop.is_running():
+        elt.stop()
+    set_event_loop_thread(None)
+
+
+class TestZombieThreadsWithoutFix:
+    """Prove that stopping the event loop without cancelling tasks creates zombie threads."""
+
+    def test_threads_become_zombies(self, event_loop_thread: EventLoopThread) -> None:
+        ready = threading.Event()
+        thread_ref: threading.Thread | None = None
+        exited = threading.Event()
+
+        async def slow_coro() -> str:
+            await asyncio.sleep(300)
+            return "done"
+
+        def worker() -> None:
+            nonlocal thread_ref
+            thread_ref = threading.current_thread()
+            ready.set()
+            try:
+                event_loop_thread.run_coroutine(slow_coro())
+            except (RuntimeError, Interrupt):
+                pass
+            exited.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        ready.wait()
+        time.sleep(0.2)
+
+        # Stop event loop while coroutine is in-flight
+        event_loop_thread.stop()
+
+        # Thread should be stuck — it hasn't exited after 1 second
+        assert not exited.wait(timeout=1.0), "Thread should be a zombie but it exited"
+        assert t.is_alive()
+
+        # Only TimeLimit can unstick it
+        assert thread_ref is not None
+        raise_in_thread(thread_ref, FakeTimeLimitExceeded)
+        t.join(timeout=3.0)
+        assert not t.is_alive()
+
+
+class TestGracefulAsyncIOMiddleware:
+    """Verify the fix: cancelling tasks before stopping prevents zombies."""
+
+    def test_no_zombie_threads_on_shutdown(self) -> None:
+        middleware = GracefulAsyncIOMiddleware()
+        broker = StubBroker()
+        broker.add_middleware(middleware)
+
+        worker = Worker(broker, worker_timeout=100)
+        middleware.before_worker_boot(broker, worker)
+
+        elt = dramatiq.asyncio.get_event_loop_thread()
+        assert elt is not None
+
+        n_workers = 4
+        ready_events = [threading.Event() for _ in range(n_workers)]
+        exit_events = [threading.Event() for _ in range(n_workers)]
+        threads: list[threading.Thread] = []
+
+        async def slow_coro() -> str:
+            await asyncio.sleep(300)
+            return "done"
+
+        def thread_worker(idx: int) -> None:
+            ready_events[idx].set()
+            try:
+                elt.run_coroutine(slow_coro())
+            except (RuntimeError, Interrupt, asyncio.CancelledError):
+                pass
+            exit_events[idx].set()
+
+        for i in range(n_workers):
+            t = threading.Thread(target=thread_worker, args=(i,))
+            threads.append(t)
+            t.start()
+
+        for e in ready_events:
+            e.wait()
+        time.sleep(0.2)
+
+        # Graceful shutdown — should cancel tasks before stopping event loop
+        middleware.after_worker_shutdown(broker, worker)
+
+        # All threads should exit within 2 seconds (no zombies)
+        for i, e in enumerate(exit_events):
+            assert e.wait(timeout=2.0), f"Thread {i} is a zombie"
+
+        for t in threads:
+            t.join(timeout=1.0)
+            assert not t.is_alive()
+
+        broker.close()
+
+    def test_clean_shutdown_with_no_pending_tasks(self) -> None:
+        middleware = GracefulAsyncIOMiddleware()
+        broker = StubBroker()
+        broker.add_middleware(middleware)
+
+        worker = Worker(broker, worker_timeout=100)
+        middleware.before_worker_boot(broker, worker)
+
+        # Shutdown with nothing running — should not raise
+        middleware.after_worker_shutdown(broker, worker)
+
+        elt = dramatiq.asyncio.get_event_loop_thread()
+        assert elt is None
+
+        broker.close()
+
+    def test_idempotent_shutdown(self) -> None:
+        middleware = GracefulAsyncIOMiddleware()
+        broker = StubBroker()
+        broker.add_middleware(middleware)
+
+        worker = Worker(broker, worker_timeout=100)
+        middleware.before_worker_boot(broker, worker)
+        middleware.after_worker_shutdown(broker, worker)
+
+        # Second call should be safe (event_loop_thread is None)
+        middleware.after_worker_shutdown(broker, worker)
+
+        broker.close()


### PR DESCRIPTION
It seems like sometimes when we have invoked shutdown, some threads gets stuck waiting for a coroutine, wherein they are spinning in a polling loop (future.result(timeout=0.1) every 100ms) because the event loop was stopped and their future can never resolve. After 60+ seconds they get a "RuntimeError: Timed out while waiting for coroutine." which will kill them

These threads are then dead / zombiefied and kept alive even after the rest of the application has shut down.

This change ensures that ensures that those pending zombies gets canceled so that the application can shut down properly which otherwise prevents a deploy from happening.

```
Deploy SIGTERM
  → worker.stop(timeout=600000)
    → ShutdownNotifications raises Shutdown in threads
    → join_all waits for threads (some are zombies)
    → join_all returns (timeout or threads done)
    → "Stopping fork process..." ← health server killed
    → middleware cleanup (close HTTPX, Redis, DB, event loop)
    → "Worker has been shut down"
  → but zombie threads still alive, process can't fully exit
  → health endpoint dead, no messages processing
  → Render health check fails for 15 minutes
  → deploy marked as FAILED
````