### PR TITLE
Add metrics codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,8 @@
 
 # Backend
 server/** @frankie567
+server/polar/metrics/** @Yopi @pieterbeulque
+server/tests/metrics/** @Yopi @pieterbeulque
 
 # Infrastructure
 terraform/** @Yopi


### PR DESCRIPTION
Metric definitions changing slightly have lead to confused user feedback, wondering why their reported numbers are different and eroding trust in Polar, so I thought it was a good idea to have a specific owner for those.