### PR TITLE
Enable merge queue for CI workflows

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize, edited]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test_dev_cli.yaml
+++ b/.github/workflows/test_dev_cli.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize, edited]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize, edited]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## 📋 Summary

**Related Issue**: N/A (minor CI configuration change)

Enable GitHub's Merge Queue by adding the `merge_group` trigger to CI workflow files.

## 🎯 What

Added `merge_group:` as a trigger event to three GitHub Actions workflow files:
- `test_client.yaml`
- `test_dev_cli.yaml`
- `test_server.yaml`

## 🤔 Why

GitHub's Merge Queue requires that required status checks run on `merge_group` events. Without this trigger, the merge queue cannot validate PRs before merging them into `main`.

## 🔧 How

Added `merge_group:` under the `on:` section of each workflow file alongside the existing `push` and `pull_request` triggers. The existing `concurrency` groups work correctly with merge queue events, falling back to `github.ref` (which is unique per merge queue entry).

## 🧪 Testing

- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)

### Test Instructions

1. Enable merge queue on the repository settings for the `main` branch
2. Merge a PR via the merge queue and verify CI runs on the merge group event

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally