### PR TITLE
polar: Backfill set created_at

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -1,6 +1,7 @@
 import builtins
 import uuid
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any
 
 import structlog
@@ -138,6 +139,8 @@ class CustomerService:
         session: AsyncSession,
         customer_create: CustomerIndividualCreate | CustomerTeamCreate,
         auth_subject: AuthSubject[User | Organization],
+        *,
+        created_at: datetime | None = None,
     ) -> Customer:
         organization = await get_payload_organization(
             session, auth_subject, customer_create
@@ -215,6 +218,8 @@ class CustomerService:
             ),
             tax_id=validated_tax_id,
         )
+        if created_at is not None:
+            customer_obj.created_at = created_at
 
         return await self._persist_customer(
             session,

--- a/server/polar/customer/tasks.py
+++ b/server/polar/customer/tasks.py
@@ -107,6 +107,7 @@ async def customer_event(
                         "customer_name": customer.name,
                         "customer_external_id": customer.external_id,
                     },
+                    timestamp=customer.created_at,
                 )
             case SystemEvent.customer_deleted:
                 event = build_system_event(

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, overload
 
@@ -584,6 +585,8 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: CustomerCreatedMetadata,
+    *,
+    timestamp: datetime | None = None,
 ) -> Event: ...
 
 
@@ -611,6 +614,8 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionCreatedMetadata,
+    *,
+    timestamp: datetime | None = None,
 ) -> Event: ...
 
 
@@ -772,14 +777,19 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: Any,
+    *,
+    timestamp: datetime | None = None,
 ) -> Event:
-    return Event(
+    event = Event(
         name=name,
         source=EventSource.system,
         customer_id=customer.id,
         organization=organization,
         user_metadata=metadata,
     )
+    if timestamp is not None:
+        event.timestamp = timestamp
+    return event
 
 
 def build_checkout_event(

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -291,6 +292,7 @@ class MemberService:
             name=name,
             external_id=external_id,
             role=MemberRole.owner,
+            created_at=customer.created_at,
         )
 
         try:
@@ -496,6 +498,7 @@ class MemberService:
         name: str | None = None,
         external_id: str | None = None,
         role: MemberRole = MemberRole.member,
+        created_at: datetime | None = None,
     ) -> Member:
         """
         Create a new member for a customer.
@@ -569,6 +572,8 @@ class MemberService:
             external_id=external_id,
             role=role,
         )
+        if created_at is not None:
+            member.created_at = created_at
 
         try:
             created_member = await repository.create(member, flush=True)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -347,6 +347,8 @@ class SubscriptionService:
         session: AsyncSession,
         subscription_create: SubscriptionCreate,
         auth_subject: AuthSubject[User | Organization],
+        *,
+        created_at: datetime | None = None,
     ) -> Subscription:
         errors: list[ValidationError] = []
 
@@ -474,6 +476,8 @@ class SubscriptionService:
             user_metadata=subscription_create.metadata,
             pending_update=None,
         )
+        if created_at is not None:
+            subscription.created_at = created_at
 
         repository = SubscriptionRepository.from_session(session)
         subscription = await repository.create(subscription, flush=True)
@@ -850,6 +854,7 @@ class SubscriptionService:
                     recurring_interval_count=subscription.recurring_interval_count,
                     started_at=subscription.started_at.isoformat(),
                 ),
+                timestamp=subscription.created_at,
             ),
         )
 

--- a/server/scripts/backfill_polar_self_customers.py
+++ b/server/scripts/backfill_polar_self_customers.py
@@ -16,6 +16,7 @@ from polar.customer.schemas.customer import CustomerTeamCreate
 from polar.customer.service import customer as customer_service
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.db.postgres import create_async_sessionmaker
+from polar.member.repository import MemberRepository
 from polar.member.schemas import MemberOwnerCreate
 from polar.member.service import member_service
 from polar.models import Customer, Organization, Product, User, UserOrganization
@@ -77,9 +78,9 @@ async def _load_active_organizations(
 
 async def _load_active_members(
     session: AsyncSession, organization_id: uuid.UUID
-) -> Sequence[User]:
+) -> Sequence[tuple[User, UserOrganization]]:
     statement = (
-        select(User)
+        select(User, UserOrganization)
         .join(UserOrganization, UserOrganization.user_id == User.id)
         .where(
             UserOrganization.organization_id == organization_id,
@@ -89,7 +90,7 @@ async def _load_active_members(
         .order_by(UserOrganization.created_at)
     )
     result = await session.execute(statement)
-    return result.unique().scalars().all()
+    return [(row[0], row[1]) for row in result.unique().all()]
 
 
 async def _load_existing_external_ids(
@@ -109,9 +110,9 @@ async def _backfill_organization(
     auth_subject: AuthSubject[Organization],
     free_product: Product,
     organization: Organization,
-    members: Sequence[User],
+    members: Sequence[tuple[User, UserOrganization]],
 ) -> _OrganizationTally:
-    owner = members[0]
+    owner, owner_user_org = members[0]
     tally = _OrganizationTally()
 
     customer = await customer_service.create(
@@ -129,21 +130,30 @@ async def _backfill_organization(
         ),
         auth_subject,
     )
+    customer.created_at = organization.created_at
     tally.customers += 1
+
+    member_repository = MemberRepository.from_session(session)
+    owner_member = await member_repository.get_by_customer_and_email(
+        session, customer, email=owner.email
+    )
+    if owner_member is not None:
+        owner_member.created_at = owner_user_org.created_at
     tally.members += 1
 
-    for member in members[1:]:
-        await member_service.create(
+    for user, user_org in members[1:]:
+        created_member = await member_service.create(
             session,
             auth_subject,
             customer_id=customer.id,
-            email=member.email,
-            name=member.public_name,
-            external_id=str(member.id),
+            email=user.email,
+            name=user.public_name,
+            external_id=str(user.id),
         )
+        created_member.created_at = user_org.created_at
         tally.members += 1
 
-    await subscription_service.create(
+    subscription = await subscription_service.create(
         session,
         SubscriptionCreateExternalCustomer(
             product_id=free_product.id,
@@ -151,8 +161,10 @@ async def _backfill_organization(
         ),
         auth_subject,
     )
+    subscription.created_at = organization.created_at
     tally.subscriptions += 1
 
+    await session.flush()
     return tally
 
 
@@ -218,7 +230,7 @@ async def run_backfill(
             if dry_run:
                 typer.echo(
                     f"  Would create {organization.name} ({organization.id}) "
-                    f"owner={members[0].email} members={len(members)}"
+                    f"owner={members[0][0].email} members={len(members)}"
                 )
                 progress.advance(task)
                 continue

--- a/server/scripts/backfill_polar_self_customers.py
+++ b/server/scripts/backfill_polar_self_customers.py
@@ -16,7 +16,6 @@ from polar.customer.schemas.customer import CustomerTeamCreate
 from polar.customer.service import customer as customer_service
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.db.postgres import create_async_sessionmaker
-from polar.member.repository import MemberRepository
 from polar.member.schemas import MemberOwnerCreate
 from polar.member.service import member_service
 from polar.models import Customer, Organization, Product, User, UserOrganization
@@ -112,7 +111,7 @@ async def _backfill_organization(
     organization: Organization,
     members: Sequence[tuple[User, UserOrganization]],
 ) -> _OrganizationTally:
-    owner, owner_user_org = members[0]
+    owner, _ = members[0]
     tally = _OrganizationTally()
 
     customer = await customer_service.create(
@@ -129,42 +128,34 @@ async def _backfill_organization(
             ),
         ),
         auth_subject,
+        created_at=organization.created_at,
     )
-    customer.created_at = organization.created_at
     tally.customers += 1
-
-    member_repository = MemberRepository.from_session(session)
-    owner_member = await member_repository.get_by_customer_and_email(
-        session, customer, email=owner.email
-    )
-    if owner_member is not None:
-        owner_member.created_at = owner_user_org.created_at
     tally.members += 1
 
     for user, user_org in members[1:]:
-        created_member = await member_service.create(
+        await member_service.create(
             session,
             auth_subject,
             customer_id=customer.id,
             email=user.email,
             name=user.public_name,
             external_id=str(user.id),
+            created_at=user_org.created_at,
         )
-        created_member.created_at = user_org.created_at
         tally.members += 1
 
-    subscription = await subscription_service.create(
+    await subscription_service.create(
         session,
         SubscriptionCreateExternalCustomer(
             product_id=free_product.id,
             external_customer_id=str(organization.id),
         ),
         auth_subject,
+        created_at=organization.created_at,
     )
-    subscription.created_at = organization.created_at
     tally.subscriptions += 1
 
-    await session.flush()
     return tally
 
 


### PR DESCRIPTION
As discussed on Slack, we might want to do this?

For the customer set created_at to the organization created_at .
For the members set it to when the UserOrganization created_at.
For the free subscription set it to organization.created_at.

The events are still created with `now` as the created_at, which might be fine semantically