### PR TITLE
fix(settings): stop infinite save loop in Billing settings

### DIFF
--- a/clients/apps/web/src/hooks/useAutoSave.ts
+++ b/clients/apps/web/src/hooks/useAutoSave.ts
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react'
-import { FieldValues, UseFormReturn, useWatch } from 'react-hook-form'
-import { useDebouncedCallback } from './utils'
+import { useEffect, useRef } from 'react'
+import { FieldValues, UseFormReturn } from 'react-hook-form'
 
 interface UseAutoSaveOptions<T extends FieldValues> {
   form: UseFormReturn<T>
@@ -15,33 +14,41 @@ export function useAutoSave<T extends FieldValues>({
   delay = 1000,
   enabled = true,
 }: UseAutoSaveOptions<T>) {
-  const [isSaving, setIsSaving] = useState(false)
+  const onSaveRef = useRef(onSave)
+  useEffect(() => {
+    onSaveRef.current = onSave
+  }, [onSave])
 
-  const { control, formState } = form
-  const { isDirty } = formState
-  const formValues = useWatch({ control })
-
-  const debouncedSave = useDebouncedCallback(
-    async () => {
-      setIsSaving(true)
-      try {
-        const data = form.getValues()
-        await onSave(data)
-      } finally {
-        setIsSaving(false)
-      }
-    },
-    delay,
-    [onSave, form],
-  )
+  const isSavingRef = useRef(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    if (!enabled || !isDirty || isSaving) {
-      return
+    if (!enabled) return
+
+    // Filter on type === 'change' so programmatic updates like `reset()`
+    // (fired after a successful save) don't re-trigger the autosave loop.
+    const subscription = form.watch((_value, info) => {
+      if (info.type !== 'change') return
+      if (isSavingRef.current) return
+
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(async () => {
+        if (isSavingRef.current) return
+
+        isSavingRef.current = true
+        try {
+          await onSaveRef.current(form.getValues())
+        } catch {
+          // Swallow: consumers handle their own errors via onSave.
+        } finally {
+          isSavingRef.current = false
+        }
+      }, delay)
+    })
+
+    return () => {
+      subscription.unsubscribe()
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
-
-    debouncedSave()
-  }, [formValues, enabled, isDirty, debouncedSave, isSaving])
-
-  return { isSaving }
+  }, [form, delay, enabled])
 }


### PR DESCRIPTION
## 📋 Summary

Toggling any switch in **Settings → Billing** fired an endless stream of `PATCH /v1/organizations/{id}` requests and accompanying `/billing` page fetches (the latter from repeated Next.js `router.refresh()`s). This PR rewrites `useAutoSave` to break the loop.

## 🎯 What

Rewrite `clients/apps/web/src/hooks/useAutoSave.ts` to subscribe to user input directly rather than watching derived state inside a `useEffect`. No other files change — consumers already ignored the hook's return value, so dropping `isSaving` from the signature is safe.

## 🤔 Why

The previous implementation had several compounding problems:

1. `onSave` is defined inline in all seven `*Settings.tsx` consumers — a new reference every render. This caused `debouncedSave` to be recreated every render, which caused the `useEffect` to re-run every render.
2. `useWatch({ control })` without a name also returns a new object reference per render, further churning the effect.
3. The effect's only protection was checking `isDirty` / `isSaving` — but RHF's `formState` proxy subscription and `useWatch` update in separate render passes, so there was a window where `formValues` reflected a fresh value while `isDirty` still read `true`.
4. `useUpdateOrganization.onSuccess` awaits two `revalidate()` server actions. Each server action triggers `router.refresh()` in the Next.js App Router, re-rendering the tree. That's what produced the repeated `/billing` fetches in the screenshot and amplified the race window.

Net effect: every toggle → save → `reset()` → revalidate → router refresh → spurious dirty-read → another save → loop.

## 🔧 How

- Subscribe via `form.watch((_value, info) => ...)` with `info.type === 'change'` so programmatic updates from `reset()` (emitted after a successful save) can't re-trigger the loop. This is the real loop-breaker.
- Hold `onSave` in a ref so we can subscribe once and still call the latest closure (consumers don't need to `useCallback` every handler — that would be a silent-regression footgun).
- Guard concurrency with `isSavingRef` instead of state — no extra re-renders.
- Clean up the subscription and pending timeout on unmount; wrap the `await onSave` call in `try/catch` so an unmount mid-save can't surface as an unhandled rejection.
- Dropped the unused `isSaving` return value (verified none of the seven callers destructured it).

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`pnpm typecheck`, `pnpm lint` for the changed file)
- [ ] I have added new tests for new functionality
- [x] I have run linting and type checking

### Test Instructions

1. Sign in and navigate to **Dashboard → Settings → Billing** for any organization.
2. Toggle any switch in any of the four sections (Payments, Subscriptions, Customer portal, Customer notifications).
3. Open the Network panel. Confirm exactly one `PATCH /v1/organizations/{id}` request fires per toggle (plus up to two `/billing` server-component refreshes from the existing `revalidate()` calls).
4. Toggle repeatedly/rapidly: saves should debounce to one PATCH per settled state, not loop.
5. Change a field with a longer debounce (Organization profile, `delay: 1000`) and confirm the behaviour is unchanged there.

## 📝 Additional Notes

The `useAutoSave` hook is also used by:
- `OrganizationSubscriptionSettings`
- `OrganizationPaymentSettings`
- `OrganizationCustomerPortalSettings`
- `OrganizationCustomerEmailSettings`
- `OrganizationNotificationSettings`
- `OrganizationProfileSettings`
- `FeatureSettings`

All seven are covered by the fix — the loop was triggered most easily on the Billing page because it hosts four forms at once, each issuing its own `revalidate()` on save.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")

🤖 Generated with [Claude Code](https://claude.com/claude-code)