### PR TITLE
fix: prevent stale Redis messages from corrupting E2E test sessions

### DIFF
--- a/server/tests/e2e/infra/task_drain.py
+++ b/server/tests/e2e/infra/task_drain.py
@@ -199,6 +199,13 @@ class TaskDrain:
         ignored = DEFAULT_IGNORED_ACTORS | (ignored_actors or set())
         result = DrainResult()
 
+        # Purge stale messages from the broker's real Redis.
+        # group().run() and pipeline enqueue directly to the broker,
+        # bypassing the drain's FakeRedis. Leftover messages from
+        # previous tests or parallel workers would be siphoned into
+        # the current test and cause spurious failures.
+        self._purge_broker_queues()
+
         # Flush the HTTP request's JQM to Redis
         try:
             jqm = JobQueueManager.get()
@@ -266,6 +273,26 @@ class TaskDrain:
 
         return None
 
+    def _purge_broker_queues(self) -> None:
+        """Remove stale messages from the broker's real Redis.
+
+        ``group().run()`` and ``dramatiq.pipeline`` write directly to the
+        broker's Redis.  If a previous test (or a parallel pytest-xdist
+        worker) left messages behind, ``_siphon_broker_messages`` would
+        pull them into the current test and cause spurious failures.
+
+        Called at the *start* of each drain — before the current test's
+        JQM is flushed — so only genuinely stale messages are removed.
+        """
+        broker = dramatiq.get_broker()
+        broker_redis = getattr(broker, "client", None)
+        if broker_redis is None or broker_redis is self._redis:
+            return
+
+        for queue_name in QUEUE_NAMES:
+            broker_redis.delete(f"dramatiq:{queue_name}")
+            broker_redis.delete(f"dramatiq:{queue_name}.msgs")
+
     async def _siphon_broker_messages(self) -> None:
         """Transfer messages from the broker's Redis to the drain's FakeRedis.
 
@@ -299,7 +326,15 @@ class TaskDrain:
         fn: Any,
         message: dict[str, Any],
     ) -> Exception | None:
-        """Execute a single task function with proper CurrentMessage context."""
+        """Execute a single task function with proper CurrentMessage context.
+
+        Each task runs inside an outer SAVEPOINT so that if the task
+        fails (and ``AsyncSessionMaker`` calls ``session.rollback()``),
+        the rollback is contained and cannot corrupt the shared test
+        session.  Successful tasks release the SAVEPOINT, making their
+        changes visible in the connection's transaction for subsequent
+        tasks and assertions.
+        """
         args = message.get("args", ())
         kwargs = message.get("kwargs", {})
         options = message.get("options", {})
@@ -318,11 +353,25 @@ class TaskDrain:
         )
         CurrentMessage._MESSAGE.set(msg)
         try:
-            await fn(*args, **kwargs)
-            return None
-        except Retry:
-            return None
-        except Exception as exc:
-            return exc
+            nested = await self._session.begin_nested()
+            try:
+                await fn(*args, **kwargs)
+            except Retry:
+                # Retry is success from the drain's perspective.
+                # The inner rollback already happened; just make sure
+                # our SAVEPOINT is cleaned up.
+                if nested.is_active:
+                    await nested.rollback()
+                return None
+            except Exception as exc:
+                if nested.is_active:
+                    await nested.rollback()
+                return exc
+            else:
+                # Task succeeded — release the SAVEPOINT so its changes
+                # are visible in the outer transaction.
+                if nested.is_active:
+                    await nested.commit()
+                return None
         finally:
             CurrentMessage._MESSAGE.set(None)


### PR DESCRIPTION
## 📋 Summary

Fixes flaky E2E test failures in `test_subscribe_renew_cancel_revoke` and `test_feature_flag_granted`.

## 🎯 What

Two changes to `server/tests/e2e/infra/task_drain.py`:

1. **Purge stale broker messages** — `_purge_broker_queues()` cleans the real Redis broker queues at the start of each drain, before the current test's JQM is flushed.
2. **SAVEPOINT isolation** — Each task execution in `_execute_task()` is wrapped in an explicit SAVEPOINT (`session.begin_nested()`) so that failed tasks cannot corrupt the shared test session.

## 🤔 Why

`enqueue_benefits_grants` uses `dramatiq.group().run()` which writes directly to the real Redis broker (bypassing the drain's FakeRedis). These messages can leak across test runs or parallel `pytest-xdist` workers. When a stale message fails (e.g. referencing a customer from a previous test), `AsyncSessionMaker` calls `session.rollback()` which corrupts the shared test session — causing all subsequent tasks to fail with "does not exist" errors.

## 🔧 How

- `_purge_broker_queues()` deletes all dramatiq queue keys from the broker's real Redis at the start of each drain, before any current-test messages are flushed. This ensures only stale messages are removed.
- `_execute_task()` creates a SAVEPOINT before calling the task function. On success, the SAVEPOINT is committed (making changes visible). On failure or Retry, it's rolled back — containing the damage to a single task without affecting the outer transaction.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have run linting and type checking

### Test Instructions

1. Run `uv run task test` — all E2E tests pass
2. Run the previously flaky tests multiple times: `pytest tests/e2e/lifecycle/test_full_lifecycle.py tests/e2e/post_purchase/test_benefit_grants.py` — passes consistently across 5+ runs

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: I have tested and executed the code locally