### PR TITLE
dramatiq: Add AsyncIO middleware wrapper

### DIFF
--- a/server/polar/worker/_asyncio.py
+++ b/server/polar/worker/_asyncio.py
@@ -1,0 +1,99 @@
+import asyncio
+import faulthandler
+import sys
+import tempfile
+import threading
+
+import dramatiq
+import structlog
+from dramatiq.asyncio import get_event_loop_thread
+from dramatiq.middleware.asyncio import AsyncIO
+
+from polar.logging import Logger
+
+log: Logger = structlog.get_logger()
+
+HEARTBEAT_INTERVAL = 5.0
+HEARTBEAT_TIMEOUT = 15.0
+
+
+class _EventLoopWatchdog(threading.Thread):
+    """Monitor thread that detects when the event loop stops responding.
+
+    Schedules a callback on the event loop every HEARTBEAT_INTERVAL seconds.
+    If the callback hasn't executed within HEARTBEAT_TIMEOUT seconds,
+    dumps all thread stacks to help diagnose what's blocking the event loop.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        heartbeat_interval: float = HEARTBEAT_INTERVAL,
+        heartbeat_timeout: float = HEARTBEAT_TIMEOUT,
+    ) -> None:
+        super().__init__(daemon=True, name="event-loop-watchdog")
+        self.loop = loop
+        self.heartbeat_interval = heartbeat_interval
+        self.heartbeat_timeout = heartbeat_timeout
+        self._stop_event = threading.Event()
+        self._heartbeat_event = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop_event.is_set():
+            self._heartbeat_event.clear()
+            try:
+                self.loop.call_soon_threadsafe(self._heartbeat_event.set)
+            except RuntimeError:
+                break
+
+            if not self._heartbeat_event.wait(timeout=self.heartbeat_timeout):
+                self._dump_stacks()
+
+            self._stop_event.wait(timeout=self.heartbeat_interval)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _dump_stacks(self) -> None:
+        with tempfile.TemporaryFile(mode="w+") as f:
+            faulthandler.dump_traceback(file=f, all_threads=True)
+            f.seek(0)
+            traceback_text = f.read()
+
+        log.error(
+            "event_loop_unresponsive",
+            timeout_seconds=self.heartbeat_timeout,
+            thread_stacks=traceback_text,
+        )
+        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+
+
+class MonitoredAsyncIO(AsyncIO):
+    """AsyncIO middleware with event loop health monitoring.
+
+    Extends the standard dramatiq AsyncIO middleware to start a watchdog
+    thread that monitors event loop responsiveness and dumps thread stacks
+    when the event loop stops responding.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._watchdog: _EventLoopWatchdog | None = None
+
+    def before_worker_boot(
+        self, broker: dramatiq.Broker, worker: dramatiq.Worker
+    ) -> None:
+        super().before_worker_boot(broker, worker)
+        event_loop_thread = get_event_loop_thread()
+        assert event_loop_thread is not None
+        self._watchdog = _EventLoopWatchdog(event_loop_thread.loop)
+        self._watchdog.start()
+
+    def after_worker_shutdown(
+        self, broker: dramatiq.Broker, worker: dramatiq.Worker
+    ) -> None:
+        if self._watchdog is not None:
+            self._watchdog.stop()
+            self._watchdog = None
+        super().after_worker_shutdown(broker, worker)

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -21,6 +21,7 @@ from polar.logfire import instrument_httpx
 from polar.logging import CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
 
+from ._asyncio import MonitoredAsyncIO
 from ._debounce import DebounceMiddleware
 from ._encoder import JSONEncoder
 from ._health import HealthMiddleware
@@ -186,7 +187,7 @@ def get_broker() -> dramatiq.Broker:
     middleware_list = [
         # Infrastructure & async support
         middleware.ShutdownNotifications(),
-        middleware.AsyncIO(),
+        MonitoredAsyncIO(),
         # Results backend for pipeline/group support
         Results(backend=result_backend, result_ttl=60_000),
         # Group completion callbacks for orchestrating task sequences

--- a/server/tests/worker/test_asyncio_watchdog.py
+++ b/server/tests/worker/test_asyncio_watchdog.py
@@ -1,0 +1,111 @@
+import asyncio
+import threading
+import time
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from polar.worker._asyncio import _EventLoopWatchdog
+
+
+@pytest.fixture
+def event_loop_thread() -> Iterator[asyncio.AbstractEventLoop]:
+    """An event loop running in a background thread."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2)
+    loop.close()
+
+
+class TestEventLoopWatchdog:
+    def test_healthy_loop_no_dump(
+        self, event_loop_thread: asyncio.AbstractEventLoop
+    ) -> None:
+        with patch.object(_EventLoopWatchdog, "_dump_stacks") as mock_dump:
+            watchdog = _EventLoopWatchdog(
+                event_loop_thread,
+                heartbeat_interval=0.05,
+                heartbeat_timeout=0.5,
+            )
+            watchdog.start()
+            time.sleep(0.3)
+            watchdog.stop()
+            watchdog.join(timeout=2)
+
+            mock_dump.assert_not_called()
+
+    def test_frozen_loop_triggers_dump(
+        self, event_loop_thread: asyncio.AbstractEventLoop
+    ) -> None:
+        blocker_started = threading.Event()
+
+        def block_loop() -> None:
+            blocker_started.set()
+            time.sleep(2)
+
+        event_loop_thread.call_soon_threadsafe(block_loop)
+        blocker_started.wait(timeout=1)
+
+        with patch.object(_EventLoopWatchdog, "_dump_stacks") as mock_dump:
+            watchdog = _EventLoopWatchdog(
+                event_loop_thread,
+                heartbeat_interval=0.05,
+                heartbeat_timeout=0.3,
+            )
+            watchdog.start()
+            time.sleep(0.6)
+            watchdog.stop()
+            watchdog.join(timeout=2)
+
+            mock_dump.assert_called()
+
+    def test_stops_cleanly_when_loop_closed(self) -> None:
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
+        watchdog = _EventLoopWatchdog(
+            loop, heartbeat_interval=0.05, heartbeat_timeout=0.5
+        )
+        watchdog.start()
+        time.sleep(0.1)
+
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+        watchdog.join(timeout=2)
+        assert not watchdog.is_alive()
+
+    def test_dump_contains_blocking_function_name(
+        self, event_loop_thread: asyncio.AbstractEventLoop
+    ) -> None:
+        blocker_started = threading.Event()
+
+        def obviously_blocking_function() -> None:
+            blocker_started.set()
+            time.sleep(2)
+
+        event_loop_thread.call_soon_threadsafe(obviously_blocking_function)
+        blocker_started.wait(timeout=1)
+
+        watchdog = _EventLoopWatchdog(
+            event_loop_thread,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+        )
+
+        with patch("polar.worker._asyncio.log") as mock_log:
+            watchdog.start()
+            time.sleep(0.6)
+            watchdog.stop()
+            watchdog.join(timeout=2)
+
+            mock_log.error.assert_called()
+            call_kwargs = mock_log.error.call_args_list[0][1]
+            assert "thread_stacks" in call_kwargs
+            assert "obviously_blocking_function" in call_kwargs["thread_stacks"]


### PR DESCRIPTION
Adds a watchdog wrapper to check if the event loop is stuck, and if so it dumps the context of all running threads.

This might be able to help us diagnose the issue where sometimes -after- deployment, the event loop gets stuck on a certain number of threads.
