### PR TITLE
fix: prevent IPv6 regex from blocking domains starting with fc/fd

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.test.ts
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { isPrivateIP } from './WebhookForm'
+
+describe('isPrivateIP', () => {
+  describe('IPv4 private ranges', () => {
+    it('blocks 10.x.x.x', () => {
+      expect(isPrivateIP('10.0.0.1')).toBe(true)
+      expect(isPrivateIP('10.255.255.255')).toBe(true)
+    })
+
+    it('blocks 172.16-31.x.x', () => {
+      expect(isPrivateIP('172.16.0.1')).toBe(true)
+      expect(isPrivateIP('172.31.255.255')).toBe(true)
+      expect(isPrivateIP('172.15.0.1')).toBe(false)
+      expect(isPrivateIP('172.32.0.1')).toBe(false)
+    })
+
+    it('blocks 192.168.x.x', () => {
+      expect(isPrivateIP('192.168.0.1')).toBe(true)
+      expect(isPrivateIP('192.168.255.255')).toBe(true)
+      expect(isPrivateIP('192.169.0.1')).toBe(false)
+    })
+
+    it('blocks 169.254.x.x (link-local)', () => {
+      expect(isPrivateIP('169.254.0.1')).toBe(true)
+      expect(isPrivateIP('169.254.255.255')).toBe(true)
+    })
+
+    it('blocks 127.x.x.x (loopback)', () => {
+      expect(isPrivateIP('127.0.0.1')).toBe(true)
+      expect(isPrivateIP('127.255.255.255')).toBe(true)
+    })
+
+    it('blocks 0.x.x.x', () => {
+      expect(isPrivateIP('0.0.0.0')).toBe(true)
+    })
+
+    it('blocks 100.64-127.x.x (CGNAT)', () => {
+      expect(isPrivateIP('100.64.0.1')).toBe(true)
+      expect(isPrivateIP('100.127.255.255')).toBe(true)
+      expect(isPrivateIP('100.63.0.1')).toBe(false)
+      expect(isPrivateIP('100.128.0.1')).toBe(false)
+    })
+
+    it('allows public IPv4 addresses', () => {
+      expect(isPrivateIP('8.8.8.8')).toBe(false)
+      expect(isPrivateIP('216.150.1.1')).toBe(false)
+      expect(isPrivateIP('1.1.1.1')).toBe(false)
+    })
+  })
+
+  describe('IPv6 private addresses', () => {
+    it('blocks fc00::/7 unique-local addresses', () => {
+      expect(isPrivateIP('fc00::1')).toBe(true)
+      expect(isPrivateIP('fd00::1')).toBe(true)
+      expect(isPrivateIP('fd12:3456:789a::1')).toBe(true)
+    })
+
+    it('blocks fe80:: link-local addresses', () => {
+      expect(isPrivateIP('fe80::1')).toBe(true)
+      expect(isPrivateIP('fe80::abcd:1234')).toBe(true)
+    })
+
+    it('blocks bracketed IPv6 addresses', () => {
+      expect(isPrivateIP('[fc00::1]')).toBe(true)
+      expect(isPrivateIP('[fd00::1]')).toBe(true)
+      expect(isPrivateIP('[fe80::1]')).toBe(true)
+    })
+  })
+
+  describe('domain names starting with fc/fd — must NOT be blocked', () => {
+    it('allows fctactix.com (the reported bug)', () => {
+      expect(isPrivateIP('fctactix.com')).toBe(false)
+    })
+
+    it('allows other domains starting with fc', () => {
+      expect(isPrivateIP('fcexample.com')).toBe(false)
+      expect(isPrivateIP('fc-app.example.com')).toBe(false)
+    })
+
+    it('allows domains starting with fd', () => {
+      expect(isPrivateIP('fdomain.example.com')).toBe(false)
+      expect(isPrivateIP('fd-service.io')).toBe(false)
+    })
+
+    it('allows subdomains of fc/fd domains', () => {
+      expect(isPrivateIP('staging.fctactix.com')).toBe(false)
+      expect(isPrivateIP('hooks.fctactix.com')).toBe(false)
+      expect(isPrivateIP('api.fdomain.com')).toBe(false)
+    })
+  })
+
+  describe('regular domain names', () => {
+    it('allows typical domains', () => {
+      expect(isPrivateIP('example.com')).toBe(false)
+      expect(isPrivateIP('api.polar.sh')).toBe(false)
+      expect(isPrivateIP('webhook.site')).toBe(false)
+      expect(isPrivateIP('hooks.slack.com')).toBe(false)
+    })
+  })
+})

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -24,7 +24,7 @@ type CreateOrUpdate =
   | schemas['WebhookEndpointCreate']
   | schemas['WebhookEndpointUpdate']
 
-const isPrivateIP = (hostname: string): boolean => {
+export const isPrivateIP = (hostname: string): boolean => {
   const parts = hostname.split('.')
   if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
     const [a, b] = parts.map(Number)
@@ -36,7 +36,8 @@ const isPrivateIP = (hostname: string): boolean => {
     if (a === 0) return true
     if (a === 100 && b >= 64 && b <= 127) return true
   }
-  if (/^\[?f[cd]/i.test(hostname) || /^\[?fe80/i.test(hostname)) return true
+  if (/^\[?f[cd][0-9a-f]*:/i.test(hostname) || /^\[?fe80:/i.test(hostname))
+    return true
   return false
 }
 

--- a/server/tests/webhooks/test_schemas.py
+++ b/server/tests/webhooks/test_schemas.py
@@ -1,0 +1,64 @@
+import pytest
+
+from polar.webhook.schemas import is_blocked_webhook_host
+
+
+class TestIsBlockedWebhookHost:
+    # --- Localhost ---
+
+    @pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "0.0.0.0", "[::1]"])
+    def test_blocks_localhost_variants(self, host: str) -> None:
+        assert is_blocked_webhook_host(host) is True
+
+    def test_blocks_localhost_case_insensitive(self) -> None:
+        assert is_blocked_webhook_host("LOCALHOST") is True
+        assert is_blocked_webhook_host("Localhost") is True
+
+    # --- Private IPv4 ---
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.0.1",
+            "100.64.0.1",
+        ],
+    )
+    def test_blocks_private_ipv4(self, ip: str) -> None:
+        assert is_blocked_webhook_host(ip) is True
+
+    # --- Private IPv6 ---
+
+    @pytest.mark.parametrize("ip", ["fc00::1", "fd00::1", "fe80::1", "::1"])
+    def test_blocks_private_ipv6(self, ip: str) -> None:
+        assert is_blocked_webhook_host(ip) is True
+
+    def test_blocks_bracketed_ipv6(self) -> None:
+        assert is_blocked_webhook_host("[fc00::1]") is True
+        assert is_blocked_webhook_host("[::1]") is True
+
+    # --- Public IPs ---
+
+    @pytest.mark.parametrize("ip", ["8.8.8.8", "216.150.1.1", "1.1.1.1"])
+    def test_allows_public_ipv4(self, ip: str) -> None:
+        assert is_blocked_webhook_host(ip) is False
+
+    # --- Domain names (must never be blocked) ---
+
+    def test_allows_regular_domains(self) -> None:
+        assert is_blocked_webhook_host("example.com") is False
+        assert is_blocked_webhook_host("api.polar.sh") is False
+        assert is_blocked_webhook_host("webhook.site") is False
+
+    def test_allows_domains_starting_with_fc_or_fd(self) -> None:
+        """Regression test: fc/fd prefixes must not be confused with IPv6 ULA."""
+        assert is_blocked_webhook_host("fctactix.com") is False
+        assert is_blocked_webhook_host("fcexample.com") is False
+        assert is_blocked_webhook_host("fdomain.example.com") is False
+        assert is_blocked_webhook_host("fd-service.io") is False
+
+    def test_allows_subdomains_of_fc_domains(self) -> None:
+        assert is_blocked_webhook_host("staging.fctactix.com") is False
+        assert is_blocked_webhook_host("hooks.fctactix.com") is False


### PR DESCRIPTION
## Summary

- Fix overly broad IPv6 regex in frontend `isPrivateIP` that incorrectly flagged domain names starting with `fc` or `fd` (e.g. `fctactix.com`) as private IPv6 addresses
- The regex `/^\[?f[cd]/i` was meant to catch IPv6 ULA addresses (`fc00::`/`fd00::`) but matched any hostname starting with those letters. Updated to `/^\[?f[cd][0-9a-f]*:/i` which requires a colon (present in IPv6, absent in domain names)
- Add frontend tests (vitest) for `isPrivateIP` covering IPv4 private ranges, IPv6 addresses, and the regression case
- Add backend tests (pytest) for `is_blocked_webhook_host` with the same coverage

## Test plan

- [x] Frontend tests pass: `pnpm vitest run WebhookForm.test.ts` — 16/16
- [x] Backend tests pass: `pytest tests/webhooks/test_schemas.py` — 21/21
- [x] Frontend lint passes
- [x] Backend lint + type check passes
- [ ] Verify webhook creation works for domains starting with `fc`/`fd` in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)