### PR TITLE
Add validation for org non-AUP names and slugs

### DIFF
--- a/clients/apps/web/src/components/Onboarding/v2/BusinessDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/v2/BusinessDetailsStep.tsx
@@ -20,6 +20,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm, useFormContext, useWatch } from 'react-hook-form'
 import slugify from 'slugify'
+import { containsBlockedWord } from '@/utils/blocked-words'
 import { CurrencySelector } from '../../CurrencySelector'
 import { SUPPORTED_PAYOUT_COUNTRIES } from './config/supported-payout-countries'
 import { useOnboardingData } from './OnboardingContext'
@@ -325,7 +326,11 @@ export function BusinessDetailsStep() {
             <FormField
               control={form.control}
               name="orgName"
-              rules={{ required: 'Organization name is required' }}
+              rules={{
+                required: 'Organization name is required',
+                validate: (v) =>
+                  !containsBlockedWord(v) || 'This name is not allowed.',
+              }}
               render={({ field }) => (
                 <FormItem className="w-full">
                   <FormLabel>Organization Name</FormLabel>
@@ -340,7 +345,11 @@ export function BusinessDetailsStep() {
             <FormField
               control={form.control}
               name="orgSlug"
-              rules={{ required: 'Slug is required' }}
+              rules={{
+                required: 'Slug is required',
+                validate: (v) =>
+                  !containsBlockedWord(v) || 'This slug is not allowed.',
+              }}
               render={({ field }) => (
                 <FormItem className="w-full">
                   <FormLabel>Organization Slug</FormLabel>

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -4,6 +4,7 @@ import { useUpdateOrganization } from '@/hooks/queries'
 import { useAutoSave } from '@/hooks/useAutoSave'
 import { useURLValidation } from '@/hooks/useURLValidation'
 import { setValidationErrors } from '@/utils/api/errors'
+import { containsBlockedWord } from '@/utils/blocked-words'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import AddPhotoAlternateOutlined from '@mui/icons-material/AddPhotoAlternateOutlined'
 import CloseOutlined from '@mui/icons-material/CloseOutlined'
@@ -311,7 +312,12 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
               <FormField
                 control={control}
                 name="name"
-                rules={{ required: 'Organization name is required' }}
+                rules={{
+                  required: 'Organization name is required',
+                  validate: (v) =>
+                    !containsBlockedWord(v ?? '') ||
+                    'This name is not allowed.',
+                }}
                 render={({ field }) => (
                   <div>
                     <Input

--- a/clients/apps/web/src/utils/blocked-words.ts
+++ b/clients/apps/web/src/utils/blocked-words.ts
@@ -1,0 +1,29 @@
+// Source of truth: server/polar/config.py, keep in sync.
+// Backend validates regardless, but this is to give the user immediate feedback in the onboarding
+// since org creation (and validation) is in the last step.
+const BLOCKED_WORDS = [
+  'porn',
+  'porno',
+  'pornography',
+  'sex',
+  'sexual',
+  'sexy',
+  'nsfw',
+  'xxx',
+  'hentai',
+  'erotic',
+  'erotica',
+  'fetish',
+  'nude',
+  'nudes',
+  'nudity',
+  'onlyfans',
+  'camgirl',
+  'escort',
+]
+
+const BLOCKED_PATTERN = new RegExp(`\\b(${BLOCKED_WORDS.join('|')})\\b`, 'i')
+
+export function containsBlockedWord(value: string): boolean {
+  return BLOCKED_PATTERN.test(value)
+}

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -400,6 +400,27 @@ class Settings(BaseSettings):
     PLATFORM_FEE_BASIS_POINTS: int = 400
     PLATFORM_FEE_FIXED: int = 40
 
+    ORGANIZATION_BLOCKED_WORDS: list[str] = [
+        "porn",
+        "porno",
+        "pornography",
+        "sex",
+        "sexual",
+        "sexy",
+        "nsfw",
+        "xxx",
+        "hentai",
+        "erotic",
+        "erotica",
+        "fetish",
+        "nude",
+        "nudes",
+        "nudity",
+        "onlyfans",
+        "camgirl",
+        "escort",
+    ]
+
     ORGANIZATION_SLUG_RESERVED_KEYWORDS: list[str] = [
         # Landing pages
         "benefits",

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -46,7 +47,24 @@ OrganizationID = Annotated[
     Field(examples=[ORGANIZATION_ID_EXAMPLE]),
 ]
 
-NameInput = Annotated[str, StringConstraints(min_length=3)]
+
+def validate_blocked_words(value: str) -> str:
+    pattern = re.compile(
+        r"\b("
+        + "|".join(re.escape(w) for w in settings.ORGANIZATION_BLOCKED_WORDS)
+        + r")\b",
+        re.IGNORECASE,
+    )
+    if pattern.search(value):
+        raise ValueError("This name is not allowed.")
+    return value
+
+
+NameInput = Annotated[
+    str,
+    StringConstraints(min_length=3),
+    AfterValidator(validate_blocked_words),
+]
 
 
 def validate_reserved_keywords(value: str) -> str:
@@ -60,6 +78,7 @@ SlugInput = Annotated[
     StringConstraints(to_lower=True, min_length=3),
     SlugValidator,
     AfterValidator(validate_reserved_keywords),
+    AfterValidator(validate_blocked_words),
 ]
 
 

--- a/server/tests/organization/test_schemas.py
+++ b/server/tests/organization/test_schemas.py
@@ -4,7 +4,7 @@ from pydantic import ValidationError
 from polar.enums import SubscriptionProrationBehavior
 from polar.kit.currency import PresentmentCurrency
 from polar.models.organization import OrganizationSubscriptionSettings
-from polar.organization.schemas import OrganizationCreate
+from polar.organization.schemas import OrganizationCreate, OrganizationUpdate
 
 
 def test_cant_set_reset_proration_behavior() -> None:
@@ -26,3 +26,62 @@ def test_cant_set_reset_proration_behavior() -> None:
             ),
             default_presentment_currency=PresentmentCurrency.usd,
         )
+
+
+class TestBlockedWords:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Porn Hub",
+            "Sex Shop",
+            "NSFW Art",
+            "xxx studio",
+            "SeX",
+            "PORN",
+        ],
+    )
+    def test_blocked_name_on_create(self, name: str) -> None:
+        with pytest.raises(ValidationError, match="not allowed"):
+            OrganizationCreate(name=name, slug="clean-slug")
+
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "porn-shop",
+            "sex-shop",
+            "nsfw-art",
+            "xxx-studio",
+        ],
+    )
+    def test_blocked_slug_on_create(self, slug: str) -> None:
+        with pytest.raises(ValidationError, match="not allowed"):
+            OrganizationCreate(name="Clean Name", slug=slug)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Porn Hub",
+            "Sex Shop",
+            "NSFW Art",
+        ],
+    )
+    def test_blocked_name_on_update(self, name: str) -> None:
+        with pytest.raises(ValidationError, match="not allowed"):
+            OrganizationUpdate(name=name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Essex County",
+            "Middlesex Corp",
+            "Sextant Navigation",
+            "Acme Inc",
+        ],
+    )
+    def test_allows_substring_matches(self, name: str) -> None:
+        org = OrganizationCreate(name=name, slug="clean-slug")
+        assert org.name == name
+
+    def test_update_without_name_skips_validation(self) -> None:
+        org = OrganizationUpdate(name=None)
+        assert org.name is None


### PR DESCRIPTION
Add basic org name and slug validation to add a small layer of protection against non-AUP orgs.

The blocked list is duplicated between frontend and backend for simplicity, it's a pretty static list so didn't wanna pollute the backend by creating a new validation endpoint.

| Onboarding | Org settings  |
|--------|--------|
| <img width="524" height="557" alt="Screenshot 2026-04-10 at 13 34 38" src="https://github.com/user-attachments/assets/eafeeeec-76f5-4f82-8383-b179f5638be3" /> | <img width="673" height="650" alt="Screenshot 2026-04-10 at 13 34 48" src="https://github.com/user-attachments/assets/2d800b32-5390-474a-be7f-96952739b82e" /> |
