### PR TITLE
Fix customer portal URL generation for seat-based orgs without member model

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/CustomersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/CustomersPage.tsx
@@ -64,9 +64,11 @@ const CustomerHeader = ({
   } = useModal()
 
   const safeCopy = useSafeCopy(toast)
+  const memberModelEnabled =
+    !!organization.feature_settings?.member_model_enabled
   const createCustomerSession = useCallback(async () => {
     let memberId: string | undefined
-    if (customer.type === 'team') {
+    if (memberModelEnabled && customer.type === 'team') {
       const { data: membersData } = await api.GET('/v1/members/', {
         params: {
           query: { customer_id: customer.id, role: 'owner', limit: 1 },
@@ -105,7 +107,7 @@ const CustomerHeader = ({
       title: 'Copied To Clipboard',
       description: `Customer Portal Link was copied to clipboard`,
     })
-  }, [safeCopy, customer, organization])
+  }, [safeCopy, customer, organization, memberModelEnabled])
 
   const deleteCustomer = useDeleteCustomer(
     customer.id,

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -37,11 +37,13 @@ export const CustomerContextView = ({
   const [customerSession, setCustomerSession] = useState<
     schemas['CustomerSession'] | null
   >(null)
+  const memberModelEnabled =
+    !!organization.feature_settings?.member_model_enabled
   const createCustomerSession = useCallback(async () => {
     setCustomerSessionLoading(true)
 
     let memberId: string | undefined
-    if (customer.type === 'team') {
+    if (memberModelEnabled && customer.type === 'team') {
       const { data: membersData } = await api.GET('/v1/members/', {
         params: {
           query: { customer_id: customer.id, role: 'owner', limit: 1 },
@@ -70,7 +72,7 @@ export const CustomerContextView = ({
       return
     }
     setCustomerSession(session)
-  }, [customer])
+  }, [customer, memberModelEnabled])
 
   const metrics = useMetrics({
     startDate: new Date(customer.created_at),


### PR DESCRIPTION
## 📋 Summary

Fix customer portal URL generation failing for organizations with `seat_based_pricing_enabled` but without `member_model_enabled`.

## 🎯 What

Added a `member_model_enabled` check before attempting to fetch owner members when generating customer portal URLs, in both `CustomersPage.tsx` and `CustomerContextView.tsx`.

## 🤔 Why

Organizations like Stilla have `seat_based_pricing_enabled` (so customers can be of type `team`) but do NOT have `member_model_enabled`. The frontend was unconditionally trying to fetch an owner member for all team customers, which fails when the members API has no data for these orgs — showing "No owner member found for this team customer."

The backend already handles this correctly: when `member_model_enabled` is false, it skips member resolution entirely and creates a regular customer session. The frontend just needed to match this behavior.

## 🔧 How

- Check `organization.feature_settings?.member_model_enabled` before attempting the `/v1/members/` API call
- When the flag is false, skip the member lookup and create a session without `member_id`
- Added `memberModelEnabled` to `useCallback` dependency arrays

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)

### Test Instructions

1. Find an organization with `seat_based_pricing_enabled` but without `member_model_enabled`
2. Navigate to a team customer's page
3. Click "Copy Customer Portal" or "Generate Customer Portal" — it should succeed instead of showing an error

## 📝 Additional Notes

No backend changes needed — the backend service (`customer_session/service.py`) already correctly branches on `member_model_enabled`.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")