### PR TITLE
yeet: redact PII and stats data from PR descriptions

### DIFF
--- a/.claude/commands/yeet.md
+++ b/.claude/commands/yeet.md
@@ -25,3 +25,8 @@ Lint, type-check, and create a PR.
 4. **If lint auto-fixed files** (e.g. ruff formatted), stage and commit those changes with a message like "lint: auto-fix formatting".
 
 5. **Create the PR** using the standard PR creation instructions from the system prompt. Use the full commit history from `main` to draft the PR title and description.
+
+   **Important — this is a public repo.** When writing the PR title and description:
+   - **No PII**: Do not include any personally identifiable information such as names, emails, user IDs, API keys, tokens, internal URLs, or customer data — even if they appear in commit messages or diffs.
+   - **No stats data**: Do not include specific metrics, revenue figures, user counts, conversion rates, or any other business/analytics data that may appear in the code changes.
+   - Describe *what* the changes do and *why*, without exposing sensitive details.


### PR DESCRIPTION
## 📋 Summary

Add guardrails to the `/yeet` command to prevent sensitive information from leaking into PR descriptions on this public repo.

## 🎯 What

Added instructions to the `/yeet` command's PR creation step that explicitly prohibit including PII (names, emails, user IDs, API keys, tokens, internal URLs, customer data) and business stats (metrics, revenue, user counts, conversion rates) in PR titles and descriptions.

## 🤔 Why

Since this repository is public, any PII or internal business metrics that end up in PR descriptions are visible to everyone. This change ensures the `/yeet` command produces safe, public-friendly PR descriptions by default.

## 🔧 How

Added a note to step 5 of `.claude/commands/yeet.md` with explicit rules about what to exclude from PR descriptions.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] ~~I have added new tests for new functionality~~ (not applicable — documentation-only change)

### Test Instructions

1. Run `/yeet` on a branch with changes
2. Verify the generated PR description does not contain any PII or stats data

## 📝 Additional Notes

This is a documentation/instruction-only change to `.claude/commands/yeet.md`. No code changes.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")