### PR TITLE
server/subscription: stick to existing period when scheduling product update

### DIFF
--- a/server/polar/subscription/update.py
+++ b/server/polar/subscription/update.py
@@ -152,12 +152,13 @@ def _generate_product_subscription_update(
         or subscription_update.proration_behavior == SubscriptionProrationBehavior.reset
     ):
         new_cycle_start = subscription_update.applies_at
+        new_cycle_end = new_product.recurring_interval.get_next_period(
+            new_cycle_start, new_cycle_start.day, new_product.recurring_interval_count
+        )
     else:
+        # Don't change the cycle if we're just changing to a different product with the same interval or if the proration behavior is not reset
         new_cycle_start = subscription.current_period_start
-
-    new_cycle_end = new_product.recurring_interval.get_next_period(
-        new_cycle_start, new_cycle_start.day, new_product.recurring_interval_count
-    )
+        new_cycle_end = subscription.current_period_end
 
     subscription_update.new_cycle_start = new_cycle_start
     subscription_update.new_cycle_end = new_cycle_end

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2751,6 +2751,67 @@ class TestUpdateProduct:
         )
         assert updated_subscription_update is None
 
+    async def test_next_period_behavior_changed_current_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        product_recurring_multiple_currencies: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        current_period_start = utc_now()
+        # Period end different than the real one, simulates a manual change of the subscription period end
+        current_period_end = current_period_start + timedelta(days=10)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product_recurring_multiple_currencies,
+            customer=customer,
+            currency="usd",
+            current_period_start=current_period_start,
+            current_period_end=current_period_end,
+        )
+        assert len(subscription.prices) == 1
+
+        updated_subscription = await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=product.id,
+            proration_behavior=SubscriptionProrationBehavior.next_period,
+        )
+
+        assert updated_subscription.product == product_recurring_multiple_currencies
+
+        event_repository = EventRepository.from_session(session)
+        events = await event_repository.get_all_by_name(
+            SystemEvent.subscription_updated
+        )
+        assert len(events) == 1
+        event = events[0]
+        assert event.user_metadata["subscription_id"] == str(subscription.id)
+        assert event.user_metadata["product_id"] == str(product.id)
+        assert (
+            event.user_metadata["proration_behavior"]
+            == SubscriptionProrationBehavior.next_period
+        )
+        assert event.customer_id == customer.id
+        assert event.organization_id == customer.organization_id
+
+        subscription_update_repository = SubscriptionUpdateRepository.from_session(
+            session
+        )
+        subscription_update = (
+            await subscription_update_repository.get_unapplied_by_subscription_id(
+                subscription.id
+            )
+        )
+        assert subscription_update is not None
+        assert subscription_update.product_id == product.id
+        assert subscription_update.applied_at is None
+        assert subscription_update.applies_at == subscription.current_period_end
+        assert subscription_update.new_cycle_start == current_period_start
+        assert subscription_update.new_cycle_end == current_period_end
+
 
 @pytest.mark.asyncio
 class TestUpdateDiscount:


### PR DESCRIPTION
- server/subscription: stick to existing period when scheduling product update