### PR TITLE
member: prevent duplicate owner when customer email drifts

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -343,7 +343,6 @@ class CustomerService:
     ) -> Customer:
         repository = CustomerRepository.from_session(session)
 
-        old_email = customer.email
         email_changed = False
 
         errors: list[ValidationError] = []
@@ -495,30 +494,8 @@ class CustomerService:
                 ) from e
             raise
 
-        # Sync owner member email when the customer email changes.
-        # Only applies to individual customers (type == individual or type is None).
-        # Team customers can have multiple members with different emails — we don't auto-sync.
-        if email_changed and old_email is not None:
-            customer_type = updated_customer.type or CustomerType.individual
-
-            if customer_type == CustomerType.individual:
-                member_repository = MemberRepository.from_session(session)
-                owner = await member_repository.get_owner_by_customer_id(
-                    session, updated_customer.id
-                )
-
-                if owner is not None and owner.email.lower() == old_email.lower():
-                    new_email = updated_customer.email
-
-                    await member_repository.update(
-                        owner, update_dict={"email": new_email}
-                    )
-                    log.info(
-                        "member.email_sync",
-                        customer_id=updated_customer.id,
-                        member_id=owner.id,
-                        new_email=new_email,
-                    )
+        if email_changed:
+            await member_service.sync_owner_email(session, updated_customer)
 
         return updated_customer
 

--- a/server/polar/customer_email_update/service.py
+++ b/server/polar/customer_email_update/service.py
@@ -15,7 +15,7 @@ from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
 from polar.kit.utils import utc_now
-from polar.member.repository import MemberRepository
+from polar.member.service import member_service
 from polar.models import Customer, Organization
 from polar.models.customer import CustomerType
 from polar.models.customer_email_verification import CustomerEmailVerification
@@ -158,23 +158,7 @@ class CustomerEmailUpdateService:
             customer, update_dict={"email": record.email, "email_verified": True}
         )
 
-        # Sync member email (same pattern as customer/service.py)
-        if old_email is not None and customer.type == CustomerType.individual:
-            member_repository = MemberRepository.from_session(session)
-            member = await member_repository.get_by_customer_and_email(
-                session, customer, old_email
-            )
-            if member is not None:
-                await member_repository.update(
-                    member, update_dict={"email": customer.email}
-                )
-                log.info(
-                    "customer_email_update.synced_member_email",
-                    customer_id=customer.id,
-                    member_id=member.id,
-                    old_email=old_email,
-                    new_email=customer.email,
-                )
+        await member_service.sync_owner_email(session, customer)
 
         if customer.stripe_customer_id is not None and customer.email is not None:
             await stripe_service.update_customer(

--- a/server/polar/member/repository.py
+++ b/server/polar/member/repository.py
@@ -119,7 +119,11 @@ class MemberRepository(
         *,
         include_deleted: bool = False,
     ) -> Member | None:
-        """Get the owner member for a customer."""
+        """Get the owner member for a customer.
+
+        A customer must have at most one active owner; raises
+        `MultipleResultsFound` otherwise so the invariant violation is loud.
+        """
         statement = (
             select(Member)
             .where(

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -217,6 +217,34 @@ class MemberService:
 
         return deleted
 
+    async def sync_owner_email(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        """Mirror customer.email to the owner member's email for individual
+        customers. Any drift otherwise causes the portal sign-in flow to
+        auto-create a duplicate owner (the owner-by-email lookup misses the
+        drifted row). Team customers legitimately have members with distinct
+        emails, so they are skipped."""
+        if customer.type != CustomerType.individual or customer.email is None:
+            return
+
+        repository = MemberRepository.from_session(session)
+        owner = await repository.get_owner_by_customer_id(session, customer.id)
+        if owner is None or owner.email.lower() == customer.email.lower():
+            return
+
+        old_email = owner.email
+        await repository.update(owner, update_dict={"email": customer.email})
+        log.info(
+            "member.sync_owner_email",
+            customer_id=customer.id,
+            member_id=owner.id,
+            old_email=old_email,
+            new_email=customer.email,
+        )
+
     async def create_owner_member(
         self,
         session: AsyncSession,
@@ -273,17 +301,19 @@ class MemberService:
         name = owner_name or customer.name
         external_id = owner_external_id or customer.external_id
 
-        existing_member = await repository.get_by_customer_and_email(
-            session, customer, email=email
-        )
-        if existing_member:
+        # A customer has at most one owner. Short-circuit on any existing owner
+        # regardless of email — if we only dedupe by (customer_id, email), a drifted
+        # owner.email (e.g., typo in original email that was later corrected on the
+        # customer) produces a duplicate owner on the next sign-in.
+        existing_owner = await repository.get_owner_by_customer_id(session, customer.id)
+        if existing_owner is not None:
             log.debug(
                 "member.create_owner_member.skipped",
-                reason="member_already_exists",
+                reason="owner_already_exists",
                 customer_id=customer.id,
-                member_id=existing_member.id,
+                member_id=existing_owner.id,
             )
-            return existing_member
+            return existing_owner
 
         member = Member(
             customer_id=customer.id,
@@ -319,18 +349,18 @@ class MemberService:
                 error=str(e),
                 reason="Likely race condition - member already exists",
             )
-            existing_member = await repository.get_by_customer_and_email(
-                session, customer, email=email
+            existing_owner = await repository.get_owner_by_customer_id(
+                session, customer.id
             )
-            if existing_member:
+            if existing_owner is not None:
                 log.info(
                     "member.create_owner_member.found_existing",
                     customer_id=customer.id,
-                    member_id=existing_member.id,
+                    member_id=existing_owner.id,
                 )
-                return existing_member
+                return existing_owner
 
-            # Weird state: IntegrityError but member doesn't exist
+            # Weird state: IntegrityError but no owner exists
             # Re-raise to fail customer creation and maintain data consistency
             log.error(
                 "member.create_owner_member.integrity_error_no_member",

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -919,6 +919,36 @@ class TestUpdate:
         assert updated_customer.name == "New Name"
         assert member.email == "same@example.com"
 
+    async def test_syncs_owner_member_email_when_owner_has_drifted_email(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Drift between owner.email and customer.email must be repaired on
+        every update, otherwise the portal sign-in flow creates a duplicate."""
+        customer = await create_customer(
+            save_fixture, organization=organization, email="foo.bar@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="foo?bar@example.com",
+            role=MemberRole.owner,
+        )
+        await save_fixture(member)
+
+        updated_customer = await customer_service.update(
+            session,
+            customer,
+            CustomerUpdate(email="foo.baz@example.com"),
+        )
+        await session.flush()
+        await session.refresh(member)
+
+        assert updated_customer.email == "foo.baz@example.com"
+        assert member.email == "foo.baz@example.com"
+
 
 @pytest.mark.asyncio
 class TestDelete:

--- a/server/tests/customer_email_update/test_service.py
+++ b/server/tests/customer_email_update/test_service.py
@@ -15,9 +15,11 @@ from polar.exceptions import PolarRequestValidationError
 from polar.integrations.stripe.service import StripeService
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
 from polar.kit.utils import utc_now
+from polar.member.repository import MemberRepository
 from polar.models import Customer, Organization
 from polar.models.customer import CustomerType
 from polar.models.customer_email_verification import CustomerEmailVerification
+from polar.models.member import Member, MemberRole
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_customer
@@ -337,3 +339,39 @@ class TestVerify:
 
         # No notification should be sent when there's no old email
         mock_enqueue_email.assert_not_called()
+
+    async def test_syncs_owner_member_email_even_when_drifted(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        """Verify flow must repair drifted owner.email, matching
+        customer_service.update."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="correct@example.com",
+            stripe_customer_id=None,
+        )
+        owner = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="drifted@example.com",
+            role=MemberRole.owner,
+        )
+        await save_fixture(owner)
+
+        _record, token = await _create_verification(
+            save_fixture, customer, "verified@example.com"
+        )
+
+        service = CustomerEmailUpdateService()
+        await service.verify(session, token)
+        await session.flush()
+        await session.refresh(owner)
+
+        assert owner.email == "verified@example.com"
+        repository = MemberRepository.from_session(session)
+        members = await repository.list_by_customer(session, customer.id)
+        assert len([m for m in members if m.role == MemberRole.owner]) == 1

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 from polar.auth.models import AuthSubject
 from polar.kit.pagination import PaginationParams
+from polar.member.repository import MemberRepository
 from polar.member.service import member_service
 from polar.models import Customer, Member, Organization, User, UserOrganization
 from polar.models.member import MemberRole
@@ -384,6 +385,40 @@ class TestCreateOwnerMember:
         assert member is not None
         assert member.external_id is None
         assert member.email == customer.email
+
+    async def test_reuses_existing_owner_when_customer_email_drifted(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """When owner.email has drifted from customer.email, auto-create must
+        reuse the existing owner rather than insert a second row."""
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="correct@example.com",
+        )
+        existing = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="drifted@example.com",
+            role=MemberRole.owner,
+        )
+        await save_fixture(existing)
+
+        member = await member_service.create_owner_member(
+            session, customer, organization
+        )
+
+        assert member is not None
+        assert member.id == existing.id
+        repository = MemberRepository.from_session(session)
+        members = await repository.list_by_customer(session, customer.id)
+        assert len([m for m in members if m.role == MemberRole.owner]) == 1
 
 
 @pytest.mark.asyncio
@@ -974,8 +1009,6 @@ class TestGetOrCreateByEmail:
         await save_fixture(existing)
 
         # Mock repository.create to raise IntegrityError, simulating a race
-        from polar.member.repository import MemberRepository
-
         original_create = MemberRepository.create
 
         call_count = 0


### PR DESCRIPTION
## Summary

Fixes a bug where correcting `customer.email` for an individual customer could leave the owner `Member`'s email stale, and the next portal sign-in would auto-create a second owner. Downstream, any call to `get_owner_by_customer_id` then raised `MultipleResultsFound`, surfacing as HTTP 500s to both the customer portal (`/{org}/portal/request` empty) and the backoffice "Generate Portal Link" action ("A network error occurred, Please try again later").

A small number of customers are currently affected in prod; the data cleanup is being handled out of band.

## Why the old sync didn't protect us

The two sync sites — `customer_service.update` and `customer_email_update.verify` — both looked up the owner scoped by the *pre-update* email:

- `customer/service.py` guarded `owner.email.lower() == old_email.lower()` and silently skipped sync on any drift.
- `customer_email_update/service.py` looked up via `get_by_customer_and_email(customer, old_email)` and returned `None` on any drift.

So if `owner.email` ever diverged from `customer.email` (typo at customer creation later corrected, whitespace, unrelated prior sync miss), the update was silently lost, and the next sign-in's email-based member lookup missed the stale owner and called `create_owner_member`, which deduped by `(customer_id, email)` — inserting a duplicate with the new email.

## What changed

- New `MemberService.sync_owner_email(session, customer)`: for individual customers, unconditionally mirrors `customer.email` to the single owner member (case-insensitive diff check, so no flap). Team customers are skipped — they legitimately have members with distinct emails.
- `customer_service.update` and `customer_email_update.verify` now call the helper instead of their own duplicated blocks.
- `MemberService.create_owner_member` now dedupes via `get_owner_by_customer_id` (by `customer_id`) instead of `get_by_customer_and_email` (by `(customer_id, email)`). A customer has at most one owner — drift should never produce a second row, regardless of whether sync was ever missed.
- `get_owner_by_customer_id` kept strict: still raises `MultipleResultsFound` on duplicates so the invariant violation stays loud.

## Test plan

- [x] `uv run pytest tests/member tests/customer/test_service.py tests/customer_email_update` — 177 passed
- [x] `uv run task lint` clean
- [x] `uv run task lint_types` clean
- [ ] After merge + deploy: re-check the affected customers' portal sign-in and backoffice "Generate Portal Link" flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)