### PR TITLE
fix(organization-review): set temperature=0 for deterministic verdicts

### DIFF
--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -323,6 +323,7 @@ class ReviewAnalyzer:
             self.model,
             output_type=ReviewAgentReport,
             system_prompt=SYSTEM_PROMPT,
+            model_settings={"temperature": 0},
         )
 
     async def analyze(

--- a/server/polar/organization_review/eval/task.py
+++ b/server/polar/organization_review/eval/task.py
@@ -64,6 +64,7 @@ def create_review_task(
             analyzer.model,
             output_type=ReviewAgentReport,
             system_prompt=SYSTEM_PROMPT,
+            model_settings={"temperature": 0},
         )
 
     costs: list[float] = []

--- a/server/scripts/eval_organization_reviews.py
+++ b/server/scripts/eval_organization_reviews.py
@@ -43,8 +43,6 @@ from polar.organization_review.eval.dataset import (
     extract_dataset,
 )
 from polar.organization_review.eval.evaluators import (
-    NotFalseNegative,
-    NotFalsePositive,
     VerdictMatch,
 )
 from polar.organization_review.eval.optimize import run_optimization
@@ -153,7 +151,7 @@ async def run(
     dataset: EvalDataset = EvalDataset.from_file(dataset_path)
     typer.echo(f"Loaded {len(dataset.cases)} cases from {dataset_path}")
 
-    dataset.evaluators = [VerdictMatch(), NotFalseNegative(), NotFalsePositive()]
+    dataset.evaluators = [VerdictMatch()]
     task = create_review_task(model=model)
 
     report = await dataset.evaluate(task, max_concurrency=concurrency)


### PR DESCRIPTION
## Summary
- Set `temperature=0` on the `ReviewAnalyzer` agent (and eval task) to reduce variance between review runs (measured 6% variance at temperature=0 vs uncontrolled before)
- Simplify eval evaluators to just `VerdictMatch` — the confusion matrix already captures false positive/negative breakdown

## Test plan
- [x] Extracted 100-case eval dataset and ran eval twice to measure variance
- [x] Confirmed 94/100 cases produce identical verdicts across runs
- [x] Backend lint passes
- [x] Backend type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)