### PR TITLE
cache: Introduce a metrics cache

### DIFF
--- a/server/polar/metrics/cache.py
+++ b/server/polar/metrics/cache.py
@@ -1,0 +1,93 @@
+import hashlib
+import json
+from collections.abc import Sequence
+from datetime import date
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+import structlog
+from redis.exceptions import RedisError
+
+from polar.kit.time_queries import TimeInterval
+from polar.logging import Logger
+from polar.models.product import ProductBillingType
+from polar.redis import Redis
+
+from .schemas import MetricsResponse
+
+log: Logger = structlog.get_logger()
+
+METRICS_CACHE_TTL_SECONDS = 60
+_CACHE_KEY_PREFIX = "metrics:response:v1"
+
+
+def _sorted_uuid_strs(values: Sequence[UUID] | None) -> list[str] | None:
+    if values is None:
+        return None
+    return sorted(str(v) for v in values)
+
+
+def _sorted_strs(values: Sequence[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    return sorted(values)
+
+
+def _sorted_billing_types(
+    values: Sequence[ProductBillingType] | None,
+) -> list[str] | None:
+    if values is None:
+        return None
+    return sorted(v.value for v in values)
+
+
+def build_cache_key(
+    *,
+    start_date: date,
+    end_date: date,
+    timezone: ZoneInfo,
+    interval: TimeInterval,
+    organization_ids: Sequence[UUID],
+    product_ids: Sequence[UUID] | None,
+    customer_ids: Sequence[UUID] | None,
+    external_customer_ids: Sequence[str] | None,
+    billing_type: Sequence[ProductBillingType] | None,
+    metrics: Sequence[str] | None,
+) -> str:
+    payload = {
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "timezone": timezone.key,
+        "interval": interval.value,
+        "organization_ids": sorted(str(v) for v in organization_ids),
+        "product_ids": _sorted_uuid_strs(product_ids),
+        "customer_ids": _sorted_uuid_strs(customer_ids),
+        "external_customer_ids": _sorted_strs(external_customer_ids),
+        "billing_type": _sorted_billing_types(billing_type),
+        "metrics": _sorted_strs(metrics),
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_CACHE_KEY_PREFIX}:{digest}"
+
+
+async def get_cached_metrics(redis: Redis, key: str) -> MetricsResponse | None:
+    try:
+        cached = await redis.get(key)
+    except RedisError as exc:
+        log.warning("metrics.cache.get_failed", error=str(exc))
+        return None
+    if cached is None:
+        return None
+    try:
+        return MetricsResponse.model_validate_json(cached)
+    except ValueError as exc:
+        log.warning("metrics.cache.deserialize_failed", error=str(exc))
+        return None
+
+
+async def set_cached_metrics(redis: Redis, key: str, response: MetricsResponse) -> None:
+    try:
+        await redis.set(key, response.model_dump_json(), ex=METRICS_CACHE_TTL_SECONDS)
+    except RedisError as exc:
+        log.warning("metrics.cache.set_failed", error=str(exc))

--- a/server/polar/metrics/endpoints.py
+++ b/server/polar/metrics/endpoints.py
@@ -29,6 +29,7 @@ from polar.postgres import (
     get_db_session,
 )
 from polar.product.schemas import ProductID
+from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 
 from . import auth
@@ -96,6 +97,7 @@ async def get(
         ),
     ),
     session: AsyncReadSession = Depends(get_db_read_session),
+    redis: Redis | None = Depends(get_redis),
 ) -> MetricsResponse:
     """
     Get metrics about your orders and subscriptions.
@@ -144,6 +146,7 @@ async def get(
         billing_type=billing_type,
         customer_id=customer_id,
         metrics=metrics,
+        redis=redis,
     )
 
 
@@ -193,6 +196,7 @@ async def export(
         ),
     ),
     session: AsyncReadSession = Depends(get_db_read_session),
+    redis: Redis | None = Depends(get_redis),
 ) -> Response:
     """Export metrics as a CSV file."""
     if metrics is not None:
@@ -237,6 +241,7 @@ async def export(
             billing_type=billing_type,
             customer_id=customer_id,
             metrics=metrics,
+            redis=redis,
         )
 
         csv_writer = IterableCSVWriter(dialect="excel")

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -22,7 +22,9 @@ from polar.models import (
 from polar.models.product import ProductBillingType
 from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncReadSession, AsyncSession
+from polar.redis import Redis
 
+from .cache import build_cache_key, get_cached_metrics, set_cached_metrics
 from .metrics import (
     METRICS,
     METRICS_POST_COMPUTE,
@@ -177,7 +179,40 @@ class MetricsService:
         customer_id: Sequence[uuid.UUID] | None = None,
         metrics: Sequence[str] | None = None,
         now: datetime | None = None,
+        redis: Redis | None = None,
     ) -> MetricsResponse:
+        pg_slugs, tb_slugs, meta_slugs = _expand_metrics_with_dependencies(metrics)
+
+        tb_filters = await self._resolve_tinybird_filters(
+            session,
+            auth_subject,
+            organization_id=organization_id,
+            product_id=product_id,
+            billing_type=billing_type,
+            customer_id=customer_id,
+            tb_needed=tb_slugs,
+        )
+
+        cache_key: str | None = None
+        if redis is not None and now is None:
+            cache_key = build_cache_key(
+                start_date=start_date,
+                end_date=end_date,
+                timezone=timezone,
+                interval=interval,
+                organization_ids=tb_filters.org_ids,
+                product_ids=tb_filters.product_id,
+                customer_ids=tb_filters.customer_ids,
+                external_customer_ids=tb_filters.external_customer_id,
+                billing_type=billing_type,
+                metrics=metrics,
+            )
+            with logfire.span("Get metrics cache", cache_key=cache_key) as span:
+                cached = await get_cached_metrics(redis, cache_key)
+                span.set_attribute("cache_hit", cached is not None)
+            if cached is not None:
+                return cached
+
         await session.execute(text(f"SET LOCAL TIME ZONE '{timezone.key}'"))
         await session.execute(text("SET LOCAL plan_cache_mode = 'force_custom_plan'"))
         start_timestamp = datetime(
@@ -202,8 +237,6 @@ class MetricsService:
 
         now_dt = now or datetime.now(tz=timezone)
 
-        pg_slugs, tb_slugs, meta_slugs = _expand_metrics_with_dependencies(metrics)
-
         filtered_pg_metrics = [m for m in METRICS_POSTGRES if m.slug in pg_slugs]
         filtered_tb_metrics = [m for m in METRICS_TINYBIRD if m.slug in tb_slugs]
         filtered_post_compute = [
@@ -216,16 +249,6 @@ class MetricsService:
         pg_query_fns: list[QueryCallable] = [
             fn for qt, fn in QUERY_TO_FUNCTION.items() if qt in required_queries
         ]
-
-        tb_filters = await self._resolve_tinybird_filters(
-            session,
-            auth_subject,
-            organization_id=organization_id,
-            product_id=product_id,
-            billing_type=billing_type,
-            customer_id=customer_id,
-            tb_needed=tb_slugs,
-        )
 
         pg_coro = self._get_metrics_from_pg(
             session,
@@ -314,13 +337,19 @@ class MetricsService:
                 for p in periods
             ]
 
-        return MetricsResponse.model_validate(
+        response = MetricsResponse.model_validate(
             {
                 "periods": periods,
                 "totals": totals,
                 "metrics": {m.slug: m for m in filtered_all_metrics},
             }
         )
+
+        if redis is not None and cache_key is not None:
+            with logfire.span("Set metrics cache", cache_key=cache_key):
+                await set_cached_metrics(redis, cache_key, response)
+
+        return response
 
     async def _get_metrics_from_pg(
         self,

--- a/server/tests/metrics/test_cache.py
+++ b/server/tests/metrics/test_cache.py
@@ -1,0 +1,253 @@
+from datetime import date
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+from pytest_mock import MockerFixture
+from redis.exceptions import RedisError
+
+from polar.kit.time_queries import TimeInterval
+from polar.metrics.cache import (
+    METRICS_CACHE_TTL_SECONDS,
+    build_cache_key,
+    get_cached_metrics,
+    set_cached_metrics,
+)
+from polar.metrics.metrics import METRICS
+from polar.metrics.schemas import MetricsResponse
+from polar.redis import Redis
+
+
+def _empty_metrics_response() -> MetricsResponse:
+    return MetricsResponse.model_validate(
+        {
+            "periods": [],
+            "totals": {m.slug: 0 for m in METRICS},
+            "metrics": {m.slug: m for m in METRICS},
+        }
+    )
+
+
+class TestBuildCacheKey:
+    def test_prefix_and_hash_shape(self) -> None:
+        key = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[uuid4()],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+
+        assert key.startswith("metrics:response:v1:")
+        assert len(key.split(":")[-1]) == 64
+
+    def test_identical_params_produce_identical_key(self) -> None:
+        org_id = uuid4()
+        key_a = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+        key_b = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+
+        assert key_a == key_b
+
+    def test_different_org_ids_produce_different_key(self) -> None:
+        key_a = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[uuid4()],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+        key_b = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[uuid4()],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+
+        assert key_a != key_b
+
+    def test_different_date_produces_different_key(self) -> None:
+        org_id = uuid4()
+        key_a = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+        key_b = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 2, 29),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+
+        assert key_a != key_b
+
+    def test_metric_order_is_normalized(self) -> None:
+        org_id = uuid4()
+        key_a = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=["orders", "revenue"],
+        )
+        key_b = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=["revenue", "orders"],
+        )
+
+        assert key_a == key_b
+
+    def test_product_id_order_is_normalized(self) -> None:
+        org_id = uuid4()
+        id_a = uuid4()
+        id_b = uuid4()
+        key_a = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=[id_a, id_b],
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+        key_b = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[org_id],
+            product_ids=[id_b, id_a],
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+
+        assert key_a == key_b
+
+    def test_org_ids_order_is_normalized(self) -> None:
+        id_a = uuid4()
+        id_b = uuid4()
+        key_a = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[id_a, id_b],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+        key_b = build_cache_key(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            timezone=ZoneInfo("UTC"),
+            interval=TimeInterval.day,
+            organization_ids=[id_b, id_a],
+            product_ids=None,
+            customer_ids=None,
+            external_customer_ids=None,
+            billing_type=None,
+            metrics=None,
+        )
+
+        assert key_a == key_b
+
+
+@pytest.mark.asyncio
+class TestGetSetCache:
+    async def test_roundtrip(self, redis: Redis) -> None:
+        response = _empty_metrics_response()
+        key = "metrics:response:v1:test-roundtrip"
+
+        assert await get_cached_metrics(redis, key) is None
+
+        await set_cached_metrics(redis, key, response)
+        cached = await get_cached_metrics(redis, key)
+
+        assert cached is not None
+        assert cached.model_dump_json() == response.model_dump_json()
+
+        ttl = await redis.ttl(key)
+        assert 0 < ttl <= METRICS_CACHE_TTL_SECONDS
+
+    async def test_get_failure_returns_none(
+        self, mocker: MockerFixture, redis: Redis
+    ) -> None:
+        mocker.patch.object(redis, "get", side_effect=RedisError("boom"))
+        assert await get_cached_metrics(redis, "some-key") is None
+
+    async def test_set_failure_is_swallowed(
+        self, mocker: MockerFixture, redis: Redis
+    ) -> None:
+        mocker.patch.object(redis, "set", side_effect=RedisError("boom"))
+        await set_cached_metrics(redis, "some-key", _empty_metrics_response())

--- a/server/tests/metrics/test_endpoints.py
+++ b/server/tests/metrics/test_endpoints.py
@@ -1,9 +1,13 @@
 import pytest
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
+from redis.exceptions import RedisError
 
 from polar.auth.scope import Scope
 from polar.kit.time_queries import TimeInterval
+from polar.metrics.service import metrics as metrics_service
 from polar.models import UserOrganization
+from polar.redis import Redis
 from tests.fixtures.auth import AuthSubjectFixture
 
 
@@ -218,6 +222,88 @@ class TestMetricsFiltering:
         assert json["metrics"]["orders"] is not None
         assert json["metrics"]["active_subscriptions"] is not None
         assert json["metrics"]["gross_margin"] is not None
+
+
+@pytest.mark.asyncio
+class TestGetMetricsCache:
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="organization", scopes={Scope.metrics_read})
+    )
+    async def test_identical_request_served_from_cache(
+        self,
+        client: AsyncClient,
+        mocker: MockerFixture,
+    ) -> None:
+        pg_spy = mocker.spy(metrics_service, "_get_metrics_from_pg")
+        tb_spy = mocker.spy(metrics_service, "_get_metrics_from_tinybird")
+        params = {
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+            "interval": "month",
+        }
+
+        first = await client.get("/v1/metrics/", params=params)
+        second = await client.get("/v1/metrics/", params=params)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        assert pg_spy.call_count == 1
+        assert tb_spy.call_count == 1
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="organization", scopes={Scope.metrics_read})
+    )
+    async def test_different_params_miss_cache(
+        self,
+        client: AsyncClient,
+        mocker: MockerFixture,
+    ) -> None:
+        pg_spy = mocker.spy(metrics_service, "_get_metrics_from_pg")
+
+        first = await client.get(
+            "/v1/metrics/",
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+                "interval": "month",
+            },
+        )
+        second = await client.get(
+            "/v1/metrics/",
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-06-30",
+                "interval": "month",
+            },
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert pg_spy.call_count == 2
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="organization", scopes={Scope.metrics_read})
+    )
+    async def test_redis_failure_does_not_break_endpoint(
+        self,
+        client: AsyncClient,
+        mocker: MockerFixture,
+        redis: Redis,
+    ) -> None:
+        mocker.patch.object(redis, "get", side_effect=RedisError("boom"))
+        mocker.patch.object(redis, "set", side_effect=RedisError("boom"))
+
+        response = await client.get(
+            "/v1/metrics/",
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+                "interval": "month",
+            },
+        )
+
+        assert response.status_code == 200
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
We need a short lived metrics cache to alleviate hitting Tinybird too hard with the same query.
