### PR TITLE
feat(backoffice): paginate organizations list with Prev/Next

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -172,7 +172,7 @@ async def list_organizations(
     sort: str = Query("priority"),
     direction: str = Query("asc"),
     page: int = Query(1, ge=1),
-    limit: int = Query(50, ge=1, le=100),
+    limit: int = Query(20, ge=1, le=100),
     # Advanced filters
     country: str | None = Query(""),
     risk_level: str | None = Query(""),
@@ -371,17 +371,9 @@ async def list_organizations(
     if has_more:
         organizations = organizations[:limit]
 
-    # Get status counts for tabs
-    status_counts = await list_view.get_status_counts()
-
-    # Get distinct countries for filter dropdown
-    countries = await list_view.get_distinct_countries()
-
-    # Check if this is an HTMX request targeting just the table
     is_htmx_table_request = request.headers.get("HX-Target") == "org-list"
 
     if is_htmx_table_request:
-        # Only return the table content
         with list_view.render_table_only(
             request,
             organizations,
@@ -393,7 +385,8 @@ async def list_organizations(
         ):
             pass
     else:
-        # Render full page with layout
+        status_counts = await list_view.get_status_counts()
+        countries = await list_view.get_distinct_countries()
         with layout(
             request,
             [("Organizations", str(request.url))],

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -116,31 +116,54 @@ class OrganizationListView:
 
         yield
 
-    def load_more_button(
+    def pagination_controls(
         self,
         request: Request,
         page: int,
+        has_more: bool,
         current_sort: str,
         current_direction: str,
         status_filter: OrganizationStatus | None,
     ) -> None:
-        hx_vals: dict[str, str | int] = {
-            "page": page + 1,
+        """Render Previous/Next pagination buttons.
+
+        Uses the limit+1 has_more detection so we never pay for a COUNT(*) just
+        to render the page controls — works for tables of arbitrary size.
+        """
+        if page <= 1 and not has_more:
+            return
+
+        common_vals: dict[str, str | int] = {
             "sort": current_sort,
             "direction": current_direction,
         }
         if status_filter is not None:
-            hx_vals["status"] = status_filter.value
-        with tag.div(classes="flex justify-center mt-6"):
-            with button(
-                variant="secondary",
+            common_vals["status"] = status_filter.value
+
+        def _nav_button(target_page: int, label: str, disabled: bool) -> None:
+            if disabled:
+                with tag.button(
+                    type="button", classes="join-item btn btn-sm", disabled=True
+                ):
+                    text(label)
+                return
+            hx_vals = {**common_vals, "page": target_page}
+            with tag.button(
+                type="button",
+                classes="join-item btn btn-sm",
                 hx_get=str(request.url_for("organizations:list")),
                 hx_vals=json.dumps(hx_vals),
                 hx_include="#filter-form",
                 hx_target="#org-list",
-                hx_swap="beforeend",
             ):
-                text("Load More")
+                text(label)
+
+        with tag.div(classes="flex justify-between items-center mt-6"):
+            with tag.div(classes="text-sm text-base-content/60"):
+                text(f"Page {page}")
+            with tag.div(classes="join"):
+                _nav_button(page - 1, "← Previous", disabled=page <= 1)
+                _nav_button(page + 1, "Next →", disabled=not has_more)
 
     @contextlib.contextmanager
     def organization_row(self, request: Request, org: Organization) -> Generator[None]:
@@ -565,10 +588,14 @@ class OrganizationListView:
                             with self.organization_row(request, org):
                                 pass
 
-                if has_more:
-                    self.load_more_button(
-                        request, page, current_sort, current_direction, status_filter
-                    )
+                self.pagination_controls(
+                    request,
+                    page,
+                    has_more,
+                    current_sort,
+                    current_direction,
+                    status_filter,
+                )
 
         yield
 
@@ -668,10 +695,14 @@ class OrganizationListView:
                             with self.organization_row(request, org):
                                 pass
 
-                if has_more:
-                    self.load_more_button(
-                        request, page, current_sort, current_direction, status_filter
-                    )
+                self.pagination_controls(
+                    request,
+                    page,
+                    has_more,
+                    current_sort,
+                    current_direction,
+                    status_filter,
+                )
 
         yield
 


### PR DESCRIPTION
## 📋 Summary

Replaces the "Load More" button on the V2 organizations backoffice list with explicit Previous/Next pagination controls.

## 🎯 What

- Swap `Load More` (hx-swap=beforeend) for Prev/Next buttons that replace the current page of rows (hx-swap=innerHTML on `#org-list`).
- Default page size dropped from 50 → 20.
- Skip `get_status_counts()` / `get_distinct_countries()` on HTMX partial responses where their results are thrown away.

## 🤔 Why

The infinite-scroll style "Load More" makes it hard to scan through orgs and leaves stale rows above the fold. Pagination gives a fixed viewport and predictable navigation.

Performance was explicit: avoid a COUNT(*) on every page load. The endpoint already uses `limit + 1` to detect `has_more`, so the new controls piggyback on that — no new queries. The status-counts/countries queries were also running on every pagination click (they're only needed for the tab bar and country filter, which the partial response doesn't render), so they're moved into the full-page branch.

## 🔧 How

`list_view.py`:
- Rename `load_more_button` → `pagination_controls` — renders a `Page N` label plus Prev/Next buttons, disabled at edges.
- Early return when there is exactly one page (`page == 1` and `not has_more`).
- Both `render` and `render_table_only` call the new method unconditionally.

`endpoints.py`:
- Default `limit` query param `50` → `20`.
- Move `get_status_counts()` and `get_distinct_countries()` into the non-HTMX branch.

## 🧪 Testing

- [x] I have tested these changes locally
- [x] I have run linting and type checking (`ruff check` and `mypy` both pass on the touched files)

### Test Instructions

1. Open `/backoffice/organizations/`.
2. Verify the list shows 20 rows, with `Page 1` and `← Previous` (disabled) / `Next →`.
3. Click `Next →` — table rows replace, `Page 2` shown, `← Previous` enabled.
4. Apply a filter or search; pagination resets to page 1 (filter-form doesn't carry `page`).
5. Sort on a column; same — filters + sort preserved across pagination via `hx-include="#filter-form"` + `hx-vals`.