### PR TITLE
Add e2e test for downloadable benefits with real MinIO S3

### DIFF
--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -8,18 +8,16 @@ Tests are organized by lifecycle phase:
 - lifecycle/     — ongoing subscription events (renewal, retry, cancellation)
 """
 
-from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
-from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
 from polar.kit.db.postgres import AsyncSession
-from polar.models import Organization, Product, User, UserOrganization
+from polar.models import Organization, User, UserOrganization
 from polar.redis import Redis
 from polar.worker import JobQueueManager
 from polar.worker._enqueue import _job_queue_manager
@@ -55,80 +53,6 @@ E2E_AUTH = pytest.mark.auth(
         },
     )
 )
-
-BUYER_EMAIL = "buyer@example.com"
-BUYER_NAME = "Test Buyer"
-BILLING_ADDRESS = {
-    "country": "US",
-    "city": "San Francisco",
-    "postal_code": "94105",
-    "line1": "123 Market St",
-    "state": "CA",
-}
-
-
-@dataclass
-class CompletedPurchase:
-    checkout_id: str
-    order_id: str
-    order: dict[str, Any]
-
-
-async def complete_purchase(
-    client: AsyncClient,
-    session: AsyncSession,
-    stripe_sim: StripeSimulator,
-    drain: DrainFn,
-    organization: Organization,
-    product: Product,
-    *,
-    amount: int,
-    seats: int | None = None,
-) -> CompletedPurchase:
-    """Run the full purchase flow: checkout -> confirm -> webhook -> drain."""
-    checkout_body: dict[str, Any] = {"products": [str(product.id)]}
-    if seats is not None:
-        checkout_body["seats"] = seats
-
-    response = await client.post("/v1/checkouts/", json=checkout_body)
-    assert response.status_code == 201, response.text
-    checkout_id = response.json()["id"]
-    client_secret = response.json()["client_secret"]
-    await drain()
-
-    stripe_sim.expect_payment(
-        amount=amount,
-        customer_name=BUYER_NAME,
-        customer_email=BUYER_EMAIL,
-        billing_address=BILLING_ADDRESS,
-    )
-    response = await client.post(
-        f"/v1/checkouts/client/{client_secret}/confirm",
-        json={
-            "confirmation_token_id": "tok_test_confirm",
-            "customer_email": BUYER_EMAIL,
-            "customer_billing_address": BILLING_ADDRESS,
-        },
-    )
-    assert response.status_code == 200, response.text
-    await drain()
-
-    await stripe_sim.send_charge_webhook(
-        session, organization_id=organization.id, checkout_id=checkout_id
-    )
-    await drain()
-
-    response = await client.get("/v1/orders/")
-    assert response.status_code == 200
-    orders = response.json()
-    assert orders["pagination"]["total_count"] >= 1
-    order = orders["items"][0]
-
-    return CompletedPurchase(
-        checkout_id=checkout_id,
-        order_id=order["id"],
-        order=order,
-    )
 
 
 @pytest.fixture(scope="session")

--- a/server/tests/e2e/lifecycle/test_full_lifecycle.py
+++ b/server/tests/e2e/lifecycle/test_full_lifecycle.py
@@ -14,7 +14,7 @@ from httpx import AsyncClient
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Organization, Product
 from polar.models.billing_entry import BillingEntryType
-from tests.e2e.conftest import BUYER_EMAIL, E2E_AUTH, complete_purchase
+from tests.e2e.conftest import E2E_AUTH
 from tests.e2e.infra import (
     DrainFn,
     EmailCapture,
@@ -22,6 +22,7 @@ from tests.e2e.infra import (
     StripeSimulator,
 )
 from tests.e2e.lifecycle.conftest import get_benefit_grants, get_billing_entries
+from tests.e2e.purchase.conftest import BUYER_EMAIL, complete_purchase
 
 
 @pytest.mark.asyncio

--- a/server/tests/e2e/lifecycle/test_seat_lifecycle.py
+++ b/server/tests/e2e/lifecycle/test_seat_lifecycle.py
@@ -24,13 +24,14 @@ from polar.models.billing_entry import (
     BillingEntryDirection,
     BillingEntryType,
 )
-from tests.e2e.conftest import E2E_AUTH, complete_purchase
+from tests.e2e.conftest import E2E_AUTH
 from tests.e2e.infra import StripeSimulator
 from tests.e2e.infra.task_drain import DrainFn
 from tests.e2e.lifecycle.conftest import (
     get_billing_entries,
     trigger_subscription_cycle,
 )
+from tests.e2e.purchase.conftest import complete_purchase
 
 
 @pytest.mark.asyncio

--- a/server/tests/e2e/post_purchase/test_benefit_grants.py
+++ b/server/tests/e2e/post_purchase/test_benefit_grants.py
@@ -11,14 +11,21 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
+from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
+from polar.auth.dependencies import _auth_subject_factory_cache
+from polar.auth.models import AuthSubject
+from polar.auth.scope import Scope
+from polar.config import settings
+from polar.customer_session.service import customer_session as cs_service
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Organization, Product
 from polar.models.benefit import BenefitType
 from polar.models.benefit_grant import BenefitGrant
+from polar.models.file import File
 from tests.e2e.conftest import E2E_AUTH
 from tests.e2e.infra import DrainFn, StripeSimulator
 from tests.e2e.purchase.conftest import complete_purchase
@@ -137,6 +144,29 @@ async def product_with_feature_flag(
         type=BenefitType.feature_flag,
         description="Pro features",
         properties={},
+    )
+    return await set_product_benefits(save_fixture, product=product, benefits=[benefit])
+
+
+@pytest_asyncio.fixture
+async def product_with_downloadable(
+    save_fixture: SaveFixture, organization: Organization, uploaded_logo_png: File
+) -> Product:
+    file = uploaded_logo_png
+
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=None,
+        name="E2E Downloadable Product",
+        prices=[(1500, "usd")],
+    )
+    benefit = await create_benefit(
+        save_fixture,
+        organization=organization,
+        type=BenefitType.downloadables,
+        description="Downloadable guide",
+        properties={"files": [str(file.id)], "archived": {}},
     )
     return await set_product_benefits(save_fixture, product=product, benefits=[benefit])
 
@@ -266,3 +296,69 @@ class TestBenefitGrants:
         assert len(grants) == 1
         assert grants[0].is_granted
         assert grants[0].benefit.type == BenefitType.feature_flag
+
+    @E2E_AUTH
+    async def test_downloadable_benefit_granted(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        stripe_sim: StripeSimulator,
+        drain: DrainFn,
+        organization: Organization,
+        product_with_downloadable: Product,
+        app: FastAPI,
+    ) -> None:
+        # Given a product with a downloadable file benefit (real file in MinIO)
+        # When the customer purchases it
+        result = await complete_purchase(
+            client,
+            session,
+            stripe_sim,
+            drain,
+            organization,
+            product_with_downloadable,
+            amount=1500,
+        )
+
+        # Then the grant is created with file references
+        grants = await _get_grants(session, result.order_id)
+        assert len(grants) == 1
+        grant = grants[0]
+        assert grant.is_granted
+        assert grant.benefit.type == BenefitType.downloadables
+        props: dict[str, Any] = grant.properties  # type: ignore[assignment]
+        assert len(props["files"]) == 1
+
+        # Switch auth to the customer so we can call the customer portal API
+        assert result.customer_session_token is not None
+        customer_session = await cs_service.get_by_token(
+            session, result.customer_session_token
+        )
+        assert customer_session is not None
+        customer_subject = AuthSubject(
+            customer_session.customer,
+            {Scope.customer_portal_read, Scope.customer_portal_write},
+            customer_session,
+        )
+        for auth_getter in _auth_subject_factory_cache.values():
+            app.dependency_overrides[auth_getter] = lambda: customer_subject
+
+        # The customer portal API lists the downloadable with a download URL
+        response = await client.get("/v1/customer-portal/downloadables/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total_count"] == 1
+        downloadable = data["items"][0]
+        assert downloadable["benefit_id"] == str(grant.benefit_id)
+        download_url = downloadable["file"]["download"]["url"]
+
+        # The download token redirects to a real presigned S3 URL
+        token = download_url.split("/")[-1]
+        response = await client.get(
+            f"/v1/customer-portal/downloadables/{token}",
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        redirect_url = response.headers["location"]
+        assert settings.S3_ENDPOINT_URL is not None
+        assert redirect_url.startswith(settings.S3_ENDPOINT_URL)

--- a/server/tests/e2e/purchase/conftest.py
+++ b/server/tests/e2e/purchase/conftest.py
@@ -27,6 +27,7 @@ class CompletedPurchase:
     checkout_id: str
     order_id: str
     order: dict[str, Any]  # Full order JSON from API
+    customer_session_token: str | None = None
 
 
 async def complete_purchase(
@@ -55,8 +56,9 @@ async def complete_purchase(
 
     response = await client.post("/v1/checkouts/", json=checkout_body)
     assert response.status_code == 201, response.text
-    checkout_id = response.json()["id"]
-    client_secret = response.json()["client_secret"]
+    checkout_data = response.json()
+    checkout_id = checkout_data["id"]
+    client_secret = checkout_data["client_secret"]
     await drain()
 
     stripe_sim.expect_payment(
@@ -74,6 +76,7 @@ async def complete_purchase(
         },
     )
     assert response.status_code == 200, response.text
+    customer_session_token = response.json().get("customer_session_token")
     await drain()
 
     await stripe_sim.send_charge_webhook(
@@ -91,4 +94,5 @@ async def complete_purchase(
         checkout_id=checkout_id,
         order_id=order["id"],
         order=order,
+        customer_session_token=customer_session_token,
     )


### PR DESCRIPTION
## 📋 Summary

Add end-to-end test coverage for the downloadable benefit flow, using real MinIO S3 instead of mocks.

## 🎯 What

- New e2e test `test_downloadable_benefit_granted` that exercises: purchase → benefit grant → customer portal list API → download token → real S3 presigned redirect
- Uploads a real file to MinIO in the test fixture using the existing `uploaded_logo_png` helper
- Captures `customer_session_token` from checkout confirm response so tests can call customer portal APIs as the buyer
- Deduplicates `CompletedPurchase` / `complete_purchase` — removed the copy from `e2e/conftest.py`, canonical version lives in `e2e/purchase/conftest.py`
- Fixes double `response.json()` parse in `complete_purchase`

## 🤔 Why

The e2e test suite had no coverage for the downloadable benefit type — the only benefit type that involves S3/file storage. This was a gap since all other benefit types (custom, license keys, meter credits, feature flags) were already tested. Using real MinIO rather than mocks ensures the full S3 presigned URL flow actually works.

## 🔧 How

- The `product_with_downloadable` fixture uses the existing `uploaded_logo_png` fixture to upload a real PNG to MinIO via multipart upload
- After purchase, the test switches auth to the customer (using the session token from checkout) and calls `GET /v1/customer-portal/downloadables/` to list downloadables
- It then follows the download token to verify a 302 redirect to a real MinIO presigned URL
- The `_block_external_http` guard already allows `127.0.0.1` (MinIO), so no mock changes were needed for S3

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Start docker services: `dev docker up -d`
2. Run e2e tests: `cd server && POLAR_ENV=testing uv run python -m pytest tests/e2e/ -v`
3. All 15 tests should pass including the new `test_downloadable_benefit_granted`

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")