### PR TITLE
Widen organization review with REVIEW and SNOOZED statuses

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPage.tsx
@@ -39,9 +39,13 @@ export default function ClientPage({
 
   const isDenied = organization.status === 'denied'
 
-  const isActive = ['active', 'initial_review', 'ongoing_review'].includes(
-    organization.status,
-  )
+  const isActive = [
+    'active',
+    'initial_review',
+    'ongoing_review',
+    'review',
+    'snoozed',
+  ].includes(organization.status)
 
   const [hasSubmittedDetails, setHasSubmittedDetails] = useState(
     !!organization.details_submitted_at,

--- a/server/migrations/versions/2026-04-14-1400_add_organization_snooze_count.py
+++ b/server/migrations/versions/2026-04-14-1400_add_organization_snooze_count.py
@@ -1,0 +1,35 @@
+"""add organization snooze_count column
+
+Revision ID: 3da90b684726
+Revises: 87c3805dd60f
+Create Date: 2026-04-14 14:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "3da90b684726"
+down_revision = "87c3805dd60f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "snooze_count",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "snooze_count")

--- a/server/polar/backoffice/components/_status_badge.py
+++ b/server/polar/backoffice/components/_status_badge.py
@@ -50,6 +50,14 @@ def status_badge(
             "class": "badge-warning",
             "aria": "ongoing review status",
         },
+        OrganizationStatus.REVIEW: {
+            "class": "badge-warning",
+            "aria": "review status",
+        },
+        OrganizationStatus.SNOOZED: {
+            "class": "badge-ghost border border-base-300",
+            "aria": "snoozed status",
+        },
         OrganizationStatus.DENIED: {
             "class": "badge-ghost border border-base-300",
             "aria": "denied status",

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -213,6 +213,10 @@ async def list_organizations(
         status_filter = OrganizationStatus.ONBOARDING_STARTED
     elif status == "offboarding":
         status_filter = OrganizationStatus.OFFBOARDING
+    elif status == "review":
+        status_filter = OrganizationStatus.REVIEW
+    elif status == "snoozed":
+        status_filter = OrganizationStatus.SNOOZED
 
     # Build query
     stmt = (

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -294,6 +294,20 @@ class OrganizationListView:
                 badge_variant="warning",
             ),
             Tab(
+                label="Review",
+                url=str(request.url_for("organizations:list")) + "?status=review",
+                active=status_filter == OrganizationStatus.REVIEW,
+                count=status_counts.get(OrganizationStatus.REVIEW, 0),
+                badge_variant="warning",
+            ),
+            Tab(
+                label="Snoozed",
+                url=str(request.url_for("organizations:list")) + "?status=snoozed",
+                active=status_filter == OrganizationStatus.SNOOZED,
+                count=status_counts.get(OrganizationStatus.SNOOZED, 0),
+                badge_variant="warning",
+            ),
+            Tab(
                 label="Active",
                 url=str(request.url_for("organizations:list")) + "?status=active",
                 active=status_filter == OrganizationStatus.ACTIVE,

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -196,10 +196,21 @@ class PlainService:
                     title = "Initial Account Review"
                 case OrganizationStatus.ONGOING_REVIEW:
                     title = "Ongoing Account Review"
+                case OrganizationStatus.REVIEW:
+                    if organization.initially_reviewed_at is not None:
+                        title = "Ongoing Account Review"
+                    else:
+                        title = "Initial Account Review"
                 case _:
                     raise ValueError("Organization is not under review")
 
-            should_send_email = organization.status == OrganizationStatus.INITIAL_REVIEW
+            should_send_email = (
+                organization.status == OrganizationStatus.INITIAL_REVIEW
+                or (
+                    organization.status == OrganizationStatus.REVIEW
+                    and organization.initially_reviewed_at is None
+                )
+            )
             assigned_to = CreateThreadAssignedToInput(
                 user_id=random.choice(SUPPORT_AGENT_IDS)
             )

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -196,6 +196,8 @@ class OrganizationStatus(StrEnum):
     ONBOARDING_STARTED = "onboarding_started"
     INITIAL_REVIEW = "initial_review"
     ONGOING_REVIEW = "ongoing_review"
+    REVIEW = "review"
+    SNOOZED = "snoozed"
     DENIED = "denied"
     ACTIVE = "active"
     OFFBOARDING = "offboarding"
@@ -206,6 +208,8 @@ class OrganizationStatus(StrEnum):
             OrganizationStatus.ONBOARDING_STARTED: "Onboarding Started",
             OrganizationStatus.INITIAL_REVIEW: "Initial Review",
             OrganizationStatus.ONGOING_REVIEW: "Ongoing Review",
+            OrganizationStatus.REVIEW: "Review",
+            OrganizationStatus.SNOOZED: "Snoozed",
             OrganizationStatus.DENIED: "Denied",
             OrganizationStatus.ACTIVE: "Active",
             OrganizationStatus.OFFBOARDING: "Offboarding",
@@ -213,7 +217,7 @@ class OrganizationStatus(StrEnum):
 
     @classmethod
     def review_statuses(cls) -> set[Self]:
-        return {cls.INITIAL_REVIEW, cls.ONGOING_REVIEW}  # pyright: ignore
+        return {cls.INITIAL_REVIEW, cls.ONGOING_REVIEW, cls.REVIEW, cls.SNOOZED}  # pyright: ignore
 
     @classmethod
     def payment_ready_statuses(cls) -> set[Self]:
@@ -288,6 +292,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
     )
     initially_reviewed_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
+    )
+
+    snooze_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
     )
 
     total_balance: Mapped[int | None] = mapped_column(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -307,6 +307,8 @@ class LegacyOrganizationStatus(StrEnum):
             ),
             OrganizationStatus.INITIAL_REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.ONGOING_REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
+            OrganizationStatus.REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
+            OrganizationStatus.SNOOZED: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.DENIED: LegacyOrganizationStatus.DENIED,
             OrganizationStatus.ACTIVE: LegacyOrganizationStatus.ACTIVE,
             OrganizationStatus.OFFBOARDING: LegacyOrganizationStatus.ACTIVE,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -733,11 +733,7 @@ class OrganizationService:
             organization.next_review_threshold >= 0
             and transfers_sum >= organization.next_review_threshold
         ):
-            organization.status = (
-                OrganizationStatus.ONGOING_REVIEW
-                if organization.initially_reviewed_at is not None
-                else OrganizationStatus.INITIAL_REVIEW
-            )
+            organization.status = OrganizationStatus.REVIEW
             organization.status_updated_at = datetime.now(UTC)
             session.add(organization)
 
@@ -749,8 +745,15 @@ class OrganizationService:
         self,
         session: AsyncSession,
         organization: Organization,
-        next_review_threshold: int,
+        next_review_threshold: int | None = None,
+        *,
+        silent: bool = False,
     ) -> Organization:
+        if next_review_threshold is None:
+            next_review_threshold = max(
+                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
+            )
+
         organization.status = OrganizationStatus.ACTIVE
         organization.status_updated_at = datetime.now(UTC)
         organization.next_review_threshold = next_review_threshold
@@ -778,6 +781,7 @@ class OrganizationService:
             "organization.reviewed",
             organization_id=organization.id,
             initial_review=initial_review,
+            silent=silent,
         )
         return organization
 
@@ -790,28 +794,27 @@ class OrganizationService:
         """Handle AI agent verdict for an ongoing threshold review.
 
         Returns True if auto-approved, False if escalated to human review (Plain ticket created).
-        Only auto-approves when: status is ONGOING_REVIEW and verdict is APPROVE.
+        Only auto-approves when: verdict is APPROVE and org has been initially reviewed.
         """
         is_eligible = (
-            organization.status == OrganizationStatus.ONGOING_REVIEW
+            organization.status
+            in (OrganizationStatus.ONGOING_REVIEW, OrganizationStatus.REVIEW)
+            and organization.initially_reviewed_at is not None
             and verdict == ReviewVerdict.APPROVE
         )
 
         if is_eligible:
-            next_threshold = max(
-                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
-            )
-            await self.confirm_organization_reviewed(
-                session, organization, next_threshold
-            )
+            await self.confirm_organization_reviewed(session, organization)
             return True
 
         # Not eligible or not approved → create Plain ticket for human review
         # Guard: only create a thread if the org is still under review
         # (it may have been handled already, e.g. on a task retry)
+        # Excludes SNOOZED — snoozed orgs shouldn't get new Plain tickets
         if organization.status in (
             OrganizationStatus.INITIAL_REVIEW,
             OrganizationStatus.ONGOING_REVIEW,
+            OrganizationStatus.REVIEW,
         ):
             await plain_service.create_organization_review_thread(session, organization)
         return False
@@ -840,7 +843,7 @@ class OrganizationService:
         *,
         enqueue_review: bool = True,
     ) -> Organization:
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         organization.status_updated_at = datetime.now(UTC)
         session.add(organization)
 

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -97,7 +97,12 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
             raise OrganizationDoesNotExist(organization_id)
 
         is_auto_approve_eligible = (
-            organization.status == OrganizationStatus.ONGOING_REVIEW
+            organization.status
+            in (
+                OrganizationStatus.ONGOING_REVIEW,
+                OrganizationStatus.REVIEW,
+            )
+            and organization.initially_reviewed_at is not None
         )
 
         if not is_auto_approve_eligible:
@@ -112,7 +117,9 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
 
 @actor(actor_name="organization.reviewed", priority=TaskPriority.LOW)
 async def organization_reviewed(
-    organization_id: uuid.UUID, initial_review: bool = False
+    organization_id: uuid.UUID,
+    initial_review: bool = False,
+    silent: bool = False,
 ) -> None:
     async with AsyncSessionMaker() as session:
         repository = OrganizationRepository.from_session(session)
@@ -125,7 +132,7 @@ async def organization_reviewed(
         await held_balance_service.release_account(session, organization.account)
 
         # Send an email after the initial review
-        if initial_review:
+        if initial_review and not silent:
             admin_user = await repository.get_admin_user(session, organization)
             if admin_user:
                 email = OrganizationReviewedEmail(

--- a/server/scripts/rerun_org_reviews.py
+++ b/server/scripts/rerun_org_reviews.py
@@ -61,8 +61,6 @@ from polar.worker import JobQueueManager
 
 log = structlog.get_logger()
 
-_MIN_REVIEW_THRESHOLD = 10_000
-
 
 async def process_organizations(
     dry_run: bool = True,
@@ -94,6 +92,7 @@ async def process_organizations(
                     [
                         OrganizationStatus.INITIAL_REVIEW,
                         OrganizationStatus.ONGOING_REVIEW,
+                        OrganizationStatus.REVIEW,
                     ]
                 )
             )
@@ -174,21 +173,17 @@ async def process_organizations(
 
             # Act on verdict
             if report.verdict == ReviewVerdict.APPROVE:
-                next_threshold = max(
-                    organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
-                )
-
                 # confirm_organization_reviewed calls enqueue_job, so we need
                 # the JobQueueManager context to flush jobs to the broker.
                 async with JobQueueManager.open(dramatiq.get_broker(), redis):
                     await organization_service.confirm_organization_reviewed(
-                        session, organization, next_threshold
+                        session, organization
                     )
 
                 stats["approved"] += 1
                 org_log.info(
                     "Auto-approved",
-                    next_threshold=next_threshold,
+                    next_threshold=organization.next_review_threshold,
                 )
             else:
                 # DENY or NEEDS_HUMAN_REVIEW → create Plain ticket

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -432,7 +432,7 @@ class TestCheckReviewThreshold:
         )
 
         # Then
-        assert result.status == OrganizationStatus.INITIAL_REVIEW
+        assert result.status == OrganizationStatus.REVIEW
         assert result.total_balance == 5000
         transaction_sum_mock.assert_called_once()
 
@@ -459,7 +459,7 @@ class TestCheckReviewThreshold:
         )
 
         # Then
-        assert result.status == OrganizationStatus.ONGOING_REVIEW
+        assert result.status == OrganizationStatus.REVIEW
         assert result.total_balance == 5000
         transaction_sum_mock.assert_called_once()
         enqueue_job_mock.assert_called_once_with(
@@ -844,7 +844,7 @@ class TestSetOrganizationUnderReview:
         )
 
         # Then
-        assert result.status == OrganizationStatus.ONGOING_REVIEW
+        assert result.status == OrganizationStatus.REVIEW
         enqueue_job_mock.assert_called_once_with(
             "organization.under_review", organization_id=organization.id
         )

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -518,6 +518,7 @@ class TestConfirmOrganizationReviewed:
             "organization.reviewed",
             organization_id=organization.id,
             initial_review=True,
+            silent=False,
         )
 
     async def test_ongoing_review(
@@ -546,6 +547,7 @@ class TestConfirmOrganizationReviewed:
             "organization.reviewed",
             organization_id=organization.id,
             initial_review=False,
+            silent=False,
         )
 
     async def test_overrides_rejected_appeal(


### PR DESCRIPTION
## 📋 Summary

Introduce unified `REVIEW` and `SNOOZED` organization statuses to simplify the review flow and support snoozing reviews.

## 🎯 What

- Add `REVIEW` and `SNOOZED` to `OrganizationStatus` enum with migration, display labels, legacy schema mapping, and backoffice UI (badges, tabs, filters)
- Add `snooze_count` column to organizations table (with Alembic migration)
- Consolidate `next_review_threshold` calculation into `confirm_organization_reviewed` (auto-doubles with `_MIN_REVIEW_THRESHOLD` floor)
- Add `silent` flag to `confirm_organization_reviewed` and `organization.reviewed` task to suppress review-complete emails on auto-approvals
- Update auto-approve eligibility to require `initially_reviewed_at is not None` alongside the new `REVIEW` status
- Exclude `SNOOZED` orgs from Plain ticket creation
- Update frontend `AccountPage` to treat `review` and `snoozed` as active statuses

## 🤔 Why

The existing `INITIAL_REVIEW` / `ONGOING_REVIEW` split at threshold-trigger time adds unnecessary complexity. A single `REVIEW` status defers the initial-vs-ongoing distinction to where it matters (Plain thread title, email sending). `SNOOZED` enables temporarily pausing reviews without losing the review state.

## 🔧 How

- New enum values added to `OrganizationStatus` with all necessary mappings
- Threshold-trigger code now sets `REVIEW` instead of branching between `INITIAL_REVIEW`/`ONGOING_REVIEW`
- `confirm_organization_reviewed` auto-calculates next threshold when not provided
- `silent` parameter threaded through `enqueue_job` to the task actor

## 🧪 Testing

- [x] All existing tests pass
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] Test assertions updated for new `silent` parameter in `enqueue_job` calls

## 📝 Additional Notes

- `SNOOZED` maps to `UNDER_REVIEW` in the legacy schema, keeping backward compatibility
- The `snooze_count` column is added with `server_default="0"` for safe deployment