### PR TITLE
logfire: Disable inspect_arguments

### DIFF
--- a/server/polar/logfire.py
+++ b/server/polar/logfire.py
@@ -169,6 +169,7 @@ def configure_logfire(service_name: Literal["server", "worker"]) -> None:
         environment=settings.ENV,
         service_name=resolved_service_name,
         service_version=os.environ.get("RELEASE_VERSION", "development"),
+        inspect_arguments=False,
         code_source=logfire.CodeSource(
             repository="https://github.com/polarsource/polar",
             revision=os.environ.get("RELEASE_VERSION", "main"),


### PR DESCRIPTION
Logfire's inspect_arguments feature (enabled by default on Python 3.11+) inspects the caller's stack frame and parses the source AST on every span creation to resolve f-string variables.

  Memray profiling showed this was the single largest allocator: 20.5 GB of allocations across 80k requests, all from ast.parse(). The allocations are short-lived but the volume causes memory fragmentation — RSS grows
  even though the objects are freed.

  With inspect_arguments=False:
  - RSS stays flat at 671 MB (vs 850+ MB growing to 1000+)
  - Throughput improves from 445 to 726 req/s for an arbitrary request that returns 401 locally
  - All observability (spans, traces, scrubbing, attributes) is preserved
  - The only loss is automatic f-string variable resolution, which we don't use
