### PR TITLE
chore: require conventional commit prefixes in yeet PR titles

### DIFF
--- a/.claude/commands/yeet.md
+++ b/.claude/commands/yeet.md
@@ -26,6 +26,13 @@ Lint, type-check, and create a PR.
 
 5. **Create the PR** using the standard PR creation instructions from the system prompt. Use the full commit history from `main` to draft the PR title and description.
 
+   **PR title must use a conventional commit prefix** — one of: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `perf:`, `ci:`, `build:`, `style:`. Choose the prefix that best describes the overall change. Examples:
+   - `feat: add webhook retry with exponential backoff`
+   - `fix: prevent duplicate subscription charges`
+   - `refactor: extract payment validation into service layer`
+
+   This is important because we use **merge queues with squash**, so the PR title becomes the final commit message on `main`.
+
    **Important — this is a public repo.** When writing the PR title and description:
    - **No PII**: Do not include any personally identifiable information such as names, emails, user IDs, API keys, tokens, internal URLs, or customer data — even if they appear in commit messages or diffs.
    - **No stats data**: Do not include specific metrics, revenue figures, user counts, conversion rates, or any other business/analytics data that may appear in the code changes.


### PR DESCRIPTION
## 📋 Summary

Update the `/yeet` command to enforce conventional commit prefixes (`feat:`, `fix:`, `refactor:`, etc.) in PR titles.

## 🎯 What

Added instructions to `.claude/commands/yeet.md` requiring PR titles to use a conventional commit prefix, with examples.

## 🤔 Why

We use merge queues with squash, so the PR title becomes the final commit message on `main`. Conventional commit prefixes keep the history consistent and machine-parseable.

## 🔧 How

Added a new section in step 5 of the yeet command listing valid prefixes, examples, and the rationale.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] I have performed a self-review of my code

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings