### PR TITLE
events: Decouple parent and child ingestion

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ColumnExpressionArgument,
     Numeric,
     Select,
+    String,
     UnaryExpression,
     and_,
     asc,
@@ -23,6 +24,7 @@ from sqlalchemy import (
     or_,
     select,
     text,
+    update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
 from sqlalchemy.orm import aliased, joinedload
@@ -69,35 +71,11 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         if not events:
             return [], 0
 
-        events_needing_parent_lookup = []
-
-        # Set root_id for root events before insertion
         for event in events:
-            if event.get("root_id") is not None:
-                continue
-            elif event.get("parent_id") is None:
-                if event.get("id") is None:
-                    event["id"] = generate_uuid()
+            if event.get("id") is None:
+                event["id"] = generate_uuid()
+            if event.get("pending_parent_external_id") is None:
                 event["root_id"] = event["id"]
-            else:
-                # Child event without root_id - needs to be looked up from parent
-                # This is a fail-safe in the event that we did not set this before calling
-                # insert_batch
-                events_needing_parent_lookup.append(event)
-
-        # Look up root_id from parents for events that need it
-        if events_needing_parent_lookup:
-            parent_ids = {event["parent_id"] for event in events_needing_parent_lookup}
-            result = await self.session.execute(
-                select(Event.id, Event.root_id).where(Event.id.in_(parent_ids))
-            )
-            parent_root_map = {
-                parent_id: root_id or parent_id for parent_id, root_id in result
-            }
-
-            for event in events_needing_parent_lookup:
-                parent_id = event["parent_id"]
-                event["root_id"] = parent_root_map.get(parent_id, parent_id)
 
         statement = (
             insert(Event)
@@ -110,6 +88,141 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         duplicates_count = len(events) - len(inserted_ids)
 
         return inserted_ids, duplicates_count
+
+    async def find_resolvable_parents(
+        self, inserted_ids: Sequence[UUID]
+    ) -> Sequence[tuple[UUID, UUID, UUID]]:
+        """
+        Find pending events that can now be resolved, scoped to a batch
+        of just-inserted events.
+
+        Uses a recursive CTE that walks DOWN from resolved parents through the
+        pending chain. Handles both directions:
+        - Newly inserted orphans whose parent already exists in the DB
+        - Existing orphans whose parent was just inserted in this batch
+
+        Events whose chain doesn't reach a resolved root are excluded.
+
+        Returns a list of (event_id, parent_id, root_id) tuples.
+        """
+        if not inserted_ids:
+            return []
+
+        events = Event.__table__
+        p = events.alias("p")
+        c = events.alias("c")
+
+        def _parent_match(
+            parent_external_id: ColumnElement[str | None],
+            parent_id: ColumnElement[UUID],
+            child_pending: ColumnElement[str | None],
+        ) -> ColumnElement[bool]:
+            return or_(
+                parent_external_id == child_pending,
+                cast(parent_id, String) == child_pending,
+            )
+
+        # Seed: resolved events that are parents of pending events,
+        # scoped to this batch on either side
+        seeds = (
+            select(
+                p.c.id,
+                p.c.external_id,
+                func.coalesce(p.c.root_id, p.c.id).label("root_id"),
+                p.c.organization_id,
+            )
+            .join(
+                c,
+                and_(
+                    c.c.organization_id == p.c.organization_id,
+                    _parent_match(
+                        p.c.external_id, p.c.id, c.c.pending_parent_external_id
+                    ),
+                ),
+            )
+            .where(
+                p.c.pending_parent_external_id.is_(None),
+                c.c.pending_parent_external_id.is_not(None),
+                or_(p.c.id.in_(inserted_ids), c.c.id.in_(inserted_ids)),
+            )
+            .distinct()
+            .cte("seeds")
+        )
+
+        # Walk down from seeds through pending children
+        child = events.alias("child")
+        base = (
+            select(
+                child.c.id,
+                seeds.c.id.label("parent_id"),
+                seeds.c.root_id,
+                child.c.external_id,
+                child.c.organization_id,
+            )
+            .join(
+                seeds,
+                and_(
+                    child.c.organization_id == seeds.c.organization_id,
+                    _parent_match(
+                        seeds.c.external_id,
+                        seeds.c.id,
+                        child.c.pending_parent_external_id,
+                    ),
+                ),
+            )
+            .where(child.c.pending_parent_external_id.is_not(None))
+        )
+
+        chain = base.cte("chain", recursive=True)
+
+        next_child = events.alias("next_child")
+        recursive = (
+            select(
+                next_child.c.id,
+                chain.c.id.label("parent_id"),
+                chain.c.root_id,
+                next_child.c.external_id,
+                next_child.c.organization_id,
+            )
+            .join(
+                chain,
+                and_(
+                    next_child.c.organization_id == chain.c.organization_id,
+                    _parent_match(
+                        chain.c.external_id,
+                        chain.c.id,
+                        next_child.c.pending_parent_external_id,
+                    ),
+                ),
+            )
+            .where(next_child.c.pending_parent_external_id.is_not(None))
+        )
+        chain = chain.union_all(recursive)
+
+        statement = select(chain.c.id, chain.c.parent_id, chain.c.root_id)
+        result = await self.session.execute(statement)
+        return [(row[0], row[1], row[2]) for row in result.all()]
+
+    async def resolve_parents(
+        self, resolvable: Sequence[tuple[UUID, UUID, UUID]]
+    ) -> None:
+        """
+        Apply parent resolutions. Takes a list of (event_id, parent_id, root_id)
+        tuples as returned by find_resolvable_parents.
+        """
+        if not resolvable:
+            return
+
+        for event_id, parent_id, root_id in resolvable:
+            await self.session.execute(
+                update(Event)
+                .where(Event.id == event_id)
+                .values(
+                    parent_id=parent_id,
+                    root_id=root_id,
+                    pending_parent_external_id=None,
+                )
+            )
 
     async def get_latest_meter_reset(
         self, customer: Customer, meter_id: UUID

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -104,6 +104,56 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         Events whose chain doesn't reach a resolved root are excluded.
 
         Returns a list of (event_id, parent_id, root_id) tuples.
+
+        Equivalent SQL:
+
+            WITH RECURSIVE chain(
+                id, parent_id, root_id, external_id, organization_id
+            ) AS (
+                -- Base case: pending children whose parent is already resolved,
+                -- scoped to the just-inserted batch on either side of the edge.
+                SELECT
+                    pending.id,
+                    resolved.id AS parent_id,
+                    COALESCE(resolved.root_id, resolved.id) AS root_id,
+                    pending.external_id,
+                    pending.organization_id
+                FROM events AS pending
+                JOIN events AS resolved
+                  ON resolved.organization_id = pending.organization_id
+                 AND resolved.pending_parent_external_id IS NULL
+                 AND (
+                        resolved.external_id = pending.pending_parent_external_id
+                     OR CAST(resolved.id AS VARCHAR)
+                          = pending.pending_parent_external_id
+                     )
+                WHERE pending.pending_parent_external_id IS NOT NULL
+                  AND (
+                        resolved.id IN (:inserted_ids)
+                     OR pending.id IN (:inserted_ids)
+                     )
+
+                UNION ALL
+
+                -- Recursive step: descendants whose parent is already in chain.
+                SELECT
+                    descendant.id,
+                    chain.id AS parent_id,
+                    chain.root_id,
+                    descendant.external_id,
+                    descendant.organization_id
+                FROM events AS descendant
+                JOIN chain
+                  ON descendant.organization_id = chain.organization_id
+                 AND (
+                        chain.external_id
+                          = descendant.pending_parent_external_id
+                     OR CAST(chain.id AS VARCHAR)
+                          = descendant.pending_parent_external_id
+                     )
+                WHERE descendant.pending_parent_external_id IS NOT NULL
+            )
+            SELECT id, parent_id, root_id FROM chain;
         """
         if not inserted_ids:
             return []

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -109,8 +109,9 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             return []
 
         events = Event.__table__
-        p = events.alias("p")
-        c = events.alias("c")
+        resolved = events.alias("resolved")
+        pending = events.alias("pending")
+        descendant = events.alias("descendant")
 
         def _parent_match(
             parent_external_id: ColumnElement[str | None],
@@ -122,80 +123,62 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 cast(parent_id, String) == child_pending,
             )
 
-        # Seed: resolved events that are parents of pending events,
-        # scoped to this batch on either side
-        seeds = (
+        # Base: first-level resolvable events — pending children whose parent is
+        # already resolved. Scoped on either side of the edge so we catch both
+        # "batch inserted the parent (unblocking a pre-existing orphan)" and
+        # "batch inserted the pending child (whose parent already existed)".
+        base = (
             select(
-                p.c.id,
-                p.c.external_id,
-                func.coalesce(p.c.root_id, p.c.id).label("root_id"),
-                p.c.organization_id,
+                pending.c.id,
+                resolved.c.id.label("parent_id"),
+                func.coalesce(resolved.c.root_id, resolved.c.id).label("root_id"),
+                pending.c.external_id,
+                pending.c.organization_id,
             )
             .join(
-                c,
+                resolved,
                 and_(
-                    c.c.organization_id == p.c.organization_id,
+                    resolved.c.organization_id == pending.c.organization_id,
+                    resolved.c.pending_parent_external_id.is_(None),
                     _parent_match(
-                        p.c.external_id, p.c.id, c.c.pending_parent_external_id
+                        resolved.c.external_id,
+                        resolved.c.id,
+                        pending.c.pending_parent_external_id,
                     ),
                 ),
             )
             .where(
-                p.c.pending_parent_external_id.is_(None),
-                c.c.pending_parent_external_id.is_not(None),
-                or_(p.c.id.in_(inserted_ids), c.c.id.in_(inserted_ids)),
-            )
-            .distinct()
-            .cte("seeds")
-        )
-
-        # Walk down from seeds through pending children
-        child = events.alias("child")
-        base = (
-            select(
-                child.c.id,
-                seeds.c.id.label("parent_id"),
-                seeds.c.root_id,
-                child.c.external_id,
-                child.c.organization_id,
-            )
-            .join(
-                seeds,
-                and_(
-                    child.c.organization_id == seeds.c.organization_id,
-                    _parent_match(
-                        seeds.c.external_id,
-                        seeds.c.id,
-                        child.c.pending_parent_external_id,
-                    ),
+                pending.c.pending_parent_external_id.is_not(None),
+                or_(
+                    resolved.c.id.in_(inserted_ids),
+                    pending.c.id.in_(inserted_ids),
                 ),
             )
-            .where(child.c.pending_parent_external_id.is_not(None))
         )
 
         chain = base.cte("chain", recursive=True)
 
-        next_child = events.alias("next_child")
+        # Walk further down: descendants whose parent is already in the chain.
         recursive = (
             select(
-                next_child.c.id,
+                descendant.c.id,
                 chain.c.id.label("parent_id"),
                 chain.c.root_id,
-                next_child.c.external_id,
-                next_child.c.organization_id,
+                descendant.c.external_id,
+                descendant.c.organization_id,
             )
             .join(
                 chain,
                 and_(
-                    next_child.c.organization_id == chain.c.organization_id,
+                    descendant.c.organization_id == chain.c.organization_id,
                     _parent_match(
                         chain.c.external_id,
                         chain.c.id,
-                        next_child.c.pending_parent_external_id,
+                        descendant.c.pending_parent_external_id,
                     ),
                 ),
             )
-            .where(next_child.c.pending_parent_external_id.is_not(None))
+            .where(descendant.c.pending_parent_external_id.is_not(None))
         )
         chain = chain.union_all(recursive)
 

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -1,5 +1,4 @@
 import uuid
-from collections import defaultdict, deque
 from collections.abc import Callable, Mapping, Sequence
 from datetime import date, datetime
 from decimal import Decimal
@@ -77,55 +76,6 @@ class EventIngestValidationError(EventError):
     def __init__(self, errors: list[ValidationError]) -> None:
         self.errors = errors
         super().__init__("Event ingest validation failed.")
-
-
-def _topological_sort_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """
-    Sort events by dependency order so parents come before children.
-    Events without parents come first, followed by their children in order.
-
-    Handles parent_id references that can be either Polar IDs or external_id strings.
-    Uses Kahn's algorithm for topological sorting.
-    """
-    if not events:
-        return []
-
-    id_to_index: dict[uuid.UUID | str, int] = {}
-    for idx, event in enumerate(events):
-        if "id" in event:
-            id_to_index[event["id"]] = idx
-        if "external_id" in event and event["external_id"] is not None:
-            id_to_index[event["external_id"]] = idx
-
-    graph: dict[int, list[int]] = defaultdict(list)
-    in_degree: dict[int, int] = {}
-
-    for idx in range(len(events)):
-        in_degree[idx] = 0
-
-    for idx, event in enumerate(events):
-        parent_id = event.get("parent_id")
-        if parent_id and parent_id in id_to_index:
-            parent_idx = id_to_index[parent_id]
-            graph[parent_idx].append(idx)
-            in_degree[idx] += 1
-
-    queue = deque(idx for idx in range(len(events)) if in_degree[idx] == 0)
-    sorted_indices: list[int] = []
-
-    while queue:
-        current_idx = queue.popleft()
-        sorted_indices.append(current_idx)
-
-        for child_idx in graph[current_idx]:
-            in_degree[child_idx] -= 1
-            if in_degree[child_idx] == 0:
-                queue.append(child_idx)
-
-    if len(sorted_indices) != len(events):
-        raise EventError("Circular dependency detected in event parent relationships")
-
-    return [events[idx] for idx in sorted_indices]
 
 
 class EventService:
@@ -923,126 +873,65 @@ class EventService:
         event_type_repository = EventTypeRepository.from_session(session)
         event_types_cache: dict[tuple[str, uuid.UUID], uuid.UUID] = {}
 
-        batch_external_id_map: dict[str, uuid.UUID] = {}
-        for event_create in ingest.events:
-            if event_create.external_id is not None:
-                batch_external_id_map[event_create.external_id] = uuid.uuid4()
-
-        # Build lightweight event metadata for sorting
-        event_metadata: list[dict[str, Any]] = []
-        for index, event_create in enumerate(ingest.events):
-            metadata: dict[str, Any] = {
-                "index": index,
-                "external_id": event_create.external_id,
-                "parent_id": event_create.parent_id,
-            }
-            if event_create.external_id:
-                metadata["id"] = batch_external_id_map[event_create.external_id]
-            event_metadata.append(metadata)
-
-        with logfire.span("topological_sort", event_count=len(event_metadata)):
-            sorted_metadata = _topological_sort_events(event_metadata)
-
-        # Process events in sorted order
         events: list[dict[str, Any]] = []
         errors: list[ValidationError] = []
-        processed_events: dict[uuid.UUID, dict[str, Any]] = {}
+        for index, event_create in enumerate(ingest.events):
+            try:
+                organization_id = validate_organization_id(
+                    index, event_create.organization_id
+                )
+                if isinstance(event_create, EventCreateCustomer):
+                    validate_customer_id(index, event_create.customer_id)
+                    if event_create.member_id is not None:
+                        validate_member_id(index, event_create.member_id)
 
-        with logfire.span("process_events", event_count=len(sorted_metadata)):
-            # Events needs to be sorted here primarily for the purpose of root id
-            # resolution. Hierarchical events with parent_id in the same batch should
-            # get the same root id assigned.
-            for metadata in sorted_metadata:
-                index = metadata["index"]
-                event_create = ingest.events[index]
-
-                try:
-                    organization_id = validate_organization_id(
-                        index, event_create.organization_id
+                event_label_cache_key = (event_create.name, organization_id)
+                if event_label_cache_key not in event_types_cache:
+                    event_type = await event_type_repository.get_or_create(
+                        event_create.name, organization_id
                     )
-                    if isinstance(event_create, EventCreateCustomer):
-                        validate_customer_id(index, event_create.customer_id)
-                        if event_create.member_id is not None:
-                            validate_member_id(index, event_create.member_id)
+                    event_types_cache[event_label_cache_key] = event_type.id
+                event_type_id = event_types_cache[event_label_cache_key]
+            except EventIngestValidationError as e:
+                errors.extend(e.errors)
+                continue
 
-                    parent_event: Event | None = None
-                    parent_id_in_batch: uuid.UUID | None = None
-                    if event_create.parent_id is not None:
-                        parent_event, parent_id_in_batch = await self._resolve_parent(
-                            session,
-                            index,
-                            event_create.parent_id,
-                            organization_id,
-                            batch_external_id_map,
-                        )
+            event_dict = event_create.model_dump(
+                exclude={"organization_id", "parent_id"}, by_alias=True
+            )
+            event_dict["source"] = EventSource.user
+            event_dict["organization_id"] = organization_id
+            event_dict["event_type_id"] = event_type_id
 
-                    event_label_cache_key = (event_create.name, organization_id)
-                    if event_label_cache_key not in event_types_cache:
-                        event_type = await event_type_repository.get_or_create(
-                            event_create.name, organization_id
-                        )
-                        event_types_cache[event_label_cache_key] = event_type.id
-                    event_type_id = event_types_cache[event_label_cache_key]
-                except EventIngestValidationError as e:
-                    errors.extend(e.errors)
-                    continue
-                else:
-                    event_dict = event_create.model_dump(
-                        exclude={"organization_id", "parent_id"}, by_alias=True
-                    )
-                    event_dict["source"] = EventSource.user
-                    event_dict["organization_id"] = organization_id
-                    event_dict["event_type_id"] = event_type_id
+            if event_create.parent_id is not None:
+                event_dict["pending_parent_external_id"] = event_create.parent_id
 
-                    if event_create.external_id is not None:
-                        event_dict["id"] = batch_external_id_map[
-                            event_create.external_id
-                        ]
-
-                    if parent_event is not None:
-                        event_dict["parent_id"] = parent_event.id
-                        event_dict["root_id"] = parent_event.root_id or parent_event.id
-                        if (
-                            not event_dict.get("customer_id")
-                            and parent_event.customer_id
-                        ):
-                            event_dict["customer_id"] = parent_event.customer_id
-                        if (
-                            not event_dict.get("external_customer_id")
-                            and parent_event.external_customer_id
-                        ):
-                            event_dict["external_customer_id"] = (
-                                parent_event.external_customer_id
-                            )
-                    elif parent_id_in_batch is not None:
-                        event_dict["parent_id"] = parent_id_in_batch
-                        # Parent was already processed, look it up
-                        parent_dict = processed_events.get(parent_id_in_batch)
-                        if parent_dict:
-                            event_dict["root_id"] = parent_dict.get(
-                                "root_id", parent_id_in_batch
-                            )
-                            if not event_dict.get("customer_id") and parent_dict.get(
-                                "customer_id"
-                            ):
-                                event_dict["customer_id"] = parent_dict["customer_id"]
-                            if not event_dict.get(
-                                "external_customer_id"
-                            ) and parent_dict.get("external_customer_id"):
-                                event_dict["external_customer_id"] = parent_dict[
-                                    "external_customer_id"
-                                ]
-
-                    events.append(event_dict)
-                    if event_dict.get("id"):
-                        processed_events[event_dict["id"]] = event_dict
+            events.append(event_dict)
 
         if len(errors) > 0:
             raise PolarRequestValidationError(errors)
 
         repository = EventRepository.from_session(session)
-        with logfire.span("insert_batch", event_count=len(events)):
-            event_ids, duplicates_count = await repository.insert_batch(events)
+        event_ids, duplicates_count = await repository.insert_batch(events)
+
+        has_hierarchy = any(
+            event_dict.get("pending_parent_external_id") for event_dict in events
+        )
+
+        if has_hierarchy:
+            resolvable = await repository.find_resolvable_parents(event_ids)
+            await repository.resolve_parents(resolvable)
+            resolved_ids = {r[0] for r in resolvable}
+            pending_ids = {
+                event_dict["id"]
+                for event_dict in events
+                if event_dict.get("pending_parent_external_id")
+            }
+            ready_ids = [eid for eid in event_ids if eid not in pending_ids] + [
+                eid for eid in resolved_ids
+            ]
+        else:
+            ready_ids = list(event_ids)
 
         # Temporarily: fetch inserted events and create meter_events
         with logfire.span("create_meter_events", event_count=len(event_ids)):
@@ -1052,8 +941,7 @@ class EventService:
                 )
                 await self._create_meter_events(session, inserted_events)
 
-        with logfire.span("enqueue_events", event_count=len(event_ids)):
-            enqueue_events(*event_ids)
+        enqueue_events(*ready_ids)
 
         return EventsIngestResponse(
             inserted=len(event_ids), duplicates=duplicates_count
@@ -1386,58 +1274,6 @@ class EventService:
             return member_id
 
         return _validate_member_id
-
-    async def _resolve_parent(
-        self,
-        session: AsyncSession,
-        index: int,
-        parent_id: str,
-        organization_id: uuid.UUID,
-        batch_external_id_map: dict[str, uuid.UUID],
-    ) -> tuple[Event | None, uuid.UUID | None]:
-        """
-        Resolve and return the parent event.
-        Returns a tuple of (parent_event_from_db, parent_id_from_batch).
-        Only one of these will be set - if the parent is in the current batch,
-        parent_id_from_batch will be set. Otherwise, parent_event_from_db will be set.
-        """
-        # Check if parent is in current batch
-        if parent_id in batch_external_id_map:
-            return None, batch_external_id_map[parent_id]
-
-        # Look up parent in database by ID or external_id
-        try:
-            parent_uuid = uuid.UUID(parent_id)
-        except ValueError:
-            parent_uuid = None
-
-        if parent_uuid:
-            statement = select(Event).where(
-                Event.organization_id == organization_id,
-                or_(Event.id == parent_uuid, Event.external_id == parent_id),
-            )
-        else:
-            statement = select(Event).where(
-                Event.organization_id == organization_id,
-                Event.external_id == parent_id,
-            )
-
-        result = await session.execute(statement)
-        parent_event = result.scalar_one_or_none()
-
-        if parent_event is not None:
-            return parent_event, None
-
-        raise EventIngestValidationError(
-            [
-                {
-                    "type": "parent_id",
-                    "msg": "Parent event not found.",
-                    "loc": ("body", "events", index, "parent_id"),
-                    "input": parent_id,
-                }
-            ]
-        )
 
     async def _get_readable_organization_ids(
         self,

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -914,24 +914,17 @@ class EventService:
         repository = EventRepository.from_session(session)
         event_ids, duplicates_count = await repository.insert_batch(events)
 
-        has_hierarchy = any(
-            event_dict.get("pending_parent_external_id") for event_dict in events
+        resolvable = await repository.find_resolvable_parents(event_ids)
+        await repository.resolve_parents(resolvable)
+        resolved_ids = {r[0] for r in resolvable}
+        pending_ids = {
+            event_dict["id"]
+            for event_dict in events
+            if event_dict.get("pending_parent_external_id")
+        }
+        ready_ids = [eid for eid in event_ids if eid not in pending_ids] + list(
+            resolved_ids
         )
-
-        if has_hierarchy:
-            resolvable = await repository.find_resolvable_parents(event_ids)
-            await repository.resolve_parents(resolvable)
-            resolved_ids = {r[0] for r in resolvable}
-            pending_ids = {
-                event_dict["id"]
-                for event_dict in events
-                if event_dict.get("pending_parent_external_id")
-            }
-            ready_ids = [eid for eid in event_ids if eid not in pending_ids] + [
-                eid for eid in resolved_ids
-            ]
-        else:
-            ready_ids = list(event_ids)
 
         # Temporarily: fetch inserted events and create meter_events
         with logfire.span("create_meter_events", event_count=len(event_ids)):

--- a/server/tests/event/test_resolve_pending_parents.py
+++ b/server/tests/event/test_resolve_pending_parents.py
@@ -1,0 +1,387 @@
+import uuid
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from polar.event.repository import EventRepository
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Account, Event, Organization
+from polar.models.event import EventSource
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_organization
+
+
+def _make_event(
+    organization: Organization,
+    external_id: str,
+    *,
+    pending_parent_external_id: str | None = None,
+) -> dict[str, Any]:
+    event_id = uuid.uuid4()
+    return {
+        "id": event_id,
+        "name": f"event.{external_id}",
+        "source": EventSource.user,
+        "organization_id": organization.id,
+        "external_id": external_id,
+        "pending_parent_external_id": pending_parent_external_id,
+        "root_id": event_id if pending_parent_external_id is None else None,
+    }
+
+
+async def _get_events(
+    session: AsyncSession, organization: Organization
+) -> dict[str | None, Event]:
+    result = await session.execute(
+        select(Event).where(Event.organization_id == organization.id)
+    )
+    return {e.external_id: e for e in result.scalars().all()}
+
+
+async def _resolve(
+    repository: EventRepository, event_ids: Sequence[UUID]
+) -> list[UUID]:
+    resolvable = await repository.find_resolvable_parents(event_ids)
+    await repository.resolve_parents(resolvable)
+    return [r[0] for r in resolvable]
+
+
+@pytest.mark.asyncio
+class TestResolvePendingParents:
+    async def test_no_pending_events(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [_make_event(organization, "a"), _make_event(organization, "b")]
+        event_ids, _ = await repository.insert_batch(events)
+
+        resolved = await _resolve(repository, event_ids)
+
+        assert resolved == []
+
+    async def test_parent_and_child_in_same_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Child references parent, both in the same batch."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+            _make_event(organization, "parent"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        child = by_ext["child"]
+        parent = by_ext["parent"]
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+        assert child.pending_parent_external_id is None
+
+    async def test_three_level_hierarchy_in_same_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """root → child → grandchild, all in one batch, inserted in reverse order."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "grandchild", pending_parent_external_id="child"),
+            _make_event(organization, "child", pending_parent_external_id="root"),
+            _make_event(organization, "root"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 2
+        by_ext = await _get_events(session, organization)
+        root = by_ext["root"]
+        child = by_ext["child"]
+        grandchild = by_ext["grandchild"]
+
+        assert child.parent_id == root.id
+        assert child.root_id == root.id
+
+        assert grandchild.parent_id == child.id
+        assert grandchild.root_id == root.id
+
+    async def test_parent_already_in_db(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Parent was inserted in a previous batch, child arrives later."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: insert parent
+        parent_events = [_make_event(organization, "parent")]
+        await repository.insert_batch(parent_events)
+        await session.flush()
+
+        # Batch 2: insert child referencing parent
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+        ]
+        event_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        child = by_ext["child"]
+        parent = by_ext["parent"]
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+
+    async def test_child_arrives_before_parent_cross_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Child arrives first, stays pending. Parent arrives later, resolves it."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: child arrives, parent doesn't exist yet
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+        ]
+        child_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, child_ids)
+        assert resolved == []
+        await session.flush()
+
+        # Verify child is still pending
+        by_ext = await _get_events(session, organization)
+        assert by_ext["child"].pending_parent_external_id == "parent"
+        assert by_ext["child"].parent_id is None
+        assert by_ext["child"].root_id is None
+
+        # Batch 2: parent arrives, child should be resolved
+        parent_events = [_make_event(organization, "parent")]
+        parent_ids, _ = await repository.insert_batch(parent_events)
+        resolved = await _resolve(repository, parent_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        child = by_ext["child"]
+        parent = by_ext["parent"]
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+        assert child.pending_parent_external_id is None
+
+    async def test_deep_chain_cross_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """
+        OTEL-like scenario: grandchild, child, root arrive in three separate batches.
+        grandchild and child stay pending until root arrives.
+        """
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: grandchild (both parent and root missing)
+        gc_events = [
+            _make_event(organization, "grandchild", pending_parent_external_id="child"),
+        ]
+        gc_ids, _ = await repository.insert_batch(gc_events)
+        resolved = await _resolve(repository, gc_ids)
+        assert resolved == []
+        await session.flush()
+
+        # Batch 2: child arrives (parent "root" still missing)
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="root"),
+        ]
+        child_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, child_ids)
+        # grandchild can't resolve yet because child is also pending
+        assert resolved == []
+        await session.flush()
+
+        # Batch 3: root arrives, entire chain should resolve
+        root_events = [_make_event(organization, "root")]
+        root_ids, _ = await repository.insert_batch(root_events)
+        resolved = await _resolve(repository, root_ids)
+
+        assert len(resolved) == 2
+        by_ext = await _get_events(session, organization)
+        root = by_ext["root"]
+        child = by_ext["child"]
+        grandchild = by_ext["grandchild"]
+
+        assert child.parent_id == root.id
+        assert child.root_id == root.id
+
+        assert grandchild.parent_id == child.id
+        assert grandchild.root_id == root.id
+
+    async def test_branching_hierarchy(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """
+        Root with two children, each with a grandchild.
+        All in one batch, out of order.
+        """
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "gc1", pending_parent_external_id="child1"),
+            _make_event(organization, "gc2", pending_parent_external_id="child2"),
+            _make_event(organization, "child2", pending_parent_external_id="root"),
+            _make_event(organization, "root"),
+            _make_event(organization, "child1", pending_parent_external_id="root"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 4
+        by_ext = await _get_events(session, organization)
+        root = by_ext["root"]
+
+        for child_ext in ("child1", "child2"):
+            child = by_ext[child_ext]
+            assert child.parent_id == root.id
+            assert child.root_id == root.id
+
+        assert by_ext["gc1"].parent_id == by_ext["child1"].id
+        assert by_ext["gc1"].root_id == root.id
+        assert by_ext["gc2"].parent_id == by_ext["child2"].id
+        assert by_ext["gc2"].root_id == root.id
+
+    async def test_partial_chain_does_not_resolve(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """
+        Grandchild is pending on child. Child arrives but is itself pending on
+        a missing root. Neither should resolve — the chain doesn't reach a root.
+        """
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: grandchild, parent "child" doesn't exist yet
+        gc_events = [
+            _make_event(organization, "grandchild", pending_parent_external_id="child"),
+        ]
+        gc_ids, _ = await repository.insert_batch(gc_events)
+        resolved = await _resolve(repository, gc_ids)
+        assert resolved == []
+        await session.flush()
+
+        # Batch 2: child arrives, but its parent "root" is missing
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="root"),
+        ]
+        child_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, child_ids)
+
+        assert resolved == []
+
+        by_ext = await _get_events(session, organization)
+        assert by_ext["grandchild"].pending_parent_external_id == "child"
+        assert by_ext["grandchild"].parent_id is None
+        assert by_ext["grandchild"].root_id is None
+
+        assert by_ext["child"].pending_parent_external_id == "root"
+        assert by_ext["child"].parent_id is None
+        assert by_ext["child"].root_id is None
+
+    async def test_parent_referenced_by_uuid(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Parent referenced by UUID string instead of external_id."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        parent_id = uuid.uuid4()
+        events = [
+            _make_event(
+                organization,
+                "child",
+                pending_parent_external_id=str(parent_id),
+            ),
+            {
+                "id": parent_id,
+                "name": "event.parent",
+                "source": EventSource.user,
+                "organization_id": organization.id,
+                "external_id": "parent",
+                "root_id": parent_id,
+            },
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        assert by_ext["child"].parent_id == parent_id
+        assert by_ext["child"].root_id == parent_id
+
+    async def test_cross_org_isolation(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        account: Account,
+        account_second: Account,
+    ) -> None:
+        """Events in different orgs with same external_id don't cross-resolve."""
+        org1 = await create_organization(save_fixture, account)
+        org2 = await create_organization(save_fixture, account_second)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(org1, "child", pending_parent_external_id="parent"),
+            _make_event(org2, "parent"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        # Should NOT resolve — parent is in a different org
+        assert resolved == []
+        by_ext_org1 = await _get_events(session, org1)
+        assert by_ext_org1["child"].pending_parent_external_id == "parent"
+        assert by_ext_org1["child"].parent_id is None
+        assert by_ext_org1["child"].root_id is None
+
+    async def test_returns_only_newly_resolved_ids(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Return value contains only the IDs of events that were resolved."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "orphan", pending_parent_external_id="missing"),
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+            _make_event(organization, "parent"),
+            _make_event(organization, "standalone"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        by_ext = await _get_events(session, organization)
+        # Only child should be resolved
+        assert len(resolved) == 1
+        assert by_ext["child"].id in resolved
+
+        # Orphan stays pending
+        assert by_ext["orphan"].pending_parent_external_id == "missing"
+        assert by_ext["orphan"].parent_id is None
+        assert by_ext["orphan"].root_id is None
+
+        # Resolved child has correct root_id
+        parent = by_ext["parent"]
+        child = by_ext["child"]
+        assert child.root_id == parent.id
+
+        # Standalone root has root_id == self
+        standalone = by_ext["standalone"]
+        assert standalone.root_id == standalone.id

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -805,6 +805,83 @@ class TestIngest:
         assert child.id in second_call_args
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_deep_chain_resolves_when_root_arrives_last(
+        self,
+        enqueue_events_mock: AsyncMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+    ) -> None:
+        event_repository = EventRepository.from_session(session)
+
+        for name, external_id, parent_id in [
+            ("ggc", "ggc-id", "gc-id"),
+            ("gc", "gc-id", "c-id"),
+            ("c", "c-id", "p-id"),
+        ]:
+            await event_service.ingest(
+                session,
+                auth_subject,
+                EventsIngest(
+                    events=[
+                        EventCreateExternalCustomer(
+                            name=name,
+                            external_customer_id="test-customer-123",
+                            external_id=external_id,
+                            parent_id=parent_id,
+                        ),
+                    ]
+                ),
+            )
+
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        assert len(events) == 3
+        for e in events:
+            assert e.parent_id is None
+            assert e.pending_parent_external_id is not None
+
+        await event_service.ingest(
+            session,
+            auth_subject,
+            EventsIngest(
+                events=[
+                    EventCreateExternalCustomer(
+                        name="p",
+                        external_customer_id="test-customer-123",
+                        external_id="p-id",
+                    ),
+                ]
+            ),
+        )
+
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        by_name = {e.name: e for e in events}
+        p = by_name["p"]
+        c = by_name["c"]
+        gc = by_name["gc"]
+        ggc = by_name["ggc"]
+
+        for e in events:
+            await session.refresh(e)
+
+        assert p.parent_id is None
+        assert p.root_id == p.id
+
+        assert c.parent_id == p.id
+        assert c.root_id == p.id
+        assert c.pending_parent_external_id is None
+
+        assert gc.parent_id == c.id
+        assert gc.root_id == p.id
+        assert gc.pending_parent_external_id is None
+
+        assert ggc.parent_id == gc.id
+        assert ggc.root_id == p.id
+        assert ggc.pending_parent_external_id is None
+
+        final_call_args = set(enqueue_events_mock.call_args_list[-1][0])
+        assert {p.id, c.id, gc.id, ggc.id} == final_call_args
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_ingest_with_member_id(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -755,6 +755,56 @@ class TestIngest:
         }
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_parent_arrives_after_child_cross_batch(
+        self,
+        enqueue_events_mock: AsyncMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+    ) -> None:
+        event_repository = EventRepository.from_session(session)
+
+        child_ingest = EventsIngest(
+            events=[
+                EventCreateExternalCustomer(
+                    name="email_sent",
+                    external_customer_id="test-customer-123",
+                    parent_id="parent-event-123",
+                ),
+            ]
+        )
+        await event_service.ingest(session, auth_subject, child_ingest)
+
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        assert len(events) == 1
+        child = events[0]
+        assert child.parent_id is None
+        assert child.pending_parent_external_id == "parent-event-123"
+
+        parent_ingest = EventsIngest(
+            events=[
+                EventCreateExternalCustomer(
+                    name="support_request",
+                    external_customer_id="test-customer-123",
+                    external_id="parent-event-123",
+                ),
+            ]
+        )
+        await event_service.ingest(session, auth_subject, parent_ingest)
+
+        await session.refresh(child)
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        parent = next(e for e in events if e.name == "support_request")
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+        assert child.pending_parent_external_id is None
+
+        assert enqueue_events_mock.call_count == 2
+        second_call_args = set(enqueue_events_mock.call_args_list[1][0])
+        assert parent.id in second_call_args
+        assert child.id in second_call_args
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_ingest_with_member_id(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
This allows us to decouple the ingestion of a child event and its parent. By storing the pending parent id on events, we can at a later date resolve this relationship. We write the events to postgres always, but we wait with writing to Tinybird until we have resolved the relationship.

An orphan child will not show up anywhere, although we could have a list of orphan events in the dashboard. This is intentional as we want to avoid writing and updating data in Tinybird. Especially since we will need to update both the root_id, as well as the ancestor_chain. If you are ingesting a grand-grand child and then their parent, you will have to ingest two more events before you complete the chain and can truly know the events full ancestry.
