### PR TITLE
docs: add Refgrow affiliate tracking integration guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,6 +113,7 @@
                   "features/integrations/fernand",
                   "features/integrations/framer",
                   "features/integrations/paritydeals",
+                  "features/integrations/refgrow",
                   "features/integrations/raycast",
                   "features/integrations/zapier"
                 ]

--- a/docs/features/integrations/affonso.mdx
+++ b/docs/features/integrations/affonso.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Affonso Affiliates with Polar"
-sidebarTitle: "Affonso Affiliates"
+sidebarTitle: "Affonso (Affiliates)"
 ---
 
 This guide explains how to integrate

--- a/docs/features/integrations/refgrow.mdx
+++ b/docs/features/integrations/refgrow.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Affiliate & Referral Tracking with Refgrow"
-sidebarTitle: "Refgrow"
+sidebarTitle: "Refgrow (Affiliates)"
 description: "Set up an affiliate and referral program for your Polar products with Refgrow"
 ---
 
@@ -18,15 +18,17 @@ description: "Set up an affiliate and referral program for your Polar products w
 - Embeddable widget for your website or app
 - Coupon-based attribution as an alternative to referral links
 
-## Setup
+## Setup Guide
 
 <Steps>
 
-### Create a Refgrow account
+<Step title="Create a Refgrow account">
 
 Sign up at [refgrow.com](https://refgrow.com) and create a new program. Set your commission structure (e.g., 20% recurring) and configure your program settings.
 
-### Connect Polar
+</Step>
+
+<Step title="Connect Polar">
 
 1. In Refgrow, go to **Integration** (Setup section in the sidebar)
 2. Expand the **Polar** section
@@ -36,7 +38,9 @@ Sign up at [refgrow.com](https://refgrow.com) and create a new program. Set your
 
 The webhook endpoint is created automatically — no manual webhook configuration needed. Refgrow registers a webhook with Polar that listens for subscription and order events.
 
-### Add the tracking script
+</Step>
+
+<Step title="Add the tracking script">
 
 Add the Refgrow tracking script to your marketing site or landing pages. This captures referral clicks when visitors arrive via an affiliate link:
 
@@ -51,12 +55,16 @@ Add the Refgrow tracking script to your marketing site or landing pages. This ca
 
 Replace `YOUR_PROJECT_ID` with your actual project ID from the Integration page in Refgrow.
 
-### Invite affiliates
+</Step>
+
+<Step title="Invite affiliates">
 
 You can invite affiliates in two ways:
 
 - **Manually**: Go to **Affiliates** in Refgrow and click **Add Affiliate** — they'll receive an email invitation with their referral link
 - **Self-signup**: Enable the affiliate portal and share your portal link (e.g., `yourprogram.refgrow.com`) — affiliates can sign up on their own
+
+</Step>
 
 </Steps>
 
@@ -97,5 +105,12 @@ Replace `{{user.email}}` with the logged-in user's email from your auth system. 
 ## Resources
 
 - [Refgrow Documentation](https://refgrow.com/docs)
-- [Refgrow Setup Guide](https://refgrow.com/setup-guide)
+- [Refgrow Setup Guide](https://refgrow.com/docs/installation)
 - [Polar Webhook Documentation](https://polar.sh/docs/integrate/webhooks)
+
+## Getting Help
+
+More details about the integration: [Polar Affiliate Program](https://refgrow.com/polar-affiliate-software)
+
+If you need assistance with your Refgrow integration, contact Refgrow's support team:
+- Email: support@refgrow.com


### PR DESCRIPTION
## Summary

Adds an integration guide for [Refgrow](https://refgrow.com) — affiliate and referral tracking for Polar products.

Covers:
- Connecting Polar with Refgrow (access token + automatic webhook setup)
- Adding the tracking script for referral click attribution
- How conversions are tracked (cookie, coupon code, metadata, email matching)
- Optional embedded affiliate widget for SaaS products

Placed in `docs/integrate/refgrow.mdx` alongside other integration guides.

This was requested by your team — happy to make any adjustments!