### PR TITLE
fix(backoffice): clean up organization list view

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -163,11 +163,17 @@ class OrganizationListView:
                         ),
                         classes="font-semibold hover:underline flex items-center gap-2",
                     ):
-                        with tag.span(classes="truncate max-w-[200px] inline-block", title=org.name):
+                        with tag.span(
+                            classes="truncate max-w-[200px] inline-block",
+                            title=org.name,
+                        ):
                             text(org.name)
                         with status_badge(org.status):
                             pass
-                    with tag.div(classes="text-xs text-base-content/60 font-mono truncate max-w-[200px]", title=org.slug):
+                    with tag.div(
+                        classes="text-xs text-base-content/60 font-mono truncate max-w-[200px]",
+                        title=org.slug,
+                    ):
                         text(org.slug)
                     # Appeal indicator
                     if (
@@ -508,7 +514,6 @@ class OrganizationListView:
                                     ):
                                         pass
 
-
                                     with self.sortable_header(
                                         request,
                                         "Country",
@@ -588,7 +593,6 @@ class OrganizationListView:
                                     status_filter=status_filter,
                                 ):
                                     pass
-
 
                                 with self.sortable_header(
                                     request,
@@ -722,7 +726,6 @@ class OrganizationListView:
                                     ):
                                         pass
 
-
                                     with self.sortable_header(
                                         request,
                                         "Country",
@@ -802,7 +805,6 @@ class OrganizationListView:
                                     status_filter=status_filter,
                                 ):
                                     pass
-
 
                                 with self.sortable_header(
                                     request,


### PR DESCRIPTION
## 📋 Summary

Clean up the backoffice organization list view by removing the email column and adding truncation for long names/slugs.

## 🎯 What

- Removed the Email column from the organization list table (both headers and row cells)
- Added CSS truncation (`truncate max-w-[200px]`) to organization name and slug with hover tooltips
- Updated the search placeholder to no longer reference email
- Applied `max-w-xs` to the Organization cell to constrain its width

## 🤔 Why

The email column adds clutter without providing useful information at a glance. Long organization names and slugs break the table layout.

## 🔧 How

All changes are in `server/polar/backoffice/organizations_v2/views/list_view.py`:
- Removed Email `<th>` headers from all 4 table renderings (Needs Attention + Regular in both `render` and `render_table_only`)
- Removed Email `<td>` cell from `organization_row`
- Wrapped org name in a `<span>` with `truncate` and `title` attribute for hover
- Added `truncate` class and `title` attribute to the slug `<div>`

## 🧪 Testing

- [ ] I have tested these changes locally

### Test Instructions

1. Navigate to the backoffice Organizations page (v2 view)
2. Verify the Email column is no longer shown
3. Verify long org names and slugs are truncated with ellipsis
4. Hover over truncated text to see the full value in a tooltip

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")