### PR TITLE
feat: Stop dual-writing blocked_at when blocking organizations (PR5)

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1353,9 +1353,6 @@ async def unblock_approve_dialog(
                 reason=override_reason,
             )
 
-            # Unblock the organization (set blocked_at to None)
-            organization.blocked_at = None
-
             # Approve the organization
             await organization_service.confirm_organization_reviewed(
                 session, organization, threshold

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -328,7 +328,8 @@ class Organization(RateLimitGroupMixin, RecordModel):
         TIMESTAMP(timezone=True), nullable=True, default=None
     )
 
-    # Time of blocking traffic/activity to given organization
+    # DEPRECATED: Use `status == OrganizationStatus.BLOCKED` instead.
+    # This column is no longer written to and will be dropped in a future migration.
     blocked_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True),
         nullable=True,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -771,8 +771,7 @@ class OrganizationService:
         session: AsyncSession,
         organization: Organization,
     ) -> Organization:
-        """Block an organization, dual-writing blocked_at and status during migration."""
-        organization.blocked_at = datetime.now(UTC)
+        """Block an organization by setting status to BLOCKED."""
         organization.set_status(OrganizationStatus.BLOCKED)
         session.add(organization)
         return organization


### PR DESCRIPTION
## Summary

Part 5 of 7 in the migration from `blocked_at` timestamp to `OrganizationStatus.BLOCKED` enum.

PR4 (#11025) switched every read path from `blocked_at` to `status == OrganizationStatus.BLOCKED`, so the timestamp column is no longer read anywhere in the codebase. This PR stops writing to it:

- `block_organization()` no longer sets `blocked_at = datetime.now(UTC)` — only sets `status = BLOCKED`
- Unblock/approve flow in `backoffice/organizations_v2/endpoints.py` no longer clears `blocked_at = None` — `confirm_organization_reviewed()` already sets `status = ACTIVE`
- `blocked_at` column marked as `# DEPRECATED` in the model with a note pointing readers to `OrganizationStatus.BLOCKED`

The column remains in the database schema for rollback safety. It will be dropped in PR7 after a 1–2 week production soak.

## Context

This is the 5th step in the 7-PR migration plan:

| PR | Description | Status |
|----|-------------|--------|
| 1  | Add `BLOCKED` enum value | Merged (#11020) |
| 2  | Dual-write `blocked_at` + `status` | Merged (#11022) |
| 3  | Backfill migration | Merged (#11023) |
| 4  | Switch all reads to `status`-based | Merged (#11025) |
| 5  | **Stop dual-writing `blocked_at`** | **This PR** |
| 6  | Clean up review system schemas | — |
| 7  | Drop `blocked_at` column | — |

## Risk & Rollback

**Low risk.** All read paths were switched in PR4 and have been running in production against a backfilled, dual-written column. Stopping the write only affects the now-unused column.

**Rollback**: If PR4 needs to be reverted while PR5 is deployed, new blocks would not populate `blocked_at`, breaking the reverted read paths. Hence the 2–3 day soak between PR4 and PR5 before rolling out.

## Test plan

- [ ] Block an organization from the backoffice — verify `status = BLOCKED` and the organization is denied access
- [ ] Unblock + approve from the backoffice — verify `status = ACTIVE`
- [ ] Existing tests in `tests/checkout/`, `tests/checkout_link/`, `tests/order/`, `tests/organization_review/` still pass (they were updated in PR4 to use `status=BLOCKED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)