### PR TITLE
seats: Require checkout secret when assinging seat anonymously

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -24,7 +24,11 @@ interface EmailInput {
 const CheckoutSeatInvitations = ({
   checkout,
 }: CheckoutSeatInvitationsProps) => {
-  const { seats, id: checkoutId } = checkout
+  const {
+    seats,
+    id: checkoutId,
+    client_secret: checkoutClientSecret,
+  } = checkout
 
   // Check if this is a seat-based product
   const isSeatBased =
@@ -42,7 +46,7 @@ const CheckoutSeatInvitations = ({
   const [isSending, setIsSending] = useState(false)
   const [sentCount, setSentCount] = useState(0)
 
-  const assignSeat = useAssignSeatFromCheckout(checkoutId)
+  const assignSeat = useAssignSeatFromCheckout(checkoutId, checkoutClientSecret)
 
   const availableSeats = (seats || 1) - sentCount
   const canAddMore = emailInputs.length < availableSeats

--- a/clients/apps/web/src/hooks/queries/seats.ts
+++ b/clients/apps/web/src/hooks/queries/seats.ts
@@ -4,14 +4,17 @@ import { schemas, unwrap } from '@polar-sh/client'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
-export const useAssignSeatFromCheckout = (checkoutId: string) => {
+export const useAssignSeatFromCheckout = (
+  checkoutId: string,
+  checkoutClientSecret: string,
+) => {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (
       variables: Omit<
         schemas['SeatAssign'],
-        'checkout_id' | 'immediate_claim'
+        'checkout_id' | 'checkout_client_secret' | 'immediate_claim'
       > & {
         immediate_claim?: boolean
       },
@@ -24,6 +27,7 @@ export const useAssignSeatFromCheckout = (checkoutId: string) => {
         body: JSON.stringify({
           ...variables,
           checkout_id: checkoutId,
+          checkout_client_secret: checkoutClientSecret,
           immediate_claim: variables.immediate_claim ?? false,
         }),
       })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1382,7 +1382,7 @@ export interface paths {
     }
     /**
      * List Benefit Grants
-     * @description List benefit grants across all benefits for the authenticated organization.
+     * @description List benefit grants across all benefits accessible to the authenticated subject.
      *
      *     **Scopes**: `benefits:read` `benefits:write`
      */
@@ -15011,7 +15011,7 @@ export interface components {
     /** CustomerPortalCustomerSettings */
     CustomerPortalCustomerSettings: {
       /** Allow Email Change */
-      allow_email_change: boolean
+      allow_email_change?: boolean
     }
     /** CustomerPortalCustomerUpdate */
     CustomerPortalCustomerUpdate: {
@@ -23495,7 +23495,7 @@ export interface components {
       /** Allow Multiple Subscriptions */
       allow_multiple_subscriptions: boolean
       /**
-       * Proration Behavior
+       * PublicSubscriptionProrationBehavior
        * @enum {string}
        */
       proration_behavior: 'invoice' | 'prorate' | 'next_period'
@@ -25878,6 +25878,11 @@ export interface components {
        * @description Checkout ID. Used to look up subscription or order from the checkout page.
        */
       checkout_id?: string | null
+      /**
+       * Checkout Client Secret
+       * @description Client secret of the checkout. Required when assigning seats via checkout_id as an anonymous caller (e.g. the checkout confirmation page).
+       */
+      checkout_client_secret?: string | null
       /**
        * Order Id
        * @description Order ID for one-time purchases. Required if subscription_id and checkout_id are not provided.
@@ -39172,7 +39177,6 @@ export interface operations {
     parameters: {
       query: {
         platform: components['schemas']['CustomerOAuthPlatform']
-        customer_id: string
         return_to?: string | null
       }
       header?: never

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -1,3 +1,4 @@
+import secrets
 from typing import Annotated, cast
 
 from fastapi import Depends, Query, Request
@@ -93,6 +94,20 @@ async def assign_seat(
 
         if not checkout:
             raise ResourceNotFound("Checkout not found")
+
+        if isinstance(auth_subject.subject, Anonymous):
+            if seat_assign.checkout_client_secret is None or not secrets.compare_digest(
+                seat_assign.checkout_client_secret, checkout.client_secret
+            ):
+                raise NotPermitted(
+                    "checkout_client_secret is required and must match the "
+                    "checkout when assigning seats as an anonymous caller."
+                )
+        elif seat_assign.checkout_client_secret is not None:
+            if not secrets.compare_digest(
+                seat_assign.checkout_client_secret, checkout.client_secret
+            ):
+                raise NotPermitted("checkout_client_secret does not match.")
 
         # Try to find subscription first (for recurring purchases)
         subscription = await subscription_repository.get_by_checkout_id(

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -13,6 +13,7 @@ from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
 from polar.exceptions import BadRequest, NotPermitted, ResourceNotFound
 from polar.models import CustomerSeat, Order, Product, Subscription
+from polar.models.checkout import CheckoutStatus
 from polar.models.customer_seat import SeatStatus
 from polar.openapi import APITag
 from polar.order.repository import OrderRepository
@@ -108,6 +109,14 @@ async def assign_seat(
                 seat_assign.checkout_client_secret, checkout.client_secret
             ):
                 raise NotPermitted("checkout_client_secret does not match.")
+
+        if checkout.status != CheckoutStatus.succeeded:
+            raise NotPermitted("Seats can only be assigned from a successful checkout.")
+
+        if checkout.is_expired:
+            raise NotPermitted(
+                "Seats can no longer be assigned from this checkout because it has expired."
+            )
 
         # Try to find subscription first (for recurring purchases)
         subscription = await subscription_repository.get_by_checkout_id(

--- a/server/polar/customer_seat/schemas.py
+++ b/server/polar/customer_seat/schemas.py
@@ -20,6 +20,14 @@ class SeatAssign(Schema):
         None,
         description="Checkout ID. Used to look up subscription or order from the checkout page.",
     )
+    checkout_client_secret: str | None = Field(
+        None,
+        description=(
+            "Client secret of the checkout. Required when assigning seats "
+            "via checkout_id as an anonymous caller (e.g. the checkout "
+            "confirmation page)."
+        ),
+    )
     order_id: UUID | None = Field(
         None,
         description="Order ID for one-time purchases. Required if subscription_id and checkout_id are not provided.",

--- a/server/tests/customer_seat/conftest.py
+++ b/server/tests/customer_seat/conftest.py
@@ -12,6 +12,7 @@ from polar.models import (
     User,
     UserOrganization,
 )
+from polar.models.checkout import CheckoutStatus
 from polar.models.customer_seat import CustomerSeat, SeatStatus
 from polar.models.order import OrderStatus
 from polar.models.subscription import SubscriptionStatus
@@ -150,6 +151,7 @@ async def checkout_with_order(
         save_fixture,
         products=[order_with_seats.product],
         customer=order_with_seats.customer,
+        status=CheckoutStatus.succeeded,
     )
     # Link order to checkout
     order_with_seats.checkout_id = checkout.id

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -14,6 +14,7 @@ from polar.models import (
     Subscription,
     UserOrganization,
 )
+from polar.models.checkout import CheckoutStatus
 from polar.models.customer_seat import SeatStatus
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -382,6 +383,7 @@ class TestAssignSeat:
             price=subscription_with_seats.product.prices[0],
             subscription=subscription_with_seats,
             seats=5,
+            status=CheckoutStatus.succeeded,
         )
 
         subscription_with_seats.checkout_id = checkout.id
@@ -479,6 +481,127 @@ class TestAssignSeat:
         )
 
         assert response.status_code == 403, f"Error: {response.json()}"
+
+    async def _create_checkout_for_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        subscription_with_seats: Subscription,
+        status: CheckoutStatus,
+    ) -> Checkout:
+        await create_customer(
+            save_fixture,
+            organization=subscription_with_seats.product.organization,
+            email="checkout-user@example.com",
+        )
+        await session.refresh(subscription_with_seats.product, ["prices"])
+        checkout = await create_checkout(
+            save_fixture,
+            products=[subscription_with_seats.product],
+            price=subscription_with_seats.product.prices[0],
+            subscription=subscription_with_seats,
+            seats=5,
+            status=status,
+        )
+        subscription_with_seats.checkout_id = checkout.id
+        await save_fixture(subscription_with_seats)
+        return checkout
+
+    @pytest.mark.parametrize(
+        "checkout_status",
+        [
+            CheckoutStatus.open,
+            CheckoutStatus.expired,
+            CheckoutStatus.confirmed,
+            CheckoutStatus.failed,
+        ],
+    )
+    async def test_assign_seat_from_checkout_anonymous_rejected_when_not_succeeded(
+        self,
+        checkout_status: CheckoutStatus,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        subscription_with_seats: Subscription,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        checkout = await self._create_checkout_for_subscription(
+            save_fixture, session, subscription_with_seats, checkout_status
+        )
+
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "checkout_client_secret": checkout.client_secret,
+                "email": "checkout-user@example.com",
+            },
+        )
+
+        assert response.status_code == 403, f"Error: {response.json()}"
+        assert "successful checkout" in response.json()["detail"].lower()
+
+    async def test_assign_seat_from_checkout_anonymous_rejected_when_expired(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        subscription_with_seats: Subscription,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        await create_customer(
+            save_fixture,
+            organization=subscription_with_seats.product.organization,
+            email="checkout-user@example.com",
+        )
+        await session.refresh(subscription_with_seats.product, ["prices"])
+        checkout = await create_checkout(
+            save_fixture,
+            products=[subscription_with_seats.product],
+            price=subscription_with_seats.product.prices[0],
+            subscription=subscription_with_seats,
+            seats=5,
+            status=CheckoutStatus.succeeded,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        subscription_with_seats.checkout_id = checkout.id
+        await save_fixture(subscription_with_seats)
+
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "checkout_client_secret": checkout.client_secret,
+                "email": "checkout-user@example.com",
+            },
+        )
+
+        assert response.status_code == 403, f"Error: {response.json()}"
+        assert "expired" in response.json()["detail"].lower()
+
+    @pytest.mark.auth(SEAT_AUTH)
+    async def test_assign_seat_from_checkout_rejected_when_not_succeeded_authenticated(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        subscription_with_seats: Subscription,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        checkout = await self._create_checkout_for_subscription(
+            save_fixture, session, subscription_with_seats, CheckoutStatus.expired
+        )
+
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "email": "checkout-user@example.com",
+            },
+        )
+
+        assert response.status_code == 403, f"Error: {response.json()}"
+        assert "successful checkout" in response.json()["detail"].lower()
 
     @pytest.mark.auth(SEAT_AUTH)
     async def test_assign_seat_immediate_claim_success(

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -391,6 +391,7 @@ class TestAssignSeat:
             "/v1/customer-seats",
             json={
                 "checkout_id": str(checkout.id),
+                "checkout_client_secret": checkout.client_secret,
                 "email": "checkout-user@example.com",
             },
         )
@@ -399,6 +400,85 @@ class TestAssignSeat:
         data = response.json()
         assert data["status"] == "pending"
         assert data["subscription_id"] == str(subscription_with_seats.id)
+
+    async def test_assign_seat_from_checkout_anonymous_missing_client_secret(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        subscription_with_seats: Subscription,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        from tests.fixtures.random_objects import create_checkout, create_customer
+
+        await create_customer(
+            save_fixture,
+            organization=subscription_with_seats.product.organization,
+            email="checkout-user@example.com",
+        )
+
+        await session.refresh(subscription_with_seats.product, ["prices"])
+
+        checkout = await create_checkout(
+            save_fixture,
+            products=[subscription_with_seats.product],
+            price=subscription_with_seats.product.prices[0],
+            subscription=subscription_with_seats,
+            seats=5,
+        )
+
+        subscription_with_seats.checkout_id = checkout.id
+        await save_fixture(subscription_with_seats)
+
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "email": "attacker@example.com",
+            },
+        )
+
+        assert response.status_code == 403, f"Error: {response.json()}"
+
+    async def test_assign_seat_from_checkout_anonymous_wrong_client_secret(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        subscription_with_seats: Subscription,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        from tests.fixtures.random_objects import create_checkout, create_customer
+
+        await create_customer(
+            save_fixture,
+            organization=subscription_with_seats.product.organization,
+            email="checkout-user@example.com",
+        )
+
+        await session.refresh(subscription_with_seats.product, ["prices"])
+
+        checkout = await create_checkout(
+            save_fixture,
+            products=[subscription_with_seats.product],
+            price=subscription_with_seats.product.prices[0],
+            subscription=subscription_with_seats,
+            seats=5,
+        )
+
+        subscription_with_seats.checkout_id = checkout.id
+        await save_fixture(subscription_with_seats)
+
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "checkout_client_secret": "not-the-real-secret",
+                "email": "attacker@example.com",
+            },
+        )
+
+        assert response.status_code == 403, f"Error: {response.json()}"
 
     @pytest.mark.auth(SEAT_AUTH)
     async def test_assign_seat_immediate_claim_success(
@@ -869,6 +949,7 @@ class TestOrderBasedSeats:
             "/v1/customer-seats",
             json={
                 "checkout_id": str(checkout_with_order.id),
+                "checkout_client_secret": checkout_with_order.client_secret,
                 "email": "holder@example.com",
             },
         )


### PR DESCRIPTION
If someone has purchased a product, we previously allowed them to assign a seat only with the checkout id. This also requires the checkout secret, which someone will have if they are in the buy flow.
