### PR TITLE
fix: isolate broker Redis per test to prevent cross-test message leaks

### DIFF
--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -8,9 +8,12 @@ Tests are organized by lifecycle phase:
 - lifecycle/     — ongoing subscription events (renewal, retry, cancellation)
 """
 
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock
 
+import dramatiq
+import fakeredis
 import pytest
 import pytest_asyncio
 from pytest_mock import MockerFixture
@@ -63,6 +66,30 @@ def actor_registry() -> dict[str, Any]:
 @pytest.fixture(autouse=True)
 def _set_job_queue_manager() -> None:
     _job_queue_manager.set(JobQueueManager())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_broker_redis() -> Iterator[None]:
+    """Give each test its own broker Redis so ``group().run()`` can't leak
+    messages between parallel pytest-xdist workers.
+    """
+    broker = dramatiq.get_broker()
+    original_client = broker.client  # type: ignore[attr-defined]
+    broker.client = fakeredis.FakeRedis()  # type: ignore[attr-defined]
+    yield
+    broker.client = original_client  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def _protect_test_transaction(session: AsyncSession) -> None:
+    """Prevent ``session.rollback()`` inside ``AsyncSessionMaker`` from
+    propagating to the outer test transaction.
+
+    With ``create_savepoint``, the session auto-begins inside its own
+    SAVEPOINT, so ``Session.rollback(_to_root=True)`` stops there
+    instead of rolling back T1.
+    """
+    session.sync_session.join_transaction_mode = "create_savepoint"
 
 
 @pytest.fixture(autouse=True)

--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -72,24 +72,24 @@ def _set_job_queue_manager() -> None:
 def _isolate_broker_redis() -> Iterator[None]:
     """Give each test its own broker Redis so ``group().run()`` can't leak
     messages between parallel pytest-xdist workers.
+
+    Replacing ``broker.client`` alone is not enough: the broker registers Lua
+    scripts (``broker.scripts``) against the original client at init time, so
+    ``broker.enqueue()`` would still write to the old Redis.  We must
+    re-register the scripts on the new client as well.
     """
     broker = dramatiq.get_broker()
     original_client = broker.client  # type: ignore[attr-defined]
-    broker.client = fakeredis.FakeRedis()  # type: ignore[attr-defined]
+    original_scripts = broker.scripts  # type: ignore[attr-defined]
+    fake = fakeredis.FakeRedis()
+    broker.client = fake  # type: ignore[attr-defined]
+    broker.scripts = {  # type: ignore[attr-defined]
+        name: fake.register_script(script.script)
+        for name, script in original_scripts.items()
+    }
     yield
     broker.client = original_client  # type: ignore[attr-defined]
-
-
-@pytest.fixture(autouse=True)
-def _protect_test_transaction(session: AsyncSession) -> None:
-    """Prevent ``session.rollback()`` inside ``AsyncSessionMaker`` from
-    propagating to the outer test transaction.
-
-    With ``create_savepoint``, the session auto-begins inside its own
-    SAVEPOINT, so ``Session.rollback(_to_root=True)`` stops there
-    instead of rolling back T1.
-    """
-    session.sync_session.join_transaction_mode = "create_savepoint"
+    broker.scripts = original_scripts  # type: ignore[attr-defined]
 
 
 @pytest.fixture(autouse=True)

--- a/server/tests/e2e/infra/task_drain.py
+++ b/server/tests/e2e/infra/task_drain.py
@@ -199,13 +199,6 @@ class TaskDrain:
         ignored = DEFAULT_IGNORED_ACTORS | (ignored_actors or set())
         result = DrainResult()
 
-        # Purge stale messages from the broker's real Redis.
-        # group().run() and pipeline enqueue directly to the broker,
-        # bypassing the drain's FakeRedis. Leftover messages from
-        # previous tests or parallel workers would be siphoned into
-        # the current test and cause spurious failures.
-        self._purge_broker_queues()
-
         # Flush the HTTP request's JQM to Redis
         try:
             jqm = JobQueueManager.get()
@@ -272,26 +265,6 @@ class TaskDrain:
             return message_data
 
         return None
-
-    def _purge_broker_queues(self) -> None:
-        """Remove stale messages from the broker's real Redis.
-
-        ``group().run()`` and ``dramatiq.pipeline`` write directly to the
-        broker's Redis.  If a previous test (or a parallel pytest-xdist
-        worker) left messages behind, ``_siphon_broker_messages`` would
-        pull them into the current test and cause spurious failures.
-
-        Called at the *start* of each drain — before the current test's
-        JQM is flushed — so only genuinely stale messages are removed.
-        """
-        broker = dramatiq.get_broker()
-        broker_redis = getattr(broker, "client", None)
-        if broker_redis is None or broker_redis is self._redis:
-            return
-
-        for queue_name in QUEUE_NAMES:
-            broker_redis.delete(f"dramatiq:{queue_name}")
-            broker_redis.delete(f"dramatiq:{queue_name}.msgs")
 
     async def _siphon_broker_messages(self) -> None:
         """Transfer messages from the broker's Redis to the drain's FakeRedis.


### PR DESCRIPTION
## 📋 Summary

Fix E2E test flakiness where `benefit.revoke` was never executed during subscription cancellation.

## 🎯 What

- Added `_isolate_broker_redis` autouse fixture that swaps the broker's Redis client **and Lua scripts** with per-test FakeRedis instances
- Removed `_purge_broker_queues()` from `TaskDrain` since broker isolation is now handled at the fixture level

## 🤔 Why

`group().run()` (used by benefit revocation) enqueues messages via `broker.enqueue()`, which executes Lua scripts registered at broker init time. The scripts are bound to the original Redis client — simply replacing `broker.client` with a FakeRedis left the scripts writing to the old client. Messages written there were never picked up by the drain's `_siphon_broker_messages`, so `benefit.revoke` silently never ran.

Re-registering the scripts on the new FakeRedis ensures `group().run()` writes to the isolated per-test Redis, where the drain can find and execute them.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types`)
- [x] Test passes consistently across 5 sequential runs and 3 parallel xdist runs

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally