### PR TITLE
fix: resolve alembic multiple heads conflict

### DIFF
--- a/server/migrations/versions/2026-03-19-1600_add_total_balance_to_organizations.py
+++ b/server/migrations/versions/2026-03-19-1600_add_total_balance_to_organizations.py
@@ -1,8 +1,8 @@
 """Add total_balance to organizations
 
 Revision ID: 006a22ac6a34
-Revises: 5dd64c82a092
-Create Date: 2026-03-19 12:00:00.000000
+Revises: 817c66202639
+Create Date: 2026-03-19 16:00:00.000000
 
 """
 
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "006a22ac6a34"
-down_revision = "5dd64c82a092"
+down_revision = "817c66202639"
 branch_labels: tuple[str] | None = None
 depends_on: tuple[str] | None = None
 


### PR DESCRIPTION
## Summary

- Fixes `Multiple head revisions are present` Alembic error by reordering migrations
- `add_total_balance_to_organizations` (`006a22ac6a34`) now correctly depends on `transform_tax_id_to_null` (`817c66202639`) instead of both sharing the same `down_revision`
- Renamed migration file from `2026-03-19-1200_` to `2026-03-19-1600_` to reflect correct chronological order

## Test plan

- [ ] Verify `alembic heads` returns a single head
- [ ] Verify `alembic upgrade head` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)