### PR TITLE
backoffice: validate impersonation cookie token before reuse

### DIFF
--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from polar.auth.scope import Scope
 from polar.auth.service import auth as auth_service
 from polar.config import settings
+from polar.kit.crypto import get_token_hash
 from polar.models import (
     User,
     UserSession,
@@ -57,9 +58,13 @@ async def start_impersonation(
         expire_in=timedelta(minutes=60),
     )
 
-    admin_token = request.cookies.get(
-        settings.IMPERSONATION_COOKIE_KEY
-    ) or request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
+    admin_token = request.cookies.get(settings.IMPERSONATION_COOKIE_KEY)
+    if admin_token:
+        token_hash = get_token_hash(admin_token, secret=settings.SECRET)
+        if token_hash != admin_session.token:
+            admin_token = None
+    if not admin_token:
+        admin_token = request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
 
     # Create response object
     org_repository = OrganizationRepository.from_session(session)


### PR DESCRIPTION
A stale polar_original_session cookie with an expired token would get blindly propagated on each new impersonation start, creating a permanent 403 loop on end_impersonation since get_admin could never resolve the expired token back to the admin session.

Validate the cookie token against the authenticated admin session before using it, falling back to polar_session if it doesn't match.