### PR TITLE
refactor: Remove deprecated organization status values

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPage.tsx
@@ -39,13 +39,7 @@ export default function ClientPage({
 
   const isDenied = organization.status === 'denied'
 
-  const isActive = [
-    'active',
-    'initial_review',
-    'ongoing_review',
-    'review',
-    'snoozed',
-  ].includes(organization.status)
+  const isActive = ['active', 'review', 'snoozed'].includes(organization.status)
 
   const [hasSubmittedDetails, setHasSubmittedDetails] = useState(
     !!organization.details_submitted_at,

--- a/server/polar/backoffice/components/_status_badge.py
+++ b/server/polar/backoffice/components/_status_badge.py
@@ -18,11 +18,8 @@ def status_badge(
 
     Generates a badge element with appropriate styling based on organization status.
     Uses DaisyUI badge classes with semantic color mapping:
-    - ACTIVE: success (green)
-    - INITIAL_REVIEW: warning (yellow)
-    - ONGOING_REVIEW: warning (yellow)
-    - DENIED: error (red)
-    - CREATED, ONBOARDING_STARTED: secondary (gray)
+    - REVIEW, OFFBOARDING: warning (yellow)
+    - ACTIVE, SNOOZED, DENIED, CREATED: ghost (gray)
 
     Args:
         status: The organization status to display.
@@ -42,14 +39,6 @@ def status_badge(
             "class": "badge-ghost border border-base-300",
             "aria": "active status",
         },
-        OrganizationStatus.INITIAL_REVIEW: {
-            "class": "badge-warning",
-            "aria": "initial review status",
-        },
-        OrganizationStatus.ONGOING_REVIEW: {
-            "class": "badge-warning",
-            "aria": "ongoing review status",
-        },
         OrganizationStatus.REVIEW: {
             "class": "badge-warning",
             "aria": "review status",
@@ -65,10 +54,6 @@ def status_badge(
         OrganizationStatus.CREATED: {
             "class": "badge-ghost border border-base-300",
             "aria": "created status",
-        },
-        OrganizationStatus.ONBOARDING_STARTED: {
-            "class": "badge-ghost border border-base-300",
-            "aria": "onboarding started status",
         },
         OrganizationStatus.OFFBOARDING: {
             "class": "badge-warning",

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -333,12 +333,16 @@ async def list(
 
     # Add review cycle filter
     if review_cycle:
+        statement = statement.where(Organization.status == OrganizationStatus.REVIEW)
         match review_cycle:
             case "first":
-                status = OrganizationStatus.INITIAL_REVIEW
+                statement = statement.where(
+                    Organization.initially_reviewed_at.is_(None)
+                )
             case "subsequent":
-                status = OrganizationStatus.ONGOING_REVIEW
-        statement = statement.where(Organization.status == status)
+                statement = statement.where(
+                    Organization.initially_reviewed_at.is_not(None)
+                )
 
     statement = repository.apply_sorting(statement, sorting)
     items, count = await repository.paginate(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -203,14 +203,8 @@ async def list_organizations(
         status_filter = OrganizationStatus.ACTIVE
     elif status == "denied":
         status_filter = OrganizationStatus.DENIED
-    elif status == "initial_review":
-        status_filter = OrganizationStatus.INITIAL_REVIEW
-    elif status == "ongoing_review":
-        status_filter = OrganizationStatus.ONGOING_REVIEW
     elif status == "created":
         status_filter = OrganizationStatus.CREATED
-    elif status == "onboarding_started":
-        status_filter = OrganizationStatus.ONBOARDING_STARTED
     elif status == "offboarding":
         status_filter = OrganizationStatus.OFFBOARDING
     elif status == "review":

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -452,10 +452,7 @@ class OrganizationDetailView:
                             ):
                                 text("Set Offboarding")
 
-                    elif self.org.status in (
-                        OrganizationStatus.CREATED,
-                        OrganizationStatus.ONBOARDING_STARTED,
-                    ):
+                    elif self.org.status == OrganizationStatus.CREATED:
                         with tag.div(classes="w-full"):
                             with button(
                                 variant="secondary",

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -278,22 +278,6 @@ class OrganizationListView:
                 count=sum(status_counts.values()),
             ),
             Tab(
-                label="Initial Review",
-                url=str(request.url_for("organizations:list"))
-                + "?status=initial_review",
-                active=status_filter == OrganizationStatus.INITIAL_REVIEW,
-                count=status_counts.get(OrganizationStatus.INITIAL_REVIEW, 0),
-                badge_variant="warning",
-            ),
-            Tab(
-                label="Ongoing Review",
-                url=str(request.url_for("organizations:list"))
-                + "?status=ongoing_review",
-                active=status_filter == OrganizationStatus.ONGOING_REVIEW,
-                count=status_counts.get(OrganizationStatus.ONGOING_REVIEW, 0),
-                badge_variant="warning",
-            ),
-            Tab(
                 label="Review",
                 url=str(request.url_for("organizations:list")) + "?status=review",
                 active=status_filter == OrganizationStatus.REVIEW,

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -193,10 +193,6 @@ class PlainService:
                 ) from e
 
             match organization.status:
-                case OrganizationStatus.INITIAL_REVIEW:
-                    title = "Initial Account Review"
-                case OrganizationStatus.ONGOING_REVIEW:
-                    title = "Ongoing Account Review"
                 case OrganizationStatus.REVIEW:
                     if organization.initially_reviewed_at is not None:
                         title = "Ongoing Account Review"

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -193,9 +193,6 @@ OrganizationLegalEntity = (
 
 class OrganizationStatus(StrEnum):
     CREATED = "created"
-    ONBOARDING_STARTED = "onboarding_started"
-    INITIAL_REVIEW = "initial_review"
-    ONGOING_REVIEW = "ongoing_review"
     REVIEW = "review"
     SNOOZED = "snoozed"
     DENIED = "denied"
@@ -205,9 +202,6 @@ class OrganizationStatus(StrEnum):
     def get_display_name(self) -> str:
         return {
             OrganizationStatus.CREATED: "Created",
-            OrganizationStatus.ONBOARDING_STARTED: "Onboarding Started",
-            OrganizationStatus.INITIAL_REVIEW: "Initial Review",
-            OrganizationStatus.ONGOING_REVIEW: "Ongoing Review",
             OrganizationStatus.REVIEW: "Review",
             OrganizationStatus.SNOOZED: "Snoozed",
             OrganizationStatus.DENIED: "Denied",
@@ -217,7 +211,7 @@ class OrganizationStatus(StrEnum):
 
     @classmethod
     def review_statuses(cls) -> set[Self]:
-        return {cls.INITIAL_REVIEW, cls.ONGOING_REVIEW, cls.REVIEW, cls.SNOOZED}  # pyright: ignore
+        return {cls.REVIEW, cls.SNOOZED}  # pyright: ignore
 
     @classmethod
     def payment_ready_statuses(cls) -> set[Self]:

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -290,7 +290,6 @@ class LegacyOrganizationStatus(StrEnum):
     """
 
     CREATED = "created"
-    ONBOARDING_STARTED = "onboarding_started"
     UNDER_REVIEW = "under_review"
     DENIED = "denied"
     ACTIVE = "active"
@@ -299,11 +298,6 @@ class LegacyOrganizationStatus(StrEnum):
     def from_status(cls, status: OrganizationStatus) -> "LegacyOrganizationStatus":
         mapping = {
             OrganizationStatus.CREATED: LegacyOrganizationStatus.CREATED,
-            OrganizationStatus.ONBOARDING_STARTED: (
-                LegacyOrganizationStatus.ONBOARDING_STARTED
-            ),
-            OrganizationStatus.INITIAL_REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
-            OrganizationStatus.ONGOING_REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.REVIEW: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.SNOOZED: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.DENIED: LegacyOrganizationStatus.DENIED,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -797,8 +797,7 @@ class OrganizationService:
         Only auto-approves when: verdict is APPROVE and org has been initially reviewed.
         """
         is_eligible = (
-            organization.status
-            in (OrganizationStatus.ONGOING_REVIEW, OrganizationStatus.REVIEW)
+            organization.status == OrganizationStatus.REVIEW
             and organization.initially_reviewed_at is not None
             and verdict == ReviewVerdict.APPROVE
         )
@@ -811,11 +810,7 @@ class OrganizationService:
         # Guard: only create a thread if the org is still under review
         # (it may have been handled already, e.g. on a task retry)
         # Excludes SNOOZED — snoozed orgs shouldn't get new Plain tickets
-        if organization.status in (
-            OrganizationStatus.INITIAL_REVIEW,
-            OrganizationStatus.ONGOING_REVIEW,
-            OrganizationStatus.REVIEW,
-        ):
+        if organization.status == OrganizationStatus.REVIEW:
             await plain_service.create_organization_review_thread(session, organization)
         return False
 

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -97,11 +97,7 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
             raise OrganizationDoesNotExist(organization_id)
 
         is_auto_approve_eligible = (
-            organization.status
-            in (
-                OrganizationStatus.ONGOING_REVIEW,
-                OrganizationStatus.REVIEW,
-            )
+            organization.status == OrganizationStatus.REVIEW
             and organization.initially_reviewed_at is not None
         )
 

--- a/server/scripts/rerun_org_reviews.py
+++ b/server/scripts/rerun_org_reviews.py
@@ -87,15 +87,7 @@ async def process_organizations(
         # Query organizations under review
         statement = (
             select(Organization)
-            .where(
-                Organization.status.in_(
-                    [
-                        OrganizationStatus.INITIAL_REVIEW,
-                        OrganizationStatus.ONGOING_REVIEW,
-                        OrganizationStatus.REVIEW,
-                    ]
-                )
-            )
+            .where(Organization.status == OrganizationStatus.REVIEW)
             .options(joinedload(Organization.account))
             .order_by(Organization.status_updated_at.desc())
         )

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -367,7 +367,7 @@ class TestCheckReviewThreshold:
         organization: Organization,
     ) -> None:
         # Given organization already under review
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 1000
         organization.total_balance = None
 
@@ -382,7 +382,7 @@ class TestCheckReviewThreshold:
         )
 
         # Then - status unchanged but total_balance is updated
-        assert result.status == OrganizationStatus.INITIAL_REVIEW
+        assert result.status == OrganizationStatus.REVIEW
         assert result.total_balance == 7500
 
     async def test_below_review_threshold(
@@ -501,7 +501,7 @@ class TestConfirmOrganizationReviewed:
         organization: Organization,
     ) -> None:
         # Given organization under review
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        organization.status = OrganizationStatus.REVIEW
 
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
@@ -528,7 +528,7 @@ class TestConfirmOrganizationReviewed:
         organization: Organization,
     ) -> None:
         # Given organization under review
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        organization.status = OrganizationStatus.REVIEW
 
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
@@ -555,7 +555,7 @@ class TestConfirmOrganizationReviewed:
         organization: Organization,
     ) -> None:
         # Given organization under review
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         organization.initially_reviewed_at = initially_reviewed_at
 
@@ -623,8 +623,8 @@ class TestHandleOngoingReviewVerdict:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is ONGOING_REVIEW with threshold=$500 (50_000 cents)
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        # Given: org is REVIEW with threshold=$500 (50_000 cents)
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 50_000
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -651,8 +651,8 @@ class TestHandleOngoingReviewVerdict:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is ONGOING_REVIEW with threshold=$500
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        # Given: org is REVIEW with threshold=$500
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 50_000
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -668,7 +668,7 @@ class TestHandleOngoingReviewVerdict:
 
         # Then: escalated, Plain ticket created, status unchanged
         assert result is False
-        assert organization.status == OrganizationStatus.ONGOING_REVIEW
+        assert organization.status == OrganizationStatus.REVIEW
         plain_mock.assert_called_once_with(session, organization)
         enqueue_job_mock.assert_not_called()
 
@@ -678,8 +678,8 @@ class TestHandleOngoingReviewVerdict:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is ONGOING_REVIEW with threshold=$500
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        # Given: org is REVIEW with threshold=$500
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 50_000
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -695,7 +695,7 @@ class TestHandleOngoingReviewVerdict:
 
         # Then: escalated, Plain ticket created
         assert result is False
-        assert organization.status == OrganizationStatus.ONGOING_REVIEW
+        assert organization.status == OrganizationStatus.REVIEW
         plain_mock.assert_called_once_with(session, organization)
         enqueue_job_mock.assert_not_called()
 
@@ -705,8 +705,8 @@ class TestHandleOngoingReviewVerdict:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is ONGOING_REVIEW with a low threshold (no min threshold required)
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        # Given: org is REVIEW with a low threshold (no min threshold required)
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 100
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -733,8 +733,8 @@ class TestHandleOngoingReviewVerdict:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is ONGOING_REVIEW with default threshold of $0
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        # Given: org is REVIEW with default threshold of $0
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 0
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -755,14 +755,14 @@ class TestHandleOngoingReviewVerdict:
         enqueue_job_mock.assert_called_once()
         plain_mock.assert_not_called()
 
-    async def test_not_eligible_initial_review(
+    async def test_not_eligible_no_initial_review(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is INITIAL_REVIEW with threshold=$500
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        # Given: org is REVIEW without initially_reviewed_at
+        organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 50_000
 
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
@@ -770,14 +770,14 @@ class TestHandleOngoingReviewVerdict:
             "polar.organization.service.plain_service.create_organization_review_thread"
         )
 
-        # When: verdict is APPROVE but status is INITIAL_REVIEW
+        # When: verdict is APPROVE but org hasn't been initially reviewed
         result = await organization_service.handle_ongoing_review_verdict(
             session, organization, ReviewVerdict.APPROVE
         )
 
         # Then: not eligible, escalated to Plain
         assert result is False
-        assert organization.status == OrganizationStatus.INITIAL_REVIEW
+        assert organization.status == OrganizationStatus.REVIEW
         plain_mock.assert_called_once_with(session, organization)
         enqueue_job_mock.assert_not_called()
 
@@ -797,7 +797,7 @@ class TestHandleOngoingReviewVerdict:
             "polar.organization.service.plain_service.create_organization_review_thread"
         )
 
-        # When: verdict is APPROVE but status is ACTIVE (not ONGOING_REVIEW)
+        # When: verdict is APPROVE but status is ACTIVE (not REVIEW)
         result = await organization_service.handle_ongoing_review_verdict(
             session, organization, ReviewVerdict.APPROVE
         )
@@ -1074,7 +1074,7 @@ class TestApproveAppeal:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         review = OrganizationReview(
             organization_id=organization.id,
             verdict=OrganizationReview.Verdict.FAIL,
@@ -1830,8 +1830,8 @@ class TestSetOrganizationOffboarding:
     @pytest.mark.parametrize(
         "status",
         [
-            OrganizationStatus.INITIAL_REVIEW,
-            OrganizationStatus.ONGOING_REVIEW,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
         ],
     )
     async def test_from_review_statuses(
@@ -1875,7 +1875,7 @@ class TestSetOrganizationOffboarding:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        organization.status = OrganizationStatus.ONGOING_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         organization.internal_notes = None
 
         result = await organization_service.set_organization_offboarding(

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -62,7 +62,7 @@ class TestOrganizationUnderReview:
         user: User,
     ) -> None:
         # Update organization to have under review status
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         await save_fixture(organization)
 
         # then
@@ -87,7 +87,7 @@ class TestOrganizationUnderReview:
         user: User,
     ) -> None:
         # Update organization to have under review status
-        organization.status = OrganizationStatus.INITIAL_REVIEW
+        organization.status = OrganizationStatus.REVIEW
         await save_fixture(organization)
 
         # then

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -131,9 +131,8 @@ class TestCreate:
         "status",
         [
             OrganizationStatus.CREATED,
-            OrganizationStatus.ONBOARDING_STARTED,
-            OrganizationStatus.INITIAL_REVIEW,
-            OrganizationStatus.ONGOING_REVIEW,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
             OrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING,
         ],


### PR DESCRIPTION
## 📋 Summary

Phase 4 (Narrow) of the organization status consolidation: removes `ONBOARDING_STARTED`, `INITIAL_REVIEW`, and `ONGOING_REVIEW` from the `OrganizationStatus` enum and all code references, now that PR3 has migrated all DB rows to use the new values.

## 🎯 What

- Removed 3 deprecated enum values from `OrganizationStatus`
- Narrowed `review_statuses()` from `{INITIAL_REVIEW, ONGOING_REVIEW, REVIEW, SNOOZED}` → `{REVIEW, SNOOZED}`
- Simplified status checks across service, tasks, Plain integration, backoffice, and frontend
- Updated backoffice v1 review cycle filter to use `REVIEW` + `initially_reviewed_at` instead of old status values
- Removed deprecated tabs, filter options, and badge configs from backoffice UI
- Removed `ONBOARDING_STARTED` from `LegacyOrganizationStatus` schema mapping
- Updated all tests to use `REVIEW`/`SNOOZED` instead of deprecated statuses

## 🤔 Why

After the widen (PR2) and migrate (PR3) phases, no DB rows contain the old status values. Keeping them in the enum is dead code that adds confusion and maintenance burden. The `StringEnum` type would also crash if it encountered an unknown value, so cleaning up keeps the enum in sync with actual DB state.

## 🔧 How

Pure code removal — no migrations, no new logic. Every `status in (INITIAL_REVIEW, ONGOING_REVIEW, REVIEW)` simplified to `status == REVIEW`. The backoffice v1 review cycle filter now distinguishes first vs subsequent reviews via `initially_reviewed_at IS NULL` instead of separate status values.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Verify `uv run task lint` passes
2. Verify `uv run task lint_types` passes (0 issues in 1229 files)
3. Verify `pnpm lint` passes in clients/
4. Check backoffice org list — deprecated tabs (Initial Review, Ongoing Review) should be gone

## 📝 Additional Notes

- Migration files are intentionally NOT touched — they're historical records
- Generated client types (`v1.ts`, `openapi.yaml`) will need regeneration (`pnpm generate`) but are not included in this PR
- Method names like `handle_ongoing_review_verdict` and `send_initial_review_action_email` are retained as they describe business concepts, not status values

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")