### PR TITLE
event-loop: Make sure that stacktrace doesnt get scrubbed

### DIFF
--- a/server/polar/logfire.py
+++ b/server/polar/logfire.py
@@ -117,6 +117,15 @@ def _scrubbing_callback(match: logfire.ScrubMatch) -> Any | None:
     # Don't scrub auth subject in log messages
     if match.path == ("attributes", "subject"):
         return match.value
+    # Don't scrub thread stacks from the event loop watchdog — they contain
+    # "session" via SQLAlchemy frames which triggers the default scrubber,
+    # but these are stack traces, not secrets.
+    if match.path == ("attributes", "thread_stacks"):
+        return match.value
+    if match.path == ("attributes", "event_loop_stack"):
+        return match.value
+    if match.path == ("attributes", "asyncio_tasks"):
+        return match.value
     return None
 
 

--- a/server/polar/worker/_asyncio.py
+++ b/server/polar/worker/_asyncio.py
@@ -1,8 +1,10 @@
 import asyncio
+import concurrent.futures
 import faulthandler
 import sys
 import tempfile
 import threading
+import traceback
 
 import dramatiq
 import structlog
@@ -38,6 +40,7 @@ class _EventLoopWatchdog(threading.Thread):
         self.heartbeat_timeout = heartbeat_timeout
         self._stop_event = threading.Event()
         self._heartbeat_event = threading.Event()
+        self._consecutive_misses = 0
 
     def run(self) -> None:
         while not self._stop_event.is_set():
@@ -48,22 +51,90 @@ class _EventLoopWatchdog(threading.Thread):
                 break
 
             if not self._heartbeat_event.wait(timeout=self.heartbeat_timeout):
+                self._consecutive_misses += 1
                 self._dump_stacks()
+            else:
+                if self._consecutive_misses > 0:
+                    total_blocked = self._consecutive_misses * (
+                        self.heartbeat_interval + self.heartbeat_timeout
+                    )
+                    log.warning(
+                        "event_loop_recovered",
+                        consecutive_misses=self._consecutive_misses,
+                        estimated_blocked_seconds=round(total_blocked, 1),
+                    )
+                self._consecutive_misses = 0
 
             self._stop_event.wait(timeout=self.heartbeat_interval)
 
     def stop(self) -> None:
         self._stop_event.set()
 
+    def _get_event_loop_stack(self) -> str:
+        """Extract the stack trace of the event loop thread specifically."""
+        loop_thread_id: int | None = None
+        for thread in threading.enumerate():
+            if thread.name == "dramatiq-asyncio":
+                loop_thread_id = thread.ident
+                break
+
+        if loop_thread_id is None:
+            return "<event loop thread not found>"
+
+        frame = sys._current_frames().get(loop_thread_id)
+        if frame is None:
+            return "<no frame for event loop thread>"
+
+        return "".join(traceback.format_stack(frame))
+
+    def _get_asyncio_tasks(self) -> str:
+        """Get info about asyncio tasks running on the event loop.
+
+        Submits a coroutine to the loop to snapshot tasks. If the loop is
+        blocked this will time out, which is itself useful information.
+        """
+
+        async def _snapshot_tasks() -> str:
+            tasks = asyncio.all_tasks(self.loop)
+            lines = []
+            for task in sorted(tasks, key=lambda t: t.get_name()):
+                coro = task.get_coro()
+                coro_name = getattr(coro, "__qualname__", str(coro))
+                state = task._state if hasattr(task, "_state") else "unknown"
+                lines.append(f"  {task.get_name()} state={state} coro={coro_name}")
+            return f"{len(tasks)} tasks:\n" + "\n".join(lines)
+
+        try:
+            future = asyncio.run_coroutine_threadsafe(_snapshot_tasks(), self.loop)
+            return future.result(timeout=min(self.heartbeat_timeout, 2.0))
+        except concurrent.futures.TimeoutError:
+            return "<timed out collecting tasks — loop still blocked>"
+        except Exception as e:
+            return f"<error collecting tasks: {e}>"
+
     def _dump_stacks(self) -> None:
+        # Collect fast diagnostics first — these don't touch the event loop
+        event_loop_stack = self._get_event_loop_stack()
+
         with tempfile.TemporaryFile(mode="w+") as f:
             faulthandler.dump_traceback(file=f, all_threads=True)
             f.seek(0)
             traceback_text = f.read()
 
+        # Collect async tasks last — this may wait up to 2s if the loop is blocked
+        asyncio_tasks = self._get_asyncio_tasks()
+
+        total_blocked = self._consecutive_misses * (
+            self.heartbeat_interval + self.heartbeat_timeout
+        )
+
         log.error(
             "event_loop_unresponsive",
             timeout_seconds=self.heartbeat_timeout,
+            consecutive_misses=self._consecutive_misses,
+            estimated_blocked_seconds=round(total_blocked, 1),
+            event_loop_stack=event_loop_stack,
+            asyncio_tasks=asyncio_tasks,
             thread_stacks=traceback_text,
         )
         faulthandler.dump_traceback(file=sys.stderr, all_threads=True)

--- a/server/tests/worker/test_asyncio_watchdog.py
+++ b/server/tests/worker/test_asyncio_watchdog.py
@@ -109,3 +109,40 @@ class TestEventLoopWatchdog:
             call_kwargs = mock_log.error.call_args_list[0][1]
             assert "thread_stacks" in call_kwargs
             assert "obviously_blocking_function" in call_kwargs["thread_stacks"]
+            assert "event_loop_stack" in call_kwargs
+            assert "asyncio_tasks" in call_kwargs
+            assert "consecutive_misses" in call_kwargs
+            assert call_kwargs["consecutive_misses"] >= 1
+
+    def test_consecutive_misses_tracked(
+        self, event_loop_thread: asyncio.AbstractEventLoop
+    ) -> None:
+        blocker_started = threading.Event()
+
+        def block_loop() -> None:
+            blocker_started.set()
+            time.sleep(3)
+
+        event_loop_thread.call_soon_threadsafe(block_loop)
+        blocker_started.wait(timeout=1)
+
+        watchdog = _EventLoopWatchdog(
+            event_loop_thread,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+        )
+
+        with patch("polar.worker._asyncio.log") as mock_log:
+            watchdog.start()
+            time.sleep(1.0)
+            watchdog.stop()
+            watchdog.join(timeout=5)
+
+            error_calls = [
+                c
+                for c in mock_log.error.call_args_list
+                if c[0][0] == "event_loop_unresponsive"
+            ]
+            assert len(error_calls) >= 2
+            assert error_calls[0][1]["consecutive_misses"] == 1
+            assert error_calls[1][1]["consecutive_misses"] == 2


### PR DESCRIPTION
We need to investigate _why_ the event loop is getting stuck. It's being scrubbed due to the session scrubbing in logfire.
