### PR TITLE
organization: defer refunds_blocked ahead of drop (Phase A)

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -3529,60 +3529,6 @@ async def add_payment_method_domain(
                     text("Add Domain")
 
 
-@router.post(
-    "/{organization_id}/refunds-blocked",
-    name="organizations:set_refunds_blocked",
-    dependencies=[Depends(get_admin)],
-)
-async def set_refunds_blocked(
-    request: Request,
-    organization_id: UUID4,
-    blocked: bool,
-    session: AsyncSession = Depends(get_db_session),
-) -> Any:
-    repository = OrganizationRepository.from_session(session)
-    organization = await repository.get_by_id(organization_id)
-
-    if organization is None:
-        raise HTTPException(status_code=404)
-
-    if organization.refunds_blocked == blocked:
-        status = "blocked" if blocked else "not blocked"
-        await add_toast(
-            request,
-            f"Refunds are already {status} for this organization.",
-            "error",
-        )
-        return HXRedirectResponse(
-            request,
-            str(
-                request.url_for("organizations:detail", organization_id=organization_id)
-            )
-            + "?section=settings",
-            303,
-        )
-
-    new_capabilities = {
-        **organization.get_effective_capabilities(),
-        "refunds": not blocked,
-    }
-    organization = await repository.update(
-        organization,
-        update_dict={"refunds_blocked": blocked, "capabilities": new_capabilities},
-    )
-
-    action = "blocked" if blocked else "unblocked"
-    await add_toast(
-        request, f"Refunds have been {action} for this organization.", "success"
-    )
-    return HXRedirectResponse(
-        request,
-        str(request.url_for("organizations:detail", organization_id=organization_id))
-        + "?section=settings",
-        303,
-    )
-
-
 @router.api_route(
     "/{organization_id}/capabilities/{capability}",
     name="organizations:set_capability",

--- a/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
@@ -398,45 +398,6 @@ class SettingsSection:
                     text("Danger Zone")
 
                 with tag.div(classes="space-y-3"):
-                    # Block/Unblock Refunds
-                    with tag.div(classes="flex items-center justify-between"):
-                        with tag.div():
-                            with tag.div(classes="font-semibold text-sm"):
-                                if self.org.refunds_blocked:
-                                    text("Unblock Refunds")
-                                else:
-                                    text("Block Refunds")
-                            with tag.div(classes="text-xs text-base-content/60"):
-                                if self.org.refunds_blocked:
-                                    text(
-                                        "Allow refunds for all orders in this organization"
-                                    )
-                                else:
-                                    text(
-                                        "Prevent refunds for all orders in this organization"
-                                    )
-
-                        with tag.form(
-                            method="POST",
-                            action=str(
-                                request.url_for(
-                                    "organizations:set_refunds_blocked",
-                                    organization_id=self.org.id,
-                                )
-                            )
-                            + f"?blocked={'false' if self.org.refunds_blocked else 'true'}",
-                        ):
-                            with button(
-                                type="submit",
-                                variant="error",
-                                size="sm",
-                                outline=True,
-                            ):
-                                if self.org.refunds_blocked:
-                                    text("Unblock Refunds")
-                                else:
-                                    text("Block Refunds")
-
                     # Delete Organization
                     with tag.div(classes="flex items-center justify-between"):
                         with tag.div():

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -224,14 +224,6 @@ class OrganizationStatus(StrEnum):
     def review_statuses(cls) -> set[Self]:
         return {cls.REVIEW, cls.SNOOZED}  # pyright: ignore
 
-    @classmethod
-    def payment_ready_statuses(cls) -> set[Self]:
-        return {cls.ACTIVE, cls.OFFBOARDING, *cls.review_statuses()}  # pyright: ignore
-
-    @classmethod
-    def payout_ready_statuses(cls) -> set[Self]:
-        return {cls.ACTIVE}  # pyright: ignore
-
 
 class OrganizationCapabilities(TypedDict):
     checkout_payments: bool
@@ -513,10 +505,13 @@ class Organization(RateLimitGroupMixin, RecordModel):
         TIMESTAMP(timezone=True), nullable=True, default=None
     )
 
-    # Flag to block refunds for all orders in this organization
+    # DEPRECATED: use `capabilities["refunds"]` instead.
+    # `deferred=True` so default SELECTs don't include it, allowing the
+    # column to be dropped in a follow-up migration without a CD race.
     refunds_blocked: Mapped[bool] = mapped_column(
         nullable=False,
         default=False,
+        deferred=True,
     )
 
     capabilities: Mapped[OrganizationCapabilities | None] = mapped_column(
@@ -681,8 +676,6 @@ class Organization(RateLimitGroupMixin, RecordModel):
         self.status = status
         self.status_updated_at = datetime.now(UTC)
         self.capabilities = {**STATUS_CAPABILITIES[status]}
-        # Mirror to the legacy column so the two stay in sync.
-        self.refunds_blocked = not self.capabilities["refunds"]
 
     @hybrid_property
     def is_under_review(self) -> bool:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1220,9 +1220,6 @@ class OrganizationService:
             reason=reason,
         )
 
-        if capability == "refunds":
-            organization.refunds_blocked = not value
-
         session.add(organization)
         return organization
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -2351,32 +2351,6 @@ class TestSetCapability:
         assert organization.capabilities == initial
         assert organization.internal_notes is None
 
-    async def test_mirrors_refunds_blocked(
-        self,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.set_status(OrganizationStatus.ACTIVE)
-        organization.refunds_blocked = False
-
-        await organization_service.set_capability(
-            session,
-            organization,
-            "refunds",
-            False,
-            reason="Fraud investigation in progress",
-        )
-        assert organization.refunds_blocked is True
-
-        await organization_service.set_capability(
-            session,
-            organization,
-            "refunds",
-            True,
-            reason="Investigation resolved, re-enabling refunds",
-        )
-        assert organization.refunds_blocked is False
-
     async def test_status_transition_resets_override(
         self,
         session: AsyncSession,

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -891,17 +891,17 @@ class TestOrganizationRefundsBlocked:
         product: Product,
         customer: Customer,
     ) -> None:
-        """Test that refunds are blocked when organization.refunds_blocked is True."""
-        # Set organization refunds_blocked flag
+        """Test that refunds are blocked when the refunds capability is disabled."""
         from polar.organization.repository import OrganizationRepository
 
         org_repository = OrganizationRepository.from_session(session)
-        assert organization.capabilities is not None
         organization = await org_repository.update(
             organization,
             update_dict={
-                "refunds_blocked": True,
-                "capabilities": {**organization.capabilities, "refunds": False},
+                "capabilities": {
+                    **organization.get_effective_capabilities(),
+                    "refunds": False,
+                },
             },
         )
 
@@ -936,7 +936,7 @@ class TestOrganizationRefundsBlocked:
         product: Product,
         customer: Customer,
     ) -> None:
-        """Test that refunds work normally when organization.refunds_blocked is False."""
+        """Test that refunds work normally when the refunds capability is enabled."""
         # Create an order with payment
         order, payment, _transaction = await create_order_and_payment(
             save_fixture,


### PR DESCRIPTION
## Summary

Phase A of retiring `Organization.refunds_blocked` in favor of
`capabilities["refunds"]`. Follows the same two-step pattern used to
retire `Organization.blocked_at` (#11062 → #11120): first defer the
column and strip every app-level read/write, then drop it in a
follow-up PR after this soak.

## What

- Mark `Organization.refunds_blocked` as `deferred=True` so default
  `SELECT`s (including `get_base_statement()` on every repository) no
  longer project it. The column stays in the DB and is still accessible
  if explicitly referenced.
- Remove every app-level read/write of `Organization.refunds_blocked`:
  - The mirror in `Organization.set_status`.
  - The mirror in `organization_service.set_capability`.
  - The backoffice `organizations:set_refunds_blocked` endpoint.
  - The "Block/Unblock Refunds" tile in the settings Danger Zone.
- Delete the now-unused `OrganizationStatus.payment_ready_statuses()`
  and `payout_ready_statuses()` — PR 2 (#11104) migrated every call
  site off them.
- Drop `test_mirrors_refunds_blocked` and switch the refund integration
  test to flip `capabilities["refunds"]` only.

## Why

Dropping the column in a single PR races old pods during Render
rollout: their cached `SELECT` statements still project the column and
fail once `DROP COLUMN` ships. By deferring first and shipping a PR
with no references to the column, we ensure that by the time Phase B's
migration runs, every live pod is already on code that doesn't select
it.

The per-capability override UI already covers the refunds toggle, so
the legacy Danger Zone entry and its endpoint are no longer needed.

## How

- `deferred=True` on the mapped column — proven approach from #11062.
- `get_effective_capabilities()` and the nullable `capabilities`
  column are intentionally left in place; they move in Phase B
  alongside `NOT NULL` + `DROP COLUMN`.

## Test plan

- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes
- [x] `uv run pytest tests/organization tests/refund tests/backoffice`
      passes (327 tests)
- [ ] Verify in a backoffice environment that the capabilities card
      still toggles `refunds` correctly and that the Danger Zone no
      longer shows the legacy tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)