### PR TITLE
web: exclude whole-project NFT trace for /api/cover route

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -95,6 +95,16 @@ const nextConfig = {
     eslint: { ignoreDuringBuilds: true },
   }),
 
+  outputFileTracingExcludes: {
+    '/api/cover': ['**/*'],
+  },
+  outputFileTracingIncludes: {
+    '/api/cover': [
+      './src/app/(main)/(website)/(landing)/(mdx)/blog/(header)/_posts/**/*',
+      './src/app/(main)/(website)/(landing)/customers/(stories)/**/*',
+    ],
+  },
+
   // This is required to support PostHog trailing slash API requests
   skipTrailingSlashRedirect: true,
 


### PR DESCRIPTION
The cover image route's dynamic fs/path operations caused Turbopack to trace the entire project into its serverless bundle. Use outputFileTracingExcludes/Includes to scope the trace to only the blog and story image directories.
