### PR TITLE
feat: make customer.email nullable (expand phase)

### DIFF
--- a/server/migrations/versions/2026-03-20-1200_make_customer_email_nullable_expand.py
+++ b/server/migrations/versions/2026-03-20-1200_make_customer_email_nullable_expand.py
@@ -1,0 +1,53 @@
+"""Make customer.email nullable — create partial indexes
+
+Revision ID: cae16e5e72ec
+Revises: 6081ae0dd6ef
+Create Date: 2026-03-20 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "cae16e5e72ec"
+down_revision = "6081ae0dd6ef"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_customers_email_not_null",
+            "customers",
+            [sa.literal_column("lower(email)"), "deleted_at"],
+            unique=False,
+            postgresql_where="email IS NOT NULL",
+            postgresql_nulls_not_distinct=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_customers_organization_id_email_not_null",
+            "customers",
+            ["organization_id", sa.literal_column("lower(email)"), "deleted_at"],
+            unique=True,
+            postgresql_where="email IS NOT NULL",
+            postgresql_nulls_not_distinct=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_customers_organization_id_email_not_null",
+        table_name="customers",
+    )
+    op.drop_index(
+        "ix_customers_email_not_null",
+        table_name="customers",
+    )

--- a/server/migrations/versions/2026-03-20-1201_make_customer_email_drop_not_null.py
+++ b/server/migrations/versions/2026-03-20-1201_make_customer_email_drop_not_null.py
@@ -1,0 +1,39 @@
+"""Make customer.email nullable — drop NOT NULL
+
+Revision ID: 1a2e0acc75e3
+Revises: cae16e5e72ec
+Create Date: 2026-03-20 12:01:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "1a2e0acc75e3"
+down_revision = "cae16e5e72ec"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("SET LOCAL lock_timeout = '2s'"))
+    op.execute(sa.text("SET LOCAL statement_timeout = '15s'"))
+
+    op.alter_column(
+        "customers",
+        "email",
+        existing_type=sa.String(320),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "customers",
+        "email",
+        existing_type=sa.String(320),
+        nullable=False,
+    )

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -224,7 +224,10 @@ class CustomerService:
                 return customer
         except IntegrityError as e:
             error_str = str(e)
-            if "ix_customers_organization_id_email_case_insensitive" in error_str:
+            if (
+                "ix_customers_organization_id_email_case_insensitive" in error_str
+                or "ix_customers_organization_id_email_not_null" in error_str
+            ):
                 raise PolarRequestValidationError(
                     [
                         {

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     UniqueConstraint,
     Uuid,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -102,6 +103,7 @@ class CustomerType(StrEnum):
 class Customer(MetadataMixin, RecordModel):
     __tablename__ = "customers"
     __table_args__ = (
+        # Old indexes (kept until PR 2 contract migration drops them)
         Index(
             "ix_customers_email_case_insensitive",
             func.lower(Column("email")),
@@ -114,6 +116,23 @@ class Customer(MetadataMixin, RecordModel):
             func.lower(Column("email")),
             "deleted_at",
             unique=True,
+            postgresql_nulls_not_distinct=True,
+        ),
+        # New partial indexes (only rows where email IS NOT NULL)
+        Index(
+            "ix_customers_email_not_null",
+            func.lower(Column("email")),
+            "deleted_at",
+            postgresql_where=text("email IS NOT NULL"),
+            postgresql_nulls_not_distinct=True,
+        ),
+        Index(
+            "ix_customers_organization_id_email_not_null",
+            "organization_id",
+            func.lower(Column("email")),
+            "deleted_at",
+            unique=True,
+            postgresql_where=text("email IS NOT NULL"),
             postgresql_nulls_not_distinct=True,
         ),
         Index(
@@ -140,7 +159,7 @@ class Customer(MetadataMixin, RecordModel):
         index=True,
         server_default=sa.text("generate_customer_short_id()"),
     )
-    email: Mapped[str] = mapped_column(String(320), nullable=False)
+    email: Mapped[str] = mapped_column(String(320), nullable=True)
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     stripe_customer_id: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None, unique=False


### PR DESCRIPTION
## 📋 Summary

First PR in expand-contract pattern to make `customer.email` optional, enabling team customers without a direct email address.

## 🎯 What

- Two Alembic migrations following production-safe expand-contract pattern:
  1. **Create partial indexes CONCURRENTLY** — non-blocking, no table lock. Indexes cover `WHERE email IS NOT NULL` so existing uniqueness constraints continue to work once old indexes are dropped (PR 2).
  2. **DROP NOT NULL** on `customers.email` — with `SET LOCAL lock_timeout = '2s'` and `SET LOCAL statement_timeout = '15s'` so it fails fast instead of blocking traffic.
- Model: add new partial index definitions to `__table_args__`, keep old indexes (dropped in PR 2), set `nullable=True` on column.

## 🤔 Why

Team customers will receive emails through their billing managers/owners rather than directly. Making `email` nullable at the DB level is the prerequisite. This PR only changes the schema — no null emails will be created yet, so all existing code remains safe.

## 🔧 How

- **Split into two migrations** per production best practice: index creation (safe, non-blocking via `CONCURRENTLY` + `autocommit_block()`) is separate from DDL change (requires `ACCESS EXCLUSIVE` lock).
- **Lock/statement timeouts** protect against blocking production queries — the migration aborts cleanly if the lock can't be acquired in 2s.
- **Model keeps `Mapped[str]`** (not `str | None`) since no null emails exist yet. Type change deferred to PR 3 alongside service/schema updates, avoiding 38 downstream mypy errors.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Apply migrations: `uv run alembic upgrade head`
2. Verify indexes exist: `SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'customers' AND indexname LIKE '%email%';`
3. Verify column is nullable: `SELECT is_nullable FROM information_schema.columns WHERE table_name = 'customers' AND column_name = 'email';`
4. Verify rollback: `uv run alembic downgrade -2`

## 📝 Additional Notes

This is PR 1 of 3:
- **PR 1 (this)**: Expand — create partial indexes + drop NOT NULL
- **PR 2**: Contract — drop old indexes, remove old index definitions from model
- **PR 3**: Service/schema — update `Mapped[str | None]`, Pydantic schemas, service layer for null emails

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")