### PR TITLE
sidebar: Handle loading of pages after 2

### DIFF
--- a/clients/apps/web/src/components/Benefit/BenefitListSidebar.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitListSidebar.tsx
@@ -53,13 +53,11 @@ export const BenefitListSidebar = ({
     parseAsBoolean.withDefault(false),
   )
 
-  const { data, fetchNextPage, hasNextPage } = useInfiniteBenefits(
-    organization.id,
-    {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteBenefits(organization.id, {
       query: query ?? undefined,
       sorting: [sorting],
-    },
-  )
+    })
 
   const benefits = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
@@ -76,10 +74,10 @@ export const BenefitListSidebar = ({
   const { ref: loadingRef, inViewport } = useInViewport<HTMLDivElement>()
 
   useEffect(() => {
-    if (inViewport && hasNextPage) {
+    if (inViewport && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
     }
-  }, [inViewport, hasNextPage, fetchNextPage])
+  }, [inViewport, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   useEffect(() => {
     if (createBenefitQuerystring) {

--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkListSidebar.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkListSidebar.tsx
@@ -53,13 +53,11 @@ export const CheckoutLinkListSidebar = ({
   const [createCheckoutLinkQuerystring, setCreateCheckoutLinkQuerystring] =
     useQueryState('create_checkout_link', parseAsBoolean.withDefault(false))
 
-  const { data, fetchNextPage, hasNextPage } = useCheckoutLinks(
-    organization.id,
-    {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useCheckoutLinks(organization.id, {
       sorting: [sorting],
       product_id: productIds,
-    },
-  )
+    })
 
   const checkoutLinks = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
@@ -75,10 +73,10 @@ export const CheckoutLinkListSidebar = ({
   const { ref: loadingRef, inViewport } = useInViewport<HTMLDivElement>()
 
   useEffect(() => {
-    if (inViewport && hasNextPage) {
+    if (inViewport && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
     }
-  }, [inViewport, hasNextPage, fetchNextPage])
+  }, [inViewport, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   useEffect(() => {
     if (createCheckoutLinkQuerystring) {

--- a/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
@@ -52,10 +52,13 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
   )
   const [query, setQuery] = useQueryState('query', parseAsString)
 
-  const { data, fetchNextPage, hasNextPage } = useCustomers(organization.id, {
-    query: query ?? undefined,
-    sorting: [sorting],
-  })
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCustomers(
+    organization.id,
+    {
+      query: query ?? undefined,
+      sorting: [sorting],
+    },
+  )
 
   const customers = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
@@ -71,10 +74,10 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
   const { ref: loadingRef, inViewport } = useInViewport<HTMLDivElement>()
 
   useEffect(() => {
-    if (inViewport && hasNextPage) {
+    if (inViewport && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
     }
-  }, [inViewport, hasNextPage, fetchNextPage])
+  }, [inViewport, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const onExport = useCallback(() => {
     const url = new URL(

--- a/clients/apps/web/src/components/Customer/CustomerSelector.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerSelector.tsx
@@ -31,10 +31,13 @@ export const CustomerSelector = ({
   const [query, setQuery] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const { data, fetchNextPage, hasNextPage } = useCustomers(organizationId, {
-    query: query || undefined,
-    sorting: ['-created_at'],
-  })
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCustomers(
+    organizationId,
+    {
+      query: query || undefined,
+      sorting: ['-created_at'],
+    },
+  )
 
   const allCustomers = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
@@ -53,10 +56,10 @@ export const CustomerSelector = ({
   const { ref: loadingRef, inViewport } = useInViewport<HTMLDivElement>()
 
   useEffect(() => {
-    if (inViewport && hasNextPage) {
+    if (inViewport && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
     }
-  }, [inViewport, hasNextPage, fetchNextPage])
+  }, [inViewport, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const handleToggleCustomer = useCallback(
     (customerId: string) => {

--- a/clients/apps/web/src/components/Meter/MeterListSidebar.tsx
+++ b/clients/apps/web/src/components/Meter/MeterListSidebar.tsx
@@ -55,15 +55,13 @@ export const MeterListSidebar: React.FC<MeterListSidebarProps> = ({
     ),
   )
 
-  const { data, hasNextPage, fetchNextPage } = useMetersInfinite(
-    organization.id,
-    {
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useMetersInfinite(organization.id, {
       sorting: [sorting],
       query,
       is_archived:
         archivedFilter === 'all' ? undefined : archivedFilter === 'archived',
-    },
-  )
+    })
 
   const meters = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
@@ -82,10 +80,10 @@ export const MeterListSidebar: React.FC<MeterListSidebarProps> = ({
   const { ref: loadingRef, inViewport } = useInViewport()
 
   useEffect(() => {
-    if (inViewport && hasNextPage) {
+    if (inViewport && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
     }
-  }, [inViewport, hasNextPage, fetchNextPage])
+  }, [inViewport, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   return (
     <div className="dark:divide-polar-800 flex h-full flex-col divide-y divide-gray-200">


### PR DESCRIPTION
If the monitor / browser window is too big, there is nothing in the dependency array that makes us fetch the 3rd+ page, since inViewport is true, hasNextPage is true.

Smaller monitors pushes the items outside of the viewport, making inViewport false