### PR TITLE
organization: Allow reset proration

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
@@ -49,7 +49,9 @@ const OrganizationSubscriptionSettings: React.FC<
 
       toast({
         title: 'Subscription Settings Update Failed',
-        description: `Error updating subscription settings: ${error.detail}`,
+        description: isValidationError(error.detail)
+          ? 'Please check the form for errors'
+          : `Error updating subscription settings: ${error.detail}`,
       })
 
       return

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -1,9 +1,10 @@
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, Self, TypedDict
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired, Self, TypedDict
 from urllib.parse import urlparse
 from uuid import UUID
 
+from pydantic.json_schema import WithJsonSchema
 from sqlalchemy import (
     TIMESTAMP,
     BigInteger,
@@ -24,7 +25,6 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 from polar.config import settings
 from polar.enums import (
     InvoiceNumbering,
-    PublicSubscriptionProrationBehavior,
     SubscriptionProrationBehavior,
     TaxBehaviorOption,
 )
@@ -83,7 +83,16 @@ _default_notification_settings: OrganizationNotificationSettings = {
 
 class OrganizationSubscriptionSettings(TypedDict):
     allow_multiple_subscriptions: bool
-    proration_behavior: PublicSubscriptionProrationBehavior
+    proration_behavior: Annotated[
+        SubscriptionProrationBehavior,
+        WithJsonSchema(
+            {
+                "enum": ["invoice", "prorate", "next_period"],
+                "title": "PublicSubscriptionProrationBehavior",
+                "type": "string",
+            }
+        ),
+    ]
     benefit_revocation_grace_period: int
     prevent_trial_abuse: bool
     # Legacy - to be removed separately

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -13,7 +13,7 @@ from polar.account.service import account as account_service
 from polar.auth.models import AuthSubject
 from polar.config import Environment, settings
 from polar.customer.repository import CustomerRepository
-from polar.enums import InvoiceNumbering
+from polar.enums import InvoiceNumbering, SubscriptionProrationBehavior
 from polar.exceptions import NotPermitted, PolarError, PolarRequestValidationError
 from polar.integrations.loops.service import loops as loops_service
 from polar.integrations.plain.service import plain as plain_service
@@ -347,6 +347,29 @@ class OrganizationService:
                 )
 
         if update_schema.subscription_settings is not None:
+            if (
+                update_schema.subscription_settings.get("proration_behavior")
+                == SubscriptionProrationBehavior.reset
+                and not organization.feature_settings.get(
+                    "reset_proration_behavior_enabled"
+                )
+            ):
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": (
+                                "body",
+                                "subscription_settings",
+                                "proration_behavior",
+                            ),
+                            "msg": "The 'reset' proration behavior is not enabled for this organization.",
+                            "input": update_schema.subscription_settings[
+                                "proration_behavior"
+                            ],
+                        }
+                    ]
+                )
             organization.subscription_settings = update_schema.subscription_settings
 
         if update_schema.notification_settings is not None:

--- a/server/tests/organization/test_schemas.py
+++ b/server/tests/organization/test_schemas.py
@@ -7,25 +7,29 @@ from polar.models.organization import OrganizationSubscriptionSettings
 from polar.organization.schemas import OrganizationCreate, OrganizationUpdate
 
 
-def test_cant_set_reset_proration_behavior() -> None:
-    with pytest.raises(ValidationError):
-        OrganizationCreate(
-            name="Test Org",
-            slug="test-org",
-            email=None,
-            website=None,
-            socials=None,
-            details=None,
-            country=None,
-            subscription_settings=OrganizationSubscriptionSettings(
-                allow_multiple_subscriptions=True,
-                proration_behavior=SubscriptionProrationBehavior.reset,  # type: ignore
-                benefit_revocation_grace_period=1,
-                prevent_trial_abuse=True,
-                allow_customer_updates=True,
-            ),
-            default_presentment_currency=PresentmentCurrency.usd,
-        )
+def test_reset_proration_behavior_accepted_in_schema() -> None:
+    org = OrganizationCreate(
+        name="Test Org",
+        slug="test-org",
+        email=None,
+        website=None,
+        socials=None,
+        details=None,
+        country=None,
+        subscription_settings=OrganizationSubscriptionSettings(
+            allow_multiple_subscriptions=True,
+            proration_behavior=SubscriptionProrationBehavior.reset,
+            benefit_revocation_grace_period=1,
+            prevent_trial_abuse=True,
+            allow_customer_updates=True,
+        ),
+        default_presentment_currency=PresentmentCurrency.usd,
+    )
+    assert org.subscription_settings is not None
+    assert (
+        org.subscription_settings["proration_behavior"]
+        == SubscriptionProrationBehavior.reset
+    )
 
 
 class TestBlockedWords:

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -11,6 +11,7 @@ from polar.config import Environment, settings
 from polar.enums import (
     InvoiceNumbering,
     PayoutAccountType,
+    SubscriptionProrationBehavior,
     SubscriptionRecurringInterval,
 )
 from polar.exceptions import PolarRequestValidationError
@@ -19,6 +20,7 @@ from polar.models.account import Account
 from polar.models.organization import (
     OrganizationNotificationSettings,
     OrganizationStatus,
+    OrganizationSubscriptionSettings,
 )
 from polar.models.organization_review import OrganizationReview
 from polar.organization.schemas import (
@@ -1846,6 +1848,67 @@ class TestUpdateSeatBasedPricing:
         )
 
         assert result.feature_settings["seat_based_pricing_enabled"] is True
+
+
+@pytest.mark.asyncio
+class TestResetProrationBehavior:
+    async def test_cant_set_without_feature_flag(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "reset_proration_behavior_enabled": False,
+        }
+        await save_fixture(organization)
+
+        with pytest.raises(PolarRequestValidationError):
+            await organization_service.update(
+                session,
+                organization,
+                OrganizationUpdate(
+                    subscription_settings=OrganizationSubscriptionSettings(
+                        allow_multiple_subscriptions=False,
+                        proration_behavior=SubscriptionProrationBehavior.reset,
+                        benefit_revocation_grace_period=0,
+                        prevent_trial_abuse=False,
+                        allow_customer_updates=True,
+                    ),
+                ),
+            )
+
+    async def test_can_set_with_feature_flag(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "reset_proration_behavior_enabled": True,
+        }
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(
+                subscription_settings=OrganizationSubscriptionSettings(
+                    allow_multiple_subscriptions=False,
+                    proration_behavior=SubscriptionProrationBehavior.reset,
+                    benefit_revocation_grace_period=0,
+                    prevent_trial_abuse=False,
+                    allow_customer_updates=True,
+                ),
+            ),
+        )
+
+        assert (
+            result.subscription_settings["proration_behavior"]
+            == SubscriptionProrationBehavior.reset
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -748,7 +748,7 @@ class TestUpdateProductProrations:
         call_proration, org_proration = proration_behavior
         expected_proration = call_proration or org_proration
 
-        organization.subscription_settings["proration_behavior"] = org_proration  # type: ignore
+        organization.subscription_settings["proration_behavior"] = org_proration
         session.add(organization)
         await session.flush()
 


### PR DESCRIPTION
We need to accept the reset proration setting, otherwise we fail the validation schema.

However, we still want to only allow it when the organization has the feature flag to enable it. As such, we move the validation from the schema layer to the service layer.

We still want to hide the part of the enum from the OpenAPI definition. We do this through Annotated + WithJsonSchema.
