### PR TITLE
fix: remove setup_complete organization review

### DIFF
--- a/server/polar/integrations/stripe/tasks.py
+++ b/server/polar/integrations/stripe/tasks.py
@@ -350,21 +350,9 @@ async def identity_verification_session_verified(event_id: uuid.UUID) -> None:
             verification_session = cast(
                 stripe_lib.identity.VerificationSession, event.stripe_data.data.object
             )
-            user = await user_service.identity_verification_verified(
+            await user_service.identity_verification_verified(
                 session, verification_session
             )
-
-            # Check if any org where this user is account admin is ready for
-            # a SETUP_COMPLETE review (identity verification is often the last step)
-            from polar.organization.service import organization as organization_service
-
-            organizations = (
-                await organization_service._get_organizations_for_account_admin(
-                    session, user.id
-                )
-            )
-            for org in organizations:
-                await organization_service.check_setup_complete_review(session, org)
 
 
 @actor(

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -134,18 +134,6 @@ class OrganizationRepository(
         )
         return await self.get_all(statement)
 
-    async def get_all_by_account_admin(self, user_id: UUID) -> Sequence[Organization]:
-        """Get all organizations where the user is the account admin."""
-        statement = (
-            self.get_base_statement()
-            .join(Account, Organization.account_id == Account.id)
-            .where(
-                Account.admin_id == user_id,
-                Organization.blocked_at.is_(None),
-            )
-        )
-        return await self.get_all(statement)
-
     def get_sorting_clause(self, property: OrganizationSortProperty) -> SortingClause:
         match property:
             case OrganizationSortProperty.created_at:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -890,10 +890,6 @@ class OrganizationService:
             await self._sync_account_status(session, organization)
             session.add(organization)
 
-            # When org just became ACTIVE, check for setup complete review
-            if became_active:
-                await self.check_setup_complete_review(session, organization)
-
     async def _sync_account_status(
         self, session: AsyncSession, organization: Organization
     ) -> None:
@@ -1161,59 +1157,6 @@ class OrganizationService:
             },
         )
         return organization
-
-    async def _get_organizations_for_account_admin(
-        self, session: AsyncSession, user_id: UUID
-    ) -> Sequence[Organization]:
-        """Get all organizations where the user is the account admin."""
-        repository = OrganizationRepository.from_session(session)
-        return await repository.get_all_by_account_admin(user_id)
-
-    async def check_setup_complete_review(
-        self, session: AsyncSession, organization: Organization
-    ) -> None:
-        """Check if all setup steps are done and trigger a SETUP_COMPLETE review.
-
-        Prerequisites:
-        1. Organization details submitted
-        2. Account exists with is_details_submitted=True
-        3. Account admin has identity_verification_status == verified
-        4. No existing SETUP_COMPLETE review
-        5. Organization is ACTIVE (not already under review/denied)
-        """
-        if not organization.is_active():
-            return
-
-        if not organization.details_submitted_at:
-            return
-
-        if not organization.account_id:
-            return
-
-        account_repository = AccountRepository.from_session(session)
-        account = await account_repository.get_by_id(
-            organization.account_id, options=(joinedload(Account.admin),)
-        )
-        if not account or not account.is_details_submitted:
-            return
-
-        admin = account.admin
-        if (
-            not admin
-            or admin.identity_verification_status != IdentityVerificationStatus.verified
-        ):
-            return
-
-        # Check for existing SETUP_COMPLETE review
-        agent_review_repository = AgentReviewRepository.from_session(session)
-        if await agent_review_repository.has_setup_complete_review(organization.id):
-            return
-
-        enqueue_job(
-            "organization_review.run_agent",
-            organization_id=organization.id,
-            context=ReviewContext.SETUP_COMPLETE,
-        )
 
 
 organization = OrganizationService()

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -228,52 +228,6 @@ Examples for APPROVE:
 - "Your account has been verified and is ready to accept payments."
 """
 
-SETUP_COMPLETE_PREAMBLE = """\
-This is a SETUP_COMPLETE review. The user just has completed ALL setup steps \
-(product created, organization details submitted, payout account connected, identity verified) but has NOT yet \
-received any payments. You have access to products, account info, identity status, \
-and Stripe account metadata.
-
-Focus on:
-- **Product price anomalies**: Flag one-time products priced above $1,000 or recurring \
-products above $500/month.
-- **Product-business mismatch**: Cross-reference products listed on Polar against the \
-organization's stated business. Look for mismatches suggesting a disguised prohibited business.
-- **Identity & account signals**:
-  - Unverified identity is a red flag. Identity verification errors (e.g. "selfie_mismatch", \
-"document_expired") indicate potential fraud even if verification eventually succeeded.
-  - Compare the account country with the support address country and the verified address \
-country from identity verification — mismatches are yellow flags.
-  - Stripe capabilities that are not "active" (e.g. "restricted", "pending") mean Stripe \
-itself has concerns about this account.
-  - Outstanding requirements_currently_due items at SETUP_COMPLETE stage are unusual.
-  - **Stripe verification errors** (requirements.errors) are critical signals. Codes like \
-"verification_document_fraudulent", "verification_document_manipulated", or "rejected.fraud" \
-in disabled_reason are strong fraud indicators. "verification_failed_keyed_identity" means \
-Stripe could not verify the person's identity information.
-  - A non-null **disabled_reason** (especially "rejected.*" values) means Stripe itself has \
-flagged this account. "requirements.past_due" items are overdue and more concerning than \
-"currently_due".
-- **Identity cross-reference**: Compare the verified name (from identity document) with \
-the Stripe business name and the Polar organization name. For individual accounts, the \
-verified name should match the business name. Significant mismatches are yellow flags.
-- **Business profile cross-reference**: There are two types of Stripe business, \
-individual and business. Compare the Stripe business name and URL with the \
-Polar organization name and website. Significant mismatches are yellow flags.
-- **Prior history** (assess under IDENTITY_TRUST): Check for prior denials or blocked organizations.
-
-Set FINANCIAL_RISK to LOW risk with confidence 0 — no payments have occurred yet.
-Set SETUP_READINESS to LOW risk with confidence 0 — setup was just completed, integration is not expected yet.
-
-Website leniency: If the website is inaccessible, returns errors, or has minor discrepancies \
-with the stated business, do NOT treat this as a red flag. Many legitimate businesses have \
-websites that are under construction, temporarily down, or not yet updated. Only flag website \
-issues if there is a clear and obvious sign of a prohibited business.
-
-Return only APPROVE or DENY.
-"""
-
-
 THRESHOLD_PREAMBLE = f"""\
 This is a THRESHOLD review triggered when a payment threshold is hit. \
 Perform a comprehensive analysis across ALL five dimensions, including SETUP_READINESS. \
@@ -383,7 +337,6 @@ class ReviewAnalyzer:
 
         instructions = {
             ReviewContext.SUBMISSION: SUBMISSION_PREAMBLE,
-            ReviewContext.SETUP_COMPLETE: SETUP_COMPLETE_PREAMBLE,
             ReviewContext.THRESHOLD: THRESHOLD_PREAMBLE,
             ReviewContext.MANUAL: MANUAL_PREAMBLE,
         }.get(context)

--- a/server/polar/organization_review/eval/task.py
+++ b/server/polar/organization_review/eval/task.py
@@ -17,7 +17,6 @@ _VERDICT_MAP = {
 
 CONTEXT_MAP = {
     "submission": ReviewContext.SUBMISSION,
-    "setup_complete": ReviewContext.SETUP_COMPLETE,
     "threshold": ReviewContext.THRESHOLD,
     "manual": ReviewContext.MANUAL,
 }

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -56,16 +56,6 @@ class OrganizationReviewRepository(
         self.session.add(agent_review)
         return agent_review
 
-    async def has_setup_complete_review(self, organization_id: UUID) -> bool:
-        """Check if a SETUP_COMPLETE agent review already exists."""
-        statement = select(func.count(OrganizationAgentReview.id)).where(
-            OrganizationAgentReview.organization_id == organization_id,
-            OrganizationAgentReview.report["review_type"].as_string()
-            == "setup_complete",
-        )
-        result = await self.session.execute(statement)
-        return (result.scalar() or 0) > 0
-
     async def get_latest_agent_review(
         self, organization_id: UUID
     ) -> OrganizationAgentReview | None:

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
 class ReviewContext(StrEnum):
     SUBMISSION = "submission"  # First review at details submission time
-    SETUP_COMPLETE = "setup_complete"  # Review when all setup steps are done
     THRESHOLD = "threshold"  # Following reviews when payment threshold hit
     MANUAL = "manual"  # Full manual review triggered from backoffice
 

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -200,25 +200,3 @@ async def run_review_agent(
                     slug=organization.slug,
                     verdict=report.verdict.value,
                 )
-
-        # For SETUP_COMPLETE context: log the flagged verdict.
-        # Do NOT set the org to INITIAL_REVIEW here — that must only happen
-        # when check_review_threshold fires (on the first sale), so the
-        # organization_under_review task creates the Plain thread.
-        if review_context == ReviewContext.SETUP_COMPLETE:
-            if report.verdict == ReviewVerdict.DENY:
-                await review_repository.record_agent_decision(
-                    organization_id=organization_id,
-                    agent_review_id=agent_review.id,
-                    decision="ESCALATE",
-                    review_context="setup_complete",
-                    verdict=report.verdict.value,
-                    risk_score=report.overall_risk_score,
-                )
-
-                log.info(
-                    "organization_review.setup_complete.flagged",
-                    organization_id=str(organization_id),
-                    slug=organization.slug,
-                    verdict=report.verdict.value,
-                )

--- a/server/tests/organization_review/test_repository.py
+++ b/server/tests/organization_review/test_repository.py
@@ -1,10 +1,8 @@
 from datetime import UTC, datetime
-from typing import Any
 
 import pytest
 
 from polar.models.organization import Organization
-from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.payment import PaymentStatus
 from polar.models.user import User
 from polar.organization_review.report import (
@@ -78,23 +76,6 @@ def _make_typed_report(
         duration_seconds=1.0,
         usage=UsageInfo(),
     )
-
-
-def _make_legacy_report(
-    *,
-    context: str | None = None,
-) -> dict[str, Any]:
-    """Build a legacy (pre-versioning) report dict for backward-compat tests.
-
-    If context is given it is nested under data_snapshot (old format).
-    """
-    report: dict[str, Any] = {
-        "report": {"verdict": "APPROVE", "overall_risk_score": 10.0},
-        "model_used": "test-model",
-    }
-    if context is not None:
-        report.setdefault("data_snapshot", {})["context"] = context
-    return report
 
 
 @pytest.mark.asyncio
@@ -178,73 +159,6 @@ class TestSaveAgentReview:
 
 
 @pytest.mark.asyncio
-class TestHasSetupCompleteReview:
-    async def test_returns_true_for_new_format(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        """New records with top-level review_type are found."""
-        repo = OrganizationReviewRepository.from_session(session)
-        typed_report = _make_typed_report(review_type="setup_complete")
-        await repo.save_agent_review(
-            organization_id=organization.id,
-            report=typed_report,
-            reviewed_at=datetime.now(UTC),
-        )
-        await session.flush()
-
-        assert await repo.has_setup_complete_review(organization.id) is True
-
-    async def test_returns_false_for_other_type(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        repo = OrganizationReviewRepository.from_session(session)
-        typed_report = _make_typed_report(review_type="submission")
-        await repo.save_agent_review(
-            organization_id=organization.id,
-            report=typed_report,
-            reviewed_at=datetime.now(UTC),
-        )
-        await session.flush()
-
-        assert await repo.has_setup_complete_review(organization.id) is False
-
-    async def test_returns_false_when_no_reviews(
-        self, session: AsyncSession, organization: Organization
-    ) -> None:
-        repo = OrganizationReviewRepository.from_session(session)
-        assert await repo.has_setup_complete_review(organization.id) is False
-
-    async def test_legacy_records_without_review_type(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        """Old records that only have data_snapshot.context are NOT matched.
-
-        This verifies we don't break on legacy data — they simply won't match
-        the new query, which is the expected behavior.
-        """
-        legacy_review = OrganizationAgentReview(
-            organization_id=organization.id,
-            report=_make_legacy_report(context="setup_complete"),
-            model_used="test-model",
-            reviewed_at=datetime.now(UTC),
-        )
-        await save_fixture(legacy_review)
-
-        repo = OrganizationReviewRepository.from_session(session)
-        # Legacy record without top-level review_type won't match
-        assert await repo.has_setup_complete_review(organization.id) is False
-
-
-@pytest.mark.asyncio
 class TestGetLatestAgentReview:
     async def test_returns_latest_by_reviewed_at(
         self,
@@ -262,7 +176,7 @@ class TestGetLatestAgentReview:
         await repo.save_agent_review(
             organization_id=organization.id,
             report=_make_typed_report(
-                review_type="setup_complete",
+                review_type="threshold",
                 model_used="model-b",
                 verdict=ReviewVerdict.DENY,
             ),
@@ -275,7 +189,7 @@ class TestGetLatestAgentReview:
         assert latest.model_used == "model-b"
         parsed = latest.parsed_report
         assert isinstance(parsed, AgentReportV2)
-        assert parsed.review_type == "setup_complete"
+        assert parsed.review_type == "threshold"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The setup_complete review provided no value and is being removed. Organizations already go through submission review before this point, making this intermediate review redundant.

## What

Removed SETUP_COMPLETE enum value, review triggers, and all supporting code. This includes:
- Removed `SETUP_COMPLETE` from `ReviewContext` enum
- Removed `has_setup_complete_review()` repository method
- Removed `check_setup_complete_review()` from organization service
- Removed setup_complete triggers on org becoming active and identity verification completion
- Removed `SETUP_COMPLETE_PREAMBLE` from analyzer

## Why

The setup_complete review occurs after submission review but before any actual payment activity. Since the submission review already evaluates the organization, this intermediate review adds no new value and wastes resources.

## How

Removed all code paths that trigger or handle setup_complete reviews. Old reviews stored in the database with setup_complete context remain queryable and displayable for historical reference.

🤖 Generated with Claude Code