### PR TITLE
postgres: Reduce the query cache

### DIFF
--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -68,6 +68,7 @@ def create_async_engine(
         pool_recycle=pool_recycle,
         pool_logging_name=pool_logging_name,
         json_serializer=json_serializer,
+        query_cache_size=128,
     )
 
 


### PR DESCRIPTION
An assumption here is that we are precisely pushing ourselves over the memory limit with the query cache. The memory growth has slowed down, but it still slowly creeps up.

If it is the query cache that is the culprit then this change would make us go from ~200MB per worker (i.e. 600MB in production and 400MB in sandbox) to ~50MB per worker
