### PR TITLE
feat: Dual-write blocked_at and status when blocking organizations

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1470,10 +1470,7 @@ async def block_dialog(
         raise HTTPException(status_code=404, detail="Organization not found")
 
     if request.method == "POST":
-        # Block the organization (set blocked_at to current time)
-        from datetime import UTC, datetime
-
-        organization.blocked_at = datetime.now(UTC)
+        await organization_service.block_organization(session, organization)
 
         return HXRedirectResponse(
             request,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -766,6 +766,17 @@ class OrganizationService:
 
         return organization
 
+    async def block_organization(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> Organization:
+        """Block an organization, dual-writing blocked_at and status during migration."""
+        organization.blocked_at = datetime.now(UTC)
+        organization.set_status(OrganizationStatus.BLOCKED)
+        session.add(organization)
+        return organization
+
     async def confirm_organization_reviewed(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

- Add `block_organization()` service method that sets both `blocked_at` and `status = BLOCKED` when blocking an org
- Backoffice block endpoint now calls this method instead of directly mutating `blocked_at`
- Unblock path unchanged — `confirm_organization_reviewed()` already sets `status = ACTIVE`

This is **PR 2 of 7** in the migration from the legacy `blocked_at` column to `OrganizationStatus.BLOCKED`. All reads still use `blocked_at`; the `status = BLOCKED` write is invisible to read paths until PR 4.

**Rollback:** Safe to revert — `status` values may say BLOCKED for some rows but nothing reads them yet.

Depends on: #11020 (PR 1 — add BLOCKED enum value)

## Test plan

- [ ] Block an org via backoffice → verify both `blocked_at` and `status` are set
- [ ] Unblock+approve an org → verify `blocked_at` is cleared and `status` is ACTIVE
- [ ] Verify no behavior change in auth, checkout, or API (reads still use `blocked_at`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)