### PR TITLE
fix(backoffice): exclude archived products from review agent

### DIFF
--- a/server/polar/backoffice/organizations/analytics.py
+++ b/server/polar/backoffice/organizations/analytics.py
@@ -245,6 +245,7 @@ class OrganizationSetupAnalyticsService:
         result = await self.session.execute(
             select(func.count(Product.id)).where(
                 Product.organization_id == organization_id,
+                Product.is_archived.is_(False),
                 Product.is_deleted.is_(False),
             )
         )

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -110,6 +110,7 @@ class OrganizationReviewRepository(
             select(Product)
             .where(
                 Product.organization_id == organization_id,
+                Product.is_archived.is_(False),
                 Product.is_deleted.is_(False),
             )
             .options(selectinload(Product.prices))


### PR DESCRIPTION
## Summary
- Exclude archived products from the review agent's product data collection, preventing false high-risk flags for products that can no longer be purchased (e.g., $999/$1,499 archived products being flagged)
- Exclude archived products from the setup checklist product count

## Test plan
- [ ] Run review agent on an org with archived high-priced products — verify they no longer appear in the summary
- [ ] Check setup checklist product count excludes archived products

🤖 Generated with [Claude Code](https://claude.com/claude-code)