### PR TITLE
metrics: Introduce a trial_monthly_recurring_revenue metric

### DIFF
--- a/server/polar/metrics/metrics.py
+++ b/server/polar/metrics/metrics.py
@@ -200,6 +200,28 @@ class TrialMonthlyRecurringRevenueMetric(SQLMetric):
         return cumulative_last(periods, cls.slug)
 
 
+class TrialCommittedMonthlyRecurringRevenueMetric(SQLMetric):
+    slug = "trial_committed_monthly_recurring_revenue"
+    display_name = "Trial Committed Monthly Recurring Revenue"
+    type = MetricType.currency
+    query = MetricQuery.active_subscriptions
+
+    @classmethod
+    def get_sql_expression(
+        cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
+    ) -> ColumnElement[int]:
+        return func.coalesce(
+            func.sum(t.table.c.monthly_amount).filter(
+                and_(_in_trial(t, i), _not_ended_as_of(t, i, now))
+            ),
+            0,
+        )
+
+    @classmethod
+    def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
+        return cumulative_last(periods, cls.slug)
+
+
 class CheckoutsMetric(SQLMetric):
     slug = "checkouts"
     display_name = "Checkouts"
@@ -762,6 +784,7 @@ METRICS_POSTGRES: list[type[SQLMetric]] = [
     MonthlyRecurringRevenueMetric,
     TrialMonthlyRecurringRevenueMetric,
     CommittedMonthlyRecurringRevenueMetric,
+    TrialCommittedMonthlyRecurringRevenueMetric,
     AverageRevenuePerUserMetric,
     CheckoutsMetric,
     SucceededCheckoutsMetric,

--- a/server/polar/metrics/metrics.py
+++ b/server/polar/metrics/metrics.py
@@ -242,6 +242,23 @@ class CommittedMonthlyRecurringRevenueMetric(SQLMetric):
         return cumulative_last(periods, cls.slug)
 
 
+class TrialMonthlyRecurringRevenueMetric(SQLMetric):
+    slug = "trial_monthly_recurring_revenue"
+    display_name = "Trial Monthly Recurring Revenue"
+    type = MetricType.currency
+    query = MetricQuery.active_subscriptions
+
+    @classmethod
+    def get_sql_expression(
+        cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
+    ) -> ColumnElement[int]:
+        raise NotImplementedError("Computed directly in get_active_subscriptions_cte")
+
+    @classmethod
+    def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
+        return cumulative_last(periods, cls.slug)
+
+
 class CheckoutsMetric(SQLMetric):
     slug = "checkouts"
     display_name = "Checkouts"
@@ -839,6 +856,7 @@ METRICS_POSTGRES: list[type[SQLMetric]] = [
     ActiveSubscriptionsMetric,
     CommittedSubscriptionsMetric,
     MonthlyRecurringRevenueMetric,
+    TrialMonthlyRecurringRevenueMetric,
     CommittedMonthlyRecurringRevenueMetric,
     AverageRevenuePerUserMetric,
     CheckoutsMetric,

--- a/server/polar/metrics/metrics.py
+++ b/server/polar/metrics/metrics.py
@@ -11,18 +11,51 @@ from sqlalchemy import (
     ColumnElement,
     Integer,
     SQLColumnExpression,
+    and_,
     case,
     func,
     or_,
 )
 
-from polar.enums import SubscriptionRecurringInterval
 from polar.kit.time_queries import TimeInterval
 from polar.models import Checkout, Subscription
 from polar.models.checkout import CheckoutStatus
 
 from .queries import MetricQuery
 from .queries_tinybird import TinybirdQuery
+
+# `t` is the `timestamp` column of the `active_subscription_buckets` CTE built
+# in queries.py; `t.table.c` gives access to sibling columns (monthly_amount,
+# trial_end, ended_or_ends_at, subscription_id, customer_id).
+
+
+def _not_in_trial(t: ColumnElement[datetime], i: TimeInterval) -> ColumnElement[bool]:
+    buckets = t.table.c
+    return or_(
+        buckets.trial_end.is_(None),
+        i.sql_date_trunc(cast(SQLColumnExpression[datetime], buckets.trial_end))
+        <= i.sql_date_trunc(t),
+    )
+
+
+def _in_trial(t: ColumnElement[datetime], i: TimeInterval) -> ColumnElement[bool]:
+    buckets = t.table.c
+    return and_(
+        buckets.trial_end.is_not(None),
+        i.sql_date_trunc(cast(SQLColumnExpression[datetime], buckets.trial_end))
+        > i.sql_date_trunc(t),
+    )
+
+
+def _not_ended_as_of(
+    t: ColumnElement[datetime], i: TimeInterval, when: datetime
+) -> ColumnElement[bool]:
+    buckets = t.table.c
+    return or_(
+        buckets.ended_or_ends_at.is_(None),
+        i.sql_date_trunc(cast(SQLColumnExpression[datetime], buckets.ended_or_ends_at))
+        < i.sql_date_trunc(when),
+    )
 
 
 class MetricType(StrEnum):
@@ -82,7 +115,7 @@ class ActiveSubscriptionsMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
-        return func.count(Subscription.id)
+        return func.count(t.table.c.subscription_id)
 
     @classmethod
     def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
@@ -99,18 +132,7 @@ class CommittedSubscriptionsMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
-        return func.count(Subscription.id).filter(
-            or_(
-                func.coalesce(Subscription.ended_at, Subscription.ends_at).is_(None),
-                i.sql_date_trunc(
-                    cast(
-                        SQLColumnExpression[datetime],
-                        func.coalesce(Subscription.ended_at, Subscription.ends_at),
-                    )
-                )
-                < i.sql_date_trunc(now),
-            )
-        )
+        return func.count(t.table.c.subscription_id).filter(_not_ended_as_of(t, i, now))
 
     @classmethod
     def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
@@ -128,44 +150,7 @@ class MonthlyRecurringRevenueMetric(SQLMetric):
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
         return func.coalesce(
-            func.sum(
-                case(
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.year,
-                        func.round(
-                            Subscription.amount
-                            / (12 * Subscription.recurring_interval_count)
-                        ),
-                    ),
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.month,
-                        func.round(
-                            Subscription.amount / Subscription.recurring_interval_count
-                        ),
-                    ),
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.week,
-                        func.round(
-                            Subscription.amount
-                            * 52
-                            / (12 * Subscription.recurring_interval_count)
-                        ),
-                    ),
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.day,
-                        func.round(
-                            Subscription.amount
-                            * 365
-                            / (12 * Subscription.recurring_interval_count)
-                        ),
-                    ),
-                )
-            ),
-            0,
+            func.sum(t.table.c.monthly_amount).filter(_not_in_trial(t, i)), 0
         )
 
     @classmethod
@@ -183,56 +168,10 @@ class CommittedMonthlyRecurringRevenueMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
+        buckets = t.table.c
         return func.coalesce(
-            func.sum(
-                case(
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.year,
-                        func.round(
-                            Subscription.amount
-                            / (12 * Subscription.recurring_interval_count)
-                        ),
-                    ),
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.month,
-                        func.round(
-                            Subscription.amount / Subscription.recurring_interval_count
-                        ),
-                    ),
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.week,
-                        func.round(
-                            Subscription.amount
-                            * 52
-                            / (12 * Subscription.recurring_interval_count)
-                        ),
-                    ),
-                    (
-                        Subscription.recurring_interval
-                        == SubscriptionRecurringInterval.day,
-                        func.round(
-                            Subscription.amount
-                            * 365
-                            / (12 * Subscription.recurring_interval_count)
-                        ),
-                    ),
-                )
-            ).filter(
-                or_(
-                    func.coalesce(Subscription.ended_at, Subscription.ends_at).is_(
-                        None
-                    ),
-                    i.sql_date_trunc(
-                        cast(
-                            SQLColumnExpression[datetime],
-                            func.coalesce(Subscription.ended_at, Subscription.ends_at),
-                        )
-                    )
-                    < i.sql_date_trunc(now),
-                )
+            func.sum(buckets.monthly_amount).filter(
+                and_(_not_in_trial(t, i), _not_ended_as_of(t, i, now))
             ),
             0,
         )
@@ -252,7 +191,9 @@ class TrialMonthlyRecurringRevenueMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
-        raise NotImplementedError("Computed directly in get_active_subscriptions_cte")
+        return func.coalesce(
+            func.sum(t.table.c.monthly_amount).filter(_in_trial(t, i)), 0
+        )
 
     @classmethod
     def get_cumulative(cls, periods: Iterable["MetricsPeriod"]) -> int | float:
@@ -341,51 +282,14 @@ class AverageRevenuePerUserMetric(SQLMetric):
     def get_sql_expression(
         cls, t: ColumnElement[datetime], i: TimeInterval, now: datetime
     ) -> ColumnElement[int]:
+        subscriber_count = func.count(t.table.c.customer_id.distinct())
+        mrr = func.coalesce(
+            func.sum(t.table.c.monthly_amount).filter(_not_in_trial(t, i)), 0
+        )
         return func.cast(
             case(
-                (func.count(Subscription.customer_id.distinct()) == 0, 0),
-                else_=func.coalesce(
-                    func.sum(
-                        case(
-                            (
-                                Subscription.recurring_interval
-                                == SubscriptionRecurringInterval.year,
-                                func.round(
-                                    Subscription.amount
-                                    / (12 * Subscription.recurring_interval_count)
-                                ),
-                            ),
-                            (
-                                Subscription.recurring_interval
-                                == SubscriptionRecurringInterval.month,
-                                func.round(
-                                    Subscription.amount
-                                    / Subscription.recurring_interval_count
-                                ),
-                            ),
-                            (
-                                Subscription.recurring_interval
-                                == SubscriptionRecurringInterval.week,
-                                func.round(
-                                    Subscription.amount
-                                    * 52
-                                    / (12 * Subscription.recurring_interval_count)
-                                ),
-                            ),
-                            (
-                                Subscription.recurring_interval
-                                == SubscriptionRecurringInterval.day,
-                                func.round(
-                                    Subscription.amount
-                                    * 365
-                                    / (12 * Subscription.recurring_interval_count)
-                                ),
-                            ),
-                        )
-                    ),
-                    0,
-                )
-                / func.count(Subscription.customer_id.distinct()),
+                (subscriber_count == 0, 0),
+                else_=func.round(mrr / subscriber_count),
             ),
             Integer,
         )

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Protocol, cast
 from sqlalchemy import (
     CTE,
     ColumnElement,
-    Integer,
     Numeric,
     Select,
     SQLColumnExpression,
@@ -271,75 +270,6 @@ def get_active_subscriptions_cte(
         ),
     )
 
-    not_in_trial = or_(
-        Subscription.trial_end.is_(None),
-        interval.sql_date_trunc(
-            cast(SQLColumnExpression[datetime], Subscription.trial_end)
-        )
-        <= interval.sql_date_trunc(timestamp_column),
-    )
-    in_trial = and_(
-        Subscription.trial_end.is_not(None),
-        interval.sql_date_trunc(
-            cast(SQLColumnExpression[datetime], Subscription.trial_end)
-        )
-        > interval.sql_date_trunc(timestamp_column),
-    )
-    monthly_recurring_revenue = func.coalesce(
-        func.sum(monthly_amount).filter(not_in_trial), 0
-    )
-    trial_monthly_recurring_revenue = func.coalesce(
-        func.sum(monthly_amount).filter(in_trial), 0
-    )
-    committed_monthly_recurring_revenue = func.coalesce(
-        func.sum(monthly_amount).filter(
-            and_(
-                not_in_trial,
-                or_(
-                    func.coalesce(Subscription.ended_at, Subscription.ends_at).is_(
-                        None
-                    ),
-                    interval.sql_date_trunc(
-                        cast(
-                            SQLColumnExpression[datetime],
-                            func.coalesce(Subscription.ended_at, Subscription.ends_at),
-                        )
-                    )
-                    < interval.sql_date_trunc(now),
-                ),
-            )
-        ),
-        0,
-    )
-    active_subscriber_count = func.count(Subscription.customer_id.distinct())
-    average_revenue_per_user = func.cast(
-        case(
-            (active_subscriber_count == 0, 0),
-            else_=func.round(monthly_recurring_revenue / active_subscriber_count),
-        ),
-        Integer,
-    )
-
-    active_subscriptions_metrics = [
-        metric for metric in metrics if metric.query == MetricQuery.active_subscriptions
-    ]
-
-    metric_columns: list[ColumnElement[int] | ColumnElement[float]] = []
-    for metric in active_subscriptions_metrics:
-        if metric.slug == "monthly_recurring_revenue":
-            expression: ColumnElement[int] | ColumnElement[float] = (
-                monthly_recurring_revenue
-            )
-        elif metric.slug == "trial_monthly_recurring_revenue":
-            expression = trial_monthly_recurring_revenue
-        elif metric.slug == "committed_monthly_recurring_revenue":
-            expression = committed_monthly_recurring_revenue
-        elif metric.slug == "average_revenue_per_user":
-            expression = average_revenue_per_user
-        else:
-            expression = metric.get_sql_expression(timestamp_column, interval, now)
-        metric_columns.append(func.coalesce(expression, 0).label(metric.slug))
-
     from_clause = timestamp_series.join(
         Subscription,
         isouter=True,
@@ -375,14 +305,39 @@ def get_active_subscriptions_cte(
         ),
     )
 
-    return cte(
+    active_subscription_buckets = cte(
         select(
             timestamp_column.label("timestamp"),
+            Subscription.id.label("subscription_id"),
+            Subscription.customer_id.label("customer_id"),
+            Subscription.trial_end.label("trial_end"),
+            func.coalesce(Subscription.ended_at, Subscription.ends_at).label(
+                "ended_or_ends_at"
+            ),
+            monthly_amount.label("monthly_amount"),
+        ).select_from(from_clause)
+    )
+
+    active_subscriptions_metrics = [
+        metric for metric in metrics if metric.query == MetricQuery.active_subscriptions
+    ]
+
+    buckets_timestamp = active_subscription_buckets.c.timestamp
+    metric_columns = [
+        func.coalesce(
+            metric.get_sql_expression(buckets_timestamp, interval, now), 0
+        ).label(metric.slug)
+        for metric in active_subscriptions_metrics
+    ]
+
+    return cte(
+        select(
+            buckets_timestamp.label("timestamp"),
             *metric_columns,
         )
-        .select_from(from_clause)
-        .group_by(timestamp_column)
-        .order_by(timestamp_column.asc())
+        .select_from(active_subscription_buckets)
+        .group_by(buckets_timestamp)
+        .order_by(buckets_timestamp.asc())
     )
 
 

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -278,8 +278,18 @@ def get_active_subscriptions_cte(
         )
         <= interval.sql_date_trunc(timestamp_column),
     )
+    in_trial = and_(
+        Subscription.trial_end.is_not(None),
+        interval.sql_date_trunc(
+            cast(SQLColumnExpression[datetime], Subscription.trial_end)
+        )
+        > interval.sql_date_trunc(timestamp_column),
+    )
     monthly_recurring_revenue = func.coalesce(
         func.sum(monthly_amount).filter(not_in_trial), 0
+    )
+    trial_monthly_recurring_revenue = func.coalesce(
+        func.sum(monthly_amount).filter(in_trial), 0
     )
     committed_monthly_recurring_revenue = func.coalesce(
         func.sum(monthly_amount).filter(
@@ -320,6 +330,8 @@ def get_active_subscriptions_cte(
             expression: ColumnElement[int] | ColumnElement[float] = (
                 monthly_recurring_revenue
             )
+        elif metric.slug == "trial_monthly_recurring_revenue":
+            expression = trial_monthly_recurring_revenue
         elif metric.slug == "committed_monthly_recurring_revenue":
             expression = committed_monthly_recurring_revenue
         elif metric.slug == "average_revenue_per_user":

--- a/server/tests/metrics/test_service.py
+++ b/server/tests/metrics/test_service.py
@@ -3438,13 +3438,16 @@ class TestGetMetrics:
         # Jan & Feb: only the active sub counts; trialing sub excluded
         jan = metrics.periods[0]
         assert jan.monthly_recurring_revenue == 100_00
+        assert jan.trial_monthly_recurring_revenue == 100_00
 
         feb = metrics.periods[1]
         assert feb.monthly_recurring_revenue == 100_00
+        assert feb.trial_monthly_recurring_revenue == 100_00
 
         # Mar: trial ends in this bucket so both subs count
         mar = metrics.periods[2]
         assert mar.monthly_recurring_revenue == 200_00
+        assert mar.trial_monthly_recurring_revenue == 0
 
     async def test_mrr_subscription_forever_discount(
         self,

--- a/server/tests/metrics/test_service.py
+++ b/server/tests/metrics/test_service.py
@@ -553,6 +553,7 @@ QUERY_CASES: tuple[QueryCase, ...] = (
         start_date=date(2024, 1, 1),
         end_date=date(2024, 3, 1),
         interval=TimeInterval.month,
+        now=datetime(2024, 2, 15, tzinfo=UTC),
         auth_type="user",
     ),
     QueryCase(
@@ -1093,6 +1094,15 @@ async def _seed_trial_excluded_from_mrr(
             "started_at": date(2024, 1, 1),
             "trial_start": date(2024, 1, 1),
             "trial_end": date(2024, 3, 1),
+            "product": "monthly_subscription",
+        },
+        # Trialing sub with scheduled cancellation before trial end — should count
+        # in trial MRR but NOT in trial committed MRR.
+        "trialing_canceling_subscription": {
+            "started_at": date(2024, 1, 1),
+            "trial_start": date(2024, 1, 1),
+            "trial_end": date(2024, 3, 1),
+            "ends_at": date(2024, 2, 20),
             "product": "monthly_subscription",
         },
     }
@@ -3435,19 +3445,26 @@ class TestGetMetrics:
 
         assert len(metrics.periods) == 3
 
-        # Jan & Feb: only the active sub counts; trialing sub excluded
+        # Jan: active sub in MRR; both trialing subs in trial MRR; only the one
+        # without a scheduled cancellation counts as trial-committed.
         jan = metrics.periods[0]
         assert jan.monthly_recurring_revenue == 100_00
-        assert jan.trial_monthly_recurring_revenue == 100_00
+        assert jan.trial_monthly_recurring_revenue == 200_00
+        assert jan.trial_committed_monthly_recurring_revenue == 100_00
 
+        # Feb: trialing_canceling's ends_at is inside this bucket, so it drops
+        # out of the active window — only the plain trialing sub remains.
         feb = metrics.periods[1]
         assert feb.monthly_recurring_revenue == 100_00
         assert feb.trial_monthly_recurring_revenue == 100_00
+        assert feb.trial_committed_monthly_recurring_revenue == 100_00
 
-        # Mar: trial ends in this bucket so both subs count
+        # Mar: trial ends in this bucket so trialing falls into MRR; trialing_canceling
+        # already dropped out.
         mar = metrics.periods[2]
         assert mar.monthly_recurring_revenue == 200_00
         assert mar.trial_monthly_recurring_revenue == 0
+        assert mar.trial_committed_monthly_recurring_revenue == 0
 
     async def test_mrr_subscription_forever_discount(
         self,


### PR DESCRIPTION
The trial mrr metric will allow a merchant to track the MRR that is currently in trials.

Additionally this PR refactors the `active_subscriptions` based metrics to be calculated in `get_sql_expression`, like all other metrics.