### PR TITLE
payment: Handle Stripe webhook coming before order is stored

### DIFF
--- a/server/polar/integrations/stripe/payment.py
+++ b/server/polar/integrations/stripe/payment.py
@@ -159,6 +159,14 @@ async def resolve_order(
             uuid.UUID(order_id), options=order_repository.get_eager_options()
         )
         if order is None:
+            if object.OBJECT_NAME == "payment_intent":
+                updated_intent = await stripe_service.get_payment_intent(object.id)
+                if (
+                    updated_intent.metadata
+                    and updated_intent.metadata.get("polar_failed_sync_payment")
+                    == "true"
+                ):
+                    return None
             raise OrderDoesNotExist(order_id)
         return order
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1072,6 +1072,8 @@ class OrderService:
                         error_code=e.code,
                         error_message=e.user_message,
                     )
+                    if payment_mode == PaymentMode.sync:
+                        await self._mark_intent_as_failed_sync(e)
                     raise PaymentFailed(PaymentFailedReason.card_error) from e
                 except stripe_lib.InvalidRequestError as e:
                     error = e.error
@@ -1097,9 +1099,20 @@ class OrderService:
                             # Mark the payment as failed to trigger dunning
                             await self.handle_payment_failure(session, order)
 
+                            if payment_mode == PaymentMode.sync:
+                                await self._mark_intent_as_failed_sync(e)
                             raise PaymentFailed(PaymentFailedReason.card_error) from e
 
                     raise
+
+    async def _mark_intent_as_failed_sync(self, error: stripe_lib.StripeError) -> None:
+        payment_intent = getattr(error.error, "payment_intent", None)
+        if payment_intent is not None:
+            intent_metadata = payment_intent.metadata or {}
+            intent_metadata["polar_failed_sync_payment"] = "true"
+            await stripe_service.modify_payment_intent(
+                payment_intent.id, metadata=intent_metadata
+            )
 
     async def process_retry_payment(
         self,


### PR DESCRIPTION
When a sync payment (subscription update) fails, the transaction rolls
back and the order is never committed. Stripe still sends a webhook, and resolve_order can't find the order.

We removed a blanket guard that returned None for all sync payments to prevent silently dropped webhooks for *successful* payments where the transaction just hadn't committed yet.

Now we mark the payment intent with metadata on failure, so the webhook side can tell the difference:
- No flag → order is coming, keep retrying
- Flag present → order was discarded, exit cleanly