### PR TITLE
fix: strip whitespace from discount codes on checkout

### DIFF
--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Literal
 
 from annotated_types import Ge, Le, MaxLen, MinLen
 from pydantic import (
@@ -46,6 +46,7 @@ from polar.kit.schemas import (
     IDSchema,
     Schema,
     SetSchemaReference,
+    StripValidator,
     TimestampedSchema,
 )
 from polar.kit.trial import (
@@ -418,15 +419,9 @@ class CheckoutUpdate(
 class CheckoutUpdatePublic(CheckoutUpdateBase):
     """Update an existing checkout session using the client secret."""
 
-    discount_code: str | None = Field(
+    discount_code: Annotated[str, StripValidator] | None = Field(
         default=None, description="Discount code to apply to the checkout."
     )
-
-    @model_validator(mode="after")
-    def _strip_discount_code(self) -> Self:
-        if self.discount_code is not None:
-            self.discount_code = self.discount_code.strip()
-        return self
 
     allow_trial: Literal[False] | None = Field(
         default=None,

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from annotated_types import Ge, Le, MaxLen, MinLen
 from pydantic import (
@@ -421,6 +421,12 @@ class CheckoutUpdatePublic(CheckoutUpdateBase):
     discount_code: str | None = Field(
         default=None, description="Discount code to apply to the checkout."
     )
+
+    @model_validator(mode="after")
+    def _strip_discount_code(self) -> Self:
+        if self.discount_code is not None:
+            self.discount_code = self.discount_code.strip()
+        return self
     allow_trial: Literal[False] | None = Field(
         default=None,
         description=(

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -427,6 +427,7 @@ class CheckoutUpdatePublic(CheckoutUpdateBase):
         if self.discount_code is not None:
             self.discount_code = self.discount_code.strip()
         return self
+
     allow_trial: Literal[False] | None = Field(
         default=None,
         description=(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3242,10 +3242,10 @@ class TestUpdate:
     @pytest.mark.parametrize(
         "pad",
         [
-            pytest.param(" ", id="trailing_space"),
-            pytest.param("  ", id="trailing_spaces"),
-            pytest.param(" \t", id="trailing_mixed"),
-            pytest.param("\t", id="leading_tab"),
+            pytest.param(" ", id="single_space"),
+            pytest.param("  ", id="double_space"),
+            pytest.param(" \t", id="mixed_space_tab"),
+            pytest.param("\t", id="tab"),
         ],
     )
     async def test_valid_discount_code_with_whitespace(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3239,6 +3239,32 @@ class TestUpdate:
             )
         )
 
+    @pytest.mark.parametrize(
+        "pad",
+        [
+            pytest.param(" ", id="trailing_space"),
+            pytest.param("  ", id="trailing_spaces"),
+            pytest.param(" \t", id="trailing_mixed"),
+            pytest.param("\t", id="leading_tab"),
+        ],
+    )
+    async def test_valid_discount_code_with_whitespace(
+        self,
+        pad: str,
+        session: AsyncSession,
+        checkout_one_time_fixed: Checkout,
+        discount_fixed_once: Discount,
+    ) -> None:
+        checkout = await checkout_service.update(
+            session,
+            checkout_one_time_fixed,
+            CheckoutUpdatePublic(
+                discount_code=f"{pad}{discount_fixed_once.code}{pad}",
+            ),
+        )
+
+        assert checkout.discount == discount_fixed_once
+
     async def test_full_discount_resets_is_business_customer(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary
- Mobile keyboards commonly auto-append trailing spaces after word completion, causing discount code lookups to fail with "Discount does not exist." even though the code is valid
- Adds a `model_validator` on `CheckoutUpdatePublic` to strip whitespace from `discount_code` before it reaches the service layer
- Adds parametrized tests covering trailing space, multiple spaces, mixed whitespace, and leading tab

## Context
Reported via Plain (T-25101): a seller's customer couldn't apply a discount code on mobile. Investigation confirmed the discount was correctly configured and the code lookup is case-insensitive, but **not whitespace-tolerant**. No server-side errors were logged because the stripped code simply didn't match.

## Test plan
- [x] `test_valid_discount_code_with_whitespace` — 4 parametrized cases all pass
- [x] Existing `test_valid_discount_code` and `test_invalid_discount_code` still pass
- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)