### PR TITLE
Fix organization update validation for inconsistent seat-based pricing state

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -289,7 +289,7 @@ class OrganizationService:
                     ]
                 )
 
-            if new_seat_based and not new_member_model:
+            if not old_seat_based and new_seat_based and not new_member_model:
                 raise PolarRequestValidationError(
                     [
                         {

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1791,3 +1791,56 @@ class TestUpdateSeatBasedPricing:
         )
 
         assert result.feature_settings["seat_based_pricing_enabled"] is True
+
+    async def test_update_unrelated_setting_with_inconsistent_state(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Orgs in inconsistent state (seat_based=True, member_model=False)
+        should still be able to update other feature settings."""
+        organization.feature_settings = {
+            "member_model_enabled": False,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                feature_settings=OrganizationFeatureSettings(
+                    checkout_localization_enabled=True,
+                ),
+            ),
+        )
+
+        assert result.feature_settings["seat_based_pricing_enabled"] is True
+        assert result.feature_settings["checkout_localization_enabled"] is True
+
+    async def test_resend_seat_based_true_with_inconsistent_state(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Orgs in inconsistent state should not be blocked when
+        seat_based_pricing_enabled=True is re-sent (no False->True transition)."""
+        organization.feature_settings = {
+            "member_model_enabled": False,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                feature_settings=OrganizationFeatureSettings(
+                    seat_based_pricing_enabled=True,
+                ),
+            ),
+        )
+
+        assert result.feature_settings["seat_based_pricing_enabled"] is True


### PR DESCRIPTION
## Summary

- **Fix overly broad validation** in `OrganizationService.update()` that blocked orgs with an inconsistent state (`seat_based_pricing_enabled=True`, `member_model_enabled=False`) from updating *any* feature setting
- The check now only fires on a `False→True` transition (`not old_seat_based and new_seat_based and not new_member_model`) instead of whenever the merged value is `True`
- **Add two new tests** covering the inconsistent-state scenarios: updating an unrelated setting, and re-sending `seat_based_pricing_enabled=True`

## Context

Organizations like Emil's ended up in an inconsistent state where `seat_based_pricing_enabled=True` but `member_model_enabled=False`. The frontend's `useAutoSave` sends all form fields on any change, so toggling an unrelated setting (e.g. `checkout_localization_enabled`) would include `seat_based_pricing_enabled=True` from defaults, triggering the validation error.

## Test plan

- [ ] Verify new tests pass: `TestUpdateSeatBasedPricing::test_update_unrelated_setting_with_inconsistent_state` and `test_resend_seat_based_true_with_inconsistent_state`
- [ ] Verify existing seat-based pricing tests still pass (enabling with/without member model, disabling, keeping enabled)
- [ ] Verify orgs in inconsistent state can now update other feature settings without error

https://claude.ai/code/session_017UyWSgHWsAP43cCNEVCW75