### PR TITLE
oat: Prevent minting a higher privilege token than used

### DIFF
--- a/server/polar/organization_access_token/endpoints.py
+++ b/server/polar/organization_access_token/endpoints.py
@@ -85,7 +85,10 @@ async def update(
         raise ResourceNotFound()
 
     return await organization_access_token_service.update(
-        session, organization_access_token, organization_access_token_update
+        session,
+        auth_subject,
+        organization_access_token,
+        organization_access_token_update,
     )
 
 

--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -6,7 +6,8 @@ from uuid import UUID
 import structlog
 from sqlalchemy import UnaryExpression, asc, desc
 
-from polar.auth.models import AuthSubject, Organization, is_user
+from polar.auth.models import AuthSubject, Organization, is_organization, is_user
+from polar.auth.scope import Scope
 from polar.config import settings
 from polar.email.schemas import (
     OrganizationAccessTokenLeakedEmail,
@@ -14,6 +15,7 @@ from polar.email.schemas import (
 )
 from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
+from polar.exceptions import PolarRequestValidationError
 from polar.integrations.loops.service import loops as loops_service
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
 from polar.kit.pagination import PaginationParams
@@ -110,6 +112,7 @@ class OrganizationAccessTokenService:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
         )
+        self._validate_scopes_within_caller(auth_subject, create_schema.scopes)
         token, token_hash = generate_token_hash_pair(
             secret=settings.SECRET, prefix=TOKEN_PREFIX
         )
@@ -139,6 +142,7 @@ class OrganizationAccessTokenService:
     async def update(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         organization_access_token: OrganizationAccessToken,
         update_schema: OrganizationAccessTokenUpdate,
     ) -> OrganizationAccessToken:
@@ -146,11 +150,34 @@ class OrganizationAccessTokenService:
 
         update_dict = update_schema.model_dump(exclude={"scopes"}, exclude_unset=True)
         if update_schema.scopes is not None:
+            self._validate_scopes_within_caller(auth_subject, update_schema.scopes)
             update_dict["scope"] = " ".join(update_schema.scopes)
 
         return await repository.update(
             organization_access_token, update_dict=update_dict
         )
+
+    def _validate_scopes_within_caller(
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        requested_scopes: Sequence[str],
+    ) -> None:
+        if not is_organization(auth_subject):
+            return
+        caller_scopes = auth_subject.scopes
+        requested = {Scope(s) for s in requested_scopes}
+        excess = requested - caller_scopes
+        if excess:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "scopes"),
+                        "msg": ("Requested scopes exceed the caller's own scopes."),
+                        "input": sorted(s.value for s in excess),
+                    }
+                ]
+            )
 
     async def delete(
         self, session: AsyncSession, organization_access_token: OrganizationAccessToken

--- a/server/tests/organization_access_token/test_endpoints.py
+++ b/server/tests/organization_access_token/test_endpoints.py
@@ -1,7 +1,33 @@
+from datetime import timedelta
+
 import pytest
 from httpx import AsyncClient
 
-from polar.models import Organization, UserOrganization
+from polar.auth.scope import Scope
+from polar.config import settings
+from polar.kit.crypto import get_token_hash
+from polar.kit.utils import utc_now
+from polar.models import Organization, OrganizationAccessToken, UserOrganization
+from tests.fixtures.auth import AuthSubjectFixture
+from tests.fixtures.database import SaveFixture
+
+
+async def _build_oat(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    scopes: set[Scope],
+    comment: str = "existing",
+) -> OrganizationAccessToken:
+    token = OrganizationAccessToken(
+        comment=comment,
+        token=get_token_hash("polar_oat_test", secret=settings.SECRET),
+        organization=organization,
+        expires_at=utc_now() + timedelta(days=1),
+        scope=" ".join(s.value for s in scopes),
+    )
+    await save_fixture(token)
+    return token
 
 
 @pytest.mark.asyncio
@@ -30,3 +56,113 @@ class TestCreateOrganizationAccessToken:
         json = response.json()
         assert "organization_access_token" in response.json()
         assert "token" in json
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(
+            subject="organization",
+            scopes={
+                Scope.web_write,
+                Scope.organization_access_tokens_write,
+            },
+        )
+    )
+    async def test_oat_caller_cannot_mint_broader_scope(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        response = await client.post(
+            "/v1/organization-access-tokens/",
+            json={
+                "comment": "elevated",
+                "scopes": ["orders:write"],
+            },
+        )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert any(
+            err.get("loc") == ["body", "scopes"] for err in body.get("detail", [])
+        )
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(
+            subject="organization",
+            scopes={
+                Scope.web_write,
+                Scope.organization_access_tokens_write,
+                Scope.metrics_read,
+            },
+        )
+    )
+    async def test_oat_caller_within_scope_ok(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        response = await client.post(
+            "/v1/organization-access-tokens/",
+            json={
+                "comment": "within scope",
+                "scopes": ["metrics:read"],
+            },
+        )
+
+        assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+class TestUpdateOrganizationAccessToken:
+    @pytest.mark.auth(
+        AuthSubjectFixture(
+            subject="organization",
+            scopes={
+                Scope.web_write,
+                Scope.organization_access_tokens_write,
+            },
+        )
+    )
+    async def test_oat_caller_cannot_elevate_scopes(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        existing = await _build_oat(
+            save_fixture, organization, scopes={Scope.metrics_read}
+        )
+
+        response = await client.patch(
+            f"/v1/organization-access-tokens/{existing.id}",
+            json={"scopes": ["orders:write"]},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(
+            subject="organization",
+            scopes={
+                Scope.web_write,
+                Scope.organization_access_tokens_write,
+                Scope.metrics_read,
+            },
+        )
+    )
+    async def test_oat_caller_within_scope_ok(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        existing: OrganizationAccessToken = await _build_oat(
+            save_fixture,
+            organization,
+            scopes={Scope.metrics_read},
+            comment="update_within_scope",
+        )
+
+        response = await client.patch(
+            f"/v1/organization-access-tokens/{existing.id}",
+            json={"scopes": ["metrics:read"]},
+        )
+
+        assert response.status_code == 200


### PR DESCRIPTION
This disables being able to create a new token (if you have `organization_access_tokens:write`) that has more privileges than the token used.