### PR TITLE
feat: Switch all read paths from blocked_at to OrganizationStatus.BLOCKED (PR4)

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -262,8 +262,7 @@ class OrganizationDetailView:
                     text("Actions")
 
                 with tag.div(classes="space-y-2"):
-                    # Check if organization is blocked
-                    is_blocked = self.org.blocked_at is not None
+                    is_blocked = self.org.is_blocked()
 
                     # Context-aware actions based on status
                     if is_blocked:

--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -34,8 +34,7 @@ class CheckoutLinkRepository(
             )
             .where(
                 CheckoutLink.client_secret == client_secret,
-                Organization.is_deleted.is_(False),
-                Organization.blocked_at.is_(None),
+                Organization.can_authenticate.is_(True),
             )
             .options(*options)
         )

--- a/server/polar/customer_portal/service/organization.py
+++ b/server/polar/customer_portal/service/organization.py
@@ -13,8 +13,7 @@ class CustomerOrganizationService(ResourceServiceReader[Organization]):
         statement = (
             select(Organization)
             .where(
-                Organization.is_deleted.is_(False),
-                Organization.blocked_at.is_(None),
+                Organization.can_authenticate.is_(True),
                 Organization.slug == slug,
             )
             .options(

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -418,12 +418,12 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     @hybrid_property
     def can_authenticate(self) -> bool:
-        return not self.is_deleted and self.blocked_at is None
+        return not self.is_deleted and self.status != OrganizationStatus.BLOCKED
 
     @can_authenticate.inplace.expression
     @classmethod
     def _can_authenticate_expression(cls) -> ColumnElement[bool]:
-        return and_(cls.is_deleted.is_(False), cls.blocked_at.is_(None))
+        return and_(cls.is_deleted.is_(False), cls.status != OrganizationStatus.BLOCKED)
 
     def set_status(self, status: OrganizationStatus) -> None:
         self.status = status
@@ -531,9 +531,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
         )
 
     def is_blocked(self) -> bool:
-        if self.blocked_at is not None:
-            return True
-        return False
+        return self.status == OrganizationStatus.BLOCKED
 
     def is_active(self) -> bool:
         return self.status == OrganizationStatus.ACTIVE

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -29,6 +29,7 @@ from polar.models.discount import (
     DiscountPercentage,
     DiscountType,
 )
+from polar.models.organization import OrganizationStatus
 from polar.models.organization_review import OrganizationReview
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncReadSession
@@ -59,7 +60,9 @@ class OrganizationRepository(
         )
 
         if not include_blocked:
-            statement = statement.where(self.model.blocked_at.is_(None))
+            statement = statement.where(
+                self.model.status != OrganizationStatus.BLOCKED
+            )
 
         return await self.get_one_or_none(statement)
 
@@ -81,7 +84,9 @@ class OrganizationRepository(
         )
 
         if not include_blocked:
-            statement = statement.where(self.model.blocked_at.is_(None))
+            statement = statement.where(
+                self.model.status != OrganizationStatus.BLOCKED
+            )
 
         return await self.get_one_or_none(statement)
 
@@ -120,7 +125,7 @@ class OrganizationRepository(
             .where(
                 UserOrganization.user_id == user,
                 UserOrganization.is_deleted.is_(False),
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
             )
         )
         return await self.get_all(statement)
@@ -132,7 +137,7 @@ class OrganizationRepository(
             self.get_base_statement()
             .where(
                 Organization.account_id == account,
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
             )
             .options(*options)
         )
@@ -164,7 +169,9 @@ class OrganizationRepository(
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization]
     ) -> Select[tuple[Organization]]:
-        statement = self.get_base_statement().where(Organization.blocked_at.is_(None))
+        statement = self.get_base_statement().where(
+            Organization.status != OrganizationStatus.BLOCKED
+        )
 
         if is_user(auth_subject):
             user = auth_subject.subject

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -60,9 +60,7 @@ class OrganizationRepository(
         )
 
         if not include_blocked:
-            statement = statement.where(
-                self.model.status != OrganizationStatus.BLOCKED
-            )
+            statement = statement.where(self.model.status != OrganizationStatus.BLOCKED)
 
         return await self.get_one_or_none(statement)
 
@@ -84,9 +82,7 @@ class OrganizationRepository(
         )
 
         if not include_blocked:
-            statement = statement.where(
-                self.model.status != OrganizationStatus.BLOCKED
-            )
+            statement = statement.where(self.model.status != OrganizationStatus.BLOCKED)
 
         return await self.get_one_or_none(statement)
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -176,7 +176,7 @@ class OrganizationService:
         repository = OrganizationRepository.from_session(session)
         statement = (
             repository.get_base_statement()
-            .where(Organization.blocked_at.is_(None))
+            .where(Organization.status != OrganizationStatus.BLOCKED)
             .where(Organization.id == id)
             .options(*options)
         )
@@ -993,10 +993,10 @@ class OrganizationService:
             return True
 
         # First check basic conditions that don't require account data
-        if (
-            organization.is_blocked()
-            or organization.status == OrganizationStatus.DENIED
-        ):
+        if organization.status in {
+            OrganizationStatus.BLOCKED,
+            OrganizationStatus.DENIED,
+        }:
             return False
 
         # Check grandfathering - if grandfathered, they're ready

--- a/server/polar/organization_review/collectors/history.py
+++ b/server/polar/organization_review/collectors/history.py
@@ -26,7 +26,7 @@ def collect_history_data(
 
         if org.status == OrganizationStatus.DENIED:
             has_prior_denials = True
-        if org.blocked_at is not None:
+        if org.status == OrganizationStatus.BLOCKED:
             has_blocked_orgs = True
 
         prior_organizations.append(

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -125,8 +125,9 @@ class SubscriptionJobStore(BaseJobStore):
             .where(
                 Customer.is_deleted.is_(False),
                 Organization.is_deleted.is_(False),
-                Organization.blocked_at.is_(None),
-                Organization.status != OrganizationStatus.DENIED,
+                Organization.status.not_in(
+                    (OrganizationStatus.BLOCKED, OrganizationStatus.DENIED)
+                ),
                 Subscription.scheduler_locked_at.is_(None),
                 Subscription.active.is_(True),
                 Subscription.current_period_end.is_not(None),

--- a/server/scripts/backfill_polar_self_customers.py
+++ b/server/scripts/backfill_polar_self_customers.py
@@ -17,6 +17,7 @@ from polar.kit.db.postgres import create_async_sessionmaker
 from polar.member.schemas import MemberOwnerCreate
 from polar.member.service import member_service
 from polar.models import Customer, Organization, Product, User, UserOrganization
+from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncSession, create_async_engine
 from polar.redis import Redis, create_redis
 from polar.subscription.schemas import SubscriptionCreateExternalCustomer
@@ -54,7 +55,7 @@ async def _load_active_organizations(
         select(Organization)
         .where(
             Organization.deleted_at.is_(None),
-            Organization.blocked_at.is_(None),
+            Organization.status != OrganizationStatus.BLOCKED,
         )
         .order_by(Organization.created_at)
     )

--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -58,6 +58,7 @@ from sqlalchemy.orm import aliased, joinedload
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Organization
 from polar.models.benefit_grant import BenefitGrant
+from polar.models.organization import OrganizationStatus
 from polar.organization.repository import OrganizationRepository
 from polar.organization.tasks import (
     _backfill_benefit_grants,
@@ -122,7 +123,7 @@ async def migrate_organizations(
             select(Organization)
             .where(
                 Organization.deleted_at.is_(None),
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
                 or_(
                     Organization.feature_settings["member_model_enabled"].is_(None),
                     Organization.feature_settings["member_model_enabled"]
@@ -298,7 +299,7 @@ async def repair(
             select(Organization)
             .where(
                 Organization.deleted_at.is_(None),
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
                 Organization.feature_settings["member_model_enabled"]
                 .as_boolean()
                 .is_(True),
@@ -335,7 +336,7 @@ async def repair(
             .select_from(Organization)
             .where(
                 Organization.deleted_at.is_(None),
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
                 Organization.feature_settings["member_model_enabled"]
                 .as_boolean()
                 .is_(True),
@@ -473,7 +474,7 @@ async def prepare(
             select(Organization)
             .where(
                 Organization.deleted_at.is_(None),
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
                 Organization.feature_settings["seat_based_pricing_enabled"]
                 .as_boolean()
                 .is_(True),

--- a/server/scripts/prepare_organizations_members.py
+++ b/server/scripts/prepare_organizations_members.py
@@ -32,6 +32,7 @@ from sqlalchemy import or_, select
 
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Organization
+from polar.models.organization import OrganizationStatus
 from polar.postgres import create_async_engine
 from polar.worker import enqueue_job
 
@@ -83,7 +84,7 @@ async def prepare(
             select(Organization)
             .where(
                 Organization.deleted_at.is_(None),
-                Organization.blocked_at.is_(None),
+                Organization.status != OrganizationStatus.BLOCKED,
                 Organization.feature_settings["seat_based_pricing_enabled"]
                 .as_boolean()
                 .is_(True),

--- a/server/scripts/void_eligible_orders.py
+++ b/server/scripts/void_eligible_orders.py
@@ -29,6 +29,7 @@ from polar.models import (
     Order,
     Organization,
 )
+from polar.models.organization import OrganizationStatus
 from polar.order.repository import OrderRepository
 from polar.order.service import OrderService
 from polar.postgres import create_async_engine
@@ -80,7 +81,10 @@ def get_query() -> Select[tuple[Order]]:
         .join(Customer, Order.customer_id == Customer.id)
         .join(Organization, Customer.organization_id == Organization.id)
         .where(
-            or_(Organization.blocked_at.is_not(None), Organization.is_deleted.is_(True))
+            or_(
+                Organization.status == OrganizationStatus.BLOCKED,
+                Organization.is_deleted.is_(True),
+            )
         )
     )
 

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -29,6 +29,7 @@ from polar.models import (
 )
 from polar.models.checkout import CheckoutStatus
 from polar.models.discount import DiscountDuration, DiscountType
+from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncSession
 from polar.tax.calculation import TaxCalculationService
 from polar.tax.calculation.base import TaxabilityReason
@@ -109,7 +110,7 @@ async def create_blocked_product(
         save_fixture,
         account,
         name_prefix="blockedorg",
-        blocked_at=utc_now(),
+        status=OrganizationStatus.BLOCKED,
     )
     product = await create_product(
         save_fixture,
@@ -188,7 +189,7 @@ class TestGet:
         auth_subject: AuthSubject[User],
     ) -> None:
         product = await create_blocked_product(save_fixture, auth_subject)
-        product.organization.blocked_at = None
+        product.organization.status = OrganizationStatus.ACTIVE
         await save_fixture(product)
 
         checkout = await checkout_service.create(
@@ -203,7 +204,7 @@ class TestGet:
         assert response.status_code == 200
 
         session.expunge_all()
-        product.organization.blocked_at = utc_now()
+        product.organization.status = OrganizationStatus.BLOCKED
         await save_fixture(product)
 
         response = await client.get(f"{api_prefix}/{checkout.id}")
@@ -286,7 +287,7 @@ class TestCreateCheckout:
         )
         assert response.status_code == 403
 
-        product.organization.blocked_at = None
+        product.organization.status = OrganizationStatus.ACTIVE
         await save_fixture(product)
 
         response = await client.post(

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -6,8 +6,8 @@ from polar.auth.scope import Scope
 from polar.checkout.repository import CheckoutRepository
 from polar.checkout.service import CHECKOUT_CLIENT_SECRET_PREFIX
 from polar.enums import SubscriptionRecurringInterval
-from polar.kit.utils import utc_now
 from polar.models import Checkout, CheckoutLink, Product, User, UserOrganization
+from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -213,7 +213,7 @@ class TestRedirect:
             save_fixture,
             account,
             name_prefix="blockedorg",
-            blocked_at=utc_now(),
+            status=OrganizationStatus.BLOCKED,
         )
         product = await create_product(
             save_fixture,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -3507,7 +3507,7 @@ class TestTriggerPayment:
             status=OrderStatus.pending,
         )
 
-        organization.blocked_at = utc_now()
+        organization.status = OrganizationStatus.BLOCKED
         await save_fixture(organization)
 
         await order_service.trigger_payment(session, order, payment_method)

--- a/server/tests/organization_review/collectors/test_history.py
+++ b/server/tests/organization_review/collectors/test_history.py
@@ -116,7 +116,10 @@ class TestCollectHistoryData:
 
     def test_blocked_org_sets_has_blocked_orgs(self) -> None:
         user = _build_user()
-        org = _build_org(blocked_at=datetime(2024, 1, 1))
+        org = _build_org(
+            status=OrganizationStatus.BLOCKED,
+            blocked_at=datetime(2024, 1, 1),
+        )
 
         result = collect_history_data(user, [org])
 
@@ -140,12 +143,16 @@ class TestCollectHistoryData:
             slug="org-2",
             status=OrganizationStatus.DENIED,
             review=review2,
+        )
+        org3 = _build_org(
+            slug="org-3",
+            status=OrganizationStatus.BLOCKED,
             blocked_at=datetime(2024, 3, 1),
         )
 
-        result = collect_history_data(user, [org1, org2])
+        result = collect_history_data(user, [org1, org2, org3])
 
-        assert len(result.prior_organizations) == 2
+        assert len(result.prior_organizations) == 3
         assert result.prior_organizations[0].slug == "org-1"
         assert result.prior_organizations[0].review_verdict == "PASS"
         assert result.prior_organizations[1].slug == "org-2"


### PR DESCRIPTION
## Summary

- Migrates every blocked-organization **read check** from the legacy `blocked_at` timestamp to `OrganizationStatus.BLOCKED` enum across 16 files
- This is PR4 in the [blocked_at → status migration series](https://github.com/polarsource/polar/pull/11020) (PRs 1-3 already merged)
- Rollback safe: `blocked_at` is still dual-written by PR2, so reverting restores working read paths

## Changes

**Model** (`organization.py`):
- `can_authenticate` hybrid property: `blocked_at is None` → `status != BLOCKED`
- `is_blocked()`: `blocked_at is not None` → `status == BLOCKED`

**Repository** (`organization/repository.py`):
- All 5 query methods: `blocked_at.is_(None)` → `status != BLOCKED`

**Service** (`organization/service.py`):
- `get_anonymous`: filter swap
- `is_organization_ready_for_payment`: simplified `is_blocked() or status == DENIED` → `status in {BLOCKED, DENIED}`

**Other modules**:
- `checkout_link/repository.py`: replaced `is_deleted + not BLOCKED` pair with `can_authenticate` hybrid
- `customer_portal/service/organization.py`: same `can_authenticate` reuse
- `subscription/scheduler.py`: merged blocked+denied checks into `status.not_in()`
- `backoffice/detail_view.py`: uses `is_blocked()` method
- `organization_review/collectors/history.py`: status-based condition for `has_blocked_orgs`

**Scripts** (4 files): all `blocked_at` filters → status-based

**Tests** (4 files): fixtures use `status=OrganizationStatus.BLOCKED` instead of `blocked_at=utc_now()`

## What's NOT changed (intentionally)

- `blocked_at` column definition — removed in PR7
- Dual-write code (`block_organization()`) — removed in PR5
- Review schemas (`OrganizationData.blocked_at`, `PriorOrganization.blocked_at`) — changed in PR6
- `User.blocked_at` — separate concern, out of scope
- `Order.refunds_blocked_at` — unrelated mechanism

## Test plan

- [x] mypy passes on all 16 modified files
- [x] ruff lint passes
- [ ] CI tests pass
- [ ] After deploy, verify no drift: `SELECT count(*) FROM organizations WHERE (blocked_at IS NOT NULL AND status != 'blocked') OR (blocked_at IS NULL AND status = 'blocked');` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)