### PR TITLE
server: improve subscription revocation to void pending orders

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -124,6 +124,20 @@ class OrderRepository(
         )
         return await self.get_all(statement)
 
+    async def get_pending_orders_for_subscription(
+        self, subscription_id: UUID
+    ) -> Sequence[Order]:
+        """Get pending orders for a specific subscription."""
+        statement = (
+            self.get_base_statement()
+            .where(
+                Order.subscription_id == subscription_id,
+                Order.status == OrderStatus.pending,
+            )
+            .options(joinedload(Order.subscription))
+        )
+        return await self.get_all(statement)
+
     async def acquire_payment_lock_by_id(self, order_id: UUID) -> bool:
         """
         Internal method to acquire a payment lock by order ID.

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1857,7 +1857,10 @@ class OrderService:
         previous_status = order.status
 
         repository = OrderRepository.from_session(session)
-        order = await repository.update(order, update_dict={"status": OrderStatus.void})
+        order = await repository.update(
+            order,
+            update_dict={"status": OrderStatus.void, "next_payment_attempt_at": None},
+        )
 
         await event_service.create_event(
             session,
@@ -1875,6 +1878,22 @@ class OrderService:
         await self._on_order_updated(session, order, previous_status=previous_status)
 
         return order
+
+    async def void_pending_orders_for_subscription(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> Sequence[Order]:
+        """Void all pending orders for a specific subscription."""
+        repository = OrderRepository.from_session(session)
+        pending_orders = await repository.get_pending_orders_for_subscription(
+            subscription.id
+        )
+
+        voided_orders: list[Order] = []
+        for order in pending_orders:
+            voided_order = await self.void(session, order)
+            voided_orders.append(voided_order)
+
+        return voided_orders
 
     async def _on_order_created(self, session: AsyncSession, order: Order) -> None:
         enqueue_job("order.created", order.id)

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -239,3 +239,19 @@ async def process_dunning_order(order_id: uuid.UUID) -> None:
             raise OrderDoesNotExist(order_id)
 
         await order_service.process_dunning_order(session, order)
+
+
+@actor(
+    actor_name="order.void_pending_orders_for_subscription", priority=TaskPriority.LOW
+)
+async def void_pending_orders_for_subscription(subscription_id: uuid.UUID) -> None:
+    """Void all pending orders for a subscription when it's revoked."""
+    async with AsyncSessionMaker() as session:
+        subscription_repository = SubscriptionRepository.from_session(session)
+        subscription = await subscription_repository.get_by_id(
+            subscription_id, options=subscription_repository.get_eager_options()
+        )
+        if subscription is None:
+            raise SubscriptionDoesNotExist(subscription_id)
+
+        await order_service.void_pending_orders_for_subscription(session, subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1965,6 +1965,9 @@ class SubscriptionService:
         if not past_due:
             await self.send_revoked_email(session, subscription)
 
+        # Void all pending orders for this subscription
+        enqueue_job("order.void_pending_orders_for_subscription", subscription.id)
+
     async def _send_new_subscription_notification(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -4382,3 +4382,81 @@ class TestVoidOrder:
             await order_service.void(session, order)
 
         assert exc_info.value.order.id == order.id
+
+    @pytest.mark.asyncio
+    async def test_void_clears_next_payment_attempt(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        """Test that voiding an order clears next_payment_attempt_at."""
+        # Given
+        next_attempt_at = utc_now() + timedelta(hours=24)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            next_payment_attempt_at=next_attempt_at,
+        )
+
+        # When
+        result_order = await order_service.void(session, order)
+
+        # Then
+        assert result_order.status == OrderStatus.void
+        assert result_order.next_payment_attempt_at is None
+
+
+@pytest.mark.asyncio
+class TestVoidPendingOrdersForSubscription:
+    @pytest.mark.asyncio
+    async def test_void_pending_orders_for_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        """Test voiding all pending orders for a subscription."""
+        # Given
+        # Create a subscription
+        subscription = await create_subscription(
+            save_fixture, customer=customer, product=product
+        )
+
+        # Create two pending orders for the subscription
+        next_attempt_at = utc_now() + timedelta(hours=24)
+        order1 = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subscription=subscription,
+            next_payment_attempt_at=next_attempt_at,
+        )
+
+        order2 = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subscription=subscription,
+            next_payment_attempt_at=next_attempt_at,
+        )
+
+        # When
+        voided_orders = await order_service.void_pending_orders_for_subscription(
+            session, subscription
+        )
+
+        # Then
+        assert len(voided_orders) == 2
+
+        # Verify both orders are voided and next_payment_attempt_at is cleared
+        for order in voided_orders:
+            assert order.status == OrderStatus.void
+            assert order.next_payment_attempt_at is None
+            assert order.subscription_id == subscription.id

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1532,6 +1532,7 @@ class TestRevoke:
         session: AsyncSession,
         save_fixture: SaveFixture,
         enqueue_benefits_grants_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
         product: Product,
         customer: Customer,
     ) -> None:
@@ -1550,6 +1551,11 @@ class TestRevoke:
 
         enqueue_benefits_grants_mock.assert_called_once_with(
             session, updated_subscription
+        )
+
+        # Verify that the void pending orders task is enqueued
+        enqueue_job_mock.assert_any_call(
+            "order.void_pending_orders_for_subscription", subscription.id
         )
 
     async def test_revoke_scheduled_cancellation_sends_canceled_hook(


### PR DESCRIPTION

This commit enhances the subscription revocation process to properly handle\npending orders by:\n\n1. Clearing so payment will not be retried\n2. Setting orders as to clearly indicate they're not paid and never will be\n3. Triggering appropriate webhooks and events\n\nChanges include:\n- Add repository method to get pending orders for a subscription\n- Update order void method to clear next_payment_attempt_at\n- Add service method to void all pending orders for a subscription\n- Add task to handle voiding orders asynchronously\n- Update subscription revocation to enqueue the new task\n- Add comprehensive tests for the new functionality\n\nThe implementation follows existing patterns and conventions, ensuring\nconsistency and maintainability.