### PR TITLE
members: Require (external) customer id for external id endpoints

### DIFF
--- a/server/polar/member/endpoints.py
+++ b/server/polar/member/endpoints.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import Depends, Query
 
 from polar.customer.schemas.customer import ExternalCustomerID
-from polar.exceptions import ResourceNotFound
+from polar.exceptions import PolarRequestValidationError, ResourceNotFound
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models.member import MemberRole
 from polar.openapi import APITag
@@ -28,6 +28,33 @@ MemberNotFound = {
     "description": "Member not found.",
     "model": ResourceNotFound.schema(),
 }
+
+
+def _validate_customer_id_params(
+    customer_id: UUID | None, external_customer_id: str | None
+) -> None:
+    if customer_id is None and external_customer_id is None:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "missing",
+                    "loc": ("query",),
+                    "msg": "One of customer_id or external_customer_id must be provided.",
+                    "input": None,
+                }
+            ]
+        )
+    if customer_id is not None and external_customer_id is not None:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("query",),
+                    "msg": "Only one of customer_id or external_customer_id may be provided.",
+                    "input": None,
+                }
+            ]
+        )
 
 
 @router.get(
@@ -145,10 +172,22 @@ async def get_member(
 async def get_member_by_external_id(
     external_id: ExternalMemberID,
     auth_subject: auth.MemberRead,
+    customer_id: UUID | None = Query(None, description="The customer ID."),
+    external_customer_id: str | None = Query(
+        None, description="The customer external ID."
+    ),
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> Member:
-    """Get a member by external ID."""
-    member = await member_service.get_by_external_id(session, auth_subject, external_id)
+    """Get a member by external ID. One of customer_id or external_customer_id must be specified."""
+    _validate_customer_id_params(customer_id, external_customer_id)
+
+    member = await member_service.get_by_external_id(
+        session,
+        auth_subject,
+        external_id,
+        customer_id=customer_id,
+        external_customer_id=external_customer_id,
+    )
 
     if member is None:
         raise ResourceNotFound("Member not found")
@@ -206,10 +245,22 @@ async def update_member_by_external_id(
     external_id: ExternalMemberID,
     member_update: MemberUpdate,
     auth_subject: auth.MemberWrite,
+    customer_id: UUID | None = Query(None, description="The customer ID."),
+    external_customer_id: str | None = Query(
+        None, description="The customer external ID."
+    ),
     session: AsyncSession = Depends(get_db_session),
 ) -> Member:
-    """Update a member by external ID."""
-    member = await member_service.get_by_external_id(session, auth_subject, external_id)
+    """Update a member by external ID. One of customer_id or external_customer_id must be specified."""
+    _validate_customer_id_params(customer_id, external_customer_id)
+
+    member = await member_service.get_by_external_id(
+        session,
+        auth_subject,
+        external_id,
+        customer_id=customer_id,
+        external_customer_id=external_customer_id,
+    )
 
     if member is None:
         raise ResourceNotFound("Member not found")
@@ -264,10 +315,22 @@ async def delete_member(
 async def delete_member_by_external_id(
     external_id: ExternalMemberID,
     auth_subject: auth.MemberWrite,
+    customer_id: UUID | None = Query(None, description="The customer ID."),
+    external_customer_id: str | None = Query(
+        None, description="The customer external ID."
+    ),
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
-    """Delete a member by external ID."""
-    member = await member_service.get_by_external_id(session, auth_subject, external_id)
+    """Delete a member by external ID. One of customer_id or external_customer_id must be specified."""
+    _validate_customer_id_params(customer_id, external_customer_id)
+
+    member = await member_service.get_by_external_id(
+        session,
+        auth_subject,
+        external_id,
+        customer_id=customer_id,
+        external_customer_id=external_customer_id,
+    )
 
     if member is None:
         raise ResourceNotFound("Member not found")

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -85,12 +85,23 @@ class MemberService:
         session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         external_id: str,
+        *,
+        customer_id: UUID | None = None,
+        external_customer_id: str | None = None,
     ) -> Member | None:
         """Get a member by external ID if the auth subject has access to it."""
         repository = MemberRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
             Member.external_id == external_id
         )
+
+        if external_customer_id is not None:
+            statement = statement.join(Customer).where(
+                Customer.external_id == external_customer_id
+            )
+        if customer_id is not None:
+            statement = statement.where(Member.customer_id == customer_id)
+
         return await repository.get_one_or_none(statement)
 
     async def delete(

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -486,11 +486,21 @@ class TestGetMemberByExternalID:
     @pytest.mark.auth
     async def test_not_existing(
         self,
+        save_fixture: SaveFixture,
         client: AsyncClient,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        response = await client.get("/v1/members/external/not-existing")
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+
+        response = await client.get(
+            "/v1/members/external/not-existing",
+            params={"customer_id": str(customer.id)},
+        )
 
         assert response.status_code == 404
 
@@ -518,7 +528,10 @@ class TestGetMemberByExternalID:
         )
         await save_fixture(member)
 
-        response = await client.get("/v1/members/external/ext_123")
+        response = await client.get(
+            "/v1/members/external/ext_123",
+            params={"customer_id": str(customer.id)},
+        )
 
         assert response.status_code == 200
         json = response.json()
@@ -554,7 +567,10 @@ class TestGetMemberByExternalID:
         )
         await save_fixture(member)
 
-        response = await client.get("/v1/members/external/ext_123")
+        response = await client.get(
+            "/v1/members/external/ext_123",
+            params={"customer_id": str(customer.id)},
+        )
 
         assert response.status_code == 404
 
@@ -585,12 +601,20 @@ class TestUpdateMemberByExternalID:
     @pytest.mark.auth
     async def test_not_existing(
         self,
+        save_fixture: SaveFixture,
         client: AsyncClient,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+
         response = await client.patch(
             "/v1/members/external/not-existing",
+            params={"customer_id": str(customer.id)},
             json={"name": "Updated Name"},
         )
 
@@ -622,6 +646,7 @@ class TestUpdateMemberByExternalID:
 
         response = await client.patch(
             "/v1/members/external/ext_456",
+            params={"customer_id": str(customer.id)},
             json={"name": "Updated Name", "role": "billing_manager"},
         )
 
@@ -659,6 +684,7 @@ class TestUpdateMemberByExternalID:
 
         response = await client.patch(
             "/v1/members/external/ext_789",
+            params={"customer_id": str(customer.id)},
             json={"name": "Updated Name"},
         )
 
@@ -685,11 +711,21 @@ class TestDeleteMemberByExternalID:
     @pytest.mark.auth
     async def test_not_existing(
         self,
+        save_fixture: SaveFixture,
         client: AsyncClient,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        response = await client.delete("/v1/members/external/not-existing")
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+
+        response = await client.delete(
+            "/v1/members/external/not-existing",
+            params={"customer_id": str(customer.id)},
+        )
 
         assert response.status_code == 404
 
@@ -717,7 +753,10 @@ class TestDeleteMemberByExternalID:
         )
         await save_fixture(member)
 
-        response = await client.delete("/v1/members/external/ext_delete")
+        response = await client.delete(
+            "/v1/members/external/ext_delete",
+            params={"customer_id": str(customer.id)},
+        )
 
         assert response.status_code == 204
 
@@ -753,7 +792,10 @@ class TestDeleteMemberByExternalID:
         )
         await save_fixture(member)
 
-        response = await client.delete("/v1/members/external/ext_other")
+        response = await client.delete(
+            "/v1/members/external/ext_other",
+            params={"customer_id": str(customer.id)},
+        )
 
         assert response.status_code == 404
 


### PR DESCRIPTION
Either customer id or external customer id are required to uniquely identify a member by their external id. Since external ids are only unique within the context of a customer.
