### PR TITLE
Add default value to review_type field in AgentReportV2

### DIFF
--- a/server/polar/organization_review/report.py
+++ b/server/polar/organization_review/report.py
@@ -122,7 +122,8 @@ class AgentReportV2(Schema):
     version: Literal[2] = 2
 
     review_type: str = Field(
-        description="Review trigger context: submission, setup_complete, threshold, manual"
+        default="unknown",
+        description="Review trigger context: submission, setup_complete, threshold, manual",
     )
 
     report: ReviewAgentReport = Field(description="The core AI analysis output")


### PR DESCRIPTION
## 📋 Summary

Adds a default value to the `review_type` field in the `AgentReportV2` schema to handle cases where the review trigger context is not explicitly provided.

## 🎯 What

Added `default="unknown"` to the `review_type` field in the `AgentReportV2` class in `server/polar/organization_review/report.py`.

## 🤔 Why

This change ensures that the `review_type` field always has a value, even when not explicitly provided during schema instantiation. This prevents potential validation errors and provides a sensible fallback value when the review trigger context is unknown.

## 🔧 How

Modified the `review_type` field definition to include a default value of `"unknown"` while maintaining the existing description that documents the possible values: submission, setup_complete, threshold, and manual.

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

N/A - This is a straightforward schema field configuration change. Existing tests that instantiate `AgentReportV2` will continue to pass, and the default value will be used when `review_type` is not provided.

## 📝 Additional Notes

This is a minor schema improvement that adds robustness by providing a sensible default for the `review_type` field.

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")

https://claude.ai/code/session_01KzaRg95T4BWRTnxtG8iJAC