### PR TITLE
Revert "tax: Handle empty tax jurisdictions (#11007)"

### DIFF
--- a/server/polar/tax/calculation/numeral.py
+++ b/server/polar/tax/calculation/numeral.py
@@ -262,26 +262,7 @@ class NumeralTaxService(TaxServiceProtocol):
             "numeral.calculation_id", calculation["id"]
         )
 
-        tax_jurisdictions = calculation["line_items"][0]["tax_jurisdictions"]
-        if len(tax_jurisdictions) == 0:
-            return TaxCalculation(
-                processor_id=calculation["id"],
-                amount=0,
-                currency=currency,
-                tax_behavior=tax_behavior,
-                taxability_reason=TaxabilityReason.not_collecting,
-                tax_rate=TaxRate(
-                    rate_type="percentage",
-                    basis_points=0,
-                    amount=None,
-                    amount_currency=None,
-                    display_name="",
-                    country=address.country,
-                    state=address.get_unprefixed_state(),
-                ),
-            )
-
-        tax_jurisdiction = tax_jurisdictions[0]
+        tax_jurisdiction = calculation["line_items"][0]["tax_jurisdictions"][0]
         tax_rate = from_numeral_tax_jurisdiction(
             tax_jurisdiction,
             country=address.country,


### PR DESCRIPTION
This reverts commit 44da9ed65b9af481c995e836afba6db6a2a3193a.

Since the reason why there was no tax_jurisdictions is due to a bug, we should not handle this case and not return tax in this case.