### PR TITLE
Fix "Currently using" in review

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -516,7 +516,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                     <Select
                       value={field.value || 'none'}
                       onValueChange={(value) => {
-                        field.onChange(value === 'none' ? undefined : value)
+                        field.onChange(value === 'none' ? null : value)
                         setValue('details.switching', value !== 'none', {
                           shouldDirty: true,
                         })
@@ -603,6 +603,13 @@ const OrganizationProfileSettings: React.FC<
       socials: body.socials?.filter(
         (social) => social.url && social.url.trim() !== '',
       ),
+      details: body.details
+        ? {
+            ...body.details,
+            switching: !!body.details.switching_from,
+            switching_from: body.details.switching_from || undefined,
+          }
+        : body.details,
     }
 
     const { data, error } = await updateOrganization.mutateAsync({


### PR DESCRIPTION
When `This is my first payment platform` is selected in the KYC form, the form submits `switching: true` and `switching_from: ""`. The API rejects the empty string because it expects a valid enum value or the field to be absent.