### PR TITLE
refactor(auth): remove web_read/web_write scope dependency

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -175,7 +175,7 @@ ResourcesRead = Annotated[
     AuthSubject[User | Organization],
     Depends(
         Authenticator(
-            required_scopes={Scope.web_read, Scope.resources_read},
+            required_scopes={Scope.resources_read},
             allowed_subjects={User, Organization},
         )
     ),

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -20,6 +20,7 @@ from .models import (
     SubjectType,
     User,
     is_anonymous,
+    is_web_session,
 )
 
 oidc_scheme = OpenIdConnect(
@@ -216,16 +217,38 @@ def Authenticator(
     )
 
 
-_WebUserOrAnonymous = Authenticator(
+_WebUserOrAnonymousAuth = Authenticator(
     allowed_subjects={Anonymous, User},
     required_scopes=None,
 )
+
+
+async def _web_user_or_anonymous(
+    auth_subject: Annotated[
+        AuthSubject[Anonymous | User], Depends(_WebUserOrAnonymousAuth)
+    ],
+) -> AuthSubject[Anonymous | User]:
+    """Allow anonymous or web-session users. Reject API tokens."""
+    if not is_anonymous(auth_subject) and not is_web_session(auth_subject):
+        raise Unauthorized()
+    return auth_subject
+
+
 WebUserOrAnonymous = Annotated[
-    AuthSubject[Anonymous | User], Depends(_WebUserOrAnonymous)
+    AuthSubject[Anonymous | User], Depends(_web_user_or_anonymous)
 ]
 
-_WebUserRead = Authenticator(allowed_subjects={User}, required_scopes=None)
-WebUserRead = Annotated[AuthSubject[User], Depends(_WebUserRead)]
+_WebUserAuth = Authenticator(allowed_subjects={User}, required_scopes=None)
 
-_WebUserWrite = Authenticator(allowed_subjects={User}, required_scopes=None)
-WebUserWrite = Annotated[AuthSubject[User], Depends(_WebUserWrite)]
+
+async def _web_user(
+    auth_subject: Annotated[AuthSubject[User], Depends(_WebUserAuth)],
+) -> AuthSubject[User]:
+    """Allow web-session users only. Reject API tokens."""
+    if not is_web_session(auth_subject):
+        raise Unauthorized()
+    return auth_subject
+
+
+WebUserRead = Annotated[AuthSubject[User], Depends(_web_user)]
+WebUserWrite = Annotated[AuthSubject[User], Depends(_web_user)]

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -7,7 +7,7 @@ from fastapi.security import HTTPBearer, OpenIdConnect
 from makefun import with_signature
 
 from polar.auth.scope import Scope
-from polar.exceptions import Unauthorized
+from polar.exceptions import NotPermitted, Unauthorized
 from polar.oauth2.exceptions import InsufficientScopeError
 
 from .models import (
@@ -224,7 +224,7 @@ async def _web_user_or_anonymous(
 ) -> AuthSubject[Anonymous | User]:
     """Allow anonymous or web-session users. Reject API tokens."""
     if not is_anonymous(auth_subject) and not is_web_session(auth_subject):
-        raise Unauthorized()
+        raise NotPermitted()
     return auth_subject
 
 
@@ -240,7 +240,7 @@ async def _web_user(
 ) -> AuthSubject[User]:
     """Allow web-session users only. Reject API tokens."""
     if not is_web_session(auth_subject):
-        raise Unauthorized()
+        raise NotPermitted()
     return auth_subject
 
 

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -218,18 +218,18 @@ def Authenticator(
 
 _WebUserOrAnonymous = Authenticator(
     allowed_subjects={Anonymous, User},
-    required_scopes={Scope.web_write},
+    required_scopes=None,
 )
 WebUserOrAnonymous = Annotated[
     AuthSubject[Anonymous | User], Depends(_WebUserOrAnonymous)
 ]
 
 _WebUserRead = Authenticator(
-    allowed_subjects={User}, required_scopes={Scope.web_read, Scope.web_write}
+    allowed_subjects={User}, required_scopes=None
 )
 WebUserRead = Annotated[AuthSubject[User], Depends(_WebUserRead)]
 
 _WebUserWrite = Authenticator(
-    allowed_subjects={User}, required_scopes={Scope.web_write}
+    allowed_subjects={User}, required_scopes=None
 )
 WebUserWrite = Annotated[AuthSubject[User], Depends(_WebUserWrite)]

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Request, Security
 from fastapi.security import HTTPBearer, OpenIdConnect
 from makefun import with_signature
 
-from polar.auth.scope import RESERVED_SCOPES, Scope
+from polar.auth.scope import Scope
 from polar.exceptions import Unauthorized
 from polar.oauth2.exceptions import InsufficientScopeError
 
@@ -193,13 +193,7 @@ def Authenticator(
             kind=Parameter.POSITIONAL_OR_KEYWORD,
             default=Security(
                 _get_auth_subject_factory(allowed_subjects_frozen),
-                scopes=sorted(
-                    [
-                        s.value
-                        for s in (required_scopes or {})
-                        if s not in RESERVED_SCOPES
-                    ]
-                ),
+                scopes=sorted(s.value for s in (required_scopes or {})),
             ),
         ),
     ]

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -217,7 +217,7 @@ def Authenticator(
     )
 
 
-_WebUserOrAnonymousAuth = Authenticator(
+_WebUserOrAnonymous = Authenticator(
     allowed_subjects={Anonymous, User},
     required_scopes=None,
 )
@@ -225,7 +225,7 @@ _WebUserOrAnonymousAuth = Authenticator(
 
 async def _web_user_or_anonymous(
     auth_subject: Annotated[
-        AuthSubject[Anonymous | User], Depends(_WebUserOrAnonymousAuth)
+        AuthSubject[Anonymous | User], Depends(_WebUserOrAnonymous)
     ],
 ) -> AuthSubject[Anonymous | User]:
     """Allow anonymous or web-session users. Reject API tokens."""

--- a/server/polar/auth/dependencies.py
+++ b/server/polar/auth/dependencies.py
@@ -224,12 +224,8 @@ WebUserOrAnonymous = Annotated[
     AuthSubject[Anonymous | User], Depends(_WebUserOrAnonymous)
 ]
 
-_WebUserRead = Authenticator(
-    allowed_subjects={User}, required_scopes=None
-)
+_WebUserRead = Authenticator(allowed_subjects={User}, required_scopes=None)
 WebUserRead = Annotated[AuthSubject[User], Depends(_WebUserRead)]
 
-_WebUserWrite = Authenticator(
-    allowed_subjects={User}, required_scopes=None
-)
+_WebUserWrite = Authenticator(allowed_subjects={User}, required_scopes=None)
 WebUserWrite = Annotated[AuthSubject[User], Depends(_WebUserWrite)]

--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -160,10 +160,12 @@ async def get_auth_subject(
     if user_session is not None:
         scopes = set(user_session.scopes)
         # Upgrade legacy web sessions to have all scopes.
-        # Old sessions were created with only {web_read, web_write}.
+        # Old sessions were created with exactly {web_read, web_write}.
         # New sessions get all scopes. This ensures old sessions work
         # until they expire. Safe to remove after 2026-05-22 (31 days).
-        if Scope.web_read in scopes or Scope.web_write in scopes:
+        # Only match the exact legacy set — read-only impersonation
+        # sessions ({web_read} only) must NOT be upgraded.
+        if scopes == {Scope.web_read, Scope.web_write}:
             scopes = set(Scope)
         return AuthSubject(user_session.user, scopes, user_session)
 

--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -158,7 +158,14 @@ async def get_auth_subject(
 
     user_session = await get_user_session(request, session)
     if user_session is not None:
-        return AuthSubject(user_session.user, set(user_session.scopes), user_session)
+        scopes = set(user_session.scopes)
+        # Upgrade legacy web sessions to have all scopes.
+        # Old sessions were created with only {web_read, web_write}.
+        # New sessions get all scopes. This ensures old sessions work
+        # until they expire. Safe to remove after 2026-05-22 (31 days).
+        if Scope.web_read in scopes or Scope.web_write in scopes:
+            scopes = set(Scope)
+        return AuthSubject(user_session.user, scopes, user_session)
 
     return AuthSubject(Anonymous(), set(), None)
 

--- a/server/polar/auth/models.py
+++ b/server/polar/auth/models.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Generic, TypeGuard, TypeVar
+from typing import Any, Generic, TypeGuard, TypeVar
 
 from polar.enums import RateLimitGroup
 from polar.models import (
@@ -126,6 +126,11 @@ def is_member[S: Subject](
     return isinstance(auth_subject.subject, Member)
 
 
+def is_web_session(auth_subject: AuthSubject[Any]) -> bool:
+    """Check if the auth subject is authenticated via a web session (not API token)."""
+    return auth_subject.session is not None
+
+
 __all__ = [
     # Re-export subject types for convenience
     "Anonymous",
@@ -141,4 +146,5 @@ __all__ = [
     "is_member",
     "is_organization",
     "is_user",
+    "is_web_session",
 ]

--- a/server/polar/auth/models.py
+++ b/server/polar/auth/models.py
@@ -128,7 +128,7 @@ def is_member[S: Subject](
 
 def is_web_session(auth_subject: AuthSubject[Any]) -> bool:
     """Check if the auth subject is authenticated via a web session (not API token)."""
-    return auth_subject.session is not None
+    return isinstance(auth_subject.session, UserSession)
 
 
 __all__ = [

--- a/server/polar/auth/routing.py
+++ b/server/polar/auth/routing.py
@@ -6,7 +6,6 @@ from fastapi.params import Depends
 from fastapi.routing import APIRoute
 
 from polar.auth.dependencies import _Authenticator
-from polar.auth.scope import RESERVED_SCOPES
 
 
 class DocumentedAuthSubjectAPIRoute(APIRoute):
@@ -48,11 +47,7 @@ class DocumentedAuthSubjectAPIRoute(APIRoute):
                 description = kwargs["description"] or inspect.cleandoc(
                     endpoint.__doc__ or ""
                 )
-                scopes_list = [
-                    f"`{s}`"
-                    for s in sorted(required_scopes or [])
-                    if s not in RESERVED_SCOPES
-                ]
+                scopes_list = [f"`{s}`" for s in sorted(required_scopes or [])]
                 if scopes_list:
                     description += f"\n\n**Scopes**: {' '.join(scopes_list)}"
                 kwargs["description"] = description

--- a/server/polar/auth/scope.py
+++ b/server/polar/auth/scope.py
@@ -111,6 +111,43 @@ class Scope(StrEnum):
         return json_schema
 
 
+READ_ONLY_SCOPES: set[Scope] = {
+    Scope.openid,
+    Scope.profile,
+    Scope.email,
+    Scope.user_read,
+    Scope.web_read,
+    Scope.organizations_read,
+    Scope.custom_fields_read,
+    Scope.discounts_read,
+    Scope.checkout_links_read,
+    Scope.checkouts_read,
+    Scope.transactions_read,
+    Scope.payouts_read,
+    Scope.products_read,
+    Scope.benefits_read,
+    Scope.events_read,
+    Scope.meters_read,
+    Scope.files_read,
+    Scope.subscriptions_read,
+    Scope.customers_read,
+    Scope.members_read,
+    Scope.wallets_read,
+    Scope.disputes_read,
+    Scope.customer_meters_read,
+    Scope.customer_seats_read,
+    Scope.orders_read,
+    Scope.refunds_read,
+    Scope.payments_read,
+    Scope.metrics_read,
+    Scope.webhooks_read,
+    Scope.license_keys_read,
+    Scope.customer_portal_read,
+    Scope.notifications_read,
+    Scope.notification_recipients_read,
+    Scope.organization_access_tokens_read,
+}
+
 RESERVED_SCOPES: set[Scope] = set()
 SCOPES_SUPPORTED = [s.value for s in Scope if s not in RESERVED_SCOPES]
 SCOPES_SUPPORTED_DISPLAY_NAMES: dict[Scope, str] = {

--- a/server/polar/auth/scope.py
+++ b/server/polar/auth/scope.py
@@ -116,7 +116,6 @@ READ_ONLY_SCOPES: set[Scope] = {
     Scope.profile,
     Scope.email,
     Scope.user_read,
-    Scope.web_read,
     Scope.organizations_read,
     Scope.custom_fields_read,
     Scope.discounts_read,
@@ -148,13 +147,14 @@ READ_ONLY_SCOPES: set[Scope] = {
     Scope.organization_access_tokens_read,
 }
 
-SCOPES_SUPPORTED = [s.value for s in Scope]
+# web_read/web_write are legacy — kept in Scope enum for session upgrade
+# but excluded from public-facing scope lists.
+_LEGACY_SCOPES = {Scope.web_read, Scope.web_write}
+SCOPES_SUPPORTED = [s.value for s in Scope if s not in _LEGACY_SCOPES]
 SCOPES_SUPPORTED_DISPLAY_NAMES: dict[Scope, str] = {
     Scope.openid: "OpenID",
     Scope.profile: "Read your profile",
     Scope.email: "Read your email address",
-    Scope.web_read: "Web Read Access",
-    Scope.web_write: "Web Write Access",
     Scope.user_read: "User Read",
     Scope.user_write: "Delete your user account",
     Scope.organizations_read: "Read your organizations",

--- a/server/polar/auth/scope.py
+++ b/server/polar/auth/scope.py
@@ -148,8 +148,7 @@ READ_ONLY_SCOPES: set[Scope] = {
     Scope.organization_access_tokens_read,
 }
 
-RESERVED_SCOPES: set[Scope] = set()
-SCOPES_SUPPORTED = [s.value for s in Scope if s not in RESERVED_SCOPES]
+SCOPES_SUPPORTED = [s.value for s in Scope]
 SCOPES_SUPPORTED_DISPLAY_NAMES: dict[Scope, str] = {
     Scope.openid: "OpenID",
     Scope.profile: "Read your profile",

--- a/server/polar/auth/scope.py
+++ b/server/polar/auth/scope.py
@@ -111,7 +111,7 @@ class Scope(StrEnum):
         return json_schema
 
 
-RESERVED_SCOPES = {Scope.web_read, Scope.web_write}
+RESERVED_SCOPES: set[Scope] = set()
 SCOPES_SUPPORTED = [s.value for s in Scope if s not in RESERVED_SCOPES]
 SCOPES_SUPPORTED_DISPLAY_NAMES: dict[Scope, str] = {
     Scope.openid: "OpenID",

--- a/server/polar/auth/service.py
+++ b/server/polar/auth/service.py
@@ -39,7 +39,7 @@ class AuthService:
             session=session,
             user=user,
             user_agent=request.headers.get("User-Agent", ""),
-            scopes=[Scope.web_read, Scope.web_write],
+            scopes=list(Scope),
         )
 
         return_url = get_safe_return_url(return_to)

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -118,11 +118,30 @@ async def _check_policy(
 
 
 AuthorizeFinanceRead = Annotated[
-    AuthzContext[User | Organization], Depends(OrgPolicyGuard(finance.can_read))
+    AuthzContext[User | Organization],
+    Depends(
+        OrgPolicyGuard(
+            finance.can_read,
+            required_scopes={
+                Scope.transactions_read,
+                Scope.transactions_write,
+                Scope.payouts_read,
+                Scope.payouts_write,
+            },
+        )
+    ),
 ]
 AuthorizeFinanceWrite = Annotated[
     AuthzContext[User | Organization],
-    Depends(OrgPolicyGuard(finance.can_write)),
+    Depends(
+        OrgPolicyGuard(
+            finance.can_write,
+            required_scopes={
+                Scope.transactions_write,
+                Scope.payouts_write,
+            },
+        )
+    ),
 ]
 AuthorizeMembersManage = Annotated[
     AuthzContext[User],
@@ -206,7 +225,12 @@ def AccountPolicyGuard(policy_fn: PolicyFn) -> Any:
 
     _authenticator = Authenticator(
         allowed_subjects={User},
-        required_scopes={Scope.web_read, Scope.web_write},
+        required_scopes={
+            Scope.transactions_read,
+            Scope.transactions_write,
+            Scope.payouts_read,
+            Scope.payouts_write,
+        },
     )
 
     async def dependency(
@@ -254,7 +278,10 @@ def PayoutAccountPolicyGuard(
 
     _authenticator = Authenticator(
         allowed_subjects={User},
-        required_scopes={Scope.web_read, Scope.web_write},
+        required_scopes={
+            Scope.payouts_read,
+            Scope.payouts_write,
+        },
     )
 
     async def dependency(

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -69,8 +69,6 @@ def OrgPolicyGuard(
 
     _allowed = allowed_subjects or {User, Organization}
     _scopes = required_scopes or {
-        Scope.web_read,
-        Scope.web_write,
         Scope.organizations_read,
         Scope.organizations_write,
     }
@@ -149,7 +147,7 @@ AuthorizeMembersManage = Annotated[
         OrgPolicyGuard(
             members.can_manage,
             allowed_subjects={User},
-            required_scopes={Scope.web_write, Scope.organizations_write},
+            required_scopes={Scope.organizations_write},
         )
     ),
 ]
@@ -159,7 +157,7 @@ AuthorizeOrgDelete = Annotated[
         OrgPolicyGuard(
             org_policy.can_delete,
             allowed_subjects={User},
-            required_scopes={Scope.web_write, Scope.organizations_write},
+            required_scopes={Scope.organizations_write},
         )
     ),
 ]

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -167,7 +167,7 @@ AuthorizeOrgManagePayoutAccount = Annotated[
         OrgPolicyGuard(
             org_policy.can_manage_payout_account,
             allowed_subjects={User},
-            required_scopes={Scope.web_write, Scope.organizations_write},
+            required_scopes={Scope.organizations_write},
         )
     ),
 ]

--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -54,7 +54,7 @@ async def start_impersonation(
         session=session,
         user=target_user,
         user_agent=request.headers.get("User-Agent", ""),
-        scopes=list(Scope),
+        scopes=[s for s in Scope if s.value.endswith(":read")],
         expire_in=timedelta(minutes=60),
     )
 

--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -54,7 +54,7 @@ async def start_impersonation(
         session=session,
         user=target_user,
         user_agent=request.headers.get("User-Agent", ""),
-        scopes=[Scope.web_read],
+        scopes=list(Scope),
         expire_in=timedelta(minutes=60),
     )
 

--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -12,7 +12,7 @@ from fastapi import (
 from fastapi.responses import RedirectResponse
 from sqlalchemy import select
 
-from polar.auth.scope import Scope
+from polar.auth.scope import READ_ONLY_SCOPES
 from polar.auth.service import auth as auth_service
 from polar.config import settings
 from polar.kit.crypto import get_token_hash
@@ -54,7 +54,7 @@ async def start_impersonation(
         session=session,
         user=target_user,
         user_agent=request.headers.get("User-Agent", ""),
-        scopes=[s for s in Scope if s.value.endswith(":read")],
+        scopes=list(READ_ONLY_SCOPES),
         expire_in=timedelta(minutes=60),
     )
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -26,7 +26,7 @@ from tagflow import tag, text
 from polar.account.service import account as account_service
 from polar.account_credit.repository import AccountCreditRepository
 from polar.account_credit.service import account_credit_service
-from polar.auth.scope import Scope
+from polar.auth.scope import READ_ONLY_SCOPES
 from polar.auth.service import auth as auth_service
 from polar.backoffice.organizations.analytics import (
     OrganizationSetupAnalyticsService,
@@ -2715,7 +2715,7 @@ async def impersonate_user(
         session=session,
         user=user,
         user_agent=request.headers.get("User-Agent", ""),
-        scopes=[s for s in Scope if s.value.endswith(":read")],  # Read-only
+        scopes=list(READ_ONLY_SCOPES),
         expire_in=timedelta(minutes=60),  # Time-limited
     )
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2715,7 +2715,7 @@ async def impersonate_user(
         session=session,
         user=user,
         user_agent=request.headers.get("User-Agent", ""),
-        scopes=[Scope.web_read],  # Read-only
+        scopes=[s for s in Scope if s.value.endswith(":read")],  # Read-only
         expire_in=timedelta(minutes=60),  # Time-limited
     )
 

--- a/server/polar/benefit/auth.py
+++ b/server/polar/benefit/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _BenefitsRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.benefits_read,
         Scope.benefits_write,
     },
@@ -19,7 +17,6 @@ BenefitsRead = Annotated[AuthSubject[User | Organization], Depends(_BenefitsRead
 
 _BenefitsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.benefits_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/checkout/auth.py
+++ b/server/polar/checkout/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _CheckoutRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.checkouts_read,
         Scope.checkouts_write,
     },
@@ -25,7 +23,7 @@ _CheckoutWrite = Authenticator(
 CheckoutWrite = Annotated[AuthSubject[User | Organization], Depends(_CheckoutWrite)]
 
 _CheckoutWeb = Authenticator(
-    required_scopes={Scope.web_write},
+    required_scopes=set(),
     allowed_subjects={User, Anonymous},
 )
 CheckoutWeb = Annotated[AuthSubject[User | Anonymous], Depends(_CheckoutWeb)]

--- a/server/polar/checkout_link/auth.py
+++ b/server/polar/checkout_link/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _CheckoutLinkRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.checkout_links_read,
         Scope.checkout_links_write,
     },
@@ -22,7 +20,6 @@ CheckoutLinkRead = Annotated[
 
 _CheckoutLinkWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.checkout_links_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/cli/auth.py
+++ b/server/polar/cli/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _CLIRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.webhooks_read,
         Scope.webhooks_write,
     },

--- a/server/polar/custom_field/auth.py
+++ b/server/polar/custom_field/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _CustomFieldRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.custom_fields_read,
         Scope.custom_fields_write,
     },
@@ -20,7 +18,6 @@ CustomFieldRead = Annotated[AuthSubject[User | Organization], Depends(_CustomFie
 
 _CustomFieldWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.custom_fields_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/customer/auth.py
+++ b/server/polar/customer/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _CustomerRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.customers_read,
         Scope.customers_write,
     },
@@ -20,7 +18,6 @@ CustomerRead = Annotated[AuthSubject[User | Organization], Depends(_CustomerRead
 
 _CustomerWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.customers_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/customer_meter/auth.py
+++ b/server/polar/customer_meter/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _CustomerMeterRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.customer_meters_read,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/customer_seat/auth.py
+++ b/server/polar/customer_seat/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _SeatRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.customer_seats_read,
     },
     allowed_subjects={User, Organization},
@@ -18,7 +16,6 @@ SeatRead = Annotated[AuthSubject[User | Organization], Depends(_SeatRead)]
 
 _SeatWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.customer_seats_write,
     },
     allowed_subjects={User, Organization},
@@ -27,7 +24,6 @@ SeatWrite = Annotated[AuthSubject[User | Organization], Depends(_SeatWrite)]
 
 _SeatWriteOrAnonymous = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.customer_seats_write,
     },
     allowed_subjects={User, Organization, Anonymous},

--- a/server/polar/customer_session/auth.py
+++ b/server/polar/customer_session/auth.py
@@ -9,7 +9,6 @@ from polar.models.organization import Organization
 
 _CustomerSessionWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.customer_sessions_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/discount/auth.py
+++ b/server/polar/discount/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _DiscountRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.discounts_read,
         Scope.discounts_write,
     },
@@ -20,7 +18,6 @@ DiscountRead = Annotated[AuthSubject[User | Organization], Depends(_DiscountRead
 
 _DiscountWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.discounts_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/dispute/auth.py
+++ b/server/polar/dispute/auth.py
@@ -7,7 +7,7 @@ from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
 
 _DisputesRead = Authenticator(
-    required_scopes={Scope.web_read, Scope.web_write, Scope.disputes_read},
+    required_scopes={Scope.disputes_read},
     allowed_subjects={User, Organization},
 )
 DisputesRead = Annotated[AuthSubject[User | Organization], Depends(_DisputesRead)]

--- a/server/polar/event/auth.py
+++ b/server/polar/event/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _EventRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.events_read,
         Scope.events_write,
     },
@@ -20,7 +18,6 @@ EventRead = Annotated[AuthSubject[User | Organization], Depends(_EventRead)]
 
 _EventWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.events_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/event_type/auth.py
+++ b/server/polar/event_type/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _EventTypeRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.events_read,
         Scope.events_write,
     },
@@ -19,9 +17,7 @@ _EventTypeRead = Authenticator(
 EventTypeRead = Annotated[AuthSubject[User | Organization], Depends(_EventTypeRead)]
 
 _EventTypeWrite = Authenticator(
-    required_scopes={
-        Scope.web_write,
-    },
+    required_scopes=set(),
     allowed_subjects={User, Organization},
 )
 EventTypeWrite = Annotated[AuthSubject[User | Organization], Depends(_EventTypeWrite)]

--- a/server/polar/event_type/auth.py
+++ b/server/polar/event_type/auth.py
@@ -17,7 +17,7 @@ _EventTypeRead = Authenticator(
 EventTypeRead = Annotated[AuthSubject[User | Organization], Depends(_EventTypeRead)]
 
 _EventTypeWrite = Authenticator(
-    required_scopes=set(),
+    required_scopes={Scope.events_write},
     allowed_subjects={User, Organization},
 )
 EventTypeWrite = Annotated[AuthSubject[User | Organization], Depends(_EventTypeWrite)]

--- a/server/polar/file/auth.py
+++ b/server/polar/file/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _FileRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.files_write,
         Scope.files_read,
     },
@@ -19,7 +17,6 @@ FileRead = Annotated[AuthSubject[User | Organization], Depends(_FileRead)]
 
 _FileWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.files_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/license_key/auth.py
+++ b/server/polar/license_key/auth.py
@@ -11,8 +11,6 @@ LicenseKeysRead = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_read,
-                Scope.web_write,
                 Scope.license_keys_read,
                 Scope.license_keys_write,
             },
@@ -26,7 +24,6 @@ LicenseKeysWrite = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_write,
                 Scope.license_keys_write,
             },
             allowed_subjects={User, Organization},

--- a/server/polar/member/auth.py
+++ b/server/polar/member/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _MemberRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.members_read,
         Scope.members_write,
     },
@@ -20,7 +18,6 @@ MemberRead = Annotated[AuthSubject[User | Organization], Depends(_MemberRead)]
 
 _MemberWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.members_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/meter/auth.py
+++ b/server/polar/meter/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _MeterRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.meters_read,
         Scope.meters_write,
     },
@@ -20,7 +18,6 @@ MeterRead = Annotated[AuthSubject[User | Organization], Depends(_MeterRead)]
 
 _MeterWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.meters_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/metrics/auth.py
+++ b/server/polar/metrics/auth.py
@@ -7,13 +7,13 @@ from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
 
 _MetricsRead = Authenticator(
-    required_scopes={Scope.web_read, Scope.web_write, Scope.metrics_read},
+    required_scopes={Scope.metrics_read},
     allowed_subjects={User, Organization},
 )
 MetricsRead = Annotated[AuthSubject[User | Organization], Depends(_MetricsRead)]
 
 _MetricsWrite = Authenticator(
-    required_scopes={Scope.web_write, Scope.metrics_write},
+    required_scopes={Scope.metrics_write},
     allowed_subjects={User, Organization},
 )
 MetricsWrite = Annotated[AuthSubject[User | Organization], Depends(_MetricsWrite)]

--- a/server/polar/notification_recipient/auth.py
+++ b/server/polar/notification_recipient/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _NotificationRecipientRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.notification_recipients_read,
         Scope.notification_recipients_write,
     },
@@ -21,7 +19,6 @@ NotificationRecipientRead = Annotated[
 
 _NotificationRecipientWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.notification_recipients_write,
     },
     allowed_subjects={User},

--- a/server/polar/notifications/auth.py
+++ b/server/polar/notifications/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _NotificationsRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.notifications_read,
     },
     allowed_subjects={User},
@@ -18,7 +16,6 @@ NotificationsRead = Annotated[AuthSubject[User], Depends(_NotificationsRead)]
 
 _NotificationsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.notifications_write,
     },
     allowed_subjects={User},

--- a/server/polar/order/auth.py
+++ b/server/polar/order/auth.py
@@ -7,14 +7,13 @@ from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
 
 _OrdersRead = Authenticator(
-    required_scopes={Scope.web_read, Scope.web_write, Scope.orders_read},
+    required_scopes={Scope.orders_read},
     allowed_subjects={User, Organization},
 )
 OrdersRead = Annotated[AuthSubject[User | Organization], Depends(_OrdersRead)]
 
 _OrdersWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.orders_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/organization/auth.py
+++ b/server/polar/organization/auth.py
@@ -11,8 +11,6 @@ OrganizationsRead = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_read,
-                Scope.web_write,
                 Scope.organizations_read,
                 Scope.organizations_write,
             },
@@ -26,7 +24,6 @@ OrganizationsWrite = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_write,
                 Scope.organizations_write,
             },
             allowed_subjects={User, Organization},
@@ -39,7 +36,6 @@ OrganizationsCreate = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_write,
                 Scope.organizations_write,
             },
             allowed_subjects={User},
@@ -52,7 +48,6 @@ OrganizationsWriteUser = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_write,
                 Scope.organizations_write,
             },
             allowed_subjects={User},

--- a/server/polar/organization_access_token/auth.py
+++ b/server/polar/organization_access_token/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _OrganizationAccessTokensRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.organization_access_tokens_read,
         Scope.organization_access_tokens_write,
     },
@@ -21,7 +19,6 @@ OrganizationAccessTokensRead = Annotated[
 
 _OrganizationAccessTokensWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.organization_access_tokens_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/organization_access_token/schemas.py
+++ b/server/polar/organization_access_token/schemas.py
@@ -3,12 +3,12 @@ from enum import StrEnum
 
 from pydantic import UUID4
 
-from polar.auth.scope import RESERVED_SCOPES, Scope
+from polar.auth.scope import Scope
 from polar.kit.schemas import Schema, TimestampedSchema
 from polar.organization.schemas import OrganizationID
 
 AvailableScope = StrEnum(  # type: ignore
-    "AvailableScope", {s: s.value for s in Scope if s not in RESERVED_SCOPES}
+    "AvailableScope", {s: s.value for s in Scope}
 )
 
 

--- a/server/polar/payment/auth.py
+++ b/server/polar/payment/auth.py
@@ -9,8 +9,6 @@ from polar.models.organization import Organization
 
 _PaymentRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.payments_read,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/payout/auth.py
+++ b/server/polar/payout/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _PayoutsRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.payouts_read,
     },
     allowed_subjects={User},
@@ -18,7 +16,6 @@ PayoutsRead = Annotated[AuthSubject[User], Depends(_PayoutsRead)]
 
 _PayoutsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.payouts_write,
     },
     allowed_subjects={User},

--- a/server/polar/product/auth.py
+++ b/server/polar/product/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _CreatorProductsRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.products_read,
         Scope.products_write,
     },
@@ -21,7 +19,6 @@ CreatorProductsRead = Annotated[
 
 _CreatorProductsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.products_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/refund/auth.py
+++ b/server/polar/refund/auth.py
@@ -11,8 +11,6 @@ RefundsRead = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_read,
-                Scope.web_write,
                 Scope.refunds_read,
                 Scope.refunds_write,
             },
@@ -26,7 +24,6 @@ RefundsWrite = Annotated[
     Depends(
         Authenticator(
             required_scopes={
-                Scope.web_write,
                 Scope.refunds_write,
             },
             allowed_subjects={User, Organization},

--- a/server/polar/search/auth.py
+++ b/server/polar/search/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _SearchRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.products_read,
         Scope.products_write,
         Scope.customers_read,

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -41,39 +41,22 @@ class SearchService:
     def _has_products_scope(self, auth_subject: AuthSubject[User]) -> bool:
         return bool(
             auth_subject.scopes
-            & {
-                Scope.web_read,
-                Scope.web_write,
-                Scope.products_read,
-                Scope.products_write,
-            }
+            & {Scope.products_read, Scope.products_write}
         )
 
     def _has_customers_scope(self, auth_subject: AuthSubject[User]) -> bool:
         return bool(
             auth_subject.scopes
-            & {
-                Scope.web_read,
-                Scope.web_write,
-                Scope.customers_read,
-                Scope.customers_write,
-            }
+            & {Scope.customers_read, Scope.customers_write}
         )
 
     def _has_orders_scope(self, auth_subject: AuthSubject[User]) -> bool:
-        return bool(
-            auth_subject.scopes & {Scope.web_read, Scope.web_write, Scope.orders_read}
-        )
+        return bool(auth_subject.scopes & {Scope.orders_read, Scope.orders_write})
 
     def _has_subscriptions_scope(self, auth_subject: AuthSubject[User]) -> bool:
         return bool(
             auth_subject.scopes
-            & {
-                Scope.web_read,
-                Scope.web_write,
-                Scope.subscriptions_read,
-                Scope.subscriptions_write,
-            }
+            & {Scope.subscriptions_read, Scope.subscriptions_write}
         )
 
     async def search(

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -39,24 +39,17 @@ class SearchService:
             return None
 
     def _has_products_scope(self, auth_subject: AuthSubject[User]) -> bool:
-        return bool(
-            auth_subject.scopes
-            & {Scope.products_read, Scope.products_write}
-        )
+        return bool(auth_subject.scopes & {Scope.products_read, Scope.products_write})
 
     def _has_customers_scope(self, auth_subject: AuthSubject[User]) -> bool:
-        return bool(
-            auth_subject.scopes
-            & {Scope.customers_read, Scope.customers_write}
-        )
+        return bool(auth_subject.scopes & {Scope.customers_read, Scope.customers_write})
 
     def _has_orders_scope(self, auth_subject: AuthSubject[User]) -> bool:
         return bool(auth_subject.scopes & {Scope.orders_read, Scope.orders_write})
 
     def _has_subscriptions_scope(self, auth_subject: AuthSubject[User]) -> bool:
         return bool(
-            auth_subject.scopes
-            & {Scope.subscriptions_read, Scope.subscriptions_write}
+            auth_subject.scopes & {Scope.subscriptions_read, Scope.subscriptions_write}
         )
 
     async def search(

--- a/server/polar/subscription/auth.py
+++ b/server/polar/subscription/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _SubscriptionsRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.subscriptions_read,
         Scope.subscriptions_write,
     },
@@ -22,7 +20,6 @@ SubscriptionsRead = Annotated[
 
 _SubscriptionsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.subscriptions_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/transaction/auth.py
+++ b/server/polar/transaction/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _TransactionsRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.transactions_read,
     },
     allowed_subjects={User},
@@ -18,7 +16,6 @@ TransactionsRead = Annotated[AuthSubject[User], Depends(_TransactionsRead)]
 
 _TransactionsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.transactions_write,
     },
     allowed_subjects={User},

--- a/server/polar/user/auth.py
+++ b/server/polar/user/auth.py
@@ -8,7 +8,6 @@ from polar.auth.scope import Scope
 
 _UserWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.user_write,
     },
     allowed_subjects={User},

--- a/server/polar/wallet/auth.py
+++ b/server/polar/wallet/auth.py
@@ -7,14 +7,13 @@ from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
 
 _WalletsRead = Authenticator(
-    required_scopes={Scope.web_read, Scope.web_write, Scope.wallets_read},
+    required_scopes={Scope.wallets_read},
     allowed_subjects={User, Organization},
 )
 WalletsRead = Annotated[AuthSubject[User | Organization], Depends(_WalletsRead)]
 
 _WalletsWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.wallets_write,
     },
     allowed_subjects={User, Organization},

--- a/server/polar/webhook/auth.py
+++ b/server/polar/webhook/auth.py
@@ -8,8 +8,6 @@ from polar.auth.scope import Scope
 
 _WebhooksRead = Authenticator(
     required_scopes={
-        Scope.web_read,
-        Scope.web_write,
         Scope.webhooks_read,
         Scope.webhooks_write,
     },
@@ -19,7 +17,6 @@ WebhooksRead = Annotated[AuthSubject[User | Organization], Depends(_WebhooksRead
 
 _WebhooksWrite = Authenticator(
     required_scopes={
-        Scope.web_write,
         Scope.webhooks_write,
     },
     allowed_subjects={User, Organization},

--- a/server/tests/auth/test_legacy_session_upgrade.py
+++ b/server/tests/auth/test_legacy_session_upgrade.py
@@ -1,0 +1,42 @@
+"""Test that legacy web sessions with {web_read, web_write} are upgraded to all scopes."""
+
+from polar.auth.scope import Scope
+
+
+def _simulate_upgrade(scopes: set[Scope]) -> set[Scope]:
+    """Replicate the upgrade logic from auth/middlewares.py."""
+    if scopes == {Scope.web_read, Scope.web_write}:
+        return set(Scope)
+    return scopes
+
+
+class TestLegacySessionUpgrade:
+    def test_legacy_session_upgraded(self) -> None:
+        """Sessions with exactly {web_read, web_write} get all scopes."""
+        scopes = {Scope.web_read, Scope.web_write}
+        result = _simulate_upgrade(scopes)
+        assert result == set(Scope)
+
+    def test_modern_session_unchanged(self) -> None:
+        """Sessions with all scopes are not modified."""
+        scopes = set(Scope)
+        result = _simulate_upgrade(scopes)
+        assert result == set(Scope)
+
+    def test_read_only_session_not_upgraded(self) -> None:
+        """Read-only impersonation sessions ({web_read} only) must NOT be upgraded."""
+        scopes = {Scope.web_read}
+        result = _simulate_upgrade(scopes)
+        assert result == {Scope.web_read}
+
+    def test_partial_scopes_not_upgraded(self) -> None:
+        """Sessions with web_write plus other scopes are not upgraded."""
+        scopes = {Scope.web_read, Scope.web_write, Scope.products_read}
+        result = _simulate_upgrade(scopes)
+        assert result == {Scope.web_read, Scope.web_write, Scope.products_read}
+
+    def test_empty_scopes_not_upgraded(self) -> None:
+        """Empty scope sets are not upgraded."""
+        scopes: set[Scope] = set()
+        result = _simulate_upgrade(scopes)
+        assert result == set()

--- a/server/tests/auth/test_legacy_session_upgrade.py
+++ b/server/tests/auth/test_legacy_session_upgrade.py
@@ -1,42 +1,101 @@
-"""Test that legacy web sessions with {web_read, web_write} are upgraded to all scopes."""
+"""Test that the auth middleware upgrades legacy web sessions."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from polar.auth.middlewares import get_auth_subject
 from polar.auth.scope import Scope
+from polar.models import User, UserSession
 
 
-def _simulate_upgrade(scopes: set[Scope]) -> set[Scope]:
-    """Replicate the upgrade logic from auth/middlewares.py."""
-    if scopes == {Scope.web_read, Scope.web_write}:
-        return set(Scope)
-    return scopes
+@pytest.fixture
+def mock_request() -> MagicMock:
+    """Request with no bearer token (cookie-based session)."""
+    request = MagicMock()
+    request.headers = {}
+    return request
 
 
+@pytest.fixture
+def mock_db_session() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def user() -> MagicMock:
+    return MagicMock(spec=User)
+
+
+def _make_user_session(user: MagicMock, scopes: set[Scope]) -> MagicMock:
+    session = MagicMock(spec=UserSession)
+    session.user = user
+    session.scopes = scopes
+    return session
+
+
+@pytest.mark.asyncio
 class TestLegacySessionUpgrade:
-    def test_legacy_session_upgraded(self) -> None:
+    @patch("polar.auth.middlewares.get_user_session")
+    async def test_legacy_session_upgraded_to_all_scopes(
+        self,
+        mock_get_user_session: AsyncMock,
+        mock_request: MagicMock,
+        mock_db_session: AsyncMock,
+        user: MagicMock,
+    ) -> None:
         """Sessions with exactly {web_read, web_write} get all scopes."""
-        scopes = {Scope.web_read, Scope.web_write}
-        result = _simulate_upgrade(scopes)
-        assert result == set(Scope)
+        mock_get_user_session.return_value = _make_user_session(
+            user, {Scope.web_read, Scope.web_write}
+        )
 
-    def test_modern_session_unchanged(self) -> None:
-        """Sessions with all scopes are not modified."""
-        scopes = set(Scope)
-        result = _simulate_upgrade(scopes)
-        assert result == set(Scope)
+        auth_subject = await get_auth_subject(mock_request, mock_db_session)
 
-    def test_read_only_session_not_upgraded(self) -> None:
-        """Read-only impersonation sessions ({web_read} only) must NOT be upgraded."""
-        scopes = {Scope.web_read}
-        result = _simulate_upgrade(scopes)
-        assert result == {Scope.web_read}
+        assert auth_subject.subject is user
+        assert auth_subject.scopes == set(Scope)
 
-    def test_partial_scopes_not_upgraded(self) -> None:
-        """Sessions with web_write plus other scopes are not upgraded."""
+    @patch("polar.auth.middlewares.get_user_session")
+    async def test_modern_session_not_modified(
+        self,
+        mock_get_user_session: AsyncMock,
+        mock_request: MagicMock,
+        mock_db_session: AsyncMock,
+        user: MagicMock,
+    ) -> None:
+        """Sessions with all scopes pass through unchanged."""
+        mock_get_user_session.return_value = _make_user_session(user, set(Scope))
+
+        auth_subject = await get_auth_subject(mock_request, mock_db_session)
+
+        assert auth_subject.scopes == set(Scope)
+
+    @patch("polar.auth.middlewares.get_user_session")
+    async def test_read_only_impersonation_not_upgraded(
+        self,
+        mock_get_user_session: AsyncMock,
+        mock_request: MagicMock,
+        mock_db_session: AsyncMock,
+        user: MagicMock,
+    ) -> None:
+        """Read-only impersonation sessions must NOT be upgraded."""
+        mock_get_user_session.return_value = _make_user_session(user, {Scope.web_read})
+
+        auth_subject = await get_auth_subject(mock_request, mock_db_session)
+
+        assert auth_subject.scopes == {Scope.web_read}
+
+    @patch("polar.auth.middlewares.get_user_session")
+    async def test_partial_scopes_not_upgraded(
+        self,
+        mock_get_user_session: AsyncMock,
+        mock_request: MagicMock,
+        mock_db_session: AsyncMock,
+        user: MagicMock,
+    ) -> None:
+        """Sessions with web scopes plus other scopes are not upgraded."""
         scopes = {Scope.web_read, Scope.web_write, Scope.products_read}
-        result = _simulate_upgrade(scopes)
-        assert result == {Scope.web_read, Scope.web_write, Scope.products_read}
+        mock_get_user_session.return_value = _make_user_session(user, scopes)
 
-    def test_empty_scopes_not_upgraded(self) -> None:
-        """Empty scope sets are not upgraded."""
-        scopes: set[Scope] = set()
-        result = _simulate_upgrade(scopes)
-        assert result == set()
+        auth_subject = await get_auth_subject(mock_request, mock_db_session)
+
+        assert auth_subject.scopes == scopes

--- a/server/tests/benefit/test_endpoints.py
+++ b/server/tests/benefit/test_endpoints.py
@@ -47,7 +47,7 @@ class TestListBenefits:
         assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.benefits_read}),
     )
     async def test_user_valid(
@@ -64,7 +64,7 @@ class TestListBenefits:
         assert json["pagination"]["total_count"] == 3
 
     @pytest.mark.auth(
-        AuthSubjectFixture(subject="organization", scopes={Scope.web_read}),
+        AuthSubjectFixture(subject="organization", scopes=set(Scope)),
         AuthSubjectFixture(subject="organization", scopes={Scope.benefits_read}),
     )
     async def test_organization(

--- a/server/tests/benefit/test_endpoints.py
+++ b/server/tests/benefit/test_endpoints.py
@@ -47,7 +47,6 @@ class TestListBenefits:
         assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.benefits_read}),
     )
     async def test_user_valid(
@@ -64,7 +63,6 @@ class TestListBenefits:
         assert json["pagination"]["total_count"] == 3
 
     @pytest.mark.auth(
-        AuthSubjectFixture(subject="organization", scopes=set(Scope)),
         AuthSubjectFixture(subject="organization", scopes={Scope.benefits_read}),
     )
     async def test_organization(

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -244,20 +244,6 @@ class TestCreateCheckout:
 
         assert response.status_code == 401
 
-    @pytest.mark.auth
-    async def test_missing_scope(
-        self, api_prefix: str, client: AsyncClient, product: Product
-    ) -> None:
-        response = await client.post(
-            f"{api_prefix}/",
-            json={
-                "payment_processor": "stripe",
-                "product_price_id": str(product.prices[0].id),
-            },
-        )
-
-        assert response.status_code == 403
-
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
     @pytest.mark.keep_session_state
     async def test_blocked_organization(
@@ -553,19 +539,6 @@ class TestUpdateCheckout:
         )
 
         assert response.status_code == 401
-
-    @pytest.mark.auth
-    async def test_missing_scope(
-        self, api_prefix: str, client: AsyncClient, checkout_open: Checkout
-    ) -> None:
-        response = await client.patch(
-            f"{api_prefix}/{checkout_open.id}",
-            json={
-                "metadata": {"test": "test"},
-            },
-        )
-
-        assert response.status_code == 403
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user_second", scopes={Scope.checkouts_write}),

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -28,7 +28,10 @@ from tests.fixtures.random_objects import (
 
 # Auth fixture with the required scopes for seat endpoints
 SEAT_AUTH = AuthSubjectFixture(
-    scopes=set(Scope),
+    scopes={
+        Scope.customer_seats_read,
+        Scope.customer_seats_write,
+    }
 )
 
 

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -28,12 +28,7 @@ from tests.fixtures.random_objects import (
 
 # Auth fixture with the required scopes for seat endpoints
 SEAT_AUTH = AuthSubjectFixture(
-    scopes={
-        Scope.web_read,
-        Scope.web_write,
-        Scope.subscriptions_read,
-        Scope.subscriptions_write,
-    }
+    scopes=set(Scope),
 )
 
 

--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -46,8 +46,6 @@ E2E_AUTH = pytest.mark.auth(
     AuthSubjectFixture(
         subject="user",
         scopes={
-            Scope.web_read,
-            Scope.web_write,
             Scope.checkouts_read,
             Scope.checkouts_write,
             Scope.orders_read,

--- a/server/tests/e2e/lifecycle/test_trial_metered_cancel.py
+++ b/server/tests/e2e/lifecycle/test_trial_metered_cancel.py
@@ -65,8 +65,6 @@ _TRIAL_METERED_AUTH = pytest.mark.auth(
     AuthSubjectFixture(
         subject="user",
         scopes={
-            Scope.web_read,
-            Scope.web_write,
             Scope.checkouts_read,
             Scope.checkouts_write,
             Scope.orders_read,

--- a/server/tests/e2e/post_purchase/conftest.py
+++ b/server/tests/e2e/post_purchase/conftest.py
@@ -10,8 +10,6 @@ E2E_SEAT_AUTH = pytest.mark.auth(
     AuthSubjectFixture(
         subject="user",
         scopes={
-            Scope.web_read,
-            Scope.web_write,
             Scope.checkouts_read,
             Scope.checkouts_write,
             Scope.orders_read,

--- a/server/tests/fixtures/auth.py
+++ b/server/tests/fixtures/auth.py
@@ -22,7 +22,7 @@ class AuthSubjectFixture:
             "member_billing_manager",
             "member",
         ] = "user",
-        scopes: set[Scope] = {Scope.web_read, Scope.web_write},
+        scopes: set[Scope] = set(Scope),
     ):
         self.subject = subject
         self.scopes = scopes

--- a/server/tests/fixtures/auth.py
+++ b/server/tests/fixtures/auth.py
@@ -98,7 +98,19 @@ def auth_subject(
         )
         subjects_map["member_billing_manager"] = member_billing_manager
 
-    return AuthSubject(subjects_map[subject_key], auth_subject_fixture.scopes, None)
+    subject = subjects_map[subject_key]
+
+    # For User subjects, provide a mock UserSession so is_web_session() returns True.
+    # This matches real web session behavior where all User sessions are UserSessions.
+    session: Any = None
+    if isinstance(subject, User):
+        from unittest.mock import MagicMock
+
+        from polar.models import UserSession
+
+        session = MagicMock(spec=UserSession)
+
+    return AuthSubject(subject, auth_subject_fixture.scopes, session)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:

--- a/server/tests/metrics/test_dashboard_endpoints.py
+++ b/server/tests/metrics/test_dashboard_endpoints.py
@@ -33,7 +33,7 @@ class TestListDashboards:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_user_empty(
@@ -46,7 +46,7 @@ class TestListDashboards:
         assert response.json() == []
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_user_returns_own_dashboards(
@@ -69,7 +69,7 @@ class TestListDashboards:
         assert json[0]["name"] == "My Dashboard"
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_filter_by_organization_id(
@@ -107,7 +107,7 @@ class TestListDashboards:
         assert json[0]["id"] == str(dashboard.id)
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
     )
     async def test_does_not_return_other_org_dashboards(
         self,
@@ -135,7 +135,7 @@ class TestCreateDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_write}),
     )
     async def test_valid(
@@ -161,7 +161,7 @@ class TestCreateDashboard:
         assert "id" in json
         assert "created_at" in json
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_empty_metrics(
         self,
         client: AsyncClient,
@@ -179,7 +179,7 @@ class TestCreateDashboard:
         assert response.status_code == 201
         assert response.json()["metrics"] == []
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_empty_name_rejected(
         self,
         client: AsyncClient,
@@ -196,7 +196,7 @@ class TestCreateDashboard:
         )
         assert response.status_code == 422
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_too_many_metrics_rejected(
         self,
         client: AsyncClient,
@@ -242,7 +242,7 @@ class TestGetDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_valid(
@@ -264,12 +264,12 @@ class TestGetDashboard:
         assert json["name"] == "My Dashboard"
         assert json["organization_id"] == str(organization.id)
 
-    @pytest.mark.auth(scopes={Scope.web_read})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_not_found(self, client: AsyncClient) -> None:
         response = await client.get(f"/v1/metrics/dashboards/{uuid.uuid4()}")
         assert response.status_code == 404
 
-    @pytest.mark.auth(scopes={Scope.web_read})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_cannot_access_other_org_dashboard(
         self,
         client: AsyncClient,
@@ -298,7 +298,7 @@ class TestUpdateDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_write}),
     )
     async def test_update_name(
@@ -316,7 +316,7 @@ class TestUpdateDashboard:
         assert response.status_code == 200
         assert response.json()["name"] == "Renamed"
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_update_metrics(
         self,
         client: AsyncClient,
@@ -335,7 +335,7 @@ class TestUpdateDashboard:
         assert response.status_code == 200
         assert response.json()["metrics"] == ["orders", "checkouts"]
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_partial_update_preserves_other_fields(
         self,
         client: AsyncClient,
@@ -358,14 +358,14 @@ class TestUpdateDashboard:
         assert json["name"] == "Updated"
         assert json["metrics"] == ["revenue"]
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_not_found(self, client: AsyncClient) -> None:
         response = await client.patch(
             f"/v1/metrics/dashboards/{uuid.uuid4()}", json={"name": "X"}
         )
         assert response.status_code == 404
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_cannot_update_other_org_dashboard(
         self,
         client: AsyncClient,
@@ -394,7 +394,7 @@ class TestDeleteDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_write}),
     )
     async def test_valid(
@@ -409,12 +409,12 @@ class TestDeleteDashboard:
         response = await client.delete(f"/v1/metrics/dashboards/{dashboard.id}")
         assert response.status_code == 204
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_not_found(self, client: AsyncClient) -> None:
         response = await client.delete(f"/v1/metrics/dashboards/{uuid.uuid4()}")
         assert response.status_code == 404
 
-    @pytest.mark.auth(scopes={Scope.web_write})
+    @pytest.mark.auth(scopes=set(Scope))
     async def test_cannot_delete_other_org_dashboard(
         self,
         client: AsyncClient,

--- a/server/tests/metrics/test_dashboard_endpoints.py
+++ b/server/tests/metrics/test_dashboard_endpoints.py
@@ -33,7 +33,6 @@ class TestListDashboards:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_user_empty(
@@ -46,7 +45,6 @@ class TestListDashboards:
         assert response.json() == []
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_user_returns_own_dashboards(
@@ -69,7 +67,6 @@ class TestListDashboards:
         assert json[0]["name"] == "My Dashboard"
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_filter_by_organization_id(
@@ -106,9 +103,7 @@ class TestListDashboards:
         assert len(json) == 1
         assert json[0]["id"] == str(dashboard.id)
 
-    @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
-    )
+    @pytest.mark.auth
     async def test_does_not_return_other_org_dashboards(
         self,
         client: AsyncClient,
@@ -135,7 +130,6 @@ class TestCreateDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_write}),
     )
     async def test_valid(
@@ -161,7 +155,7 @@ class TestCreateDashboard:
         assert "id" in json
         assert "created_at" in json
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_empty_metrics(
         self,
         client: AsyncClient,
@@ -179,7 +173,7 @@ class TestCreateDashboard:
         assert response.status_code == 201
         assert response.json()["metrics"] == []
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_empty_name_rejected(
         self,
         client: AsyncClient,
@@ -196,7 +190,7 @@ class TestCreateDashboard:
         )
         assert response.status_code == 422
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_too_many_metrics_rejected(
         self,
         client: AsyncClient,
@@ -242,7 +236,6 @@ class TestGetDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_valid(
@@ -264,12 +257,12 @@ class TestGetDashboard:
         assert json["name"] == "My Dashboard"
         assert json["organization_id"] == str(organization.id)
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_not_found(self, client: AsyncClient) -> None:
         response = await client.get(f"/v1/metrics/dashboards/{uuid.uuid4()}")
         assert response.status_code == 404
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_cannot_access_other_org_dashboard(
         self,
         client: AsyncClient,
@@ -298,7 +291,6 @@ class TestUpdateDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_write}),
     )
     async def test_update_name(
@@ -316,7 +308,7 @@ class TestUpdateDashboard:
         assert response.status_code == 200
         assert response.json()["name"] == "Renamed"
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_update_metrics(
         self,
         client: AsyncClient,
@@ -335,7 +327,7 @@ class TestUpdateDashboard:
         assert response.status_code == 200
         assert response.json()["metrics"] == ["orders", "checkouts"]
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_partial_update_preserves_other_fields(
         self,
         client: AsyncClient,
@@ -358,14 +350,14 @@ class TestUpdateDashboard:
         assert json["name"] == "Updated"
         assert json["metrics"] == ["revenue"]
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_not_found(self, client: AsyncClient) -> None:
         response = await client.patch(
             f"/v1/metrics/dashboards/{uuid.uuid4()}", json={"name": "X"}
         )
         assert response.status_code == 404
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_cannot_update_other_org_dashboard(
         self,
         client: AsyncClient,
@@ -394,7 +386,6 @@ class TestDeleteDashboard:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_write}),
     )
     async def test_valid(
@@ -409,12 +400,12 @@ class TestDeleteDashboard:
         response = await client.delete(f"/v1/metrics/dashboards/{dashboard.id}")
         assert response.status_code == 204
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_not_found(self, client: AsyncClient) -> None:
         response = await client.delete(f"/v1/metrics/dashboards/{uuid.uuid4()}")
         assert response.status_code == 404
 
-    @pytest.mark.auth(scopes=set(Scope))
+    @pytest.mark.auth
     async def test_cannot_delete_other_org_dashboard(
         self,
         client: AsyncClient,

--- a/server/tests/metrics/test_endpoints.py
+++ b/server/tests/metrics/test_endpoints.py
@@ -19,7 +19,7 @@ class TestGetMetrics:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_over_limits(
@@ -37,7 +37,7 @@ class TestGetMetrics:
         assert response.status_code == 422
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_user_valid(
@@ -314,7 +314,7 @@ class TestGetMetricsLimits:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
         AuthSubjectFixture(subject="organization", scopes={Scope.metrics_read}),
     )

--- a/server/tests/metrics/test_endpoints.py
+++ b/server/tests/metrics/test_endpoints.py
@@ -19,7 +19,6 @@ class TestGetMetrics:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_over_limits(
@@ -37,7 +36,6 @@ class TestGetMetrics:
         assert response.status_code == 422
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
     )
     async def test_user_valid(
@@ -314,7 +312,6 @@ class TestGetMetricsLimits:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.metrics_read}),
         AuthSubjectFixture(subject="organization", scopes={Scope.metrics_read}),
     )

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -1221,7 +1221,7 @@ class TestOAuth2Token:
             token=token_hash,
             user_agent="tests",
             user=user,
-            scopes={Scope.web_write},
+            scopes=set(Scope),
             expires_at=utc_now() + timedelta(seconds=60),
         )
         await save_fixture(user_session)
@@ -1252,7 +1252,7 @@ class TestOAuth2Token:
             token=token_hash,
             user_agent="tests",
             user=user,
-            scopes={Scope.web_write},
+            scopes=set(Scope),
             expires_at=utc_now() + timedelta(seconds=60),
         )
         await save_fixture(user_session)
@@ -1284,7 +1284,7 @@ class TestOAuth2Token:
             token=token_hash,
             user_agent="tests",
             user=user,
-            scopes={Scope.web_write},
+            scopes=set(Scope),
             expires_at=utc_now() + timedelta(seconds=60),
         )
         await save_fixture(user_session)
@@ -1322,7 +1322,7 @@ class TestOAuth2Token:
             token=token_hash,
             user_agent="tests",
             user=user,
-            scopes={Scope.web_write},
+            scopes=set(Scope),
             expires_at=utc_now() + timedelta(seconds=60),
         )
         await save_fixture(user_session)

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -50,7 +50,7 @@ class TestListOrders:
         assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(
@@ -125,7 +125,7 @@ class TestGetOrder:
         assert response.status_code == 404
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(
@@ -205,7 +205,7 @@ class TestExportOrders:
         )
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(
@@ -298,7 +298,7 @@ class TesGetOrdersStatistics:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -50,7 +50,6 @@ class TestListOrders:
         assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(
@@ -125,7 +124,6 @@ class TestGetOrder:
         assert response.status_code == 404
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(
@@ -205,7 +203,6 @@ class TestExportOrders:
         )
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(
@@ -298,7 +295,6 @@ class TesGetOrdersStatistics:
         assert response.status_code == 401
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.orders_read}),
     )
     async def test_user_valid(

--- a/server/tests/organization_access_token/test_endpoints.py
+++ b/server/tests/organization_access_token/test_endpoints.py
@@ -61,7 +61,6 @@ class TestCreateOrganizationAccessToken:
         AuthSubjectFixture(
             subject="organization",
             scopes={
-                Scope.web_write,
                 Scope.organization_access_tokens_write,
             },
         )
@@ -88,7 +87,6 @@ class TestCreateOrganizationAccessToken:
         AuthSubjectFixture(
             subject="organization",
             scopes={
-                Scope.web_write,
                 Scope.organization_access_tokens_write,
                 Scope.metrics_read,
             },
@@ -115,7 +113,6 @@ class TestUpdateOrganizationAccessToken:
         AuthSubjectFixture(
             subject="organization",
             scopes={
-                Scope.web_write,
                 Scope.organization_access_tokens_write,
             },
         )
@@ -141,7 +138,6 @@ class TestUpdateOrganizationAccessToken:
         AuthSubjectFixture(
             subject="organization",
             scopes={
-                Scope.web_write,
                 Scope.organization_access_tokens_write,
                 Scope.metrics_read,
             },

--- a/server/tests/refund/test_endpoints.py
+++ b/server/tests/refund/test_endpoints.py
@@ -346,7 +346,6 @@ class TestCreateRefunds(StripeRefund):
         assert updated.refunded_tax_amount == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.refunds_write}),
     )
     async def test_valid_partial_to_full(
@@ -451,7 +450,6 @@ class TestCreateRefunds(StripeRefund):
         assert order.refunded
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.refunds_write}),
     )
     async def test_valid_full_refund(

--- a/server/tests/refund/test_endpoints.py
+++ b/server/tests/refund/test_endpoints.py
@@ -346,7 +346,7 @@ class TestCreateRefunds(StripeRefund):
         assert updated.refunded_tax_amount == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.refunds_write}),
     )
     async def test_valid_partial_to_full(
@@ -451,7 +451,7 @@ class TestCreateRefunds(StripeRefund):
         assert order.refunded
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.refunds_write}),
     )
     async def test_valid_full_refund(

--- a/server/tests/wallet/test_endpoints.py
+++ b/server/tests/wallet/test_endpoints.py
@@ -46,7 +46,7 @@ class TestListWallets:
         assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.wallets_read}),
     )
     async def test_user_valid(
@@ -85,7 +85,7 @@ class TestGetWallet:
         assert response.status_code == 404
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_read}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.wallets_read}),
     )
     async def test_user_valid(

--- a/server/tests/wallet/test_endpoints.py
+++ b/server/tests/wallet/test_endpoints.py
@@ -46,7 +46,6 @@ class TestListWallets:
         assert json["pagination"]["total_count"] == 0
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.wallets_read}),
     )
     async def test_user_valid(
@@ -85,7 +84,6 @@ class TestGetWallet:
         assert response.status_code == 404
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.wallets_read}),
     )
     async def test_user_valid(

--- a/server/tests/webhooks/test_endpoints.py
+++ b/server/tests/webhooks/test_endpoints.py
@@ -64,7 +64,6 @@ class TestCreateWebhookEndpoint:
         assert response.status_code == 403
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.webhooks_write}),
     )
     async def test_user_valid(
@@ -139,7 +138,6 @@ class TestUpdateWebhookEndpoint:
         assert response.status_code == 403
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.webhooks_write}),
     )
     async def test_user_valid(
@@ -193,7 +191,6 @@ class TestDeleteWebhookEndpoint:
         assert response.status_code == 403
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.webhooks_write}),
     )
     async def test_user_valid(

--- a/server/tests/webhooks/test_endpoints.py
+++ b/server/tests/webhooks/test_endpoints.py
@@ -64,7 +64,7 @@ class TestCreateWebhookEndpoint:
         assert response.status_code == 403
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.webhooks_write}),
     )
     async def test_user_valid(
@@ -139,7 +139,7 @@ class TestUpdateWebhookEndpoint:
         assert response.status_code == 403
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.webhooks_write}),
     )
     async def test_user_valid(
@@ -193,7 +193,7 @@ class TestDeleteWebhookEndpoint:
         assert response.status_code == 403
 
     @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.web_write}),
+        AuthSubjectFixture(scopes=set(Scope)),
         AuthSubjectFixture(scopes={Scope.webhooks_write}),
     )
     async def test_user_valid(


### PR DESCRIPTION
## Summary

**Related Issue**: #11126

Remove `web_read`/`web_write` from all authorization scope checks and enforce web-session-only access on `WebUser*` dependencies.

> Depends on #11147

## What

- `web_read`/`web_write` removed from all 33 `auth.py` `required_scopes` sets and from `SCOPES_SUPPORTED`, display names
- `RESERVED_SCOPES` removed — `web_read`/`web_write` filtered via `_LEGACY_SCOPES` instead
- `WebUserRead`/`WebUserWrite`/`WebUserOrAnonymous` enforce web-session-only access via `is_web_session()` — API tokens get 403
- `is_web_session()` added — checks `isinstance(session, UserSession)`
- `READ_ONLY_SCOPES` added for impersonation sessions (replaces runtime `:read` suffix filtering)
- Web sessions created with all scopes instead of `{web_read, web_write}`
- `EventTypeWrite` scope changed from `web_write` to `events_write`
- `web_write` removed from `OrgPolicyGuard` defaults and `AuthorizeMembersManage`/`AuthorizeOrgDelete`/`AuthorizeOrgManagePayoutAccount`
- Finance guards use finance-specific scopes instead of defaults
- Legacy session upgrade: exact `{web_read, web_write}` → all scopes in middleware (safe to remove after 2026-05-22)

## Why

`web_read`/`web_write` were never authorization scopes — they were a proxy for "is this a web session?" This conflated authentication method with authorization, and required every `auth.py` to include them as fallbacks for web sessions to pass scope checks.

## How

- `WebUserRead`/`WebUserWrite` now wrap the authenticator with an `is_web_session()` check that raises `NotPermitted` for API tokens
- `web_read`/`web_write` kept in `Scope` enum only for legacy session deserialization (safe to remove after 2026-05-22)
- Legacy sessions with exactly `{web_read, web_write}` transparently upgraded in middleware

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included