### PR TITLE
fix: normalize escaped newlines in Plain messages

### DIFF
--- a/server/scripts/appeal_review.py
+++ b/server/scripts/appeal_review.py
@@ -34,6 +34,7 @@ from uuid import UUID
 
 import httpx
 import structlog
+from pydantic import model_validator
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
@@ -77,6 +78,14 @@ class AppealReviewResult(Schema):
     action: AppealAction
     reasoning: str
     draft_email: str
+
+    @model_validator(mode="after")
+    def _normalize_escaped_newlines(self) -> AppealReviewResult:
+        """LLMs sometimes produce literal '\\n' instead of real newlines in
+        structured output.  Replace them so Plain threads render correctly."""
+        self.reasoning = self.reasoning.replace("\\n", "\n")
+        self.draft_email = self.draft_email.replace("\\n", "\n")
+        return self
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📋 Summary

Fixes LLM-generated appeal review messages from displaying literal `\n` sequences in Plain threads.

## 🎯 What

Added a Pydantic `model_validator` to `AppealReviewResult` that normalizes escaped newline sequences in `draft_email` and `reasoning` fields.

## 🤔 Why

LLMs (like GPT) sometimes produce literal `\n` (backslash + n) instead of actual newline characters in structured JSON output. When these messages are posted to Plain threads, they display as literal text instead of line breaks.

## 🔧 How

Added a post-validation hook that replaces all `\n` sequences with actual newlines before the result is used anywhere. This catches the issue at the source, regardless of where the `AppealReviewResult` is consumed.

## 🧪 Testing

- [x] All existing tests pass (`uv run task lint && uv run task lint_types`)
- [x] Code follows linting and type checking standards