### PR TITLE
metrics: Intersect organization_id filter with subject's accessible orgs

### DIFF
--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -409,17 +409,21 @@ class MetricsService:
         *,
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> list[uuid.UUID]:
-        if organization_id is not None and len(organization_id) > 0:
-            return list(organization_id)
         if is_organization(auth_subject):
-            return [auth_subject.subject.id]
-        if is_user(auth_subject):
+            accessible: list[uuid.UUID] = [auth_subject.subject.id]
+        elif is_user(auth_subject):
             stmt = select(UserOrganization.organization_id).where(
                 UserOrganization.user_id == auth_subject.subject.id,
                 UserOrganization.is_deleted.is_(False),
             )
-            return list(await session.scalars(stmt))
-        return []
+            accessible = list(await session.scalars(stmt))
+        else:
+            return []
+
+        if organization_id is not None and len(organization_id) > 0:
+            accessible_set = set(accessible)
+            return [oid for oid in organization_id if oid in accessible_set]
+        return accessible
 
     async def _resolve_tinybird_filters(
         self,

--- a/server/tests/metrics/test_service_authz.py
+++ b/server/tests/metrics/test_service_authz.py
@@ -1,0 +1,116 @@
+import pytest
+
+from polar.auth.models import AuthSubject
+from polar.metrics.service import metrics as metrics_service
+from polar.models import Organization, User, UserOrganization
+from polar.postgres import AsyncSession
+from tests.fixtures.auth import AuthSubjectFixture
+
+
+@pytest.mark.asyncio
+class TestResolveTinybirdFiltersAuthz:
+    @pytest.mark.auth
+    async def test_user_passing_foreign_org_is_filtered_out(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        assert user_organization.user_id == auth_subject.subject.id
+        assert user_organization.organization_id == organization.id
+
+        result = await metrics_service._resolve_tinybird_filters(
+            session,
+            auth_subject,
+            organization_id=[organization_second.id],
+            product_id=None,
+            billing_type=None,
+            customer_id=None,
+            tb_needed=set(),
+        )
+
+        assert result.org_ids == []
+
+    @pytest.mark.auth
+    async def test_user_passing_mix_keeps_only_accessible(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        result = await metrics_service._resolve_tinybird_filters(
+            session,
+            auth_subject,
+            organization_id=[organization.id, organization_second.id],
+            product_id=None,
+            billing_type=None,
+            customer_id=None,
+            tb_needed=set(),
+        )
+
+        assert result.org_ids == [organization.id]
+
+    @pytest.mark.auth
+    async def test_user_no_filter_returns_accessible_orgs(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        organization: Organization,
+    ) -> None:
+        result = await metrics_service._resolve_tinybird_filters(
+            session,
+            auth_subject,
+            organization_id=None,
+            product_id=None,
+            billing_type=None,
+            customer_id=None,
+            tb_needed=set(),
+        )
+
+        assert result.org_ids == [organization.id]
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_organization_passing_foreign_org_is_filtered_out(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        assert auth_subject.subject.id == organization.id
+
+        result = await metrics_service._resolve_tinybird_filters(
+            session,
+            auth_subject,
+            organization_id=[organization_second.id],
+            product_id=None,
+            billing_type=None,
+            customer_id=None,
+            tb_needed=set(),
+        )
+
+        assert result.org_ids == []
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_organization_no_filter_returns_self(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+        organization: Organization,
+    ) -> None:
+        result = await metrics_service._resolve_tinybird_filters(
+            session,
+            auth_subject,
+            organization_id=None,
+            product_id=None,
+            billing_type=None,
+            customer_id=None,
+            tb_needed=set(),
+        )
+
+        assert result.org_ids == [organization.id]


### PR DESCRIPTION
Previously, `_get_org_ids_for_subject` returned any passed `organization_id` as-is without checking whether the subject actually had access. Combined with the Tinybird query path (which has no subject-level WHERE), a user could read TB metrics for any organization by passing its UUID. The PG path was already safe because its SQL applies a subject-based filter.

Always resolve the subject's accessible orgs and intersect the passed filter against them.
