### PR TITLE
Base64 encode user header in proxy middleware

### DIFF
--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -217,7 +217,9 @@ describe('middleware function', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('x-polar-user')).toBe(JSON.stringify(mockUser))
+    expect(response.headers.get('x-polar-user')).toBe(
+      Buffer.from(JSON.stringify(mockUser)).toString('base64'),
+    )
   })
 
   it('should allow unauthenticated access to public routes', async () => {

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -235,7 +235,9 @@ export async function proxy(request: NextRequest) {
     'x-polar-distinct-id': distinctId,
   }
   if (user) {
-    headers['x-polar-user'] = JSON.stringify(user)
+    headers['x-polar-user'] = Buffer.from(JSON.stringify(user)).toString(
+      'base64',
+    )
   }
 
   const response = NextResponse.next({ headers })

--- a/clients/apps/web/src/utils/user.ts
+++ b/clients/apps/web/src/utils/user.ts
@@ -36,7 +36,7 @@ const _getAuthenticatedUser = async (): Promise<
   // Middleware set this header for authenticated requests
   const userData = (await headers()).get('x-polar-user')
   if (userData) {
-    return JSON.parse(userData)
+    return JSON.parse(Buffer.from(userData, 'base64').toString('utf-8'))
   }
   return undefined
 }


### PR DESCRIPTION
## 📋 Summary

Encodes the `x-polar-user` header as base64 in the proxy middleware to ensure proper header transmission and decoding.

## 🎯 What

- Modified `proxy.ts` to base64 encode the user object before setting it in the `x-polar-user` header
- Updated `user.ts` to base64 decode the header value before parsing the JSON
- Updated corresponding test in `proxy.test.ts` to expect the base64 encoded value

## 🤔 Why

HTTP headers should contain only ASCII-safe characters. Base64 encoding ensures the JSON user object is safely transmitted through HTTP headers without encoding issues or data corruption.

## 🔧 How

1. In `proxy.ts`: Changed `headers['x-polar-user'] = JSON.stringify(user)` to `headers['x-polar-user'] = Buffer.from(JSON.stringify(user)).toString('base64')`
2. In `user.ts`: Changed `JSON.parse(userData)` to `JSON.parse(Buffer.from(userData, 'base64').toString('utf-8'))`
3. Updated the test assertion to match the new base64 encoded format

## 🧪 Testing

- [x] Existing test updated and passing (`proxy.test.ts`)
- [x] The middleware test verifies the header is correctly base64 encoded
- [x] The user utility correctly decodes and parses the header value

https://claude.ai/code/session_01R8pBcgUzzaQA9kC9RnRz5E