### PR TITLE
fix: eagerly load PayoutAccount.admin in get_by_id_with_payout_account

### DIFF
--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -18,6 +18,7 @@ from polar.models import (
     Customer,
     Order,
     Organization,
+    PayoutAccount,
     Subscription,
     User,
     UserOrganization,
@@ -71,7 +72,11 @@ class OrganizationRepository(
     ) -> Organization | None:
         statement = (
             self.get_base_statement(include_deleted=include_deleted)
-            .options(joinedload(Organization.payout_account))
+            .options(
+                joinedload(Organization.payout_account).subqueryload(
+                    PayoutAccount.admin
+                )
+            )
             .where(self.model.id == id)
         )
 


### PR DESCRIPTION
## 📋 Summary

Fix runtime crash when accessing `payout_account.admin` in the bulk appeal review script.

## 🎯 What

Added `subqueryload(PayoutAccount.admin)` to `get_by_id_with_payout_account` so that the admin user is eagerly loaded alongside the payout account.

## 🤔 Why

`PayoutAccount.admin` is defined with `lazy="raise"`, meaning it must be explicitly eager-loaded. The `appeal_review.py` script accesses `payout_account.admin` after calling `get_by_id_with_payout_account()`, which previously only loaded the payout account itself — causing a runtime `InvalidRequestError`.

## 🔧 How

Chained `.subqueryload(PayoutAccount.admin)` onto the existing `joinedload(Organization.payout_account)` in `OrganizationRepository.get_by_id_with_payout_account`.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally