### PR TITLE
customer-portal: Match base price with discount price

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/CustomerSubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/Subscriptions/CustomerSubscriptionDetails.tsx
@@ -18,6 +18,7 @@ import { useMemo, useState } from 'react'
 import CustomerPortalSubscription from '../CustomerPortal/CustomerPortalSubscription'
 import { InlineModal } from '../Modal/InlineModal'
 import { useModal } from '../Modal/useModal'
+import { getCustomerSubscriptionBasePrice } from './pricing'
 import CustomerCancellationModal from './CustomerCancellationModal'
 import CustomerChangePlanModal from './CustomerChangePlanModal'
 
@@ -61,22 +62,10 @@ const CustomerSubscriptionDetails = ({
   const uncancelSubscription = useCustomerUncancelSubscription(api)
   const router = useRouter()
 
-  const subscriptionBaseAmount = useMemo(() => {
-    const price = subscription.product.prices.find(
-      ({ amount_type }) => amount_type === 'fixed' || amount_type === 'custom',
-    )
-
-    if (!price) {
-      return null
-    }
-
-    // This should be obsolete but I don't think we have proper type guards for the generated schema
-    if ('price_amount' in price) {
-      return price.price_amount
-    }
-
-    return null
-  }, [subscription])
+  const subscriptionBasePrice = useMemo(
+    () => getCustomerSubscriptionBasePrice(subscription),
+    [subscription],
+  )
 
   if (!organization) {
     return null
@@ -90,12 +79,12 @@ const CustomerSubscriptionDetails = ({
           <div className="dark:text-polar-500 text-xl text-gray-500">
             {subscription.amount && subscription.currency ? (
               <span className="flex flex-row justify-end gap-x-1">
-                {subscriptionBaseAmount &&
-                  subscription.amount !== subscriptionBaseAmount && (
+                {subscriptionBasePrice &&
+                  subscription.amount !== subscriptionBasePrice.amount && (
                     <span className="text-gray-500 line-through">
                       {formatCurrency('compact')(
-                        subscriptionBaseAmount,
-                        subscription.currency,
+                        subscriptionBasePrice.amount,
+                        subscriptionBasePrice.currency,
                       )}
                     </span>
                   )}

--- a/clients/apps/web/src/components/Subscriptions/pricing.test.ts
+++ b/clients/apps/web/src/components/Subscriptions/pricing.test.ts
@@ -1,0 +1,135 @@
+import { schemas } from '@polar-sh/client'
+import { describe, expect, it } from 'vitest'
+import { getCustomerSubscriptionBasePrice } from './pricing'
+
+const createFixedPrice = (
+  currency: string,
+  amount: number,
+): schemas['ProductPriceFixed'] =>
+  ({
+    id: `price-${currency}`,
+    created_at: '2026-04-10T00:00:00Z',
+    modified_at: null,
+    source: 'catalog',
+    amount_type: 'fixed',
+    price_currency: currency,
+    tax_behavior: null,
+    is_archived: false,
+    product_id: 'product-1',
+    price_amount: amount,
+  }) as schemas['ProductPriceFixed']
+
+const createCustomPrice = (currency: string): schemas['ProductPriceCustom'] =>
+  ({
+    id: `price-custom-${currency}`,
+    created_at: '2026-04-10T00:00:00Z',
+    modified_at: null,
+    source: 'catalog',
+    amount_type: 'custom',
+    price_currency: currency,
+    tax_behavior: null,
+    is_archived: false,
+    product_id: 'product-1',
+    minimum_amount: 500,
+    maximum_amount: null,
+    preset_amount: 1500,
+  }) as schemas['ProductPriceCustom']
+
+const createSubscription = (
+  currency: string,
+  prices: schemas['CustomerSubscriptionProduct']['prices'],
+): schemas['CustomerSubscription'] =>
+  ({
+    created_at: '2026-04-10T00:00:00Z',
+    modified_at: null,
+    id: 'subscription-1',
+    amount: 35440,
+    currency,
+    recurring_interval: 'month',
+    recurring_interval_count: 1,
+    status: 'active',
+    current_period_start: '2026-04-10T00:00:00Z',
+    current_period_end: '2026-05-10T00:00:00Z',
+    trial_start: null,
+    trial_end: null,
+    cancel_at_period_end: false,
+    canceled_at: null,
+    started_at: '2026-04-10T00:00:00Z',
+    ends_at: null,
+    ended_at: null,
+    customer_id: 'customer-1',
+    product_id: 'product-1',
+    discount_id: null,
+    checkout_id: null,
+    customer_cancellation_reason: null,
+    customer_cancellation_comment: null,
+    product: {
+      id: 'product-1',
+      created_at: '2026-04-10T00:00:00Z',
+      modified_at: null,
+      trial_interval: null,
+      trial_interval_count: null,
+      name: 'Essential',
+      description: null,
+      visibility: 'public',
+      recurring_interval: 'month',
+      recurring_interval_count: 1,
+      is_recurring: true,
+      is_archived: false,
+      organization_id: 'org-1',
+      prices,
+      benefits: [],
+      medias: [],
+      organization: {
+        created_at: '2026-04-10T00:00:00Z',
+        modified_at: null,
+        id: 'org-1',
+        slug: 'org',
+        name: 'Org',
+        avatar_url: null,
+        proration_behavior: 'prorate',
+        allow_customer_updates: true,
+        customer_portal_settings: {
+          subscription: {
+            cancellation: {
+              enabled: true,
+              allow_multiple: true,
+              mode: 'at_period_end',
+            },
+            update_plan: true,
+          },
+        },
+      },
+    },
+    prices: [],
+    meters: [],
+    pending_update: null,
+  }) as unknown as schemas['CustomerSubscription']
+
+describe('getCustomerSubscriptionBasePrice', () => {
+  it('uses the catalog price matching the subscription currency', () => {
+    const subscription = createSubscription('dkk', [
+      createFixedPrice('usd', 5400),
+      createFixedPrice('dkk', 35440),
+    ])
+
+    expect(getCustomerSubscriptionBasePrice(subscription)).toEqual({
+      amount: 35440,
+      currency: 'dkk',
+    })
+  })
+
+  it('skips the base price when no catalog price matches the subscription currency', () => {
+    const subscription = createSubscription('dkk', [
+      createFixedPrice('usd', 5400),
+    ])
+
+    expect(getCustomerSubscriptionBasePrice(subscription)).toBeNull()
+  })
+
+  it('skips the base price when the matching catalog price is custom', () => {
+    const subscription = createSubscription('dkk', [createCustomPrice('dkk')])
+
+    expect(getCustomerSubscriptionBasePrice(subscription)).toBeNull()
+  })
+})

--- a/clients/apps/web/src/components/Subscriptions/pricing.ts
+++ b/clients/apps/web/src/components/Subscriptions/pricing.ts
@@ -1,0 +1,25 @@
+import { schemas } from '@polar-sh/client'
+
+export const getCustomerSubscriptionBasePrice = (
+  subscription: schemas['CustomerSubscription'],
+): { amount: number; currency: string } | null => {
+  const price = subscription.product.prices.find(
+    ({ amount_type, price_currency }) =>
+      (amount_type === 'fixed' || amount_type === 'custom') &&
+      price_currency === subscription.currency,
+  )
+
+  if (!price) {
+    return null
+  }
+
+  // This should be obsolete but I don't think we have proper type guards for the generated schema
+  if ('price_amount' in price) {
+    return {
+      amount: price.price_amount,
+      currency: price.price_currency,
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
We need to ensure that we're showing the crossed out price for the same currency as the one they are paying in for subscriptions.