### PR TITLE
Fix Android auth issue

### DIFF
--- a/clients/apps/app/hooks/oauth.ts
+++ b/clients/apps/app/hooks/oauth.ts
@@ -79,7 +79,10 @@ export const useOAuth = () => {
 
   const authenticate = async () => {
     try {
-      const response = await promptAsync({ preferEphemeralSession: true })
+      const response = await promptAsync({
+        preferEphemeralSession: true,
+        createTask: false,
+      })
 
       if (response?.type !== 'success') {
         return


### PR DESCRIPTION
Set `createTask: false` on `promptAsync` to open the Chrome Custom Tab in the app's own task. The default flags (`FLAG_ACTIVITY_NO_HISTORY` + singleTask) cause the browser to be destroyed immediately on certain Android devices, resolving the auth session before the login page loads.