### PR TITLE
polar: Move away from inline imports

### DIFF
--- a/server/polar/integrations/polar/_impl.py
+++ b/server/polar/integrations/polar/_impl.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any, NoReturn
+
+import logfire
+from polar_sdk import Polar
+from polar_sdk.models import (
+    Customer,
+    CustomerTeamCreate,
+    EventCreateExternalCustomer,
+    EventsIngest,
+    Member,
+    MemberCreate,
+    SubscriptionCreateExternalCustomer,
+)
+from polar_sdk.models.polarerror import PolarError
+
+from polar.integrations.polar.client import PolarSelfClientError
+
+
+def _raise_error(span: Any, error: PolarError, operation: str) -> NoReturn:
+    span.set_attribute("http.status_code", error.status_code)
+    span.set_attribute("error.body", str(error.body))
+    raise PolarSelfClientError(
+        f"{operation} failed with status {error.status_code}"
+    ) from error
+
+
+class PolarSelfClient:
+    def __init__(self, *, access_token: str, api_url: str) -> None:
+        self._sdk = Polar(
+            access_token=access_token or "unconfigured",
+            server_url=api_url,
+        )
+
+    async def create_customer(
+        self, *, external_id: str, email: str, name: str
+    ) -> Customer:
+        with logfire.span("polar.create_customer", external_id=external_id) as span:
+            try:
+                return await self._sdk.customers.create_async(
+                    request=CustomerTeamCreate(
+                        email=email,
+                        name=name,
+                        external_id=external_id,
+                    )
+                )
+            except PolarError as e:
+                if e.status_code != 409:
+                    _raise_error(span, e, "create_customer")
+                span.set_attribute("conflict", True)
+
+            try:
+                return await self._sdk.customers.get_external_async(
+                    external_id=external_id
+                )
+            except PolarError as e:
+                _raise_error(span, e, "create_customer.fetch_existing")
+
+    async def create_free_subscription(
+        self, *, external_customer_id: str, product_id: str
+    ) -> None:
+        with logfire.span(
+            "polar.create_free_subscription",
+            external_customer_id=external_customer_id,
+            product_id=product_id,
+        ) as span:
+            try:
+                await self._sdk.subscriptions.create_async(
+                    request=SubscriptionCreateExternalCustomer(
+                        product_id=product_id,
+                        external_customer_id=external_customer_id,
+                    )
+                )
+            except PolarError as e:
+                if e.status_code == 409:
+                    span.set_attribute("conflict", True)
+                    return
+                _raise_error(span, e, "create_free_subscription")
+
+    async def get_customer_by_external_id(self, external_id: str) -> Customer:
+        return await self._sdk.customers.get_external_async(external_id=external_id)
+
+    async def get_member_by_external_id(
+        self, *, external_customer_id: str, external_id: str
+    ) -> Member | None:
+        return await self._sdk.members.get_member_by_external_id_async(
+            external_id=external_id,
+        )
+
+    async def add_member(
+        self, *, customer_id: str, email: str, name: str, external_id: str
+    ) -> None:
+        with logfire.span(
+            "polar.add_member",
+            customer_id=customer_id,
+            external_id=external_id,
+        ) as span:
+            try:
+                await self._sdk.members.create_member_async(
+                    request=MemberCreate(
+                        customer_id=customer_id,
+                        email=email,
+                        name=name,
+                        external_id=external_id,
+                    )
+                )
+            except PolarError as e:
+                if e.status_code == 409:
+                    span.set_attribute("conflict", True)
+                    return
+                _raise_error(span, e, "add_member")
+
+    async def remove_member(
+        self, *, external_customer_id: str, external_id: str
+    ) -> None:
+        with logfire.span(
+            "polar.remove_member",
+            external_customer_id=external_customer_id,
+            external_id=external_id,
+        ) as span:
+            try:
+                await self._sdk.members.delete_member_by_external_id_async(
+                    external_id=external_id,
+                )
+            except PolarError as e:
+                if e.status_code == 404:
+                    span.set_attribute("not_found", True)
+                    return
+                _raise_error(span, e, "remove_member")
+
+    async def delete_customer(self, *, external_id: str) -> None:
+        with logfire.span("polar.delete_customer", external_id=external_id) as span:
+            try:
+                await self._sdk.customers.delete_external_async(
+                    external_id=external_id,
+                    anonymize=True,
+                )
+            except PolarError as e:
+                if e.status_code == 404:
+                    span.set_attribute("not_found", True)
+                    return
+                _raise_error(span, e, "delete_customer")
+
+    async def track_event_ingestion(
+        self, *, external_customer_id: str, count: int
+    ) -> None:
+        with logfire.span(
+            "polar.track_event_ingestion",
+            external_customer_id=external_customer_id,
+            event_count=count,
+        ) as span:
+            try:
+                await self._sdk.events.ingest_async(
+                    request=EventsIngest(
+                        events=[
+                            EventCreateExternalCustomer(
+                                name="event_ingestion",
+                                external_customer_id=external_customer_id,
+                                metadata={"count": count},
+                            )
+                        ]
+                    )
+                )
+            except PolarError as e:
+                if e.status_code == 409:
+                    span.set_attribute("conflict", True)
+                    return
+                _raise_error(span, e, "track_event_ingestion")

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NoReturn
-
-import logfire
+from typing import TYPE_CHECKING, Any
 
 from polar.config import settings
 from polar.exceptions import PolarError as InternalPolarError
 
 if TYPE_CHECKING:
-    from polar_sdk import Polar as PolarSDK
-    from polar_sdk.models import Customer, Member
+    from polar.integrations.polar._impl import PolarSelfClient as PolarSelfClient
 
 
 class PolarSelfClientError(InternalPolarError):
@@ -17,178 +14,13 @@ class PolarSelfClientError(InternalPolarError):
         super().__init__(message)
 
 
-def _import_sdk() -> type[PolarSDK]:
-    from polar_sdk import Polar as PolarSDK
+def __getattr__(name: str) -> Any:
+    if name == "PolarSelfClient":
+        from polar.integrations.polar._impl import PolarSelfClient
 
-    return PolarSDK
-
-
-def _raise_error(span: Any, error: Any, operation: str) -> NoReturn:
-    span.set_attribute("http.status_code", error.status_code)
-    span.set_attribute("error.body", str(error.body))
-    raise PolarSelfClientError(
-        f"{operation} failed with status {error.status_code}"
-    ) from error
-
-
-class PolarSelfClient:
-    def __init__(self, *, access_token: str, api_url: str) -> None:
-        cls = _import_sdk()
-        self._sdk = cls(
-            access_token=access_token or "unconfigured",
-            server_url=api_url,
-        )
-
-    async def create_customer(
-        self, *, external_id: str, email: str, name: str
-    ) -> Customer:
-        from polar_sdk.models import CustomerTeamCreate
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span("polar.create_customer", external_id=external_id) as span:
-            try:
-                return await self._sdk.customers.create_async(
-                    request=CustomerTeamCreate(
-                        email=email,
-                        name=name,
-                        external_id=external_id,
-                    )
-                )
-            except PolarError as e:
-                if e.status_code != 409:
-                    _raise_error(span, e, "create_customer")
-                span.set_attribute("conflict", True)
-
-            try:
-                return await self._sdk.customers.get_external_async(
-                    external_id=external_id
-                )
-            except PolarError as e:
-                _raise_error(span, e, "create_customer.fetch_existing")
-
-    async def create_free_subscription(
-        self, *, external_customer_id: str, product_id: str
-    ) -> None:
-        from polar_sdk.models import SubscriptionCreateExternalCustomer
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span(
-            "polar.create_free_subscription",
-            external_customer_id=external_customer_id,
-            product_id=product_id,
-        ) as span:
-            try:
-                await self._sdk.subscriptions.create_async(
-                    request=SubscriptionCreateExternalCustomer(
-                        product_id=product_id,
-                        external_customer_id=external_customer_id,
-                    )
-                )
-            except PolarError as e:
-                if e.status_code == 409:
-                    span.set_attribute("conflict", True)
-                    return
-                _raise_error(span, e, "create_free_subscription")
-
-    async def get_customer_by_external_id(self, external_id: str) -> Customer:
-        return await self._sdk.customers.get_external_async(external_id=external_id)
-
-    async def get_member_by_external_id(
-        self, *, external_customer_id: str, external_id: str
-    ) -> Member | None:
-        return await self._sdk.members.get_member_by_external_id_async(
-            external_id=external_id,
-        )
-
-    async def add_member(
-        self, *, customer_id: str, email: str, name: str, external_id: str
-    ) -> None:
-        from polar_sdk.models import MemberCreate
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span(
-            "polar.add_member",
-            customer_id=customer_id,
-            external_id=external_id,
-        ) as span:
-            try:
-                await self._sdk.members.create_member_async(
-                    request=MemberCreate(
-                        customer_id=customer_id,
-                        email=email,
-                        name=name,
-                        external_id=external_id,
-                    )
-                )
-            except PolarError as e:
-                if e.status_code == 409:
-                    span.set_attribute("conflict", True)
-                    return
-                _raise_error(span, e, "add_member")
-
-    async def remove_member(
-        self, *, external_customer_id: str, external_id: str
-    ) -> None:
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span(
-            "polar.remove_member",
-            external_customer_id=external_customer_id,
-            external_id=external_id,
-        ) as span:
-            try:
-                await self._sdk.members.delete_member_by_external_id_async(
-                    external_id=external_id,
-                )
-            except PolarError as e:
-                if e.status_code == 404:
-                    span.set_attribute("not_found", True)
-                    return
-                _raise_error(span, e, "remove_member")
-
-    async def delete_customer(self, *, external_id: str) -> None:
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span("polar.delete_customer", external_id=external_id) as span:
-            try:
-                await self._sdk.customers.delete_external_async(
-                    external_id=external_id,
-                    anonymize=True,
-                )
-            except PolarError as e:
-                if e.status_code == 404:
-                    span.set_attribute("not_found", True)
-                    return
-                _raise_error(span, e, "delete_customer")
-
-    async def track_event_ingestion(
-        self, *, external_customer_id: str, count: int
-    ) -> None:
-        from polar_sdk.models import EventCreateExternalCustomer, EventsIngest
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span(
-            "polar.track_event_ingestion",
-            external_customer_id=external_customer_id,
-            event_count=count,
-        ) as span:
-            try:
-                await self._sdk.events.ingest_async(
-                    request=EventsIngest(
-                        events=[
-                            EventCreateExternalCustomer(
-                                name="event_ingestion",
-                                external_customer_id=external_customer_id,
-                                metadata={"count": count},
-                            )
-                        ]
-                    )
-                )
-            except PolarError as e:
-                if e.status_code == 409:
-                    span.set_attribute("conflict", True)
-                    return
-                _raise_error(span, e, "track_event_ingestion")
+        globals()[name] = PolarSelfClient
+        return PolarSelfClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 _client: PolarSelfClient | None = None
@@ -197,6 +29,8 @@ _client: PolarSelfClient | None = None
 def get_client() -> PolarSelfClient:
     global _client
     if _client is None:
+        from polar.integrations.polar._impl import PolarSelfClient
+
         _client = PolarSelfClient(
             access_token=settings.POLAR_ACCESS_TOKEN,
             api_url=settings.POLAR_API_URL,


### PR DESCRIPTION
We want to avoid loading the entire SDK, because it doesn't get lazily loaded, but having inline imports in every method does not look great either.

By splitting the client and implementation like this, we can get code that is a bit nicer to read without getting a memory footprint in the cases where we dont want it.