### PR TITLE
feat(backoffice): add "First Reviews" filter to organizations v2

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -107,6 +107,8 @@ logger = structlog.getLogger(__name__)
 
 REVIEW_TICKET_TITLE = "Ongoing organization review"
 
+FIRST_REVIEWS_MAX_THRESHOLD_CENTS = 1000
+
 
 class DeletePayoutAccountForm(BaseModel):
     reason: str
@@ -185,6 +187,7 @@ async def list_organizations(
     risk_level: str | None = Query(""),
     days_in_status: str | None = Query(""),
     has_appeal: str | None = Query(""),
+    first_reviews: str | None = Query(""),
 ) -> None:
     """
     List organizations with enhanced filtering and smart grouping.
@@ -314,6 +317,13 @@ async def list_organizations(
         elif has_appeal == "none":
             stmt = stmt.where(OrganizationReview.appeal_submitted_at.is_(None))
 
+    if first_reviews == "true":
+        stmt = stmt.where(
+            Organization.status == OrganizationStatus.REVIEW,
+            Organization.initially_reviewed_at.is_(None),
+            Organization.next_review_threshold <= FIRST_REVIEWS_MAX_THRESHOLD_CENTS,
+        )
+
     # Apply sorting
     is_desc = direction == "desc"
 
@@ -410,6 +420,7 @@ async def list_organizations(
                 direction,
                 countries,
                 country,
+                selected_first_reviews=first_reviews,
             ):
                 pass
 

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -269,6 +269,7 @@ class OrganizationListView:
         current_direction: str = "asc",
         countries: list[str] | None = None,
         selected_country: str | None = None,
+        selected_first_reviews: str | None = None,
     ) -> Generator[None]:
         """Render the complete list view."""
 
@@ -515,6 +516,26 @@ class OrganizationListView:
                                         text("Reviewed")
                                     with tag.option(value="none"):
                                         text("No Appeal")
+
+                            # Only meaningful on the Review tab
+                            if status_filter == OrganizationStatus.REVIEW:
+                                with tag.div():
+                                    with tag.label(classes="label"):
+                                        with tag.span(
+                                            classes="label-text text-xs font-semibold"
+                                        ):
+                                            text("First Reviews")
+                                    with tag.select(
+                                        classes="select select-bordered select-sm w-full filter-select",
+                                        name="first_reviews",
+                                    ):
+                                        with tag.option(value=""):
+                                            text("All")
+                                        first_review_attrs = {"value": "true"}
+                                        if selected_first_reviews == "true":
+                                            first_review_attrs["selected"] = ""
+                                        with tag.option(**first_review_attrs):
+                                            text("First Reviews (≤ $10)")
 
         # Organization table
         with tag.div(id="org-list", classes="overflow-x-auto"):


### PR DESCRIPTION
## 📋 Summary

Adds a new **First Reviews** filter on the Review tab of the v2 organizations backoffice page. It surfaces organizations that have never been reviewed before and whose \`next_review_threshold\` is \$10 or lower — the working set eligible for an expedited first review.

## 🎯 What

- New optional \`first_reviews\` query param on \`GET /backoffice/organizations/\`.
- When active, the query filters to organizations where all of:
  - \`status = REVIEW\`
  - \`initially_reviewed_at IS NULL\`
  - \`next_review_threshold <= 1000\` (cents, i.e. ≤ \$10)
- A matching dropdown is rendered in the advanced-filters panel, but **only when the Review tab is active**.

## 🤔 Why

Operators want a quick way to triage low-risk first-time reviews without scanning every org in the Review queue. Scoping by threshold + never-reviewed-before isolates exactly that cohort.

## 🔧 How

- \`server/polar/backoffice/organizations_v2/endpoints.py\`: adds the query param, threshold constant (\`FIRST_REVIEWS_MAX_THRESHOLD_CENTS = 1000\`), and the WHERE clause. The clause itself re-asserts \`status = REVIEW\` for defense-in-depth, so the filter is a no-op if anyone constructs a URL outside the Review tab.
- \`server/polar/backoffice/organizations_v2/views/list_view.py\`: renders a new dropdown next to the existing Appeal Status select, gated on \`status_filter == OrganizationStatus.REVIEW\`.

## 🧪 Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests for new functionality
- [ ] I have run linting and type checking

### Test Instructions

1. Open the backoffice organizations page: \`/backoffice/organizations/\`.
2. Switch to the **Review** tab.
3. Click **Filters** — a new "First Reviews" dropdown appears alongside "Appeal Status".
4. Select **First Reviews (≤ \$10)** — the list narrows to orgs with \`initially_reviewed_at IS NULL\` and \`next_review_threshold <= \$10\`.
5. Switch to the **All** tab — the new dropdown is hidden.

Verified locally with seeded orgs covering matching, over-threshold, and already-reviewed cases.

## 🖼️ Screenshots/Recordings

<img width="1200" alt="First Reviews filter on Review tab" src="#" />

## 📝 Additional Notes

- The \$10 threshold is encoded as \`FIRST_REVIEWS_MAX_THRESHOLD_CENTS\` at module level — easy to tune if the cutoff changes.
- No changes to the legacy classic organizations view.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated the relevant tests
- [ ] All tests pass locally
- [x] **AI/LLM Policy**: If I used AI assistance, I have tested and executed the code locally (not just "vibe-coded")