### PR TITLE
Fix organization members query to exclude deleted users

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -453,8 +453,13 @@ async def get_organization_detail(
     # Fetch members separately
     members_stmt = (
         select(UserOrganization)
-        .options(joinedload(UserOrganization.user))
-        .where(UserOrganization.organization_id == organization_id)
+        .join(User, User.id == UserOrganization.user_id)
+        .options(contains_eager(UserOrganization.user))
+        .where(
+            UserOrganization.organization_id == organization_id,
+            UserOrganization.is_deleted.is_(False),
+            User.is_deleted.is_(False),
+        )
         .limit(10)
     )
     members_result = await session.execute(members_stmt)


### PR DESCRIPTION
## 📋 Summary

Improves the organization members query to properly filter out deleted users and organizations using explicit joins and eager loading.

## 🎯 What

Modified the `get_organization_detail` endpoint's members query to:
- Replace `joinedload` with an explicit `join` and `contains_eager` for better query control
- Add filters to exclude soft-deleted users (`User.is_deleted.is_(False)`)
- Add filters to exclude soft-deleted organization memberships (`UserOrganization.is_deleted.is_(False)`)

## 🤔 Why

The previous implementation used `joinedload`, which doesn't allow filtering on the joined table. This could result in returning organization members that have been soft-deleted. By using an explicit `join` with `contains_eager`, we can properly filter out deleted users and memberships while maintaining efficient eager loading.

## 🔧 How

Changed the SQLAlchemy query construction from:
- `joinedload(UserOrganization.user)` → explicit `.join(User, ...)` with `.contains_eager(UserOrganization.user)`
- Added `User.is_deleted.is_(False)` condition to filter deleted users
- Added `UserOrganization.is_deleted.is_(False)` condition to filter deleted memberships

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass (`uv run task test` for backend)
- [ ] I have run linting and type checking (`uv run task lint && uv run task lint_types` for backend)

## 📝 Additional Notes

This change ensures data consistency by preventing soft-deleted users and memberships from appearing in the organization members list, which is important for maintaining accurate organization member visibility.

https://claude.ai/code/session_01H12XRpScLHBgZpyAL1LZR3