### PR TITLE
Store and display total_balance on organizations

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -309,13 +309,13 @@ async def list_organizations(
             else OrganizationReview.risk_score.desc().nullslast()
         )
         stmt = stmt.join(Organization.review).order_by(risk_order)
-    elif sort == "next_review":
-        threshold_order = (
-            Organization.next_review_threshold.asc().nullsfirst()
+    elif sort == "total_balance":
+        balance_order = (
+            Organization.total_balance.desc().nullslast()
             if is_desc
-            else Organization.next_review_threshold.desc().nullslast()
+            else Organization.total_balance.asc().nullsfirst()
         )
-        stmt = stmt.order_by(threshold_order)
+        stmt = stmt.order_by(balance_order)
     elif sort == "priority":
         # Priority: Under Review > Denied > Others, then by days in status
         stmt = stmt.order_by(

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -219,10 +219,10 @@ class OrganizationListView:
                     with tag.span(classes="text-base-content/40"):
                         text("—")
 
-            # Next review
+            # Total balance
             with tag.td(classes="text-sm text-right"):
-                if org.next_review_threshold:
-                    text(f"${org.next_review_threshold / 100:,.0f}")
+                if org.total_balance is not None:
+                    text(f"${org.total_balance / 100:,.2f}")
                 else:
                     with tag.span(classes="text-base-content/40"):
                         text("—")
@@ -563,8 +563,8 @@ class OrganizationListView:
 
                                     with self.sortable_header(
                                         request,
-                                        "Next Review",
-                                        "next_review",
+                                        "Balance",
+                                        "total_balance",
                                         current_sort,
                                         current_direction,
                                         "right",
@@ -646,8 +646,8 @@ class OrganizationListView:
 
                                 with self.sortable_header(
                                     request,
-                                    "Next Review",
-                                    "next_review",
+                                    "Balance",
+                                    "total_balance",
                                     current_sort,
                                     current_direction,
                                     "right",
@@ -781,8 +781,8 @@ class OrganizationListView:
 
                                     with self.sortable_header(
                                         request,
-                                        "Next Review",
-                                        "next_review",
+                                        "Balance",
+                                        "total_balance",
                                         current_sort,
                                         current_direction,
                                         "right",
@@ -864,8 +864,8 @@ class OrganizationListView:
 
                                 with self.sortable_header(
                                     request,
-                                    "Next Review",
-                                    "next_review",
+                                    "Balance",
+                                    "total_balance",
                                     current_sort,
                                     current_direction,
                                     "right",

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -713,12 +713,17 @@ class OrganizationService:
     async def check_review_threshold(
         self, session: AsyncSession, organization: Organization
     ) -> Organization:
-        if organization.is_under_review:
-            return organization
-
         transfers_sum = await transaction_service.get_transactions_sum(
             session, organization.account_id, type=TransactionType.balance
         )
+
+        # Always keep total_balance in sync
+        organization.total_balance = transfers_sum
+        session.add(organization)
+
+        if organization.is_under_review:
+            return organization
+
         if (
             organization.next_review_threshold >= 0
             and transfers_sum >= organization.next_review_threshold

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -301,22 +301,30 @@ async def test_get_next_invoice_number_multiple_customers(
 
 @pytest.mark.asyncio
 class TestCheckReviewThreshold:
-    async def test_already_under_review(
+    async def test_already_under_review_still_updates_total_balance(
         self,
+        mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
         # Given organization already under review
         organization.status = OrganizationStatus.INITIAL_REVIEW
         organization.next_review_threshold = 1000
+        organization.total_balance = None
+
+        mocker.patch(
+            "polar.organization.service.transaction_service.get_transactions_sum",
+            return_value=7500,
+        )
 
         # When
         result = await organization_service.check_review_threshold(
             session, organization
         )
 
-        # Then
+        # Then - status unchanged but total_balance is updated
         assert result.status == OrganizationStatus.INITIAL_REVIEW
+        assert result.total_balance == 7500
 
     async def test_below_review_threshold(
         self,
@@ -340,6 +348,7 @@ class TestCheckReviewThreshold:
 
         # Then
         assert result.status == OrganizationStatus.ACTIVE
+        assert result.total_balance == 5000
         transaction_sum_mock.assert_called_once()
 
     async def test_initial_review(
@@ -365,6 +374,7 @@ class TestCheckReviewThreshold:
 
         # Then
         assert result.status == OrganizationStatus.INITIAL_REVIEW
+        assert result.total_balance == 5000
         transaction_sum_mock.assert_called_once()
 
     async def test_ongoing_review(
@@ -391,10 +401,36 @@ class TestCheckReviewThreshold:
 
         # Then
         assert result.status == OrganizationStatus.ONGOING_REVIEW
+        assert result.total_balance == 5000
         transaction_sum_mock.assert_called_once()
         enqueue_job_mock.assert_called_once_with(
             "organization.under_review", organization_id=organization.id
         )
+
+    async def test_total_balance_zero(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Given organization with no transactions
+        organization.status = OrganizationStatus.ACTIVE
+        organization.next_review_threshold = 10000
+        organization.total_balance = None
+
+        mocker.patch(
+            "polar.organization.service.transaction_service.get_transactions_sum",
+            return_value=0,
+        )
+
+        # When
+        result = await organization_service.check_review_threshold(
+            session, organization
+        )
+
+        # Then
+        assert result.status == OrganizationStatus.ACTIVE
+        assert result.total_balance == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Update `check_review_threshold` to always sync `total_balance` with the actual SUM of balance transactions (previously skipped when org was under review)
- Update `create_reversal_balance` to also trigger `total_balance` update (previously only `create_balance` did, so refunds/disputes weren't reflected)
- Add sortable "Balance" column to backoffice organizations list view

Depends on #10407

## Test plan

- [ ] Verify `total_balance` is updated when a balance transaction is created
- [ ] Verify `total_balance` is updated when a reversal balance transaction is created (refund/dispute)
- [ ] Verify the "Balance" column appears in the backoffice org list and is sortable
- [ ] Verify sorting by balance works in both ascending and descending order

🤖 Generated with [Claude Code](https://claude.com/claude-code)