### PR TITLE
backoffice: Fix DecisionType references in review endpoints

### DIFF
--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -35,7 +35,6 @@ from polar.models import (
 from polar.models.file import FileServiceTypes
 from polar.models.organization import OrganizationStatus
 from polar.models.organization_review import OrganizationReview
-from polar.models.organization_review_feedback import OrganizationReviewFeedback
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
@@ -1121,7 +1120,7 @@ async def get(
                 await review_repo.record_human_decision(
                     organization_id=id,
                     reviewer_id=user_session.user.id,
-                    decision=OrganizationReviewFeedback.DecisionType.DENY,
+                    decision=DecisionType.DENY,
                     reason=reason,
                 )
                 await organization_service.set_organization_offboarding(
@@ -1131,7 +1130,7 @@ async def get(
                 await review_repo.record_human_decision(
                     organization_id=id,
                     reviewer_id=user_session.user.id,
-                    decision=OrganizationReviewFeedback.DecisionType.APPROVE,
+                    decision=DecisionType.APPROVE,
                     reason=reason,
                 )
                 await organization_service.reactivate_organization(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -59,7 +59,6 @@ from polar.models.order import Order, OrderStatus
 from polar.models.organization import OrganizationStatus
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
-from polar.models.organization_review_feedback import OrganizationReviewFeedback
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
@@ -1606,7 +1605,7 @@ async def offboard_dialog(
         await review_repo.record_human_decision(
             organization_id=organization_id,
             reviewer_id=user_session.user.id,
-            decision=OrganizationReviewFeedback.DecisionType.DENY,
+            decision=DecisionType.DENY,
             reason=reason,
         )
 
@@ -1692,7 +1691,7 @@ async def reactivate_dialog(
         await review_repo.record_human_decision(
             organization_id=organization_id,
             reviewer_id=user_session.user.id,
-            decision=OrganizationReviewFeedback.DecisionType.APPROVE,
+            decision=DecisionType.APPROVE,
         )
 
         await organization_service.reactivate_organization(session, organization)


### PR DESCRIPTION
## 📋 Summary

Fix mypy type errors caused by referencing `OrganizationReviewFeedback.DecisionType` which doesn't exist as a nested class.

## 🎯 What

- Replace `OrganizationReviewFeedback.DecisionType.DENY/APPROVE` with the standalone `DecisionType.DENY/APPROVE` StrEnum in both `organizations/endpoints.py` and `organizations_v2/endpoints.py`
- Remove unused `OrganizationReviewFeedback` imports

## 🤔 Why

After `DecisionType` was extracted into a standalone `StrEnum` in `polar/organization_review/schemas.py`, four call sites in the backoffice endpoints were not updated, causing mypy `attr-defined` errors.

## 🔧 How

Updated imports to use `DecisionType` from `polar.organization_review.schemas` and removed the now-unused `OrganizationReviewFeedback` import.

## 🧪 Testing

- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")