### PR TITLE
Add tax included indicator in checkout

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
@@ -13,6 +13,7 @@ export interface CheckoutHeroPriceProps {
 
 const CheckoutHeroPrice = ({ checkout, locale }: CheckoutHeroPriceProps) => {
   const { product, product_price } = checkout
+
   const hasTrial =
     checkout.active_trial_interval && checkout.active_trial_interval_count
 

--- a/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
@@ -13,7 +13,6 @@ export interface CheckoutHeroPriceProps {
 
 const CheckoutHeroPrice = ({ checkout, locale }: CheckoutHeroPriceProps) => {
   const { product, product_price } = checkout
-
   const hasTrial =
     checkout.active_trial_interval && checkout.active_trial_interval_count
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -93,12 +93,13 @@ describe('CheckoutPricingBreakdown', () => {
     })
   })
 
-  describe('with taxes, no discount', () => {
+  describe('with exclusive taxes, no discount', () => {
     it('shows subtotal, tax amount, and total correctly', () => {
       const checkout = createBaseCheckout({
         amount: 999,
         net_amount: 999,
         tax_amount: 250,
+        tax_behavior: 'exclusive',
         total_amount: 1249,
       })
 
@@ -107,6 +108,23 @@ describe('CheckoutPricingBreakdown', () => {
       expect(getRowValue('Subtotal')).toBe('$9.99')
       expect(getRowValue('Taxes')).toBe('$2.50')
       expect(getRowValue('Total')).toBe('$12.49')
+    })
+  })
+
+  describe('with inclusive taxes', () => {
+    it('shows "Taxes (included)" label', () => {
+      const checkout = createBaseCheckout({
+        amount: 999,
+        net_amount: 799,
+        tax_amount: 200,
+        tax_behavior: 'inclusive',
+        total_amount: 999,
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      expect(getRowValue('Taxes (included)')).toBe('$2')
+      expect(getRowValue('Total')).toBe('$9.99')
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -195,7 +195,12 @@ const CheckoutPricingBreakdown = ({
             className="text-gray-600"
           >
             <AmountLabel
-              amount={checkout.amount}
+              amount={
+                checkout.tax_behavior === 'inclusive' &&
+                checkout.tax_amount !== null
+                  ? checkout.total_amount - checkout.tax_amount
+                  : checkout.amount
+              }
               currency={checkout.currency}
               interval={interval}
               intervalCount={intervalCount}
@@ -229,7 +234,11 @@ const CheckoutPricingBreakdown = ({
           )}
 
           <DetailRow
-            title={t('checkout.pricing.taxes')}
+            title={
+              checkout.tax_behavior === 'inclusive'
+                ? t('checkout.pricing.inclTax')
+                : t('checkout.pricing.taxes')
+            }
             className="text-gray-600"
           >
             {checkout.tax_amount !== null

--- a/clients/packages/checkout/src/test-utils/makeCheckout.ts
+++ b/clients/packages/checkout/src/test-utils/makeCheckout.ts
@@ -96,6 +96,7 @@ const defaults: ProductCheckoutPublic = {
   discount_amount: 0,
   net_amount: 999,
   tax_amount: null,
+  tax_behavior: null,
   total_amount: 999,
   currency: 'usd',
   allow_trial: null,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -9884,6 +9884,8 @@ export interface components {
        * @description Sales tax amount in cents. If `null`, it means there is no enough information yet to calculate it.
        */
       tax_amount: number | null
+      /** @description Tax behavior of the checkout. `inclusive` means the price includes tax, `exclusive` means tax is added on top. If `null`, tax is not yet calculated. */
+      tax_behavior: components['schemas']['TaxBehavior'] | null
       /**
        * Total Amount
        * @description Amount in cents, after discounts and taxes.
@@ -11558,6 +11560,8 @@ export interface components {
        * @description Sales tax amount in cents. If `null`, it means there is no enough information yet to calculate it.
        */
       tax_amount: number | null
+      /** @description Tax behavior of the checkout. `inclusive` means the price includes tax, `exclusive` means tax is added on top. If `null`, tax is not yet calculated. */
+      tax_behavior: components['schemas']['TaxBehavior'] | null
       /**
        * Total Amount
        * @description Amount in cents, after discounts and taxes.
@@ -11822,6 +11826,8 @@ export interface components {
        * @description Sales tax amount in cents. If `null`, it means there is no enough information yet to calculate it.
        */
       tax_amount: number | null
+      /** @description Tax behavior of the checkout. `inclusive` means the price includes tax, `exclusive` means tax is added on top. If `null`, tax is not yet calculated. */
+      tax_behavior: components['schemas']['TaxBehavior'] | null
       /**
        * Total Amount
        * @description Amount in cents, after discounts and taxes.
@@ -27730,6 +27736,11 @@ export interface components {
       | components['schemas']['BalanceRefundReversalEvent']
       | components['schemas']['BalanceDisputeEvent']
       | components['schemas']['BalanceDisputeReversalEvent']
+    /**
+     * TaxBehavior
+     * @enum {string}
+     */
+    TaxBehavior: 'inclusive' | 'exclusive'
     /**
      * TaxBehaviorOption
      * @enum {string}
@@ -53687,6 +53698,9 @@ export const subscriptionUncanceledEventNameValues: ReadonlyArray<
 export const subscriptionUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionUpdatedEvent']['name']
 > = ['subscription.updated']
+export const taxBehaviorValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['TaxBehavior']
+> = ['inclusive', 'exclusive']
 export const taxBehaviorOptionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TaxBehaviorOption']
 > = ['location', 'inclusive', 'exclusive']

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -171,7 +171,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -345,7 +346,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -519,7 +521,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -693,7 +696,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -867,7 +871,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1033,7 +1038,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1199,7 +1205,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1365,7 +1372,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1531,7 +1539,8 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1697,6 +1706,7 @@
     "checkout.pricing.seats.range": "{min} - {max} seats",
     "checkout.pricing.seats.minimum": "Minimum {min} seats",
     "checkout.pricing.seats.maximum": "Maximum {max} seats",
-    "checkout.pricing.seats.updateFailed": "Failed to update seats"
+    "checkout.pricing.seats.updateFailed": "Failed to update seats",
+    "checkout.pricing.inclTax": "Taxes (included)"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Maximal {max} Plätze',
         updateFailed: 'Plätze konnten nicht aktualisiert werden',
       },
+      inclTax: 'MwSt. (inklusive)',
     },
     trial: {
       ends: 'Testphase endet am {endDate}',

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -57,6 +57,11 @@ export default {
         _llmContext:
           'Taxes applied to the order. This is VAT or sales tax. Prefer the specific term used in the target locale over a generic taxes (e.g. TVA in French, BTW in Dutch, etc.)',
       },
+      inclTax: {
+        value: 'Taxes (included)',
+        _llmContext:
+          'Label for the tax line in the pricing breakdown when tax is already included in the displayed price. Prefer the specific tax term used in the target locale (e.g. TVA (incluse) in French, BTW (inbegrepen) in Dutch, Moms (inkluderad) in Swedish, etc.)',
+      },
       free: 'Free',
       payWhatYouWant: {
         value: 'Pay what you want',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Máximo {max} asientos',
         updateFailed: 'No se pudieron actualizar los asientos',
       },
+      inclTax: 'Impuestos (incluidos)',
     },
     trial: {
       ends: 'La prueba finaliza el {endDate}',

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Maximum {max} postes',
         updateFailed: 'Échec de la mise à jour des postes',
       },
+      inclTax: 'TVA (incluse)',
     },
     trial: {
       ends: "L'essai se termine le {endDate}",

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Legfeljebb {max} felhasználói hely',
         updateFailed: 'A felhasználói helyek frissítése nem sikerült',
       },
+      inclTax: 'ÁFA (tartalmazza)',
     },
     trial: {
       ends: 'A próbaidőszak ekkor jár le: {endDate}',

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Massimo {max} postazioni',
         updateFailed: 'Impossibile aggiornare le postazioni',
       },
+      inclTax: 'IVA (inclusa)',
     },
     trial: {
       ends: 'La prova termina il {endDate}',

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -102,6 +102,7 @@ export default {
         maximum: '최대 {max}석',
         updateFailed: '좌석 수를 업데이트하지 못했습니다',
       },
+      inclTax: '부가세 (포함)',
     },
     trial: {
       ends: '체험 종료일: {endDate}',

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Maximaal {max} stoelen',
         updateFailed: 'Stoelen bijwerken mislukt',
       },
+      inclTax: 'Btw (inbegrepen)',
     },
     trial: {
       ends: 'Proefperiode eindigt op {endDate}',

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Máximo de {max} licenças',
         updateFailed: 'Não foi possível atualizar as licenças',
       },
+      inclTax: 'IVA (incluído)',
     },
     trial: {
       ends: 'Teste termina a {endDate}',

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Máximo de {max} assentos',
         updateFailed: 'Falha ao atualizar os assentos',
       },
+      inclTax: 'Impostos (inclusos)',
     },
     trial: {
       ends: 'Teste termina a {endDate}',

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -102,6 +102,7 @@ export default {
         maximum: 'Högst {max} platser',
         updateFailed: 'Det gick inte att uppdatera platserna',
       },
+      inclTax: 'Moms (ingår)',
     },
     trial: {
       ends: 'Testperioden slutar {endDate}',

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -28,7 +28,7 @@ from polar.discount.schemas import (
     DiscountPercentageBase,
     DiscountRepeatDurationBase,
 )
-from polar.enums import PaymentProcessor
+from polar.enums import PaymentProcessor, TaxBehavior
 from polar.kit.address import Address, AddressInput
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.email import EmailStrDNS
@@ -524,6 +524,14 @@ class CheckoutBase(CustomFieldDataOutputMixin, TimestampedSchema, IDSchema):
         description=(
             "Sales tax amount in cents. "
             "If `null`, it means there is no enough information yet to calculate it."
+        )
+    )
+    tax_behavior: TaxBehavior | None = Field(
+        description=(
+            "Tax behavior of the checkout. "
+            "`inclusive` means the price includes tax, "
+            "`exclusive` means tax is added on top. "
+            "If `null`, tax is not yet calculated."
         )
     )
     total_amount: int = Field(description="Amount in cents, after discounts and taxes.")


### PR DESCRIPTION
This PR will clarify the checkout pricing if the org has enabled tax inclusive pricing:

* We will subtract the taxes from the subtotal
* We will show `Taxes (included)` in the pricing breakdown (as opposed to only `Taxes`)


<img width="942" height="698" alt="Screenshot 2026-04-22 at 12 03 13" src="https://github.com/user-attachments/assets/bd5f6b09-142a-4e31-87fd-8bdc698405a1" />

## Screenshots

### One time purchase, without discount

| Before | After  |
|--------|--------|
| <img width="470" height="348" alt="Screenshot 2026-04-22 at 12 02 54" src="https://github.com/user-attachments/assets/e2327626-23df-4fc2-9bac-2d345173941b" /> | <img width="471" height="349" alt="Screenshot 2026-04-22 at 12 03 13" src="https://github.com/user-attachments/assets/d151c0cf-7ff8-441c-890b-29bd407bd3b8" /> |

### One time purchase, with discount

| Before | After  |
|--------|--------|
| <img width="469" height="406" alt="Screenshot 2026-04-22 at 12 01 25" src="https://github.com/user-attachments/assets/cb94b32b-1367-48ac-9d35-bedf15228b50" /> | <img width="482" height="440" alt="Screenshot 2026-04-22 at 11 58 34" src="https://github.com/user-attachments/assets/2adccb94-2f81-4421-9131-e95a2bae7ac6" /> |


### Subscription

| Before | After  |
|--------|--------|
| <img width="472" height="349" alt="Screenshot 2026-04-22 at 12 00 23" src="https://github.com/user-attachments/assets/84a1799a-0bac-434a-a32e-0162e80d50f6" /> | <img width="481" height="349" alt="Screenshot 2026-04-22 at 12 00 06" src="https://github.com/user-attachments/assets/23a4bf06-757f-4cd3-ae49-8f3ab2344611" /> |


### Org with tax _excluded_ pricing, with a $999 product

| Before | After  |
|--------|--------|
| <img width="477" height="337" alt="Screenshot 2026-04-22 at 12 09 18" src="https://github.com/user-attachments/assets/3b55c7a0-9f2c-45ae-b771-828d8e0a7687" /> | <img width="483" height="359" alt="Screenshot 2026-04-22 at 12 08 47" src="https://github.com/user-attachments/assets/1172c82b-b15b-4f55-97c5-4e0bdc7e8cea" /> |









