### PR TITLE
fix: handle defer_seconds=0 correctly in BenefitRetriableError

### DIFF
--- a/server/polar/benefit/strategies/base/service.py
+++ b/server/polar/benefit/strategies/base/service.py
@@ -47,8 +47,13 @@ class BenefitRetriableError(BenefitServiceError):
     def defer_milliseconds(self) -> int | None:
         """
         Number of milliseconds to wait before retrying.
+
+        Uses explicit None check instead of truthiness to handle defer_seconds=0.
+        Ensures a minimum delay of 1 second (1000ms) to avoid overly aggressive retries.
         """
-        return self.defer_seconds * 1000 if self.defer_seconds else None
+        if self.defer_seconds is not None:
+            return max(1000, self.defer_seconds * 1000)
+        return None
 
 
 class BenefitActionRequiredError(BenefitServiceError):


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes defer_milliseconds truthiness bug in benefit retry logic

<!-- Brief description of what this PR does -->

## 🎯 What

Fixed the `defer_milliseconds` property in `BenefitRetriableError` class to correctly handle `defer_seconds=0`. Previously, when `defer_seconds` was set to 0, the property incorrectly returned `None` instead of applying a delay.

## 🤔 Why

The bug was caused by using a truthiness check (`if self.defer_seconds`) instead of an explicit None check. In Python, `0` is a falsy value, so when `defer_seconds=0`, the condition evaluated to `False` and returned `None`.

This caused inconsistent behavior:
- When `defer_seconds=0` (intending immediate/minimal retry), workers used their default retry delay (15 seconds minimum)
- When `defer_seconds=None`, workers also used their default retry delay
- These two scenarios should have different behaviors

## 🔧 How

**Root Cause:**
```python
# Before (buggy)
return self.defer_seconds * 1000 if self.defer_seconds else None
```

**Fix:**
```python
# After (fixed)
if self.defer_seconds is not None:
    return max(1000, self.defer_seconds * 1000)
return None
```

**Changes:**
1. Use explicit `is not None` check instead of truthiness evaluation
2. Apply conservative strategy with minimum 1 second delay (1000ms)
3. This prevents overly aggressive retries while fixing the truthiness bug

**Behavior Changes:**
| Scenario | Before | After |
|----------|--------|-------|
| `defer_seconds=0` | Returns `None` → 15s backoff | Returns `1000` → 1s delay |
| `defer_seconds=None` | Returns `None` → 15s backoff | Returns `None` → 15s backoff |
| `defer_seconds>0` | Returns `seconds * 1000` | Returns `seconds * 1000` |

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have verified the fix with standalone test scripts

### Test Instructions

The fix was verified with standalone test scripts that confirm:
- `defer_seconds=0` now returns `1000` (minimum 1 second)
- `defer_seconds=None` returns `None`
- `defer_seconds>0` returns correct milliseconds calculation

```bash
# Verification script
python -c "
from polar.benefit.strategies.base.service import BenefitRetriableError

# Test the fix
error = BenefitRetriableError(defer_seconds=0)
assert error.defer_milliseconds == 1000

error = BenefitRetriableError(defer_seconds=None)
assert error.defer_milliseconds is None

error = BenefitRetriableError(defer_seconds=60)
assert error.defer_milliseconds == 60000

print('✓ Fix verified')
"
```

## 📝 Additional Notes

The conservative fix ensures a minimum delay of 1 second even when `defer_seconds=0`, which prevents potential pressure on upstream services (GitHub API) while still fixing the truthiness bug. This is safer than allowing truly immediate retries (0ms).

The fix has no breaking changes as there are no known usages of `defer_seconds=0` in the production codebase. Rate limit handling uses `int(e.retry_after.total_seconds())` which is unlikely to return 0.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] All tests pass locally