### PR TITLE
polar: Track AI onboarding costs

### DIFF
--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -231,11 +231,11 @@ class PolarSelfClient:
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "track_event_ingestion")
 
-    async def track_llm_usage(
+    async def track_organization_review_usage(
         self,
         *,
         external_customer_id: str,
-        event_name: str,
+        review_context: str,
         vendor: str,
         model: str,
         input_tokens: int,
@@ -252,11 +252,12 @@ class PolarSelfClient:
 
         total_tokens = input_tokens + output_tokens
         cost_cents = cost_usd * Decimal(100)
+        root_external_id = f"organization_review-{external_customer_id}"
 
         with logfire.span(
-            "polar.track_llm_usage",
+            "polar.track_organization_review_usage",
             external_customer_id=external_customer_id,
-            event_name=event_name,
+            review_context=review_context,
             vendor=vendor,
             model=model,
             input_tokens=input_tokens,
@@ -268,8 +269,14 @@ class PolarSelfClient:
                     request=EventsIngest(
                         events=[
                             EventCreateExternalCustomer(
-                                name=event_name,
+                                name="organization_review",
                                 external_customer_id=external_customer_id,
+                                external_id=root_external_id,
+                            ),
+                            EventCreateExternalCustomer(
+                                name=f"organization_review.{review_context}",
+                                external_customer_id=external_customer_id,
+                                parent_id=root_external_id,
                                 metadata={
                                     "_llm": LLMMetadata(
                                         vendor=vendor,
@@ -283,7 +290,7 @@ class PolarSelfClient:
                                         currency="usd",
                                     ),
                                 },
-                            )
+                            ),
                         ]
                     )
                 )
@@ -291,9 +298,9 @@ class PolarSelfClient:
                 if e.status_code == 409:
                     span.set_attribute("conflict", True)
                     return
-                _raise_error(span, e, "track_llm_usage")
+                _raise_error(span, e, "track_organization_review_usage")
             except httpx.RequestError as e:
-                _raise_network_error(span, e, "track_llm_usage")
+                _raise_network_error(span, e, "track_organization_review_usage")
 
 
 _client: PolarSelfClient | None = None

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import httpx
@@ -229,6 +230,70 @@ class PolarSelfClient:
                 _raise_error(span, e, "track_event_ingestion")
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "track_event_ingestion")
+
+    async def track_llm_usage(
+        self,
+        *,
+        external_customer_id: str,
+        event_name: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+    ) -> None:
+        from polar_sdk.models import (
+            CostMetadataInput,
+            EventCreateExternalCustomer,
+            EventsIngest,
+            LLMMetadata,
+        )
+        from polar_sdk.models.polarerror import PolarError
+
+        total_tokens = input_tokens + output_tokens
+        cost_cents = cost_usd * Decimal(100)
+
+        with logfire.span(
+            "polar.track_llm_usage",
+            external_customer_id=external_customer_id,
+            event_name=event_name,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=str(cost_usd),
+        ) as span:
+            try:
+                await self._sdk.events.ingest_async(
+                    request=EventsIngest(
+                        events=[
+                            EventCreateExternalCustomer(
+                                name=event_name,
+                                external_customer_id=external_customer_id,
+                                metadata={
+                                    "_llm": LLMMetadata(
+                                        vendor=vendor,
+                                        model=model,
+                                        input_tokens=input_tokens,
+                                        output_tokens=output_tokens,
+                                        total_tokens=total_tokens,
+                                    ),
+                                    "_cost": CostMetadataInput(
+                                        amount=str(cost_cents),
+                                        currency="usd",
+                                    ),
+                                },
+                            )
+                        ]
+                    )
+                )
+            except PolarError as e:
+                if e.status_code == 409:
+                    span.set_attribute("conflict", True)
+                    return
+                _raise_error(span, e, "track_llm_usage")
+            except httpx.RequestError as e:
+                _raise_network_error(span, e, "track_llm_usage")
 
 
 _client: PolarSelfClient | None = None

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -1,6 +1,7 @@
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
+from decimal import Decimal
 
 from polar.config import settings
 from polar.models import Event
@@ -84,6 +85,37 @@ class PolarSelfService:
             external_customer_id=external_customer_id,
             count=count,
             organization_id=settings.POLAR_ORGANIZATION_ID,
+        )
+
+    def enqueue_track_llm_usage(
+        self,
+        *,
+        external_customer_id: str,
+        event_name: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal | float | None,
+    ) -> None:
+        if not self.is_configured:
+            return
+        if external_customer_id == settings.POLAR_ORGANIZATION_ID:
+            return
+        if cost_usd is None:
+            return
+        cost_decimal = Decimal(str(cost_usd))
+        if cost_decimal <= 0:
+            return
+        enqueue_job(
+            "polar_self.track_llm_usage",
+            external_customer_id=external_customer_id,
+            event_name=event_name,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=str(cost_decimal),
         )
 
     def enqueue_event_ingestion(self, events: Sequence[Event]) -> None:

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -87,11 +87,11 @@ class PolarSelfService:
             organization_id=settings.POLAR_ORGANIZATION_ID,
         )
 
-    def enqueue_track_llm_usage(
+    def enqueue_track_organization_review_usage(
         self,
         *,
         external_customer_id: str,
-        event_name: str,
+        review_context: str,
         vendor: str,
         model: str,
         input_tokens: int,
@@ -108,9 +108,9 @@ class PolarSelfService:
         if cost_decimal <= 0:
             return
         enqueue_job(
-            "polar_self.track_llm_usage",
+            "polar_self.track_organization_review_usage",
             external_customer_id=external_customer_id,
-            event_name=event_name,
+            review_context=review_context,
             vendor=vendor,
             model=model,
             input_tokens=input_tokens,

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from dramatiq import Retry
 
 from polar.worker import TaskPriority, actor, can_retry
@@ -94,4 +96,25 @@ async def track_event_ingestion(
     await get_client().track_event_ingestion(
         external_customer_id=external_customer_id,
         count=count,
+    )
+
+
+@actor(actor_name="polar_self.track_llm_usage", priority=TaskPriority.LOW)
+async def track_llm_usage(
+    external_customer_id: str,
+    event_name: str,
+    vendor: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: str,
+) -> None:
+    await get_client().track_llm_usage(
+        external_customer_id=external_customer_id,
+        event_name=event_name,
+        vendor=vendor,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=Decimal(cost_usd),
     )

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -99,19 +99,22 @@ async def track_event_ingestion(
     )
 
 
-@actor(actor_name="polar_self.track_llm_usage", priority=TaskPriority.LOW)
-async def track_llm_usage(
+@actor(
+    actor_name="polar_self.track_organization_review_usage",
+    priority=TaskPriority.LOW,
+)
+async def track_organization_review_usage(
     external_customer_id: str,
-    event_name: str,
+    review_context: str,
     vendor: str,
     model: str,
     input_tokens: int,
     output_tokens: int,
     cost_usd: str,
 ) -> None:
-    await get_client().track_llm_usage(
+    await get_client().track_organization_review_usage(
         external_customer_id=external_customer_id,
-        event_name=event_name,
+        review_context=review_context,
         vendor=vendor,
         model=model,
         input_tokens=input_tokens,

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -88,6 +88,7 @@ async def run_organization_review(
             report=report,
             data_snapshot=snapshot,
             model_used=review_analyzer.model_name,
+            model_provider=review_analyzer.model_provider,
             duration_seconds=round(duration, 2),
             usage=usage,
         )

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -416,6 +416,7 @@ class AgentReviewResult(Schema):
     report: ReviewAgentReport
     data_snapshot: DataSnapshot
     model_used: str
+    model_provider: str
     duration_seconds: float
     usage: UsageInfo = Field(default_factory=UsageInfo)
     timed_out: bool = False

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -5,6 +5,7 @@ import structlog
 
 from polar.config import Environment, settings
 from polar.exceptions import PolarTaskError
+from polar.integrations.polar.service import polar_self
 from polar.models.organization import OrganizationStatus
 from polar.models.organization_review import OrganizationReview
 from polar.organization.repository import (
@@ -96,6 +97,16 @@ async def run_review_agent(
             model_used=result.model_used,
             duration_seconds=result.duration_seconds,
             estimated_cost_usd=result.usage.estimated_cost_usd,
+        )
+
+        polar_self.enqueue_track_llm_usage(
+            external_customer_id=str(organization_id),
+            event_name=f"ai.organization_review.{review_context.value}",
+            vendor=result.model_provider,
+            model=result.model_used,
+            input_tokens=result.usage.input_tokens,
+            output_tokens=result.usage.output_tokens,
+            cost_usd=result.usage.estimated_cost_usd,
         )
 
         # Persist agent report to its own table (both contexts)

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -99,9 +99,9 @@ async def run_review_agent(
             estimated_cost_usd=result.usage.estimated_cost_usd,
         )
 
-        polar_self.enqueue_track_llm_usage(
+        polar_self.enqueue_track_organization_review_usage(
             external_customer_id=str(organization_id),
-            event_name=f"ai.organization_review.{review_context.value}",
+            review_context=review_context.value,
             vendor=result.model_provider,
             model=result.model_used,
             input_tokens=result.usage.input_tokens,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -118,16 +118,16 @@ class TestEnqueueEventIngestion:
         enqueue.assert_not_called()
 
 
-class TestEnqueueTrackLLMUsage:
+class TestEnqueueTrackOrganizationReviewUsage:
     def _call(
         self,
         *,
         external_customer_id: str = str(ORG_A),
         cost_usd: Decimal | float | None = Decimal("0.0123"),
     ) -> None:
-        polar_self.enqueue_track_llm_usage(
+        polar_self.enqueue_track_organization_review_usage(
             external_customer_id=external_customer_id,
-            event_name="ai.organization_review.submission",
+            review_context="submission",
             vendor="openai",
             model="gpt-4o-mini",
             input_tokens=100,
@@ -179,9 +179,9 @@ class TestEnqueueTrackLLMUsage:
         self._call(cost_usd=Decimal("0.0123"))
 
         enqueue.assert_called_once_with(
-            "polar_self.track_llm_usage",
+            "polar_self.track_organization_review_usage",
             external_customer_id=str(ORG_A),
-            event_name="ai.organization_review.submission",
+            review_context="submission",
             vendor="openai",
             model="gpt-4o-mini",
             input_tokens=100,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -1,4 +1,5 @@
 import uuid
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -115,3 +116,83 @@ class TestEnqueueEventIngestion:
         polar_self.enqueue_event_ingestion([_event(SELF_ORG_ID), _event(SELF_ORG_ID)])
 
         enqueue.assert_not_called()
+
+
+class TestEnqueueTrackLLMUsage:
+    def _call(
+        self,
+        *,
+        external_customer_id: str = str(ORG_A),
+        cost_usd: Decimal | float | None = Decimal("0.0123"),
+    ) -> None:
+        polar_self.enqueue_track_llm_usage(
+            external_customer_id=external_customer_id,
+            event_name="ai.organization_review.submission",
+            vendor="openai",
+            model="gpt-4o-mini",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=cost_usd,
+        )
+
+    def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
+        settings = mocker.patch("polar.integrations.polar.service.settings")
+        settings.POLAR_SELF_ENABLED = False
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call()
+
+        enqueue.assert_not_called()
+
+    def test_noop_for_self_organization(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(external_customer_id=str(SELF_ORG_ID))
+
+        enqueue.assert_not_called()
+
+    def test_noop_when_cost_is_none(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=None)
+
+        enqueue.assert_not_called()
+
+    def test_noop_when_cost_is_zero(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=Decimal(0))
+
+        enqueue.assert_not_called()
+
+    def test_enqueues_job_with_serialized_cost(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=Decimal("0.0123"))
+
+        enqueue.assert_called_once_with(
+            "polar_self.track_llm_usage",
+            external_customer_id=str(ORG_A),
+            event_name="ai.organization_review.submission",
+            vendor="openai",
+            model="gpt-4o-mini",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd="0.0123",
+        )
+
+    def test_accepts_float_cost(self, configured: None, mocker: MockerFixture) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=0.5)
+
+        assert enqueue.call_count == 1
+        assert enqueue.call_args.kwargs["cost_usd"] == "0.5"

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -7,7 +8,12 @@ from polar_sdk.models.resourcenotfound import ResourceNotFound, ResourceNotFound
 from pytest_mock import MockerFixture
 
 from polar.integrations.polar.client import PolarSelfClient
-from polar.integrations.polar.tasks import add_member, delete_customer, remove_member
+from polar.integrations.polar.tasks import (
+    add_member,
+    delete_customer,
+    remove_member,
+    track_llm_usage,
+)
 
 
 @pytest.mark.asyncio
@@ -178,3 +184,33 @@ class TestDeleteCustomer:
         await delete_customer(external_id="org-123")
 
         client.delete_customer.assert_called_once_with(external_id="org-123")
+
+
+@pytest.mark.asyncio
+class TestTrackLLMUsage:
+    async def test_calls_client_with_decimal_cost(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await track_llm_usage(
+            external_customer_id="org-123",
+            event_name="ai.organization_review.submission",
+            vendor="openai",
+            model="gpt-4o-mini",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd="0.0123",
+        )
+
+        client.track_llm_usage.assert_called_once_with(
+            external_customer_id="org-123",
+            event_name="ai.organization_review.submission",
+            vendor="openai",
+            model="gpt-4o-mini",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=Decimal("0.0123"),
+        )

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -12,7 +12,7 @@ from polar.integrations.polar.tasks import (
     add_member,
     delete_customer,
     remove_member,
-    track_llm_usage,
+    track_organization_review_usage,
 )
 
 
@@ -187,7 +187,7 @@ class TestDeleteCustomer:
 
 
 @pytest.mark.asyncio
-class TestTrackLLMUsage:
+class TestTrackOrganizationReviewUsage:
     async def test_calls_client_with_decimal_cost(
         self,
         mocker: MockerFixture,
@@ -195,9 +195,9 @@ class TestTrackLLMUsage:
         client = AsyncMock(spec=PolarSelfClient)
         mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
 
-        await track_llm_usage(
+        await track_organization_review_usage(
             external_customer_id="org-123",
-            event_name="ai.organization_review.submission",
+            review_context="submission",
             vendor="openai",
             model="gpt-4o-mini",
             input_tokens=100,
@@ -205,9 +205,9 @@ class TestTrackLLMUsage:
             cost_usd="0.0123",
         )
 
-        client.track_llm_usage.assert_called_once_with(
+        client.track_organization_review_usage.assert_called_once_with(
             external_customer_id="org-123",
-            event_name="ai.organization_review.submission",
+            review_context="submission",
             vendor="openai",
             model="gpt-4o-mini",
             input_tokens=100,

--- a/server/tests/organization_review/test_report.py
+++ b/server/tests/organization_review/test_report.py
@@ -76,6 +76,7 @@ def _make_agent_review_result() -> AgentReviewResult:
         report=_make_review_report(),
         data_snapshot=_make_data_snapshot(),
         model_used="gpt-4o-mini",
+        model_provider="openai",
         duration_seconds=2.5,
         usage=UsageInfo(input_tokens=100, output_tokens=50, total_tokens=150),
     )

--- a/server/tests/organization_review/test_tasks.py
+++ b/server/tests/organization_review/test_tasks.py
@@ -75,6 +75,7 @@ def _make_agent_result(
             collected_at=datetime(2026, 1, 1, tzinfo=UTC),
         ),
         model_used=model_used,
+        model_provider="openai",
         duration_seconds=1.0,
         usage=UsageInfo(),
         timed_out=False,


### PR DESCRIPTION
By ingesting an event named ai.organization_review.{submission|setup_complete|threshold|manual|appeal} with the llm tokens and cost, we can start to track the onboarding costs for our customers inside Polar.
