### PR TITLE
Unify metric date ranges between app and web

### DIFF
--- a/clients/apps/app/components/Metrics/utils.ts
+++ b/clients/apps/app/components/Metrics/utils.ts
@@ -1,4 +1,4 @@
-import { schemas } from '@polar-sh/client'
+import { getMetricsRangeDates, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import {
   differenceInDays,
@@ -49,32 +49,44 @@ export const dateRangeToInterval = (startDate: Date, endDate: Date) => {
 }
 
 export const timeRange = (organization: schemas['Organization']) =>
-  ({
-    '24h': {
-      startDate: subDays(new Date(), 1),
-      endDate: new Date(),
-      title: '24h',
-      description: 'Last 24 hours',
-    },
-    '30d': {
-      startDate: subDays(new Date(), 30),
-      endDate: new Date(),
-      title: '30d',
-      description: 'Last 30 days',
-    },
-    '3m': {
-      startDate: subMonths(new Date(), 3),
-      endDate: new Date(),
-      title: '3m',
-      description: 'Last 3 months',
-    },
-    all_time: {
-      startDate: new Date(organization.created_at),
-      endDate: new Date(),
-      title: 'All Time',
-      description: 'All time',
-    },
-  }) as const
+  (() => {
+    const [last24hStartDate, last24hEndDate] = getMetricsRangeDates('24h')
+    const [last30dStartDate, last30dEndDate] = getMetricsRangeDates('30d')
+    const [last3mStartDate, last3mEndDate] = getMetricsRangeDates('3m')
+    const [allTimeStartDate, allTimeEndDate] = getMetricsRangeDates(
+      'all_time',
+      {
+        createdAt: organization.created_at,
+      },
+    )
+
+    return {
+      '24h': {
+        startDate: last24hStartDate,
+        endDate: last24hEndDate,
+        title: '24h',
+        description: 'Last 24 hours',
+      },
+      '30d': {
+        startDate: last30dStartDate,
+        endDate: last30dEndDate,
+        title: '30d',
+        description: 'Last 30 days',
+      },
+      '3m': {
+        startDate: last3mStartDate,
+        endDate: last3mEndDate,
+        title: '3m',
+        description: 'Last 3 months',
+      },
+      all_time: {
+        startDate: allTimeStartDate,
+        endDate: allTimeEndDate,
+        title: 'All Time',
+        description: 'All time',
+      },
+    } as const
+  })()
 
 export const getPreviousParams = (
   startDate: Date,

--- a/clients/apps/web/src/components/Metrics/dashboards/ClientPage.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/ClientPage.tsx
@@ -2,7 +2,7 @@
 
 import { useMetrics } from '@/hooks/queries'
 import { fromISODate, METRIC_GROUPS, toISODate } from '@/utils/metrics'
-import { subMonths } from 'date-fns/subMonths'
+import { getMetricsRangeDates } from '@polar-sh/client'
 import {
   createParser,
   parseAsArrayOf,
@@ -34,8 +34,10 @@ export default function ClientPage({
   metric,
   organizationId,
 }: ClientPageProps) {
-  const defaultStartDate = useMemo(() => subMonths(new Date(), 1), [])
-  const defaultEndDate = useMemo(() => new Date(), [])
+  const [defaultStartDate, defaultEndDate] = useMemo(
+    () => getMetricsRangeDates('30d'),
+    [],
+  )
 
   const [interval] = useQueryState(
     'interval',

--- a/clients/apps/web/src/components/Metrics/dashboards/DashboardDetailClientPage.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/DashboardDetailClientPage.tsx
@@ -2,8 +2,7 @@
 
 import { useMetricDashboards, useMetrics } from '@/hooks/queries/metrics'
 import { fromISODate, toISODate } from '@/utils/metrics'
-import { schemas } from '@polar-sh/client'
-import { subMonths } from 'date-fns/subMonths'
+import { getMetricsRangeDates, schemas } from '@polar-sh/client'
 import {
   createParser,
   parseAsArrayOf,
@@ -34,8 +33,10 @@ export default function DashboardDetailClientPage({
   organization,
   dashboard: initialDashboard,
 }: DashboardDetailClientPageProps) {
-  const defaultStartDate = useMemo(() => subMonths(new Date(), 1), [])
-  const defaultEndDate = useMemo(() => new Date(), [])
+  const [defaultStartDate, defaultEndDate] = useMemo(
+    () => getMetricsRangeDates('30d'),
+    [],
+  )
 
   // Use live query data so edits in the header modal are reflected immediately
   const { data: dashboards } = useMetricDashboards(organization.id)

--- a/clients/apps/web/src/components/Metrics/dashboards/useMetricsFilters.ts
+++ b/clients/apps/web/src/components/Metrics/dashboards/useMetricsFilters.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { fromISODate, toISODate } from '@/utils/metrics'
-import { subMonths } from 'date-fns/subMonths'
+import { getMetricsRangeDates } from '@polar-sh/client'
 import {
   createParser,
   parseAsArrayOf,
@@ -27,8 +27,10 @@ export function useMetricsFilters(earliestDateISOString: string) {
     () => fromISODate(earliestDateISOString),
     [earliestDateISOString],
   )
-  const defaultStartDate = useMemo(() => subMonths(new Date(), 1), [])
-  const defaultEndDate = useMemo(() => new Date(), [])
+  const [defaultStartDate, defaultEndDate] = useMemo(
+    () => getMetricsRangeDates('30d'),
+    [],
+  )
 
   const [interval, setInterval] = useQueryState(
     'interval',

--- a/clients/apps/web/src/utils/metrics.ts
+++ b/clients/apps/web/src/utils/metrics.ts
@@ -1,4 +1,4 @@
-import { schemas } from '@polar-sh/client'
+import { getMetricsRangeDates, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import {
   differenceInDays,
@@ -6,10 +6,6 @@ import {
   differenceInWeeks,
   differenceInYears,
   parse,
-  startOfDay,
-  subDays,
-  subMonths,
-  subYears,
 } from 'date-fns'
 import { formatPercentage, formatScalar } from './formatters'
 
@@ -119,24 +115,9 @@ export const getChartRangeParams = (
   range: ChartRange,
   createdAt: string | Date,
 ): [Date, Date, schemas['TimeInterval']] => {
-  const endDate = new Date()
-  const parsedCreatedAt = new Date(createdAt)
-  const _getStartDate = (range: ChartRange) => {
-    const now = new Date()
-    switch (range) {
-      case 'all_time':
-        return parsedCreatedAt
-      case '12m':
-        return subYears(now, 1)
-      case '3m':
-        return subMonths(now, 3)
-      case '30d':
-        return startOfDay(subDays(now, 30))
-      case 'today':
-        return startOfDay(now)
-    }
-  }
-  const startDate = _getStartDate(range)
+  const [startDate, endDate] = getMetricsRangeDates(range, {
+    createdAt,
+  })
   const interval = dateRangeToInterval(startDate, endDate)
   return [startDate, endDate, interval]
 }

--- a/clients/packages/client/package.json
+++ b/clients/packages/client/package.json
@@ -35,6 +35,7 @@
     "access": "public"
   },
   "dependencies": {
+    "date-fns": "^4.1.0",
     "openapi-fetch": "^0.15.0",
     "openapi-typescript-helpers": "^0.0.15"
   }

--- a/clients/packages/client/src/index.ts
+++ b/clients/packages/client/src/index.ts
@@ -117,6 +117,7 @@ export const isValidationError = (
 
 export type { Middleware } from 'openapi-fetch'
 export * as enums from './enums'
+export { getMetricsRangeDates, type MetricsRange } from './metrics'
 export type { components, operations, paths } from './v1'
 export type schemas = components['schemas']
 export type Client = ReturnType<typeof createClient>

--- a/clients/packages/client/src/metrics.ts
+++ b/clients/packages/client/src/metrics.ts
@@ -1,0 +1,31 @@
+import { startOfDay, subDays, subMonths, subYears } from 'date-fns'
+
+export type MetricsRange = '24h' | '30d' | '3m' | '12m' | 'today' | 'all_time'
+
+export const getMetricsRangeDates = (
+  range: MetricsRange,
+  options?: {
+    createdAt?: string | Date
+    now?: Date
+  },
+): [Date, Date] => {
+  const endDate = options?.now ?? new Date()
+
+  switch (range) {
+    case '24h':
+      return [subDays(endDate, 1), endDate]
+    case '30d':
+      return [subDays(endDate, 30), endDate]
+    case '3m':
+      return [subMonths(endDate, 3), endDate]
+    case '12m':
+      return [subYears(endDate, 1), endDate]
+    case 'today':
+      return [startOfDay(endDate), endDate]
+    case 'all_time':
+      if (!options?.createdAt) {
+        throw new Error('createdAt is required for all_time metrics range')
+      }
+      return [new Date(options.createdAt), endDate]
+  }
+}

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -657,6 +657,9 @@ importers:
 
   packages/client:
     dependencies:
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       openapi-fetch:
         specifier: ^0.15.0
         version: 0.15.0


### PR DESCRIPTION
The app and web calculates time period differently, causing inconsistencies in the metrics. The two platforms defines the 30 day date range in two different ways:

* Web: `subMonths(new Date(), 1)` (past month)
* App: `subDays(new Date(), 30)` (past 30 days)

So looking at the same metric in the app and web will show two different values. The fix is to share a function between the web and app which uses 30 day format.
