### PR TITLE
feat: enable seat-based billing by default for all new organizations

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -206,6 +206,7 @@ class OrganizationService:
         create_data = create_schema.model_dump(exclude_unset=True, exclude_none=True)
         feature_settings = create_data.get("feature_settings", {})
         feature_settings["member_model_enabled"] = True
+        feature_settings["seat_based_pricing_enabled"] = True
         create_data["feature_settings"] = feature_settings
 
         organization = await repository.create(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -88,7 +88,10 @@ class TestCreate:
 
         assert organization.name == "My New Organization"
         assert organization.slug == slug
-        assert organization.feature_settings == {"member_model_enabled": True}
+        assert organization.feature_settings == {
+            "member_model_enabled": True,
+            "seat_based_pricing_enabled": True,
+        }
 
         user_organization = await user_organization_service.get_by_user_and_org(
             session, auth_subject.subject.id, organization.id
@@ -120,6 +123,7 @@ class TestCreate:
         assert organization.feature_settings == {
             "issue_funding_enabled": False,
             "member_model_enabled": True,
+            "seat_based_pricing_enabled": True,
         }
 
     @pytest.mark.auth


### PR DESCRIPTION
## Summary

Enables seat-based billing by default for all new organizations. These organizations cannot disable this setting once enabled.

## What

- New organizations are created with `seat_based_pricing_enabled: true` in their feature settings
- Updated test assertions to expect seat-based pricing enabled by default
- All existing validation preventing disabling of seat-based pricing remains in place

## Why

Making seat-based billing the default for new organizations ensures all organizations adopt this billing model automatically.

## Testing

- All 100 organization service tests pass
- All 47 organization endpoint tests pass
- Lint and type checking pass