### PR TITLE
feat: add support docs sync pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Sync AUP to server
         run: cp "clients/apps/web/src/app/(main)/(website)/(landing)/(mdx)/legal/acceptable-use-policy/page.mdx" "server/polar/organization_review/acceptable-use-policy.mdx"
 
+      - name: Sync docs for support agent
+        run: cp -r docs/ server/support-docs/
+
       - uses: useblacksmith/build-push-action@v2
         id: push
         with:

--- a/server/migrations/versions/2026-04-09-0001_add_support_documents_table.py
+++ b/server/migrations/versions/2026-04-09-0001_add_support_documents_table.py
@@ -1,0 +1,136 @@
+"""Add support_documents table
+
+Revision ID: f1a2b3c4d5e6
+Revises: ad9ec49d44d2
+Create Date: 2026-04-09 00:01:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "b3af3591c62d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "support_documents",
+        sa.Column(
+            "id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("modified_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("slug", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("search_vector", postgresql.TSVECTOR(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index(
+        "ix_support_documents_created_at",
+        "support_documents",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_support_documents_deleted_at",
+        "support_documents",
+        ["deleted_at"],
+    )
+    op.create_index(
+        "ix_support_documents_search_vector",
+        "support_documents",
+        ["search_vector"],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+    public_support_documents_search_vector_update = PGFunction(
+        schema="public",
+        signature="support_documents_search_vector_update()",
+        definition=(
+            "RETURNS trigger AS $$\n"
+            "BEGIN\n"
+            "    NEW.search_vector := to_tsvector(\n"
+            "        'english',\n"
+            "        coalesce(NEW.title, '') || ' ' ||\n"
+            "        coalesce(NEW.description, '') || ' ' ||\n"
+            "        coalesce(NEW.content, '')\n"
+            "    );\n"
+            "    RETURN NEW;\n"
+            "END\n"
+            "$$ LANGUAGE plpgsql"
+        ),
+    )
+    op.create_entity(public_support_documents_search_vector_update)
+
+    public_support_documents_search_vector_trigger = PGTrigger(
+        schema="public",
+        signature="support_documents_search_vector_trigger",
+        on_entity="public.support_documents",
+        is_constraint=False,
+        definition=(
+            "BEFORE INSERT OR UPDATE ON support_documents\n"
+            "FOR EACH ROW EXECUTE FUNCTION support_documents_search_vector_update()"
+        ),
+    )
+    op.create_entity(public_support_documents_search_vector_trigger)
+
+
+def downgrade() -> None:
+    public_support_documents_search_vector_trigger = PGTrigger(
+        schema="public",
+        signature="support_documents_search_vector_trigger",
+        on_entity="public.support_documents",
+        is_constraint=False,
+        definition=(
+            "BEFORE INSERT OR UPDATE ON support_documents\n"
+            "FOR EACH ROW EXECUTE FUNCTION support_documents_search_vector_update()"
+        ),
+    )
+    op.drop_entity(public_support_documents_search_vector_trigger)
+
+    public_support_documents_search_vector_update = PGFunction(
+        schema="public",
+        signature="support_documents_search_vector_update()",
+        definition=(
+            "RETURNS trigger AS $$\n"
+            "BEGIN\n"
+            "    NEW.search_vector := to_tsvector(\n"
+            "        'english',\n"
+            "        coalesce(NEW.title, '') || ' ' ||\n"
+            "        coalesce(NEW.description, '') || ' ' ||\n"
+            "        coalesce(NEW.content, '')\n"
+            "    );\n"
+            "    RETURN NEW;\n"
+            "END\n"
+            "$$ LANGUAGE plpgsql"
+        ),
+    )
+    op.drop_entity(public_support_documents_search_vector_update)
+
+    op.drop_index(
+        "ix_support_documents_search_vector",
+        table_name="support_documents",
+        postgresql_using="gin",
+    )
+    op.drop_index("ix_support_documents_deleted_at", table_name="support_documents")
+    op.drop_index("ix_support_documents_created_at", table_name="support_documents")
+    op.drop_table("support_documents")

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -79,6 +79,7 @@ from .subscription import Subscription
 from .subscription_meter import SubscriptionMeter
 from .subscription_product_price import SubscriptionProductPrice
 from .subscription_update import SubscriptionUpdate
+from .support_document import SupportDocument
 from .transaction import Transaction
 from .trial_redemption import TrialRedemption
 from .user import OAuthAccount, User
@@ -174,6 +175,7 @@ __all__ = [
     "SubscriptionMeter",
     "SubscriptionProductPrice",
     "SubscriptionUpdate",
+    "SupportDocument",
     "TimestampedModel",
     "Transaction",
     "TrialRedemption",

--- a/server/polar/models/support_document.py
+++ b/server/polar/models/support_document.py
@@ -1,0 +1,63 @@
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
+from sqlalchemy import Index, String, Text
+from sqlalchemy.dialects.postgresql import TSVECTOR
+from sqlalchemy.orm import Mapped, mapped_column
+
+from polar.kit.db.models import RecordModel
+
+
+class SupportDocument(RecordModel):
+    __tablename__ = "support_documents"
+
+    slug: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+    url: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    search_vector: Mapped[str] = mapped_column(TSVECTOR, nullable=False, deferred=True)
+
+    __table_args__ = (
+        Index(
+            "ix_support_documents_search_vector",
+            "search_vector",
+            postgresql_using="gin",
+        ),
+    )
+
+
+support_documents_search_vector_update_function = PGFunction(
+    schema="public",
+    signature="support_documents_search_vector_update()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        NEW.search_vector := to_tsvector(
+            'english',
+            coalesce(NEW.title, '') || ' ' ||
+            coalesce(NEW.description, '') || ' ' ||
+            coalesce(NEW.content, '')
+        );
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+support_documents_search_vector_trigger = PGTrigger(
+    schema="public",
+    signature="support_documents_search_vector_trigger",
+    on_entity="support_documents",
+    definition="""
+    BEFORE INSERT OR UPDATE ON support_documents
+    FOR EACH ROW EXECUTE FUNCTION support_documents_search_vector_update();
+    """,
+)
+
+register_entities(
+    (
+        support_documents_search_vector_update_function,
+        support_documents_search_vector_trigger,
+    )
+)


### PR DESCRIPTION
## Summary
- **CI**: Vendor `docs/` into the server image (`server/support-docs/`) during build, following the same pattern as the AUP sync
- **Model**: New `SupportDocument` table with PostgreSQL tsvector full-text search (GIN index + trigger), matching existing `Benefit`/`Product` search patterns
- **Sync**: Cron task (`daily at 4am UTC`) parses MDX files — extracts frontmatter, strips JSX — and upserts into DB by slug
- **Path resolution**: checks `SUPPORT_DOCS_PATH` env var → `/app/server/support-docs/` (production) → `../../docs/` (local dev)

This is the foundation for the support agent (next PR) which will search these docs via tsvector to answer customer questions.

## Test plan
- [ ] Verify migration creates `support_documents` table with GIN index and trigger
- [ ] Run `sync_from_filesystem` locally against the `docs/` directory — verify rows are created with correct titles/URLs
- [ ] Verify tsvector search returns relevant results for queries like "webhook", "subscription", "license key"
- [ ] Verify CI step copies docs into `server/support-docs/` before Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)