### PR TITLE
fix(backoffice): preserve filters on organizations "Load More"

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -386,7 +386,6 @@ async def list_organizations(
             request,
             organizations,
             status_filter,
-            status_counts,
             page,
             has_more,
             sort,

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -1,6 +1,7 @@
 """Enhanced organization list view with tabs and quick actions."""
 
 import contextlib
+import json
 from collections.abc import Generator
 from datetime import UTC, datetime
 
@@ -90,8 +91,6 @@ class OrganizationListView:
         if status_filter is not None:
             hx_vals_dict["status"] = status_filter.value
 
-        import json
-
         hx_vals = json.dumps(hx_vals_dict)
 
         with tag.th(
@@ -116,6 +115,32 @@ class OrganizationListView:
                     text(indicator)
 
         yield
+
+    def load_more_button(
+        self,
+        request: Request,
+        page: int,
+        current_sort: str,
+        current_direction: str,
+        status_filter: OrganizationStatus | None,
+    ) -> None:
+        hx_vals: dict[str, str | int] = {
+            "page": page + 1,
+            "sort": current_sort,
+            "direction": current_direction,
+        }
+        if status_filter is not None:
+            hx_vals["status"] = status_filter.value
+        with tag.div(classes="flex justify-center mt-6"):
+            with button(
+                variant="secondary",
+                hx_get=str(request.url_for("organizations:list")),
+                hx_vals=json.dumps(hx_vals),
+                hx_include="#filter-form",
+                hx_target="#org-list",
+                hx_swap="beforeend",
+            ):
+                text("Load More")
 
     @contextlib.contextmanager
     def organization_row(self, request: Request, org: Organization) -> Generator[None]:
@@ -540,17 +565,10 @@ class OrganizationListView:
                             with self.organization_row(request, org):
                                 pass
 
-                # Pagination
                 if has_more:
-                    with tag.div(classes="flex justify-center mt-6"):
-                        with button(
-                            variant="secondary",
-                            hx_get=str(request.url_for("organizations:list"))
-                            + f"?page={page + 1}",
-                            hx_target="#org-list",
-                            hx_swap="beforeend",
-                        ):
-                            text("Load More")
+                    self.load_more_button(
+                        request, page, current_sort, current_direction, status_filter
+                    )
 
         yield
 
@@ -560,7 +578,6 @@ class OrganizationListView:
         request: Request,
         organizations: list[Organization],
         status_filter: OrganizationStatus | None,
-        status_counts: dict[OrganizationStatus, int],
         page: int,
         has_more: bool,
         current_sort: str = "priority",
@@ -651,17 +668,10 @@ class OrganizationListView:
                             with self.organization_row(request, org):
                                 pass
 
-                # Pagination
                 if has_more:
-                    with tag.div(classes="flex justify-center mt-6"):
-                        with button(
-                            variant="secondary",
-                            hx_get=str(request.url_for("organizations:list"))
-                            + f"?page={page + 1}",
-                            hx_target="#org-list",
-                            hx_swap="beforeend",
-                        ):
-                            text("Load More")
+                    self.load_more_button(
+                        request, page, current_sort, current_direction, status_filter
+                    )
 
         yield
 


### PR DESCRIPTION
## 📋 Summary

The "Load More" button in the backoffice organizations list view dropped the active status filter and sort state from the HTMX request, so clicking it on the **Review** tab loaded organizations with other statuses (notably Snoozed).

## 🎯 What

- Rebuild the Load More request to include `page`, `sort`, `direction`, and `status` via `hx-vals`, plus `hx-include="#filter-form"` for the remaining advanced filters.
- Extract the now-shared button into a `load_more_button` helper on `OrganizationListView`, used by both `render` and `render_table_only`.
- Drop the unused `status_counts` parameter from `render_table_only` (tabs aren't rendered in the HTMX partial) and update the endpoint call site.

## 🤔 Why

The old button URL was just `?page=N+1`. With no `status` query param and no other filters, the endpoint fell back to its default behavior: priority sort by `Organization.status.desc()`. Alphabetically descending, `"snoozed"` sorts highest, so the second page appeared to be Snoozed orgs regardless of which tab you were on.

## 🔧 How

Mirrors the `sortable_header` pattern already present in the same file — `hx-vals` for the state that isn't in the form, `hx-include` for the filter form itself.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Open the backoffice organizations v2 list view.
2. Click the **Review** tab.
3. If there are >50 organizations in Review, click **Load More**.
4. Verify the appended rows are all Review organizations (not Snoozed).
5. Repeat with a sort applied (e.g. click the "Created" header, then Load More) and with an advanced filter (e.g. country) applied — both should be preserved across pages.

## 📝 Additional Notes

Out of scope but worth a follow-up: `render_table_only` wraps its output in `<div id="org-list">` and is swapped with `hx-swap="beforeend"`, which produces nested duplicate-ID wrappers on repeated clicks. Fixing that needs a broader refactor of the append strategy (e.g. target the `tbody` and swap the button via `hx-swap-oob`).