### PR TITLE
Increase default review threshold to $10

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -260,7 +260,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
         default=OrganizationStatus.CREATED,
     )
     next_review_threshold: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0
+        Integer, nullable=False, default=1000
     )
     status_updated_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True


### PR DESCRIPTION
## Summary
- Changes the default `next_review_threshold` for new organizations from $0 to $10 (1000 cents)
- Test/integration sales under $10 will no longer trigger initial review tickets in Plain
- Organizations that grow past $10 will still be caught by the threshold — no org permanently skips review

## Context
Currently, the very first balance transaction triggers an initial review because the default threshold is $0. Many customers create test sales during integration that never grow past $10.

## Test plan
- [ ] Verify new organizations are created with `next_review_threshold = 1000`
- [ ] Verify existing organizations are unaffected
- [ ] Confirm a balance transaction under $10 does NOT trigger initial review
- [ ] Confirm a balance transaction crossing $10 DOES trigger initial review


🤖 Generated with [Claude Code](https://claude.com/claude-code)