### PR TITLE
fix(preview): always build backoffice assets on deploy

### DIFF
--- a/infra/preview/deploy.sh
+++ b/infra/preview/deploy.sh
@@ -118,10 +118,12 @@ deploy() {
 
         log "Building email renderer"
         uv run task emails
-
-        log "Building backoffice assets"
-        uv run task backoffice
     fi
+
+    # Built every deploy (not gated on BACKEND_CHANGED): assets are
+    # gitignored so they can be missing even when backend is unchanged.
+    log "Building backoffice assets"
+    uv run task backoffice
 
     # --- Backend .env (must be written before migrations) ---
     log "Writing backend .env"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
 
 [tool.taskipy.tasks]
 emails = { cmd = "cd emails && pnpm i --frozen-lockfile && pnpm run build", help = "build emails" }
-backoffice = { cmd = "pnpm -C polar/backoffice install && pnpm -C polar/backoffice build", help = "build backoffice CSS and JS" }
+backoffice = { cmd = "pnpm -C polar/backoffice install --frozen-lockfile && pnpm -C polar/backoffice build", help = "build backoffice CSS and JS" }
 api = { cmd = "env AUTHLIB_INSECURE_TRANSPORT=true uvicorn polar.app:app --reload --workers 1 --host 127.0.0.1 --port 8000", help = "run api service" }
 worker = { cmd = "dramatiq -p 1 -t 1 --watch polar -f polar.worker.scheduler:start polar.worker.run", help = "run worker" }
 test = { cmd = "POLAR_ENV=testing python -m pytest --cov polar/ --cov-report=term-missing", help = "run all tests" }


### PR DESCRIPTION
## 📋 Summary

Ensure backoffice static assets (CSS, JS, icon fonts) are always built during preview deploys so the backoffice UI renders with styling.

## 🎯 What

- Move `uv run task backoffice` outside the `BACKEND_CHANGED` gate in `infra/preview/deploy.sh` so it runs on every deploy.
- Add `--frozen-lockfile` to the `backoffice` taskipy task to match the `emails` task and prevent pnpm from mutating the lockfile in CI.

## 🤔 Why

The backoffice static assets are `.gitignore`d, so `git checkout` can't restore them. The previous [fix #11017](https://github.com/polarsource/polar/pull/11017) added the build step but gated it on `BACKEND_CHANGED=true`. If a deploy runs with `BACKEND_CHANGED=false` while the assets don't exist on disk (first deploy that somehow missed the build, or any other path that leaves the static dir empty), the backoffice renders unstyled. Since the build is fast and idempotent, running it unconditionally is the simplest fix.

## 🔧 How

`pnpm install --frozen-lockfile` is a no-op when the store is already populated, and the tailwind + esbuild build takes ~100ms. The extra cost per deploy is negligible compared to the reliability win.

## 🧪 Testing

- [x] `pnpm install --frozen-lockfile && pnpm run build` verified locally in `server/polar/backoffice/` — produces `static/styles.css`, `static/scripts.js`, and the `lucide.*` font files.

### Test Instructions

1. Deploy this PR to a preview environment.
2. Visit `<preview-url>/backoffice/` — the UI should render with full Tailwind/DaisyUI styling and icons.

## 📝 Additional Notes

⚠️ `/srv/preview-tools/deploy.sh` on the preview VM is installed by `setup-vm.sh` and is intentionally **not** synced from PR checkouts (security boundary — untrusted PR code cannot modify infra). After this PR merges, someone with root on the preview VM needs to re-run `setup-vm.sh` (or `install -m 755 infra/preview/deploy.sh /srv/preview-tools/deploy.sh`) for the change to take effect on existing previews. Same rollout story as #11017.

## ✅ Pre-submission Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] **AI/LLM Policy**: Tested the backoffice build locally.