### PR TITLE
onboarding: Separate submit for review to other endpoint

### DIFF
--- a/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useAuth } from '@/hooks'
+import { useCreateOrganization } from '@/hooks/queries'
 import { useOnboardingV2Tracking } from '@/hooks/onboardingV2'
 import { enums, schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
@@ -222,9 +224,11 @@ function SubmitButton({ loading }: { loading: boolean }) {
 
 export function BusinessDetailsStep() {
   const router = useRouter()
+  const { setUserOrganizations } = useAuth()
   const { trackStepViewed, trackStepCompleted } = useOnboardingV2Tracking()
   const { data, updateData, setApiLoading, showApiResponse } =
     useOnboardingData()
+  const createOrganization = useCreateOrganization()
   const [submitting, setSubmitting] = useState(false)
 
   trackStepViewed('business')
@@ -248,7 +252,7 @@ export function BusinessDetailsStep() {
     },
   })
 
-  const { handleSubmit, setValue } = form
+  const { handleSubmit, setError, setValue } = form
 
   const onSubmit = async (formData: FormSchema) => {
     setSubmitting(true)
@@ -263,8 +267,46 @@ export function BusinessDetailsStep() {
       registeredBusinessName: formData.registeredBusinessName,
     })
 
-    trackStepCompleted('business')
-    await showApiResponse(200, 'OK')
+    const { data: organization, error } = await createOrganization.mutateAsync({
+      name: formData.orgName,
+      slug: formData.orgSlug,
+      default_presentment_currency:
+        formData.defaultCurrency as schemas['PresentmentCurrency'],
+      country: (formData.businessCountry || undefined) as
+        | schemas['OrganizationCreate']['country']
+        | undefined,
+      default_tax_behavior: 'location',
+      legal_entity:
+        formData.organizationType === 'company'
+          ? {
+              type: 'company' as const,
+              registered_name: formData.registeredBusinessName,
+            }
+          : { type: 'individual' as const },
+    })
+
+    if (error) {
+      setSubmitting(false)
+      setError('root', {
+        message:
+          typeof error.detail === 'string'
+            ? error.detail
+            : Array.isArray(error.detail)
+              ? (error.detail[0]?.msg ?? 'Failed to create organization')
+              : 'Failed to create organization',
+      })
+      await showApiResponse(400, 'Failed to create organization')
+      return
+    }
+
+    setUserOrganizations((previous) => [...previous, organization])
+    updateData({
+      organizationId: organization.id,
+      orgSlug: organization.slug,
+    })
+
+    trackStepCompleted('business', { organization_id: organization.id })
+    await showApiResponse(201, 'Created')
     router.push('/onboarding/product')
   }
 
@@ -387,6 +429,12 @@ export function BusinessDetailsStep() {
           />
 
           <CurrencyAndCountryFields />
+
+          {form.formState.errors.root && (
+            <p className="text-sm text-red-500 dark:text-red-500">
+              {form.formState.errors.root.message}
+            </p>
+          )}
 
           <SubmitButton loading={submitting} />
         </Box>

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useAuth } from '@/hooks'
 import * as Sentry from '@sentry/nextjs'
-import { useCreateOrganization } from '@/hooks/queries'
+import { useUpdateOrganization } from '@/hooks/queries'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import Button from '@polar-sh/ui/components/atoms/Button'
@@ -66,11 +65,10 @@ interface FormSchema {
 
 export function ProductDetailsStep() {
   const router = useRouter()
-  const { setUserOrganizations } = useAuth()
   const { data, updateData, setApiLoading, showApiResponse } =
     useOnboardingData()
   const { trackStepViewed, trackStepCompleted } = useOnboardingV2Tracking()
-  const createOrganization = useCreateOrganization()
+  const updateOrganization = useUpdateOrganization()
   const [loading, setLoading] = useState<
     'validating' | 'submitting' | 'submitting-anyway' | null
   >(null)
@@ -132,36 +130,32 @@ export function ProductDetailsStep() {
   const submitOrg = async (formData: FormSchema) => {
     setApiLoading(true)
 
+    if (!data.organizationId) {
+      form.setError('root', {
+        message: 'Organization setup is incomplete. Please start again.',
+      })
+      await showApiResponse(400, 'Failed to update organization')
+      return false
+    }
+
     const switching = formData.currentlySellingOn.length > 0
     const switchingFrom = (
       switching ? formData.currentlySellingOn[0] : null
     ) as schemas['OrganizationDetails']['switching_from']
 
-    const { data: org, error } = await createOrganization.mutateAsync({
-      name: data.orgName!,
-      slug: data.orgSlug!,
-      default_presentment_currency:
-        (data.defaultCurrency as schemas['PresentmentCurrency']) || 'usd',
-      country: (data.businessCountry || data.country || undefined) as
-        | schemas['OrganizationCreate']['country']
-        | undefined,
-      default_tax_behavior: 'location',
-      legal_entity:
-        data.organizationType === 'company'
-          ? {
-              type: 'company' as const,
-              registered_name: data.registeredBusinessName!,
-            }
-          : { type: 'individual' as const },
-      ...(formData.supportEmail && { email: formData.supportEmail }),
-      ...(formData.productUrl && { website: formData.productUrl }),
-      details: {
-        product_description: formData.productDescription,
-        selling_categories: formData.sellingCategories,
-        pricing_models: formData.pricingModel,
-        switching,
-        switching_from: switchingFrom,
-      } satisfies schemas['OrganizationDetails'],
+    const { error } = await updateOrganization.mutateAsync({
+      id: data.organizationId,
+      body: {
+        ...(formData.supportEmail && { email: formData.supportEmail }),
+        ...(formData.productUrl && { website: formData.productUrl }),
+        details: {
+          product_description: formData.productDescription,
+          selling_categories: formData.sellingCategories,
+          pricing_models: formData.pricingModel,
+          switching,
+          switching_from: switchingFrom,
+        } satisfies schemas['OrganizationDetails'],
+      },
     })
 
     if (error) {
@@ -173,14 +167,11 @@ export function ProductDetailsStep() {
               ? (error.detail[0]?.msg ?? 'Validation failed')
               : 'Something went wrong, please try again.',
       })
-      showApiResponse(400, 'Failed to create organization')
+      await showApiResponse(400, 'Failed to update organization')
       return false
     }
 
-    setUserOrganizations((prev) => [...prev, org])
-    updateData({ organizationId: org.id, orgSlug: org.slug })
-
-    trackStepCompleted('product', { organization_id: org.id })
+    trackStepCompleted('product', { organization_id: data.organizationId })
     await showApiResponse(200, 'OK')
     router.push('/onboarding/complete')
     return true

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@/hooks'
 import { useOrganizationKYC } from '@/hooks/queries/org'
 import { useUpdateOrganization } from '@/hooks/queries'
+import { api } from '@/utils/client'
 import { useAutoSave } from '@/hooks/useAutoSave'
 import { useURLValidation } from '@/hooks/useURLValidation'
 import { setValidationErrors } from '@/utils/api/errors'
@@ -651,13 +652,59 @@ const OrganizationProfileSettings: React.FC<
       return
     }
 
-    reset({
-      ...data,
-      default_presentment_currency:
-        data.default_presentment_currency as schemas['PresentmentCurrency'],
-      country: data.country as schemas['CountryAlpha2Input'] | undefined,
-      socials: [...(data.socials || []), ...emptySocials],
-    })
+    if (inKYCMode) {
+      const submitReviewResult = await api.POST(
+        '/v1/organizations/{id}/submit-review',
+        {
+          params: { path: { id: organization.id } },
+        },
+      )
+      const { data: submittedOrganization, error: submitError } =
+        submitReviewResult
+
+      if (submitError) {
+        const errorMessage = Array.isArray(submitError.detail)
+          ? submitError.detail[0]?.msg ||
+            'An error occurred while submitting the organization for review'
+          : typeof submitError.detail === 'string'
+            ? submitError.detail
+            : 'An error occurred while submitting the organization for review'
+
+        if (isValidationError(submitError.detail)) {
+          setValidationErrors(submitError.detail, setError)
+        } else {
+          setError('root', { message: errorMessage })
+        }
+
+        toast({
+          title: 'Review Submission Failed',
+          description: errorMessage,
+        })
+
+        return
+      }
+
+      reset({
+        ...submittedOrganization,
+        default_presentment_currency:
+          submittedOrganization.default_presentment_currency as schemas['PresentmentCurrency'],
+        country: submittedOrganization.country as
+          | schemas['CountryAlpha2Input']
+          | undefined,
+        socials: [...(submittedOrganization.socials || []), ...emptySocials],
+        details: cleanedBody.details,
+      })
+    }
+
+    if (!inKYCMode) {
+      reset({
+        ...data,
+        default_presentment_currency:
+          data.default_presentment_currency as schemas['PresentmentCurrency'],
+        country: data.country as schemas['CountryAlpha2Input'] | undefined,
+        socials: [...(data.socials || []), ...emptySocials],
+      })
+    }
 
     // Refresh the router to get the updated organization data from the server
     router.refresh()

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -692,6 +692,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/organizations/{id}/submit-review': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Submit Organization for Review
+     * @description Submit an organization's saved details for review.
+     *
+     *     **Scopes**: `organizations:write`
+     */
+    post: operations['organizations:submit_review']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/organizations/{id}/payment-status': {
     parameters: {
       query?: never
@@ -31377,6 +31399,46 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['OrganizationKYC']
+        }
+      }
+      /** @description Organization not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:submit_review': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Organization submitted for review. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Organization']
         }
       }
       /** @description Organization not found. */

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -260,6 +260,30 @@ async def update(
     return await organization_service.update(session, organization, organization_update)
 
 
+@router.post(
+    "/{id}/submit-review",
+    response_model=OrganizationSchema,
+    summary="Submit Organization for Review",
+    responses={
+        200: {"description": "Organization submitted for review."},
+        404: OrganizationNotFound,
+    },
+    tags=[APITag.private],
+)
+async def submit_review(
+    id: OrganizationID,
+    auth_subject: auth.OrganizationsWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> Organization:
+    """Submit an organization's saved details for review."""
+    organization = await organization_service.get(session, auth_subject, id)
+
+    if organization is None:
+        raise ResourceNotFound()
+
+    return await organization_service.submit_for_review(session, organization)
+
+
 @router.delete(
     "/{id}",
     response_model=OrganizationDeletionResponse,

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -486,6 +486,33 @@ class OrganizationUpdate(Schema):
     )
 
 
+class OrganizationReviewSubmissionDetails(Schema):
+    product_description: Annotated[
+        str, StringConstraints(strip_whitespace=True, min_length=30)
+    ]
+
+
+def _empty_review_submission_details_to_dict(value: Any) -> Any:
+    if value is None:
+        return {}
+    return value
+
+
+class OrganizationReviewSubmission(Schema):
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+    website: Annotated[str, StringConstraints(min_length=1)]
+    email: EmailStrDNS
+    socials: list[OrganizationSocialLink] = Field(min_length=1)
+    details: Annotated[
+        OrganizationReviewSubmissionDetails,
+        BeforeValidator(_empty_review_submission_details_to_dict),
+    ]
+
+
+class OrganizationReviewSubmissionBody(Schema):
+    body: OrganizationReviewSubmission
+
+
 class OrganizationPaymentStatus(Schema):
     payment_ready: bool = Field(
         description="Whether the organization is ready to accept payments"

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,3 +1,4 @@
+import builtins
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -15,7 +16,11 @@ from polar.authz.service import get_accessible_org_ids
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
 from polar.enums import InvoiceNumbering, SubscriptionProrationBehavior
-from polar.exceptions import PolarError, PolarRequestValidationError
+from polar.exceptions import (
+    PolarError,
+    PolarRequestValidationError,
+    ValidationError,
+)
 from polar.integrations.loops.service import loops as loops_service
 from polar.integrations.plain.service import plain as plain_service
 from polar.integrations.polar.service import polar_self as polar_self_service
@@ -398,15 +403,88 @@ class OrganizationService:
             },
         )
 
-        # Only store details once to avoid API overrides later w/o review
-        # We do allow initial details being set upon creation that will still require review,
-        # so upon creation we set details but not details_submitted_at
-        # so details_submitted_at effectively doubles as a "submit for review"
-        # timestamp, for now. We'll revisit this soon enough. @pieterbeulque
-        if not organization.details_submitted_at and update_schema.details:
+        if update_schema.details:
             organization.details = cast(
                 OrganizationDetails, update_schema.details.model_dump()
             )
+
+        organization = await repository.update(organization, update_dict=update_dict)
+
+        await self._after_update(session, organization)
+        return organization
+
+    def _validate_review_submission(
+        self, organization: Organization
+    ) -> builtins.list[ValidationError]:
+        errors: builtins.list[ValidationError] = []
+
+        if not organization.name or not organization.name.strip():
+            errors.append(
+                {
+                    "loc": ("body", "name"),
+                    "msg": "Organization name is required.",
+                    "type": "value_error",
+                    "input": organization.name,
+                }
+            )
+
+        if not organization.website:
+            errors.append(
+                {
+                    "loc": ("body", "website"),
+                    "msg": "Website is required.",
+                    "type": "value_error",
+                    "input": organization.website,
+                }
+            )
+
+        if not organization.email:
+            errors.append(
+                {
+                    "loc": ("body", "email"),
+                    "msg": "Support email is required.",
+                    "type": "value_error",
+                    "input": organization.email,
+                }
+            )
+
+        if not any(
+            social.get("url", "").strip() for social in (organization.socials or [])
+        ):
+            errors.append(
+                {
+                    "loc": ("body", "socials"),
+                    "msg": "At least one social media link is required.",
+                    "type": "value_error",
+                    "input": organization.socials,
+                }
+            )
+
+        product_description = (organization.details or {}).get("product_description")
+        if (
+            not isinstance(product_description, str)
+            or len(product_description.strip()) < 30
+        ):
+            errors.append(
+                {
+                    "loc": ("body", "details", "product_description"),
+                    "msg": "Please provide at least 30 characters.",
+                    "type": "value_error",
+                    "input": product_description,
+                }
+            )
+
+        return errors
+
+    async def submit_for_review(
+        self, session: AsyncSession, organization: Organization
+    ) -> Organization:
+        errors = self._validate_review_submission(organization)
+
+        if errors:
+            raise PolarRequestValidationError(errors)
+
+        if organization.details_submitted_at is None:
             organization.details_submitted_at = datetime.now(UTC)
             enqueue_job(
                 "organization_review.run_agent",
@@ -414,7 +492,7 @@ class OrganizationService:
                 context=ReviewContext.SUBMISSION,
             )
 
-        organization = await repository.update(organization, update_dict=update_dict)
+        session.add(organization)
 
         await self._after_update(session, organization)
         return organization
@@ -1064,8 +1142,8 @@ class OrganizationService:
     ) -> OrganizationReview | None:
         """Get the existing AI review for an organization, if any.
 
-        The actual AI review is now triggered asynchronously via a background
-        task when organization details are first submitted (see update()).
+        The actual AI review is triggered asynchronously via a background
+        task when organization details are submitted for review.
         """
         repository = OrganizationReviewRepository.from_session(session)
         return await repository.get_by_organization(organization.id)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,4 +1,3 @@
-import builtins
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -7,6 +6,7 @@ from uuid import UUID
 
 import structlog
 from pydantic import BaseModel, Field
+from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
@@ -68,6 +68,7 @@ from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (
     OrganizationCreate,
     OrganizationDeletionBlockedReason,
+    OrganizationReviewSubmissionBody,
     OrganizationUpdate,
 )
 from .sorting import OrganizationSortProperty
@@ -413,76 +414,15 @@ class OrganizationService:
         await self._after_update(session, organization)
         return organization
 
-    def _validate_review_submission(
-        self, organization: Organization
-    ) -> builtins.list[ValidationError]:
-        errors: builtins.list[ValidationError] = []
-
-        if not organization.name or not organization.name.strip():
-            errors.append(
-                {
-                    "loc": ("body", "name"),
-                    "msg": "Organization name is required.",
-                    "type": "value_error",
-                    "input": organization.name,
-                }
-            )
-
-        if not organization.website:
-            errors.append(
-                {
-                    "loc": ("body", "website"),
-                    "msg": "Website is required.",
-                    "type": "value_error",
-                    "input": organization.website,
-                }
-            )
-
-        if not organization.email:
-            errors.append(
-                {
-                    "loc": ("body", "email"),
-                    "msg": "Support email is required.",
-                    "type": "value_error",
-                    "input": organization.email,
-                }
-            )
-
-        if not any(
-            social.get("url", "").strip() for social in (organization.socials or [])
-        ):
-            errors.append(
-                {
-                    "loc": ("body", "socials"),
-                    "msg": "At least one social media link is required.",
-                    "type": "value_error",
-                    "input": organization.socials,
-                }
-            )
-
-        product_description = (organization.details or {}).get("product_description")
-        if (
-            not isinstance(product_description, str)
-            or len(product_description.strip()) < 30
-        ):
-            errors.append(
-                {
-                    "loc": ("body", "details", "product_description"),
-                    "msg": "Please provide at least 30 characters.",
-                    "type": "value_error",
-                    "input": product_description,
-                }
-            )
-
-        return errors
-
     async def submit_for_review(
         self, session: AsyncSession, organization: Organization
     ) -> Organization:
-        errors = self._validate_review_submission(organization)
-
-        if errors:
-            raise PolarRequestValidationError(errors)
+        try:
+            OrganizationReviewSubmissionBody.model_validate({"body": organization})
+        except PydanticValidationError as e:
+            raise PolarRequestValidationError(
+                cast(Sequence[ValidationError], e.errors())
+            ) from e
 
         if organization.details_submitted_at is None:
             organization.details_submitted_at = datetime.now(UTC)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -403,7 +403,7 @@ class OrganizationService:
             },
         )
 
-        if update_schema.details:
+        if update_schema.details and organization.status == OrganizationStatus.CREATED:
             organization.details = cast(
                 OrganizationDetails, update_schema.details.model_dump()
             )

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -351,6 +351,77 @@ class TestUpdateOrganization:
         assert settings["customer"]["allow_email_change"] is True
 
 
+    async def test_submit_for_review_requires_relevant_fields(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        update_response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "details": {
+                    "product_description": "Too short",
+                    "selling_categories": ["Software / SaaS"],
+                    "pricing_models": ["Subscription"],
+                    "switching": False,
+                }
+            },
+        )
+        assert update_response.status_code == 200
+
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/submit-review"
+        )
+
+        assert response.status_code == 422
+        error_locations = {tuple(error["loc"]) for error in response.json()["detail"]}
+        assert ("body", "website") in error_locations
+        assert ("body", "email") in error_locations
+        assert ("body", "socials") in error_locations
+        assert ("body", "details", "product_description") in error_locations
+
+    @pytest.mark.auth
+    async def test_submit_for_review_valid(
+        self,
+        client: AsyncClient,
+        mocker: MockerFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        update_response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "website": "https://example.com",
+                "email": "support@example.com",
+                "socials": [{"platform": "x", "url": "https://x.com/polar"}],
+                "details": {
+                    "product_description": "Subscription SaaS for software teams and agencies.",
+                    "selling_categories": ["Software / SaaS"],
+                    "pricing_models": ["Subscription"],
+                    "switching": False,
+                },
+            },
+        )
+        assert update_response.status_code == 200
+
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/submit-review"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["details_submitted_at"] is not None
+        enqueue_job_mock.assert_called_once()
+
+    @pytest.mark.auth
+    async def test_submit_for_review_not_existing(self, client: AsyncClient) -> None:
+        response = await client.post(f"/v1/organizations/{uuid.uuid4()}/submit-review")
+
+        assert response.status_code == 404
+
+
 @pytest.mark.asyncio
 class TestInviteOrganization:
     @pytest.mark.auth

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture
 
 from polar.models import Product, User
 from polar.models.account import Account
-from polar.models.organization import Organization
+from polar.models.organization import Organization, OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.models.user_organization import UserOrganization
 from polar.payout_account.service import PayoutAccountServiceError
@@ -386,10 +386,14 @@ class TestUpdateOrganization:
         self,
         client: AsyncClient,
         mocker: MockerFixture,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        organization.status = OrganizationStatus.CREATED
+        await save_fixture(organization)
 
         update_response = await client.patch(
             f"/v1/organizations/{organization.id}",

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -350,7 +350,7 @@ class TestUpdateOrganization:
         settings = response.json()["customer_portal_settings"]
         assert settings["customer"]["allow_email_change"] is True
 
-
+    @pytest.mark.auth
     async def test_submit_for_review_requires_relevant_fields(
         self,
         client: AsyncClient,
@@ -379,6 +379,31 @@ class TestUpdateOrganization:
         assert ("body", "website") in error_locations
         assert ("body", "email") in error_locations
         assert ("body", "socials") in error_locations
+        assert ("body", "details", "product_description") in error_locations
+
+    @pytest.mark.auth
+    async def test_submit_for_review_requires_details(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        update_response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "website": "https://example.com",
+                "email": "support@example.com",
+                "socials": [{"platform": "x", "url": "https://x.com/polar"}],
+            },
+        )
+        assert update_response.status_code == 200
+
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/submit-review"
+        )
+
+        assert response.status_code == 422
+        error_locations = {tuple(error["loc"]) for error in response.json()["detail"]}
         assert ("body", "details", "product_description") in error_locations
 
     @pytest.mark.auth

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime, timedelta
+from typing import cast
 
 import pytest
-from pydantic import ValidationError
+from pydantic import HttpUrl, ValidationError
 from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
@@ -26,12 +27,15 @@ from polar.models.organization_review import OrganizationReview
 from polar.models.user import IdentityVerificationStatus
 from polar.organization.schemas import (
     OrganizationCreate,
+    OrganizationDetails,
     OrganizationFeatureSettings,
+    OrganizationSocialLink,
+    OrganizationSocialPlatforms,
     OrganizationUpdate,
 )
 from polar.organization.service import OrganizationError
 from polar.organization.service import organization as organization_service
-from polar.organization_review.schemas import ReviewVerdict
+from polar.organization_review.schemas import ReviewContext, ReviewVerdict
 from polar.postgres import AsyncSession
 from polar.user_organization.service import (
     user_organization as user_organization_service,
@@ -204,6 +208,107 @@ class TestCreate:
         )
 
         assert organization.subscription_settings is not None
+
+
+@pytest.mark.asyncio
+class TestUpdateReviewSubmission:
+    @pytest.mark.auth
+    async def test_update_details_does_not_submit_for_review(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                details=OrganizationDetails(
+                    product_description="Subscription SaaS for software teams.",
+                    selling_categories=["Software / SaaS"],
+                    pricing_models=["Subscription"],
+                    switching=False,
+                )
+            ),
+        )
+
+        assert result.details is not None
+        assert (
+            result.details["product_description"]
+            == "Subscription SaaS for software teams."
+        )
+        assert result.details["selling_categories"] == ["Software / SaaS"]
+        assert result.details["pricing_models"] == ["Subscription"]
+        assert result.details["switching"] is False
+        assert result.details_submitted_at is None
+        enqueue_job_mock.assert_not_called()
+
+    @pytest.mark.auth
+    async def test_update_with_submit_for_review(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                website=cast(HttpUrl, "https://example.com"),
+                email="support@example.com",
+                socials=[
+                    OrganizationSocialLink(
+                        platform=cast(OrganizationSocialPlatforms, "x"),
+                        url=cast(HttpUrl, "https://x.com/polar"),
+                    )
+                ],
+                details=OrganizationDetails(
+                    product_description="Subscription SaaS for software teams and agencies.",
+                    selling_categories=["Software / SaaS"],
+                    pricing_models=["Subscription"],
+                    switching=False,
+                ),
+            ),
+        )
+        result = await organization_service.submit_for_review(session, organization)
+
+        assert result.details_submitted_at is not None
+        enqueue_job_mock.assert_called_once_with(
+            "organization_review.run_agent",
+            organization_id=organization.id,
+            context=ReviewContext.SUBMISSION,
+        )
+
+    @pytest.mark.auth
+    async def test_update_with_submit_for_review_requires_relevant_fields(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                details=OrganizationDetails(
+                    product_description="Too short",
+                    selling_categories=["Software / SaaS"],
+                    pricing_models=["Subscription"],
+                    switching=False,
+                ),
+            ),
+        )
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await organization_service.submit_for_review(session, organization)
+
+        error_locations = {tuple(error["loc"]) for error in exc_info.value.errors()}
+        assert ("body", "website") in error_locations
+        assert ("body", "email") in error_locations
+        assert ("body", "socials") in error_locations
+        assert ("body", "details", "product_description") in error_locations
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -23,6 +23,9 @@ from polar.models.organization import (
     OrganizationStatus,
     OrganizationSubscriptionSettings,
 )
+from polar.models.organization import (
+    OrganizationDetails as OrganizationDetailsDict,
+)
 from polar.models.organization_review import OrganizationReview
 from polar.models.user import IdentityVerificationStatus
 from polar.organization.schemas import (
@@ -221,6 +224,10 @@ class TestUpdateReviewSubmission:
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
+
         result = await organization_service.update(
             session,
             organization,
@@ -253,6 +260,9 @@ class TestUpdateReviewSubmission:
         organization: Organization,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
         await organization_service.update(
             session,
             organization,
@@ -288,6 +298,9 @@ class TestUpdateReviewSubmission:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
         await organization_service.update(
             session,
             organization,
@@ -309,6 +322,38 @@ class TestUpdateReviewSubmission:
         assert ("body", "email") in error_locations
         assert ("body", "socials") in error_locations
         assert ("body", "details", "product_description") in error_locations
+
+    @pytest.mark.auth
+    async def test_update_details_ignored_after_initial_status(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        original_details: OrganizationDetailsDict = {
+            "product_description": "Original description for the organization.",
+            "selling_categories": ["Software / SaaS"],
+            "pricing_models": ["Subscription"],
+            "switching": False,
+        }
+        organization.details = original_details
+        organization.status = OrganizationStatus.ACTIVE
+        session.add(organization)
+        await session.flush()
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                details=OrganizationDetails(
+                    product_description="Attempted tampering after approval.",
+                    selling_categories=["Other"],
+                    pricing_models=["One-time"],
+                    switching=True,
+                )
+            ),
+        )
+
+        assert result.details == original_details
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -324,6 +324,36 @@ class TestUpdateReviewSubmission:
         assert ("body", "details", "product_description") in error_locations
 
     @pytest.mark.auth
+    async def test_update_with_submit_for_review_requires_details(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
+        await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                website=cast(HttpUrl, "https://example.com"),
+                email="support@example.com",
+                socials=[
+                    OrganizationSocialLink(
+                        platform=cast(OrganizationSocialPlatforms, "x"),
+                        url=cast(HttpUrl, "https://x.com/polar"),
+                    )
+                ],
+            ),
+        )
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await organization_service.submit_for_review(session, organization)
+
+        error_locations = {tuple(error["loc"]) for error in exc_info.value.errors()}
+        assert ("body", "details", "product_description") in error_locations
+
+    @pytest.mark.auth
     async def test_update_details_ignored_after_initial_status(
         self,
         session: AsyncSession,


### PR DESCRIPTION
Split save details and submit for review into two separate endpoints. This clarifies the button, and makes sure that submitting for review is explicit