### PR TITLE
backoffice: add Resync Stripe Account action

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2640,6 +2640,55 @@ async def setup_account(
     return None
 
 
+@router.post(
+    "/{organization_id}/resync-stripe-account",
+    name="organizations:resync_stripe_account",
+    response_model=None,
+)
+async def resync_stripe_account(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse:
+    repository = OrganizationRepository(session)
+    organization = await repository.get_by_id_with_account(organization_id)
+
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if not organization.account:
+        raise HTTPException(status_code=400, detail="Organization has no account")
+
+    if organization.account.account_type != AccountType.stripe:
+        raise HTTPException(status_code=400, detail="Account is not a Stripe account")
+
+    if not organization.account.stripe_id:
+        raise HTTPException(status_code=400, detail="Account does not have a Stripe ID")
+
+    stripe_account = await stripe_lib.Account.retrieve_async(
+        organization.account.stripe_id
+    )
+    await account_service.update_account_from_stripe(
+        session, stripe_account=stripe_account
+    )
+
+    logger.info(
+        "Stripe account resynced from backoffice",
+        organization_id=str(organization_id),
+        stripe_id=organization.account.stripe_id,
+        admin_user_id=str(user_session.user_id),
+    )
+
+    await add_toast(request, "Account resynced from Stripe", variant="success")
+
+    redirect_url = (
+        str(request.url_for("organizations:detail", organization_id=organization_id))
+        + "?section=account"
+    )
+    return HXRedirectResponse(request, redirect_url, 303)
+
+
 @router.api_route(
     "/{organization_id}/disconnect-stripe-account",
     name="organizations:disconnect_stripe_account",

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -520,6 +520,18 @@ class OrganizationDetailView:
                                     hx_target="#modal",
                                 ):
                                     text("Add Domain to Allowlist")
+                            if self.org.account and self.org.account.stripe_id:
+                                with tag.li():
+                                    with tag.a(
+                                        hx_post=str(
+                                            request.url_for(
+                                                "organizations:resync_stripe_account",
+                                                organization_id=self.org.id,
+                                            )
+                                        ),
+                                        hx_confirm="Resync account data from Stripe?",
+                                    ):
+                                        text("Resync Stripe Account")
                             with tag.li(classes="border-t border-base-200 mt-1 pt-1"):
                                 with tag.a(
                                     hx_get=str(


### PR DESCRIPTION
## Summary
- Adds a "Resync Stripe Account" action to the backoffice organization detail hamburger menu
- Fetches the latest account state directly from the Stripe API and updates our DB via `update_account_from_stripe`
- Only shown when the organization has a connected Stripe account

## Context
Stripe can silently enable `payouts_enabled` on connected accounts (particularly in countries like KZ, TR, IN) without sending the `account.updated` webhook. This leaves organizations stuck in `onboarding_started` status indefinitely. This action allows backoffice admins to manually trigger a resync to resolve the desync.

## Test plan
- [ ] Navigate to a backoffice organization detail page with a Stripe account
- [ ] Click the `⋮` hamburger menu — verify "Resync Stripe Account" appears
- [ ] Click "Resync Stripe Account" — verify confirmation dialog appears
- [ ] Confirm — verify toast "Account resynced from Stripe" appears and account data is updated
- [ ] Verify the menu item does NOT appear for organizations without a Stripe account

🤖 Generated with [Claude Code](https://claude.com/claude-code)