### PR TITLE
tinybird: Pass external + customer ids via readable filter

### DIFF
--- a/server/polar/event_type/service.py
+++ b/server/polar/event_type/service.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from polar.auth.models import AuthSubject
+from polar.customer.repository import CustomerRepository
 from polar.event.system import SYSTEM_EVENT_LABELS
 from polar.event.tinybird_repository import TinybirdEventRepository
 from polar.event_type.repository import EventTypeRepository
@@ -54,6 +55,22 @@ class EventTypeService:
         if not organization_ids:
             return [], 0
 
+        customer_repository = CustomerRepository.from_session(session)
+        all_customer_ids: list[UUID] = list(customer_id or [])
+        all_external_ids: list[str] = list(external_customer_id or [])
+        if customer_id is not None:
+            all_external_ids.extend(
+                await customer_repository.get_readable_external_ids_by_ids(
+                    auth_subject, customer_id
+                )
+            )
+        if external_customer_id is not None:
+            all_customer_ids.extend(
+                await customer_repository.get_readable_ids_by_external_ids(
+                    auth_subject, external_customer_id
+                )
+            )
+
         tinybird_repository = TinybirdEventRepository()
         tinybird_sorting: list[tuple[str, bool]] = []
         for criterion, is_desc in sorting:
@@ -68,8 +85,8 @@ class EventTypeService:
 
         tinybird_stats = await tinybird_repository.get_event_type_stats(
             organization_id=organization_ids,
-            customer_id=customer_id,
-            external_customer_id=external_customer_id,
+            customer_id=all_customer_ids if all_customer_ids else None,
+            external_customer_id=all_external_ids if all_external_ids else None,
             root_events=root_events,
             parent_id=parent_id,
             source=source,

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -10,6 +10,7 @@ from sqlalchemy import ColumnElement, FromClause, select, text
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.config import settings
+from polar.customer.repository import CustomerRepository
 from polar.kit.time_queries import TimeInterval, get_timestamp_series_cte
 from polar.models import (
     Customer,
@@ -436,20 +437,22 @@ class MetricsService:
         customer_id: Sequence[uuid.UUID] | None = None,
         tb_needed: set[str],
     ) -> _TinybirdFilters:
-        external_customer_id: list[str] | None = None
-        if customer_id is not None:
-            stmt = select(Customer.external_id).where(
-                Customer.id.in_(customer_id),
-                Customer.external_id.is_not(None),
-                Customer.external_id != "",
-            )
-            external_ids = [eid for eid in await session.scalars(stmt) if eid]
-            if external_ids:
-                external_customer_id = external_ids
-
         tb_org_ids = await self._get_org_ids_for_subject(
             session, auth_subject, organization_id=organization_id
         )
+
+        external_customer_id: list[str] | None = None
+        if customer_id is not None:
+            customer_repository = CustomerRepository.from_session(session)
+            external_ids = [
+                eid
+                for eid in await customer_repository.get_readable_external_ids_by_ids(
+                    auth_subject, customer_id
+                )
+                if eid
+            ]
+            if external_ids:
+                external_customer_id = external_ids
 
         tb_product_id = product_id
         if billing_type is not None and tb_org_ids:


### PR DESCRIPTION
Even though the queries are already guarded by the readable org id filter,
it's a good idea to pass these through the readable filter as well