### PR TITLE
fix: ignore www subdomain in checkout URL redirect detection

### DIFF
--- a/server/polar/organization_review/collectors/setup.py
+++ b/server/polar/organization_review/collectors/setup.py
@@ -41,6 +41,22 @@ def _extract_domain(url: str) -> str | None:
         return None
 
 
+def _normalize_domain(domain: str) -> str:
+    """Strip leading 'www.' so that bare and www variants are treated as the same domain."""
+    return domain.removeprefix("www.")
+
+
+def _is_cross_domain(original: str | None, final: str | None) -> bool:
+    """Return True if two domains differ after www-normalization.
+
+    Returns False if either domain is None (unparseable URLs are not
+    treated as cross-domain redirects — they surface via the error field).
+    """
+    if original is None or final is None:
+        return False
+    return _normalize_domain(original) != _normalize_domain(final)
+
+
 def _unique_domains(urls: list[str]) -> list[str]:
     """Extract and deduplicate domains from a list of URLs, preserving order."""
     seen: set[str] = set()
@@ -110,7 +126,7 @@ async def _resolve_redirect(
             final_url = str(response.url)
             final_domain = _extract_domain(final_url)
             original_domain = _extract_domain(url)
-            redirected = final_domain != original_domain
+            redirected = _is_cross_domain(original_domain, final_domain)
             return UrlRedirectInfo(
                 original_url=url,
                 final_url=final_url,
@@ -196,7 +212,7 @@ async def _resolve_redirect_with_browser(url: str) -> UrlRedirectInfo:
         final_url = page.url
         final_domain = _extract_domain(final_url)
         original_domain = _extract_domain(url)
-        redirected = final_domain != original_domain
+        redirected = _is_cross_domain(original_domain, final_domain)
 
         return UrlRedirectInfo(
             original_url=url,

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 
 from polar.organization_review.collectors.setup import (
     _extract_domain,
+    _normalize_domain,
     collect_setup_data,
     resolve_url_redirects,
 )
@@ -68,6 +69,20 @@ class TestExtractDomain:
 
     def test_http_url(self) -> None:
         assert _extract_domain("http://my-site.org") == "my-site.org"
+
+
+class TestNormalizeDomain:
+    def test_strips_www(self) -> None:
+        assert _normalize_domain("www.example.com") == "example.com"
+
+    def test_bare_domain_unchanged(self) -> None:
+        assert _normalize_domain("example.com") == "example.com"
+
+    def test_non_www_subdomain_unchanged(self) -> None:
+        assert _normalize_domain("app.example.com") == "app.example.com"
+
+    def test_www_only(self) -> None:
+        assert _normalize_domain("www.com") == "com"
 
 
 class TestCollectSetupDataEmpty:
@@ -422,6 +437,68 @@ class TestResolveUrlRedirects:
 
         assert len(results) == 1
         assert results[0].redirected is False
+
+    @pytest.mark.asyncio
+    async def test_www_redirect_not_flagged(self, mocker: MockerFixture) -> None:
+        """Redirect from bare domain to www (or vice versa) is not flagged."""
+        import respx
+
+        mocker.patch(
+            "polar.organization_review.collectors.setup._validate_url_host",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_with_browser",
+            return_value=UrlRedirectInfo(
+                original_url="https://example.com/thanks",
+                final_url="https://www.example.com/thanks",
+                final_domain="www.example.com",
+                redirected=False,
+            ),
+        )
+
+        with respx.mock:
+            respx.head("https://example.com/thanks").respond(
+                301, headers={"Location": "https://www.example.com/thanks"}
+            )
+            respx.head("https://www.example.com/thanks").respond(200)
+            results = await resolve_url_redirects(["https://example.com/thanks"])
+
+        assert len(results) == 1
+        assert results[0].redirected is False
+        assert results[0].final_domain == "www.example.com"
+
+    @pytest.mark.asyncio
+    async def test_www_to_bare_redirect_not_flagged(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Redirect from www to bare domain is not flagged."""
+        import respx
+
+        mocker.patch(
+            "polar.organization_review.collectors.setup._validate_url_host",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_with_browser",
+            return_value=UrlRedirectInfo(
+                original_url="https://www.example.com/thanks",
+                final_url="https://example.com/thanks",
+                final_domain="example.com",
+                redirected=False,
+            ),
+        )
+
+        with respx.mock:
+            respx.head("https://www.example.com/thanks").respond(
+                301, headers={"Location": "https://example.com/thanks"}
+            )
+            respx.head("https://example.com/thanks").respond(200)
+            results = await resolve_url_redirects(["https://www.example.com/thanks"])
+
+        assert len(results) == 1
+        assert results[0].redirected is False
+        assert results[0].final_domain == "example.com"
 
     @pytest.mark.asyncio
     async def test_timeout_error(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary
- The cross-domain redirect detector was flagging `bare → www` and `www → bare` redirects as suspicious (e.g. `example.com` → `www.example.com`), causing false positives for 46 out of 89 flagged organizations (52%)
- Added `_normalize_domain()` to strip the `www.` prefix and `_is_cross_domain()` helper to centralize the domain comparison logic used in both HTTP HEAD and Playwright browser redirect detection passes
- Added tests for domain normalization and both www redirect directions

## Test plan
- [x] All 41 existing + new tests pass in `tests/organization_review/collectors/test_setup.py`
- [x] Backend lint passes
- [x] Backend type check passes
- [ ] Verify in prod that www-only redirects no longer appear in review reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)