### PR TITLE
events: Decouple parent and child ingestion

### DIFF
--- a/server/migrations/versions/2026-04-22-0833_add_pending_parent_external_id_to_events.py
+++ b/server/migrations/versions/2026-04-22-0833_add_pending_parent_external_id_to_events.py
@@ -1,0 +1,38 @@
+"""add pending_parent_external_id to events
+
+Revision ID: f96e4424ec70
+Revises: 9e14393a579f
+Create Date: 2026-03-19 15:21:24.903188
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f96e4424ec70"
+down_revision = "9e14393a579f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("pending_parent_external_id", sa.String(), nullable=True),
+    )
+    op.create_index(
+        "ix_events_org_pending_parent",
+        "events",
+        ["organization_id", "pending_parent_external_id"],
+        unique=False,
+        postgresql_where=sa.text("pending_parent_external_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_events_org_pending_parent",
+        table_name="events",
+    )
+    op.drop_column("events", "pending_parent_external_id")

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -225,6 +225,12 @@ class Event(Model, MetadataMixin):
             literal_column("ingested_at DESC"),
             postgresql_where="customer_id IS NOT NULL",
         ),
+        Index(
+            "ix_events_org_pending_parent",
+            "organization_id",
+            "pending_parent_external_id",
+            postgresql_where="pending_parent_external_id IS NOT NULL",
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
@@ -263,6 +269,10 @@ class Event(Model, MetadataMixin):
 
     root_id: Mapped[UUID | None] = mapped_column(
         Uuid, ForeignKey("events.id"), nullable=True, index=True
+    )
+
+    pending_parent_external_id: Mapped[str | None] = mapped_column(
+        String, nullable=True
     )
 
     @declared_attr


### PR DESCRIPTION
This allows us to decouple the ingestion of a child event and its parent. By storing the pending parent id on events,
we can at a later date resolve this relationship. We write the events to postgres always, but we wait with writing
to Tinybird until we have resolved the relationship.

An orphan child will not show up anywhere, although we could have a list of orphan events in the dashboard. This is
intentional as we want to avoid writing and updating data in Tinybird. Especially since we will need to update both the
root_id, as well as the ancestor_chain. If you are ingesting a grand-grand child and then their parent, you will have to ingest
two more events before you complete the chain and can truly know the events full ancestry.