### PR TITLE
Fix NoPendingBillingEntries error with 100% discount seat update

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1420,6 +1420,7 @@ class SubscriptionService:
             if (
                 proration_behavior == SubscriptionProrationBehavior.invoice
                 and not subscription.trialing
+                and len(billing_entries) > 0
             ):
                 # Invoice and attempt to pay immediately
                 await self._create_subscription_update_order(session, subscription)

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4239,6 +4239,120 @@ class TestUpdateSeats:
         assert entry.discount is None
         assert entry.discount_amount is None
 
+    async def test_seat_increase_with_100_percent_discount_invoice(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        frozen_time: datetime,
+        enqueue_job_mock: MagicMock,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        # Mock webhook calls to avoid serialization issues with discount
+        mocker.patch.object(
+            subscription_service, "_after_subscription_updated", new=AsyncMock()
+        )
+
+        # Given: Subscription with 1 seat and 100% discount
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],  # $10 per seat
+        )
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=10_000,  # 100% discount
+            duration=DiscountDuration.forever,
+            organization=organization,
+            products=[product],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=1,
+            discount=discount,
+        )
+        assert subscription.seats == 1
+
+        # When: Increase to 2 seats with invoice proration behavior
+        updated = await subscription_service.update_seats(
+            session,
+            subscription,
+            seats=2,
+            proration_behavior=SubscriptionProrationBehavior.invoice,
+        )
+        await session.flush()
+
+        # Then: Seats updated successfully, no billing entries created
+        assert updated.seats == 2
+        billing_entry_repo = BillingEntryRepository.from_session(session)
+        entries = await billing_entry_repo.get_pending_by_subscription(subscription.id)
+        proration_entries = [
+            e for e in entries if e.type == BillingEntryType.subscription_seats_increase
+        ]
+        assert len(proration_entries) == 0
+
+    async def test_seat_increase_with_100_percent_discount_prorate(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        frozen_time: datetime,
+        enqueue_job_mock: MagicMock,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        # Mock webhook calls to avoid serialization issues with discount
+        mocker.patch.object(
+            subscription_service, "_after_subscription_updated", new=AsyncMock()
+        )
+
+        # Given: Subscription with 1 seat and 100% discount
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],  # $10 per seat
+        )
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=10_000,  # 100% discount
+            duration=DiscountDuration.forever,
+            organization=organization,
+            products=[product],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=1,
+            discount=discount,
+        )
+        assert subscription.seats == 1
+
+        # When: Increase to 2 seats with prorate behavior
+        updated = await subscription_service.update_seats(
+            session,
+            subscription,
+            seats=2,
+            proration_behavior=SubscriptionProrationBehavior.prorate,
+        )
+        await session.flush()
+
+        # Then: Seats updated successfully, no billing entries created
+        assert updated.seats == 2
+        billing_entry_repo = BillingEntryRepository.from_session(session)
+        entries = await billing_entry_repo.get_pending_by_subscription(subscription.id)
+        proration_entries = [
+            e for e in entries if e.type == BillingEntryType.subscription_seats_increase
+        ]
+        assert len(proration_entries) == 0
+
 
 @pytest.mark.asyncio
 class TestEnqueueBenefitsGrantsGracePeriod:


### PR DESCRIPTION
## Summary

- Fix 500 `NoPendingBillingEntries` error when calling `subscriptions.update()` with seat changes on a subscription that has a 100% discount
- Skip order creation when there are no billing entries to invoice (prorated amount is $0 with 100% discount)
- Add tests for seat updates with 100% discount for both `invoice` and `prorate` proration behaviors

## Root Cause

In `_generate_seats_subscription_update()`, a 100% discount makes the prorated amount $0, so no billing entries are created. However, `update_seats()` still attempted to create an invoice order, which failed because there were no pending billing entries.

The fix adds a `len(billing_entries) > 0` guard before order creation, mirroring the existing pattern for trialing subscriptions.

## Test plan

- [ ] Verify new test `test_seat_increase_with_100_percent_discount_invoice` passes
- [ ] Verify new test `test_seat_increase_with_100_percent_discount_prorate` passes
- [ ] Verify existing `TestUpdateSeats` tests still pass (no regressions)

Closes #10567

https://claude.ai/code/session_01NhVMPY4wuXdNA85p241Rvf