### PR TITLE
polar: Remove members and customers on removal

### DIFF
--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -828,7 +828,11 @@ async def remove_member(
         user_email = user.email if user else str(user_id)
 
         # Attempt to remove the member safely
-        await user_organization_service.remove_member_safe(session, user_id, id)
+        await user_organization_service.remove_member_safe(
+            session,
+            user_id=user_id,
+            organization_id=id,
+        )
 
         # Add success toast and redirect
         await add_toast(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2670,7 +2670,11 @@ async def remove_member(
             user_organization as user_organization_service,
         )
 
-        await user_organization_service.remove_member(session, organization.id, user_id)
+        await user_organization_service.remove_member(
+            session,
+            user_id=user_id,
+            organization_id=organization.id,
+        )
     except Exception as e:
         logger.error("Failed to remove member", error=str(e))
         raise HTTPException(status_code=400, detail=str(e))

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -11,7 +11,7 @@ from polar.logging import Logger
 
 if TYPE_CHECKING:
     from polar_sdk import Polar as PolarSDK
-    from polar_sdk.models import Customer
+    from polar_sdk.models import Customer, Member
 
 log: Logger = structlog.get_logger()
 
@@ -36,16 +36,15 @@ class PolarSelfClient:
         )
 
     async def create_customer(self, *, external_id: str, email: str, name: str) -> None:
-        from polar_sdk.models import CustomerCreate, CustomerType
+        from polar_sdk.models import CustomerTeamCreate
         from polar_sdk.models.polarerror import PolarError
 
         try:
             await self._sdk.customers.create_async(
-                request=CustomerCreate(
+                request=CustomerTeamCreate(
                     email=email,
                     name=name,
                     external_id=external_id,
-                    type=CustomerType.TEAM,
                 )
             )
         except PolarError as e:
@@ -74,6 +73,13 @@ class PolarSelfClient:
     async def get_customer_by_external_id(self, external_id: str) -> Customer:
         return await self._sdk.customers.get_external_async(external_id=external_id)
 
+    async def get_member_by_external_id(
+        self, *, external_customer_id: str, external_id: str
+    ) -> Member | None:
+        return await self._sdk.members.get_member_by_external_id_async(
+            external_id=external_id,
+        )
+
     async def add_member(
         self, *, customer_id: str, email: str, name: str, external_id: str
     ) -> None:
@@ -92,13 +98,48 @@ class PolarSelfClient:
         except PolarError as e:
             self._handle_error(e, "add_member", external_id=external_id)
 
-    async def remove_member(self, *, member_id: str) -> None:
+    async def remove_member(
+        self, *, external_customer_id: str, external_id: str
+    ) -> None:
         from polar_sdk.models.polarerror import PolarError
 
         try:
-            await self._sdk.members.delete_member_async(id=member_id)
+            await self._sdk.members.delete_member_by_external_id_async(
+                external_id=external_id,
+            )
         except PolarError as e:
-            self._handle_error(e, "remove_member", member_id=member_id)
+            if e.status_code == 404:
+                log.debug(
+                    "polar_self.not_found",
+                    operation="remove_member",
+                    external_customer_id=external_customer_id,
+                    external_id=external_id,
+                )
+                return
+            self._handle_error(
+                e,
+                "remove_member",
+                external_customer_id=external_customer_id,
+                external_id=external_id,
+            )
+
+    async def delete_customer(self, *, external_id: str) -> None:
+        from polar_sdk.models.polarerror import PolarError
+
+        try:
+            await self._sdk.customers.delete_external_async(
+                external_id=external_id,
+                anonymize=True,
+            )
+        except PolarError as e:
+            if e.status_code == 404:
+                log.debug(
+                    "polar_self.not_found",
+                    operation="delete_customer",
+                    external_id=external_id,
+                )
+                return
+            self._handle_error(e, "delete_customer", external_id=external_id)
 
     async def track_event_ingestion(
         self, *, external_customer_id: str, count: int

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -45,10 +45,24 @@ class PolarSelfService:
             external_id=external_id,
         )
 
-    def enqueue_remove_member(self, *, member_id: str) -> None:
+    def enqueue_remove_member(
+        self, *, external_customer_id: str, external_id: str
+    ) -> None:
         if not self.is_configured:
             return
-        enqueue_job("polar_self.remove_member", member_id=member_id)
+        enqueue_job(
+            "polar_self.remove_member",
+            external_customer_id=external_customer_id,
+            external_id=external_id,
+        )
+
+    def enqueue_delete_customer(self, *, organization_id: uuid.UUID) -> None:
+        if not self.is_configured:
+            return
+        enqueue_job(
+            "polar_self.delete_customer",
+            external_id=str(organization_id),
+        )
 
     def enqueue_track_ingestion(self, *, external_customer_id: str, count: int) -> None:
         if not self.is_configured:

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -52,8 +52,31 @@ async def add_member(
 
 
 @actor(actor_name="polar_self.remove_member", priority=TaskPriority.LOW)
-async def remove_member(member_id: str) -> None:
-    await get_client().remove_member(member_id=member_id)
+async def remove_member(external_customer_id: str, external_id: str) -> None:
+    from polar_sdk.models.polarerror import PolarError
+
+    client = get_client()
+    try:
+        await client.get_member_by_external_id(
+            external_customer_id=external_customer_id,
+            external_id=external_id,
+        )
+    except PolarError as e:
+        if e.status_code == 404 and can_retry():
+            raise Retry(delay=1000) from e
+        if e.status_code == 404:
+            return
+        raise
+
+    await client.remove_member(
+        external_customer_id=external_customer_id,
+        external_id=external_id,
+    )
+
+
+@actor(actor_name="polar_self.delete_customer", priority=TaskPriority.LOW)
+async def delete_customer(external_id: str) -> None:
+    await get_client().delete_customer(external_id=external_id)
 
 
 @actor(actor_name="polar_self.track_event_ingestion", priority=TaskPriority.LOW)

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -441,7 +441,11 @@ async def leave_organization(
         raise NotPermitted("Cannot leave organization as the only member.")
 
     # Remove the user from the organization
-    await user_organization_service.remove_member(session, user.id, organization.id)
+    await user_organization_service.remove_member(
+        session,
+        user_id=user.id,
+        organization_id=organization.id,
+    )
 
 
 @router.delete(
@@ -495,7 +499,9 @@ async def remove_member(
 
     try:
         await user_organization_service.remove_member_safe(
-            session, target_user_id, organization.id
+            session,
+            user_id=target_user_id,
+            organization_id=organization.id,
         )
     except UserNotMemberOfOrganization:
         raise ResourceNotFound()

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -417,6 +417,7 @@ class OrganizationService:
 
         organization = await repository.update(organization, update_dict=update_dict)
         await repository.soft_delete(organization)
+        polar_self_service.enqueue_delete_customer(organization_id=organization.id)
 
         return organization
 
@@ -570,6 +571,7 @@ class OrganizationService:
 
         organization = await repository.update(organization, update_dict=update_dict)
         await repository.soft_delete(organization)
+        polar_self_service.enqueue_delete_customer(organization_id=organization.id)
 
         log.info(
             "organization.deleted",

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -5,6 +5,7 @@ from sqlalchemy import Select, func
 from sqlalchemy.orm import joinedload
 
 from polar.exceptions import PolarError
+from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.utils import utc_now
 from polar.models import UserOrganization
 from polar.postgres import AsyncReadSession, AsyncSession, sql
@@ -111,6 +112,7 @@ class UserOrganizationService:
     async def remove_member(
         self,
         session: AsyncSession,
+        *,
         user_id: UUID,
         organization_id: UUID,
     ) -> None:
@@ -122,12 +124,20 @@ class UserOrganizationService:
                 UserOrganization.is_deleted.is_(False),
             )
             .values(deleted_at=utc_now())
+            .returning(UserOrganization.user_id)
         )
-        await session.execute(stmt)
+        result = await session.execute(stmt)
+        removed_user_id = result.scalar_one_or_none()
+        if removed_user_id is not None:
+            polar_self_service.enqueue_remove_member(
+                external_customer_id=str(organization_id),
+                external_id=str(user_id),
+            )
 
     async def remove_member_safe(
         self,
         session: AsyncSession,
+        *,
         user_id: UUID,
         organization_id: UUID,
     ) -> None:
@@ -158,7 +168,11 @@ class UserOrganizationService:
             raise CannotRemoveOrganizationAdmin(user_id, organization_id)
 
         # Remove the member
-        await self.remove_member(session, user_id, organization_id)
+        await self.remove_member(
+            session,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
 
     def _get_list_by_user_id_query(
         self, user_id: UUID, ordered: bool = True

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "clickhouse-connect>=0.8.0",
   "playwright>=1.50.0",
   "trafilatura>=2.0.0",
-  "polar-sdk==0.30.1",
+  "polar-sdk==0.31.3",
   "anyio>=4.12.1",
 ]
 
@@ -172,3 +172,4 @@ exclude-newer = "1 week"
 
 [tool.uv.sources]
 dramatiq = { git = "https://github.com/frankie567/dramatiq", rev = "memory-leak-asyncio-ter" }
+polar-sdk = { url = "https://files.pythonhosted.org/packages/ef/23/bd856ec12a8faef40bfb6b30e7add657952c7266f5f0ac7c156067fa30ea/polar_sdk-0.31.3-py3-none-any.whl" }

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -7,7 +7,7 @@ from polar_sdk.models.resourcenotfound import ResourceNotFound, ResourceNotFound
 from pytest_mock import MockerFixture
 
 from polar.integrations.polar.client import PolarSelfClient
-from polar.integrations.polar.tasks import add_member
+from polar.integrations.polar.tasks import add_member, delete_customer, remove_member
 
 
 @pytest.mark.asyncio
@@ -88,3 +88,93 @@ class TestAddMember:
                 name="User Example",
                 external_id="user-123",
             )
+
+
+@pytest.mark.asyncio
+class TestRemoveMember:
+    async def test_removes_existing_member(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.return_value = MagicMock(id="member-123")
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await remove_member(
+            external_customer_id="org-123",
+            external_id="user-123",
+        )
+
+        client.get_member_by_external_id.assert_called_once_with(
+            external_customer_id="org-123",
+            external_id="user-123",
+        )
+        client.remove_member.assert_called_once_with(
+            external_customer_id="org-123",
+            external_id="user-123",
+        )
+
+    async def test_retries_when_member_is_not_ready(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.side_effect = ResourceNotFound(
+            ResourceNotFoundData(detail="Not found"),
+            httpx.Response(
+                404,
+                request=httpx.Request(
+                    "GET",
+                    "http://127.0.0.1:8000/v1/members/external/user-123?external_customer_id=org-123",
+                ),
+            ),
+        )
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+        mocker.patch("polar.integrations.polar.tasks.can_retry", return_value=True)
+
+        with pytest.raises(Retry):
+            await remove_member(
+                external_customer_id="org-123",
+                external_id="user-123",
+            )
+
+        client.remove_member.assert_not_called()
+
+    async def test_noops_when_member_never_appears(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.side_effect = ResourceNotFound(
+            ResourceNotFoundData(detail="Not found"),
+            httpx.Response(
+                404,
+                request=httpx.Request(
+                    "GET",
+                    "http://127.0.0.1:8000/v1/members/external/user-123?external_customer_id=org-123",
+                ),
+            ),
+        )
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+        mocker.patch("polar.integrations.polar.tasks.can_retry", return_value=False)
+
+        await remove_member(
+            external_customer_id="org-123",
+            external_id="user-123",
+        )
+
+        client.remove_member.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestDeleteCustomer:
+    async def test_deletes_customer_by_external_id(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await delete_customer(external_id="org-123")
+
+        client.delete_customer.assert_called_once_with(external_id="org-123")

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1554,6 +1554,22 @@ class TestRequestDeletion:
 
 @pytest.mark.asyncio
 class TestSoftDeleteOrganization:
+    async def test_enqueues_polar_self_customer_deletion(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_delete_customer_mock = mocker.patch(
+            "polar.organization.service.polar_self_service.enqueue_delete_customer"
+        )
+
+        await organization_service.soft_delete_organization(session, organization)
+
+        enqueue_delete_customer_mock.assert_called_once_with(
+            organization_id=organization.id
+        )
+
     async def test_anonymizes_pii_preserves_slug(
         self,
         session: AsyncSession,
@@ -1608,6 +1624,25 @@ class TestSoftDeleteOrganization:
 
         assert result.details == {}
         assert result.socials == []
+
+
+@pytest.mark.asyncio
+class TestDelete:
+    async def test_enqueues_polar_self_customer_deletion(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_delete_customer_mock = mocker.patch(
+            "polar.organization.service.polar_self_service.enqueue_delete_customer"
+        )
+
+        await organization_service.delete(session, organization)
+
+        enqueue_delete_customer_mock.assert_called_once_with(
+            organization_id=organization.id
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -2,6 +2,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from pytest_mock import MockerFixture
 
 from polar.models import Account, Organization, User, UserOrganization
 from polar.user_organization.service import (
@@ -33,7 +34,9 @@ class TestRemoveMemberSafe:
 
         # Test successful member removal
         await user_organization_service.remove_member_safe(
-            session, user_second.id, organization.id
+            session,
+            user_id=user_second.id,
+            organization_id=organization.id,
         )
 
         # Verify the member was soft deleted
@@ -52,7 +55,9 @@ class TestRemoveMemberSafe:
 
         with pytest.raises(OrganizationNotFound) as exc_info:
             await user_organization_service.remove_member_safe(
-                session, user.id, non_existent_org_id
+                session,
+                user_id=user.id,
+                organization_id=non_existent_org_id,
             )
 
         assert exc_info.value.organization_id == non_existent_org_id
@@ -66,7 +71,9 @@ class TestRemoveMemberSafe:
         # Test with user who is not a member
         with pytest.raises(UserNotMemberOfOrganization) as exc_info:
             await user_organization_service.remove_member_safe(
-                session, user.id, organization.id
+                session,
+                user_id=user.id,
+                organization_id=organization.id,
             )
 
         assert exc_info.value.user_id == user.id
@@ -95,7 +102,9 @@ class TestRemoveMemberSafe:
         # Test trying to remove organization admin
         with pytest.raises(CannotRemoveOrganizationAdmin) as exc_info:
             await user_organization_service.remove_member_safe(
-                session, user.id, organization.id
+                session,
+                user_id=user.id,
+                organization_id=organization.id,
             )
 
         assert exc_info.value.user_id == user.id
@@ -122,7 +131,9 @@ class TestRemoveMemberSafe:
 
         # Test removing a non-admin member from organization with account
         await user_organization_service.remove_member_safe(
-            session, user_second.id, organization.id
+            session,
+            user_id=user_second.id,
+            organization_id=organization.id,
         )
 
         # Verify the member was soft deleted
@@ -144,7 +155,11 @@ class TestRemoveMember:
         user_organization: UserOrganization,
     ) -> None:
         # Test that remove_member performs soft delete
-        await user_organization_service.remove_member(session, user.id, organization.id)
+        await user_organization_service.remove_member(
+            session,
+            user_id=user.id,
+            organization_id=organization.id,
+        )
 
         # Verify the member was soft deleted (not returned by get_by_user_and_org)
         user_org = await user_organization_service.get_by_user_and_org(
@@ -165,6 +180,48 @@ class TestRemoveMember:
         assert deleted_user_org is not None
         assert deleted_user_org.deleted_at is not None
 
+    async def test_enqueues_polar_self_member_removal(
+        self,
+        mocker: MockerFixture,
+        session: Any,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        enqueue_remove_member_mock = mocker.patch(
+            "polar.user_organization.service.polar_self_service.enqueue_remove_member"
+        )
+
+        await user_organization_service.remove_member(
+            session,
+            user_id=user.id,
+            organization_id=organization.id,
+        )
+
+        enqueue_remove_member_mock.assert_called_once_with(
+            external_customer_id=str(organization.id),
+            external_id=str(user.id),
+        )
+
+    async def test_does_not_enqueue_when_member_not_found(
+        self,
+        mocker: MockerFixture,
+        session: Any,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        enqueue_remove_member_mock = mocker.patch(
+            "polar.user_organization.service.polar_self_service.enqueue_remove_member"
+        )
+
+        await user_organization_service.remove_member(
+            session,
+            user_id=user.id,
+            organization_id=organization.id,
+        )
+
+        enqueue_remove_member_mock.assert_not_called()
+
 
 @pytest.mark.asyncio
 class TestListByOrg:
@@ -181,7 +238,11 @@ class TestListByOrg:
         assert members[0].user_id == user.id
 
         # After soft delete, should not return the member
-        await user_organization_service.remove_member(session, user.id, organization.id)
+        await user_organization_service.remove_member(
+            session,
+            user_id=user.id,
+            organization_id=organization.id,
+        )
 
         members = await user_organization_service.list_by_org(session, organization.id)
         assert len(members) == 0

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14.0"
 
 [options]
-exclude-newer = "2026-04-02T12:11:04.483478914Z"
+exclude-newer = "2026-04-03T09:50:38.682842Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -2171,7 +2171,7 @@ requires-dist = [
     { name = "makefun", specifier = ">=1.15.6" },
     { name = "plain-client", specifier = ">=0.0.3" },
     { name = "playwright", specifier = ">=1.50.0" },
-    { name = "polar-sdk", specifier = "==0.30.1" },
+    { name = "polar-sdk", url = "https://files.pythonhosted.org/packages/ef/23/bd856ec12a8faef40bfb6b30e7add657952c7266f5f0ac7c156067fa30ea/polar_sdk-0.31.3-py3-none-any.whl" },
     { name = "posthog", specifier = ">=3.6.0" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.5" },
@@ -2233,8 +2233,8 @@ dev = [
 
 [[package]]
 name = "polar-sdk"
-version = "0.30.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.31.3"
+source = { url = "https://files.pythonhosted.org/packages/ef/23/bd856ec12a8faef40bfb6b30e7add657952c7266f5f0ac7c156067fa30ea/polar_sdk-0.31.3-py3-none-any.whl" }
 dependencies = [
     { name = "httpcore" },
     { name = "httpx" },
@@ -2242,9 +2242,17 @@ dependencies = [
     { name = "pydantic" },
     { name = "standardwebhooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/8b/10d59b566b72202eed1ee30fe212752ce97a90cc95f20909681d32cbaba9/polar_sdk-0.30.1.tar.gz", hash = "sha256:8d2583655ce6cf1a876e9fd7b9542dfda3115146f1ebdbd4b450e90339c11469", size = 288948, upload-time = "2026-03-11T09:10:18.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/33/37e1f7a7d67d4a64cf342e25ac4fdea88448f92beac02d3ecc4cc063c427/polar_sdk-0.30.1-py3-none-any.whl", hash = "sha256:047899ccd89d987e93612f0558ec39c4a689bd65de8a9b7ed919fa23c54579fc", size = 820158, upload-time = "2026-03-11T09:10:16.613Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/23/bd856ec12a8faef40bfb6b30e7add657952c7266f5f0ac7c156067fa30ea/polar_sdk-0.31.3-py3-none-any.whl", hash = "sha256:22fa1ae3fa2c79cf2279dd3b1ff633d193132197dcdd807ec7191fb14544ff80" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpcore", specifier = ">=1.0.9" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "jsonpath-python", specifier = ">=1.0.6" },
+    { name = "pydantic", specifier = ">=2.11.2" },
+    { name = "standardwebhooks", specifier = ">=1.0.0,<2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
When a user is removed from an organization, we should remove the member. When an organization is removed, we should archive the customer
