### PR TITLE
Create non-org dependent deep links for the dashboard

### DIFF
--- a/clients/apps/web/src/app/(main)/to/[...path]/page.tsx
+++ b/clients/apps/web/src/app/(main)/to/[...path]/page.tsx
@@ -1,0 +1,38 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getLastVisitedOrg } from '@/utils/cookies'
+import { getUserOrganizations } from '@/utils/user'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+// Deep-link redirect: /to/dashboard/<rest> → /dashboard/<user-org>/<rest>
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ path: string[] }>
+  searchParams: Promise<Record<string, string>>
+}) {
+  const { path } = await params
+  const resolvedSearchParams = await searchParams
+  const query = new URLSearchParams(resolvedSearchParams).toString()
+  const qs = query ? `?${query}` : ''
+
+  const api = await getServerSideAPI()
+  const userOrganizations = await getUserOrganizations(api, true)
+
+  if (userOrganizations.length === 0) {
+    redirect(`/onboarding/start${qs}`)
+  }
+
+  const organization =
+    getLastVisitedOrg(await cookies(), userOrganizations) ??
+    userOrganizations[0]
+
+  if (path[0] !== 'dashboard') {
+    redirect(`/dashboard/${organization.slug}${qs}`)
+  }
+
+  const rest = path.slice(1).join('/')
+  const tail = rest ? `/${rest}` : ''
+  redirect(`/dashboard/${organization.slug}${tail}${qs}`)
+}

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -281,4 +281,19 @@ describe('middleware function', () => {
     expect(response.status).toBe(307)
     expect(response.headers.get('location')).toContain('/login')
   })
+
+  it('should redirect unauthenticated /to/* requests to login preserving the deep link', async () => {
+    const request = new NextRequest(
+      'https://example.com/to/dashboard/settings/billing',
+    )
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    const location = response.headers.get('location')
+    expect(location).toContain('/login')
+    expect(location).toContain(
+      'return_to=%2Fto%2Fdashboard%2Fsettings%2Fbilling',
+    )
+  })
 })

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -38,6 +38,7 @@ const AUTHENTICATED_ROUTES = [
   new RegExp('^/finance(/.*)?'),
   new RegExp('^/settings(/.*)?'),
   new RegExp('^/oauth2(/.*)?'),
+  new RegExp('^/to(/.*)?'),
 ]
 
 const getOrCreateDistinctId = (
@@ -205,10 +206,9 @@ export async function proxy(request: NextRequest) {
   }
 
   let user: schemas['UserRead'] | undefined = undefined
-  let api: Awaited<ReturnType<typeof createServerSideAPI>> | undefined
 
   if (request.cookies.has(POLAR_AUTH_COOKIE_KEY)) {
-    api = await createServerSideAPI(
+    const api = await createServerSideAPI(
       request.headers,
       RequestCookiesAdapter.seal(request.cookies),
     )
@@ -230,48 +230,11 @@ export async function proxy(request: NextRequest) {
     return getLoginResponse(request)
   }
 
-  // If the first segment isn't one of the user's org slugs then treat
-  // it as a route name and prepend the user's last-visited (or first) org slug.
-
-  // If the first segment matches the `last_visited_org` cookie, skip the API call
-  if (user && api) {
-    const dashboardMatch = request.nextUrl.pathname.match(
-      /^\/dashboard\/([^/]+)(\/.*)?$/,
-    )
-    if (dashboardMatch) {
-      const firstSegment = dashboardMatch[1]
-      const rest = dashboardMatch[2] ?? ''
-      const lastVisitedSlug = request.cookies.get('last_visited_org')?.value
-
-      if (lastVisitedSlug !== firstSegment) {
-        const { data: orgsData } = await api.GET('/v1/organizations/', {
-          params: { query: { limit: 100, sorting: ['name'] } },
-          cache: 'no-cache',
-        })
-        const userOrgs = orgsData?.items ?? []
-
-        if (!userOrgs.some((o) => o.slug === firstSegment)) {
-          if (userOrgs.length === 0) {
-            const url = request.nextUrl.clone()
-            url.pathname = '/onboarding/start'
-            return NextResponse.redirect(url)
-          }
-          const defaultOrg =
-            userOrgs.find((o) => o.slug === lastVisitedSlug) ?? userOrgs[0]
-          const redirectURL = request.nextUrl.clone()
-          redirectURL.pathname = `/dashboard/${defaultOrg.slug}/${firstSegment}${rest}`
-          return NextResponse.redirect(redirectURL)
-        }
-      }
-    }
-  }
-
   const { id: distinctId, isNew: isNewDistinctId } =
     getOrCreateDistinctId(request)
 
   const headers: Record<string, string> = {
     'x-polar-distinct-id': distinctId,
-    'x-pathname': request.nextUrl.pathname,
   }
   if (user) {
     headers['x-polar-user'] = Buffer.from(JSON.stringify(user)).toString(

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -205,9 +205,10 @@ export async function proxy(request: NextRequest) {
   }
 
   let user: schemas['UserRead'] | undefined = undefined
+  let api: Awaited<ReturnType<typeof createServerSideAPI>> | undefined
 
   if (request.cookies.has(POLAR_AUTH_COOKIE_KEY)) {
-    const api = await createServerSideAPI(
+    api = await createServerSideAPI(
       request.headers,
       RequestCookiesAdapter.seal(request.cookies),
     )
@@ -229,11 +230,48 @@ export async function proxy(request: NextRequest) {
     return getLoginResponse(request)
   }
 
+  // If the first segment isn't one of the user's org slugs then treat
+  // it as a route name and prepend the user's last-visited (or first) org slug.
+
+  // If the first segment matches the `last_visited_org` cookie, skip the API call
+  if (user && api) {
+    const dashboardMatch = request.nextUrl.pathname.match(
+      /^\/dashboard\/([^/]+)(\/.*)?$/,
+    )
+    if (dashboardMatch) {
+      const firstSegment = dashboardMatch[1]
+      const rest = dashboardMatch[2] ?? ''
+      const lastVisitedSlug = request.cookies.get('last_visited_org')?.value
+
+      if (lastVisitedSlug !== firstSegment) {
+        const { data: orgsData } = await api.GET('/v1/organizations/', {
+          params: { query: { limit: 100, sorting: ['name'] } },
+          cache: 'no-cache',
+        })
+        const userOrgs = orgsData?.items ?? []
+
+        if (!userOrgs.some((o) => o.slug === firstSegment)) {
+          if (userOrgs.length === 0) {
+            const url = request.nextUrl.clone()
+            url.pathname = '/onboarding/start'
+            return NextResponse.redirect(url)
+          }
+          const defaultOrg =
+            userOrgs.find((o) => o.slug === lastVisitedSlug) ?? userOrgs[0]
+          const redirectURL = request.nextUrl.clone()
+          redirectURL.pathname = `/dashboard/${defaultOrg.slug}/${firstSegment}${rest}`
+          return NextResponse.redirect(redirectURL)
+        }
+      }
+    }
+  }
+
   const { id: distinctId, isNew: isNewDistinctId } =
     getOrCreateDistinctId(request)
 
   const headers: Record<string, string> = {
     'x-polar-distinct-id': distinctId,
+    'x-pathname': request.nextUrl.pathname,
   }
   if (user) {
     headers['x-polar-user'] = Buffer.from(JSON.stringify(user)).toString(


### PR DESCRIPTION
It's often useful to link to specific parts of the dashboard, however to do that we always need to include the org slug otherwise the link will 404. E.g https://polar.sh/dashboard/acme-org/products.

This PR adds the ability to automatically deep link into a specific part of the dashboard without having to specify the org slug, e.g: https://polar.sh/to/dashboard/products which then redirects to https://polar.sh/dashboard/acme-org/products.

Examples:
* `/to/dashboard/products` → `/dashboard/acme-org/products`
* `/to/dashboard/products?foo=bar` → `/dashboard/acme-org/products?foo=bar`
* `/to/dashboard/products/checkout-links/123?foo=bar` → `/dashboard/acme-org/products/checkout-links/123?foo=bar`