### PR TITLE
feat: Add BLOCKED value to OrganizationStatus enum

### DIFF
--- a/server/polar/backoffice/components/_status_badge.py
+++ b/server/polar/backoffice/components/_status_badge.py
@@ -51,6 +51,10 @@ def status_badge(
             "class": "badge-ghost border border-base-300",
             "aria": "denied status",
         },
+        OrganizationStatus.BLOCKED: {
+            "class": "badge-error",
+            "aria": "blocked status",
+        },
         OrganizationStatus.CREATED: {
             "class": "badge-ghost border border-base-300",
             "aria": "created status",

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -211,6 +211,8 @@ async def list_organizations(
         status_filter = OrganizationStatus.REVIEW
     elif status == "snoozed":
         status_filter = OrganizationStatus.SNOOZED
+    elif status == "blocked":
+        status_filter = OrganizationStatus.BLOCKED
 
     # Build query
     stmt = (
@@ -227,8 +229,15 @@ async def list_organizations(
     if status_filter:
         stmt = stmt.where(Organization.status == status_filter)
     elif not q:
-        # By default, exclude denied organizations (but not when searching)
-        stmt = stmt.where(Organization.status != OrganizationStatus.DENIED)
+        # By default, exclude denied and blocked organizations (but not when searching)
+        stmt = stmt.where(
+            Organization.status.notin_(
+                [
+                    OrganizationStatus.DENIED,
+                    OrganizationStatus.BLOCKED,
+                ]
+            )
+        )
 
     if q:
         try:

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -306,6 +306,13 @@ class OrganizationListView:
                 badge_variant="error",
             ),
             Tab(
+                label="Blocked",
+                url=str(request.url_for("organizations:list")) + "?status=blocked",
+                active=status_filter == OrganizationStatus.BLOCKED,
+                count=status_counts.get(OrganizationStatus.BLOCKED, 0),
+                badge_variant="error",
+            ),
+            Tab(
                 label="Offboarding",
                 url=str(request.url_for("organizations:list")) + "?status=offboarding",
                 active=status_filter == OrganizationStatus.OFFBOARDING,

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -197,6 +197,7 @@ class OrganizationStatus(StrEnum):
     SNOOZED = "snoozed"
     DENIED = "denied"
     ACTIVE = "active"
+    BLOCKED = "blocked"
     OFFBOARDING = "offboarding"
 
     def get_display_name(self) -> str:
@@ -206,6 +207,7 @@ class OrganizationStatus(StrEnum):
             OrganizationStatus.SNOOZED: "Snoozed",
             OrganizationStatus.DENIED: "Denied",
             OrganizationStatus.ACTIVE: "Active",
+            OrganizationStatus.BLOCKED: "Blocked",
             OrganizationStatus.OFFBOARDING: "Offboarding",
         }[self]
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -302,6 +302,7 @@ class LegacyOrganizationStatus(StrEnum):
             OrganizationStatus.SNOOZED: LegacyOrganizationStatus.UNDER_REVIEW,
             OrganizationStatus.DENIED: LegacyOrganizationStatus.DENIED,
             OrganizationStatus.ACTIVE: LegacyOrganizationStatus.ACTIVE,
+            OrganizationStatus.BLOCKED: LegacyOrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING: LegacyOrganizationStatus.ACTIVE,
         }
         try:


### PR DESCRIPTION
## Summary
- Adds `BLOCKED = "blocked"` to the `OrganizationStatus` enum as the first step in migrating `blocked_at` to a proper status value
- Adds the legacy status mapping (`BLOCKED → DENIED`) to prevent errors if a blocked org reaches the public API
- Adds backoffice UI support: red error badge, list tab with filter, and default view exclusion

## Context
This is **PR 1 of 7** in the `blocked_at` → `OrganizationStatus.BLOCKED` migration. This PR is purely additive — no database migration, no behavioral changes. Since enums are stored as VARCHAR via `StringEnum`, adding a new Python value requires zero schema changes.

Subsequent PRs will:
- PR2: Dual-write both `blocked_at` and `status = BLOCKED` on block actions
- PR3: Backfill historical `blocked_at` rows
- PR4: Switch all read paths from `blocked_at` to `status`
- PR5-7: Stop dual-writing, clean up schemas, drop the column

## Test plan
- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes (0 errors across 1,230 files)
- [ ] Verify backoffice Blocked tab renders and filters correctly
- [ ] Verify no regressions in organization list/detail views

🤖 Generated with [Claude Code](https://claude.com/claude-code)