### PR TITLE
fix: fetch Tinybird token before seeding to ensure valid credentials

### DIFF
--- a/dev/docker/scripts/startup.sh
+++ b/dev/docker/scripts/startup.sh
@@ -92,6 +92,34 @@ else
     sleep 10
 fi
 
+# Auto-discover Tinybird token
+# Always refresh the token from the running Tinybird container, since it
+# generates a new admin token on each startup and any token from server/.env
+# may be stale.
+if [[ -n "${POLAR_TINYBIRD_CLICKHOUSE_URL:-}" ]]; then
+    TINYBIRD_HOST=$(echo "$POLAR_TINYBIRD_CLICKHOUSE_URL" | sed 's|http://||' | cut -d: -f1)
+    TINYBIRD_API="http://${TINYBIRD_HOST}:7181"
+    echo "Fetching Tinybird admin token from ${TINYBIRD_API}..."
+    max_attempts=30
+    attempt=0
+    while true; do
+        TB_TOKEN=$(curl -sf "${TINYBIRD_API}/tokens" 2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['admin_token'])" 2>/dev/null) && break
+        attempt=$((attempt + 1))
+        if [[ $attempt -ge $max_attempts ]]; then
+            echo "WARNING: Could not fetch Tinybird token after $max_attempts attempts, continuing without it"
+            break
+        fi
+        sleep 2
+    done
+    if [[ -n "${TB_TOKEN:-}" ]]; then
+        export POLAR_TINYBIRD_API_TOKEN="$TB_TOKEN"
+        export POLAR_TINYBIRD_CLICKHOUSE_TOKEN="$TB_TOKEN"
+        export POLAR_TINYBIRD_READ_TOKEN="$TB_TOKEN"
+        echo "Tinybird token configured"
+    fi
+fi
+
 # Load seed data if database is empty (first run) - only for API
 if [[ "${1:-api}" == "api" ]]; then
     # Check if any organizations exist to determine if seeds are needed
@@ -130,31 +158,6 @@ if [[ "${1:-api}" == "worker" ]] && [[ ! -f "$PLAYWRIGHT_MARKER" ]]; then
     echo "Playwright browsers installed"
 elif [[ "${1:-api}" == "worker" ]]; then
     echo "Playwright browsers already installed"
-fi
-
-# Auto-discover Tinybird token if not already set
-if [[ -n "${POLAR_TINYBIRD_CLICKHOUSE_URL:-}" ]] && [[ -z "${POLAR_TINYBIRD_CLICKHOUSE_TOKEN:-}" ]]; then
-    TINYBIRD_HOST=$(echo "$POLAR_TINYBIRD_CLICKHOUSE_URL" | sed 's|http://||' | cut -d: -f1)
-    TINYBIRD_API="http://${TINYBIRD_HOST}:7181"
-    echo "Fetching Tinybird admin token from ${TINYBIRD_API}..."
-    max_attempts=30
-    attempt=0
-    while true; do
-        TB_TOKEN=$(curl -sf "${TINYBIRD_API}/tokens" 2>/dev/null \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['admin_token'])" 2>/dev/null) && break
-        attempt=$((attempt + 1))
-        if [[ $attempt -ge $max_attempts ]]; then
-            echo "WARNING: Could not fetch Tinybird token after $max_attempts attempts, continuing without it"
-            break
-        fi
-        sleep 2
-    done
-    if [[ -n "${TB_TOKEN:-}" ]]; then
-        export POLAR_TINYBIRD_API_TOKEN="$TB_TOKEN"
-        export POLAR_TINYBIRD_CLICKHOUSE_TOKEN="$TB_TOKEN"
-        export POLAR_TINYBIRD_READ_TOKEN="$TB_TOKEN"
-        echo "Tinybird token configured"
-    fi
 fi
 
 # Start the requested service


### PR DESCRIPTION
## 📋 Summary

Moves the Tinybird token auto-discovery earlier in the Docker startup script so it runs before seed data loading.

## 🎯 What

- Relocated the Tinybird token fetch block in `dev/docker/scripts/startup.sh` to execute before the seed data step
- Removed the guard that skipped token refresh when a token was already set, since the Tinybird container generates a new admin token on each startup making any cached token stale

## 🤔 Why

The seed script needs valid Tinybird credentials, but the token discovery previously ran after seeding. Since Tinybird generates a fresh admin token on each container startup, the old token in `server/.env` would be stale, causing seed failures.

## 🔧 How

Moved the existing token fetch block (unchanged logic) to run before `seeds_load`, and always refresh the token regardless of whether one is already set.

## 🧪 Testing

- [x] I have tested these changes locally

### Test Instructions

1. Run `docker compose down -v && docker compose up` to start fresh containers
2. Verify the startup logs show "Tinybird token configured" before seed loading
3. Confirm seed data loads successfully with Tinybird events

## 📝 Additional Notes

No logic changes to the token fetch itself — only repositioned and removed the stale-token guard.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")