### PR TITLE
web: Add max requests to uvicorn

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -88,7 +88,7 @@ ENV POLAR_IP_GEOLOCATION_DATABASE_NAME=country_asn.mmdb
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}
 
-CMD ["uv", "run", "uvicorn", "polar.app:app", "--host", "0.0.0.0", "--port", "10000"]
+CMD ["uv", "run", "uvicorn", "polar.app:app", "--host", "0.0.0.0", "--port", "10000", "--limit-max-requests", "50000", "--limit-max-requests-jitter", "10000"]
 
 # Stage 5: Playwright image (for browser automation workers)
 FROM production AS playwright


### PR DESCRIPTION
This will restart the web worker after 50k requests (with 10k jitter to ensure that they don't restart at the same time). This will help with memory compaction and trailing memory leaks due to e.g. memory fragmentation.
