### PR TITLE
fix: allow manual approval to override rejected appeals

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -762,10 +762,14 @@ class OrganizationService:
         await self._sync_account_status(session, organization)
         session.add(organization)
 
-        # If there's a pending appeal, mark it as approved
+        # If there's an appeal, mark it as approved (handles both pending and previously rejected appeals)
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
-        if review and review.appeal_submitted_at and review.appeal_decision is None:
+        if (
+            review
+            and review.appeal_submitted_at
+            and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
+        ):
             review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
             review.appeal_reviewed_at = datetime.now(UTC)
             session.add(review)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -489,6 +489,43 @@ class TestConfirmOrganizationReviewed:
             initial_review=False,
         )
 
+    async def test_overrides_rejected_appeal(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Given: org denied with a rejected appeal
+        organization.status = OrganizationStatus.DENIED
+        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=80.0,
+            violated_sections=["tos"],
+            reason="Violation",
+            model_used="test",
+            appeal_submitted_at=datetime(2025, 2, 1, tzinfo=UTC),
+            appeal_reason="Please reconsider",
+            appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+            appeal_reviewed_at=datetime(2025, 2, 2, tzinfo=UTC),
+        )
+        session.add(review)
+        await session.flush()
+
+        mocker.patch("polar.organization.service.enqueue_job")
+
+        # When: operator manually approves the org
+        result = await organization_service.confirm_organization_reviewed(
+            session, organization, 15000
+        )
+
+        # Then: appeal decision is overridden to approved
+        assert result.status == OrganizationStatus.ACTIVE
+        assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
+        assert review.appeal_reviewed_at is not None
+
 
 @pytest.mark.asyncio
 class TestHandleOngoingReviewVerdict:


### PR DESCRIPTION
## 📋 Summary

When an operator manually approves an org (via backoffice "confirm reviewed") after an appeal was already rejected, the merchant still saw a "rejected" status because `appeal_decision` was not updated.

## 🎯 What

Changed the condition in `confirm_organization_reviewed` from `appeal_decision is None` to `appeal_decision != APPROVED`, so manual approval also overrides previously rejected appeals.

## 🤔 Why

If an appeal is rejected but the team changes their mind, putting the org under review and approving it should override the appeal decision. Previously, the `appeal_decision` stayed `rejected` because the code only updated it when it was `None` (pending). This caused the frontend to keep showing the rejected state.

## 🔧 How

- `server/polar/organization/service.py`: Broadened the condition so any non-approved appeal gets set to `approved` on manual org approval.
- `server/tests/organization/test_service.py`: Added `test_overrides_rejected_appeal` covering this scenario.

## 🧪 Testing

- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Reject an org's appeal in backoffice
2. Put the org under review again, then approve it
3. Verify the merchant now sees "Appeal approved" and the account is active

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests