### PR TITLE
test: quote emergency merge workflow name

### DIFF
--- a/.github/workflows/emergency_merge.yml
+++ b/.github/workflows/emergency_merge.yml
@@ -1,4 +1,4 @@
-name: Emergency Merge 🚨
+name: "Emergency Merge 🚨"
 
 on:
   issue_comment:


### PR DESCRIPTION
Trivial change to test the `/emergency` merge workflow. Quotes the workflow name string.

Safe to close if not needed.