### PR TITLE
Fix dev/conductor-run to use full length options to align with #10946

### DIFF
--- a/dev/conductor-run
+++ b/dev/conductor-run
@@ -27,4 +27,4 @@ echo "Building backoffice..."
 (cd server && uv run task backoffice)
 
 # Start all services in detached mode (instance auto-detected from CONDUCTOR_PORT)
-./dev/cli/dev docker up -d
+./dev/cli/dev docker up --detach


### PR DESCRIPTION
<!--
Thank you for contributing to Polar! 🎉

Before submitting your PR, please ensure:
- An issue exists and you're assigned to it (unless it's a minor fix)
- You've tested your changes locally
- All tests pass
- Code follows our style guidelines

For minor fixes (typos, broken links, formatting), you may skip the issue requirement.
-->

## 📋 Summary

#10946 removed support for using the shorthand `-d` flag (as opposed to `--detach`) for `dev docker up`. This PR aligns `dev/conductor-run` with that change.

## 🎯 What

☝️ 

## 🤔 Why

So `dev/conductor-run` works again

## 🔧 How

Switch from `dev docker up -d` to `dev docker up --detach`.

## 🧪 Testing

<!-- Check all that apply -->

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

<!-- Provide step-by-step instructions for reviewers to test your changes -->

1. Run `dev/conductor-run` on `main` and verify you get an error with `No such option: -d`
2. Checkout this branch and run `dev/conductor-run` and get a successful run

## ✅ Pre-submission Checklist

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [ ] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")
