### PR TITLE
products: Increase product limit on orders page

### DIFF
--- a/clients/apps/web/src/hooks/queries/products.ts
+++ b/clients/apps/web/src/hooks/queries/products.ts
@@ -46,7 +46,7 @@ export const useSelectedProducts = (id: string[], includeArchived = false) =>
                 id,
                 is_archived: includeArchived ? null : false,
                 page,
-                limit: 1,
+                limit: 100,
               },
             },
           }),


### PR DESCRIPTION
Instead of iterating one product at a time, we can get multiple products at the same time.

This speeds up the toggling of selected products a lot when dealing with > 2 products.
