### PR TITLE
fix(appeal-review): re-check Plain thread state before auto-replying

### DIFF
--- a/server/scripts/bulk_appeal_review.py
+++ b/server/scripts/bulk_appeal_review.py
@@ -211,9 +211,7 @@ async def get_thread_state(
     return status, answered
 
 
-async def is_thread_answered(
-    http_client: httpx.AsyncClient, thread_id: str
-) -> bool:
+async def is_thread_answered(http_client: httpx.AsyncClient, thread_id: str) -> bool:
     """Check if a thread already has a staff reply (userActor) or outbound email."""
     _, answered = await get_thread_state(http_client, thread_id)
     return answered

--- a/server/scripts/bulk_appeal_review.py
+++ b/server/scripts/bulk_appeal_review.py
@@ -60,7 +60,10 @@ from plain_client import (  # noqa: E402
 
 from polar.config import settings  # noqa: E402
 from polar.kit.db.postgres import create_async_sessionmaker  # noqa: E402
-from polar.organization.repository import OrganizationRepository  # noqa: E402
+from polar.organization.repository import (  # noqa: E402
+    OrganizationRepository,
+    OrganizationReviewRepository,
+)
 from polar.organization.service import (  # noqa: E402
     organization as organization_service,
 )
@@ -77,6 +80,7 @@ SLUG_PATTERN = re.compile(r"Organization Appeal - (\S+)")
 TIMELINE_QUERY = """
 query ThreadTimeline($threadId: ID!) {
   thread(threadId: $threadId) {
+    status
     timelineEntries(first: 50) {
       edges {
         node {
@@ -162,31 +166,34 @@ async def get_appeal_threads(plain: Plain) -> list[dict[str, str]]:
     return threads
 
 
-async def is_thread_answered(plain_token: str, thread_id: str) -> bool:
-    """Check if a thread already has a staff reply (userActor) or outbound email."""
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            "https://core-api.uk.plain.com/graphql/v1",
-            headers={
-                "Authorization": f"Bearer {plain_token}",
-                "Content-Type": "application/json",
-            },
-            json={"query": TIMELINE_QUERY, "variables": {"threadId": thread_id}},
-            timeout=15.0,
-        )
+async def get_thread_state(
+    http_client: httpx.AsyncClient, thread_id: str
+) -> tuple[str | None, bool]:
+    """Fetch (status, has_staff_reply) for a thread.
+
+    Returns (None, True) on any error so callers err on the side of skipping.
+    """
+    response = await http_client.post(
+        "https://core-api.uk.plain.com/graphql/v1",
+        headers={"Content-Type": "application/json"},
+        json={"query": TIMELINE_QUERY, "variables": {"threadId": thread_id}},
+        timeout=15.0,
+    )
 
     if response.status_code != 200:
         log.warning(
             "Failed to fetch timeline", thread_id=thread_id, status=response.status_code
         )
-        return True  # Treat errors as "answered" to skip safely
+        return None, True
 
     data = response.json()
     thread_data = data.get("data", {}).get("thread")
     if not thread_data:
-        return True
+        return None, True
 
+    status = thread_data.get("status")
     entries = thread_data.get("timelineEntries", {}).get("edges", [])
+    answered = False
     for edge in entries:
         node = edge.get("node", {})
         actor = node.get("actor", {})
@@ -198,9 +205,33 @@ async def is_thread_answered(plain_token: str, thread_id: str) -> bool:
             "ChatEntry",
             "EmailEntry",
         ):
-            return True
+            answered = True
+            break
 
-    return False
+    return status, answered
+
+
+async def is_thread_answered(
+    http_client: httpx.AsyncClient, thread_id: str
+) -> bool:
+    """Check if a thread already has a staff reply (userActor) or outbound email."""
+    _, answered = await get_thread_state(http_client, thread_id)
+    return answered
+
+
+async def is_appeal_already_decided(session_maker: Any, slug: str) -> bool:
+    """Return True if the appeal has already been approved or denied in the DB.
+
+    Covers the case where a human used the backoffice without replying in Plain.
+    """
+    async with session_maker() as session:
+        org_repo = OrganizationRepository.from_session(session)
+        org = await org_repo.get_by_slug(slug)
+        if org is None:
+            return False
+        review_repo = OrganizationReviewRepository.from_session(session)
+        review = await review_repo.get_by_organization(org.id)
+        return review is not None and review.appeal_decision is not None
 
 
 async def handle_org(
@@ -318,7 +349,7 @@ async def process_appeals(
             unanswered: list[dict[str, str]] = []
             for thread_data in all_threads:
                 answered = await is_thread_answered(
-                    plain_token, thread_data["thread_id"]
+                    http_client, thread_data["thread_id"]
                 )
                 if not answered:
                     unanswered.append(thread_data)
@@ -381,6 +412,31 @@ async def process_appeals(
                             slug=slug,
                             action=result.action,
                             draft_email_preview=result.draft_email[:200],
+                        )
+                        continue
+
+                    # The job can run for hours (AI review + website scraping
+                    # per org), so a human may have replied or decided the
+                    # appeal between the initial filter and now. Re-check to
+                    # avoid sending a contradicting automated reply.
+                    current_status, already_answered = await get_thread_state(
+                        http_client, thread_id
+                    )
+                    if already_answered or current_status != ThreadStatus.TODO.value:
+                        log.info(
+                            "Skipping reply — thread state changed during run",
+                            thread_id=thread_id,
+                            slug=slug,
+                            status=current_status,
+                            answered=already_answered,
+                        )
+                        continue
+
+                    if await is_appeal_already_decided(session_maker, slug):
+                        log.info(
+                            "Skipping reply — appeal already decided in DB",
+                            thread_id=thread_id,
+                            slug=slug,
                         )
                         continue
 


### PR DESCRIPTION
## 📋 Summary

The bulk appeal-review cron was sending follow-up emails on appeals that a human had already actioned. One case: an approval was sent at 09:45 UTC and an automated follow-up went out at 10:00 UTC, contradicting support and confusing the customer.

## 🎯 What

In `server/scripts/bulk_appeal_review.py`:

- Extend `TIMELINE_QUERY` to also return the thread's current `status`.
- Replace `is_thread_answered` with `get_thread_state`, returning `(status, has_staff_reply)`. Keep `is_thread_answered` as a thin wrapper so the upfront filter is unchanged.
- Add `is_appeal_already_decided(session_maker, slug)` as a DB-level guard.
- Just before `plain.reply_to_thread`, re-check both Plain state (must still be `TODO` and unanswered) and the DB appeal decision. Skip with a log line if either signal changed.
- Reuse the existing `httpx.AsyncClient` (which already carries the Plain auth header) instead of creating a new client per check.

## 🤔 Why

The cron (`0 */6 * * *`) precomputes the unanswered-threads list once at the start of a run, then processes each sequentially. Each appeal runs a full AI review + website scrape, so a single run can keep going for hours. During that window a human can reply in Plain and/or approve via the backoffice — the old code never rechecked, so it happily posted an automated reply on top.

The DB layer already raises if `appeal_decision` is set, but by the time that check ran the email was already sent.

## 🔧 How

TOCTOU window goes from hours down to the few ms between the re-check and the reply API call. Two signals are checked because they cover different human workflows:

- Plain re-check catches the case where a human replied + marked done directly in Plain (the notecorn case).
- DB check catches the reverse: a human decided the appeal via the backoffice without touching Plain.

Both checks happen only on the happy path right before the reply, so the overhead is bounded to one extra GraphQL call + one short DB query per appeal that reaches the reply step.

## 🧪 Testing

- [x] `uv run ruff check scripts/bulk_appeal_review.py`
- [x] `uv run mypy scripts/bulk_appeal_review.py`
- [ ] Will validate by running the cron in dry-run mode (`uv run python -m scripts.bulk_appeal_review --limit 0`, no `--execute`) before next scheduled run.

### Test Instructions

1. Trigger or wait for the `bulk-appeal-review` cron in staging/production.
2. In parallel, manually reply to one of the TODO appeal threads in Plain and mark it DONE before the cron reaches it.
3. Confirm the cron logs `Skipping reply — thread state changed during run` for that thread and does not send an email.
4. Repeat with a human approval via the backoffice (no Plain reply) — confirm `Skipping reply — appeal already decided in DB`.

## 📝 Additional Notes

Related incident: [Plain thread T-24760](https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01KNFJTMTZBXYZPJXMF4SW65BA).

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: AI-assisted; ran locally through `ruff` + `mypy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)