### PR TITLE
Fix trial interval suffix in checkout

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.test.tsx
@@ -190,4 +190,68 @@ describe('CheckoutTrialHeroPrice', () => {
       expect(container.textContent).not.toContain('starting')
     })
   })
+
+  describe('recurring interval count', () => {
+    it('reflects quarterly billing (month x3) instead of "/month"', () => {
+      const checkout = createTrialCheckout({
+        amount: 4106,
+        net_amount: 4106,
+        total_amount: 4106,
+        active_trial_interval: 'day',
+        active_trial_interval_count: 7,
+        product: {
+          ...trialProduct,
+          recurring_interval: 'month',
+          recurring_interval_count: 3,
+          trial_interval: 'day',
+          trial_interval_count: 7,
+        },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$41.06 / 3rd mo')
+      expect(container.textContent).not.toMatch(/\$41\.06\/month/)
+    })
+
+    it('keeps "/month" when recurring_interval_count is 1', () => {
+      const checkout = createTrialCheckout({
+        amount: 999,
+        net_amount: 999,
+        total_amount: 999,
+        product: {
+          ...trialProduct,
+          recurring_interval: 'month',
+          recurring_interval_count: 1,
+        },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$9.99/month')
+    })
+
+    it('reflects bi-yearly billing (year x2)', () => {
+      const checkout = createTrialCheckout({
+        amount: 19999,
+        net_amount: 19999,
+        total_amount: 19999,
+        product: {
+          ...trialProduct,
+          recurring_interval: 'year',
+          recurring_interval_count: 2,
+        },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$199.99 / 2nd yr')
+    })
+  })
 })

--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
@@ -2,8 +2,13 @@
 
 import { formatCurrency } from '@polar-sh/currency'
 import type { AcceptedLocale } from '@polar-sh/i18n'
-import { DEFAULT_LOCALE, useTranslations } from '@polar-sh/i18n'
+import {
+  DEFAULT_LOCALE,
+  getTranslations,
+  useTranslations,
+} from '@polar-sh/i18n'
 import { formatDate } from '@polar-sh/i18n/formatters/date'
+import { formatOrdinal } from '@polar-sh/i18n/formatters/ordinal'
 import type { ProductCheckoutPublic } from '../guards'
 import { isLegacyRecurringPrice } from '../utils/product'
 
@@ -49,10 +54,18 @@ const CheckoutTrialHeroPrice = ({
 
   const currency = checkout.currency ?? product_price.price_currency
   const recurringAmount = checkout.total_amount ?? checkout.net_amount ?? 0
-  const intervalSuffix =
-    interval && interval in INTERVAL_SUFFIX_KEYS
-      ? t(INTERVAL_SUFFIX_KEYS[interval as keyof typeof INTERVAL_SUFFIX_KEYS])
-      : ''
+  const intervalCount = product.recurring_interval_count
+  const intervalSuffix = (() => {
+    if (!interval || !(interval in INTERVAL_SUFFIX_KEYS)) return ''
+    if (intervalCount && intervalCount > 1) {
+      const shortInterval =
+        getTranslations(effectiveLocale).intervals.short[interval]
+      return ` / ${formatOrdinal(intervalCount, effectiveLocale)} ${shortInterval}`
+    }
+    return t(
+      INTERVAL_SUFFIX_KEYS[interval as keyof typeof INTERVAL_SUFFIX_KEYS],
+    )
+  })()
   const format = formatCurrency('standard', effectiveLocale)
   const priceStr = `${format(recurringAmount, currency)}${intervalSuffix}`
 


### PR DESCRIPTION
Steps to reproduce:

1. Create a 3month recurring subscription
2. Add a trial period
3. Go to checkout
4. Trial period incorrectly says `$X/month`

| Before | After  |
|--------|--------|
| <img width="389" height="306" alt="Screenshot 2026-04-14 at 15 08 15" src="https://github.com/user-attachments/assets/a354cd56-ec5f-4095-8383-9284224d3621" /> | <img width="387" height="300" alt="Screenshot 2026-04-14 at 15 07 58" src="https://github.com/user-attachments/assets/ce11416c-a151-4940-a2e7-fbd4f989c208" /> |




