### PR TITLE
polar: Hook up event ingestion

### DIFF
--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -19,6 +19,7 @@ from polar.customer_meter.repository import CustomerMeterRepository
 from polar.event.tinybird_repository import TinybirdEventRepository
 from polar.event_type.repository import EventTypeRepository
 from polar.exceptions import PolarError, PolarRequestValidationError, ValidationError
+from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.integrations.tinybird.service import (
     TinybirdTimeseriesStats,
     events_to_tinybird,
@@ -964,6 +965,8 @@ class EventService:
         if organization_ids_for_revops:
             organization_repository = OrganizationRepository.from_session(session)
             await organization_repository.enable_revops(organization_ids_for_revops)
+
+        polar_self_service.enqueue_event_ingestion(events)
 
     async def _create_meter_events(
         self, session: AsyncSession, events: Sequence[Event]

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -1,6 +1,10 @@
 import uuid
+from collections import defaultdict
+from collections.abc import Sequence
 
 from polar.config import settings
+from polar.models import Event
+from polar.models.event import EventSource
 from polar.worker import enqueue_job
 
 
@@ -73,6 +77,25 @@ class PolarSelfService:
             count=count,
             organization_id=settings.POLAR_ORGANIZATION_ID,
         )
+
+    def enqueue_event_ingestion(self, events: Sequence[Event]) -> None:
+        if not self.is_configured:
+            return
+
+        self_organization_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
+        counts: dict[uuid.UUID, int] = defaultdict(int)
+        for event in events:
+            if event.source != EventSource.user:
+                continue
+            if event.organization_id == self_organization_id:
+                continue
+            counts[event.organization_id] += 1
+
+        for organization_id, count in counts.items():
+            self.enqueue_track_ingestion(
+                external_customer_id=str(organization_id),
+                count=count,
+            )
 
 
 polar_self = PolarSelfService()

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -1,0 +1,117 @@
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.integrations.polar.service import polar_self
+from polar.models.event import EventSource
+
+SELF_ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+ORG_A = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+ORG_B = uuid.UUID("00000000-0000-0000-0000-00000000000b")
+
+
+def _event(
+    organization_id: uuid.UUID, source: EventSource = EventSource.user
+) -> MagicMock:
+    event = MagicMock()
+    event.organization_id = organization_id
+    event.source = source
+    return event
+
+
+@pytest.fixture
+def configured(mocker: MockerFixture) -> None:
+    settings = mocker.patch("polar.integrations.polar.service.settings")
+    settings.POLAR_SELF_ENABLED = True
+    settings.POLAR_ORGANIZATION_ID = str(SELF_ORG_ID)
+
+
+class TestEnqueueEventIngestion:
+    def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
+        settings = mocker.patch("polar.integrations.polar.service.settings")
+        settings.POLAR_SELF_ENABLED = False
+        enqueue = mocker.patch(
+            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
+        )
+
+        polar_self.enqueue_event_ingestion([_event(ORG_A)])
+
+        enqueue.assert_not_called()
+
+    def test_noop_on_empty(self, configured: None, mocker: MockerFixture) -> None:
+        enqueue = mocker.patch(
+            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
+        )
+
+        polar_self.enqueue_event_ingestion([])
+
+        enqueue.assert_not_called()
+
+    def test_aggregates_per_organization(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch(
+            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
+        )
+
+        polar_self.enqueue_event_ingestion(
+            [
+                _event(ORG_A),
+                _event(ORG_A),
+                _event(ORG_A),
+                _event(ORG_B),
+                _event(ORG_B),
+            ]
+        )
+
+        assert enqueue.call_count == 2
+        calls = {
+            call.kwargs["external_customer_id"]: call.kwargs["count"]
+            for call in enqueue.call_args_list
+        }
+        assert calls == {str(ORG_A): 3, str(ORG_B): 2}
+
+    def test_skips_system_events(self, configured: None, mocker: MockerFixture) -> None:
+        enqueue = mocker.patch(
+            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
+        )
+
+        polar_self.enqueue_event_ingestion(
+            [
+                _event(ORG_A, source=EventSource.user),
+                _event(ORG_A, source=EventSource.system),
+                _event(ORG_A, source=EventSource.system),
+            ]
+        )
+
+        enqueue.assert_called_once_with(external_customer_id=str(ORG_A), count=1)
+
+    def test_skips_self_organization(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch(
+            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
+        )
+
+        polar_self.enqueue_event_ingestion(
+            [
+                _event(SELF_ORG_ID),
+                _event(SELF_ORG_ID),
+                _event(ORG_A),
+            ]
+        )
+
+        enqueue.assert_called_once_with(external_customer_id=str(ORG_A), count=1)
+
+    def test_noop_when_only_self_org_events(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch(
+            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
+        )
+
+        polar_self.enqueue_event_ingestion([_event(SELF_ORG_ID), _event(SELF_ORG_ID)])
+
+        enqueue.assert_not_called()


### PR DESCRIPTION
Bundle events into a single event with a count for now.
Ignore events sent in for the Polar organization