### PR TITLE
events: Only search if you enter more than 3 characters

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/EventsPage.tsx
@@ -121,7 +121,8 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       sorting: [sorting] as ['-timestamp' | 'timestamp'],
       start_timestamp: startDate.toISOString(),
       end_timestamp: endDate.toISOString(),
-      query: debouncedQuery ?? null,
+      query:
+        debouncedQuery && debouncedQuery.length >= 3 ? debouncedQuery : null,
       metadata: debouncedMetadata ?? null,
       cursor_pagination: false,
     }
@@ -227,13 +228,22 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             )}
             onScroll={handleScroll}
           >
-            <div className="flex flex-row items-center gap-3">
-              <Input
-                placeholder="Search Events"
-                value={query ?? undefined}
-                onChange={(e) => setQuery(e.target.value)}
-                preSlot={<Search fontSize="small" />}
-              />
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-row items-center gap-3">
+                <Input
+                  placeholder="Search Events"
+                  value={query ?? undefined}
+                  onChange={(e) => setQuery(e.target.value)}
+                  preSlot={<Search fontSize="small" />}
+                />
+              </div>
+              {debouncedQuery &&
+                debouncedQuery.length > 0 &&
+                debouncedQuery.length < 3 && (
+                  <p className="dark:text-polar-500 text-xs text-gray-400">
+                    Type at least 3 characters to search
+                  </p>
+                )}
             </div>
             <div className="flex h-full grow flex-col gap-y-6">
               <div className="flex flex-col gap-y-2">

--- a/server/polar/event/endpoints.py
+++ b/server/polar/event/endpoints.py
@@ -157,6 +157,18 @@ async def list(
             ]
         )
 
+    if query is not None and len(query) < 3:
+        raise RequestValidationError(
+            [
+                {
+                    "type": "query",
+                    "msg": "Query must be at least 3 characters.",
+                    "loc": ("query", "query"),
+                    "input": query,
+                }
+            ]
+        )
+
     result = await event_service.list(
         session,
         auth_subject,
@@ -350,6 +362,18 @@ async def list_statistics_timeseries(
                 {
                     "type": "query",
                     "msg": "Query is only supported when organization_id is provided.",
+                }
+            ]
+        )
+
+    if query is not None and len(query) < 3:
+        raise RequestValidationError(
+            [
+                {
+                    "type": "query",
+                    "msg": "Query must be at least 3 characters.",
+                    "loc": ("query", "query"),
+                    "input": query,
                 }
             ]
         )


### PR DESCRIPTION
It makes sense to not allow too broad searches, and if you have a lot of customers we end up with a huge `IN ()` query, which goes above the size limit for Tinybird