### PR TITLE
Make TS checks for i18n more lenient to improve DX

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: 💅 Lint
         run: pnpm run lint
 
+      - name: 🌍 Validate i18n
+        run: pnpm --filter @polar-sh/i18n validate
+
       - name: 👀 Typecheck
         run: pnpm run typecheck
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -168,14 +168,15 @@ const CheckoutPricingBreakdown = ({
           {seatRows?.map((row, i) => (
             <DetailRow
               key={i}
-              title={`${row.seats} ${row.seats === 1 ? 'seat' : 'seats'}`}
+              title={t('checkout.pricing.seats.count', { count: row.seats })}
               subtitle={
                 '· ' +
-                formatCurrency('compact', locale)(
+                formatCurrency('standard', locale)(
                   row.pricePerSeat,
                   checkout.currency!,
                 ) +
-                ' per seat'
+                ' ' +
+                t('checkout.pricing.perSeat')
               }
               className="text-gray-600"
             >

--- a/clients/packages/checkout/src/components/CheckoutSeatSelector.tsx
+++ b/clients/packages/checkout/src/components/CheckoutSeatSelector.tsx
@@ -2,10 +2,14 @@
 
 import { type schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import type { AcceptedLocale } from '@polar-sh/i18n'
+import {
+  DEFAULT_LOCALE,
+  useTranslations,
+  type AcceptedLocale,
+} from '@polar-sh/i18n'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import Input from '@polar-sh/ui/components/atoms/Input'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ProductCheckoutPublic } from '../guards'
 import { ErrorResponse } from '../providers/CheckoutProvider'
 import MeteredPricesDisplay from './MeteredPricesDisplay'
@@ -22,24 +26,26 @@ export interface CheckoutSeatSelectorProps {
 const CheckoutSeatSelector = ({
   checkout,
   update,
-  locale,
+  locale = DEFAULT_LOCALE,
   compact = false,
 }: CheckoutSeatSelectorProps) => {
+  const t = useTranslations(locale)
   const [isUpdating, setIsUpdating] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [inputValue, setInputValue] = useState('')
   const [error, setError] = useState<string | null>(null)
   const autoCorrectAttempted = useRef(false)
 
-  const getErrorMessage = (
-    error: ErrorResponse<'checkouts:client_update'> | null,
-  ): string => {
-    if (error && error.error === 'PolarRequestValidationError') {
-      return error.detail[0]?.msg
-    }
+  const getErrorMessage = useCallback(
+    (error: ErrorResponse<'checkouts:client_update'> | null): string => {
+      if (error && error.error === 'PolarRequestValidationError') {
+        return error.detail[0]?.msg
+      }
 
-    return 'Failed to update seats'
-  }
+      return t('checkout.pricing.seats.updateFailed')
+    },
+    [t],
+  )
 
   // Check if the product has seat-based pricing
   const productPrice = checkout.product_price
@@ -92,6 +98,7 @@ const CheckoutSeatSelector = ({
     minimumSeats,
     isUpdating,
     update,
+    getErrorMessage,
   ])
 
   if (!isSeatBased) {
@@ -155,11 +162,14 @@ const CheckoutSeatSelector = ({
   // Build seat limit description
   const getSeatLimitText = () => {
     if (minimumSeats > 1 && hasMaximumLimit) {
-      return `${minimumSeats} - ${maximumSeats} seats`
+      return t('checkout.pricing.seats.range', {
+        min: minimumSeats,
+        max: maximumSeats,
+      })
     } else if (minimumSeats > 1) {
-      return `Minimum ${minimumSeats} seats`
+      return t('checkout.pricing.seats.minimum', { min: minimumSeats })
     } else if (hasMaximumLimit) {
-      return `Maximum ${maximumSeats} seats`
+      return t('checkout.pricing.seats.maximum', { max: maximumSeats })
     }
     return null
   }
@@ -171,7 +181,9 @@ const CheckoutSeatSelector = ({
       <div className="flex flex-col gap-3">
         <div className="flex flex-row items-center justify-between">
           <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium dark:text-white">Seats</span>
+            <span className="text-sm font-medium dark:text-white">
+              {t('checkout.pricing.seats.label')}
+            </span>
           </div>
           {isFixedSeats ? (
             <span className="text-sm font-medium dark:text-white">
@@ -275,7 +287,9 @@ const CheckoutSeatSelector = ({
 
       {/* Seat Selector */}
       <div className="flex flex-col gap-2">
-        <label className="text-lg">Number of seats</label>
+        <label className="text-lg">
+          {t('checkout.pricing.seats.numberOfSeats')}
+        </label>
         {isFixedSeats ? (
           <span className="min-w-[3.5rem] text-2xl font-light text-gray-900 dark:text-white">
             {displaySeats}

--- a/clients/packages/i18n/package.json
+++ b/clients/packages/i18n/package.json
@@ -40,10 +40,11 @@
   ],
   "devDependencies": {
     "@ai-sdk/google": "^2.0.67",
+    "@ai-sdk/openai": "^3.0.52",
     "@polar-sh/eslint-config": "workspace:*",
     "@polar-sh/typescript-config": "workspace:*",
     "@types/react": "^19.2.14",
-    "ai": "^5.0.171",
+    "ai": "^6.0.154",
     "dotenv": "^16.6.1",
     "react": "^19.2.5",
     "tsup": "^8.5.1",

--- a/clients/packages/i18n/scripts/translate.ts
+++ b/clients/packages/i18n/scripts/translate.ts
@@ -70,7 +70,6 @@ async function callLLM(
     model: openai('gpt-5.4-mini'),
     system: systemPromptPart,
     prompt: userPromptPart,
-    temperature: 0.3,
   })
 
   // Strip markdown code fences if present

--- a/clients/packages/i18n/scripts/translate.ts
+++ b/clients/packages/i18n/scripts/translate.ts
@@ -1,4 +1,4 @@
-import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createOpenAI } from '@ai-sdk/openai'
 import { generateText } from 'ai'
 import dotenv from 'dotenv'
 import { execSync } from 'node:child_process'
@@ -39,9 +39,9 @@ const PROMPT_FILE = path.join(CONFIG_DIR, 'prompt.md')
 const LOCKS_FILE = path.join(CONFIG_DIR, 'locks.json')
 const CACHE_FILE = path.join(CONFIG_DIR, '.cache.json')
 
-const google = createGoogleGenerativeAI({
+const openai = createOpenAI({
   apiKey: process.env.PYDANTIC_AI_GATEWAY_API_KEY,
-  baseURL: 'https://gateway.pydantic.dev/proxy/google-vertex',
+  baseURL: 'https://gateway-us.pydantic.dev/proxy/chat/',
 })
 
 async function callLLM(
@@ -64,10 +64,10 @@ async function callLLM(
     .replace('{EN_JSON}', JSON.stringify(sourceStrings, null, 2))
     .trim()
 
-  log.step(`Calling Gemini 3 Pro (Preview)...`)
+  log.step(`Calling OpenAI (gpt-5.4-mini)...`)
 
   const { text } = await generateText({
-    model: google('gemini-3-pro-preview'),
+    model: openai('gpt-5.4-mini'),
     system: systemPromptPart,
     prompt: userPromptPart,
     temperature: 0.3,
@@ -84,7 +84,7 @@ async function callLLM(
     return normalizeResponse(parsed)
   } catch {
     throw new Error(
-      `Invalid JSON response from Gemini for ${targetLocale}: ${cleaned}`,
+      `Invalid JSON response from OpenAI for ${targetLocale}: ${cleaned}`,
     )
   }
 }

--- a/clients/packages/i18n/src/index.ts
+++ b/clients/packages/i18n/src/index.ts
@@ -6,7 +6,12 @@ export type { TranslateFn, TranslationKey, Translations } from './types'
 
 import type { AcceptedLocale, SupportedLocale } from './config'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from './config'
-import type { LocaleShape, TranslateFn, Translations } from './types'
+import type {
+  DeepPartialLocale,
+  LocaleShape,
+  TranslateFn,
+  Translations,
+} from './types'
 
 export function getTranslationLocale(locale: AcceptedLocale): SupportedLocale {
   if (SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
@@ -40,7 +45,12 @@ import ptPT from './locales/pt-PT'
 import sv from './locales/sv'
 import ko from './locales/ko'
 
-const translations: Record<SupportedLocale, LocaleShape<Translations>> = {
+type LocalesRecord = { en: LocaleShape<Translations> } & Record<
+  Exclude<SupportedLocale, 'en'>,
+  DeepPartialLocale<LocaleShape<Translations>>
+>
+
+const translations: LocalesRecord = {
   en,
   nl,
   sv,
@@ -54,12 +64,41 @@ const translations: Record<SupportedLocale, LocaleShape<Translations>> = {
   ko,
 }
 
+const isAtomicLeaf = (v: unknown): boolean => {
+  if (v === null || typeof v !== 'object') return true
+  if ('_mode' in v) return true
+  const value = (v as { value?: unknown }).value
+  if (typeof value === 'string') return true
+  return false
+}
+
+const deepMerge = (base: unknown, override: unknown): unknown => {
+  if (override === undefined) return base
+  if (isAtomicLeaf(override) || isAtomicLeaf(base)) return override
+  const result: Record<string, unknown> = {
+    ...(base as Record<string, unknown>),
+  }
+  for (const key of Object.keys(override as Record<string, unknown>)) {
+    result[key] = deepMerge(
+      (base as Record<string, unknown>)[key],
+      (override as Record<string, unknown>)[key],
+    )
+  }
+  return result
+}
+
+const mergedCache = new Map<SupportedLocale, Translations>()
+
 export function getTranslations(
   locale: AcceptedLocale = DEFAULT_LOCALE,
 ): Translations {
   const translationLocale = getTranslationLocale(locale)
-  return (translations[translationLocale] ??
-    translations[DEFAULT_LOCALE]) as Translations
+  if (translationLocale === DEFAULT_LOCALE) return en
+  const cached = mergedCache.get(translationLocale)
+  if (cached) return cached
+  const merged = deepMerge(en, translations[translationLocale]) as Translations
+  mergedCache.set(translationLocale, merged)
+  return merged
 }
 
 export const useTranslations = (locale: AcceptedLocale): TranslateFn => {

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -163,7 +163,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -329,7 +337,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -495,7 +511,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -661,7 +685,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -827,7 +859,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -985,7 +1025,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1143,7 +1191,15 @@
     "benefitTypes.feature_flag": "Feature flag",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1301,7 +1357,15 @@
     "checkout.pricing.everyInterval.year.other": "Every # years",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1459,7 +1523,15 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1617,6 +1689,14 @@
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
     "checkout.footer.buyerTermsLink": "Buyer Terms",
-    "checkout.pricing.perSeat": "per seat"
+    "checkout.pricing.perSeat": "per seat",
+    "checkout.pricing.seats.label": "Seats",
+    "checkout.pricing.seats.numberOfSeats": "Number of seats",
+    "checkout.pricing.seats.count.=1": "# seat",
+    "checkout.pricing.seats.count.other": "# seats",
+    "checkout.pricing.seats.range": "{min} - {max} seats",
+    "checkout.pricing.seats.minimum": "Minimum {min} seats",
+    "checkout.pricing.seats.maximum": "Maximum {max} seats",
+    "checkout.pricing.seats.updateFailed": "Failed to update seats"
   }
 }

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -162,7 +162,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -327,7 +328,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -492,7 +494,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -657,7 +660,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -822,7 +826,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -979,7 +984,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1136,7 +1142,8 @@
     "checkout.productDescription.readLess": "Read less",
     "benefitTypes.feature_flag": "Feature flag",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1293,7 +1300,8 @@
     "checkout.pricing.everyInterval.year.=2": "Every other year",
     "checkout.pricing.everyInterval.year.other": "Every # years",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1450,7 +1458,8 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1607,6 +1616,7 @@
     "checkout.trial.summary.totalDueToday": "Total due today",
     "checkout.pricing.discount.until": "Until {date}",
     "checkout.productSwitcher.fromPrefix": "From",
-    "checkout.footer.buyerTermsLink": "Buyer Terms"
+    "checkout.footer.buyerTermsLink": "Buyer Terms",
+    "checkout.pricing.perSeat": "per seat"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'pro Platz',
     },
     trial: {
       ends: 'Testphase endet am {endDate}',
@@ -272,4 +275,4 @@ export default {
     many: '.',
     other: '.',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'pro Platz',
+      seats: {
+        label: 'Plätze',
+        numberOfSeats: 'Anzahl der Plätze',
+        count: {
+          '=1': '# Platz',
+          other: '# Plätze',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} Plätze',
+        minimum: 'Mindestens {min} Plätze',
+        maximum: 'Maximal {max} Plätze',
+        updateFailed: 'Plätze konnten nicht aktualisiert werden',
+      },
     },
     trial: {
       ends: 'Testphase endet am {endDate}',
@@ -275,4 +286,4 @@ export default {
     many: '.',
     other: '.',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -92,6 +92,32 @@ export default {
       },
       additionalMeteredUsage: 'Additional metered usage',
       perUnit: '/ unit',
+      perSeat: 'per seat',
+      seats: {
+        label: 'Seats',
+        numberOfSeats: 'Number of seats',
+        count: {
+          _mode: 'plural',
+          '=1': '# seat',
+          other: '# seats',
+        },
+        range: {
+          value: '{min} - {max} seats',
+          _llmContext:
+            'Shown when a seat-based product has both a minimum and maximum seat count. Displayed as: "5 - 100 seats". Always plural.',
+        },
+        minimum: {
+          value: 'Minimum {min} seats',
+          _llmContext:
+            'Shown when a seat-based product has a minimum seat count but no maximum. The {min} value is always > 1 in this context, so the noun is always plural.',
+        },
+        maximum: {
+          value: 'Maximum {max} seats',
+          _llmContext:
+            'Shown when a seat-based product has a maximum seat count but no minimum constraint. The {max} value can be any number, but the message is always rendered with the plural noun.',
+        },
+        updateFailed: 'Failed to update seats',
+      },
       discount: {
         duration: {
           months: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'por usuario',
+      seats: {
+        label: 'Asientos',
+        numberOfSeats: 'Número de asientos',
+        count: {
+          '=1': '# asiento',
+          other: '# asientos',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} asientos',
+        minimum: 'Mínimo {min} asientos',
+        maximum: 'Máximo {max} asientos',
+        updateFailed: 'No se pudieron actualizar los asientos',
+      },
     },
     trial: {
       ends: 'La prueba finaliza el {endDate}',
@@ -271,4 +282,4 @@ export default {
     many: 'º',
     other: 'º',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'por usuario',
     },
     trial: {
       ends: 'La prueba finaliza el {endDate}',
@@ -268,4 +271,4 @@ export default {
     many: 'º',
     other: 'º',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'par siège',
     },
     trial: {
       ends: "L'essai se termine le {endDate}",
@@ -270,4 +273,4 @@ export default {
     many: 'e',
     other: 'e',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'par siège',
+      seats: {
+        label: 'Postes',
+        numberOfSeats: 'Nombre de postes',
+        count: {
+          '=1': '# poste',
+          other: '# postes',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} postes',
+        minimum: 'Minimum {min} postes',
+        maximum: 'Maximum {max} postes',
+        updateFailed: 'Échec de la mise à jour des postes',
+      },
     },
     trial: {
       ends: "L'essai se termine le {endDate}",
@@ -273,4 +284,4 @@ export default {
     many: 'e',
     other: 'e',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'felhasználónként',
     },
     trial: {
       ends: 'A próbaidőszak ekkor jár le: {endDate}',
@@ -266,4 +269,4 @@ export default {
     many: '.',
     other: '.',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'felhasználónként',
+      seats: {
+        label: 'Felhasználói helyek',
+        numberOfSeats: 'Felhasználói helyek száma',
+        count: {
+          '=1': '# felhasználói hely',
+          other: '# felhasználói hely',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} felhasználói hely',
+        minimum: 'Legalább {min} felhasználói hely',
+        maximum: 'Legfeljebb {max} felhasználói hely',
+        updateFailed: 'A felhasználói helyek frissítése nem sikerült',
+      },
     },
     trial: {
       ends: 'A próbaidőszak ekkor jár le: {endDate}',
@@ -269,4 +280,4 @@ export default {
     many: '.',
     other: '.',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
         },
         until: 'Fino al {date}',
       },
+      perSeat: 'per postazione',
     },
     trial: {
       ends: 'La prova termina il {endDate}',
@@ -268,4 +271,4 @@ export default {
     many: '°',
     other: '°',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         until: 'Fino al {date}',
       },
       perSeat: 'per postazione',
+      seats: {
+        label: 'Postazioni',
+        numberOfSeats: 'Numero di postazioni',
+        count: {
+          '=1': '# postazione',
+          other: '# postazioni',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} postazioni',
+        minimum: 'Minimo {min} postazioni',
+        maximum: 'Massimo {max} postazioni',
+        updateFailed: 'Impossibile aggiornare le postazioni',
+      },
     },
     trial: {
       ends: 'La prova termina il {endDate}',
@@ -271,4 +282,4 @@ export default {
     many: '°',
     other: '°',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: '좌석당',
     },
     trial: {
       ends: '체험 종료일: {endDate}',
@@ -265,4 +268,4 @@ export default {
     many: '번째',
     other: '번째',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: '좌석당',
+      seats: {
+        label: '좌석',
+        numberOfSeats: '좌석 수',
+        count: {
+          '=1': '#석',
+          other: '#석',
+          _mode: 'plural',
+        },
+        range: '{min} - {max}석',
+        minimum: '최소 {min}석',
+        maximum: '최대 {max}석',
+        updateFailed: '좌석 수를 업데이트하지 못했습니다',
+      },
     },
     trial: {
       ends: '체험 종료일: {endDate}',
@@ -268,4 +279,4 @@ export default {
     many: '번째',
     other: '번째',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'per gebruiker',
+      seats: {
+        label: 'Stoelen',
+        numberOfSeats: 'Aantal stoelen',
+        count: {
+          '=1': '# stoel',
+          other: '# stoelen',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} stoelen',
+        minimum: 'Minimaal {min} stoelen',
+        maximum: 'Maximaal {max} stoelen',
+        updateFailed: 'Stoelen bijwerken mislukt',
+      },
     },
     trial: {
       ends: 'Proefperiode eindigt op {endDate}',
@@ -271,4 +282,4 @@ export default {
     many: 'e',
     other: 'e',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'per gebruiker',
     },
     trial: {
       ends: 'Proefperiode eindigt op {endDate}',
@@ -268,4 +271,4 @@ export default {
     many: 'e',
     other: 'e',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'por utilizador',
     },
     trial: {
       ends: 'Teste termina a {endDate}',
@@ -266,4 +269,4 @@ export default {
     many: 'º',
     other: 'º',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'por utilizador',
+      seats: {
+        label: 'Licenças',
+        numberOfSeats: 'Número de licenças',
+        count: {
+          '=1': '# licença',
+          other: '# licenças',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} licenças',
+        minimum: 'Mínimo de {min} licenças',
+        maximum: 'Máximo de {max} licenças',
+        updateFailed: 'Não foi possível atualizar as licenças',
+      },
     },
     trial: {
       ends: 'Teste termina a {endDate}',
@@ -269,4 +280,4 @@ export default {
     many: 'º',
     other: 'º',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'por assento',
+      seats: {
+        label: 'Assentos',
+        numberOfSeats: 'Número de assentos',
+        count: {
+          '=1': '# assento',
+          other: '# assentos',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} assentos',
+        minimum: 'Mínimo de {min} assentos',
+        maximum: 'Máximo de {max} assentos',
+        updateFailed: 'Falha ao atualizar os assentos',
+      },
     },
     trial: {
       ends: 'Teste termina a {endDate}',
@@ -269,4 +280,4 @@ export default {
     many: 'º',
     other: 'º',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'por assento',
     },
     trial: {
       ends: 'Teste termina a {endDate}',
@@ -266,4 +269,4 @@ export default {
     many: 'º',
     other: 'º',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -1,5 +1,3 @@
-import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
-
 export default {
   checkout: {
     footer: {
@@ -91,6 +89,19 @@ export default {
         },
       },
       perSeat: 'per plats',
+      seats: {
+        label: 'Platser',
+        numberOfSeats: 'Antal platser',
+        count: {
+          '=1': '# plats',
+          other: '# platser',
+          _mode: 'plural',
+        },
+        range: '{min} - {max} platser',
+        minimum: 'Minst {min} platser',
+        maximum: 'Högst {max} platser',
+        updateFailed: 'Det gick inte att uppdatera platserna',
+      },
     },
     trial: {
       ends: 'Testperioden slutar {endDate}',
@@ -268,4 +279,4 @@ export default {
     many: ':e',
     other: ':e',
   },
-} as const satisfies DeepPartialLocale<LocaleShape<Translations>>
+} as const

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -1,3 +1,5 @@
+import type { DeepPartialLocale, LocaleShape, Translations } from '../types'
+
 export default {
   checkout: {
     footer: {
@@ -88,6 +90,7 @@ export default {
           _mode: 'plural',
         },
       },
+      perSeat: 'per plats',
     },
     trial: {
       ends: 'Testperioden slutar {endDate}',
@@ -265,4 +268,4 @@ export default {
     many: ':e',
     other: ':e',
   },
-} as const
+} as const satisfies DeepPartialLocale<LocaleShape<Translations>>

--- a/clients/packages/i18n/src/types.ts
+++ b/clients/packages/i18n/src/types.ts
@@ -77,6 +77,19 @@ export type LocaleShape<T> = {
           : T[K]
 }
 
+// A locale shape where every nested key is optional, except plural objects
+// and annotated entries which remain atomic (all-or-nothing). This lets non-
+// English locale files lag behind en.ts without breaking type checking — the
+// CI translation job fills the gaps on every PR, and at runtime missing keys
+// fall back to English via getTranslations' deep merge.
+export type DeepPartialLocale<T> = T extends { _mode: string }
+  ? T
+  : T extends { value: string }
+    ? T
+    : T extends object
+      ? { [K in keyof T]?: DeepPartialLocale<T[K]> }
+      : T
+
 // Get all required interpolation keys for a translation key
 // Plurals always require 'count' + any {placeholders} in the templates
 type InterpolationKeys<K extends TranslationKey> =

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         version: 16.2.3(@mdx-js/loader@3.1.1(webpack@5.102.1))(@mdx-js/react@3.1.1(@types/react@19.2.13)(react@19.2.5))
       '@next/third-parties':
         specifier: ^16.2.3
-        version: 16.2.3(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.3(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@polar-sh/checkout':
         specifier: workspace:^
         version: link:../../packages/checkout
@@ -354,7 +354,7 @@ importers:
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@sentry/nextjs':
         specifier: ^10.48.0
-        version: 10.48.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1)
+        version: 10.48.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1)
       '@shikijs/rehype':
         specifier: ^3.23.0
         version: 3.23.0
@@ -411,7 +411,7 @@ importers:
         version: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.7.0(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
@@ -432,13 +432,13 @@ importers:
         version: 5.1.7
       next:
         specifier: ^16.2.3
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.8.9(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       posthog-js:
         specifier: ^1.366.2
         version: 1.366.2
@@ -733,6 +733,9 @@ importers:
       '@ai-sdk/google':
         specifier: ^2.0.67
         version: 2.0.67(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: ^3.0.52
+        version: 3.0.52(zod@4.3.6)
       '@polar-sh/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -743,8 +746,8 @@ importers:
         specifier: 19.2.13
         version: 19.2.13
       ai:
-        specifier: ^5.0.171
-        version: 5.0.171(zod@4.3.6)
+        specifier: ^6.0.154
+        version: 6.0.154(zod@4.3.6)
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -960,12 +963,6 @@ packages:
 
   '@ai-sdk/anthropic@3.0.68':
     resolution: {integrity: sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@2.0.75':
-    resolution: {integrity: sha512-5bZN8RKr/HHBbFPd0ql+5mKTe3DngsyS4y9983qUdG+AYWIoMi3VlU7Gr0J6YNYYD4sxkZdLMfAVWVpFGb5WSA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -5394,12 +5391,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  ai@5.0.171:
-    resolution: {integrity: sha512-c3Eczgg7wp8Y/PZ1HF5dUA5FXjJy0JmubVuHeD49++9ma9EfX8S8UNlRZ2xN3Oaep1OAt0qXXcDoR1JG31Syig==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   ai@6.0.154:
     resolution: {integrity: sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ==}
@@ -11731,13 +11722,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@2.0.75(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
-      zod: 4.3.6
-
   '@ai-sdk/gateway@3.0.94(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -13992,9 +13976,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
 
-  '@next/third-parties@16.2.3(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@16.2.3(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       third-party-capital: 1.0.20
 
@@ -15928,7 +15912,7 @@ snapshots:
 
   '@sentry/core@10.48.0': {}
 
-  '@sentry/nextjs@10.48.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1)':
+  '@sentry/nextjs@10.48.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -15941,7 +15925,7 @@ snapshots:
       '@sentry/react': 10.48.0(react@19.2.5)
       '@sentry/vercel-edge': 10.48.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.102.1)
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rollup: 4.53.5
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -16887,7 +16871,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.9))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.0.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.9))(msw@2.12.10(@types/node@25.0.2)(typescript@5.9.3))(vite@7.3.0(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -16943,7 +16927,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.9))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.0.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.9))(msw@2.12.10(@types/node@25.0.2)(typescript@5.9.3))(vite@7.3.0(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -17087,14 +17071,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  ai@5.0.171(zod@4.3.6):
-    dependencies:
-      '@ai-sdk/gateway': 2.0.75(zod@4.3.6)
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
 
   ai@6.0.154(zod@4.3.6):
     dependencies:
@@ -19432,9 +19408,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  geist@1.7.0(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  geist@1.7.0(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   generator-function@2.0.1: {}
 
@@ -22015,7 +21991,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -22024,7 +22000,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -22085,12 +22061,12 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuqs@2.8.9(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  nuqs@2.8.9(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.5
     optionalDependencies:
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   nwsapi@2.2.23: {}
 
@@ -23935,12 +23911,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
+  styled-jsx@5.1.6(react@19.2.5):
     dependencies:
       client-only: 0.0.1
       react: 19.2.5
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   styleq@0.1.3: {}
 


### PR DESCRIPTION
Currently if you add a new i18n key to `en.ts` the following will happen:

1. Build and TS check fails, because the key is missing from the other translations (`sv.ts` etc) meaning you are somewhat blocked from doing any local work
2. You have to push the commit and open a PR to trigger the CI translation job
3. You then have to pull the new translations
4. You can continue to work as usual

With this change, we're improving DX a bit so after adding a new i18n key to `en.ts` the following will happen:

1. Build and TS checks passes
2. You can continue working locally as normal
3. Creating a PR will trigger the CI translation job
4. A new CI workflow will validate that all keys exists in all i18n files to ensure nothing is missing