### PR TITLE
feat(organization): enforce status transition rules

### DIFF
--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -1134,16 +1134,6 @@ async def get(
                 await organization_service.set_organization_offboarding(
                     session, organization, reason=reason
                 )
-            elif account_status.action == "reactivate":
-                await review_repo.record_human_decision(
-                    organization_id=id,
-                    reviewer_id=user_session.user.id,
-                    decision=DecisionType.APPROVE,
-                    reason=reason,
-                )
-                await organization_service.reactivate_organization(
-                    session, organization
-                )
             return HXRedirectResponse(request, request.url, 303)
         except PydanticCustomError as e:
             await add_toast(request, str(e.message_template), variant="error")

--- a/server/polar/backoffice/organizations/forms.py
+++ b/server/polar/backoffice/organizations/forms.py
@@ -78,18 +78,13 @@ class OffboardOrganizationForm(forms.BaseForm):
     ]
 
 
-class ReactivateOrganizationForm(forms.BaseForm):
-    action: Annotated[Literal["reactivate"], forms.SkipField]
-
-
 OrganizationStatusForm = Annotated[
     ApproveOrganizationForm
     | DenyOrganizationForm
     | UnderReviewOrganizationForm
     | ApproveOrganizationAppealForm
     | DenyOrganizationAppealForm
-    | OffboardOrganizationForm
-    | ReactivateOrganizationForm,
+    | OffboardOrganizationForm,
     Discriminator("action"),
 ]
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1072,9 +1072,9 @@ async def approve_denied_dialog(
 
         override_reason = str(data.get("override_reason", "")).strip() or None
 
-        if is_override and not override_reason:
+        if not override_reason:
             error_message = (
-                "A reason is required when overriding the AI recommendation."
+                "A reason is required when reactivating a denied organization."
             )
         else:
             # Record review decision before approving denied org
@@ -1087,7 +1087,7 @@ async def approve_denied_dialog(
 
             # Approve the organization
             await organization_service.confirm_organization_reviewed(
-                session, organization, threshold
+                session, organization, threshold, reason=override_reason
             )
 
             return HXRedirectResponse(
@@ -1103,21 +1103,20 @@ async def approve_denied_dialog(
     reason_label = (
         "Reason for override (required)"
         if is_override
-        else "Reason for approval (optional)"
+        else "Reason for reactivation (required)"
     )
     reason_placeholder = (
         "Why are you overriding the AI recommendation?"
         if is_override
-        else "Why are you approving this organization?"
+        else "Why are you reactivating this denied organization?"
     )
     textarea_attrs: dict[str, Any] = {
         "name": "override_reason",
         "classes": "textarea textarea-bordered w-full",
         "placeholder": reason_placeholder,
         "rows": "3",
+        "required": True,
     }
-    if is_override:
-        textarea_attrs["required"] = True
 
     with modal("Approve Denied Organization", open=True):
         with tag.form(
@@ -1332,10 +1331,8 @@ async def unblock_approve_dialog(
 
         override_reason = str(data.get("override_reason", "")).strip() or None
 
-        if is_override and not override_reason:
-            error_message = (
-                "A reason is required when overriding the AI recommendation."
-            )
+        if not override_reason:
+            error_message = "A reason is required when unblocking an organization."
         else:
             # Record review decision before unblocking
             await review_repo.record_human_decision(
@@ -1347,7 +1344,7 @@ async def unblock_approve_dialog(
 
             # Approve the organization
             await organization_service.confirm_organization_reviewed(
-                session, organization, threshold
+                session, organization, threshold, reason=override_reason
             )
 
             return HXRedirectResponse(
@@ -1363,21 +1360,20 @@ async def unblock_approve_dialog(
     reason_label = (
         "Reason for override (required)"
         if is_override
-        else "Reason for approval (optional)"
+        else "Reason for unblocking (required)"
     )
     reason_placeholder = (
         "Why are you overriding the AI recommendation?"
         if is_override
-        else "Why are you approving this organization?"
+        else "Why are you unblocking this organization?"
     )
     textarea_attrs: dict[str, Any] = {
         "name": "override_reason",
         "classes": "textarea textarea-bordered w-full",
         "placeholder": reason_placeholder,
         "rows": "3",
+        "required": True,
     }
-    if is_override:
-        textarea_attrs["required"] = True
 
     with modal("Unblock & Approve Organization", open=True):
         with tag.form(
@@ -1796,77 +1792,6 @@ async def offboard_dialog(
                         text("Cancel")
                 with button(variant="warning", type="submit"):
                     text("Set Offboarding")
-
-    return None
-
-
-@router.api_route(
-    "/{organization_id}/reactivate-dialog",
-    name="organizations:reactivate_dialog",
-    methods=["GET", "POST"],
-    response_model=None,
-)
-async def reactivate_dialog(
-    request: Request,
-    organization_id: UUID4,
-    session: AsyncSession = Depends(get_db_session),
-    user_session: UserSession = Depends(get_admin),
-) -> HXRedirectResponse | None:
-    """Reactivate an offboarding organization dialog and action."""
-    repository = OrganizationRepository(session)
-
-    organization = await repository.get_by_id(organization_id, include_blocked=True)
-    if not organization:
-        raise HTTPException(status_code=404, detail="Organization not found")
-
-    if request.method == "POST":
-        review_repo = OrganizationReviewRepository.from_session(session)
-        await review_repo.record_human_decision(
-            organization_id=organization_id,
-            reviewer_id=user_session.user.id,
-            decision=DecisionType.APPROVE,
-        )
-
-        await organization_service.reactivate_organization(session, organization)
-
-        return HXRedirectResponse(
-            request,
-            str(
-                request.url_for("organizations:detail", organization_id=organization_id)
-            ),
-            303,
-        )
-
-    with modal("Reactivate Organization", open=True):
-        with tag.div(classes="flex flex-col gap-4"):
-            with tag.p(classes="font-semibold text-success"):
-                text("Reactivate Organization")
-
-            with tag.div(
-                classes="bg-success/10 border border-success/20 p-4 rounded-lg"
-            ):
-                with tag.p(classes="font-semibold mb-2"):
-                    text("This action will:")
-                with tag.ul(classes="list-disc list-inside space-y-1 text-sm"):
-                    with tag.li():
-                        text("Change the organization status back to Active")
-                    with tag.li():
-                        text("Re-enable payouts for the organization")
-
-            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
-                with tag.form(
-                    hx_post=str(
-                        request.url_for(
-                            "organizations:reactivate_dialog",
-                            organization_id=organization_id,
-                        )
-                    ),
-                ):
-                    with button(variant="success", type="submit"):
-                        text("Reactivate")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -352,18 +352,6 @@ class OrganizationDetailView:
                             ):
                                 text("Deny")
 
-                    elif self.org.status == OrganizationStatus.OFFBOARDING:
-                        # Reactivation from OFFBOARDING is not yet implemented.
-                        # Blocking remains available from the shared actions.
-                        with tag.div(
-                            classes="bg-warning/10 border border-warning/20 p-3 rounded-lg text-xs"
-                        ):
-                            text(
-                                "Reactivation out of offboarding is not yet "
-                                "implemented. The only action available on "
-                                "this organization is Block."
-                            )
-
                     elif self.org.status == OrganizationStatus.REVIEW:
                         # Compute suggested threshold: double current or $250 min
                         current_threshold = self.org.next_review_threshold or 0

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -353,20 +353,16 @@ class OrganizationDetailView:
                                 text("Deny")
 
                     elif self.org.status == OrganizationStatus.OFFBOARDING:
-                        with tag.div(classes="w-full"):
-                            with button(
-                                variant="secondary",
-                                size="sm",
-                                outline=True,
-                                hx_get=str(
-                                    request.url_for(
-                                        "organizations:reactivate_dialog",
-                                        organization_id=self.org.id,
-                                    )
-                                ),
-                                hx_target="#modal",
-                            ):
-                                text("Reactivate")
+                        # Reactivation from OFFBOARDING is not yet implemented.
+                        # Blocking remains available from the shared actions.
+                        with tag.div(
+                            classes="bg-warning/10 border border-warning/20 p-3 rounded-lg text-xs"
+                        ):
+                            text(
+                                "Reactivation out of offboarding is not yet "
+                                "implemented. The only action available on "
+                                "this organization is Block."
+                            )
 
                     elif self.org.status == OrganizationStatus.REVIEW:
                         # Compute suggested threshold: double current or $250 min
@@ -535,21 +531,6 @@ class OrganizationDetailView:
                                 hx_target="#modal",
                             ):
                                 text("Deny")
-
-                        with tag.div(classes="w-full"):
-                            with button(
-                                variant="secondary",
-                                size="sm",
-                                outline=True,
-                                hx_get=str(
-                                    request.url_for(
-                                        "organizations:offboard_dialog",
-                                        organization_id=self.org.id,
-                                    )
-                                ),
-                                hx_target="#modal",
-                            ):
-                                text("Set Offboarding")
 
                     elif self.org.status == OrganizationStatus.CREATED:
                         with tag.div(classes="w-full"):

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -317,9 +317,7 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
 
 # DENIED → ACTIVE and BLOCKED → ACTIVE additionally require a reason,
 # enforced at the service layer.
-ALLOWED_STATUS_TRANSITIONS: dict[
-    OrganizationStatus, frozenset[OrganizationStatus]
-] = {
+ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatus]] = {
     OrganizationStatus.CREATED: frozenset(
         {
             OrganizationStatus.REVIEW,

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -242,6 +242,19 @@ class OrganizationCapabilities(TypedDict):
     dashboard_access: bool
 
 
+class InvalidStatusTransitionError(PolarError):
+    def __init__(
+        self, current: "OrganizationStatus", target: "OrganizationStatus"
+    ) -> None:
+        self.current = current
+        self.target = target
+        super().__init__(
+            f"Cannot transition organization status from "
+            f"{current.get_display_name()} to {target.get_display_name()}.",
+            400,
+        )
+
+
 STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
     OrganizationStatus.CREATED: {
         "checkout_payments": False,
@@ -299,6 +312,62 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
         "api_access": False,
         "dashboard_access": False,
     },
+}
+
+
+# DENIED → ACTIVE and BLOCKED → ACTIVE additionally require a reason,
+# enforced at the service layer.
+ALLOWED_STATUS_TRANSITIONS: dict[
+    OrganizationStatus, frozenset[OrganizationStatus]
+] = {
+    OrganizationStatus.CREATED: frozenset(
+        {
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+        }
+    ),
+    OrganizationStatus.REVIEW: frozenset(
+        {
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.SNOOZED,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.OFFBOARDING,
+            OrganizationStatus.BLOCKED,
+        }
+    ),
+    OrganizationStatus.SNOOZED: frozenset(
+        {
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+        }
+    ),
+    OrganizationStatus.ACTIVE: frozenset(
+        {
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+        }
+    ),
+    OrganizationStatus.DENIED: frozenset(
+        {
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.BLOCKED,
+        }
+    ),
+    OrganizationStatus.OFFBOARDING: frozenset(
+        {
+            OrganizationStatus.BLOCKED,
+        }
+    ),
+    OrganizationStatus.BLOCKED: frozenset(
+        {
+            OrganizationStatus.ACTIVE,
+        }
+    ),
 }
 
 
@@ -517,6 +586,11 @@ class Organization(RateLimitGroupMixin, RecordModel):
         return and_(cls.is_deleted.is_(False), cls.status != OrganizationStatus.BLOCKED)
 
     def set_status(self, status: OrganizationStatus) -> None:
+        if (
+            status != self.status
+            and status not in ALLOWED_STATUS_TRANSITIONS[self.status]
+        ):
+            raise InvalidStatusTransitionError(self.status, status)
         self.status = status
         self.status_updated_at = datetime.now(UTC)
         self.capabilities = {**STATUS_CAPABILITIES[status]}

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -320,7 +320,6 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
 ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatus]] = {
     OrganizationStatus.CREATED: frozenset(
         {
-            OrganizationStatus.REVIEW,
             OrganizationStatus.ACTIVE,
             OrganizationStatus.DENIED,
             OrganizationStatus.BLOCKED,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -809,16 +809,33 @@ class OrganizationService:
         organization: Organization,
         next_review_threshold: int | None = None,
         *,
+        reason: str | None = None,
         silent: bool = False,
     ) -> Organization:
+        reactivation_notes = {
+            OrganizationStatus.DENIED: "Organization reactivated from denied.",
+            OrganizationStatus.BLOCKED: "Organization unblocked.",
+        }
+        if organization.status in reactivation_notes and not reason:
+            raise OrganizationError(
+                "A reason is required when reactivating a "
+                f"{organization.status.get_display_name()} organization.",
+                400,
+            )
+
         if next_review_threshold is None:
             next_review_threshold = max(
                 organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
             )
 
-        organization.status = OrganizationStatus.ACTIVE
-        organization.status_updated_at = datetime.now(UTC)
+        previous_status = organization.status
+        organization.set_status(OrganizationStatus.ACTIVE)
         organization.next_review_threshold = next_review_threshold
+
+        if previous_status in reactivation_notes:
+            _append_internal_note(
+                organization, reactivation_notes[previous_status], reason=reason
+            )
 
         initial_review = False
         if organization.initially_reviewed_at is None:
@@ -874,8 +891,7 @@ class OrganizationService:
     async def deny_organization(
         self, session: AsyncSession, organization: Organization
     ) -> Organization:
-        organization.status = OrganizationStatus.DENIED
-        organization.status_updated_at = datetime.now(UTC)
+        organization.set_status(OrganizationStatus.DENIED)
         session.add(organization)
 
         # If there's a pending appeal, mark it as rejected
@@ -936,8 +952,7 @@ class OrganizationService:
         *,
         enqueue_review: bool = True,
     ) -> Organization:
-        organization.status = OrganizationStatus.REVIEW
-        organization.status_updated_at = datetime.now(UTC)
+        organization.set_status(OrganizationStatus.REVIEW)
         session.add(organization)
 
         # Record a human ESCALATE decision so the agent knows not to auto-act
@@ -961,13 +976,12 @@ class OrganizationService:
         *,
         reason: str | None = None,
     ) -> Organization:
-        if organization.status not in OrganizationStatus.review_statuses():
+        if organization.status != OrganizationStatus.REVIEW:
             raise OrganizationError(
                 "Only organizations under review can be set to offboarding.",
                 403,
             )
-        organization.status = OrganizationStatus.OFFBOARDING
-        organization.status_updated_at = datetime.now(UTC)
+        organization.set_status(OrganizationStatus.OFFBOARDING)
         _append_internal_note(
             organization, "Organization set to offboarding.", reason=reason
         )
@@ -979,14 +993,8 @@ class OrganizationService:
         session: AsyncSession,
         organization: Organization,
     ) -> Organization:
-        if organization.status != OrganizationStatus.OFFBOARDING:
-            raise OrganizationError(
-                "Only offboarding organizations can be reactivated.", 403
-            )
-        organization.status = OrganizationStatus.ACTIVE
-        organization.status_updated_at = datetime.now(UTC)
-        session.add(organization)
-        return organization
+        # Reactivation out of OFFBOARDING is not yet implemented.
+        raise OrganizationError("Offboarding reactivation is not yet implemented.", 400)
 
     async def get_payment_status(
         self,
@@ -1108,8 +1116,7 @@ class OrganizationService:
         if review.appeal_decision is not None:
             raise ValueError("Appeal has already been reviewed")
 
-        organization.status = OrganizationStatus.ACTIVE
-        organization.status_updated_at = datetime.now(UTC)
+        organization.set_status(OrganizationStatus.ACTIVE)
         review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
         review.appeal_reviewed_at = datetime.now(UTC)
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -988,14 +988,6 @@ class OrganizationService:
         session.add(organization)
         return organization
 
-    async def reactivate_organization(
-        self,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> Organization:
-        # Reactivation out of OFFBOARDING is not yet implemented.
-        raise OrganizationError("Offboarding reactivation is not yet implemented.", 400)
-
     async def get_payment_status(
         self,
         session: AsyncReadSession,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -2204,7 +2204,7 @@ class TestStatusTransitions:
             )
 
     @pytest.mark.parametrize(
-        "current, expected_note_fragment",
+        ("current", "expected_note_fragment"),
         [
             (OrganizationStatus.DENIED, "reactivated from denied"),
             (OrganizationStatus.BLOCKED, "unblocked"),

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -17,6 +17,7 @@ from polar.exceptions import PolarRequestValidationError
 from polar.models import Customer, Organization, Product, User
 from polar.models.account import Account
 from polar.models.organization import (
+    InvalidStatusTransitionError,
     OrganizationNotificationSettings,
     OrganizationStatus,
     OrganizationSubscriptionSettings,
@@ -27,6 +28,7 @@ from polar.organization.schemas import (
     OrganizationFeatureSettings,
     OrganizationUpdate,
 )
+from polar.organization.service import OrganizationError
 from polar.organization.service import organization as organization_service
 from polar.organization_review.schemas import ReviewVerdict
 from polar.postgres import AsyncSession
@@ -658,9 +660,9 @@ class TestConfirmOrganizationReviewed:
 
         mocker.patch("polar.organization.service.enqueue_job")
 
-        # When: operator manually approves the org
+        # When: operator manually approves the org with a reason
         result = await organization_service.confirm_organization_reviewed(
-            session, organization, 15000
+            session, organization, 15000, reason="Appeal re-examined"
         )
 
         # Then: appeal decision is overridden to approved
@@ -1891,20 +1893,12 @@ class TestResetProrationBehavior:
 
 @pytest.mark.asyncio
 class TestSetOrganizationOffboarding:
-    @pytest.mark.parametrize(
-        "status",
-        [
-            OrganizationStatus.REVIEW,
-            OrganizationStatus.SNOOZED,
-        ],
-    )
-    async def test_from_review_statuses(
+    async def test_from_review(
         self,
-        status: OrganizationStatus,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        organization.status = status
+        organization.status = OrganizationStatus.REVIEW
 
         result = await organization_service.set_organization_offboarding(
             session, organization
@@ -1916,6 +1910,7 @@ class TestSetOrganizationOffboarding:
     @pytest.mark.parametrize(
         "status",
         [
+            OrganizationStatus.SNOOZED,
             OrganizationStatus.ACTIVE,
             OrganizationStatus.DENIED,
             OrganizationStatus.CREATED,
@@ -1953,28 +1948,24 @@ class TestSetOrganizationOffboarding:
 
 @pytest.mark.asyncio
 class TestReactivateOrganization:
-    async def test_from_offboarding(
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.OFFBOARDING,
+            OrganizationStatus.ACTIVE,
+        ],
+    )
+    async def test_always_raises_not_implemented(
         self,
+        status: OrganizationStatus,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        organization.status = OrganizationStatus.OFFBOARDING
+        organization.status = status
 
-        result = await organization_service.reactivate_organization(
-            session, organization
-        )
-
-        assert result.status == OrganizationStatus.ACTIVE
-        assert result.status_updated_at is not None
-
-    async def test_from_non_offboarding_raises(
-        self,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = OrganizationStatus.ACTIVE
-
-        with pytest.raises(Exception, match="Only offboarding organizations"):
+        with pytest.raises(
+            Exception, match="Offboarding reactivation is not yet implemented"
+        ):
             await organization_service.reactivate_organization(session, organization)
 
 
@@ -2139,3 +2130,130 @@ class TestSetPayoutAccount:
             await organization_service.set_payout_account(
                 session, auth_subject, organization, uuid.uuid4()
             )
+
+
+@pytest.mark.asyncio
+class TestStatusTransitions:
+    """Tests for the organization status transition rules enforced in
+    Organization.set_status()."""
+
+    @pytest.mark.parametrize(
+        "current",
+        [
+            OrganizationStatus.CREATED,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.OFFBOARDING,
+        ],
+    )
+    async def test_every_status_can_go_to_blocked(
+        self,
+        current: OrganizationStatus,
+        organization: Organization,
+    ) -> None:
+        organization.status = current
+        organization.set_status(OrganizationStatus.BLOCKED)
+        assert organization.status == OrganizationStatus.BLOCKED
+
+    async def test_review_can_go_to_offboarding(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        organization.set_status(OrganizationStatus.OFFBOARDING)
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+    @pytest.mark.parametrize(
+        "current",
+        [
+            OrganizationStatus.CREATED,
+            OrganizationStatus.SNOOZED,
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+        ],
+    )
+    async def test_only_review_can_go_to_offboarding(
+        self,
+        current: OrganizationStatus,
+        organization: Organization,
+    ) -> None:
+        organization.status = current
+        with pytest.raises(InvalidStatusTransitionError):
+            organization.set_status(OrganizationStatus.OFFBOARDING)
+
+    @pytest.mark.parametrize(
+        "current",
+        [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],
+    )
+    async def test_reactivation_requires_reason(
+        self,
+        current: OrganizationStatus,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = current
+        mocker.patch("polar.organization.service.enqueue_job")
+
+        with pytest.raises(OrganizationError):
+            await organization_service.confirm_organization_reviewed(
+                session, organization, 15000
+            )
+
+    @pytest.mark.parametrize(
+        "current, expected_note_fragment",
+        [
+            (OrganizationStatus.DENIED, "reactivated from denied"),
+            (OrganizationStatus.BLOCKED, "unblocked"),
+        ],
+    )
+    async def test_reactivation_with_reason_succeeds(
+        self,
+        current: OrganizationStatus,
+        expected_note_fragment: str,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = current
+        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.confirm_organization_reviewed(
+            session, organization, 15000, reason="Merchant provided additional docs"
+        )
+
+        assert result.status == OrganizationStatus.ACTIVE
+        assert result.internal_notes is not None
+        assert expected_note_fragment in result.internal_notes
+        assert "Merchant provided additional docs" in result.internal_notes
+
+    async def test_self_transition_is_noop(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.BLOCKED
+        organization.set_status(OrganizationStatus.BLOCKED)
+        assert organization.status == OrganizationStatus.BLOCKED
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            OrganizationStatus.CREATED,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.OFFBOARDING,
+        ],
+    )
+    async def test_blocked_only_transitions_to_active(
+        self,
+        target: OrganizationStatus,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.BLOCKED
+        with pytest.raises(InvalidStatusTransitionError):
+            organization.set_status(target)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1947,29 +1947,6 @@ class TestSetOrganizationOffboarding:
 
 
 @pytest.mark.asyncio
-class TestReactivateOrganization:
-    @pytest.mark.parametrize(
-        "status",
-        [
-            OrganizationStatus.OFFBOARDING,
-            OrganizationStatus.ACTIVE,
-        ],
-    )
-    async def test_always_raises_not_implemented(
-        self,
-        status: OrganizationStatus,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = status
-
-        with pytest.raises(
-            Exception, match="Offboarding reactivation is not yet implemented"
-        ):
-            await organization_service.reactivate_organization(session, organization)
-
-
-@pytest.mark.asyncio
 class TestSnoozeOrganization:
     async def test_from_review(
         self,


### PR DESCRIPTION
## 📋 Summary

Introduces an explicit organization status transition map and enforces it at the model layer, so all service code paths share one source of truth for which status changes are valid.

<img width="1327" height="515" alt="image" src="https://github.com/user-attachments/assets/8934caff-2ae2-4a0d-a9ee-8300ea651ce7" />


## 🎯 What

- New `ALLOWED_STATUS_TRANSITIONS` map in `polar/models/organization.py` and a new `InvalidStatusTransitionError(PolarError, 400)`.
- `Organization.set_status()` now rejects transitions that aren't in the map.
- All service-layer status mutations (`confirm_organization_reviewed`, `deny_organization`, `set_organization_under_review`, `set_organization_offboarding`, `approve_appeal`) route through `set_status()` — no more direct `organization.status = ...` assignments that bypass validation and capability sync.
- `confirm_organization_reviewed` now requires a `reason` when the source status is DENIED or BLOCKED, and appends it to the organization's internal notes.
- Backoffice: `approve_denied_dialog` and `unblock_approve_dialog` always require a reason and forward it to the service; the orphaned `reactivate_dialog` and the "Set Offboarding" button on SNOOZED orgs are removed; OFFBOARDING orgs see a "reactivation not yet implemented" notice.
- `reactivate_organization` raises `OrganizationError(400)` — offboarding reactivation isn't implemented yet.

### Transition rules encoded

| From → To | Allowed |
|---|---|
| CREATED | REVIEW, ACTIVE, DENIED, BLOCKED |
| REVIEW | ACTIVE, SNOOZED, DENIED, OFFBOARDING, BLOCKED |
| SNOOZED | REVIEW, ACTIVE, DENIED, BLOCKED |
| ACTIVE | REVIEW, DENIED, BLOCKED |
| DENIED | ACTIVE (reason required), BLOCKED |
| OFFBOARDING | BLOCKED |
| BLOCKED | ACTIVE (reason required) |

## 🤔 Why

The three rules requested:
1. Offboarded isn't fully implemented yet — only REVIEW may enter it, and reactivation out of it is blocked.
2. Every status can transition to BLOCKED.
3. DENIED → ACTIVE (and now BLOCKED → ACTIVE) requires a human-provided reason for auditability.

Without central enforcement, each endpoint/service method had its own ad-hoc checks (or none), and inconsistent `organization.status = X; status_updated_at = ...` assignments could drift out of sync with `capabilities`.

## 🔧 How

- Transition map lives alongside `STATUS_CAPABILITIES` in the model, validated in `set_status()`.
- Reason enforcement for DENIED/BLOCKED → ACTIVE is in `confirm_organization_reviewed` and surfaces as `OrganizationError(400)`; backoffice dialogs enforce it client-side too and forward the reason to the service.
- Capability recomputation now happens on every transition (previously bypassed for some paths that did direct assignment).

## 🧪 Testing

- [x] I have tested these changes locally
- [x] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [x] I have added new tests for new functionality
- [x] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. In the backoffice, open an organization in the REVIEW status and verify "Approve / Deny / Snooze / Set Offboarding" buttons appear; "Set Offboarding" does **not** appear on SNOOZED orgs anymore.
2. Deny an organization, then open the "Approve" dialog: the reason textarea is required and the submit is rejected (with a visible error) if the reason is blank.
3. Block an organization, then open "Unblock & Approve": the reason textarea is required.
4. Open an OFFBOARDING organization: the "Reactivate" button is gone, replaced with a "not yet implemented" notice. Only Block remains available.

## 📝 Additional Notes

`reactivate_organization` is still called by the v1 (legacy) backoffice endpoint at `polar/backoffice/organizations/endpoints.py`. It now raises `OrganizationError(400)`, which the v1 handler will surface as an error to the operator. This is acceptable given offboarding reactivation isn't implemented; the v1 UI is on the way out.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have updated the relevant tests
- [x] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")

🤖 Generated with [Claude Code](https://claude.com/claude-code)