### PR TITLE
Link in-app notifications

### DIFF
--- a/clients/apps/app/app/(authenticated)/notifications/index.tsx
+++ b/clients/apps/app/app/(authenticated)/notifications/index.tsx
@@ -1,6 +1,7 @@
 import { Notification } from '@/components/Notifications/Notification'
 import { Box } from '@/components/Shared/Box'
 import { Text } from '@/components/Shared/Text'
+import { Touchable } from '@/components/Shared/Touchable'
 import { useTheme } from '@/design-system/useTheme'
 import {
   Notification as PolarNotification,
@@ -9,9 +10,24 @@ import {
 } from '@/hooks/polar/notifications'
 import { FlashList } from '@shopify/flash-list'
 import { setBadgeCountAsync } from 'expo-notifications'
-import { Stack } from 'expo-router'
+import { Href, Link, Stack } from 'expo-router'
 import React, { useEffect, useRef } from 'react'
 import { RefreshControl } from 'react-native'
+
+const getNotificationHref = (notification: PolarNotification): Href | null => {
+  switch (notification.type) {
+    case 'MaintainerNewProductSaleNotification':
+      return notification.payload.order_id
+        ? `/orders/${notification.payload.order_id}`
+        : null
+    case 'MaintainerNewPaidSubscriptionNotification':
+      return notification.payload.subscription_id
+        ? `/subscriptions/${notification.payload.subscription_id}`
+        : null
+    default:
+      return null
+  }
+}
 
 const groupNotificationsByDate = (notifications: PolarNotification[]) => {
   if (!notifications?.length) return []
@@ -86,13 +102,24 @@ export default function Notifications() {
             )
           }
 
-          return (
+          const href = getNotificationHref(item)
+          const notification = (
             <Notification
               type={item.type}
               payload={item.payload}
               createdAt={item.created_at}
               style={{ marginBottom: theme.spacing['spacing-16'] }}
             />
+          )
+
+          if (!href) {
+            return notification
+          }
+
+          return (
+            <Link href={href} asChild>
+              <Touchable>{notification}</Touchable>
+            </Link>
           )
         }}
         contentContainerStyle={{

--- a/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
@@ -1,3 +1,4 @@
+import { CustomField } from '@/components/CustomFields/CustomField'
 import { CustomerRow } from '@/components/Customers/CustomerRow'
 import { Box } from '@/components/Shared/Box'
 import { DetailRow, Details } from '@/components/Shared/Details'
@@ -7,8 +8,6 @@ import { Touchable } from '@/components/Shared/Touchable'
 import { useTheme } from '@/design-system/useTheme'
 import { useCustomFields } from '@/hooks/polar/custom_fields'
 import { useOrder } from '@/hooks/polar/orders'
-import MaterialIcons from '@expo/vector-icons/MaterialIcons'
-import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import * as Clipboard from 'expo-clipboard'
 import { Stack, useLocalSearchParams } from 'expo-router'
@@ -21,43 +20,6 @@ const statusColors = {
   partially_refunded: 'blue',
   void: 'red',
 } as const
-
-const numberFormat = new Intl.NumberFormat(undefined, {})
-
-const formatCustomFieldValue = (
-  field: schemas['CustomField'],
-  value: string | number | boolean | null | undefined,
-  iconColor: string,
-): React.ReactNode => {
-  if (value === undefined || value === null) {
-    return '—'
-  }
-
-  switch (field.type) {
-    case 'number':
-      return numberFormat.format(value as number)
-    case 'date':
-      return new Date(value as string).toLocaleDateString('en-US', {
-        dateStyle: 'medium',
-      })
-    case 'checkbox':
-      return (
-        <MaterialIcons
-          name={value === true ? 'check' : 'close'}
-          size={16}
-          color={iconColor}
-        />
-      )
-    case 'select':
-      return (
-        field.properties.options.find((option) => option.value === value)
-          ?.label ?? String(value)
-      )
-    case 'text':
-    default:
-      return String(value)
-  }
-}
 
 export default function Index() {
   const { id } = useLocalSearchParams()
@@ -257,19 +219,20 @@ export default function Index() {
           <Text variant="subtitle" marginBottom="spacing-8">
             Custom Fields
           </Text>
-          <Details>
+          <Box
+            backgroundColor="card"
+            padding="spacing-16"
+            borderRadius="border-radius-12"
+            gap="spacing-16"
+          >
             {customFields.items.map((field) => (
-              <DetailRow
+              <CustomField
                 key={field.id}
-                label={field.name}
-                value={formatCustomFieldValue(
-                  field,
-                  order.custom_field_data?.[field.slug],
-                  theme.colors.text,
-                )}
+                field={field}
+                value={order.custom_field_data?.[field.slug]}
               />
             ))}
-          </Details>
+          </Box>
         </Box>
       ) : null}
 

--- a/clients/apps/app/components/CustomFields/CustomField.tsx
+++ b/clients/apps/app/components/CustomFields/CustomField.tsx
@@ -1,0 +1,80 @@
+import { Box } from '@/components/Shared/Box'
+import { Text } from '@/components/Shared/Text'
+import { Touchable } from '@/components/Shared/Touchable'
+import { useTheme } from '@/design-system/useTheme'
+import { useToast } from '@/providers/ToastProvider'
+import MaterialIcons from '@expo/vector-icons/MaterialIcons'
+import { schemas } from '@polar-sh/client'
+import * as Clipboard from 'expo-clipboard'
+
+const numberFormat = new Intl.NumberFormat(undefined, {})
+
+type CustomFieldValueType = string | number | boolean | null | undefined
+
+interface Props {
+  field: schemas['CustomField']
+  value: CustomFieldValueType
+}
+
+export const CustomField = ({ field, value }: Props) => {
+  const theme = useTheme()
+  const toast = useToast()
+
+  const renderValue = () => {
+    if (value === undefined || value === null) {
+      return <Text>—</Text>
+    }
+
+    if (field.type === 'checkbox') {
+      return (
+        <MaterialIcons
+          color={theme.colors.text}
+          name={value === true ? 'check' : 'close'}
+          size={16}
+        />
+      )
+    }
+
+    const text = formatText(field, value)
+
+    return (
+      <Touchable
+        onPress={() => {
+          Clipboard.setStringAsync(text)
+          toast.showInfo('Copied to clipboard')
+        }}
+      >
+        <Text>{text}</Text>
+      </Touchable>
+    )
+  }
+
+  return (
+    <Box gap="spacing-4">
+      <Text color="subtext">{field.name}</Text>
+      {renderValue()}
+    </Box>
+  )
+}
+
+const formatText = (
+  field: schemas['CustomField'],
+  value: Exclude<CustomFieldValueType, null | undefined>,
+): string => {
+  switch (field.type) {
+    case 'number':
+      return numberFormat.format(value as number)
+    case 'date':
+      return new Date(value as string).toLocaleDateString('en-US', {
+        dateStyle: 'medium',
+      })
+    case 'select':
+      return (
+        field.properties.options.find((option) => option.value === value)
+          ?.label ?? String(value)
+      )
+    case 'text':
+    default:
+      return String(value)
+  }
+}


### PR DESCRIPTION
This PR will:

* Link to the order/subscription in our in-app notification list
* Update the layout for custom fields, and add copy-to-clipboard functionality

| Notifications pressable | Update custom field layout  |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-22 at 16 00 20" src="https://github.com/user-attachments/assets/2082f4b2-111b-4ec6-8c61-345e042321ca" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-22 at 16 00 13" src="https://github.com/user-attachments/assets/364ac7e0-5b7f-4a83-850f-4d1c7e1b08b2" /> |








