### PR TITLE
ci: ignore major version of @types/node to stay in sync with our Noe version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,15 +21,24 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/docs"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/handbook"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
- ci: ignore major version of @types/node to stay in sync with our Noe version