### PR TITLE
fix: Defer initial review email until AI agent denies

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -174,14 +174,15 @@ class PlainService:
 
     async def create_organization_review_thread(
         self, session: AsyncSession, organization: Organization
-    ) -> None:
-        if not self.enabled:
-            return
+    ) -> str | None:
+        """Create a Plain thread for organization review.
 
-        user_repository = UserRepository.from_session(session)
-        admin = await user_repository.get_by_id(organization.account.admin_id)
-        if admin is None:
-            raise AccountAdminDoesNotExistError(organization.account.admin_id)
+        Returns the Plain thread ID, or None if Plain is disabled.
+        """
+        if not self.enabled:
+            return None
+
+        admin = await self._get_account_admin(session, organization)
 
         async with self._get_plain_client() as plain:
             try:
@@ -199,7 +200,6 @@ class PlainService:
                 case _:
                     raise ValueError("Organization is not under review")
 
-            should_send_email = organization.status == OrganizationStatus.INITIAL_REVIEW
             assigned_to = CreateThreadAssignedToInput(
                 user_id=random.choice(SUPPORT_AGENT_IDS)
             )
@@ -237,62 +237,80 @@ class PlainService:
                     organization.account.id, thread_result.error.message
                 )
 
-            # For initial reviews, send the review action checklist as an outbound reply
-            if should_send_email and thread_result.thread is not None:
-                issues = self._check_org_issues(organization, admin)
-                message = self._build_review_message(
-                    organization.name or organization.slug, issues
+            return thread_result.thread.id if thread_result.thread else None
+
+    async def send_initial_review_action_email(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        thread_id: str,
+    ) -> None:
+        """Send the review action checklist as an outbound Plain reply.
+
+        Called after the AI agent denies an initial review, so the user
+        knows what to fix.
+        """
+        if not self.enabled:
+            return
+
+        admin = await self._get_account_admin(session, organization)
+
+        issues = self._check_org_issues(organization, admin)
+        message = self._build_review_message(
+            organization.name or organization.slug, issues
+        )
+
+        async with self._get_plain_client() as plain:
+            reply_result = await plain.reply_to_thread(
+                ReplyToThreadInput(
+                    thread_id=thread_id,
+                    text_content=message,
+                    markdown_content=message,
                 )
-                reply_result = await plain.reply_to_thread(
-                    ReplyToThreadInput(
-                        thread_id=thread_result.thread.id,
-                        text_content=message,
-                        markdown_content=message,
+            )
+            if reply_result.error is not None:
+                log.error(
+                    "Failed to post review action message",
+                    thread_id=thread_id,
+                    slug=organization.slug,
+                    error=reply_result.error.message,
+                )
+
+            email_log_repository = EmailLogRepository.from_session(session)
+            await email_log_repository.create_log(
+                status=EmailLogStatus.failed
+                if reply_result.error
+                else EmailLogStatus.sent,
+                processor=EmailSender.plain,
+                processor_id=thread_id,
+                to_email_addr=admin.email,
+                from_email_addr=DEFAULT_FROM_EMAIL_ADDRESS,
+                from_name=DEFAULT_FROM_NAME,
+                subject="Initial Account Review",
+                email_template="_build_review_message",
+                error=reply_result.error.message if reply_result.error else None,
+            )
+
+            # Snooze the thread if we asked the customer for more details
+            has_action_items = (
+                issues.missing_website
+                or issues.missing_socials
+                or issues.admin_not_verified
+            )
+            if has_action_items:
+                snooze_result = await plain.snooze_thread(
+                    SnoozeThreadInput(
+                        thread_id=thread_id,
+                        status_detail=SnoozeStatusDetail.WAITING_FOR_CUSTOMER,
                     )
                 )
-                if reply_result.error is not None:
+                if snooze_result.error is not None:
                     log.error(
-                        "Failed to post review action message",
-                        thread_id=thread_result.thread.id,
+                        "Failed to snooze thread",
+                        thread_id=thread_id,
                         slug=organization.slug,
-                        error=reply_result.error.message,
+                        error=snooze_result.error.message,
                     )
-
-                email_log_repository = EmailLogRepository.from_session(session)
-                await email_log_repository.create_log(
-                    status=EmailLogStatus.failed
-                    if reply_result.error
-                    else EmailLogStatus.sent,
-                    processor=EmailSender.plain,
-                    processor_id=thread_result.thread.id,
-                    to_email_addr=admin.email,
-                    from_email_addr=DEFAULT_FROM_EMAIL_ADDRESS,
-                    from_name=DEFAULT_FROM_NAME,
-                    subject=title,
-                    email_template="_build_review_message",
-                    error=reply_result.error.message if reply_result.error else None,
-                )
-
-                # Snooze the thread if we asked the customer for more details
-                has_action_items = (
-                    issues.missing_website
-                    or issues.missing_socials
-                    or issues.admin_not_verified
-                )
-                if has_action_items:
-                    snooze_result = await plain.snooze_thread(
-                        SnoozeThreadInput(
-                            thread_id=thread_result.thread.id,
-                            status_detail=SnoozeStatusDetail.WAITING_FOR_CUSTOMER,
-                        )
-                    )
-                    if snooze_result.error is not None:
-                        log.error(
-                            "Failed to snooze thread",
-                            thread_id=thread_result.thread.id,
-                            slug=organization.slug,
-                            error=snooze_result.error.message,
-                        )
 
     async def create_appeal_review_thread(
         self,
@@ -1522,6 +1540,15 @@ class PlainService:
                     nr_threads += 1
             log.info(f"There are {nr_threads} threads for user {customer_email}")
             return nr_threads > 0
+
+    async def _get_account_admin(
+        self, session: AsyncSession, organization: Organization
+    ) -> User:
+        user_repository = UserRepository.from_session(session)
+        admin = await user_repository.get_by_id(organization.account.admin_id)
+        if admin is None:
+            raise AccountAdminDoesNotExistError(organization.account.admin_id)
+        return admin
 
     def _check_org_issues(
         self,

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -100,13 +100,17 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
             organization.status == OrganizationStatus.ONGOING_REVIEW
         )
 
+        plain_thread_id: str | None = None
         if not is_auto_approve_eligible:
-            await plain_service.create_organization_review_thread(session, organization)
+            plain_thread_id = await plain_service.create_organization_review_thread(
+                session, organization
+            )
 
         enqueue_job(
             "organization_review.run_agent",
             organization_id=organization_id,
             auto_approve_eligible=is_auto_approve_eligible,
+            plain_thread_id=plain_thread_id,
         )
 
 

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -53,6 +53,7 @@ async def run_review_agent(
     organization_id: uuid.UUID,
     context: str = ReviewContext.THRESHOLD,
     auto_approve_eligible: bool = False,
+    plain_thread_id: str | None = None,
 ) -> None:
     """Run the organization review agent as a background task.
 
@@ -158,6 +159,17 @@ async def run_review_agent(
                     verdict=report.verdict,
                     risk_score=report.overall_risk_score,
                 )
+
+        # For initial reviews, notify the user of action items via Plain
+        if (
+            review_context == ReviewContext.THRESHOLD
+            and not auto_approve_eligible
+            and report.verdict == ReviewVerdict.DENY
+            and plain_thread_id is not None
+        ):
+            await plain_service.send_initial_review_action_email(
+                session, organization, plain_thread_id
+            )
 
         # For SUBMISSION context: also create OrganizationReview record and act
         if review_context == ReviewContext.SUBMISSION:

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -69,7 +69,8 @@ class TestOrganizationUnderReview:
         session.expunge_all()
 
         create_organization_review_thread_mock = mocker.patch(
-            "polar.organization.tasks.plain_service.create_organization_review_thread"
+            "polar.organization.tasks.plain_service.create_organization_review_thread",
+            return_value="thread_123",
         )
 
         await organization_under_review(organization.id)
@@ -93,7 +94,8 @@ class TestOrganizationUnderReview:
         session.expunge_all()
 
         create_organization_review_thread_mock = mocker.patch(
-            "polar.organization.tasks.plain_service.create_organization_review_thread"
+            "polar.organization.tasks.plain_service.create_organization_review_thread",
+            return_value="thread_123",
         )
 
         await organization_under_review(organization.id)


### PR DESCRIPTION
## 📋 Summary

Previously, the review action email was sent immediately when an org entered `INITIAL_REVIEW` status via Plain's outbound reply. Now the email is deferred until the AI review agent runs and only sent when the verdict is `DENY`.

## 🎯 What

- Removed immediate email sending from `create_organization_review_thread` for initial reviews
- Extracted email logic into new `send_initial_review_action_email` method on `PlainService`
- `create_organization_review_thread` now returns the Plain thread ID
- Thread ID is passed through `organization_under_review` → `run_review_agent` task chain
- `run_review_agent` sends the email only on `DENY` verdict for initial reviews
- Extracted `_get_account_admin` helper to deduplicate admin lookup

## 🤔 Why

Organizations that pass the AI review don't need to be notified about the review process at all — the review is invisible to them and they can continue operating. Only orgs that are denied need the action email telling them what to fix.

## 🔧 How

The Plain thread is still created upfront (for internal tracking), but the outbound email reply is deferred. The thread ID flows from `create_organization_review_thread` → `organization_under_review` task → `run_review_agent` task via job parameters. On `DENY`, the new `send_initial_review_action_email` method sends the review checklist email and snoozes the thread if action items exist.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Trigger an initial review by having an org hit the payment threshold for the first time
2. Verify no email is sent immediately — only the Plain thread is created
3. After the AI agent runs, verify the email is sent only if the verdict is DENY

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")