### PR TITLE
feat: add terminal OFFBOARDED organization status

### DIFF
--- a/server/polar/backoffice/components/_status_badge.py
+++ b/server/polar/backoffice/components/_status_badge.py
@@ -19,6 +19,7 @@ def status_badge(
     Generates a badge element with appropriate styling based on organization status.
     Uses DaisyUI badge classes with semantic color mapping:
     - REVIEW, OFFBOARDING: warning (yellow)
+    - BLOCKED, OFFBOARDED: error (red)
     - ACTIVE, SNOOZED, DENIED, CREATED: ghost (gray)
 
     Args:
@@ -62,6 +63,10 @@ def status_badge(
         OrganizationStatus.OFFBOARDING: {
             "class": "badge-warning",
             "aria": "offboarding status",
+        },
+        OrganizationStatus.OFFBOARDED: {
+            "class": "badge-error",
+            "aria": "offboarded status",
         },
     }
 

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -118,6 +118,8 @@ def organization_badge(organization: Organization) -> Generator[None]:
             or organization.status == OrganizationStatus.OFFBOARDING
         ):
             classes("badge-warning")
+        elif organization.status == OrganizationStatus.OFFBOARDED:
+            classes("badge-error")
         else:
             classes("badge-secondary")
         text(organization.status.get_display_name())

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -207,6 +207,8 @@ async def list_organizations(
         status_filter = OrganizationStatus.CREATED
     elif status == "offboarding":
         status_filter = OrganizationStatus.OFFBOARDING
+    elif status == "offboarded":
+        status_filter = OrganizationStatus.OFFBOARDED
     elif status == "review":
         status_filter = OrganizationStatus.REVIEW
     elif status == "snoozed":
@@ -229,12 +231,14 @@ async def list_organizations(
     if status_filter:
         stmt = stmt.where(Organization.status == status_filter)
     elif not q:
-        # By default, exclude denied and blocked organizations (but not when searching)
+        # By default, exclude terminal statuses (denied, blocked, offboarded)
+        # from the list (but not when searching).
         stmt = stmt.where(
             Organization.status.notin_(
                 [
                     OrganizationStatus.DENIED,
                     OrganizationStatus.BLOCKED,
+                    OrganizationStatus.OFFBOARDED,
                 ]
             )
         )
@@ -1788,6 +1792,12 @@ async def offboard_dialog(
                         text("Change the organization status to Offboarding")
                     with tag.li():
                         text("Block payouts while the organization is offboarding")
+                    with tag.li():
+                        text(
+                            "Automatically move the organization to Offboarded "
+                            "after 120 days, a terminal state that allows "
+                            "payouts but blocks new payments and refunds"
+                        )
 
             with tag.div(classes="form-control"):
                 with tag.label(classes="label"):

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -231,16 +231,9 @@ async def list_organizations(
     if status_filter:
         stmt = stmt.where(Organization.status == status_filter)
     elif not q:
-        # By default, exclude terminal statuses (denied, blocked, offboarded)
-        # from the list (but not when searching).
+        # Hide terminal statuses from the default list (not when searching).
         stmt = stmt.where(
-            Organization.status.notin_(
-                [
-                    OrganizationStatus.DENIED,
-                    OrganizationStatus.BLOCKED,
-                    OrganizationStatus.OFFBOARDED,
-                ]
-            )
+            Organization.status.notin_(OrganizationStatus.terminal_statuses())
         )
 
     if q:

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -319,6 +319,13 @@ class OrganizationListView:
                 count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
                 badge_variant="warning",
             ),
+            Tab(
+                label="Offboarded",
+                url=str(request.url_for("organizations:list")) + "?status=offboarded",
+                active=status_filter == OrganizationStatus.OFFBOARDED,
+                count=status_counts.get(OrganizationStatus.OFFBOARDED, 0),
+                badge_variant="error",
+            ),
         ]
 
         with tab_nav(tabs):

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -199,6 +199,7 @@ class OrganizationStatus(StrEnum):
     ACTIVE = "active"
     BLOCKED = "blocked"
     OFFBOARDING = "offboarding"
+    OFFBOARDED = "offboarded"
 
     def get_display_name(self) -> str:
         return {
@@ -209,6 +210,7 @@ class OrganizationStatus(StrEnum):
             OrganizationStatus.ACTIVE: "Active",
             OrganizationStatus.BLOCKED: "Blocked",
             OrganizationStatus.OFFBOARDING: "Offboarding",
+            OrganizationStatus.OFFBOARDED: "Offboarded",
         }[self]
 
     @classmethod
@@ -221,7 +223,11 @@ class OrganizationStatus(StrEnum):
 
     @classmethod
     def payout_ready_statuses(cls) -> set[Self]:
-        return {cls.ACTIVE}  # pyright: ignore
+        return {cls.ACTIVE, cls.OFFBOARDED}  # pyright: ignore
+
+    @classmethod
+    def terminal_statuses(cls) -> set[Self]:
+        return {cls.DENIED, cls.BLOCKED, cls.OFFBOARDED}  # pyright: ignore
 
 
 class Organization(RateLimitGroupMixin, RecordModel):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1016,11 +1016,11 @@ class OrderService:
         organization = order.organization
         if (
             organization.is_blocked()
-            or organization.status == OrganizationStatus.DENIED
-            or organization.status == OrganizationStatus.OFFBOARDED
+            or organization.status in OrganizationStatus.terminal_statuses()
         ):
             log.info(
-                "Organization is blocked, denied or offboarded, skipping payment",
+                "Organization is blocked or in a terminal status, "
+                "skipping payment",
                 order_id=order.id,
                 organization_id=organization.id,
                 organization_status=organization.status,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1017,9 +1017,10 @@ class OrderService:
         if (
             organization.is_blocked()
             or organization.status == OrganizationStatus.DENIED
+            or organization.status == OrganizationStatus.OFFBOARDED
         ):
             log.info(
-                "Organization is blocked or denied, skipping payment",
+                "Organization is blocked, denied or offboarded, skipping payment",
                 order_id=order.id,
                 organization_id=organization.id,
                 organization_status=organization.status,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1019,8 +1019,7 @@ class OrderService:
             or organization.status in OrganizationStatus.terminal_statuses()
         ):
             log.info(
-                "Organization is blocked or in a terminal status, "
-                "skipping payment",
+                "Organization is blocked or in a terminal status, skipping payment",
                 order_id=order.id,
                 organization_id=organization.id,
                 organization_status=organization.status,

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -304,6 +304,7 @@ class LegacyOrganizationStatus(StrEnum):
             OrganizationStatus.ACTIVE: LegacyOrganizationStatus.ACTIVE,
             OrganizationStatus.BLOCKED: LegacyOrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING: LegacyOrganizationStatus.ACTIVE,
+            OrganizationStatus.OFFBOARDED: LegacyOrganizationStatus.DENIED,
         }
         try:
             return mapping[status]

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -985,8 +985,7 @@ class OrganizationService:
                 "Only offboarding organizations can be set to offboarded.",
                 403,
             )
-        organization.status = OrganizationStatus.OFFBOARDED
-        organization.status_updated_at = datetime.now(UTC)
+        organization.set_status(OrganizationStatus.OFFBOARDED)
         _append_internal_note(
             organization,
             "Organization automatically moved to offboarded after "
@@ -1043,13 +1042,11 @@ class OrganizationService:
         if settings.ENV == Environment.sandbox:
             return True
 
-        # First check basic conditions that don't require account data.
-        # OFFBOARDED is a terminal state that blocks all new payments, even
-        # for grandfathered organizations.
+        # Terminal statuses block all new payments, even for grandfathered
+        # organizations.
         if (
             organization.is_blocked()
-            or organization.status == OrganizationStatus.DENIED
-            or organization.status == OrganizationStatus.OFFBOARDED
+            or organization.status in OrganizationStatus.terminal_statuses()
         ):
             return False
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -997,7 +997,7 @@ class OrganizationService:
     async def transition_expired_offboarding_organizations(
         self,
         session: AsyncSession,
-    ) -> list[Organization]:
+    ) -> Sequence[Organization]:
         """
         Move organizations from OFFBOARDING to OFFBOARDED once they have
         spent the retention period in the offboarding state.
@@ -1011,11 +1011,9 @@ class OrganizationService:
         )
         organizations = await repository.get_all(statement)
 
-        transitioned: list[Organization] = []
         for organization in organizations:
             await self.set_organization_offboarded(session, organization)
-            transitioned.append(organization)
-        return transitioned
+        return organizations
 
     async def get_payment_status(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -68,6 +68,7 @@ log = structlog.get_logger()
 
 _MIN_REVIEW_THRESHOLD = 10_000
 SNOOZE_GRACE_PERIOD = timedelta(hours=24)
+OFFBOARDING_RETENTION_PERIOD = timedelta(days=120)
 
 
 def _append_internal_note(
@@ -967,6 +968,56 @@ class OrganizationService:
         session.add(organization)
         return organization
 
+    async def set_organization_offboarded(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> Organization:
+        """
+        Move an offboarding organization to the terminal OFFBOARDED state.
+
+        The OFFBOARDED state allows payouts (so merchants can retrieve any
+        remaining balance) but blocks new payments and refunds. It is
+        terminal — organizations cannot leave it.
+        """
+        if organization.status != OrganizationStatus.OFFBOARDING:
+            raise OrganizationError(
+                "Only offboarding organizations can be set to offboarded.",
+                403,
+            )
+        organization.status = OrganizationStatus.OFFBOARDED
+        organization.status_updated_at = datetime.now(UTC)
+        _append_internal_note(
+            organization,
+            "Organization automatically moved to offboarded after "
+            f"{OFFBOARDING_RETENTION_PERIOD.days} days.",
+        )
+        session.add(organization)
+        return organization
+
+    async def transition_expired_offboarding_organizations(
+        self,
+        session: AsyncSession,
+    ) -> list[Organization]:
+        """
+        Move organizations from OFFBOARDING to OFFBOARDED once they have
+        spent the retention period in the offboarding state.
+        """
+        threshold = datetime.now(UTC) - OFFBOARDING_RETENTION_PERIOD
+        repository = OrganizationRepository.from_session(session)
+        statement = repository.get_base_statement().where(
+            Organization.status == OrganizationStatus.OFFBOARDING,
+            Organization.status_updated_at.is_not(None),
+            Organization.status_updated_at <= threshold,
+        )
+        organizations = await repository.get_all(statement)
+
+        transitioned: list[Organization] = []
+        for organization in organizations:
+            await self.set_organization_offboarded(session, organization)
+            transitioned.append(organization)
+        return transitioned
+
     async def get_payment_status(
         self,
         session: AsyncReadSession,
@@ -992,10 +1043,13 @@ class OrganizationService:
         if settings.ENV == Environment.sandbox:
             return True
 
-        # First check basic conditions that don't require account data
+        # First check basic conditions that don't require account data.
+        # OFFBOARDED is a terminal state that blocks all new payments, even
+        # for grandfathered organizations.
         if (
             organization.is_blocked()
             or organization.status == OrganizationStatus.DENIED
+            or organization.status == OrganizationStatus.OFFBOARDED
         ):
             return False
 

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -22,9 +22,16 @@ from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
-from polar.worker import AsyncSessionMaker, TaskPriority, actor, enqueue_job
+from polar.worker import (
+    AsyncSessionMaker,
+    CronTrigger,
+    TaskPriority,
+    actor,
+    enqueue_job,
+)
 
 from .repository import OrganizationRepository
+from .service import organization as organization_service
 
 log = structlog.get_logger()
 
@@ -169,6 +176,31 @@ async def organization_deletion_requested(
         await plain_service.create_organization_deletion_thread(
             session, organization, user, blocked_reasons
         )
+
+
+@actor(
+    actor_name="organization.transition_offboarding_to_offboarded",
+    cron_trigger=CronTrigger(hour=0, minute=0),
+    priority=TaskPriority.LOW,
+    max_retries=0,
+)
+async def transition_offboarding_to_offboarded() -> None:
+    """
+    Move organizations that have been OFFBOARDING for longer than the
+    retention period (120 days) to the terminal OFFBOARDED status.
+    """
+    async with AsyncSessionMaker() as session:
+        transitioned = (
+            await organization_service.transition_expired_offboarding_organizations(
+                session
+            )
+        )
+        if transitioned:
+            log.info(
+                "organization.transition_offboarding_to_offboarded",
+                count=len(transitioned),
+                organization_ids=[str(o.id) for o in transitioned],
+            )
 
 
 @actor(

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -199,7 +199,7 @@ async def transition_offboarding_to_offboarded() -> None:
             log.info(
                 "organization.transition_offboarding_to_offboarded",
                 count=len(transitioned),
-                organization_ids=[str(o.id) for o in transitioned],
+                organization_ids=[str(o.id) for o in transitioned[:20]],
             )
 
 

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -31,6 +31,7 @@ from polar.models import (
 )
 from polar.models.dispute import DisputeAlertProcessor
 from polar.models.order import RefundAmountTooHigh
+from polar.models.organization import OrganizationStatus
 from polar.models.refund import Refund, RefundFailureReason, RefundReason, RefundStatus
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.order.repository import OrderRepository
@@ -206,8 +207,14 @@ class RefundService:
     ) -> Refund:
         repository = RefundRepository.from_session(session)
 
-        # Check if refunds are blocked at order level or organization level
-        if order.refunds_blocked or order.organization.refunds_blocked:
+        # Check if refunds are blocked at order level or organization level.
+        # Refunds are also blocked once an organization reaches the terminal
+        # OFFBOARDED state.
+        if (
+            order.refunds_blocked
+            or order.organization.refunds_blocked
+            or order.organization.status == OrganizationStatus.OFFBOARDED
+        ):
             raise RefundsBlocked(order)
 
         if order.refunded:

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -207,9 +207,6 @@ class RefundService:
     ) -> Refund:
         repository = RefundRepository.from_session(session)
 
-        # Check if refunds are blocked at order level or organization level.
-        # Refunds are also blocked once an organization reaches the terminal
-        # OFFBOARDED state.
         if (
             order.refunds_blocked
             or order.organization.refunds_blocked

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -126,7 +126,12 @@ class SubscriptionJobStore(BaseJobStore):
                 Customer.is_deleted.is_(False),
                 Organization.is_deleted.is_(False),
                 Organization.blocked_at.is_(None),
-                Organization.status != OrganizationStatus.DENIED,
+                Organization.status.notin_(
+                    [
+                        OrganizationStatus.DENIED,
+                        OrganizationStatus.OFFBOARDED,
+                    ]
+                ),
                 Subscription.scheduler_locked_at.is_(None),
                 Subscription.active.is_(True),
                 Subscription.current_period_end.is_not(None),

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -126,12 +126,7 @@ class SubscriptionJobStore(BaseJobStore):
                 Customer.is_deleted.is_(False),
                 Organization.is_deleted.is_(False),
                 Organization.blocked_at.is_(None),
-                Organization.status.notin_(
-                    [
-                        OrganizationStatus.DENIED,
-                        OrganizationStatus.OFFBOARDED,
-                    ]
-                ),
+                Organization.status.notin_(OrganizationStatus.terminal_statuses()),
                 Subscription.scheduler_locked_at.is_(None),
                 Subscription.active.is_(True),
                 Subscription.current_period_end.is_not(None),

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -2037,7 +2037,6 @@ class TestTransitionExpiredOffboardingOrganizations:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
-        # Organization offboarded just a moment ago — should NOT transition.
         organization.status = OrganizationStatus.OFFBOARDING
         organization.status_updated_at = datetime.now(UTC) - timedelta(days=10)
         await save_fixture(organization)
@@ -2056,7 +2055,6 @@ class TestTransitionExpiredOffboardingOrganizations:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
-        # Organization offboarding for longer than the retention period.
         organization.status = OrganizationStatus.OFFBOARDING
         organization.status_updated_at = datetime.now(UTC) - timedelta(days=121)
         await save_fixture(organization)
@@ -2216,8 +2214,8 @@ class TestOffboardingPaymentReady:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
-        """Offboarded organizations must no longer accept payments."""
-        # Even grandfathered organizations must be blocked from new payments.
+        """Offboarded organizations must no longer accept payments, even when
+        grandfathered."""
         organization.created_at = datetime(2025, 8, 4, 8, 0, tzinfo=UTC)
         organization.status = OrganizationStatus.OFFBOARDED
         await save_fixture(organization)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1989,6 +1989,107 @@ class TestReactivateOrganization:
 
 
 @pytest.mark.asyncio
+class TestSetOrganizationOffboarded:
+    async def test_from_offboarding(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+
+        result = await organization_service.set_organization_offboarded(
+            session, organization
+        )
+
+        assert result.status == OrganizationStatus.OFFBOARDED
+        assert result.status_updated_at is not None
+        assert result.internal_notes is not None
+        assert "offboarded" in result.internal_notes.lower()
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.OFFBOARDED,
+        ],
+    )
+    async def test_from_non_offboarding_raises(
+        self,
+        status: OrganizationStatus,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = status
+
+        with pytest.raises(Exception, match="Only offboarding organizations"):
+            await organization_service.set_organization_offboarded(
+                session, organization
+            )
+
+
+@pytest.mark.asyncio
+class TestTransitionExpiredOffboardingOrganizations:
+    async def test_transitions_only_expired(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        # Organization offboarded just a moment ago — should NOT transition.
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.status_updated_at = datetime.now(UTC) - timedelta(days=10)
+        await save_fixture(organization)
+
+        result = (
+            await organization_service.transition_expired_offboarding_organizations(
+                session
+            )
+        )
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+    async def test_transitions_when_retention_period_elapsed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        # Organization offboarding for longer than the retention period.
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.status_updated_at = datetime.now(UTC) - timedelta(days=121)
+        await save_fixture(organization)
+
+        result = (
+            await organization_service.transition_expired_offboarding_organizations(
+                session
+            )
+        )
+        assert len(result) == 1
+        assert result[0].id == organization.id
+        assert result[0].status == OrganizationStatus.OFFBOARDED
+
+    async def test_ignores_non_offboarding_statuses(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.ACTIVE
+        organization.status_updated_at = datetime.now(UTC) - timedelta(days=200)
+        await save_fixture(organization)
+
+        result = (
+            await organization_service.transition_expired_offboarding_organizations(
+                session
+            )
+        )
+        assert result == []
+        assert organization.status == OrganizationStatus.ACTIVE
+
+
+@pytest.mark.asyncio
 class TestSnoozeOrganization:
     async def test_from_review(
         self,
@@ -2108,6 +2209,24 @@ class TestOffboardingPaymentReady:
         )
 
         assert result is True
+
+    async def test_offboarded_blocks_payments(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Offboarded organizations must no longer accept payments."""
+        # Even grandfathered organizations must be blocked from new payments.
+        organization.created_at = datetime(2025, 8, 4, 8, 0, tzinfo=UTC)
+        organization.status = OrganizationStatus.OFFBOARDED
+        await save_fixture(organization)
+
+        result = await organization_service.is_organization_ready_for_payment(
+            session, organization
+        )
+
+        assert result is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -202,6 +202,40 @@ class TestCreate:
 
         payout_transaction_service_mock.create.assert_called_once()
 
+    async def test_valid_offboarded(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        user: User,
+        account: Account,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        """Offboarded organizations must still be able to receive payouts."""
+        organization.status = OrganizationStatus.OFFBOARDED
+        await save_fixture(organization)
+
+        payout_account = await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction_1 = await create_payment_transaction(save_fixture)
+        balance_transaction_1 = await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction_1
+        )
+
+        payment_transaction_2 = await create_payment_transaction(save_fixture)
+        balance_transaction_2 = await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction_2
+        )
+
+        payout_transaction_service_mock.create.return_value = Transaction()
+
+        payout = await payout_service.create(session, locker, organization)
+
+        assert payout.account == account
+        assert payout.payout_account == payout_account
+        payout_transaction_service_mock.create.assert_called_once()
+
     async def test_valid_different_currencies(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -923,6 +923,43 @@ class TestOrganizationRefundsBlocked:
 
         assert exc_info.value.order.id == order.id
 
+    async def test_create_refund_blocked_when_organization_offboarded(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """Refunds must be blocked for organizations in the OFFBOARDED status."""
+        from polar.models.organization import OrganizationStatus
+        from polar.organization.repository import OrganizationRepository
+
+        org_repository = OrganizationRepository.from_session(session)
+        organization = await org_repository.update(
+            organization, update_dict={"status": OrganizationStatus.OFFBOARDED}
+        )
+
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.paid,
+        )
+
+        create_schema = RefundCreate(
+            order_id=order.id,
+            amount=100,
+            reason=RefundReason.customer_request,
+        )
+
+        from polar.refund.service import RefundsBlocked
+
+        with pytest.raises(RefundsBlocked) as exc_info:
+            await refund_service.create(session, order, create_schema)
+
+        assert exc_info.value.order.id == order.id
+
     async def test_create_refund_allowed_when_organization_not_blocked(
         self,
         session: AsyncSession,


### PR DESCRIPTION
Introduce a new OrganizationStatus.OFFBOARDED terminal state that
organizations automatically reach 120 days after entering OFFBOARDING.
OFFBOARDED allows payouts (so merchants can retrieve remaining balance)
but blocks new payments and refunds.

Adds a daily scheduled task that moves eligible organizations from
OFFBOARDING to OFFBOARDED, updates payment/payout helpers, the refund
service, the subscription billing scheduler, and the backoffice status
badge / list view / dialog. Tests cover the transition, payout
eligibility, and the refund + payment blocks.

https://claude.ai/code/session_01WkMzyyd3dREc4KegxpCuvx