### PR TITLE
fix(subscription): atomic claim in scheduler to prevent duplicate cycle tasks

### DIFF
--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -36,26 +36,10 @@ class SubscriptionJobStore(BaseJobStore):
         return None
 
     def get_due_jobs(self, now: datetime.datetime) -> list[Job]:
-        # Atomic claim: concurrent scheduler instances must not each enqueue
-        # ``subscription.cycle`` for the same subscription.
-        claim_subquery = (
-            self.scheduling_statement()
-            .where(Subscription.current_period_end <= now)
-            .with_only_columns(Subscription.id)
-            .with_for_update(skip_locked=True, of=Subscription)
+        statement = self.scheduling_statement().where(
+            Subscription.current_period_end <= now,
         )
-        claim_statement = (
-            update(Subscription)
-            .where(Subscription.id.in_(claim_subquery))
-            .values(scheduler_locked_at=utc_now())
-            .returning(Subscription.id, Subscription.current_period_end)
-            .execution_options(synchronize_session=False)
-        )
-        jobs: list[Job] = []
-        with self.engine.begin() as connection:
-            result = connection.execute(claim_statement)
-            for subscription_id, current_period_end in result:
-                jobs.append(self._build_job(subscription_id, current_period_end))
+        jobs = self._list_jobs_from_statement(statement)
         log.debug("Due jobs", count=len(jobs))
         return jobs
 
@@ -78,8 +62,22 @@ class SubscriptionJobStore(BaseJobStore):
         return jobs
 
     def remove_job(self, job_id: str) -> None:
-        # The row was already claimed by ``get_due_jobs``; just enqueue.
+        # Atomic claim: only the instance whose conditional UPDATE flips
+        # ``scheduler_locked_at`` from NULL proceeds to enqueue. Concurrent
+        # schedulers that lose the race see 0 rows and bail out.
         subscription_id = job_id.split(":")[-1]
+        statement = (
+            update(Subscription)
+            .where(
+                Subscription.id == subscription_id,
+                Subscription.scheduler_locked_at.is_(None),
+            )
+            .values(scheduler_locked_at=utc_now())
+            .returning(Subscription.id)
+        )
+        with self.engine.begin() as connection:
+            if connection.execute(statement).first() is None:
+                return
         actor = dramatiq.get_broker().get_actor("subscription.cycle")
         actor.send(subscription_id=subscription_id)
 

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -1,5 +1,4 @@
 import datetime
-import uuid
 
 import dramatiq
 import structlog
@@ -62,9 +61,7 @@ class SubscriptionJobStore(BaseJobStore):
         return jobs
 
     def remove_job(self, job_id: str) -> None:
-        # Atomic claim: only the instance whose conditional UPDATE flips
-        # ``scheduler_locked_at`` from NULL proceeds to enqueue. Concurrent
-        # schedulers that lose the race see 0 rows and bail out.
+        # Conditional UPDATE dedupes concurrent schedulers: losers see 0 rows.
         subscription_id = job_id.split(":")[-1]
         statement = (
             update(Subscription)
@@ -73,10 +70,9 @@ class SubscriptionJobStore(BaseJobStore):
                 Subscription.scheduler_locked_at.is_(None),
             )
             .values(scheduler_locked_at=utc_now())
-            .returning(Subscription.id)
         )
         with self.engine.begin() as connection:
-            if connection.execute(statement).first() is None:
+            if connection.execute(statement).rowcount == 0:
                 return
         actor = dramatiq.get_broker().get_actor("subscription.cycle")
         actor.send(subscription_id=subscription_id)
@@ -102,26 +98,21 @@ class SubscriptionJobStore(BaseJobStore):
             )
             for result in results.yield_per(250):
                 subscription_id, current_period_end = result._tuple()
-                jobs.append(self._build_job(subscription_id, current_period_end))
+                trigger = DateTrigger(current_period_end, datetime.UTC)
+                job_kwargs = {
+                    **(self._scheduler._job_defaults if self._scheduler else {}),
+                    "trigger": trigger,
+                    "executor": self.executor,
+                    "func": lambda: None,
+                    "args": (),
+                    "kwargs": {},
+                    "id": f"subscriptions:cycle:{subscription_id}",
+                    "name": None,
+                    "next_run_time": trigger.run_date,
+                    "misfire_grace_time": None,
+                }
+                jobs.append(Job(self._scheduler, **job_kwargs))
         return jobs
-
-    def _build_job(
-        self, subscription_id: uuid.UUID, current_period_end: datetime.datetime
-    ) -> Job:
-        trigger = DateTrigger(current_period_end, datetime.UTC)
-        job_kwargs = {
-            **(self._scheduler._job_defaults if self._scheduler else {}),
-            "trigger": trigger,
-            "executor": self.executor,
-            "func": lambda: None,
-            "args": (),
-            "kwargs": {},
-            "id": f"subscriptions:cycle:{subscription_id}",
-            "name": None,
-            "next_run_time": trigger.run_date,
-            "misfire_grace_time": None,
-        }
-        return Job(self._scheduler, **job_kwargs)
 
     @staticmethod
     def scheduling_statement() -> Select[tuple[Subscription]]:

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 import dramatiq
 import structlog
@@ -35,10 +36,26 @@ class SubscriptionJobStore(BaseJobStore):
         return None
 
     def get_due_jobs(self, now: datetime.datetime) -> list[Job]:
-        statement = self.scheduling_statement().where(
-            Subscription.current_period_end <= now,
+        # Atomic claim: concurrent scheduler instances must not each enqueue
+        # ``subscription.cycle`` for the same subscription.
+        claim_subquery = (
+            self.scheduling_statement()
+            .where(Subscription.current_period_end <= now)
+            .with_only_columns(Subscription.id)
+            .with_for_update(skip_locked=True, of=Subscription)
         )
-        jobs = self._list_jobs_from_statement(statement)
+        claim_statement = (
+            update(Subscription)
+            .where(Subscription.id.in_(claim_subquery))
+            .values(scheduler_locked_at=utc_now())
+            .returning(Subscription.id, Subscription.current_period_end)
+            .execution_options(synchronize_session=False)
+        )
+        jobs: list[Job] = []
+        with self.engine.begin() as connection:
+            result = connection.execute(claim_statement)
+            for subscription_id, current_period_end in result:
+                jobs.append(self._build_job(subscription_id, current_period_end))
         log.debug("Due jobs", count=len(jobs))
         return jobs
 
@@ -61,14 +78,8 @@ class SubscriptionJobStore(BaseJobStore):
         return jobs
 
     def remove_job(self, job_id: str) -> None:
+        # The row was already claimed by ``get_due_jobs``; just enqueue.
         subscription_id = job_id.split(":")[-1]
-        statement = (
-            update(Subscription)
-            .where(Subscription.id == subscription_id)
-            .values(scheduler_locked_at=utc_now())
-        )
-        with self.engine.begin() as connection:
-            connection.execute(statement)
         actor = dramatiq.get_broker().get_actor("subscription.cycle")
         actor.send(subscription_id=subscription_id)
 
@@ -93,22 +104,26 @@ class SubscriptionJobStore(BaseJobStore):
             )
             for result in results.yield_per(250):
                 subscription_id, current_period_end = result._tuple()
-                trigger = DateTrigger(current_period_end, datetime.UTC)
-                job_kwargs = {
-                    **(self._scheduler._job_defaults if self._scheduler else {}),
-                    "trigger": trigger,
-                    "executor": self.executor,
-                    "func": lambda: None,
-                    "args": (),
-                    "kwargs": {},
-                    "id": f"subscriptions:cycle:{subscription_id}",
-                    "name": None,
-                    "next_run_time": trigger.run_date,
-                    "misfire_grace_time": None,
-                }
-                job = Job(self._scheduler, **job_kwargs)
-                jobs.append(job)
+                jobs.append(self._build_job(subscription_id, current_period_end))
         return jobs
+
+    def _build_job(
+        self, subscription_id: uuid.UUID, current_period_end: datetime.datetime
+    ) -> Job:
+        trigger = DateTrigger(current_period_end, datetime.UTC)
+        job_kwargs = {
+            **(self._scheduler._job_defaults if self._scheduler else {}),
+            "trigger": trigger,
+            "executor": self.executor,
+            "func": lambda: None,
+            "args": (),
+            "kwargs": {},
+            "id": f"subscriptions:cycle:{subscription_id}",
+            "name": None,
+            "next_run_time": trigger.run_date,
+            "misfire_grace_time": None,
+        }
+        return Job(self._scheduler, **job_kwargs)
 
     @staticmethod
     def scheduling_statement() -> Select[tuple[Subscription]]:


### PR DESCRIPTION
## 📋 Summary

Fix `subscription.cycle` being enqueued multiple times for the same subscription when concurrent scheduler instances overlap (rolling deploy, extra replica, restart window).

## 🎯 What

Make the scheduler's "pick due subscriptions" step atomic: `SubscriptionJobStore.get_due_jobs` now does a single `UPDATE … WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED) RETURNING …`. Only one scheduler wins each row. `remove_job` is reduced to just firing the dramatiq task (the DB claim already happened).

## 🤔 Why

Logfire shows the same `subscription.cycle` enqueued multiple times for the same `subscription_id` — sometimes with sub-millisecond gaps between distinct `message_id`s. A single-threaded `BlockingScheduler` cannot produce that; it's only explainable by two scheduler processes running concurrently.

The old flow was a read-then-write with no atomic claim:
1. `get_due_jobs` → `SELECT … WHERE scheduler_locked_at IS NULL AND current_period_end <= now`
2. `remove_job` → `UPDATE subscriptions SET scheduler_locked_at = NOW()` + `actor.send(...)`

Any overlap between instance A's step 1 and instance B's step 1 let both see the same row with `scheduler_locked_at IS NULL`, and both sent a dramatiq message. The Redis lock inside the task (`subscription:cycle:{id}`) prevents concurrent *execution*, not duplicate *enqueues*.

## 🔧 How

In `server/polar/subscription/scheduler.py`:

- `get_due_jobs` rewrites the claim as a single statement:
  ```sql
  UPDATE subscriptions
  SET scheduler_locked_at = NOW()
  WHERE id IN (
    SELECT id FROM subscriptions JOIN customers JOIN organizations
    WHERE scheduler_locked_at IS NULL AND current_period_end <= :now AND ...
    FOR UPDATE OF subscriptions SKIP LOCKED
  )
  RETURNING id, current_period_end;
  ```
  `SKIP LOCKED` makes the losing instance's subquery return nothing rather than blocking and re-claiming after commit.
- `remove_job` loses its DB work and only calls `actor.send(...)`.
- Extract `_build_job(subscription_id, current_period_end)` so the `RETURNING` path and the existing `_list_jobs_from_statement` path share construction.

`scheduler_locked_at` reset logic in `tasks.py` and `service.py` is unchanged — those still correctly release the claim after the task runs.

## 🧪 Testing

- [x] Existing `tests/subscription/` tests pass (197/197).
- [x] Ran a standalone 2-process verification script against `polar_test` (docker compose up). Seeded 20 due subscriptions, spawned 2 OS processes each calling `get_due_jobs`:
  - **Without the fix**: 40 claims, 20 duplicates.
  - **With the fix**: 20 claims, 0 duplicates — one process claimed 20, the other claimed 0.
- [x] `uv run ruff check` and `uv run mypy polar/subscription/scheduler.py` clean.

### Test Instructions

1. `docker compose up -d` (from `server/`)
2. `POLAR_ENV=testing uv run alembic upgrade head`
3. `POLAR_ENV=testing uv run pytest tests/subscription/ --no-cov`

## 📝 Additional Notes

Follow-ups worth considering separately (out of scope here):
- Add a `debounce_key=subscription_id` to the `subscription.cycle` actor for belt-and-suspenders dedup at the dramatiq layer.
- Audit the `pending_update_changed_interval` branch in `service.cycle` — when that path is taken, `current_period_end` is not advanced; combined with the task clearing `scheduler_locked_at`, a subscription can re-fire on the next tick.
- Consider a composite partial index `(scheduler_locked_at, current_period_end) WHERE scheduler_locked_at IS NULL` to keep the 1s tick query cheap as the subscriptions table grows.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: I used AI assistance; I tested and executed the code locally (manual 2-process verification on `polar_test`).