### PR TITLE
fix(backoffice): align refund rate queries between backoffice and AI review

### DIFF
--- a/server/polar/backoffice/organizations/analytics.py
+++ b/server/polar/backoffice/organizations/analytics.py
@@ -20,6 +20,7 @@ from polar.models import (
 )
 from polar.models.dispute import DisputeStatus
 from polar.models.payment import PaymentStatus
+from polar.models.refund import RefundStatus
 from polar.models.transaction import TransactionType
 from polar.payment.repository import PaymentRepository
 from polar.postgres import AsyncSession
@@ -90,7 +91,10 @@ class PaymentAnalyticsService:
                 onclause=(Transaction.refund_id == Refund.id)
                 & (Transaction.type == TransactionType.refund),
             )
-            .where(Customer.organization_id == organization_id)
+            .where(
+                Customer.organization_id == organization_id,
+                Refund.status == RefundStatus.succeeded,
+            )
         )
         result_row = result.first()
         if result_row:

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -164,7 +164,6 @@ class OrganizationReviewRepository(
         ).where(
             Refund.organization_id == organization_id,
             Refund.status == RefundStatus.succeeded,
-            Refund.is_deleted.is_(False),
         )
         result = await self.session.execute(statement)
         row = result.one()


### PR DESCRIPTION
## Summary
- Backoffice `get_refund_stats` was counting all refunds (including pending/failed/canceled) while the AI review query only counted succeeded ones, leading to inconsistent refund rate calculations
- Added `Refund.status == succeeded` filter to the backoffice analytics query
- Removed unnecessary `is_deleted` filter from the AI review query (refunds are never soft-deleted

## Test plan
- [ ] Verify backoffice organization overview page still loads correctly
- [ ] Compare refund rate displayed in payment card vs AI summary — should now use consistent counting

🤖 Generated with [Claude Code](https://claude.com/claude-code)