### PR TITLE
Handle external customer ID conflicts during checkout confirmation

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2589,6 +2589,21 @@ class CheckoutService:
         if checkout.locale is not None:
             customer.locale = checkout.locale
 
+        if checkout.external_customer_id is not None and not created:
+            if (
+                customer.external_id is not None
+                and customer.external_id != checkout.external_customer_id
+            ):
+                raise CheckoutCustomerExternalIdMismatch()
+            if customer.external_id is None:
+                existing = await repository.get_by_external_id_and_organization(
+                    checkout.external_customer_id,
+                    checkout.organization.id,
+                )
+                if existing is not None and existing.id != customer.id:
+                    raise CheckoutCustomerExternalIdMismatch()
+                customer.external_id = checkout.external_customer_id
+
         customer.stripe_customer_id = stripe_customer_id
         customer.user_metadata = {
             **customer.user_metadata,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4767,7 +4767,7 @@ class TestConfirm:
         """
         Customer exists, no external ID set.
 
-        Checkout should link to the existing customer by email, but not set the external ID.
+        Checkout should link to the existing customer by email and set the external ID.
         """
         customer = await create_customer(
             save_fixture,
@@ -4802,7 +4802,107 @@ class TestConfirm:
         assert checkout.customer is not None
         assert checkout.customer == customer
         assert checkout.customer.email == customer.email
-        assert checkout.customer.external_id is None
+        assert checkout.customer.external_id == "external_id_1"
+
+    async def test_existing_email_conflicting_external_id(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        """
+        Customer exists with a different external ID.
+
+        Should raise CheckoutCustomerExternalIdMismatch.
+        """
+        await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer1@example.com",
+            external_id="existing_external_id",
+        )
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            external_customer_id="different_external_id",
+        )
+
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        with pytest.raises(CheckoutCustomerExternalIdMismatch):
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "customer1@example.com",
+                        "customer_billing_address": {
+                            "country": "FR",
+                        },
+                    }
+                ),
+            )
+
+    async def test_existing_email_external_id_owned_by_other_customer(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        """
+        Customer exists by email without external ID, but another customer
+        already owns the checkout's external_customer_id.
+
+        Should raise CheckoutCustomerExternalIdMismatch.
+        """
+        await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer1@example.com",
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization,
+            email="other@example.com",
+            external_id="external_id_1",
+        )
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            external_customer_id="external_id_1",
+        )
+
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        with pytest.raises(CheckoutCustomerExternalIdMismatch):
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "customer1@example.com",
+                        "customer_billing_address": {
+                            "country": "FR",
+                        },
+                    }
+                ),
+            )
 
     async def test_existing_customer_email_changed(
         self,


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: Fixes #<!-- issue number -->

This PR fixes the checkout confirmation flow to properly handle external customer ID conflicts and ensures external IDs are set when linking to existing customers.

## 🎯 What

1. **Fixed external ID assignment**: When confirming a checkout with an external customer ID and linking to an existing customer by email, the external ID is now properly set on the customer (previously it was not being set).

2. **Added conflict detection**: The checkout confirmation now validates that:
   - If a customer already has a different external ID, a `CheckoutCustomerExternalIdMismatch` exception is raised
   - If another customer already owns the external ID being used, a `CheckoutCustomerExternalIdMismatch` exception is raised

3. **Added comprehensive test coverage**: Two new test cases validate the conflict scenarios:
   - `test_existing_email_conflicting_external_id`: Customer exists with a different external ID
   - `test_existing_email_external_id_owned_by_other_customer`: External ID is owned by a different customer

## 🤔 Why

This change prevents data integrity issues where:
- A customer could be linked to multiple external IDs
- An external ID could be associated with multiple customers
- External IDs wouldn't be properly synchronized when confirming checkouts

## 🔧 How

Modified `_create_or_update_customer` in `server/polar/checkout/service.py` to:
1. Check if the customer already has an external ID that conflicts with the checkout's external ID
2. Verify that no other customer owns the external ID before assigning it
3. Assign the external ID to the customer if validation passes

Updated the test in `test_existing_email_external_id_provided` to verify the external ID is now correctly set.

## 🧪 Testing

- [x] All existing tests pass
- [x] Added new tests for conflict scenarios
- [x] Updated existing test assertion to verify external ID is set

The changes are covered by:
- `test_existing_email_external_id_provided`: Verifies external ID is set when linking by email
- `test_existing_email_conflicting_external_id`: Verifies exception on conflicting external ID
- `test_existing_email_external_id_owned_by_other_customer`: Verifies exception when external ID is owned by another customer

https://claude.ai/code/session_01TeYjM9p86prrFUTs923iA4