### PR TITLE
backoffice/organizations_v2: preserve status tab when changing filters

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -353,6 +353,17 @@ class OrganizationListView:
                 hx_trigger="submit, change from:.filter-select",
                 hx_target="#org-list",
             ):
+                # Preserve the active status tab across filter submissions.
+                # Without this, changing any filter drops the `status` query
+                # param and the listing falls back to the default view.
+                if status_filter is not None:
+                    with tag.input(
+                        type="hidden",
+                        name="status",
+                        value=status_filter.value,
+                    ):
+                        pass
+
                 # Search bar with filter toggle
                 with tag.div(classes="flex gap-3"):
                     # Search input


### PR DESCRIPTION
## Summary

- The filter form on the backoffice organizations list (v2) submits via htmx `hx-get` without the `status` query param, so changing any filter (e.g. Days in Status) drops the active tab.
- Reported symptom: on the Review tab, picking Days in Status `>3 days` returns Snoozed orgs instead of `>3`-day Review orgs, because the listing falls back to the default view (everything except DENIED/BLOCKED).
- Fix: add a hidden `status` input to the filter form so submissions keep the current tab.

## Test plan

- [ ] Load `/backoffice/organizations` and confirm the default (All) view still works.
- [ ] Open the Review tab, expand filters, choose Days in Status `>3 days`, and verify only Review orgs older than 3 days are shown.
- [ ] Repeat on Snoozed, Active, Denied, Blocked, Offboarding — each should keep its tab when filters change.
- [ ] Confirm Clear filters keeps the current tab and only clears the filter inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)