### PR TITLE
fix: don't regress org status on Stripe capability changes

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -866,7 +866,6 @@ class OrganizationService:
                 continue
 
             # If account is fully set up, set organization to ACTIVE
-            became_active = False
             if all(
                 (
                     not organization.is_under_review,
@@ -878,18 +877,6 @@ class OrganizationService:
                 )
             ):
                 organization.status = OrganizationStatus.ACTIVE
-                organization.status_updated_at = datetime.now(UTC)
-                became_active = True
-
-            # If Stripe disables some capabilities, reset to ONBOARDING_STARTED
-            if any(
-                (
-                    not account.is_details_submitted,
-                    not account.is_charges_enabled,
-                    not account.is_payouts_enabled,
-                )
-            ):
-                organization.status = OrganizationStatus.ONBOARDING_STARTED
                 organization.status_updated_at = datetime.now(UTC)
 
             await self._sync_account_status(session, organization)


### PR DESCRIPTION
## Summary
- Removes the code that automatically reset organization status to `ONBOARDING_STARTED` when Stripe account capabilities were disabled (e.g., payout account removed)
- This was causing active organizations to be knocked back to onboarding status, requiring manual intervention via backoffice
- The promotion path (onboarding → active when all Stripe capabilities are enabled) is preserved

## Test plan
- [x] Organization tests pass (209 tests)
- [x] Account tests pass (20 tests)
- [x] Backend lint passes
- [x] Backend type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)