### PR TITLE
fix: forward Stripe Connect webhooks to separate endpoint in dev CLI

### DIFF
--- a/dev/cli/commands/stripe.py
+++ b/dev/cli/commands/stripe.py
@@ -81,6 +81,7 @@ def _save_stripe_keys(secret_key: str, publishable_key: str, webhook_secret: str
     _update_secrets_file("POLAR_STRIPE_PUBLISHABLE_KEY", publishable_key)
     if webhook_secret:
         _update_secrets_file("POLAR_STRIPE_WEBHOOK_SECRET", webhook_secret)
+        _update_secrets_file("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", webhook_secret)
 
 
 def register(app: typer.Typer, prompt_setup: callable) -> None:
@@ -163,9 +164,14 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
 def _start_webhook_listener() -> None:
     """Start Stripe webhook forwarding."""
     console.print("\n[bold]Starting Stripe webhook forwarding...[/bold]")
-    console.print("[dim]Forwarding to: http://127.0.0.1:8000/v1/integrations/stripe/webhook[/dim]")
+    console.print("[dim]Forwarding to:         http://127.0.0.1:8000/v1/integrations/stripe/webhook[/dim]")
+    console.print("[dim]Connect forwarding to: http://127.0.0.1:8000/v1/integrations/stripe/webhook-connect[/dim]")
     console.print("[dim]Press Ctrl+C to stop[/dim]\n")
     run_command(
-        ["stripe", "listen", "--forward-to", "http://127.0.0.1:8000/v1/integrations/stripe/webhook"],
+        [
+            "stripe", "listen",
+            "--forward-to", "http://127.0.0.1:8000/v1/integrations/stripe/webhook",
+            "--forward-connect-to", "http://127.0.0.1:8000/v1/integrations/stripe/webhook-connect",
+        ],
         capture=False,
     )

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -81,6 +81,7 @@ def save_stripe_keys(secret_key: str, publishable_key: str, webhook_secret: str 
     _update_secrets_file("POLAR_STRIPE_PUBLISHABLE_KEY", publishable_key)
     if webhook_secret:
         _update_secrets_file("POLAR_STRIPE_WEBHOOK_SECRET", webhook_secret)
+        _update_secrets_file("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", webhook_secret)
 
 
 def _update_secrets_file(key: str, value: str | None) -> None:
@@ -213,8 +214,8 @@ def _setup_stripe() -> None:
     console.print("[dim]Updating environment files...[/dim]")
     run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
 
-    console.print("\n[bold]To receive webhooks locally, run in a separate terminal:[/bold]")
-    console.print("  [bold]stripe listen --forward-to http://127.0.0.1:8000/v1/integrations/stripe/webhook[/bold]\n")
+    console.print("\n[bold]To receive webhooks locally, run:[/bold]")
+    console.print("  [bold]dev stripe --listen[/bold]\n")
 
 
 def run(ctx: Context) -> bool:


### PR DESCRIPTION
## 📋 Summary

The `dev stripe` command was forwarding all Stripe webhooks to a single endpoint, but the backend has two separate endpoints: `/webhook` for direct events and `/webhook-connect` for Connect events, each with its own signing secret.

## 🎯 What

- Updated `_start_webhook_listener()` to use `--forward-connect-to` for Connect events (account.updated, payout.*)
- Save the webhook signing secret to both `POLAR_STRIPE_WEBHOOK_SECRET` and `POLAR_STRIPE_CONNECT_WEBHOOK_SECRET`
- Simplified the `dev up` hint to point to `dev stripe --listen` instead of a raw `stripe listen` command

## 🤔 Why

Connect webhooks (account.updated, payout.updated, payout.paid) were being sent to `/webhook` instead of `/webhook-connect`, so they were verified against the wrong secret and handled by the wrong handler.

## 🔧 How

Used the Stripe CLI's `--forward-connect-to` flag to route Connect events to the correct endpoint. Since `stripe listen` uses a single signing secret for both forwarding targets, the same secret is saved for both env vars.

## 🧪 Testing

- [ ] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Run `dev stripe --listen`
2. Verify output shows both forwarding targets (direct and connect)
3. Trigger a Connect event (e.g. payout) and verify it hits `/webhook-connect`

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")