### PR TITLE
fix(customer_seat): don't create individual customer on email-only seat assignment when member_model_enabled

### DIFF
--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -306,7 +306,11 @@ class SeatService:
         organization_repository = OrganizationRepository.from_session(session)
         organization = await organization_repository.get_by_id(organization_id)
 
-        if external_member_id or member_id:
+        member_model_enabled = (
+            organization is not None and organization.is_member_model_enabled
+        )
+
+        if member_model_enabled or external_member_id or member_id:
             target = await self._resolve_member_model_target(
                 session,
                 repository,
@@ -490,9 +494,7 @@ class SeatService:
         # Both paths use seat.customer_id, but it points to different customers:
         # - member_model: billing customer (purchaser)
         # - legacy: seat member's customer
-        member_model_enabled = organization.feature_settings.get(
-            "member_model_enabled", False
-        )
+        member_model_enabled = organization.is_member_model_enabled
 
         if member_model_enabled:
             # Load billing customer for session
@@ -596,9 +598,7 @@ class SeatService:
         await self.check_seat_feature_enabled(session, organization_id)
 
         # Check feature flag
-        member_model_enabled = organization.feature_settings.get(
-            "member_model_enabled", False
-        )
+        member_model_enabled = organization.is_member_model_enabled
 
         # Capture customer_id and member_id before clearing to avoid race condition
         original_customer_id = seat.customer_id

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -387,6 +387,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
         JSONB, nullable=False, default=dict
     )
 
+    @property
+    def is_member_model_enabled(self) -> bool:
+        return self.feature_settings.get("member_model_enabled", False)
+
     #
     # Currency and tax settings
     #

--- a/server/tests/customer_seat/test_service.py
+++ b/server/tests/customer_seat/test_service.py
@@ -695,6 +695,66 @@ class TestAssignSeat:
         assert seat.member.organization_id == organization.id
 
     @pytest.mark.asyncio
+    async def test_assign_seat_with_email_only_member_model_enabled_does_not_create_customer(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Regression test: when member_model_enabled=True and only an email is
+        provided, no individual Customer should be created for the seat holder.
+        The seat holder is represented as a Member under the billing customer.
+        """
+        from polar.customer.repository import CustomerRepository
+
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "seat_based_pricing_enabled": True,
+                "member_model_enabled": True,
+            },
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        billing_customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="billing@example.com",
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture, product=product, customer=billing_customer, seats=5
+        )
+
+        with patch("polar.customer_seat.service.send_seat_invitation_email"):
+            seat = await seat_service.assign_seat(
+                session, subscription, email="seat@example.com"
+            )
+
+        # Seat is linked to the billing customer via a Member — not a new
+        # individual Customer.
+        assert seat.customer_id == billing_customer.id
+        assert seat.email == "seat@example.com"
+        assert seat.member_id is not None
+
+        await session.refresh(seat, ["member"])
+        assert seat.member is not None
+        assert seat.member.customer_id == billing_customer.id
+        assert seat.member.email == "seat@example.com"
+
+        customer_repository = CustomerRepository.from_session(session)
+        assert (
+            await customer_repository.get_by_email_and_organization(
+                "seat@example.com", organization.id
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
     async def test_assign_seat_without_member_model_enabled(
         self,
         session: AsyncSession,
@@ -764,7 +824,9 @@ class TestAssignSeat:
         assert seat is not None
         assert seat.email == "seat@example.com"
         assert seat.member_id is not None
-        assert seat.customer_id == seat_customer.id
+        # When member_model_enabled=True, customer_id on the seat is the billing
+        # customer and the seat holder is represented as a Member.
+        assert seat.customer_id == billing_customer.id
 
     @pytest.mark.asyncio
     async def test_assign_seat_with_external_customer_id_backward_compat(
@@ -810,7 +872,9 @@ class TestAssignSeat:
         assert seat is not None
         assert seat.email == "ext-seat@example.com"
         assert seat.member_id is not None
-        assert seat.customer_id == seat_customer.id
+        # When member_model_enabled=True, customer_id on the seat is the billing
+        # customer and the seat holder is represented as a Member.
+        assert seat.customer_id == billing_customer.id
 
     @pytest.mark.asyncio
     async def test_assign_seat_customer_id_not_found_member_model(
@@ -843,7 +907,7 @@ class TestAssignSeat:
             save_fixture, product=product, customer=billing_customer, seats=5
         )
 
-        with pytest.raises(CustomerNotFound):
+        with pytest.raises(InvalidSeatAssignmentRequest):
             await seat_service.assign_seat(
                 session, subscription, customer_id=uuid.uuid4()
             )


### PR DESCRIPTION
## 📋 Summary

Fixes a bug reported on sandbox: when an organization has both \`seat_based_pricing_enabled\` and \`member_model_enabled\` turned on, calling \`assign_seat\` with only an \`email\` was also creating a second \`Customer\` row (type=\`individual\`) for the seat holder, alongside the existing \`team\` billing customer.

## 🎯 What

- Branch \`assign_seat\` on the organization's \`member_model_enabled\` flag instead of on which fields the caller happened to pass.
- Extract \`Organization.is_member_model_enabled\` property and replace the three duplicated \`feature_settings.get("member_model_enabled", False)\` reads inside \`customer_seat/service.py\` (\`assign_seat\`, \`claim_seat\`, \`revoke_seat\`).
- Update two "backward_compat" tests that asserted the buggy behaviour, and update one error-type assertion that shifted from \`CustomerNotFound\` to \`InvalidSeatAssignmentRequest\` now that the member-model resolver handles the \`customer_id\`-not-found case.
- Add a regression test: \`test_assign_seat_with_email_only_member_model_enabled_does_not_create_customer\`.

## 🤔 Why

Previously the branching was:

\`\`\`python
if external_member_id or member_id:
    target = await self._resolve_member_model_target(...)
else:
    target = await self._resolve_legacy_target(...)
\`\`\`

So an email-only assignment against a member-model org still went down the legacy path, which calls \`_find_or_create_customer\` → creates a new \`Customer\` with the default \`type=individual\`. With \`member_model_enabled=True\`, a seat holder should be represented as a \`Member\` under the billing customer, not as a separate customer.

## 🔧 How

\`\`\`python
member_model_enabled = (
    organization is not None and organization.is_member_model_enabled
)

if member_model_enabled or external_member_id or member_id:
    target = await self._resolve_member_model_target(...)
else:
    target = await self._resolve_legacy_target(...)
\`\`\`

\`_resolve_member_model_target\` already handles all input shapes (\`email\`, \`customer_id\`, \`external_customer_id\`, \`external_member_id\`, \`member_id\`) including the backward-compat \`customer_id\`→email resolution, so no additional logic was needed.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (\`uv run pytest tests/customer_seat/\` → 157 passed)
- [x] I have added new tests for new functionality
- [ ] I have run linting and type checking

### Test Instructions

1. \`cd server && uv run pytest tests/customer_seat/ -q\`
2. Specifically verify the regression test:
   \`uv run pytest tests/customer_seat/test_service.py::TestAssignSeat::test_assign_seat_with_email_only_member_model_enabled_does_not_create_customer -v\`

## 📝 Additional Notes

Out of scope but noticed during review (leaving for a follow-up):

- \`assign_seat\` loads the organization twice (once inside \`check_seat_feature_enabled\` and once via \`OrganizationRepository.get_by_id\`). Not introduced here.
- The \`or external_member_id or member_id\` disjunct lets a caller opt into the member-model resolver even when the org has the flag off. Kept for now to minimise behaviour change in this PR; worth revisiting once the rollout is complete.
- \`_resolve_member_model_target\` / \`_resolve_legacy_target\` take 10 positional arguments — candidate for a small request dataclass later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)