### PR TITLE
Include archived metrics in analytics dashboard query

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/layout.tsx
@@ -24,7 +24,7 @@ export default async function Layout(props: {
           query: {
             organization_id: organization.id,
             limit: 100,
-            is_archived: false,
+            is_archived: null,
           },
         },
       }),


### PR DESCRIPTION
We only show subscription metrics if you have recurring products, but that didn't take archived products into account, so your subscription metrics disappeared if you removed your last recurring product.