### PR TITLE
Add proton.me to allowed email domains list

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -270,6 +270,7 @@ class Settings(BaseSettings):
         "icloud.com",
         "mail.com",
         "protonmail.com",
+        "proton.me",
         "zoho.com",
         "gmx.com",
         "yandex.com",


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Add `proton.me` to the list of allowed email domains in the application configuration.

## What

Added `"proton.me"` to the `ALLOWED_EMAIL_DOMAINS` list in `server/polar/config.py`, positioned after the existing `"protonmail.com"` entry.

## Why

Proton Mail has introduced `proton.me` as an alternative domain for email addresses. This change ensures that users with `proton.me` email addresses are recognized as valid, consistent with the existing support for `protonmail.com`.

## How

Added a single line to the email domain whitelist configuration.

## Checklist

- [x] This PR addresses a single concern (one config addition)
- [x] The diff is reasonably sized and easy to review
- [x] No testing needed (configuration change)
- [x] No unrelated changes included

https://claude.ai/code/session_01VYERftEJaqJ6vJb6qAmqKC