### PR TITLE
Remove account search endpoint and service method

### DIFF
--- a/server/polar/account/endpoints.py
+++ b/server/polar/account/endpoints.py
@@ -7,7 +7,6 @@ from polar.account_credit.schemas import AccountCredit as AccountCreditSchema
 from polar.auth.dependencies import WebUserRead, WebUserWrite
 from polar.enums import AccountType
 from polar.exceptions import InternalServerError, ResourceNotFound
-from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models import Account
 from polar.openapi import APITag
 from polar.organization.service import organization as organization_service
@@ -24,23 +23,6 @@ from .schemas import AccountCreateForOrganization, AccountLink, AccountUpdate
 from .service import account as account_service
 
 router = APIRouter(tags=["accounts", APITag.private])
-
-
-@router.get("/accounts/search", response_model=ListResource[AccountSchema])
-async def search(
-    auth_subject: WebUserRead,
-    pagination: PaginationParamsQuery,
-    session: AsyncReadSession = Depends(get_db_read_session),
-) -> ListResource[AccountSchema]:
-    results, count = await account_service.search(
-        session, auth_subject, pagination=pagination
-    )
-
-    return ListResource.from_paginated_results(
-        [AccountSchema.model_validate(result) for result in results],
-        count,
-        pagination,
-    )
 
 
 @router.get("/accounts/{id}", response_model=AccountSchema)

--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Sequence
 
 import stripe as stripe_lib
 from sqlalchemy.orm.strategy_options import joinedload
@@ -14,7 +13,6 @@ from polar.enums import AccountType
 from polar.exceptions import PolarError
 from polar.integrations.loops.service import loops as loops_service
 from polar.integrations.stripe.service import stripe
-from polar.kit.pagination import PaginationParams
 from polar.models import Account, Organization, User
 from polar.models.user import IdentityVerificationStatus
 from polar.postgres import AsyncReadSession, AsyncSession
@@ -51,24 +49,6 @@ class UserNotOrganizationMemberError(AccountServiceError):
 
 
 class AccountService:
-    async def search(
-        self,
-        session: AsyncReadSession,
-        auth_subject: AuthSubject[User],
-        *,
-        pagination: PaginationParams,
-    ) -> tuple[Sequence[Account], int]:
-        repository = AccountRepository.from_session(session)
-        statement = repository.get_readable_statement(auth_subject).options(
-            joinedload(Account.users),
-            joinedload(Account.organizations),
-        )
-        accounts, count = await repository.paginate(
-            statement, limit=pagination.limit, page=pagination.page
-        )
-
-        return accounts, count
-
     async def get(
         self,
         session: AsyncReadSession,

--- a/server/tests/account/test_service.py
+++ b/server/tests/account/test_service.py
@@ -8,7 +8,6 @@ from polar.account.service import (
     account as account_service,
 )
 from polar.auth.models import AuthSubject
-from polar.kit.pagination import PaginationParams
 from polar.kit.utils import utc_now
 from polar.models import Account, Organization, Transaction, User, UserOrganization
 from polar.models.transaction import Processor, TransactionType
@@ -225,95 +224,6 @@ class TestChangeAdmin:
             await account_service.change_admin(
                 session, account, user.id, organization.id
             )
-
-
-@pytest.mark.asyncio
-class TestSearch:
-    async def test_search_filters_deleted_organizations(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        user: User,
-        organization: Organization,
-    ) -> None:
-        # Create account with user as admin
-        account = await create_account(
-            save_fixture, admin=user, status=Account.Status.ACTIVE
-        )
-
-        # Associate the existing organization with the account
-        organization.account_id = account.id
-        await save_fixture(organization)
-
-        # Create a second organization that will be marked as deleted
-        organization_deleted = Organization(
-            name="Deleted Organization",
-            slug="deleted-org",
-            account_id=account.id,
-            customer_invoice_prefix="DEL",
-            deleted_at=utc_now(),  # Mark as deleted
-        )
-        await save_fixture(organization_deleted)
-
-        # Create auth subject
-        auth_subject = AuthSubject[User](subject=user, scopes=set(), session=None)
-
-        # Search for accounts
-        accounts, count = await account_service.search(
-            session, auth_subject, pagination=PaginationParams(limit=10, page=1)
-        )
-
-        # Verify results
-        assert count == 1
-        assert len(accounts) == 1
-        assert accounts[0].id == account.id
-
-        # Verify only active organization is included
-        assert len(accounts[0].organizations) == 1
-        assert accounts[0].organizations[0].id == organization.id
-        assert accounts[0].organizations[0].slug == organization.slug
-
-    async def test_search_includes_all_active_organizations(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        user: User,
-        organization: Organization,
-    ) -> None:
-        # Create account with user as admin
-        account = await create_account(
-            save_fixture, admin=user, status=Account.Status.ACTIVE
-        )
-
-        # Associate the existing organization with the account
-        organization.account_id = account.id
-        await save_fixture(organization)
-
-        # Create a second active organization
-        organization_two = Organization(
-            name="Organization Two",
-            slug="org-two",
-            account_id=account.id,
-            customer_invoice_prefix="ORG2",
-        )
-        await save_fixture(organization_two)
-
-        # Create auth subject
-        auth_subject = AuthSubject[User](subject=user, scopes=set(), session=None)
-
-        # Search for accounts
-        accounts, count = await account_service.search(
-            session, auth_subject, pagination=PaginationParams(limit=10, page=1)
-        )
-
-        # Verify both active organizations are included
-        assert count == 1
-        assert len(accounts) == 1
-        assert len(accounts[0].organizations) == 2
-
-        # Verify organization slugs
-        organization_slugs = {org.slug for org in accounts[0].organizations}
-        assert organization_slugs == {organization.slug, "org-two"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📋 Summary

Removes the `/accounts/search` endpoint and the corresponding `AccountService.search()` method that are no longer needed.

## 🎯 What

- Removed `GET /accounts/search` endpoint from `polar/account/endpoints.py`
- Removed `AccountService.search()` method from `polar/account/service.py`
- Removed associated test class `TestSearch` from `server/tests/account/test_service.py`
- Cleaned up unused imports (`PaginationParams`, `PaginationParamsQuery`, `ListResource`, `Sequence`)

## 🤔 Why

The account search functionality is being deprecated in favor of other endpoints or approaches for retrieving account data.

## 🔧 How

Removed the search endpoint, service method, and all related tests and imports. The remaining account operations (`get`, etc.) continue to function normally.

## 🧪 Testing

- Removed tests that specifically covered the search functionality
- Existing tests for other account operations remain unchanged and should continue to pass

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Removed unused imports
- [x] All related tests have been updated

https://claude.ai/code/session_01HhTux5VjdErNhXXBzPzsNr