### PR TITLE
Add deny button for created/onboarding_started orgs in backoffice v2

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -452,6 +452,25 @@ class OrganizationDetailView:
                             ):
                                 text("Set Offboarding")
 
+                    elif self.org.status in (
+                        OrganizationStatus.CREATED,
+                        OrganizationStatus.ONBOARDING_STARTED,
+                    ):
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:deny_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Deny")
+
                     # Always available actions
                     with tag.div(classes="divider my-2"):
                         pass


### PR DESCRIPTION
## 📋 Summary

Organizations in `created` or `onboarding_started` status had no action buttons in the backoffice v2 detail view.

## 🎯 What

Added a "Deny" button to the actions sidebar for organizations with `CREATED` or `ONBOARDING_STARTED` status.

## 🤔 Why

The actions card if/elif chain handled `blocked`, `DENIED`, `ACTIVE`, `OFFBOARDING`, and `is_under_review` statuses but had no branch for `CREATED` or `ONBOARDING_STARTED`, so no actions were rendered for those orgs.

## 🔧 How

Added an `elif` branch for these two statuses that renders a Deny button pointing to the existing `organizations:deny_dialog` endpoint. No backend changes needed — the deny dialog and service already work for any status.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Open backoffice v2 detail view for an org in `created` or `onboarding_started` status
2. Verify the "Deny" button appears in the Actions sidebar
3. Click "Deny" and confirm the deny dialog opens correctly

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally