### PR TITLE
Show custom fields in app orders

### DIFF
--- a/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
@@ -5,7 +5,10 @@ import { Pill } from '@/components/Shared/Pill'
 import { Text } from '@/components/Shared/Text'
 import { Touchable } from '@/components/Shared/Touchable'
 import { useTheme } from '@/design-system/useTheme'
+import { useCustomFields } from '@/hooks/polar/custom_fields'
 import { useOrder } from '@/hooks/polar/orders'
+import MaterialIcons from '@expo/vector-icons/MaterialIcons'
+import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import * as Clipboard from 'expo-clipboard'
 import { Stack, useLocalSearchParams } from 'expo-router'
@@ -19,11 +22,51 @@ const statusColors = {
   void: 'red',
 } as const
 
+const numberFormat = new Intl.NumberFormat(undefined, {})
+
+const formatCustomFieldValue = (
+  field: schemas['CustomField'],
+  value: string | number | boolean | null | undefined,
+  iconColor: string,
+): React.ReactNode => {
+  if (value === undefined || value === null) {
+    return '—'
+  }
+
+  switch (field.type) {
+    case 'number':
+      return numberFormat.format(value as number)
+    case 'date':
+      return new Date(value as string).toLocaleDateString('en-US', {
+        dateStyle: 'medium',
+      })
+    case 'checkbox':
+      return (
+        <MaterialIcons
+          name={value === true ? 'check' : 'close'}
+          size={16}
+          color={iconColor}
+        />
+      )
+    case 'select':
+      return (
+        field.properties.options.find((option) => option.value === value)
+          ?.label ?? String(value)
+      )
+    case 'text':
+    default:
+      return String(value)
+  }
+}
+
 export default function Index() {
   const { id } = useLocalSearchParams()
   const theme = useTheme()
 
   const { data: order, refetch, isRefetching } = useOrder(id as string)
+  const { data: customFields } = useCustomFields(
+    order?.customer.organization_id,
+  )
 
   if (!order) {
     return (
@@ -208,6 +251,27 @@ export default function Index() {
           value={order.customer.billing_address?.country}
         />
       </Details>
+
+      {customFields && customFields.items.length > 0 ? (
+        <Box>
+          <Text variant="subtitle" marginBottom="spacing-8">
+            Custom Fields
+          </Text>
+          <Details>
+            {customFields.items.map((field) => (
+              <DetailRow
+                key={field.id}
+                label={field.name}
+                value={formatCustomFieldValue(
+                  field,
+                  order.custom_field_data?.[field.slug],
+                  theme.colors.text,
+                )}
+              />
+            ))}
+          </Details>
+        </Box>
+      ) : null}
 
       {order.metadata && Object.keys(order.metadata).length > 0 ? (
         <Box>

--- a/clients/apps/app/hooks/polar/custom_fields.ts
+++ b/clients/apps/app/hooks/polar/custom_fields.ts
@@ -1,0 +1,29 @@
+import { usePolarClient } from '@/providers/PolarClientProvider'
+import { operations, unwrap } from '@polar-sh/client'
+import { useQuery } from '@tanstack/react-query'
+
+export const useCustomFields = (
+  organizationId: string | undefined,
+  parameters?: Omit<
+    NonNullable<operations['custom-fields:list']['parameters']['query']>,
+    'organization_id'
+  >,
+) => {
+  const { polar } = usePolarClient()
+
+  return useQuery({
+    queryKey: ['custom_fields', { organizationId, ...(parameters || {}) }],
+    queryFn: () =>
+      unwrap(
+        polar.GET('/v1/custom-fields/', {
+          params: {
+            query: {
+              organization_id: organizationId,
+              ...(parameters || {}),
+            },
+          },
+        }),
+      ),
+    enabled: !!organizationId,
+  })
+}


### PR DESCRIPTION
<img width="325" align="right" alt="" src="https://github.com/user-attachments/assets/e541f6ac-5514-40a5-b5fe-3a0e458aa504" />

This PR will show any custom fields that are set in the app, similar to what we do on web