### PR TITLE
Fix: Use standard datetime.timedelta instead of sqlalchemy_utils

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -1,7 +1,7 @@
 import builtins
 import uuid
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import structlog
@@ -9,7 +9,6 @@ from pydantic import TypeAdapter
 from sqlalchemy import UnaryExpression, asc, desc, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
-from sqlalchemy_utils.types.range import timedelta
 
 from polar.auth.models import AuthSubject
 from polar.benefit.grant.repository import BenefitGrantRepository


### PR DESCRIPTION
Fixes #10374 - Wrong timedelta import causes incorrect Redis TTL handling

The code was importing timedelta from `sqlalchemy_utils.types.range` which is intended for database range types, not general time calculations. This could cause incorrect `.total_seconds()` behavior and wrong Redis TTL values.

Changed to use standard library `datetime.timedelta` for proper time calculations and Redis cache expiration.