### PR TITLE
server/tests: add authn/authz coverage for tier 2 commerce endpoints

### DIFF
--- a/server/tests/benefit/test_endpoints.py
+++ b/server/tests/benefit/test_endpoints.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 
 from polar.auth.scope import Scope
@@ -17,6 +18,14 @@ from polar.models.benefit import BenefitType
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_benefit, create_benefit_grant
+
+
+@pytest_asyncio.fixture
+async def benefit_second_organization(
+    save_fixture: SaveFixture,
+    organization_second: Organization,
+) -> Benefit:
+    return await create_benefit(save_fixture, organization=organization_second)
 
 
 @pytest.mark.asyncio
@@ -240,6 +249,17 @@ class TestGetBenefit:
         assert json["id"] == str(benefit_organization.id)
         assert "properties" in json
 
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_benefit(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        benefit_second_organization: Benefit,
+    ) -> None:
+        response = await client.get(f"/v1/benefits/{benefit_second_organization.id}")
+
+        assert response.status_code == 404
+
 
 @pytest.mark.asyncio
 class TestCreateBenefit:
@@ -386,6 +406,23 @@ class TestUpdateBenefit:
         assert "properties" in json
 
     @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_benefit(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        benefit_second_organization: Benefit,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/benefits/{benefit_second_organization.id}",
+            json={
+                "type": benefit_second_organization.type,
+                "description": "Updated Name",
+            },
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
     async def test_can_update_custom_properties(
         self,
         save_fixture: SaveFixture,
@@ -445,6 +482,17 @@ class TestDeleteBenefit:
 
         assert response.status_code == 204
 
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_benefit(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        benefit_second_organization: Benefit,
+    ) -> None:
+        response = await client.delete(f"/v1/benefits/{benefit_second_organization.id}")
+
+        assert response.status_code == 404
+
 
 @pytest.mark.asyncio
 class TestViewGrants:
@@ -463,6 +511,19 @@ class TestViewGrants:
     async def test_not_existing(self, client: AsyncClient) -> None:
         response = await client.get(
             f"/v1/benefits/{uuid.uuid4()}/grants",
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_benefit(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        benefit_second_organization: Benefit,
+    ) -> None:
+        response = await client.get(
+            f"/v1/benefits/{benefit_second_organization.id}/grants",
         )
 
         assert response.status_code == 404

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
@@ -27,6 +29,47 @@ async def checkout_link(save_fixture: SaveFixture, product: Product) -> Checkout
         success_url="https://example.com/success",
         user_metadata={"key": "value"},
     )
+
+
+@pytest_asyncio.fixture
+async def checkout_link_organization_second(
+    save_fixture: SaveFixture,
+    product_organization_second: Product,
+) -> CheckoutLink:
+    return await create_checkout_link(
+        save_fixture,
+        products=[product_organization_second],
+        success_url="https://example.com/success",
+    )
+
+
+@pytest.mark.asyncio
+class TestListCheckoutLinks:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/checkout-links/")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetCheckoutLink:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/checkout-links/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_checkout_link(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        checkout_link_organization_second: CheckoutLink,
+    ) -> None:
+        response = await client.get(
+            f"/v1/checkout-links/{checkout_link_organization_second.id}"
+        )
+
+        assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer_meter/test_endpoints.py
+++ b/server/tests/customer_meter/test_endpoints.py
@@ -8,7 +8,6 @@ from httpx import AsyncClient
 from polar.models import (
     Customer,
     CustomerMeter,
-    Meter,
     Organization,
     UserOrganization,
 )

--- a/server/tests/customer_meter/test_endpoints.py
+++ b/server/tests/customer_meter/test_endpoints.py
@@ -1,0 +1,80 @@
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from polar.models import (
+    Customer,
+    CustomerMeter,
+    Meter,
+    Organization,
+    UserOrganization,
+)
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_meter
+
+
+@pytest_asyncio.fixture
+async def customer_meter_organization_second(
+    save_fixture: SaveFixture,
+    organization_second: Organization,
+    customer_organization_second: Customer,
+) -> CustomerMeter:
+    meter = await create_meter(
+        save_fixture,
+        id=uuid.uuid4(),
+        organization=organization_second,
+    )
+    customer_meter = CustomerMeter(
+        customer=customer_organization_second,
+        meter=meter,
+        consumed_units=Decimal(0),
+        credited_units=0,
+        balance=Decimal(0),
+    )
+    await save_fixture(customer_meter)
+    return customer_meter
+
+
+@pytest.mark.asyncio
+class TestListCustomerMeters:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/customer-meters/")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_does_not_see_other_organization_customer_meters(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        customer_meter_organization_second: CustomerMeter,
+    ) -> None:
+        response = await client.get("/v1/customer-meters/")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 0
+
+
+@pytest.mark.asyncio
+class TestGetCustomerMeter:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/customer-meters/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_customer_meter(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        customer_meter_organization_second: CustomerMeter,
+    ) -> None:
+        response = await client.get(
+            f"/v1/customer-meters/{customer_meter_organization_second.id}"
+        )
+
+        assert response.status_code == 404

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -1174,6 +1174,49 @@ class TestOrderBasedSeats:
         assert data["can_claim"] is True
 
 
+# Seat endpoints use `SeatWriteOrAnonymous`, a hybrid dependency that returns
+# 403 (not 401) for anonymous callers, since assign/claim flows accept
+# checkout_client_secret or invitation_token. Claim endpoints are
+# intentionally public (token-gated).
+
+
+@pytest.mark.asyncio
+class TestCustomerSeatsAuthentication:
+    async def test_list_seats_anonymous_rejected(
+        self,
+        client: AsyncClient,
+        subscription_with_seats: Subscription,
+    ) -> None:
+        response = await client.get(
+            "/v1/customer-seats",
+            params={"subscription_id": str(subscription_with_seats.id)},
+        )
+
+        assert response.status_code == 403
+
+    async def test_revoke_seat_anonymous_rejected(
+        self,
+        client: AsyncClient,
+        customer_seat_claimed: CustomerSeat,
+    ) -> None:
+        response = await client.delete(
+            f"/v1/customer-seats/{customer_seat_claimed.id}",
+        )
+
+        assert response.status_code == 403
+
+    async def test_resend_invitation_anonymous_rejected(
+        self,
+        client: AsyncClient,
+        customer_seat_pending: CustomerSeat,
+    ) -> None:
+        response = await client.post(
+            f"/v1/customer-seats/{customer_seat_pending.id}/resend",
+        )
+
+        assert response.status_code == 403
+
+
 @pytest.mark.asyncio
 class TestMemberEntityInResponse:
     """Tests for member entity nested in seat API responses."""

--- a/server/tests/discount/test_endpoints.py
+++ b/server/tests/discount/test_endpoints.py
@@ -1,10 +1,12 @@
+import uuid
 from typing import Any
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 
 from polar.discount.repository import DiscountRepository
-from polar.models import Organization, UserOrganization
+from polar.models import Discount, Organization, UserOrganization
 from polar.models.discount import (
     DiscountDuration,
     DiscountFixed,
@@ -16,12 +18,39 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_discount
 
 
+@pytest_asyncio.fixture
+async def discount_organization_second(
+    save_fixture: SaveFixture,
+    organization_second: Organization,
+) -> Discount:
+    return await create_discount(
+        save_fixture,
+        type=DiscountType.percentage,
+        basis_points=1000,
+        duration=DiscountDuration.once,
+        organization=organization_second,
+    )
+
+
 @pytest.mark.asyncio
 class TestListDiscounts:
     async def test_anonymous(self, client: AsyncClient) -> None:
         response = await client.get("/v1/discounts/")
 
         assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_does_not_see_other_organization_discounts(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        discount_organization_second: Discount,
+    ) -> None:
+        response = await client.get("/v1/discounts/")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth
     async def test_valid(
@@ -219,3 +248,65 @@ class TestCreateDiscount:
         assert discount.amounts == {"usd": 1000}
         assert discount.amount == 1000
         assert discount.currency == "usd"
+
+
+@pytest.mark.asyncio
+class TestGetDiscount:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/discounts/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_discount(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        discount_organization_second: Discount,
+    ) -> None:
+        response = await client.get(f"/v1/discounts/{discount_organization_second.id}")
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateDiscount:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.patch(f"/v1/discounts/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_discount(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        discount_organization_second: Discount,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/discounts/{discount_organization_second.id}",
+            json={"name": "Updated"},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestDeleteDiscount:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.delete(f"/v1/discounts/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_discount(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        discount_organization_second: Discount,
+    ) -> None:
+        response = await client.delete(
+            f"/v1/discounts/{discount_organization_second.id}"
+        )
+
+        assert response.status_code == 404

--- a/server/tests/event/test_endpoints.py
+++ b/server/tests/event/test_endpoints.py
@@ -4,14 +4,24 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 
+from polar.integrations.tinybird.client import TinybirdClient
 from polar.kit.utils import utc_now
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
-from polar.models import Organization, UserOrganization
+from polar.models import Event, Organization, UserOrganization
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_event
+
+
+@pytest_asyncio.fixture
+async def event_organization_second(
+    save_fixture: SaveFixture,
+    organization_second: Organization,
+) -> Event:
+    return await create_event(save_fixture, organization=organization_second)
 
 
 @pytest.mark.asyncio
@@ -461,3 +471,63 @@ class TestAggregateFieldsValidation:
         )
 
         assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestGetStatisticsByProperty:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events/statistics/by-property")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetStatisticsByCustomer:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events/statistics/by-customer")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetStatisticsByVariance:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events/statistics/by-variance")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestListStatisticsTimeseries:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events/statistics/timeseries")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestListEventNames:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events/names")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetEvent:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/events/{uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_event(
+        self,
+        client: AsyncClient,
+        tinybird_client: TinybirdClient,
+        user_organization: UserOrganization,
+        event_organization_second: Event,
+    ) -> None:
+        response = await client.get(f"/v1/events/{event_organization_second.id}")
+
+        assert response.status_code == 404

--- a/server/tests/license_key/test_endpoints.py
+++ b/server/tests/license_key/test_endpoints.py
@@ -1,6 +1,8 @@
+import uuid
 from uuid import UUID
 
 import pytest
+import pytest_asyncio
 from dateutil.relativedelta import relativedelta
 from httpx import AsyncClient
 
@@ -13,7 +15,14 @@ from polar.kit.pagination import PaginationParams
 from polar.kit.utils import generate_uuid, utc_now
 from polar.license_key.repository import LicenseKeyRepository
 from polar.license_key.service import license_key as license_key_service
-from polar.models import Customer, Organization, Product, User, UserOrganization
+from polar.models import (
+    Customer,
+    LicenseKey,
+    Organization,
+    Product,
+    User,
+    UserOrganization,
+)
 from polar.models.license_key import LicenseKeyStatus
 from polar.postgres import AsyncSession
 from polar.redis import Redis
@@ -446,3 +455,179 @@ class TestLicenseKeyEndpoints:
         assert activate.status_code == 403, (
             f"Expected 403 but got {activate.status_code}. Response: {activate.json()}"
         )
+
+
+@pytest_asyncio.fixture
+async def license_key_organization_second(
+    session: AsyncSession,
+    redis: Redis,
+    save_fixture: SaveFixture,
+    organization_second: Organization,
+    product_organization_second: Product,
+    customer_organization_second: Customer,
+) -> LicenseKey:
+    _, granted = await TestLicenseKey.create_benefit_and_grant(
+        session,
+        redis,
+        save_fixture,
+        customer=customer_organization_second,
+        organization=organization_second,
+        product=product_organization_second,
+        properties=BenefitLicenseKeysCreateProperties(prefix="second"),
+    )
+    repository = LicenseKeyRepository.from_session(session)
+    lk = await repository.get_by_id(UUID(granted["license_key_id"]))
+    assert lk is not None
+    return lk
+
+
+@pytest.mark.asyncio
+class TestListLicenseKeys:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/license-keys/")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetLicenseKey:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/license-keys/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_license_key(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        license_key_organization_second: LicenseKey,
+    ) -> None:
+        response = await client.get(
+            f"/v1/license-keys/{license_key_organization_second.id}"
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateLicenseKey:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.patch(f"/v1/license-keys/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_license_key(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        license_key_organization_second: LicenseKey,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/license-keys/{license_key_organization_second.id}",
+            json={"usage": 1},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetActivation:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(
+            f"/v1/license-keys/{uuid.uuid4()}/activations/{uuid.uuid4()}"
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_license_key(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        license_key_organization_second: LicenseKey,
+    ) -> None:
+        response = await client.get(
+            f"/v1/license-keys/{license_key_organization_second.id}"
+            f"/activations/{uuid.uuid4()}"
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestValidateLicenseKey:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/license-keys/validate")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_validate_other_organization_license_key(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        license_key_organization_second: LicenseKey,
+    ) -> None:
+        response = await client.post(
+            "/v1/license-keys/validate",
+            json={
+                "key": license_key_organization_second.key,
+                "organization_id": str(license_key_organization_second.organization_id),
+            },
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestActivateLicenseKey:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/license-keys/activate")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_activate_other_organization_license_key(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        license_key_organization_second: LicenseKey,
+    ) -> None:
+        response = await client.post(
+            "/v1/license-keys/activate",
+            json={
+                "key": license_key_organization_second.key,
+                "organization_id": str(license_key_organization_second.organization_id),
+                "label": "test",
+            },
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestDeactivateLicenseKey:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/license-keys/deactivate")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_deactivate_other_organization_license_key(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        license_key_organization_second: LicenseKey,
+    ) -> None:
+        response = await client.post(
+            "/v1/license-keys/deactivate",
+            json={
+                "key": license_key_organization_second.key,
+                "organization_id": str(license_key_organization_second.organization_id),
+                "activation_id": str(uuid.uuid4()),
+            },
+        )
+
+        assert response.status_code == 404

--- a/server/tests/meter/test_endpoints.py
+++ b/server/tests/meter/test_endpoints.py
@@ -1,0 +1,117 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from polar.models import Meter, Organization, UserOrganization
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_meter
+
+
+@pytest_asyncio.fixture
+async def meter_organization_second(
+    save_fixture: SaveFixture,
+    organization_second: Organization,
+) -> Meter:
+    return await create_meter(
+        save_fixture,
+        id=uuid.uuid4(),
+        organization=organization_second,
+    )
+
+
+@pytest.mark.asyncio
+class TestListMeters:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/meters/")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_does_not_see_other_organization_meters(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        meter_organization_second: Meter,
+    ) -> None:
+        response = await client.get("/v1/meters/")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 0
+
+
+@pytest.mark.asyncio
+class TestGetMeter:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/meters/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_meter(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        meter_organization_second: Meter,
+    ) -> None:
+        response = await client.get(f"/v1/meters/{meter_organization_second.id}")
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetMeterQuantities:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/meters/{uuid.uuid4()}/quantities")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_meter_quantities(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        meter_organization_second: Meter,
+    ) -> None:
+        response = await client.get(
+            f"/v1/meters/{meter_organization_second.id}/quantities",
+            params={
+                "start_timestamp": "2024-01-01T00:00:00Z",
+                "end_timestamp": "2024-01-31T00:00:00Z",
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestCreateMeter:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/meters/")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestUpdateMeter:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.patch(f"/v1/meters/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_update_other_organization_meter(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        meter_organization_second: Meter,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/meters/{meter_organization_second.id}",
+            json={"name": "Updated"},
+        )
+
+        assert response.status_code == 404

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -18,6 +18,19 @@ async def orders(
     return [await create_order(save_fixture, product=product, customer=customer)]
 
 
+@pytest_asyncio.fixture
+async def order_organization_second(
+    save_fixture: SaveFixture,
+    product_organization_second: Product,
+    customer_organization_second: Customer,
+) -> Order:
+    return await create_order(
+        save_fixture,
+        product=product_organization_second,
+        customer=customer_organization_second,
+    )
+
+
 @pytest.mark.asyncio
 class TestListOrders:
     async def test_anonymous(self, client: AsyncClient) -> None:
@@ -308,3 +321,67 @@ class TesGetOrdersStatistics:
 
         json = response.json()
         assert len(json["periods"]) == 12
+
+
+@pytest.mark.asyncio
+class TestUpdateOrder:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.patch(f"/v1/orders/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_order(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        order_organization_second: Order,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/orders/{order_organization_second.id}",
+            json={},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGenerateOrderInvoice:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(f"/v1/orders/{uuid.uuid4()}/invoice")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_order(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        order_organization_second: Order,
+    ) -> None:
+        response = await client.post(
+            f"/v1/orders/{order_organization_second.id}/invoice"
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetOrderInvoice:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/orders/{uuid.uuid4()}/invoice")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_order(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        order_organization_second: Order,
+    ) -> None:
+        response = await client.get(
+            f"/v1/orders/{order_organization_second.id}/invoice"
+        )
+
+        assert response.status_code == 404

--- a/server/tests/product/test_endpoints.py
+++ b/server/tests/product/test_endpoints.py
@@ -34,6 +34,19 @@ class TestListProducts:
         assert response.status_code == 401
 
     @pytest.mark.auth
+    async def test_user_does_not_see_other_organization_products(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product_organization_second: Product,
+    ) -> None:
+        response = await client.get("/v1/products/")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 0
+
+    @pytest.mark.auth
     async def test_with_benefits(
         self,
         session: AsyncSession,
@@ -78,6 +91,17 @@ class TestGetProduct:
     @pytest.mark.auth
     async def test_not_existing(self, client: AsyncClient) -> None:
         response = await client.get(f"/v1/products/{uuid.uuid4()}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_product(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product_organization_second: Product,
+    ) -> None:
+        response = await client.get(f"/v1/products/{product_organization_second.id}")
 
         assert response.status_code == 404
 
@@ -353,6 +377,20 @@ class TestUpdateProduct:
         assert response.status_code == 404
 
     @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_product(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product_organization_second: Product,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/products/{product_organization_second.id}",
+            json={"name": "Updated Name"},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
     async def test_valid(
         self,
         client: AsyncClient,
@@ -462,6 +500,20 @@ class TestUpdateProductBenefits:
     async def test_not_existing(self, client: AsyncClient) -> None:
         response = await client.post(
             f"/v1/products/{uuid.uuid4()}/benefits",
+            json={"benefits": []},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_product(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product_organization_second: Product,
+    ) -> None:
+        response = await client.post(
+            f"/v1/products/{product_organization_second.id}/benefits",
             json={"benefits": []},
         )
 

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 
 from polar.enums import SubscriptionRecurringInterval
@@ -26,6 +27,19 @@ from tests.fixtures.random_objects import (
     create_subscription,
     create_subscription_with_seats,
 )
+
+
+@pytest_asyncio.fixture
+async def subscription_organization_second(
+    save_fixture: SaveFixture,
+    product_organization_second: Product,
+    customer_organization_second: Customer,
+) -> Subscription:
+    return await create_active_subscription(
+        save_fixture,
+        product=product_organization_second,
+        customer=customer_organization_second,
+    )
 
 
 @pytest.mark.asyncio
@@ -1277,3 +1291,53 @@ class TestSubscriptionUpdateBillingPeriod:
         )
 
         assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestExportSubscriptions:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/subscriptions/export")
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetSubscription:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/subscriptions/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_subscription(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        subscription_organization_second: Subscription,
+    ) -> None:
+        response = await client.get(
+            f"/v1/subscriptions/{subscription_organization_second.id}"
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetChargePreview:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/subscriptions/{uuid.uuid4()}/charge-preview")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_subscription(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        subscription_organization_second: Subscription,
+    ) -> None:
+        response = await client.get(
+            f"/v1/subscriptions/{subscription_organization_second.id}/charge-preview"
+        )
+
+        assert response.status_code == 404


### PR DESCRIPTION
## 📋 Summary

Follow-up to #11103 (tier 1 finance endpoints). Extends the same authn/authz baseline to tier 2 commerce endpoints across 11 modules.

## 🎯 What

Adds anonymous (401) and cross-org (404) tests for endpoints in:

- `license_key`, `checkout_link`, `subscription`, `event`, `benefit`
- `product`, `order`, `discount`, `customer_seat`
- `meter`, `customer_meter` (new test files)

Each endpoint gets a `TestXxx` class with:
- `test_anonymous` — unauthenticated request → 401
- `test_user_cannot_access_other_organization_*` — authenticated as primary org's user, targets a resource owned by `organization_second` → 404

## 🤔 Why

Tier 2 covers the commerce surface (subscriptions, products, orders, license keys, etc.) — a regression that leaks resources across orgs here would expose customer data and entitlements. We had no anonymous-access baseline and no cross-org authz guarantees pinned by tests.

## 🔧 How

Mirrors the tier 1 pattern from #11103:
- Per-endpoint test classes (matches the file convention)
- `client: AsyncClient` fixture for anonymous calls (no JSON body — auth fires before body validation)
- `@pytest.mark.auth` + `user_organization` + `{resource}_organization_second` fixture for cross-org checks
- Reuses existing `organization_second`, `customer_organization_second`, `product_organization_second` fixtures from `tests/fixtures/random_objects.py`

**One exception — `customer_seat`:** the assign/claim flow uses the `SeatWriteOrAnonymous` hybrid dependency, which returns **403** (not 401) for anonymous callers — the flow legitimately accepts `checkout_client_secret` or `invitation_token`. Coverage there pins 403 instead and skips cross-org. Documented inline.

## 🧪 Testing

- [x] All 322 affected tests pass (`uv run pytest` across the 11 modules)
- [x] 4 skipped are Tinybird-dependent (expected when Tinybird isn't running locally)
- [x] `uv run ruff format` clean

### Test Instructions

```bash
cd server
uv run pytest tests/license_key/test_endpoints.py tests/checkout_link/test_endpoints.py \
  tests/subscription/test_endpoints.py tests/event/test_endpoints.py \
  tests/benefit/test_endpoints.py tests/product/test_endpoints.py \
  tests/order/test_endpoints.py tests/discount/test_endpoints.py \
  tests/customer_seat/test_endpoints.py tests/meter/test_endpoints.py \
  tests/customer_meter/test_endpoints.py
```

## 📝 Additional Notes

- No production code changes — tests only.
- Found one pre-existing bug while reviewing: the shared fixture `benefit_organization_second` at `server/tests/fixtures/random_objects.py:1609` is misnamed — it actually creates a benefit on the **primary** org, not on `organization_second`. Not fixed here to keep scope tight; worth a follow-up.

## ✅ Pre-submission Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] **AI/LLM Policy**: AI-assisted; tested and executed locally