### PR TITLE
subscription: assert anchor_day preserved, not clamped to period start

### DIFF
--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1602,10 +1602,7 @@ class TestCycle:
                 old_period_end, updated_subscription.current_period_start.day, 1
             )
         )
-        assert (
-            updated_subscription.anchor_day
-            == updated_subscription.current_period_start.day
-        )
+        assert updated_subscription.anchor_day == subscription.anchor_day
         assert updated_subscription.product == annual_product
         assert updated_subscription.pending_update is None
 


### PR DESCRIPTION
When a subscription cycles into a shorter month (e.g. March 31 → April 30), anchor_day correctly stays 31 while current_period_start.day is clamped to 30. The old assertion expected them to match, which failed on the 29th-31st of months.