### PR TITLE
server/organization: add offboarding status

### DIFF
--- a/server/polar/backoffice/components/_status_badge.py
+++ b/server/polar/backoffice/components/_status_badge.py
@@ -62,6 +62,10 @@ def status_badge(
             "class": "badge-ghost border border-base-300",
             "aria": "onboarding started status",
         },
+        OrganizationStatus.OFFBOARDING: {
+            "class": "badge-warning",
+            "aria": "offboarding status",
+        },
     }
 
     config = status_config.get(

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -35,6 +35,7 @@ from polar.models import (
 from polar.models.file import FileServiceTypes
 from polar.models.organization import OrganizationStatus
 from polar.models.organization_review import OrganizationReview
+from polar.models.organization_review_feedback import OrganizationReviewFeedback
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
@@ -1121,7 +1122,7 @@ async def get(
                 await review_repo.record_human_decision(
                     organization_id=id,
                     reviewer_id=user_session.user.id,
-                    decision="OFFBOARD",
+                    decision=OrganizationReviewFeedback.DecisionType.DENY,
                     reason=reason,
                 )
                 await organization_service.set_organization_offboarding(
@@ -1131,7 +1132,7 @@ async def get(
                 await review_repo.record_human_decision(
                     organization_id=id,
                     reviewer_id=user_session.user.id,
-                    decision="REACTIVATE",
+                    decision=OrganizationReviewFeedback.DecisionType.APPROVE,
                     reason=reason,
                 )
                 await organization_service.reactivate_organization(

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -114,6 +114,7 @@ def organization_badge(organization: Organization) -> Generator[None]:
         elif (
             organization.is_under_review
             or organization.status == OrganizationStatus.DENIED
+            or organization.status == OrganizationStatus.OFFBOARDING
         ):
             classes("badge-warning")
         else:
@@ -1116,6 +1117,26 @@ async def get(
                     reason=reason,
                 )
                 await organization_service.deny_appeal(session, organization)
+            elif account_status.action == "offboard":
+                await review_repo.record_human_decision(
+                    organization_id=id,
+                    reviewer_id=user_session.user.id,
+                    decision="OFFBOARD",
+                    reason=reason,
+                )
+                await organization_service.set_organization_offboarding(
+                    session, organization, reason=reason
+                )
+            elif account_status.action == "reactivate":
+                await review_repo.record_human_decision(
+                    organization_id=id,
+                    reviewer_id=user_session.user.id,
+                    decision="REACTIVATE",
+                    reason=reason,
+                )
+                await organization_service.reactivate_organization(
+                    session, organization
+                )
             return HXRedirectResponse(request, request.url, 303)
         except PydanticCustomError as e:
             await add_toast(request, str(e.message_template), variant="error")

--- a/server/polar/backoffice/organizations/forms.py
+++ b/server/polar/backoffice/organizations/forms.py
@@ -69,12 +69,27 @@ class DenyOrganizationAppealForm(forms.BaseForm):
     ]
 
 
+class OffboardOrganizationForm(forms.BaseForm):
+    action: Annotated[Literal["offboard"], forms.SkipField]
+    reason: Annotated[
+        str | None,
+        forms.TextAreaField(rows=3, placeholder="Reason for offboarding"),
+        Field(default=None, title="Reason"),
+    ]
+
+
+class ReactivateOrganizationForm(forms.BaseForm):
+    action: Annotated[Literal["reactivate"], forms.SkipField]
+
+
 OrganizationStatusForm = Annotated[
     ApproveOrganizationForm
     | DenyOrganizationForm
     | UnderReviewOrganizationForm
     | ApproveOrganizationAppealForm
-    | DenyOrganizationAppealForm,
+    | DenyOrganizationAppealForm
+    | OffboardOrganizationForm
+    | ReactivateOrganizationForm,
     Discriminator("action"),
 ]
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -206,6 +206,8 @@ async def list_organizations(
         status_filter = OrganizationStatus.CREATED
     elif status == "onboarding_started":
         status_filter = OrganizationStatus.ONBOARDING_STARTED
+    elif status == "offboarding":
+        status_filter = OrganizationStatus.OFFBOARDING
 
     # Build query
     stmt = (
@@ -1579,6 +1581,166 @@ async def under_review_dialog(
                 ):
                     with button(variant="warning", type="submit"):
                         text("Set Under Review")
+
+    return None
+
+
+@router.api_route(
+    "/{organization_id}/offboard-dialog",
+    name="organizations:offboard_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def offboard_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    """Set organization to offboarding status dialog and action."""
+    repository = OrganizationRepository(session)
+
+    organization = await repository.get_by_id(organization_id, include_blocked=True)
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if request.method == "POST":
+        form_data = await request.form()
+        reason = str(form_data.get("reason", "")).strip() or None
+
+        review_repo = OrganizationReviewRepository.from_session(session)
+        await review_repo.record_human_decision(
+            organization_id=organization_id,
+            reviewer_id=user_session.user.id,
+            decision="OFFBOARD",
+            reason=reason,
+        )
+
+        await organization_service.set_organization_offboarding(
+            session, organization, reason=reason
+        )
+
+        return HXRedirectResponse(
+            request,
+            str(
+                request.url_for("organizations:detail", organization_id=organization_id)
+            ),
+            303,
+        )
+
+    with modal("Set Offboarding", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:offboard_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            classes="flex flex-col gap-4",
+        ):
+            with tag.p(classes="font-semibold text-warning"):
+                text("Set Organization to Offboarding")
+
+            with tag.div(
+                classes="bg-warning/10 border border-warning/20 p-4 rounded-lg"
+            ):
+                with tag.p(classes="font-semibold mb-2"):
+                    text("This action will:")
+                with tag.ul(classes="list-disc list-inside space-y-1 text-sm"):
+                    with tag.li():
+                        text("Change the organization status to Offboarding")
+                    with tag.li():
+                        text("Block payouts while the organization is offboarding")
+
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text"):
+                        text("Reason for offboarding")
+                with tag.textarea(
+                    name="reason",
+                    classes="textarea textarea-bordered w-full",
+                    placeholder="Why is this organization being offboarded?",
+                    rows="3",
+                ):
+                    pass
+
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(variant="warning", type="submit"):
+                    text("Set Offboarding")
+
+    return None
+
+
+@router.api_route(
+    "/{organization_id}/reactivate-dialog",
+    name="organizations:reactivate_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def reactivate_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    """Reactivate an offboarding organization dialog and action."""
+    repository = OrganizationRepository(session)
+
+    organization = await repository.get_by_id(organization_id, include_blocked=True)
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if request.method == "POST":
+        review_repo = OrganizationReviewRepository.from_session(session)
+        await review_repo.record_human_decision(
+            organization_id=organization_id,
+            reviewer_id=user_session.user.id,
+            decision="REACTIVATE",
+        )
+
+        await organization_service.reactivate_organization(session, organization)
+
+        return HXRedirectResponse(
+            request,
+            str(
+                request.url_for("organizations:detail", organization_id=organization_id)
+            ),
+            303,
+        )
+
+    with modal("Reactivate Organization", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.p(classes="font-semibold text-success"):
+                text("Reactivate Organization")
+
+            with tag.div(
+                classes="bg-success/10 border border-success/20 p-4 rounded-lg"
+            ):
+                with tag.p(classes="font-semibold mb-2"):
+                    text("This action will:")
+                with tag.ul(classes="list-disc list-inside space-y-1 text-sm"):
+                    with tag.li():
+                        text("Change the organization status back to Active")
+                    with tag.li():
+                        text("Re-enable payouts for the organization")
+
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with tag.form(
+                    hx_post=str(
+                        request.url_for(
+                            "organizations:reactivate_dialog",
+                            organization_id=organization_id,
+                        )
+                    ),
+                ):
+                    with button(variant="success", type="submit"):
+                        text("Reactivate")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -59,6 +59,7 @@ from polar.models.order import Order, OrderStatus
 from polar.models.organization import OrganizationStatus
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
+from polar.models.organization_review_feedback import OrganizationReviewFeedback
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
@@ -1612,7 +1613,7 @@ async def offboard_dialog(
         await review_repo.record_human_decision(
             organization_id=organization_id,
             reviewer_id=user_session.user.id,
-            decision="OFFBOARD",
+            decision=OrganizationReviewFeedback.DecisionType.DENY,
             reason=reason,
         )
 
@@ -1698,7 +1699,7 @@ async def reactivate_dialog(
         await review_repo.record_human_decision(
             organization_id=organization_id,
             reviewer_id=user_session.user.id,
-            decision="REACTIVATE",
+            decision=OrganizationReviewFeedback.DecisionType.APPROVE,
         )
 
         await organization_service.reactivate_organization(session, organization)

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -351,6 +351,22 @@ class OrganizationDetailView:
                             ):
                                 text("Deny")
 
+                    elif self.org.status == OrganizationStatus.OFFBOARDING:
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:reactivate_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Reactivate")
+
                     elif self.org.is_under_review:
                         # Compute suggested threshold: double current or $250 min
                         current_threshold = self.org.next_review_threshold or 0
@@ -419,6 +435,21 @@ class OrganizationDetailView:
                                 hx_target="#modal",
                             ):
                                 text("Deny")
+
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:offboard_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Set Offboarding")
 
                     # Always available actions
                     with tag.div(classes="divider my-2"):

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -307,6 +307,13 @@ class OrganizationListView:
                 count=status_counts.get(OrganizationStatus.DENIED, 0),
                 badge_variant="error",
             ),
+            Tab(
+                label="Offboarding",
+                url=str(request.url_for("organizations:list")) + "?status=offboarding",
+                active=status_filter == OrganizationStatus.OFFBOARDING,
+                count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
+                badge_variant="warning",
+            ),
         ]
 
         with tab_nav(tabs):

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -190,6 +190,7 @@ class OrganizationStatus(StrEnum):
     ONGOING_REVIEW = "ongoing_review"
     DENIED = "denied"
     ACTIVE = "active"
+    OFFBOARDING = "offboarding"
 
     def get_display_name(self) -> str:
         return {
@@ -199,6 +200,7 @@ class OrganizationStatus(StrEnum):
             OrganizationStatus.ONGOING_REVIEW: "Ongoing Review",
             OrganizationStatus.DENIED: "Denied",
             OrganizationStatus.ACTIVE: "Active",
+            OrganizationStatus.OFFBOARDING: "Offboarding",
         }[self]
 
     @classmethod
@@ -207,7 +209,7 @@ class OrganizationStatus(StrEnum):
 
     @classmethod
     def payment_ready_statuses(cls) -> set[Self]:
-        return {cls.ACTIVE, *cls.review_statuses()}  # pyright: ignore
+        return {cls.ACTIVE, cls.OFFBOARDING, *cls.review_statuses()}  # pyright: ignore
 
     @classmethod
     def payout_ready_statuses(cls) -> set[Self]:

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -290,6 +290,7 @@ class LegacyOrganizationStatus(StrEnum):
             OrganizationStatus.ONGOING_REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.DENIED: LegacyOrganizationStatus.DENIED,
             OrganizationStatus.ACTIVE: LegacyOrganizationStatus.ACTIVE,
+            OrganizationStatus.OFFBOARDING: LegacyOrganizationStatus.ACTIVE,
         }
         try:
             return mapping[status]

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -821,6 +821,47 @@ class OrganizationService:
             enqueue_job("organization.under_review", organization_id=organization.id)
         return organization
 
+    async def set_organization_offboarding(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        *,
+        reason: str | None = None,
+    ) -> Organization:
+        if organization.status not in OrganizationStatus.review_statuses():
+            raise OrganizationError(
+                "Only organizations under review can be set to offboarding.",
+                403,
+            )
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.status_updated_at = datetime.now(UTC)
+
+        timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+        note = f"[{timestamp}] Organization set to offboarding."
+        if reason:
+            note += f"\nReason: {reason}"
+        if organization.internal_notes:
+            organization.internal_notes = f"{organization.internal_notes}\n\n{note}"
+        else:
+            organization.internal_notes = note
+
+        session.add(organization)
+        return organization
+
+    async def reactivate_organization(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> Organization:
+        if organization.status != OrganizationStatus.OFFBOARDING:
+            raise OrganizationError(
+                "Only offboarding organizations can be reactivated.", 403
+            )
+        organization.status = OrganizationStatus.ACTIVE
+        organization.status_updated_at = datetime.now(UTC)
+        session.add(organization)
+        return organization
+
     async def get_payment_status(
         self,
         session: AsyncReadSession,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1708,3 +1708,113 @@ class TestUpdateSeatBasedPricing:
         )
 
         assert result.feature_settings["seat_based_pricing_enabled"] is True
+
+
+@pytest.mark.asyncio
+class TestSetOrganizationOffboarding:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.INITIAL_REVIEW,
+            OrganizationStatus.ONGOING_REVIEW,
+        ],
+    )
+    async def test_from_review_statuses(
+        self,
+        status: OrganizationStatus,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = status
+
+        result = await organization_service.set_organization_offboarding(
+            session, organization
+        )
+
+        assert result.status == OrganizationStatus.OFFBOARDING
+        assert result.status_updated_at is not None
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.CREATED,
+        ],
+    )
+    async def test_from_non_review_raises(
+        self,
+        status: OrganizationStatus,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = status
+
+        with pytest.raises(Exception, match="Only organizations under review"):
+            await organization_service.set_organization_offboarding(
+                session, organization
+            )
+
+    async def test_with_reason_appends_internal_notes(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.ONGOING_REVIEW
+        organization.internal_notes = None
+
+        result = await organization_service.set_organization_offboarding(
+            session, organization, reason="Requested by merchant"
+        )
+
+        assert result.status == OrganizationStatus.OFFBOARDING
+        assert result.internal_notes is not None
+        assert "Requested by merchant" in result.internal_notes
+
+
+@pytest.mark.asyncio
+class TestReactivateOrganization:
+    async def test_from_offboarding(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+
+        result = await organization_service.reactivate_organization(
+            session, organization
+        )
+
+        assert result.status == OrganizationStatus.ACTIVE
+        assert result.status_updated_at is not None
+
+    async def test_from_non_offboarding_raises(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.ACTIVE
+
+        with pytest.raises(Exception, match="Only offboarding organizations"):
+            await organization_service.reactivate_organization(session, organization)
+
+
+@pytest.mark.asyncio
+class TestOffboardingPaymentReady:
+    async def test_offboarding_allows_payments(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Offboarding organizations should still be able to accept payments."""
+        # Grandfathered organization so we skip account setup checks
+        organization.created_at = datetime(2025, 8, 4, 8, 0, tzinfo=UTC)
+        organization.status = OrganizationStatus.OFFBOARDING
+        await save_fixture(organization)
+
+        result = await organization_service.is_organization_ready_for_payment(
+            session, organization
+        )
+
+        assert result is True

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -135,6 +135,7 @@ class TestCreate:
             OrganizationStatus.INITIAL_REVIEW,
             OrganizationStatus.ONGOING_REVIEW,
             OrganizationStatus.DENIED,
+            OrganizationStatus.OFFBOARDING,
         ],
     )
     async def test_organization_under_review(


### PR DESCRIPTION
## 📋 Summary

Add a new `OFFBOARDING` organization status to the state machine, allowing admins to mark organizations under review as offboarding.

## 🎯 What

- New `OFFBOARDING` enum value on `OrganizationStatus`
- Transition allowed from review statuses (initial_review, ongoing_review) only
- Reverse transition (reactivate) back to active from backoffice
- Payments remain enabled; payouts are blocked
- Backoffice UI: offboard/reactivate dialogs, status badge (warning/yellow), list tab

## 🤔 Why

Need a way to represent organizations that are winding down on the platform, distinct from denied or blocked states, where existing payment flows should continue but payouts are held.

## 🔧 How

- Added `OFFBOARDING` to `OrganizationStatus` enum with display name, payment_ready inclusion, and legacy schema mapping
- Added `set_organization_offboarding()` and `reactivate_organization()` service methods with status guards
- Offboarding appends a timestamped note (with optional reason) to `internal_notes`
- Added backoffice forms, V1/V2 endpoint handlers, modal dialogs, detail view actions, and list view tab
- Added warning badge styling for the new status

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Set an organization to `initial_review` or `ongoing_review` status
2. Use backoffice to click "Set Offboarding" — verify status changes and internal notes are appended
3. Verify payouts are blocked (`OrganizationUnderReview` raised) but payments still work
4. Use "Reactivate" to return to active — verify payouts are re-enabled
5. Verify the Offboarding tab appears in the backoffice list view

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally