### PR TITLE
fix: remove Ghana from allowed payout countries

### DIFF
--- a/server/polar/account/schemas.py
+++ b/server/polar/account/schemas.py
@@ -44,7 +44,6 @@ class StripeAccountCountry(StrEnum):
     FR = "FR"
     GM = "GM"
     DE = "DE"
-    GH = "GH"
     GR = "GR"
     GT = "GT"
     GY = "GY"


### PR DESCRIPTION
## Summary

Removes Ghana (GH) from the list of allowed countries for Stripe payout account creation due to temporary processing limitations.

## What

Removed the `GH = "GH"` entry from the `StripeAccountCountry` enum in `server/polar/account/schemas.py`.

## Why

Stripe is temporarily unable to process payouts to Ghana. This change prevents new accounts from being created with Ghana as their payout country.

## How

The enum is only used in the account creation schema (`AccountCreateForOrganization`), so this prevents new Ghana accounts from being created. The read schema uses a plain `str` type, so existing Ghana accounts will continue to serialize without issues.

## Testing

- [x] All existing tests pass
- [x] Linting and type checking pass