### PR TITLE
fix: AI initial approval now runs full org review lifecycle

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -749,8 +749,15 @@ class OrganizationService:
         self,
         session: AsyncSession,
         organization: Organization,
-        next_review_threshold: int,
+        next_review_threshold: int | None = None,
+        *,
+        silent: bool = False,
     ) -> Organization:
+        if next_review_threshold is None:
+            next_review_threshold = max(
+                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
+            )
+
         organization.status = OrganizationStatus.ACTIVE
         organization.status_updated_at = datetime.now(UTC)
         organization.next_review_threshold = next_review_threshold
@@ -778,6 +785,7 @@ class OrganizationService:
             "organization.reviewed",
             organization_id=organization.id,
             initial_review=initial_review,
+            silent=silent,
         )
         return organization
 
@@ -798,12 +806,7 @@ class OrganizationService:
         )
 
         if is_eligible:
-            next_threshold = max(
-                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
-            )
-            await self.confirm_organization_reviewed(
-                session, organization, next_threshold
-            )
+            await self.confirm_organization_reviewed(session, organization)
             return True
 
         # Not eligible or not approved → create Plain ticket for human review

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -112,7 +112,9 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
 
 @actor(actor_name="organization.reviewed", priority=TaskPriority.LOW)
 async def organization_reviewed(
-    organization_id: uuid.UUID, initial_review: bool = False
+    organization_id: uuid.UUID,
+    initial_review: bool = False,
+    silent: bool = False,
 ) -> None:
     async with AsyncSessionMaker() as session:
         repository = OrganizationRepository.from_session(session)
@@ -125,7 +127,7 @@ async def organization_reviewed(
         await held_balance_service.release_account(session, organization.account)
 
         # Send an email after the initial review
-        if initial_review:
+        if initial_review and not silent:
             admin_user = await repository.get_admin_user(session, organization)
             if admin_user:
                 email = OrganizationReviewedEmail(

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -227,6 +227,6 @@ async def run_review_agent(
                     verdict=report.verdict.value,
                 )
             elif report.verdict == ReviewVerdict.APPROVE:
-                organization.status = OrganizationStatus.ACTIVE
-                organization.status_updated_at = datetime.now(UTC)
-                session.add(organization)
+                await organization_service.confirm_organization_reviewed(
+                    session, organization, silent=True
+                )

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -518,6 +518,34 @@ class TestConfirmOrganizationReviewed:
             "organization.reviewed",
             organization_id=organization.id,
             initial_review=True,
+            silent=False,
+        )
+
+    async def test_initial_review_silent(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Given organization under review
+        organization.status = OrganizationStatus.INITIAL_REVIEW
+
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        # When
+        result = await organization_service.confirm_organization_reviewed(
+            session, organization, 15000, silent=True
+        )
+
+        # Then
+        assert result.status == OrganizationStatus.ACTIVE
+        assert result.initially_reviewed_at is not None
+        assert result.next_review_threshold == 15000
+        enqueue_job_mock.assert_called_once_with(
+            "organization.reviewed",
+            organization_id=organization.id,
+            initial_review=True,
+            silent=True,
         )
 
     async def test_ongoing_review(
@@ -546,6 +574,7 @@ class TestConfirmOrganizationReviewed:
             "organization.reviewed",
             organization_id=organization.id,
             initial_review=False,
+            silent=False,
         )
 
     async def test_overrides_rejected_appeal(

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -176,3 +176,32 @@ class TestOrganizationReviewed:
         email_arg = enqueue_email_template_mock.call_args[0][0]
         assert isinstance(email_arg, OrganizationReviewedEmail)
         get_admin_user_mock.assert_called_once()
+
+    async def test_silent_skips_email(
+        self,
+        mocker: MockerFixture,
+        enqueue_email_template_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # Update organization to have active status
+        organization.status = OrganizationStatus.ACTIVE
+        await save_fixture(organization)
+
+        release_account_mock = mocker.patch.object(
+            held_balance_service,
+            "release_account",
+            spec=HeldBalanceService.release_account,
+        )
+
+        # then
+        session.expunge_all()
+
+        await organization_reviewed(organization.id, initial_review=True, silent=True)
+
+        # Held balances are still released
+        release_account_mock.assert_called_once()
+        # But no email is sent
+        enqueue_email_template_mock.assert_not_called()


### PR DESCRIPTION
## 📋 Summary

When AI approved an organization on SUBMISSION context, it set status to ACTIVE directly without calling `confirm_organization_reviewed()`. This skipped setting `initially_reviewed_at`, updating `next_review_threshold`, and releasing held balances.

## 🎯 What

- Add `silent: bool` parameter to `confirm_organization_reviewed()` and the `organization.reviewed` task to suppress email on AI approvals while keeping all other lifecycle steps
- Replace direct status assignment in `organization_review/tasks.py` with proper `confirm_organization_reviewed()` call
- Consolidate threshold doubling logic into `confirm_organization_reviewed()` (was duplicated in `handle_ongoing_review_verdict`)

## 🤔 Why

The AI approval path was a bug — it skipped critical lifecycle steps (setting `initially_reviewed_at`, updating the review threshold, releasing held balances). No email being sent on AI approval is the desired behavior, which is now explicitly controlled via the `silent` flag rather than being an accidental side-effect of skipping the lifecycle entirely.

## 🔧 How

- Made `next_review_threshold` optional in `confirm_organization_reviewed()` — when `None`, it defaults to doubling the current threshold (clamped to `_MIN_REVIEW_THRESHOLD`), eliminating the duplicate calculation
- Added `silent` as a keyword-only parameter that flows through to the `organization.reviewed` task, where it gates email sending while leaving held balance release unconditional
- The SUBMISSION APPROVE branch now calls `confirm_organization_reviewed(session, organization, silent=True)` instead of directly mutating status

## 🧪 Testing

- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)
- [x] I have added new tests for new functionality

### Test Instructions

1. Verify `confirm_organization_reviewed(silent=True)` sets `initially_reviewed_at`, updates threshold, enqueues task with `silent=True`
2. Verify `organization_reviewed(silent=True)` releases held balances but does NOT send email
3. Verify existing tests pass (threshold doubling, ongoing review, appeal override)

## 📝 Additional Notes

- No migration needed — logic-only fix
- `handle_ongoing_review_verdict` (THRESHOLD context) does not need `silent=True` because ongoing reviews already have `initially_reviewed_at` set, so `initial_review` is always `False` and no email is sent regardless

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")