### PR TITLE
fix(pledge): use utc_now for disputed_at timestamp

### DIFF
--- a/server/polar/pledge/service.py
+++ b/server/polar/pledge/service.py
@@ -427,7 +427,7 @@ class PledgeService(ResourceServiceReader[Pledge]):
             .values(
                 state=PledgeState.disputed,
                 dispute_reason=reason,
-                disputed_at=datetime.datetime.now(),
+                disputed_at=utc_now(),
                 disputed_by_user_id=by_user_id,
             )
         )


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #10378

Ensures that the `disputed_at` timestamp in `PledgeService.mark_disputed` uses a timezone-aware UTC datetime instead of a naive local datetime.

## 🎯 What

* Replaced `datetime.datetime.now()` with the `utc_now()` utility function in the `mark_disputed` method.
* Standardized the `disputed_at` field to align with the project's requirement for timezone-aware (UTC) objects.

## 🤔 Why

Using `datetime.now()` creates "naive" timestamps based on the server's local time. This causes `TypeError` crashes when the system tries to compare these naive objects against "offset-aware" (UTC) objects during business logic calculations, such as generating monthly reports or checking dispute windows.

## 🔧 How

I modified the SQL update statement in `server/polar/pledge/service.py` to call `utc_now()` for the `disputed_at` value. This ensures consistency across the service layer and prevents runtime comparison errors.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types`)

## 🖼️ Screenshots/Recordings

N/A — Backend logic fix.

## 📝 Additional Notes

This change normalizes the application boundary for timestamps. While historical naive records may exist in some environments, all future entries will follow the UTC standard, preventing further "offset-naive vs offset-aware" divergence.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: I have tested and executed the code locally.
