### PR TITLE
fix: auto-deploy Tinybird data project in local dev environment

### DIFF
--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -22,7 +22,7 @@ ENV_FILE = DOCKER_DIR / ".env.docker"
 SERVER_ENV_FILE = SERVER_DIR / ".env"
 SERVER_ENV_TEMPLATE = SERVER_DIR / ".env.template"
 
-VALID_SERVICES = ["api", "worker", "web", "db", "redis", "minio", "minio-setup", "prometheus", "grafana"]
+VALID_SERVICES = ["api", "worker", "web", "db", "redis", "minio", "minio-setup", "tinybird", "prometheus", "grafana"]
 
 
 def _read_stored_instance() -> int | None:
@@ -168,6 +168,11 @@ def _build_compose_env(instance: int) -> dict[str, str]:
         "MINIO_CONSOLE_PORT": str(9001 + offset),
         "PROMETHEUS_PORT": str(9090 + offset),
         "GRAFANA_PORT": str(3001 + offset),
+        "TINYBIRD_PORT": str(7181 + offset),
+        "TINYBIRD_ADMIN_PORT": str(7182 + offset),
+        # Base compose file (server/docker-compose.yml) uses these names
+        "POLAR_POSTGRES_PORT": str(5432 + offset),
+        "POLAR_REDIS_PORT": str(6379 + offset),
     }
 
 
@@ -208,6 +213,7 @@ def _print_access_info(ctx: typer.Context, instance: int, monitoring: bool = Fal
     console.print(f"  MinIO Console: http://localhost:{9001 + offset}")
     console.print(f"  PostgreSQL:    localhost:{5432 + offset}")
     console.print(f"  Redis:         localhost:{6379 + offset}")
+    console.print(f"  Tinybird:      http://localhost:{7181 + offset}")
     if monitoring:
         console.print(f"  Prometheus:    http://localhost:{9090 + offset}")
         console.print(f"  Grafana:       http://localhost:{3001 + offset} (admin/polar)")

--- a/dev/cli/up_steps/05_wait_for_services.py
+++ b/dev/cli/up_steps/05_wait_for_services.py
@@ -1,10 +1,12 @@
 """Wait for infrastructure services to be healthy."""
 
+import json
 import time
+import urllib.request
 
 from shared import (
-    Context,
     SERVER_DIR,
+    Context,
     console,
     run_command,
     step_status,
@@ -43,8 +45,60 @@ def wait_for_redis(timeout: int = 60) -> bool:
     return False
 
 
+def wait_for_tinybird_and_get_token(timeout: int = 90) -> str | None:
+    """Wait for Tinybird to be ready and return the admin token.
+
+    Tries to detect the host-mapped port via docker compose, falling
+    back to the default port 7181.
+    """
+    # Try to get the mapped port from docker compose
+    port = 7181
+    result = run_command(
+        ["docker", "compose", "port", "tinybird", "7181"],
+        cwd=SERVER_DIR,
+        capture=True,
+    )
+    if result and result.returncode == 0 and result.stdout.strip():
+        try:
+            port = int(result.stdout.strip().rsplit(":", 1)[-1])
+        except ValueError:
+            pass
+
+    url = f"http://localhost:{port}/tokens"
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                data = json.loads(resp.read())
+                return data.get("admin_token")
+        except Exception:
+            time.sleep(2)
+    return None
+
+
+def _update_env_var(key: str, value: str) -> None:
+    """Set an env var in server/.env, adding or updating as needed."""
+    env_file = SERVER_DIR / ".env"
+    if not env_file.exists():
+        return
+
+    lines = env_file.read_text().splitlines()
+    found = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith(f"{key}=") or stripped.startswith(f"# {key}="):
+            lines[i] = f'{key}="{value}"'
+            found = True
+            break
+
+    if not found:
+        lines.append(f'{key}="{value}"')
+
+    env_file.write_text("\n".join(lines) + "\n")
+
+
 def run(ctx: Context) -> bool:
-    """Wait for PostgreSQL and Redis to be ready."""
+    """Wait for PostgreSQL, Redis, and Tinybird to be ready."""
     with console.status("[bold]Waiting for PostgreSQL...[/bold]"):
         if wait_for_postgres(timeout=60):
             step_status(True, "PostgreSQL", "ready")
@@ -58,5 +112,16 @@ def run(ctx: Context) -> bool:
         else:
             step_status(False, "Redis", "timeout after 60s")
             return False
+
+    with console.status("[bold]Waiting for Tinybird...[/bold]"):
+        token = wait_for_tinybird_and_get_token(timeout=90)
+        if token:
+            _update_env_var("POLAR_TINYBIRD_API_TOKEN", token)
+            _update_env_var("POLAR_TINYBIRD_READ_TOKEN", token)
+            _update_env_var("POLAR_TINYBIRD_CLICKHOUSE_TOKEN", token)
+            step_status(True, "Tinybird", "ready (token configured)")
+        else:
+            step_status(False, "Tinybird", "timeout - continuing without it")
+            # Don't fail the whole setup for tinybird
 
     return True

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -1,11 +1,15 @@
 # Docker Compose for full-stack Polar development environment
 # Usage: dev docker up
 #
-# This file defines all services needed to run Polar in development mode
-# with hot-reloading support. Source code is mounted from the host.
+# Infrastructure services (db, redis, minio, tinybird, etc.) are defined in
+# server/docker-compose.yml and included here. This file only adds the
+# application services (api, worker, web) with development configuration.
 #
 # For multiple isolated instances, use: dev docker up -i <instance_number>
 # Each instance uses different ports (offset by 100 * instance_number)
+
+include:
+  - path: ../../server/docker-compose.yml
 
 # Load environment variables from server/.env
 x-common-env-file: &common-env-file
@@ -46,6 +50,11 @@ x-common-backend-env: &common-backend-env
   POLAR_FRONTEND_BASE_URL: http://localhost:${WEB_PORT:-3000}
   POLAR_CHECKOUT_BASE_URL: http://localhost:${API_PORT:-8000}/v1/checkout-links/{client_secret}/redirect
   POLAR_USER_SESSION_COOKIE_DOMAIN: localhost
+  # Tinybird - uses service name for container networking
+  # Note: env_prefix="polar_" in Settings, so these need the POLAR_ prefix
+  # Tokens are auto-discovered from the Tinybird container at startup (see startup.sh)
+  POLAR_TINYBIRD_API_URL: http://tinybird:7181
+  POLAR_TINYBIRD_CLICKHOUSE_URL: http://tinybird:7182
   # OAuth insecure transport for development
   AUTHLIB_INSECURE_TRANSPORT: "true"
   # Note: Secrets like POLAR_GITHUB_CLIENT_ID, POLAR_STRIPE_* are loaded from
@@ -69,84 +78,6 @@ x-worker-volumes: &worker-volumes
   - pnpm_store:/root/.local/share/pnpm/store
 
 services:
-  # ============================================
-  # Infrastructure Services
-  # ============================================
-
-  db:
-    image: postgres:15.1-bullseye
-    environment:
-      POSTGRES_USER: ${POLAR_POSTGRES_USER:-polar}
-      POSTGRES_PASSWORD: ${POLAR_POSTGRES_PWD:-polar}
-      POSTGRES_DB: ${POLAR_POSTGRES_DATABASE:-polar}
-      POLAR_READ_USER: ${POLAR_POSTGRES_READ_USER:-polar_read}
-      POLAR_READ_PASSWORD: ${POLAR_POSTGRES_READ_PWD:-polar}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - ../../server/init-readonly-user.sql:/docker-entrypoint-initdb.d/init-readonly-user.sql:ro
-    ports:
-      - "${DB_PORT:-5432}:5432"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "pg_isready",
-          "-q",
-          "-d",
-          "${POLAR_POSTGRES_DATABASE:-polar}",
-          "-U",
-          "${POLAR_POSTGRES_USER:-polar}",
-        ]
-      interval: 2s
-      timeout: 40s
-      retries: 20
-
-  redis:
-    image: redis:alpine
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 2s
-      timeout: 10s
-      retries: 10
-
-  minio:
-    image: bitnamilegacy/minio:2024.5.28
-    ports:
-      - "${MINIO_API_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
-    volumes:
-      - minio_data:/minio
-    environment:
-      MINIO_ROOT_USER: ${POLAR_MINIO_USER:-polar}
-      MINIO_ROOT_PASSWORD: ${POLAR_MINIO_PWD:-polarpolar}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 5s
-      timeout: 10s
-      retries: 10
-
-  minio-setup:
-    image: bitnamilegacy/minio-client:2024.5.24
-    depends_on:
-      minio:
-        condition: service_healthy
-    volumes:
-      - ../../server/.minio:/tmp/config:ro
-    environment:
-      MINIO_HOST: minio
-      MINIO_ROOT_USER: ${POLAR_MINIO_USER:-polar}
-      MINIO_ROOT_PASSWORD: ${POLAR_MINIO_PWD:-polarpolar}
-      BUCKET_NAME: ${POLAR_S3_FILES_BUCKET_NAME:-polar-s3}
-      PUBLIC_BUCKET_NAME: ${POLAR_S3_FILES_PUBLIC_BUCKET_NAME:-polar-s3-public}
-      BUCKET_TESTING_NAME: testing-${POLAR_S3_FILES_BUCKET_NAME:-polar-s3}
-      ACCESS_KEY: ${POLAR_AWS_ACCESS_KEY_ID:-polar-development}
-      SECRET_ACCESS_KEY: ${POLAR_AWS_SECRET_ACCESS_KEY:-polar123456789}
-      POLICY_FILE: /tmp/config/policy.json
-    entrypoint:
-      ["bash", "-c", "bash /tmp/config/local.sh /tmp/config/configure.sh"]
-
   # ============================================
   # Application Services
   # ============================================
@@ -224,51 +155,10 @@ services:
         limits:
           memory: 6G
 
-  # ============================================
-  # Optional Services (use --profile flag)
-  # ============================================
-
-  prometheus:
-    image: prom/prometheus:v3.7.3
-    ports:
-      - "${PROMETHEUS_PORT:-9090}:9090"
-    volumes:
-      - ../../server/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus_data:/prometheus
-    command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention.time=1d"
-      - "--web.enable-lifecycle"
-      - "--web.enable-remote-write-receiver"
-    profiles:
-      - monitoring
-
-  grafana:
-    image: grafana/grafana:12.3.0
-    ports:
-      - "${GRAFANA_PORT:-3001}:3000"
-    volumes:
-      - ../../server/monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ../../server/monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
-      - grafana_data:/var/lib/grafana
-    environment:
-      GF_SECURITY_ADMIN_USER: polar
-      GF_SECURITY_ADMIN_PASSWORD: polar
-      GF_USERS_ALLOW_SIGN_UP: "false"
-    depends_on:
-      - prometheus
-    profiles:
-      - monitoring
-
 volumes:
-  postgres_data:
-  minio_data:
   server_uv_cache:
   api_venv:
   worker_venv:
   pnpm_store:
   web_node_modules:
   web_next_cache:
-  prometheus_data:
-  grafana_data:

--- a/dev/docker/scripts/startup.sh
+++ b/dev/docker/scripts/startup.sh
@@ -132,6 +132,31 @@ elif [[ "${1:-api}" == "worker" ]]; then
     echo "Playwright browsers already installed"
 fi
 
+# Auto-discover Tinybird token if not already set
+if [[ -n "${POLAR_TINYBIRD_CLICKHOUSE_URL:-}" ]] && [[ -z "${POLAR_TINYBIRD_CLICKHOUSE_TOKEN:-}" ]]; then
+    TINYBIRD_HOST=$(echo "$POLAR_TINYBIRD_CLICKHOUSE_URL" | sed 's|http://||' | cut -d: -f1)
+    TINYBIRD_API="http://${TINYBIRD_HOST}:7181"
+    echo "Fetching Tinybird admin token from ${TINYBIRD_API}..."
+    max_attempts=30
+    attempt=0
+    while true; do
+        TB_TOKEN=$(curl -sf "${TINYBIRD_API}/tokens" 2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['admin_token'])" 2>/dev/null) && break
+        attempt=$((attempt + 1))
+        if [[ $attempt -ge $max_attempts ]]; then
+            echo "WARNING: Could not fetch Tinybird token after $max_attempts attempts, continuing without it"
+            break
+        fi
+        sleep 2
+    done
+    if [[ -n "${TB_TOKEN:-}" ]]; then
+        export POLAR_TINYBIRD_API_TOKEN="$TB_TOKEN"
+        export POLAR_TINYBIRD_CLICKHOUSE_TOKEN="$TB_TOKEN"
+        export POLAR_TINYBIRD_READ_TOKEN="$TB_TOKEN"
+        echo "Tinybird token configured"
+    fi
+fi
+
 # Start the requested service
 case "${1:-api}" in
     api)

--- a/dev/docker/scripts/tinybird-setup.sh
+++ b/dev/docker/scripts/tinybird-setup.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Wrapper entrypoint for the Tinybird container that starts the server
+# and then builds the data project.
+
+set -euo pipefail
+
+TINYBIRD_API="http://localhost:7181"
+DATA_PROJECT_DIR="/tinybird"
+
+# Start supervisord (the default CMD) in the background
+/usr/bin/supervisord &
+SUPERVISOR_PID=$!
+
+# Wait for Tinybird to be fully ready
+echo "=== Tinybird Setup: waiting for server ==="
+max_attempts=120
+attempt=0
+while true; do
+    if curl -sf "${TINYBIRD_API}/" >/dev/null 2>&1; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    if [[ $attempt -ge $max_attempts ]]; then
+        echo "ERROR: Tinybird server not ready after $max_attempts attempts"
+        wait $SUPERVISOR_PID
+        exit 1
+    fi
+    sleep 1
+done
+
+# Get admin token
+attempt=0
+while true; do
+    TOKEN=$(curl -sf "${TINYBIRD_API}/tokens" 2>/dev/null \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['admin_token'])" 2>/dev/null) && break
+    attempt=$((attempt + 1))
+    if [[ $attempt -ge $max_attempts ]]; then
+        echo "WARNING: Could not fetch Tinybird token, skipping data project build"
+        wait $SUPERVISOR_PID
+        exit 0
+    fi
+    sleep 1
+done
+
+# Wait for workspace API
+attempt=0
+while true; do
+    if curl -sf "${TINYBIRD_API}/v1/workspace?token=${TOKEN}" >/dev/null 2>&1; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    if [[ $attempt -ge $max_attempts ]]; then
+        echo "WARNING: Tinybird workspace API not ready, skipping data project build"
+        wait $SUPERVISOR_PID
+        exit 0
+    fi
+    sleep 1
+done
+
+# Build data project if the directory exists
+if [[ -d "${DATA_PROJECT_DIR}" ]]; then
+    # Copy to writable dir (tb writes .tinyb file)
+    WORK_DIR="/tmp/tinybird-deploy"
+    cp -r "${DATA_PROJECT_DIR}" "${WORK_DIR}"
+    cd "${WORK_DIR}"
+
+    echo "=== Tinybird Setup: building data project ==="
+    if tb --host "${TINYBIRD_API}" --token "${TOKEN}" build; then
+        echo "=== Tinybird Setup: data project built successfully ==="
+    else
+        echo "WARNING: Tinybird data project build failed, continuing anyway"
+    fi
+fi
+
+# Keep supervisord in the foreground
+wait $SUPERVISOR_PID

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,8 +1,13 @@
 services:
   redis:
-    image: redis
+    image: redis:alpine
     ports:
-      - "${POLAR_REDIS_PORT}:6379"
+      - "${POLAR_REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
 
   db:
     image: postgres:15.1-bullseye
@@ -10,16 +15,14 @@ services:
       - POSTGRES_USER=${POLAR_POSTGRES_USER}
       - POSTGRES_PASSWORD=${POLAR_POSTGRES_PWD}
       - POSTGRES_DB=${POLAR_POSTGRES_DATABASE}
-      - POSTGRES_PORT=${POLAR_POSTGRES_PORT}
+      - POSTGRES_PORT=${POLAR_POSTGRES_PORT:-5432}
       - POLAR_READ_USER=${POLAR_POSTGRES_READ_USER:-polar_read}
       - POLAR_READ_PASSWORD=${POLAR_POSTGRES_READ_PWD}
     volumes:
       - postgres_data:/var/lib/postgresql/data/
       - ./init-readonly-user.sql:/docker-entrypoint-initdb.d/init-readonly-user.sql
     ports:
-      - "${POLAR_POSTGRES_PORT}:5432"
-    expose:
-      - ${POLAR_POSTGRES_PORT}
+      - "${POLAR_POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test:
         [
@@ -38,20 +41,26 @@ services:
   minio:
     image: bitnamilegacy/minio:2024.5.28
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
     volumes:
       - "minio_data:/minio"
     environment:
       - MINIO_ROOT_USER=${POLAR_MINIO_USER}
       - MINIO_ROOT_PASSWORD=${POLAR_MINIO_PWD}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
 
   minio-setup:
     image: bitnamilegacy/minio-client:2024.5.24
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     volumes:
-      - ./.minio:/tmp/config
+      - ./.minio:/tmp/config:ro
     environment:
       - MINIO_HOST=minio
       - MINIO_ROOT_USER=${POLAR_MINIO_USER}
@@ -63,16 +72,12 @@ services:
       - ACCESS_KEY=${POLAR_AWS_ACCESS_KEY_ID}
       - SECRET_ACCESS_KEY=${POLAR_AWS_SECRET_ACCESS_KEY}
     entrypoint:
-      [
-        "bash",
-        "-c",
-        "chmod +x /tmp/config/local.sh && chmod +x /tmp/config/configure.sh && /tmp/config/local.sh /tmp/config/configure.sh",
-      ]
+      ["bash", "-c", "bash /tmp/config/local.sh /tmp/config/configure.sh"]
 
   prometheus:
     image: prom/prometheus:v3.7.3
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_PORT:-9090}:9090"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
@@ -88,7 +93,7 @@ services:
   grafana:
     image: grafana/grafana:12.3.0
     ports:
-      - "3001:3000"
+      - "${GRAFANA_PORT:-3001}:3000"
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
@@ -106,8 +111,17 @@ services:
     image: tinybirdco/tinybird-local:latest
     platform: linux/amd64
     ports:
-      - "7181:7181"
-      - "7182:7182"
+      - "${TINYBIRD_PORT:-7181}:7181"
+      - "${TINYBIRD_ADMIN_PORT:-7182}:7182"
+    volumes:
+      - ./tinybird:/tinybird:ro
+      - ../dev/docker/scripts/tinybird-setup.sh:/scripts/tinybird-setup.sh:ro
+    command: ["bash", "/scripts/tinybird-setup.sh"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7181/"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## 📋 Summary

Tinybird local instance was starting without its data project deployed, causing 404/403 errors when querying metrics or events.

## 🎯 What

- Add `tinybird-setup.sh` wrapper entrypoint that starts the Tinybird server then runs `tb build` to deploy all datasources, pipes, and endpoints
- Add `POLAR_TINYBIRD_API_URL` and `POLAR_TINYBIRD_CLICKHOUSE_URL` env vars to dev compose for container-to-container networking
- Add Tinybird token auto-discovery to `dev up` flow (writes tokens to `server/.env`)
- Deduplicate infrastructure services from dev compose by using `include` from `server/docker-compose.yml`
- Add healthchecks and port variable defaults to base server compose

## 🤔 Why

When running `dev docker up`, the API container tried to connect to Tinybird at `localhost:7182` instead of `tinybird:7182` (Docker networking). Even after fixing that, the Tinybird instance had no datasources/pipes deployed, so all metrics and event queries failed with 404. For `dev up` (native), the Tinybird auth token was never configured.

## 🔧 How

- `server/docker-compose.yml`: Mount `./tinybird` data project into the container and override CMD with a wrapper script that starts supervisord, waits for readiness, then runs `tb build`
- `dev/docker/docker-compose.dev.yml`: Add Tinybird connection env vars, switch from duplicated service definitions to `include` from server compose
- `dev/cli/up_steps/05_wait_for_services.py`: After Tinybird is healthy, fetch admin token via `/tokens` endpoint and write it to `server/.env`

## 🧪 Testing

- [x] I have tested these changes locally

### Test Instructions

1. `dev docker cleanup -f && dev docker up -d`
2. Check tinybird logs: `docker logs <tinybird-container> | grep "Build completed"`
3. Verify API can query events/metrics without 404/403 errors

## 📝 Additional Notes

The `tb build` command runs from inside the Tinybird container (which has Docker runtime), not from a separate init container. This avoids the Docker-in-Docker requirement that `tb deploy`/`tb build` has when run from external containers.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")