### PR TITLE
organization: drop deprecated blocked_at column

### DIFF
--- a/server/migrations/versions/2026-04-21-1628_drop_organization_blocked_at_column.py
+++ b/server/migrations/versions/2026-04-21-1628_drop_organization_blocked_at_column.py
@@ -1,0 +1,35 @@
+"""drop organization blocked_at column
+
+Revision ID: 9e14393a579f
+Revises: 532186b5c028
+Create Date: 2026-04-21 16:28:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "9e14393a579f"
+down_revision = "532186b5c028"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("organizations", "blocked_at")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "blocked_at",
+            postgresql.TIMESTAMP(timezone=True),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -473,16 +473,6 @@ class Organization(RateLimitGroupMixin, RecordModel):
         TIMESTAMP(timezone=True), nullable=True, default=None
     )
 
-    # DEPRECATED: Use `status == OrganizationStatus.BLOCKED` instead.
-    # Kept mapped so the ORM stays in sync with the DB column on prod. Drop
-    # will happen in a follow-up PR once this fix is fully rolled out.
-    blocked_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=True,
-        default=None,
-        deferred=True,
-    )
-
     # Flag to block refunds for all orders in this organization
     refunds_blocked: Mapped[bool] = mapped_column(
         nullable=False,


### PR DESCRIPTION
## Summary

Re-lands the `organizations.blocked_at` column drop that was reverted in #11119.

- New migration `9e14393a579f` chained off current head `532186b5c028`, drops `organizations.blocked_at`.
- Removes the mapped attribute from `Organization` — the `deferred=True` workaround is no longer needed.

## Why now

#11119 fixed the real bug: `RepositoryBase.paginate()` and `kit.pagination.paginate()` now project only explicit columns (`self.model.id` / `literal(1)`) into the count subquery, so `deferred=True` columns (or columns that have just been dropped at the DB level) are no longer rendered into SQL. With that fix fully rolled out to prod, it's safe to drop the column and remove the mapped attribute.

## Rolling-deploy safety

- After #11119 is deployed, no running code references `Organization.blocked_at` — the attribute is kept mapped only to match the on-disk schema.
- This PR removes both the column and the mapped attribute in one step. The ORM no longer references the column, so old pods (post-#11119) won't emit `organizations.blocked_at` in any generated SQL; new pods have the attribute fully removed.
- **Do not merge until #11119 is fully rolled out to prod.**

## Audit of other query patterns

Confirmed no other code path could render `organizations.blocked_at`:

- All `.subquery()` / `.cte()` / `.alias()` sites over `Organization` use explicit column projection (`with_only_columns(Organization.id)`, `literal(1)`, etc.).
- Zero direct references to `Organization.blocked_at` in the codebase (`User.blocked_at` is an unrelated column on a different table).
- Zero raw SQL (`text()`) referring to `organizations.blocked_at`.
- No `undefer` / `load_only` / `selectin_polymorphic` patterns on `Organization`.
- No column-introspection-based serializers.

## Test plan

Tested locally against a DB reset to the exact sandbox recovery state (`alembic_version = 532186b5c028`, column present):

- [x] `alembic upgrade head` → drops column cleanly, version at `9e14393a579f`.
- [x] `alembic downgrade -1` → re-adds column cleanly.
- [x] Smoke test against post-drop schema — pagination count subquery SQL = `SELECT count(*) FROM (SELECT organizations.id FROM organizations)` (no `blocked_at`), full `SELECT organizations.*` no longer contains `blocked_at`. Both queries execute successfully.
- [x] `tests/organization/` + `tests/kit/` → 299 passed.

## Deployment

- Sandbox pre-deploy should run this migration as a no-op-then-drop once #11119 is live.
- Prod pre-deploy will drop the column in a single statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)