### PR TITLE
checkout: Pass POLAR_PREVIEW_ACCESS_TOKEN for SSR requests

### DIFF
--- a/clients/apps/web/src/app/checkout/[clientSecret]/confirmation/page.tsx
+++ b/clients/apps/web/src/app/checkout/[clientSecret]/confirmation/page.tsx
@@ -1,6 +1,7 @@
 import { CheckoutConfirmation } from '@/components/Checkout/CheckoutConfirmation'
 import CheckoutLayout from '@/components/Checkout/CheckoutLayout'
 import { getServerURL } from '@/utils/api'
+import { getSSRHeaders } from '@/utils/client'
 import { resolveLocale } from '@/utils/i18n'
 import {
   ClientResponseError,
@@ -27,7 +28,7 @@ export default async function Page(props: {
 
   const { clientSecret } = params
 
-  const client = createClient(getServerURL())
+  const client = createClient(getServerURL(), undefined, getSSRHeaders())
 
   let checkout
   try {

--- a/clients/apps/web/src/app/checkout/[clientSecret]/page.tsx
+++ b/clients/apps/web/src/app/checkout/[clientSecret]/page.tsx
@@ -1,4 +1,5 @@
 import { getPublicServerURL, getServerURL } from '@/utils/api'
+import { getSSRHeaders } from '@/utils/client'
 import { resolveLocale } from '@/utils/i18n'
 import {
   CheckoutFormProvider,
@@ -20,7 +21,7 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { clientSecret } = params
 
-  const client = createClient(getServerURL())
+  const client = createClient(getServerURL(), undefined, getSSRHeaders())
   const { data: checkout } = await client.GET(
     '/v1/checkouts/client/{client_secret}',
     { params: { path: { client_secret: clientSecret } } },
@@ -52,7 +53,7 @@ export default async function Page(props: {
   const { clientSecret } = params
 
   const embed = _embed === 'true'
-  const client = createClient(getServerURL())
+  const client = createClient(getServerURL(), undefined, getSSRHeaders())
 
   let checkout
   try {

--- a/clients/apps/web/src/utils/client/index.ts
+++ b/clients/apps/web/src/utils/client/index.ts
@@ -24,6 +24,20 @@ export const createClientSideAPI = (token?: string): Client => {
 
 export const api = createClientSideAPI()
 
+export const getSSRHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = {}
+
+  if (process.env.GITHUB_TOKEN) {
+    headers['X-Github-Token'] = process.env.GITHUB_TOKEN
+  }
+
+  if (process.env.POLAR_PREVIEW_ACCESS_TOKEN) {
+    headers['X-Preview-Token'] = process.env.POLAR_PREVIEW_ACCESS_TOKEN
+  }
+
+  return headers
+}
+
 export const createServerSideAPI = async (
   headers: NextRequest['headers'],
   cookies: ReadonlyRequestCookies,

--- a/infra/preview/polar-preview-backend@.service
+++ b/infra/preview/polar-preview-backend@.service
@@ -8,6 +8,7 @@ User=deploy
 Group=deploy
 WorkingDirectory=/srv/previews/pr-%i/server
 EnvironmentFile=/srv/previews/pr-%i/server/.env
+EnvironmentFile=-/etc/preview-secrets/stripe.env
 ExecStart=/srv/previews/pr-%i/server/run-preview-backend.sh
 Restart=on-failure
 RestartSec=5

--- a/infra/preview/setup-vm.sh
+++ b/infra/preview/setup-vm.sh
@@ -27,6 +27,8 @@ read -rp "Tailscale auth key (tskey-auth-...): " TAILSCALE_AUTH_KEY
 read -rp "Tailscale tags (e.g. tag:preview) [tag:preview]: " TAILSCALE_TAGS
 TAILSCALE_TAGS="${TAILSCALE_TAGS:-tag:preview}"
 read -rp "Vercel bypass secret (from Vercel project settings): " VERCEL_BYPASS_SECRET
+read -rp "Stripe test-mode secret key (sk_test_...): " STRIPE_SECRET_KEY
+read -rp "Stripe test-mode webhook secret (whsec_...): " STRIPE_WEBHOOK_SECRET
 
 echo ""
 echo "=== Setting up preview VM ==="
@@ -78,7 +80,7 @@ if ! command -v caddy &>/dev/null; then
     caddy version
 fi
 
-mkdir -p /etc/caddy/previews
+mkdir -p /etc/caddy/previews /etc/preview-secrets
 
 # Generate a preview access token for gating funnel (public internet) access.
 # Tailnet users get full access via tailscale serve on :443.
@@ -89,6 +91,11 @@ if [[ ! -f /etc/caddy/env ]]; then
 POLAR_PREVIEW_ACCESS_TOKEN=${PREVIEW_ACCESS_TOKEN}
 VERCEL_BYPASS_SECRET=${VERCEL_BYPASS_SECRET}
 ENVFILE
+    cat > /etc/preview-secrets/stripe.env <<ENVFILE
+POLAR_STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+POLAR_STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+ENVFILE
+    chmod 600 /etc/preview-secrets/stripe.env
     chmod 600 /etc/caddy/env
     echo ""
     echo "Generated preview access token: ${PREVIEW_ACCESS_TOKEN}"
@@ -99,6 +106,14 @@ else
     if ! grep -q VERCEL_BYPASS_SECRET /etc/caddy/env; then
         echo "VERCEL_BYPASS_SECRET=${VERCEL_BYPASS_SECRET}" >> /etc/caddy/env
     fi
+fi
+
+if [[ ! -f /etc/preview-secrets/stripe.env ]]; then
+    cat > /etc/preview-secrets/stripe.env <<ENVFILE
+POLAR_STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+POLAR_STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+ENVFILE
+    chmod 600 /etc/preview-secrets/stripe.env
 fi
 
 cat > /etc/caddy/Caddyfile <<'CADDYFILE'


### PR DESCRIPTION
By using the existing createServerSideAPI instead of creating a new client
