### PR TITLE
postgres: Disable prepared statement cache

### DIFF
--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -54,7 +54,7 @@ def create_async_engine(
     command_timeout: float | None = None,
     debug: bool = False,
 ) -> AsyncEngine:
-    connect_args: dict[str, Any] = {}
+    connect_args: dict[str, Any] = {"prepared_statement_cache_size": 0}
     if application_name is not None:
         connect_args["server_settings"] = {"application_name": application_name}
     if command_timeout is not None:


### PR DESCRIPTION
In the hopes that what we are seeing in terms of memory usage is this:
1. SQLAlchemy query cache (engine-level, 1 per engine)
- LRU, 500 entries
- Caches compiled SQL by query shape
- When evicted, compiled objects SHOULD be freed by GC

2. SQLAlchemy asyncpg adapter prepared statement cache (per connection, 100 entries)
- LRU, 100 per connection × 20 pool connections = 2,000 entries
- Caches by SQL string → prepared statement mapping
- Holds references to compiled result column metadata (ResultColumnsEntry, _ColumnsPlusNames, etc.)

3. asyncpg's own prepared statement cache (per connection, 100 entries)
- LRU, 100 per connection × 20 pool connections = 2,000 entries
- Caches by SQL string → PostgreSQL prepared statement handle
- Holds asyncpg.types.Type and asyncpg.types.Attribute for result type descriptions

Request comes in: SQLAlchemy compiles query (cache `#1` stores compiled objects) → SA asyncpg adapter prepares statement (cache `#2` references compiled objects) → asyncpg sends PREPARE to PostgreSQL (cache `#3` stores type info)

SQLAlchemy LRU evicts old query from cache `#1`, compiled objects should be freed but cache `#2` still holds a reference to them so they stay alive