### PR TITLE
fix: build backoffice assets in preview deployments

### DIFF
--- a/infra/preview/deploy.sh
+++ b/infra/preview/deploy.sh
@@ -118,6 +118,9 @@ deploy() {
 
         log "Building email renderer"
         uv run task emails
+
+        log "Building backoffice assets"
+        uv run task backoffice
     fi
 
     # --- Backend .env (must be written before migrations) ---


### PR DESCRIPTION
## Summary

- Add backoffice asset build step (`uv run task backoffice`) to the preview deploy script

## Problem

The backoffice CSS, JS, and icon fonts (`static/styles.css`, `static/scripts.js`, `static/lucide.*`) are gitignored — they're build artifacts produced by Tailwind CSS and esbuild. The Dockerfile handles this in its `build-backoffice` stage, but the preview deploy script (`deploy.sh`) runs the server directly from a git checkout and never built these assets. This caused the backoffice to render as unstyled HTML with no interactivity in all preview branches.

## Fix

Added `uv run task backoffice` to `deploy.sh` inside the existing `BACKEND_CHANGED` block, right after the email renderer build. This runs `pnpm install && pnpm build` for the backoffice, compiling Tailwind + DaisyUI CSS and bundling HTMX + Hyperscript JS. Node.js and pnpm are already installed on the preview VM (`setup-vm.sh` step 5).

## Test plan

- [ ] Deploy a preview branch and verify backoffice pages at `{preview_url}/backoffice/` render with proper styling and interactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)