### PR TITLE
polar: Skip team customer email and bypass schema DNS validation in backfill

### DIFF
--- a/server/scripts/backfill_polar_self_customers.py
+++ b/server/scripts/backfill_polar_self_customers.py
@@ -14,6 +14,7 @@ from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.customer.schemas.customer import CustomerTeamCreate
 from polar.customer.service import customer as customer_service
+from polar.exceptions import PolarRequestValidationError
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.member.schemas import MemberOwnerCreate
 from polar.member.service import member_service
@@ -38,6 +39,7 @@ class BackfillResult:
     members_created: int = 0
     subscriptions_created: int = 0
     skipped_no_members: int = 0
+    skipped_validation: int = 0
     errors: int = 0
     error_details: list[tuple[str, str, str]] = field(default_factory=list)
 
@@ -114,12 +116,12 @@ async def _backfill_organization(
 
     customer = await customer_service.create(
         session,
-        CustomerTeamCreate(
+        CustomerTeamCreate.model_construct(
             type="team",
-            email=owner.email,
+            email=None,
             name=organization.name,
             external_id=str(organization.id),
-            owner=MemberOwnerCreate(
+            owner=MemberOwnerCreate.model_construct(
                 email=owner.email,
                 name=owner.public_name,
                 external_id=str(owner.id),
@@ -231,6 +233,8 @@ async def run_backfill(
                         organization=organization,
                         members=members,
                     )
+            except PolarRequestValidationError:
+                result.skipped_validation += 1
             except Exception:
                 result.errors += 1
                 result.error_details.append(
@@ -297,6 +301,7 @@ async def backfill(
             f"{result.members_created} members, "
             f"{result.subscriptions_created} subscriptions, "
             f"{result.skipped_no_members} skipped (no members), "
+            f"{result.skipped_validation} skipped (validation conflict), "
             f"{result.errors} errors"
         )
         if result.error_details:

--- a/server/tests/scripts/test_backfill_polar_self_customers.py
+++ b/server/tests/scripts/test_backfill_polar_self_customers.py
@@ -10,6 +10,7 @@ from polar.models import (
     Member,
     Organization,
     Subscription,
+    User,
     UserOrganization,
 )
 from polar.worker._enqueue import _job_queue_manager
@@ -192,18 +193,17 @@ class TestBackfillPolarSelfCustomers:
         self_org = await _setup_self_org(save_fixture, account, monkeypatch)
 
         failing_org = await create_organization(save_fixture, account_second)
-        failing_user = await create_user(save_fixture)
+        # User with empty email triggers IndexError in User.public_name
+        # (email[0] on ""), exercising the real except-Exception error path.
+        failing_user = User(
+            email="",
+            email_verified=True,
+            avatar_url="",
+            oauth_accounts=[],
+        )
+        await save_fixture(failing_user)
         await save_fixture(
             UserOrganization(user=failing_user, organization=failing_org)
-        )
-
-        # Block failing_org by occupying its email slot in self_org's unique index.
-        await create_customer(
-            save_fixture,
-            organization=self_org,
-            external_id="blocker-external-id",
-            email=failing_user.email,
-            name="Blocker",
         )
 
         ok_account = await create_account(save_fixture, await create_user(save_fixture))


### PR DESCRIPTION
Team customers don't need a top-level email — the owner member carries it. Using model_construct() avoids DNS validation on emails already in our database.
