### PR TITLE
fix(organization): allow CREATED -> REVIEW transition

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -320,6 +320,7 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
 ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatus]] = {
     OrganizationStatus.CREATED: frozenset(
         {
+            OrganizationStatus.REVIEW,
             OrganizationStatus.ACTIVE,
             OrganizationStatus.DENIED,
             OrganizationStatus.BLOCKED,


### PR DESCRIPTION
## 📋 Summary

Re-add `REVIEW` to the allowed transitions from `CREATED` so the order-balance worker can move a newly-selling org into review instead of erroring out. Unblocks Sentry [SERVER-4DG](https://polar-sh.sentry.io/issues/7427049649/).


This is meant only for SANDBOX until we find a better solution.

## 🎯 What

- `ALLOWED_STATUS_TRANSITIONS[CREATED]` now includes `REVIEW` (in addition to `ACTIVE`, `DENIED`, `BLOCKED`).

## 🤔 Why

After #11066, `CREATED -> REVIEW` was dropped on the assumption that `CREATED` orgs never have paid checkouts (they'd go via `ACTIVE` after AI approval first). That assumption breaks in sandbox:

- `is_organization_ready_for_payment` short-circuits to `True` in sandbox (`server/polar/organization/service.py:1012-1014`), so a `CREATED` org with no submitted details / no review can reach a paid checkout.
- Once the payment crosses `next_review_threshold`, `check_review_threshold` calls `set_status(REVIEW)`, which raises `InvalidStatusTransitionError`.
- The `order.balance` dramatiq task loops on retries — no `balance` transactions ever get written for the paid order.

Concrete example (sandbox): org `NextVeo Sandbox` (`9f9638bc-55b8-4fa9-bab2-1adf2734f848`) took a $20 subscription payment at 13:46:30 on 2026-04-20, then the worker has been retrying ever since.

Chose `REVIEW` over `ACTIVE` because `check_review_threshold` runs in prod too — if some other path ever lands a `CREATED` org there, we want it routed through review, not granted payout-ready status.

## 🔧 How

Single-line change to the transition map in `server/polar/models/organization.py`.

## 🧪 Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend, `pnpm test` for frontend)
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

### Test Instructions

1. Retry the stuck `order.balance` task for order `29d24ae2-83a2-4c21-b3ba-1fb39b48cf69` in sandbox and confirm it completes (org moves `CREATED -> REVIEW`, balance transactions written).
2. Confirm Sentry issue SERVER-4DG stops recurring.

## 📝 Additional Notes

Follow-up worth considering separately: the sandbox bypass in `is_organization_ready_for_payment` lets `CREATED` orgs sell without details submission or review. That's the upstream cause — this PR just unblocks the worker.