### PR TITLE
fix: add setup_complete to ReviewContext enum

### DIFF
--- a/server/polar/organization_review/eval/task.py
+++ b/server/polar/organization_review/eval/task.py
@@ -17,6 +17,7 @@ _VERDICT_MAP = {
 
 CONTEXT_MAP = {
     "submission": ReviewContext.SUBMISSION,
+    "setup_complete": ReviewContext.SETUP_COMPLETE,
     "threshold": ReviewContext.THRESHOLD,
     "manual": ReviewContext.MANUAL,
 }

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class ReviewContext(StrEnum):
     SUBMISSION = "submission"  # First review at details submission time
+    SETUP_COMPLETE = "setup_complete"  # Review when account setup is complete
     THRESHOLD = "threshold"  # Following reviews when payment threshold hit
     MANUAL = "manual"  # Full manual review triggered from backoffice
 


### PR DESCRIPTION
## Summary
- Adds `SETUP_COMPLETE = "setup_complete"` to the `ReviewContext` enum in `schemas.py`
- Adds `setup_complete` mapping to `CONTEXT_MAP` in `eval/task.py`
- Fixes `ValidationError` when parsing agent reports that have `context: "setup_complete"` in their `data_snapshot` (30 occurrences, 3 users impacted)

Fixes SERVER-46M

## Test plan
- [x] Verified `ReviewContext` enum includes the new value
- [x] Verified `DataSnapshot` can parse `context: "setup_complete"` without error
- [x] Backend lint passes
- [x] Backend type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)