### PR TITLE
Add short flag aliases (-d, -b, -i) to dev docker CLI

### DIFF
--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -234,7 +234,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
     def docker_callback(
         ctx: typer.Context,
         instance: Annotated[
-            int | None, typer.Option("--instance", help="Instance number for port isolation (auto-detected if not set)")
+            int | None, typer.Option("--instance", "-i", help="Instance number for port isolation (auto-detected if not set)")
         ] = None,
     ) -> None:
         """Isolated Docker development environment."""
@@ -253,10 +253,10 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
     def docker_up(
         ctx: typer.Context,
         detach: Annotated[
-            bool, typer.Option("--detach", help="Run in background")
+            bool, typer.Option("--detach", "-d", help="Run in background")
         ] = True,
         build: Annotated[
-            bool, typer.Option("--build", help="Force rebuild images")
+            bool, typer.Option("--build", "-b", help="Force rebuild images")
         ] = False,
         monitoring: Annotated[
             bool, typer.Option("--monitoring", help="Include Prometheus and Grafana")


### PR DESCRIPTION
## 📋 Summary

The dev docker CLI only accepted long-form flags (`--detach`, `--build`, `--instance`) but all documentation and examples use short forms (`-d`, `-b`, `-i`), causing `No such option: -d` errors.

## 🎯 What

Added short flag aliases to three Typer options in `dev/cli/commands/docker.py`:
- `--detach` → `-d`
- `--build` → `-b`
- `--instance` → `-i`

## 🤔 Why

Commands like `dev docker up -d` failed with "No such option: -d" because the Typer option definitions didn't include short-form aliases, despite being documented everywhere (DEVELOPMENT.md, AGENTS.md, SKILL.md, etc.).

## 🔧 How

Added the short flag as a second positional argument to each `typer.Option()` call.

## 🧪 Testing

- [x] I have tested these changes locally

### Test Instructions

1. Run `dev docker up -d` — should no longer error
2. Run `dev docker up --help` — should show `-d`, `-b`, `-i` aliases