### PR TITLE
Add download link for Polar for Android

### DIFF
--- a/clients/apps/web/src/app/(main)/(website)/(landing)/downloads/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/downloads/page.tsx
@@ -46,6 +46,8 @@ const downloads = [
     title: 'Polar for Android',
     description:
       'The perfect companion app for your business on Polar. Built for Android.',
+    href: 'https://play.google.com/store/apps/details?id=com.polarsource.Polar',
+    target: '_blank',
     icon: <Google size={20} />,
   },
 ]


### PR DESCRIPTION
The [Polar app on Play Store](https://play.google.com/store/apps/details?id=com.polarsource.Polar) was released on March 27th. Updating to add that in the /downloads route.
