### PR TITLE
Allow region subtags to switch within primary language IETF for better currency formatting

### DIFF
--- a/clients/apps/web/src/utils/i18n/index.test.ts
+++ b/clients/apps/web/src/utils/i18n/index.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@polar-sh/i18n', () => {
+  const SUPPORTED_LOCALES = ['en', 'fr', 'nl'] as const
+  return {
+    DEFAULT_LOCALE: 'en',
+    SUPPORTED_LOCALES,
+    isAcceptedLocale: (value: string) => {
+      const language = value.split('-')[0].toLowerCase()
+      return (SUPPORTED_LOCALES as readonly string[]).includes(language)
+    },
+  }
+})
+
+const headerGet = vi.fn<(name: string) => string | null>()
+
+vi.mock('next/headers', () => ({
+  headers: () => ({ get: headerGet }),
+}))
+
+import {
+  findMatchingLocaleInAcceptLanguageHeader,
+  parseAcceptLanguageHeader,
+  resolveLocale,
+} from './index'
+
+describe('parseAcceptLanguageHeader', () => {
+  it('returns [] for null', () => {
+    expect(parseAcceptLanguageHeader(null)).toEqual([])
+  })
+
+  it('returns [] for empty string', () => {
+    expect(parseAcceptLanguageHeader('')).toEqual([])
+  })
+
+  it('parses a single code with default q=1', () => {
+    expect(parseAcceptLanguageHeader('fr')).toEqual([{ code: 'fr', q: 1 }])
+  })
+
+  it('sorts entries by descending q', () => {
+    expect(parseAcceptLanguageHeader('fr;q=0.3,nl;q=0.9,en-CA;q=0.7')).toEqual([
+      { code: 'nl', q: 0.9 },
+      { code: 'en-CA', q: 0.7 },
+      { code: 'fr', q: 0.3 },
+    ])
+  })
+})
+
+describe('findMatchingLocaleInAcceptLanguageHeader', () => {
+  it('returns the header region variant sharing the target primary language', () => {
+    expect(
+      findMatchingLocaleInAcceptLanguageHeader('en-CA,fr;q=0.8', 'en-US'),
+    ).toBe('en-CA')
+  })
+
+  it('returns null when no header code shares the target primary language', () => {
+    expect(
+      findMatchingLocaleInAcceptLanguageHeader('fr,nl;q=0.8', 'en-US'),
+    ).toBeNull()
+  })
+
+  it('returns null when there is no match', () => {
+    expect(findMatchingLocaleInAcceptLanguageHeader('xx', 'en-US')).toBeNull()
+  })
+})
+
+describe('resolveLocale', () => {
+  beforeEach(() => {
+    headerGet.mockReset()
+  })
+
+  it('returns searchParamLocale when it is accepted', async () => {
+    headerGet.mockReturnValue('nl')
+    await expect(resolveLocale('fr', 'en-CA')).resolves.toBe('fr')
+  })
+
+  it('falls through to the header when searchParamLocale is unsupported', async () => {
+    headerGet.mockReturnValue('nl')
+    await expect(resolveLocale('xx')).resolves.toBe('nl')
+  })
+
+  it('returns the first accepted header code when no search param or checkout locale is given', async () => {
+    headerGet.mockReturnValue('xx,fr;q=0.9')
+    await expect(resolveLocale()).resolves.toBe('fr')
+  })
+
+  it('returns DEFAULT_LOCALE when nothing matches', async () => {
+    headerGet.mockReturnValue('xx,yy;q=0.5')
+    await expect(resolveLocale()).resolves.toBe('en')
+  })
+
+  it('overrides checkoutLocale with region within the same primary language', async () => {
+    headerGet.mockReturnValue('en-US')
+    await expect(resolveLocale(undefined, 'en-CA')).resolves.toBe('en-US')
+  })
+
+  it('keeps checkoutLocale when no header entry shares its primary language', async () => {
+    headerGet.mockReturnValue('fr')
+    await expect(resolveLocale(undefined, 'en-CA')).resolves.toBe('en-CA')
+  })
+
+  it('falls back to the header locale when checkoutLocale is unsupported', async () => {
+    headerGet.mockReturnValue('nl')
+    await expect(resolveLocale(undefined, 'xx')).resolves.toBe('nl')
+  })
+})

--- a/clients/apps/web/src/utils/i18n/index.ts
+++ b/clients/apps/web/src/utils/i18n/index.ts
@@ -5,7 +5,7 @@ import {
 } from '@polar-sh/i18n'
 import { headers } from 'next/headers'
 
-function parseAcceptLanguageHeader(
+export function parseAcceptLanguageHeader(
   acceptLanguageHeader: string | null,
 ): { code: string; q: number }[] {
   if (!acceptLanguageHeader) return []
@@ -40,7 +40,7 @@ function getPrimaryLanguageForLocale(locale: string): string {
   return locale.split('-')[0].toLowerCase()
 }
 
-function findMatchingLocaleInAcceptLanguageHeader(
+export function findMatchingLocaleInAcceptLanguageHeader(
   acceptLanguageHeader: string | null,
   targetLocale: AcceptedLocale,
 ): AcceptedLocale | null {

--- a/clients/apps/web/src/utils/i18n/index.ts
+++ b/clients/apps/web/src/utils/i18n/index.ts
@@ -2,9 +2,7 @@ import {
   type AcceptedLocale,
   DEFAULT_LOCALE,
   isAcceptedLocale,
-  isSupportedLocale,
 } from '@polar-sh/i18n'
-import { match } from 'assert'
 import { headers } from 'next/headers'
 
 function parseAcceptLanguageHeader(

--- a/clients/apps/web/src/utils/i18n/index.ts
+++ b/clients/apps/web/src/utils/i18n/index.ts
@@ -2,15 +2,17 @@ import {
   type AcceptedLocale,
   DEFAULT_LOCALE,
   isAcceptedLocale,
+  isSupportedLocale,
 } from '@polar-sh/i18n'
+import { match } from 'assert'
 import { headers } from 'next/headers'
 
-function getLocaleFromAcceptLanguage(
-  acceptLanguage: string | null,
-): AcceptedLocale {
-  if (!acceptLanguage) return DEFAULT_LOCALE
+function parseAcceptLanguageHeader(
+  acceptLanguageHeader: string | null,
+): { code: string; q: number }[] {
+  if (!acceptLanguageHeader) return []
 
-  const languages = acceptLanguage
+  return acceptLanguageHeader
     .split(',')
     .map((lang) => {
       const [code, qValue] = lang.trim().split(';q=')
@@ -20,6 +22,12 @@ function getLocaleFromAcceptLanguage(
       }
     })
     .sort((a, b) => b.q - a.q)
+}
+
+function getLocaleFromAcceptLanguageHeader(
+  acceptLanguageHeader: string | null,
+): AcceptedLocale {
+  const languages = parseAcceptLanguageHeader(acceptLanguageHeader)
 
   for (const { code } of languages) {
     if (isAcceptedLocale(code)) {
@@ -30,6 +38,31 @@ function getLocaleFromAcceptLanguage(
   return DEFAULT_LOCALE
 }
 
+function getPrimaryLanguageForLocale(locale: string): string {
+  return locale.split('-')[0].toLowerCase()
+}
+
+function findMatchingLocaleInAcceptLanguageHeader(
+  acceptLanguageHeader: string | null,
+  targetLocale: AcceptedLocale,
+): AcceptedLocale | null {
+  const languages = parseAcceptLanguageHeader(acceptLanguageHeader)
+
+  const matchingLocale = languages.find(
+    ({ code }) =>
+      getPrimaryLanguageForLocale(code) ===
+      getPrimaryLanguageForLocale(targetLocale),
+  )
+
+  if (!matchingLocale) return null
+
+  if (isAcceptedLocale(matchingLocale.code)) {
+    return matchingLocale.code as AcceptedLocale
+  }
+
+  return null
+}
+
 export async function resolveLocale(
   searchParamLocale?: string,
   checkoutLocale?: string | null,
@@ -38,12 +71,25 @@ export async function resolveLocale(
     return searchParamLocale
   }
 
-  if (checkoutLocale && isAcceptedLocale(checkoutLocale)) {
-    return checkoutLocale
-  }
-
   const headersList = await headers()
   const acceptLanguage = headersList.get('accept-language')
 
-  return getLocaleFromAcceptLanguage(acceptLanguage)
+  const headerLocale = getLocaleFromAcceptLanguageHeader(acceptLanguage)
+
+  if (checkoutLocale && isAcceptedLocale(checkoutLocale)) {
+    // If there's a primary language match, allow the header locale to switch region tags within the same primary language
+    // For example, switch `en` or `en-US` to `en-CA`. This can happen with our default locale or if the API
+    // has set a too specific locale that doesn't match the user's preferred locales but does match the primary language.
+    // This is helpful for currency & date formatting.
+    const matchingPrimaryLanguageLocale =
+      findMatchingLocaleInAcceptLanguageHeader(acceptLanguage, checkoutLocale)
+
+    if (matchingPrimaryLanguageLocale) {
+      return matchingPrimaryLanguageLocale
+    }
+
+    return checkoutLocale
+  }
+
+  return headerLocale
 }

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -607,7 +607,7 @@ class CheckoutService:
         if not product.organization.feature_settings.get(
             "checkout_localization_enabled", False
         ):
-            checkout.locale = "en-US"
+            checkout.locale = "en"
 
         session.add(checkout)
 
@@ -843,7 +843,7 @@ class CheckoutService:
                 if locale is not None and isinstance(locale, str):
                     checkout.locale = locale
         else:
-            checkout.locale = "en-US"
+            checkout.locale = "en"
 
         session.add(checkout)
 
@@ -2091,7 +2091,7 @@ class CheckoutService:
         if not checkout.organization.feature_settings.get(
             "checkout_localization_enabled", False
         ):
-            checkout.locale = "en-US"
+            checkout.locale = "en"
 
         checkout = await self._update_trial_end(checkout)
 

--- a/server/polar/kit/locale.py
+++ b/server/polar/kit/locale.py
@@ -19,7 +19,7 @@ Locale = Annotated[
         description=(
             "Locale of the customer, given as an IETF BCP 47 language tag. "
             "Supported: language code (e.g. `en`) or language + region (e.g. `en-US`). "
-            "If `null` or unsupported, the locale will default to `en-US`."
+            "If `null` or unsupported, the locale will default to `en`."
         ),
         examples=["en", "en-US", "fr", "fr-CA"],
     ),


### PR DESCRIPTION
Helpful context to review this PR:

 - We have _supported locales_: `en`, `nl`, `fr`, …
 - From these, we derive _accepted locales_: `en-US`, `nl-BE`, `fr-FR`, `fr-CA`

Browsers report their support languages in a HTTP header `Accept-Language` in a list like this:

<img width="618" height="203" alt="image" src="https://github.com/user-attachments/assets/26af1a4c-b327-459b-bc18-5c20ec37c3b5" />

would match, for example, `en-CA q=1.0; en-US q=0.8; nl q=0.8; en`.

The regional part of the IETF tag (e.g. CA / US), it what `Intl` relies on to show `US$` and `$` for `usd` / `$` and `CA$` for `cad` for Canada & USA respectively.

When localized checkout is set and the checkout locale isn't explicitly set (i.e. `null`), we fall back to auto-detecting based on the `Accept-Language` header, and everything works as expected. However, we lost this user preference when merchants set a language-only IETF locale (e.g. `en`) or when we the default to `en-US` (when people didn't opt in to localized checkout).

What this PR does: even when the checkout locale is explicitly set, find the first IETF tag matching on the primary language in the `Accept-Language` header, and then override the checkout setting with the regional variant as preferred by the user, mapping `en` or `en-US` to `en-CA`. For the translations themselves this will have no impact, but it helps the `Intl` formatting helpers to use the proper regional variants if relevant. 