### PR TITLE
fix(org): unblock Customer Portal settings toggles for legacy orgs

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -147,7 +147,7 @@ class CustomerPortalSubscriptionSettings(TypedDict):
 
 
 class CustomerPortalCustomerSettings(TypedDict):
-    allow_email_change: bool
+    allow_email_change: NotRequired[bool]
 
 
 class OrganizationCustomerPortalSettings(TypedDict):

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -262,6 +262,92 @@ class TestUpdateOrganization:
 
         assert response.status_code == 422
 
+    @pytest.mark.auth
+    async def test_update_customer_portal_settings_without_customer_key(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Regression test: orgs created before `customer.allow_email_change`
+        # was added have no "customer" key in customer_portal_settings.
+        # The frontend form sends the full settings on any toggle without
+        # necessarily providing a "customer" value, which previously failed
+        # validation with a 422.
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "customer_portal_settings": {
+                    "usage": {"show": True},
+                    "subscription": {
+                        "update_seats": False,
+                        "update_plan": True,
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        settings = response.json()["customer_portal_settings"]
+        assert settings["subscription"]["update_seats"] is False
+        assert settings["subscription"]["update_plan"] is True
+
+    @pytest.mark.auth
+    async def test_update_customer_portal_settings_with_empty_customer(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Regression test: react-hook-form registers the
+        # `customer.allow_email_change` field but existing orgs have no
+        # value, so the form serializes `customer: {}` (undefined stripped
+        # by JSON). allow_email_change must be NotRequired so this validates.
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "customer_portal_settings": {
+                    "usage": {"show": True},
+                    "subscription": {
+                        "update_seats": False,
+                        "update_plan": True,
+                    },
+                    "customer": {},
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.json()["customer_portal_settings"]["subscription"]["update_seats"]
+            is False
+        )
+
+    @pytest.mark.auth
+    async def test_update_customer_portal_settings_with_full_customer(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "customer_portal_settings": {
+                    "usage": {"show": True},
+                    "subscription": {
+                        "update_seats": True,
+                        "update_plan": True,
+                    },
+                    "customer": {"allow_email_change": True},
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        settings = response.json()["customer_portal_settings"]
+        assert settings["customer"]["allow_email_change"] is True
+
 
 @pytest.mark.asyncio
 class TestInviteOrganization:


### PR DESCRIPTION
## 📋 Summary

Fixes a 422 that blocked every Customer Portal settings toggle (including *Enable subscription seat management*) for organizations created before polarsource/polar#10678.

## 🎯 What

- Make `CustomerPortalCustomerSettings.allow_email_change` a `NotRequired[bool]` in the TypedDict
- Add regression tests for PATCH `/v1/organizations/{id}` with partial `customer_portal_settings` payloads

## 🤔 Why

polarsource/polar#10678 added the `customer.allow_email_change` field to `customer_portal_settings` JSONB but did not include a data migration. Legacy orgs' JSONB has no `customer` key.

On the settings page, `<FormField name="customer.allow_email_change">` registers the path with react-hook-form, but with no initial value. Toggling any *other* switch triggers auto-save; `form.getValues()` includes `customer: { allow_email_change: undefined }`; JSON serialization drops `undefined` → the body sends `customer: {}`; Pydantic rejects with `Field required`.

Logfire shows ~14k failed `PATCH /v1/organizations/{id}` in 7 days across 18 orgs (sandbox + production), driven by auto-save retrying once a second.

## 🔧 How

The read paths already tolerate a missing key — `customer_email_update.py` uses `.get("allow_email_change", False)`, and the storage default is `False`. Making the TypedDict field `NotRequired` aligns the write-path validation with the existing defensive reads, so every caller (UI + API/SDK) stops hitting the 422. No data migration needed: legacy rows keep working unchanged.

I considered a frontend-only fix (merging defaults into `useForm`'s `defaultValues`). Rejected it because it only patches the UI — raw API/SDK callers still fail — and it would codify the backend's default inside the React component.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend)
- [x] I have added new tests for new functionality

### Test Instructions

```bash
cd server
uv run pytest tests/organization/test_endpoints.py::TestUpdateOrganization -v
```

Three new regression tests in `TestUpdateOrganization`:
- `test_update_customer_portal_settings_without_customer_key` — omitting `customer` entirely (legacy shape) succeeds
- `test_update_customer_portal_settings_with_empty_customer` — sending `customer: {}` (the actual rhf-serialized payload) succeeds
- `test_update_customer_portal_settings_with_full_customer` — sending the full object continues to work

Verified: `test_update_customer_portal_settings_with_empty_customer` fails when `allow_email_change` is reverted to a required `bool`.

## 📝 Additional Notes

- No data migration required: read paths already default missing keys to `False`
- Affected org in sandbox that reported this: `4937cd90-5d94-4586-9e3c-c1b5d7d5b8fa` (8.6k failed PATCHes in the last 7 days alone)

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: I used AI assistance; the fix and tests were executed and verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)