### PR TITLE
Upgrade production API to pro_plus plan

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -156,7 +156,7 @@ module "production" {
     custom_domains  = [{ name = "api.polar.sh" }, { name = "api-alt.polar.sh" }, { name = "buy.polar.sh" }, { name = "backoffice.polar.sh" }]
     image_url       = data.render_web_service.production_api.runtime_source.image.image_url
     image_digest    = data.render_web_service.production_api.runtime_source.image.digest
-    plan            = "pro"
+    plan            = "pro_plus"
     web_concurrency = "4"
   }
 


### PR DESCRIPTION
## Summary
- Upgrades the production API Render plan from `pro` (4 GB) to `pro_plus`
- 4 uvicorn workers each grow to ~1,050 MB RSS from cache warmup, totaling ~4.2 GB which exceeds the `pro` plan's 4 GB limit
- This caused repeated OOM crashes on instances `6d29z` and `9578d` on March 28-29

## Test plan
- [ ] `terraform plan` shows only the plan attribute change
- [ ] After apply, monitor RSS — workers should no longer hit container memory limit


🤖 Generated with [Claude Code](https://claude.com/claude-code)