### PR TITLE
Scale Tinybird worker to 4 processes / 32 threads

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -211,7 +211,7 @@ module "production" {
       database_pool_size = "16"
     }
     "worker-tinybird" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues tinybird"
+      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 32 --queues tinybird"
       image_url          = data.render_web_service.production_worker["worker-tinybird"].runtime_source.image.image_url
       image_digest       = data.render_web_service.production_worker["worker-tinybird"].runtime_source.image.digest
       dramatiq_prom_port = "10002"


### PR DESCRIPTION
## Summary
- Increases Tinybird worker parallelism from `-p 1 -t 16` to `-p 4 -t 32`
- Should improve queue throughput for Tinybird data sync

## Test plan
- [ ] `terraform plan` shows only the start_command change
- [ ] After apply, monitor `polar_queue_size` and `polar_queue_oldest_message_age_seconds` for the tinybird queue


🤖 Generated with [Claude Code](https://claude.com/claude-code)