### PR TITLE
server/subscription: compute next cycle using anchor day when available

### DIFF
--- a/server/polar/enums.py
+++ b/server/polar/enums.py
@@ -1,3 +1,4 @@
+import calendar
 from datetime import datetime
 from enum import StrEnum
 from typing import Literal
@@ -63,16 +64,26 @@ class SubscriptionRecurringInterval(StrEnum):
     def as_literal(self) -> Literal["day", "week", "month", "year"]:
         return self.value
 
-    def get_next_period(self, d: datetime, leap: int = 1) -> datetime:
+    def get_next_period(
+        self, d: datetime, anchor_day: int | None, leap: int = 1
+    ) -> datetime:
         match self:
             case SubscriptionRecurringInterval.day:
                 return d + relativedelta(days=leap)
             case SubscriptionRecurringInterval.week:
                 return d + relativedelta(weeks=leap)
             case SubscriptionRecurringInterval.month:
-                return d + relativedelta(months=leap)
+                next = d + relativedelta(months=leap)
+                if anchor_day is not None and next.day != anchor_day:
+                    _, max_month_day = calendar.monthrange(next.year, next.month)
+                    next = next.replace(day=min(anchor_day, max_month_day))
+                return next
             case SubscriptionRecurringInterval.year:
-                return d + relativedelta(years=leap)
+                next = d + relativedelta(years=leap)
+                if anchor_day is not None and next.day != anchor_day:
+                    _, max_month_day = calendar.monthrange(next.year, next.month)
+                    next = next.replace(day=min(anchor_day, max_month_day))
+                return next
 
 
 class SubscriptionProrationBehavior(StrEnum):

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -1,7 +1,7 @@
 import functools
 import operator
 from collections.abc import Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Self, TypeVar
 from uuid import UUID
@@ -396,14 +396,6 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
             self.cancel_at_period_end
             and self.status in SubscriptionStatus.billable_statuses()
         )
-
-    def set_started_at(self) -> None:
-        """
-        Stores the starting date when the subscription
-        becomes active for the first time.
-        """
-        if self.active and self.started_at is None:
-            self.started_at = datetime.now(UTC)
 
     def update_amount_and_currency(
         self, prices: Sequence["SubscriptionProductPrice"], discount: "Discount | None"

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -453,7 +453,7 @@ class SubscriptionService:
 
         current_period_start = utc_now()
         current_period_end = recurring_interval.get_next_period(
-            current_period_start, recurring_interval_count
+            current_period_start, current_period_start.day, recurring_interval_count
         )
 
         subscription = Subscription(
@@ -554,7 +554,7 @@ class SubscriptionService:
             current_period_end = trial_end
         else:
             current_period_end = recurring_interval.get_next_period(
-                current_period_start, recurring_interval_count
+                current_period_start, current_period_start.day, recurring_interval_count
             )
 
         # New subscription
@@ -573,6 +573,7 @@ class SubscriptionService:
         subscription.current_period_end = current_period_end
         subscription.trial_start = trial_start
         subscription.trial_end = trial_end
+        subscription.anchor_day = current_period_start.day
 
         subscription.recurring_interval = recurring_interval
         subscription.recurring_interval_count = recurring_interval_count
@@ -694,7 +695,9 @@ class SubscriptionService:
                 subscription.current_period_start = current_period_end
                 subscription.current_period_end = (
                     subscription.recurring_interval.get_next_period(
-                        current_period_end, subscription.recurring_interval_count
+                        current_period_end,
+                        subscription.anchor_day,
+                        subscription.recurring_interval_count,
                     )
                 )
 
@@ -1492,6 +1495,7 @@ class SubscriptionService:
         old_period_end = subscription.current_period_end
 
         subscription.current_period_end = new_period_end
+        subscription.anchor_day = new_period_end.day
 
         await event_service.create_event(
             session,

--- a/server/polar/subscription/update.py
+++ b/server/polar/subscription/update.py
@@ -152,7 +152,7 @@ def _generate_product_subscription_update(
         new_cycle_start = subscription.current_period_start
 
     new_cycle_end = new_product.recurring_interval.get_next_period(
-        new_cycle_start, new_product.recurring_interval_count
+        new_cycle_start, new_cycle_start.day, new_product.recurring_interval_count
     )
 
     subscription_update.new_cycle_start = new_cycle_start

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1061,9 +1061,12 @@ async def create_subscription(
     now = datetime.now(UTC)
     if not current_period_start:
         current_period_start = now
+
+    anchor_day = current_period_start.day
+
     if not current_period_end:
         current_period_end = recurring_interval.get_next_period(
-            current_period_start, recurring_interval_count
+            current_period_start, anchor_day, recurring_interval_count
         )
 
     canceled_at = None
@@ -1085,6 +1088,7 @@ async def create_subscription(
         tax_exempted=tax_exempted,
         current_period_start=current_period_start,
         current_period_end=current_period_end,
+        anchor_day=anchor_day,
         trial_start=trial_start,
         trial_end=trial_end,
         cancel_at_period_end=cancel_at_period_end,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1,7 +1,7 @@
 import uuid
 from collections import namedtuple
 from collections.abc import Generator
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, call
 
@@ -558,6 +558,7 @@ class TestCreateOrUpdateFromCheckout:
         assert subscription.current_period_end is not None
         assert subscription.started_at == subscription.current_period_start
         assert subscription.current_period_end > subscription.current_period_start
+        assert subscription.anchor_day == subscription.current_period_start.day
 
         publish_checkout_event_mock.assert_called_once_with(
             checkout.client_secret, CheckoutEvent.subscription_created
@@ -776,6 +777,10 @@ class TestCreateOrUpdateFromCheckout:
         assert updated_subscription.current_period_end is not None
         assert previous_current_period_end is not None
         assert updated_subscription.current_period_end > previous_current_period_end
+        assert (
+            updated_subscription.anchor_day
+            == updated_subscription.current_period_start.day
+        )
 
         publish_checkout_event_mock.assert_called_once_with(
             checkout.client_secret, CheckoutEvent.subscription_created
@@ -824,6 +829,7 @@ class TestCreateOrUpdateFromCheckout:
         assert subscription.current_period_end > subscription.current_period_start
         assert subscription.current_period_end == checkout.trial_end
         assert subscription.trial_start == subscription.current_period_start
+        assert subscription.anchor_day == subscription.current_period_start.day
 
         publish_checkout_event_mock.assert_called_once_with(
             checkout.client_secret, CheckoutEvent.subscription_created
@@ -1094,6 +1100,46 @@ class TestCycle:
             third_cycle_billing_entry.end_timestamp
             == third_cycle_subscription.current_period_end
         )
+
+    async def test_anchor_monthly_cycle(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+            current_period_start=datetime(2024, 1, 31, tzinfo=UTC),
+        )
+        assert subscription.anchor_day == 31
+        assert subscription.recurring_interval_count == 1
+        assert subscription.current_period_start.month == 1
+        assert subscription.current_period_end.month == 2
+
+        second_cycle_subscription = await subscription_service.cycle(
+            session, subscription
+        )
+        second_period_start = second_cycle_subscription.current_period_start
+        assert second_period_start.month == 2
+        assert second_period_start.day == 29
+        second_period_end = second_cycle_subscription.current_period_end
+        assert second_period_end.month == 3
+        assert second_period_end.day == 31
+
+        third_cycle_subscription = await subscription_service.cycle(
+            session, second_cycle_subscription
+        )
+        third_period_start = third_cycle_subscription.current_period_start
+        assert third_period_start.month == 3
+        assert third_period_start.day == 31
+        third_period_end = third_cycle_subscription.current_period_end
+        assert third_period_end.month == 4
+        assert third_period_end.day == 30
 
     async def test_cancel_at_period_end(
         self,
@@ -1551,7 +1597,13 @@ class TestCycle:
         assert updated_subscription.current_period_start == old_period_end
         # The new period should end one year after the old period end (not two years)
         assert updated_subscription.current_period_end == (
-            SubscriptionRecurringInterval.year.get_next_period(old_period_end, 1)
+            SubscriptionRecurringInterval.year.get_next_period(
+                old_period_end, updated_subscription.current_period_start.day, 1
+            )
+        )
+        assert (
+            updated_subscription.anchor_day
+            == updated_subscription.current_period_start.day
         )
         assert updated_subscription.product == annual_product
         assert updated_subscription.pending_update is None
@@ -4589,7 +4641,7 @@ class TestEnqueueBenefitsGrantsGracePeriod:
 
 @pytest.mark.asyncio
 class TestUpdateBillingPeriod:
-    async def test_emits_event(
+    async def test_basic(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -4614,6 +4666,7 @@ class TestUpdateBillingPeriod:
         )
 
         assert updated_subscription.current_period_end == new_period_end
+        assert updated_subscription.anchor_day == new_period_end.day
 
         event_repository = EventRepository.from_session(session)
         events = await event_repository.get_all_by_name(


### PR DESCRIPTION
Fix #10664


- server/subscription: compute next cycle using anchor day when available
