### PR TITLE
fix: split deploy workflow to prevent merge queue concurrency issues

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,176 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "server/**"
+      - ".github/workflows/deploy-backend.yml"
+      - ".github/workflows/deploy_server.sh"
+  workflow_dispatch:
+
+# Workflow-level concurrency ensures:
+# - A running deploy is never cancelled mid-flight (cancel-in-progress: false)
+# - Only the most recent pending run is kept (GitHub auto-cancels older pending runs)
+# - Backend deploys are fully independent from frontend deploys
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build Docker Image 🐳"
+    timeout-minutes: 20
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      digest-playwright: ${{ steps.push-playwright.outputs.digest }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            migrations:
+              - 'server/migrations/**'
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ghcr.io/polarsource/polar
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Sync AUP to server
+        run: cp "clients/apps/web/src/app/(main)/(website)/(landing)/(mdx)/legal/acceptable-use-policy/page.mdx" "server/polar/organization_review/acceptable-use-policy.mdx"
+
+      - uses: useblacksmith/build-push-action@v2
+        id: push
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: ./server
+          target: production
+          platforms: linux/amd64
+          build-args: |
+            RELEASE_VERSION=${{ github.sha }}
+          secrets: |
+            IPINFO_ACCESS_TOKEN=${{ secrets.IPINFO_ACCESS_TOKEN }}
+
+      - name: Docker meta (Playwright)
+        id: meta-playwright
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/polarsource/polar-playwright
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: useblacksmith/build-push-action@v2
+        id: push-playwright
+        with:
+          push: true
+          tags: ${{ steps.meta-playwright.outputs.tags }}
+          context: ./server
+          target: playwright
+          platforms: linux/amd64
+          build-args: |
+            RELEASE_VERSION=${{ github.sha }}
+          secrets: |
+            IPINFO_ACCESS_TOKEN=${{ secrets.IPINFO_ACCESS_TOKEN }}
+
+  deploy-sandbox:
+    name: "Deploy to Sandbox 🧪"
+    concurrency:
+      group: deploy-backend-sandbox
+      cancel-in-progress: false
+    needs: build
+    runs-on: ubuntu-latest
+    environment: sandbox
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy Backend to Render
+        run: |
+          ./.github/workflows/deploy_server.sh \
+            "${{ needs.build.outputs.digest }}" \
+            "${{ needs.build.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}" \
+            "srv-crkocgbtq21c73ddsdbg" \
+            "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng" \
+            "${{ needs.build.outputs.digest-playwright }}" \
+            "srv-d089jj7diees73934kgg"
+        env:
+          RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
+
+      - name: Sentry Release
+        uses: getsentry/action-release@v3.6.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        with:
+          environment: sandbox
+          dist: ${{ needs.build.outputs.digest }}
+          release: ${{ github.sha }}
+          projects: server
+          working_directory: ./server
+
+  deploy-production:
+    name: "Deploy to Production 🚀"
+    concurrency:
+      group: deploy-backend-production
+      cancel-in-progress: false
+    needs: [build, deploy-sandbox]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy Backend to Render
+        run: |
+          ./.github/workflows/deploy_server.sh \
+            "${{ needs.build.outputs.digest }}" \
+            "${{ needs.build.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}" \
+            "srv-ci4r87h8g3ne0dmvvl60" \
+            "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g" \
+            "${{ needs.build.outputs.digest-playwright }}" \
+            "srv-d4k6otfgi27c73cicnpg"
+        env:
+          RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
+
+      - name: Sentry Release
+        uses: getsentry/action-release@v3.6.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        with:
+          environment: production
+          dist: ${{ needs.build.outputs.digest }}
+          release: ${{ github.sha }}
+          projects: server
+          working_directory: ./server

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,91 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "clients/**"
+      - "!clients/apps/app/**"
+      - ".github/workflows/deploy-frontend.yml"
+  workflow_dispatch:
+
+# Workflow-level concurrency ensures:
+# - A running deploy is never cancelled mid-flight (cancel-in-progress: false)
+# - Only the most recent pending run is kept (GitHub auto-cancels older pending runs)
+# - Frontend deploys are fully independent from backend deploys
+concurrency:
+  group: deploy-frontend
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-sandbox:
+    name: "Deploy to Sandbox 🧪"
+    concurrency:
+      group: deploy-frontend-sandbox
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    environment: sandbox
+    outputs:
+      deployment-url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Deploy to Vercel (Staged Production)
+        id: deploy
+        run: |
+          DEPLOYMENT_URL=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          echo "deployment-url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+          echo "Staged production deployment URL: $DEPLOYMENT_URL"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Promote to Sandbox
+        run: |
+          echo "Promoting deployment: ${{ steps.deploy.outputs.deployment-url }}"
+          vercel promote ${{ steps.deploy.outputs.deployment-url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+          echo "Successfully promoted to sandbox: ${{ steps.deploy.outputs.deployment-url }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+  deploy-production:
+    name: "Deploy to Production 🚀"
+    concurrency:
+      group: deploy-frontend-production
+      cancel-in-progress: false
+    needs: deploy-sandbox
+    runs-on: ubuntu-latest
+    environment: production
+    outputs:
+      deployment-url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Deploy to Vercel (Staged Production)
+        id: deploy
+        run: |
+          DEPLOYMENT_URL=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          echo "deployment-url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+          echo "Staged production deployment URL: $DEPLOYMENT_URL"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Promote to Production
+        run: |
+          echo "Promoting deployment: ${{ steps.deploy.outputs.deployment-url }}"
+          vercel promote ${{ steps.deploy.outputs.deployment-url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+          echo "Successfully promoted to production: ${{ steps.deploy.outputs.deployment-url }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,51 +1,13 @@
-name: Build and Deploy
+name: Build and Deploy (Full)
 
+# Manual-only workflow for coordinated full deploys (backend + frontend together).
+# For automatic deploys on push to main, see deploy-backend.yml and deploy-frontend.yml.
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - "server/**"
-      - "clients/**"
-      - "!clients/apps/app/**"
-      - ".github/workflows/deploy.yml"
-      - ".github/workflows/deploy-environment.yml"
-      - ".github/workflows/deploy_server.sh"
   workflow_dispatch:
 
 jobs:
-  changes:
-    name: "Detect Changes 🔍"
-    runs-on: ubuntu-latest
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      migrations: ${{ steps.filter.outputs.migrations }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            backend:
-              - 'server/**'
-              - '.github/workflows/deploy.yml'
-              - '.github/workflows/deploy-environment.yml'
-              - '.github/workflows/deploy_server.sh'
-            frontend:
-              - 'clients/**'
-              - '.github/workflows/deploy.yml'
-              - '.github/workflows/deploy-environment.yml'
-            migrations:
-              - 'server/migrations/**'
-
   build:
     name: "Build Docker Image 🐳"
-    concurrency:
-      group: build-deploy
-      cancel-in-progress: true
-
-    needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
@@ -122,8 +84,7 @@ jobs:
 
   deploy-sandbox:
     name: "Deploy to Sandbox 🧪"
-    needs: [changes, build]
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    needs: build
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: sandbox
@@ -132,9 +93,9 @@ jobs:
       render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng"
       docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d089jj7diees73934kgg"
-      has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
-      skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
-      skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
+      has-migrations: true
+      skip-backend: false
+      skip-frontend: false
     secrets:
       RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -145,8 +106,8 @@ jobs:
 
   deploy-production:
     name: "Deploy to Production 🚀"
-    needs: [changes, build, deploy-sandbox]
-    if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    needs: [build, deploy-sandbox]
+    if: always() && !failure() && !cancelled()
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: production
@@ -155,9 +116,9 @@ jobs:
       render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g"
       docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
-      has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
-      skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
-      skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
+      has-migrations: true
+      skip-backend: false
+      skip-frontend: false
     secrets:
       RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -21,6 +21,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       server: ${{ steps.filter.outputs.server }}
+      clients: ${{ steps.filter.outputs.clients }}
       migrations: ${{ steps.filter.outputs.migrations }}
       tinybird: ${{ steps.filter.outputs.tinybird }}
       server_files: ${{ steps.filter.outputs.server_files }}
@@ -34,6 +35,8 @@ jobs:
             server:
               - 'server/**'
               - '.github/workflows/test_server.yaml'
+            clients:
+              - 'clients/**'
             migrations:
               - 'server/migrations/versions/**'
             tinybird:
@@ -189,6 +192,62 @@ jobs:
       - name: Fail check
         if: steps.check.outputs.has_disallowed == 'true'
         run: exit 1
+
+  deploy-coordination-check:
+    name: "Server: Deploy Coordination Check 🚦"
+    needs: changes
+    if: (needs.changes.outputs.server == 'true' || needs.changes.outputs.clients == 'true') && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for mixed backend + frontend changes
+        id: check
+        run: |
+          if [ "${{ needs.changes.outputs.server }}" = "true" ] && [ "${{ needs.changes.outputs.clients }}" = "true" ]; then
+            echo "mixed=true" >> $GITHUB_OUTPUT
+          else
+            echo "mixed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v4
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: "<!-- __DEPLOY_COORDINATION_CHECK -->"
+
+      - name: Create or update warning comment
+        if: steps.check.outputs.mixed == 'true'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- __DEPLOY_COORDINATION_CHECK -->
+            ## ⚠️ Deploy Coordination Warning
+
+            This PR changes both **backend** (`server/`) and **frontend** (`clients/`) code. These are deployed independently after merge:
+
+            - **Backend** → Docker build → Render (sandbox → production)
+            - **Frontend** → Vercel (sandbox → production)
+
+            They run in parallel with no ordering guarantee. If the frontend depends on a new backend API, the frontend may be promoted before the backend is ready.
+
+            ### Options
+            1. **Split into two PRs** (recommended for breaking API changes): merge backend first, then frontend
+            2. **Use the manual full deploy**: after merge, trigger the "Build and Deploy (Full)" workflow from the Actions tab — this deploys backend first, then promotes frontend
+            3. **No action needed** if the changes are independently deployable
+
+      - name: Delete resolved comment
+        if: steps.check.outputs.mixed == 'false' && steps.fc.outputs.comment-id != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }}
+            })
 
   test:
     name: "Server: Tests 🐍"


### PR DESCRIPTION
## 📋 Summary

Split the monolithic `deploy.yml` into independent backend and frontend deploy workflows to fix concurrency issues with GitHub merge queues.

## 🎯 What

- **`deploy-backend.yml`** (new): Independent workflow for backend deploys (`server/**` → Docker build → Render sandbox → production)
- **`deploy-frontend.yml`** (new): Independent workflow for frontend deploys (`clients/**` → Vercel sandbox → production)
- **`deploy.yml`** (modified): Now `workflow_dispatch` only — manual "full deploy" for coordinated backend+frontend changes
- **`test_server.yaml`** (modified): Added deploy coordination check that posts a warning comment on PRs touching both `server/` and `clients/`

## 🤔 Why

With merge queues enabled, rapid successive merges cause deploy interference:

1. **Two backend PRs**: The shared `build-deploy` concurrency group (`cancel-in-progress: true`) cancels the first build mid-flight, killing its entire deploy pipeline
2. **Backend + frontend PRs**: Both enter the same workflow and shared concurrency groups can cause cross-interference

## 🔧 How

Each new workflow has **workflow-level** `concurrency` with `cancel-in-progress: false`. GitHub's semantics guarantee:
- The in-progress deploy is **never cancelled** mid-flight
- Only the **most recent** pending run is kept (older pending runs are auto-cancelled before starting)
- Backend and frontend are in **separate groups** — completely independent

Job-level concurrency groups (`deploy-backend-{sandbox,production}`, `deploy-frontend-{sandbox,production}`) match `deploy-environment.yml`'s groups, preventing races between automatic and manual deploys.

The deploy coordination check (non-blocking) warns PR authors when both backend and frontend change, since they deploy independently after merge.

## 🧪 Testing

- [x] YAML lint passes on all workflow files
- [ ] Verified workflow triggers on push to main (requires merge)

### Test Instructions

1. Merge a backend-only PR → verify only `Deploy Backend` workflow runs
2. Merge a frontend-only PR → verify only `Deploy Frontend` workflow runs
3. Open a PR touching both `server/` and `clients/` → verify warning comment appears
4. Trigger "Build and Deploy (Full)" manually → verify coordinated deploy works

## 📝 Additional Notes

**Trade-off**: The old workflow coordinated frontend promotion after backend deploy. With the split, they deploy independently. For breaking API changes where frontend depends on a new backend endpoint:
- Merge backend PR first, wait for deploy, then merge frontend
- Or use the manual "Build and Deploy (Full)" workflow dispatch

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")