### PR TITLE
fix: make CustomerPortalCustomer email nullable

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/EditBillingDetails.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/EditBillingDetails.tsx
@@ -91,7 +91,7 @@ const EditBillingDetails = ({ onSuccess }: { onSuccess: () => void }) => {
           <FormControl>
             <Input
               type="email"
-              value={customer.email}
+              value={customer.email ?? ''}
               disabled
               readOnly
               className="bg-white shadow-xs"

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -14627,7 +14627,7 @@ export interface components {
        */
       id: string
       /** Email */
-      email: string
+      email: string | null
       /** Email Verified */
       email_verified: boolean
       /** Name */

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -41675,7 +41675,14 @@
             "description": "The ID of the object."
           },
           "email": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Email"
           },
           "email_verified": {

--- a/server/polar/customer_portal/schemas/customer.py
+++ b/server/polar/customer_portal/schemas/customer.py
@@ -24,7 +24,7 @@ class CustomerPortalOAuthAccount(Schema):
 
 
 class CustomerPortalCustomer(IDSchema, TimestampedSchema):
-    email: str
+    email: str | None
     email_verified: bool
     name: str | None
     billing_name: str | None


### PR DESCRIPTION
## 📋 Summary

Fixes a `ResponseValidationError` on `GET /v1/customer-portal/customers/me` when the customer has a null email (e.g., team customers).

## 🎯 What

Made the `email` field nullable in the `CustomerPortalCustomer` schema, matching the change already applied to the main `Customer` schema in #10579.

## 🤔 Why

PR #10579 made customer email nullable for team customers at the database and main schema level, but the customer portal schema was missed. This caused a Pydantic response validation error when a team customer with no email accessed the customer portal.

## 🔧 How

- Updated `CustomerPortalCustomer.email` from `str` to `str | None` in the Python schema
- Updated the OpenAPI spec to reflect the nullable email field
- Updated the generated TypeScript client type (`email: string` → `email: string | null`)
- Added null coalescing in `EditBillingDetails.tsx` for the email input value

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Create a team customer with no email
2. Access `GET /v1/customer-portal/customers/me` with that customer's session
3. Verify it returns a valid response with `"email": null` instead of a 500 error

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")