### PR TITLE
events: Simplify parent resolution and move it to worker

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ColumnExpressionArgument,
     Numeric,
     Select,
+    String,
     UnaryExpression,
     and_,
     asc,
@@ -23,6 +24,7 @@ from sqlalchemy import (
     or_,
     select,
     text,
+    update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
 from sqlalchemy.orm import aliased, joinedload
@@ -68,35 +70,11 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         if not events:
             return [], 0
 
-        events_needing_parent_lookup = []
-
-        # Set root_id for root events before insertion
         for event in events:
-            if event.get("root_id") is not None:
-                continue
-            elif event.get("parent_id") is None:
-                if event.get("id") is None:
-                    event["id"] = generate_uuid()
+            if event.get("id") is None:
+                event["id"] = generate_uuid()
+            if event.get("pending_parent_external_id") is None:
                 event["root_id"] = event["id"]
-            else:
-                # Child event without root_id - needs to be looked up from parent
-                # This is a fail-safe in the event that we did not set this before calling
-                # insert_batch
-                events_needing_parent_lookup.append(event)
-
-        # Look up root_id from parents for events that need it
-        if events_needing_parent_lookup:
-            parent_ids = {event["parent_id"] for event in events_needing_parent_lookup}
-            result = await self.session.execute(
-                select(Event.id, Event.root_id).where(Event.id.in_(parent_ids))
-            )
-            parent_root_map = {
-                parent_id: root_id or parent_id for parent_id, root_id in result
-            }
-
-            for event in events_needing_parent_lookup:
-                parent_id = event["parent_id"]
-                event["root_id"] = parent_root_map.get(parent_id, parent_id)
 
         statement = (
             insert(Event)
@@ -109,6 +87,150 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         duplicates_count = len(events) - len(inserted_ids)
 
         return inserted_ids, duplicates_count
+
+    async def resolve_pending_parents(
+        self, inserted_ids: Sequence[UUID]
+    ) -> Sequence[UUID]:
+        """
+        Resolve pending parents and propagate root_id for events affected by
+        the just-inserted batch. Returns the IDs of events whose root_id was
+        just set (chain now reaches a real root).
+
+        All work is scoped to the batch — only edges with one side in the
+        batch can be newly resolvable.
+
+        Step 1: link parent_id wherever a pending ref now matches a parent
+        row. Run as four UPDATEs to keep each plan cleanly indexed:
+          1a — child in batch, parent in DB, ref by external_id
+          1b — parent in batch, child pending in DB, ref by external_id
+          1c — child in batch, parent in DB, ref by UUID string
+          1d — parent in batch, child pending in DB, ref by UUID string
+
+        Step 2: walk UP from each batch event to find its root_id, then walk
+        DOWN to descendants. Bounded by `batch × (chain depth + descendant
+        subtree)` — never expands the forest.
+
+        Note: walk_down also propagates root_id into pre-existing descendants
+        of a batch event — i.e. an old orphan chain that was sitting in the DB
+        waiting for an ancestor that just arrived in this batch. Those IDs flow
+        through RETURNING, so the result can include events that weren't in
+        inserted_ids.
+        """
+        if not inserted_ids:
+            return []
+
+        parent_1a = Event.__table__.alias("parent_1a")
+        await self.session.execute(
+            update(Event)
+            .values(parent_id=parent_1a.c.id, pending_parent_external_id=None)
+            .where(
+                Event.organization_id == parent_1a.c.organization_id,
+                Event.pending_parent_external_id == parent_1a.c.external_id,
+                Event.id.in_(inserted_ids),
+            )
+        )
+
+        parent_1b = Event.__table__.alias("parent_1b")
+        await self.session.execute(
+            update(Event)
+            .values(parent_id=parent_1b.c.id, pending_parent_external_id=None)
+            .where(
+                Event.organization_id == parent_1b.c.organization_id,
+                Event.pending_parent_external_id.is_not(None),
+                Event.pending_parent_external_id == parent_1b.c.external_id,
+                parent_1b.c.id.in_(inserted_ids),
+            )
+        )
+
+        batch_pending_rows = await self.session.execute(
+            select(Event.id, Event.pending_parent_external_id).where(
+                Event.id.in_(inserted_ids),
+                Event.pending_parent_external_id.is_not(None),
+            )
+        )
+        uuid_pending_in_batch: list[UUID] = []
+        for event_id, pending_ref in batch_pending_rows.all():
+            try:
+                UUID(pending_ref)
+            except (ValueError, TypeError):
+                continue
+            uuid_pending_in_batch.append(event_id)
+
+        if uuid_pending_in_batch:
+            parent_1c = Event.__table__.alias("parent_1c")
+            await self.session.execute(
+                update(Event)
+                .values(parent_id=parent_1c.c.id, pending_parent_external_id=None)
+                .where(
+                    Event.organization_id == parent_1c.c.organization_id,
+                    cast(Event.pending_parent_external_id, SA_UUID) == parent_1c.c.id,
+                    Event.id.in_(uuid_pending_in_batch),
+                )
+            )
+
+        # Pending refs are matched against the canonical lowercase string of
+        # batch ids; non-canonical (e.g. uppercase) refs won't link here, but
+        # `str(uuid.uuid4())` is always lowercase and that's what callers emit.
+        parent_1d = Event.__table__.alias("parent_1d")
+        await self.session.execute(
+            update(Event)
+            .values(parent_id=parent_1d.c.id, pending_parent_external_id=None)
+            .where(
+                Event.organization_id == parent_1d.c.organization_id,
+                Event.pending_parent_external_id.is_not(None),
+                Event.pending_parent_external_id == cast(parent_1d.c.id, String),
+                parent_1d.c.id.in_(inserted_ids),
+            )
+        )
+
+        walk_up_anchor = select(
+            Event.id.label("seed"),
+            Event.id.label("cur"),
+            Event.parent_id.label("parent_id"),
+            Event.root_id.label("root_id"),
+        ).where(Event.id.in_(inserted_ids))
+        walk_up = walk_up_anchor.cte("walk_up", recursive=True)
+
+        p_up = Event.__table__.alias("p_up")
+        walk_up = walk_up.union_all(
+            select(
+                walk_up.c.seed,
+                p_up.c.id,
+                p_up.c.parent_id,
+                p_up.c.root_id,
+            )
+            .select_from(walk_up.join(p_up, p_up.c.id == walk_up.c.parent_id))
+            .where(walk_up.c.root_id.is_(None))
+        )
+
+        walk_down_anchor = select(
+            walk_up.c.seed.label("cur"),
+            walk_up.c.root_id.label("root_id"),
+        ).where(walk_up.c.root_id.is_not(None))
+        walk_down = walk_down_anchor.cte("walk_down", recursive=True)
+
+        c_down = Event.__table__.alias("c_down")
+        walk_down = walk_down.union_all(
+            select(c_down.c.id, walk_down.c.root_id).select_from(
+                walk_down.join(c_down, c_down.c.parent_id == walk_down.c.cur)
+            )
+        )
+
+        propagate_root = (
+            update(Event)
+            .add_cte(walk_up, walk_down)
+            .values(root_id=walk_down.c.root_id)
+            .where(
+                Event.id == walk_down.c.cur,
+                or_(
+                    Event.root_id.is_(None),
+                    Event.root_id != walk_down.c.root_id,
+                ),
+            )
+            .returning(Event.id)
+        )
+        result = await self.session.execute(propagate_root)
+        return [row[0] for row in result.all()]
 
     async def get_latest_meter_reset(
         self, customer: Customer, meter_id: UUID

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -50,7 +50,7 @@ from .system import SystemEvent
 # Real chains are tens at most; this exists purely to bail out if a cycle
 # (A.parent_id → B → A) ever sneaks into the data, instead of spinning until
 # statement_timeout kills the worker.
-_MAX_RESOLVE_DEPTH = 1000
+_MAX_RESOLVE_DEPTH = 100
 
 
 class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -108,23 +108,25 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         Step 1: link parent_id wherever a pending ref now matches a parent
         row. Run as four UPDATEs to keep each plan cleanly indexed:
           1a — child in batch, parent in DB, ref by external_id
+          1c — child in batch, parent in DB, ref by Polar ID (UUID)
           1b — parent in batch, child pending in DB, ref by external_id
-          1c — child in batch, parent in DB, ref by UUID string
-          1d — parent in batch, child pending in DB, ref by UUID string
+          1d — parent in batch, child pending in DB, ref by Polar ID (UUID)
 
-        Step 2: walk UP from each batch event to find its root_id, then walk
-        DOWN to descendants. Bounded by `batch × (chain depth + descendant
-        subtree)` — never expands the forest.
-
-        Note: walk_down also propagates root_id into pre-existing descendants
-        of a batch event — i.e. an old orphan chain that was sitting in the DB
-        waiting for an ancestor that just arrived in this batch. Those IDs flow
-        through RETURNING, so the result can include events that weren't in
-        inserted_ids.
+        Step 2: propagate root_id along parent_id edges with a single
+        iterative UPDATE. Each round roots every event whose immediate
+        parent is already rooted. Starting frontier = the batch; each
+        subsequent round shifts the frontier to the events just rooted,
+        so the scope stays bounded and we only touch relevant descendants.
+        This covers both directions in one pass: batch events inherit
+        root_id from rooted ancestors, and DB orphans inherit it from
+        ancestors that just arrived in this batch.
         """
         if not inserted_ids:
             return []
 
+        # parent_1a, parent_1b, parent_1c, parent_1d
+        # are all four ways we can resolve pending_parent_id to parent_id
+        # (pointing to a internal event ID).
         parent_1a = Event.__table__.alias("parent_1a")
         await self.session.execute(
             update(Event)
@@ -133,18 +135,6 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 Event.organization_id == parent_1a.c.organization_id,
                 Event.pending_parent_external_id == parent_1a.c.external_id,
                 Event.id.in_(inserted_ids),
-            )
-        )
-
-        parent_1b = Event.__table__.alias("parent_1b")
-        await self.session.execute(
-            update(Event)
-            .values(parent_id=parent_1b.c.id, pending_parent_external_id=None)
-            .where(
-                Event.organization_id == parent_1b.c.organization_id,
-                Event.pending_parent_external_id.is_not(None),
-                Event.pending_parent_external_id == parent_1b.c.external_id,
-                parent_1b.c.id.in_(inserted_ids),
             )
         )
 
@@ -163,16 +153,28 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             uuid_pending_in_batch.append(event_id)
 
         if uuid_pending_in_batch:
-            parent_1c = Event.__table__.alias("parent_1c")
+            parent_1b = Event.__table__.alias("parent_1b")
             await self.session.execute(
                 update(Event)
-                .values(parent_id=parent_1c.c.id, pending_parent_external_id=None)
+                .values(parent_id=parent_1b.c.id, pending_parent_external_id=None)
                 .where(
-                    Event.organization_id == parent_1c.c.organization_id,
-                    cast(Event.pending_parent_external_id, SA_UUID) == parent_1c.c.id,
+                    Event.organization_id == parent_1b.c.organization_id,
+                    cast(Event.pending_parent_external_id, SA_UUID) == parent_1b.c.id,
                     Event.id.in_(uuid_pending_in_batch),
                 )
             )
+
+        parent_1c = Event.__table__.alias("parent_1c")
+        await self.session.execute(
+            update(Event)
+            .values(parent_id=parent_1c.c.id, pending_parent_external_id=None)
+            .where(
+                Event.organization_id == parent_1c.c.organization_id,
+                Event.pending_parent_external_id.is_not(None),
+                Event.pending_parent_external_id == parent_1c.c.external_id,
+                parent_1c.c.id.in_(inserted_ids),
+            )
+        )
 
         # Pending refs are matched against the canonical lowercase string of
         # batch ids; non-canonical (e.g. uppercase) refs won't link here, but
@@ -189,64 +191,30 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             )
         )
 
-        walk_up_anchor = select(
-            Event.id.label("seed"),
-            Event.id.label("cur"),
-            Event.parent_id.label("parent_id"),
-            Event.root_id.label("root_id"),
-            literal(0).label("depth"),
-        ).where(Event.id.in_(inserted_ids))
-        walk_up = walk_up_anchor.cte("walk_up", recursive=True)
-
-        p_up = Event.__table__.alias("p_up")
-        walk_up = walk_up.union_all(
-            select(
-                walk_up.c.seed,
-                p_up.c.id,
-                p_up.c.parent_id,
-                p_up.c.root_id,
-                (walk_up.c.depth + 1).label("depth"),
-            )
-            .select_from(walk_up.join(p_up, p_up.c.id == walk_up.c.parent_id))
-            .where(
-                walk_up.c.root_id.is_(None),
-                walk_up.c.depth < _MAX_RESOLVE_DEPTH,
-            )
-        )
-
-        walk_down_anchor = select(
-            walk_up.c.seed.label("cur"),
-            walk_up.c.root_id.label("root_id"),
-            literal(0).label("depth"),
-        ).where(walk_up.c.root_id.is_not(None))
-        walk_down = walk_down_anchor.cte("walk_down", recursive=True)
-
-        c_down = Event.__table__.alias("c_down")
-        walk_down = walk_down.union_all(
-            select(
-                c_down.c.id,
-                walk_down.c.root_id,
-                (walk_down.c.depth + 1).label("depth"),
-            )
-            .select_from(walk_down.join(c_down, c_down.c.parent_id == walk_down.c.cur))
-            .where(walk_down.c.depth < _MAX_RESOLVE_DEPTH)
-        )
-
-        propagate_root = (
-            update(Event)
-            .add_cte(walk_up, walk_down)
-            .values(root_id=walk_down.c.root_id)
-            .where(
-                Event.id == walk_down.c.cur,
-                or_(
+        frontier: set[UUID] = set(inserted_ids)
+        newly_rooted: list[UUID] = []
+        for _ in range(_MAX_RESOLVE_DEPTH):
+            if not frontier:
+                break
+            parent_alias = Event.__table__.alias("p_root")
+            result = await self.session.execute(
+                update(Event)
+                .values(root_id=parent_alias.c.root_id)
+                .where(
+                    or_(Event.id.in_(frontier), Event.parent_id.in_(frontier)),
                     Event.root_id.is_(None),
-                    Event.root_id != walk_down.c.root_id,
-                ),
+                    Event.parent_id == parent_alias.c.id,
+                    parent_alias.c.root_id.is_not(None),
+                )
+                .returning(Event.id)
             )
-            .returning(Event.id)
-        )
-        result = await self.session.execute(propagate_root)
-        return [row[0] for row in result.all()]
+            newly = [row[0] for row in result.all()]
+            if not newly:
+                break
+            newly_rooted.extend(newly)
+            frontier = set(newly)
+
+        return newly_rooted
 
     async def get_latest_meter_reset(
         self, customer: Customer, meter_id: UUID

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -46,6 +46,12 @@ from polar.models.product_price import ProductPriceMeteredUnit
 
 from .system import SystemEvent
 
+# Hard cap on parent_id chain depth traversed by resolve_pending_parents.
+# Real chains are tens at most; this exists purely to bail out if a cycle
+# (A.parent_id → B → A) ever sneaks into the data, instead of spinning until
+# statement_timeout kills the worker.
+_MAX_RESOLVE_DEPTH = 1000
+
 
 class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
     model = Event
@@ -188,6 +194,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             Event.id.label("cur"),
             Event.parent_id.label("parent_id"),
             Event.root_id.label("root_id"),
+            literal(0).label("depth"),
         ).where(Event.id.in_(inserted_ids))
         walk_up = walk_up_anchor.cte("walk_up", recursive=True)
 
@@ -198,22 +205,31 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 p_up.c.id,
                 p_up.c.parent_id,
                 p_up.c.root_id,
+                (walk_up.c.depth + 1).label("depth"),
             )
             .select_from(walk_up.join(p_up, p_up.c.id == walk_up.c.parent_id))
-            .where(walk_up.c.root_id.is_(None))
+            .where(
+                walk_up.c.root_id.is_(None),
+                walk_up.c.depth < _MAX_RESOLVE_DEPTH,
+            )
         )
 
         walk_down_anchor = select(
             walk_up.c.seed.label("cur"),
             walk_up.c.root_id.label("root_id"),
+            literal(0).label("depth"),
         ).where(walk_up.c.root_id.is_not(None))
         walk_down = walk_down_anchor.cte("walk_down", recursive=True)
 
         c_down = Event.__table__.alias("c_down")
         walk_down = walk_down.union_all(
-            select(c_down.c.id, walk_down.c.root_id).select_from(
-                walk_down.join(c_down, c_down.c.parent_id == walk_down.c.cur)
+            select(
+                c_down.c.id,
+                walk_down.c.root_id,
+                (walk_down.c.depth + 1).label("depth"),
             )
+            .select_from(walk_down.join(c_down, c_down.c.parent_id == walk_down.c.cur))
+            .where(walk_down.c.depth < _MAX_RESOLVE_DEPTH)
         )
 
         propagate_root = (

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -914,16 +914,6 @@ class EventService:
         repository = EventRepository.from_session(session)
         event_ids, duplicates_count = await repository.insert_batch(events)
 
-        resolved_ids = set(await repository.resolve_pending_parents(event_ids))
-        pending_ids = {
-            event_dict["id"]
-            for event_dict in events
-            if event_dict.get("pending_parent_external_id")
-        }
-        ready_ids = [eid for eid in event_ids if eid not in pending_ids] + list(
-            resolved_ids
-        )
-
         # Temporarily: fetch inserted events and create meter_events
         with logfire.span("create_meter_events", event_count=len(event_ids)):
             if event_ids:
@@ -932,7 +922,10 @@ class EventService:
                 )
                 await self._create_meter_events(session, inserted_events)
 
-        enqueue_events(*ready_ids)
+        # Parent resolution and root_id propagation run out-of-band in the
+        # `event.ingested` task — they're not needed on the request path and
+        # can be slow under contention.
+        enqueue_events(*event_ids)
 
         return EventsIngestResponse(
             inserted=len(event_ids), duplicates=duplicates_count
@@ -964,14 +957,32 @@ class EventService:
     async def ingested(
         self, session: AsyncSession, event_ids: Sequence[uuid.UUID]
     ) -> None:
-        ancestors_by_event = await self._build_ancestors_batch(session, event_ids)
         repository = EventRepository.from_session(session)
+
+        # Resolve parent links and propagate root_id here so it's off the
+        # ingestion hot path. `resolved_ids` includes pre-existing orphan
+        # events whose root_id was just set because an ancestor arrived in
+        # this batch — they also need downstream processing.
+        resolved_ids = await repository.resolve_pending_parents(event_ids)
+        candidate_ids = {*event_ids, *resolved_ids}
+        if not candidate_ids:
+            return
+
+        # Only process events whose chain is complete (root_id set). Events
+        # still pending a parent stay out of Tinybird/meters until a future
+        # batch resolves their root.
         statement = (
             repository.get_base_statement()
-            .where(Event.id.in_(event_ids))
+            .where(Event.id.in_(candidate_ids), Event.root_id.is_not(None))
             .options(*repository.get_eager_options())
         )
         events = await repository.get_all(statement)
+        if not events:
+            return
+
+        complete_ids = [event.id for event in events]
+        ancestors_by_event = await self._build_ancestors_batch(session, complete_ids)
+
         customers: set[Customer] = set()
         organization_ids: set[uuid.UUID] = set()
         for event in events:
@@ -988,15 +999,14 @@ class EventService:
         # await self._create_meter_events(session, events)
 
         await self._activate_matching_customer_meters(
-            session, repository, event_ids, customers
+            session, repository, complete_ids, customers
         )
 
         for customer in customers:
             enqueue_job("customer_meter.update_customer", customer.id)
 
-        if events:
-            tinybird_events = events_to_tinybird(events, ancestors_by_event)
-            enqueue_job("tinybird.ingest", tinybird_events)
+        tinybird_events = events_to_tinybird(events, ancestors_by_event)
+        enqueue_job("tinybird.ingest", tinybird_events)
 
         polar_self_service.enqueue_event_ingestion(events)
 

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -1,5 +1,4 @@
 import uuid
-from collections import defaultdict, deque
 from collections.abc import Callable, Mapping, Sequence
 from datetime import date, datetime
 from decimal import Decimal
@@ -79,55 +78,6 @@ class EventIngestValidationError(EventError):
     def __init__(self, errors: list[ValidationError]) -> None:
         self.errors = errors
         super().__init__("Event ingest validation failed.")
-
-
-def _topological_sort_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """
-    Sort events by dependency order so parents come before children.
-    Events without parents come first, followed by their children in order.
-
-    Handles parent_id references that can be either Polar IDs or external_id strings.
-    Uses Kahn's algorithm for topological sorting.
-    """
-    if not events:
-        return []
-
-    id_to_index: dict[uuid.UUID | str, int] = {}
-    for idx, event in enumerate(events):
-        if "id" in event:
-            id_to_index[event["id"]] = idx
-        if "external_id" in event and event["external_id"] is not None:
-            id_to_index[event["external_id"]] = idx
-
-    graph: dict[int, list[int]] = defaultdict(list)
-    in_degree: dict[int, int] = {}
-
-    for idx in range(len(events)):
-        in_degree[idx] = 0
-
-    for idx, event in enumerate(events):
-        parent_id = event.get("parent_id")
-        if parent_id and parent_id in id_to_index:
-            parent_idx = id_to_index[parent_id]
-            graph[parent_idx].append(idx)
-            in_degree[idx] += 1
-
-    queue = deque(idx for idx in range(len(events)) if in_degree[idx] == 0)
-    sorted_indices: list[int] = []
-
-    while queue:
-        current_idx = queue.popleft()
-        sorted_indices.append(current_idx)
-
-        for child_idx in graph[current_idx]:
-            in_degree[child_idx] -= 1
-            if in_degree[child_idx] == 0:
-                queue.append(child_idx)
-
-    if len(sorted_indices) != len(events):
-        raise EventError("Circular dependency detected in event parent relationships")
-
-    return [events[idx] for idx in sorted_indices]
 
 
 class EventService:
@@ -923,126 +873,56 @@ class EventService:
         event_type_repository = EventTypeRepository.from_session(session)
         event_types_cache: dict[tuple[str, uuid.UUID], uuid.UUID] = {}
 
-        batch_external_id_map: dict[str, uuid.UUID] = {}
-        for event_create in ingest.events:
-            if event_create.external_id is not None:
-                batch_external_id_map[event_create.external_id] = uuid.uuid4()
-
-        # Build lightweight event metadata for sorting
-        event_metadata: list[dict[str, Any]] = []
-        for index, event_create in enumerate(ingest.events):
-            metadata: dict[str, Any] = {
-                "index": index,
-                "external_id": event_create.external_id,
-                "parent_id": event_create.parent_id,
-            }
-            if event_create.external_id:
-                metadata["id"] = batch_external_id_map[event_create.external_id]
-            event_metadata.append(metadata)
-
-        with logfire.span("topological_sort", event_count=len(event_metadata)):
-            sorted_metadata = _topological_sort_events(event_metadata)
-
-        # Process events in sorted order
         events: list[dict[str, Any]] = []
         errors: list[ValidationError] = []
-        processed_events: dict[uuid.UUID, dict[str, Any]] = {}
+        for index, event_create in enumerate(ingest.events):
+            try:
+                organization_id = validate_organization_id(
+                    index, event_create.organization_id
+                )
+                if isinstance(event_create, EventCreateCustomer):
+                    validate_customer_id(index, event_create.customer_id)
+                    if event_create.member_id is not None:
+                        validate_member_id(index, event_create.member_id)
 
-        with logfire.span("process_events", event_count=len(sorted_metadata)):
-            # Events needs to be sorted here primarily for the purpose of root id
-            # resolution. Hierarchical events with parent_id in the same batch should
-            # get the same root id assigned.
-            for metadata in sorted_metadata:
-                index = metadata["index"]
-                event_create = ingest.events[index]
-
-                try:
-                    organization_id = validate_organization_id(
-                        index, event_create.organization_id
+                event_label_cache_key = (event_create.name, organization_id)
+                if event_label_cache_key not in event_types_cache:
+                    event_type = await event_type_repository.get_or_create(
+                        event_create.name, organization_id
                     )
-                    if isinstance(event_create, EventCreateCustomer):
-                        validate_customer_id(index, event_create.customer_id)
-                        if event_create.member_id is not None:
-                            validate_member_id(index, event_create.member_id)
+                    event_types_cache[event_label_cache_key] = event_type.id
+                event_type_id = event_types_cache[event_label_cache_key]
+            except EventIngestValidationError as e:
+                errors.extend(e.errors)
+                continue
 
-                    parent_event: Event | None = None
-                    parent_id_in_batch: uuid.UUID | None = None
-                    if event_create.parent_id is not None:
-                        parent_event, parent_id_in_batch = await self._resolve_parent(
-                            session,
-                            index,
-                            event_create.parent_id,
-                            organization_id,
-                            batch_external_id_map,
-                        )
+            event_dict = event_create.model_dump(
+                exclude={"organization_id", "parent_id"}, by_alias=True
+            )
+            event_dict["source"] = EventSource.user
+            event_dict["organization_id"] = organization_id
+            event_dict["event_type_id"] = event_type_id
 
-                    event_label_cache_key = (event_create.name, organization_id)
-                    if event_label_cache_key not in event_types_cache:
-                        event_type = await event_type_repository.get_or_create(
-                            event_create.name, organization_id
-                        )
-                        event_types_cache[event_label_cache_key] = event_type.id
-                    event_type_id = event_types_cache[event_label_cache_key]
-                except EventIngestValidationError as e:
-                    errors.extend(e.errors)
-                    continue
-                else:
-                    event_dict = event_create.model_dump(
-                        exclude={"organization_id", "parent_id"}, by_alias=True
-                    )
-                    event_dict["source"] = EventSource.user
-                    event_dict["organization_id"] = organization_id
-                    event_dict["event_type_id"] = event_type_id
+            if event_create.parent_id is not None:
+                event_dict["pending_parent_external_id"] = event_create.parent_id
 
-                    if event_create.external_id is not None:
-                        event_dict["id"] = batch_external_id_map[
-                            event_create.external_id
-                        ]
-
-                    if parent_event is not None:
-                        event_dict["parent_id"] = parent_event.id
-                        event_dict["root_id"] = parent_event.root_id or parent_event.id
-                        if (
-                            not event_dict.get("customer_id")
-                            and parent_event.customer_id
-                        ):
-                            event_dict["customer_id"] = parent_event.customer_id
-                        if (
-                            not event_dict.get("external_customer_id")
-                            and parent_event.external_customer_id
-                        ):
-                            event_dict["external_customer_id"] = (
-                                parent_event.external_customer_id
-                            )
-                    elif parent_id_in_batch is not None:
-                        event_dict["parent_id"] = parent_id_in_batch
-                        # Parent was already processed, look it up
-                        parent_dict = processed_events.get(parent_id_in_batch)
-                        if parent_dict:
-                            event_dict["root_id"] = parent_dict.get(
-                                "root_id", parent_id_in_batch
-                            )
-                            if not event_dict.get("customer_id") and parent_dict.get(
-                                "customer_id"
-                            ):
-                                event_dict["customer_id"] = parent_dict["customer_id"]
-                            if not event_dict.get(
-                                "external_customer_id"
-                            ) and parent_dict.get("external_customer_id"):
-                                event_dict["external_customer_id"] = parent_dict[
-                                    "external_customer_id"
-                                ]
-
-                    events.append(event_dict)
-                    if event_dict.get("id"):
-                        processed_events[event_dict["id"]] = event_dict
+            events.append(event_dict)
 
         if len(errors) > 0:
             raise PolarRequestValidationError(errors)
 
         repository = EventRepository.from_session(session)
-        with logfire.span("insert_batch", event_count=len(events)):
-            event_ids, duplicates_count = await repository.insert_batch(events)
+        event_ids, duplicates_count = await repository.insert_batch(events)
+
+        resolved_ids = set(await repository.resolve_pending_parents(event_ids))
+        pending_ids = {
+            event_dict["id"]
+            for event_dict in events
+            if event_dict.get("pending_parent_external_id")
+        }
+        ready_ids = [eid for eid in event_ids if eid not in pending_ids] + list(
+            resolved_ids
+        )
 
         # Temporarily: fetch inserted events and create meter_events
         with logfire.span("create_meter_events", event_count=len(event_ids)):
@@ -1052,8 +932,7 @@ class EventService:
                 )
                 await self._create_meter_events(session, inserted_events)
 
-        with logfire.span("enqueue_events", event_count=len(event_ids)):
-            enqueue_events(*event_ids)
+        enqueue_events(*ready_ids)
 
         return EventsIngestResponse(
             inserted=len(event_ids), duplicates=duplicates_count
@@ -1386,58 +1265,6 @@ class EventService:
             return member_id
 
         return _validate_member_id
-
-    async def _resolve_parent(
-        self,
-        session: AsyncSession,
-        index: int,
-        parent_id: str,
-        organization_id: uuid.UUID,
-        batch_external_id_map: dict[str, uuid.UUID],
-    ) -> tuple[Event | None, uuid.UUID | None]:
-        """
-        Resolve and return the parent event.
-        Returns a tuple of (parent_event_from_db, parent_id_from_batch).
-        Only one of these will be set - if the parent is in the current batch,
-        parent_id_from_batch will be set. Otherwise, parent_event_from_db will be set.
-        """
-        # Check if parent is in current batch
-        if parent_id in batch_external_id_map:
-            return None, batch_external_id_map[parent_id]
-
-        # Look up parent in database by ID or external_id
-        try:
-            parent_uuid = uuid.UUID(parent_id)
-        except ValueError:
-            parent_uuid = None
-
-        if parent_uuid:
-            statement = select(Event).where(
-                Event.organization_id == organization_id,
-                or_(Event.id == parent_uuid, Event.external_id == parent_id),
-            )
-        else:
-            statement = select(Event).where(
-                Event.organization_id == organization_id,
-                Event.external_id == parent_id,
-            )
-
-        result = await session.execute(statement)
-        parent_event = result.scalar_one_or_none()
-
-        if parent_event is not None:
-            return parent_event, None
-
-        raise EventIngestValidationError(
-            [
-                {
-                    "type": "parent_id",
-                    "msg": "Parent event not found.",
-                    "loc": ("body", "events", index, "parent_id"),
-                    "input": parent_id,
-                }
-            ]
-        )
 
     async def _get_organization_ids_for_subject(
         self,

--- a/server/tests/event/test_ancestors.py
+++ b/server/tests/event/test_ancestors.py
@@ -201,11 +201,13 @@ class TestGetAncestorsBatch:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        # Build ancestors (normally done by background worker)
+        # Parent resolution runs in the background `event.ingested` task; drive
+        # it here so `parent_id`/`root_id` are populated before assertions.
         id_result = await session.execute(
             select(Event.id).where(Event.organization_id == organization.id)
         )
         event_ids = [row[0] for row in id_result.all()]
+        await event_service.ingested(session, event_ids)
 
         repository = EventRepository.from_session(session)
         ancestors = await repository.get_ancestors_batch(event_ids)

--- a/server/tests/event/test_resolve_pending_parents.py
+++ b/server/tests/event/test_resolve_pending_parents.py
@@ -1,0 +1,387 @@
+import uuid
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from polar.event.repository import EventRepository
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Account, Event, Organization
+from polar.models.event import EventSource
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_organization
+
+
+def _make_event(
+    organization: Organization,
+    external_id: str,
+    *,
+    pending_parent_external_id: str | None = None,
+) -> dict[str, Any]:
+    event_id = uuid.uuid4()
+    return {
+        "id": event_id,
+        "name": f"event.{external_id}",
+        "source": EventSource.user,
+        "organization_id": organization.id,
+        "external_id": external_id,
+        "pending_parent_external_id": pending_parent_external_id,
+        "root_id": event_id if pending_parent_external_id is None else None,
+    }
+
+
+async def _get_events(
+    session: AsyncSession, organization: Organization
+) -> dict[str | None, Event]:
+    result = await session.execute(
+        select(Event).where(Event.organization_id == organization.id)
+    )
+    return {e.external_id: e for e in result.scalars().all()}
+
+
+async def _resolve(
+    repository: EventRepository, event_ids: Sequence[UUID]
+) -> list[UUID]:
+    return list(await repository.resolve_pending_parents(event_ids))
+
+
+@pytest.mark.asyncio
+class TestResolvePendingParents:
+    async def test_no_pending_events(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [_make_event(organization, "a"), _make_event(organization, "b")]
+        event_ids, _ = await repository.insert_batch(events)
+
+        resolved = await _resolve(repository, event_ids)
+
+        assert resolved == []
+
+    async def test_parent_and_child_in_same_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Child references parent, both in the same batch."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+            _make_event(organization, "parent"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        child = by_ext["child"]
+        parent = by_ext["parent"]
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+        assert child.pending_parent_external_id is None
+
+    async def test_three_level_hierarchy_in_same_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """root → child → grandchild, all in one batch, inserted in reverse order."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "grandchild", pending_parent_external_id="child"),
+            _make_event(organization, "child", pending_parent_external_id="root"),
+            _make_event(organization, "root"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 2
+        by_ext = await _get_events(session, organization)
+        root = by_ext["root"]
+        child = by_ext["child"]
+        grandchild = by_ext["grandchild"]
+
+        assert child.parent_id == root.id
+        assert child.root_id == root.id
+
+        assert grandchild.parent_id == child.id
+        assert grandchild.root_id == root.id
+
+    async def test_parent_already_in_db(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Parent was inserted in a previous batch, child arrives later."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: insert parent
+        parent_events = [_make_event(organization, "parent")]
+        await repository.insert_batch(parent_events)
+        await session.flush()
+
+        # Batch 2: insert child referencing parent
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+        ]
+        event_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        child = by_ext["child"]
+        parent = by_ext["parent"]
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+
+    async def test_child_arrives_before_parent_cross_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Child arrives first, stays pending. Parent arrives later, resolves it."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: child arrives, parent doesn't exist yet
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+        ]
+        child_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, child_ids)
+        assert resolved == []
+        await session.flush()
+
+        # Verify child is still pending
+        by_ext = await _get_events(session, organization)
+        assert by_ext["child"].pending_parent_external_id == "parent"
+        assert by_ext["child"].parent_id is None
+        assert by_ext["child"].root_id is None
+
+        # Batch 2: parent arrives, child should be resolved
+        parent_events = [_make_event(organization, "parent")]
+        parent_ids, _ = await repository.insert_batch(parent_events)
+        resolved = await _resolve(repository, parent_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        child = by_ext["child"]
+        parent = by_ext["parent"]
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+        assert child.pending_parent_external_id is None
+
+    async def test_deep_chain_cross_batch(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """
+        OTEL-like scenario: grandchild, child, root arrive in three separate batches.
+        grandchild and child stay pending until root arrives.
+        """
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: grandchild (both parent and root missing)
+        gc_events = [
+            _make_event(organization, "grandchild", pending_parent_external_id="child"),
+        ]
+        gc_ids, _ = await repository.insert_batch(gc_events)
+        resolved = await _resolve(repository, gc_ids)
+        assert resolved == []
+        await session.flush()
+
+        # Batch 2: child arrives (parent "root" still missing)
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="root"),
+        ]
+        child_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, child_ids)
+        # grandchild can't resolve yet because child is also pending
+        assert resolved == []
+        await session.flush()
+
+        # Batch 3: root arrives, entire chain should resolve
+        root_events = [_make_event(organization, "root")]
+        root_ids, _ = await repository.insert_batch(root_events)
+        resolved = await _resolve(repository, root_ids)
+
+        assert len(resolved) == 2
+        by_ext = await _get_events(session, organization)
+        root = by_ext["root"]
+        child = by_ext["child"]
+        grandchild = by_ext["grandchild"]
+
+        assert child.parent_id == root.id
+        assert child.root_id == root.id
+
+        assert grandchild.parent_id == child.id
+        assert grandchild.root_id == root.id
+
+    async def test_branching_hierarchy(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """
+        Root with two children, each with a grandchild.
+        All in one batch, out of order.
+        """
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "gc1", pending_parent_external_id="child1"),
+            _make_event(organization, "gc2", pending_parent_external_id="child2"),
+            _make_event(organization, "child2", pending_parent_external_id="root"),
+            _make_event(organization, "root"),
+            _make_event(organization, "child1", pending_parent_external_id="root"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 4
+        by_ext = await _get_events(session, organization)
+        root = by_ext["root"]
+
+        for child_ext in ("child1", "child2"):
+            child = by_ext[child_ext]
+            assert child.parent_id == root.id
+            assert child.root_id == root.id
+
+        assert by_ext["gc1"].parent_id == by_ext["child1"].id
+        assert by_ext["gc1"].root_id == root.id
+        assert by_ext["gc2"].parent_id == by_ext["child2"].id
+        assert by_ext["gc2"].root_id == root.id
+
+    async def test_partial_chain_does_not_resolve(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """
+        Grandchild is pending on child. Child arrives but is itself pending on
+        a missing root. Neither should resolve — the chain doesn't reach a root.
+        """
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        # Batch 1: grandchild, parent "child" doesn't exist yet
+        gc_events = [
+            _make_event(organization, "grandchild", pending_parent_external_id="child"),
+        ]
+        gc_ids, _ = await repository.insert_batch(gc_events)
+        resolved = await _resolve(repository, gc_ids)
+        assert resolved == []
+        await session.flush()
+
+        # Batch 2: child arrives, but its parent "root" is missing
+        child_events = [
+            _make_event(organization, "child", pending_parent_external_id="root"),
+        ]
+        child_ids, _ = await repository.insert_batch(child_events)
+        resolved = await _resolve(repository, child_ids)
+
+        assert resolved == []
+
+        by_ext = await _get_events(session, organization)
+        # Grandchild's parent_id is linked because the child row now exists,
+        # but root_id stays None because the chain doesn't reach a real root.
+        assert by_ext["grandchild"].pending_parent_external_id is None
+        assert by_ext["grandchild"].parent_id == by_ext["child"].id
+        assert by_ext["grandchild"].root_id is None
+
+        assert by_ext["child"].pending_parent_external_id == "root"
+        assert by_ext["child"].parent_id is None
+        assert by_ext["child"].root_id is None
+
+    async def test_parent_referenced_by_uuid(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Parent referenced by UUID string instead of external_id."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        parent_id = uuid.uuid4()
+        events = [
+            _make_event(
+                organization,
+                "child",
+                pending_parent_external_id=str(parent_id),
+            ),
+            {
+                "id": parent_id,
+                "name": "event.parent",
+                "source": EventSource.user,
+                "organization_id": organization.id,
+                "external_id": "parent",
+                "root_id": parent_id,
+            },
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        assert len(resolved) == 1
+        by_ext = await _get_events(session, organization)
+        assert by_ext["child"].parent_id == parent_id
+        assert by_ext["child"].root_id == parent_id
+
+    async def test_cross_org_isolation(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        account: Account,
+        account_second: Account,
+    ) -> None:
+        """Events in different orgs with same external_id don't cross-resolve."""
+        org1 = await create_organization(save_fixture, account)
+        org2 = await create_organization(save_fixture, account_second)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(org1, "child", pending_parent_external_id="parent"),
+            _make_event(org2, "parent"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        # Should NOT resolve — parent is in a different org
+        assert resolved == []
+        by_ext_org1 = await _get_events(session, org1)
+        assert by_ext_org1["child"].pending_parent_external_id == "parent"
+        assert by_ext_org1["child"].parent_id is None
+        assert by_ext_org1["child"].root_id is None
+
+    async def test_returns_only_newly_resolved_ids(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        """Return value contains only the IDs of events that were resolved."""
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+
+        events = [
+            _make_event(organization, "orphan", pending_parent_external_id="missing"),
+            _make_event(organization, "child", pending_parent_external_id="parent"),
+            _make_event(organization, "parent"),
+            _make_event(organization, "standalone"),
+        ]
+        event_ids, _ = await repository.insert_batch(events)
+        resolved = await _resolve(repository, event_ids)
+
+        by_ext = await _get_events(session, organization)
+        # Only child should be resolved
+        assert len(resolved) == 1
+        assert by_ext["child"].id in resolved
+
+        # Orphan stays pending
+        assert by_ext["orphan"].pending_parent_external_id == "missing"
+        assert by_ext["orphan"].parent_id is None
+        assert by_ext["orphan"].root_id is None
+
+        # Resolved child has correct root_id
+        parent = by_ext["parent"]
+        child = by_ext["child"]
+        assert child.root_id == parent.id
+
+        # Standalone root has root_id == self
+        standalone = by_ext["standalone"]
+        assert standalone.root_id == standalone.id

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -700,6 +700,7 @@ class TestIngest:
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_parent_child_same_batch(
         self,
+        enqueue_job_mock: MagicMock,
         enqueue_events_mock: AsyncMock,
         session: AsyncSession,
         auth_subject: AuthSubject[Organization],
@@ -727,6 +728,7 @@ class TestIngest:
         )
 
         await event_service.ingest(session, auth_subject, ingest)
+        await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
         events = await event_repository.get_all_by_organization(auth_subject.subject.id)
         assert len(events) == 3
@@ -757,6 +759,7 @@ class TestIngest:
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_parent_arrives_after_child_cross_batch(
         self,
+        enqueue_job_mock: MagicMock,
         enqueue_events_mock: AsyncMock,
         session: AsyncSession,
         auth_subject: AuthSubject[Organization],
@@ -773,6 +776,7 @@ class TestIngest:
             ]
         )
         await event_service.ingest(session, auth_subject, child_ingest)
+        await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
         events = await event_repository.get_all_by_organization(auth_subject.subject.id)
         assert len(events) == 1
@@ -790,6 +794,7 @@ class TestIngest:
             ]
         )
         await event_service.ingest(session, auth_subject, parent_ingest)
+        await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
         await session.refresh(child)
         events = await event_repository.get_all_by_organization(auth_subject.subject.id)
@@ -799,14 +804,25 @@ class TestIngest:
         assert child.root_id == parent.id
         assert child.pending_parent_external_id is None
 
+        # `enqueue_events` only carries the batch's freshly-inserted ids;
+        # orphan resolution happens inside `ingested`, not here.
         assert enqueue_events_mock.call_count == 2
-        second_call_args = set(enqueue_events_mock.call_args_list[1][0])
-        assert parent.id in second_call_args
-        assert child.id in second_call_args
+        assert set(enqueue_events_mock.call_args_list[0][0]) == {child.id}
+        assert set(enqueue_events_mock.call_args_list[1][0]) == {parent.id}
+
+        # The parent's `ingested` run resolves the child and sends both to
+        # Tinybird.
+        tinybird_calls = [
+            c for c in enqueue_job_mock.call_args_list if c.args[0] == "tinybird.ingest"
+        ]
+        assert len(tinybird_calls) == 1
+        tinybird_payload = tinybird_calls[0].args[1]
+        assert {tb["id"] for tb in tinybird_payload} == {str(parent.id), str(child.id)}
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_deep_chain_resolves_when_root_arrives_last(
         self,
+        enqueue_job_mock: MagicMock,
         enqueue_events_mock: AsyncMock,
         session: AsyncSession,
         auth_subject: AuthSubject[Organization],
@@ -831,6 +847,9 @@ class TestIngest:
                         ),
                     ]
                 ),
+            )
+            await event_service.ingested(
+                session, list(enqueue_events_mock.call_args[0])
             )
 
         events = await event_repository.get_all_by_organization(auth_subject.subject.id)
@@ -862,6 +881,7 @@ class TestIngest:
                 ]
             ),
         )
+        await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
         events = await event_repository.get_all_by_organization(auth_subject.subject.id)
         by_name = {e.name: e for e in events}
@@ -888,8 +908,24 @@ class TestIngest:
         assert ggc.root_id == p.id
         assert ggc.pending_parent_external_id is None
 
-        final_call_args = set(enqueue_events_mock.call_args_list[-1][0])
-        assert {p.id, c.id, gc.id, ggc.id} == final_call_args
+        # `enqueue_events` only carries the batch's freshly-inserted ids,
+        # so each call has exactly the one event from that batch.
+        assert enqueue_events_mock.call_count == 4
+        assert set(enqueue_events_mock.call_args_list[-1][0]) == {p.id}
+
+        # Resolution propagates inside `p`'s `ingested` run and pulls the
+        # whole orphan chain into the Tinybird payload.
+        last_tinybird_call = next(
+            c
+            for c in reversed(enqueue_job_mock.call_args_list)
+            if c.args[0] == "tinybird.ingest"
+        )
+        assert {tb["id"] for tb in last_tinybird_call.args[1]} == {
+            str(p.id),
+            str(c.id),
+            str(gc.id),
+            str(ggc.id),
+        }
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_ingest_with_member_id(

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -755,6 +755,143 @@ class TestIngest:
         }
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_parent_arrives_after_child_cross_batch(
+        self,
+        enqueue_events_mock: AsyncMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+    ) -> None:
+        event_repository = EventRepository.from_session(session)
+
+        child_ingest = EventsIngest(
+            events=[
+                EventCreateExternalCustomer(
+                    name="email_sent",
+                    external_customer_id="test-customer-123",
+                    parent_id="parent-event-123",
+                ),
+            ]
+        )
+        await event_service.ingest(session, auth_subject, child_ingest)
+
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        assert len(events) == 1
+        child = events[0]
+        assert child.parent_id is None
+        assert child.pending_parent_external_id == "parent-event-123"
+
+        parent_ingest = EventsIngest(
+            events=[
+                EventCreateExternalCustomer(
+                    name="support_request",
+                    external_customer_id="test-customer-123",
+                    external_id="parent-event-123",
+                ),
+            ]
+        )
+        await event_service.ingest(session, auth_subject, parent_ingest)
+
+        await session.refresh(child)
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        parent = next(e for e in events if e.name == "support_request")
+
+        assert child.parent_id == parent.id
+        assert child.root_id == parent.id
+        assert child.pending_parent_external_id is None
+
+        assert enqueue_events_mock.call_count == 2
+        second_call_args = set(enqueue_events_mock.call_args_list[1][0])
+        assert parent.id in second_call_args
+        assert child.id in second_call_args
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_deep_chain_resolves_when_root_arrives_last(
+        self,
+        enqueue_events_mock: AsyncMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+    ) -> None:
+        event_repository = EventRepository.from_session(session)
+
+        for name, external_id, parent_id in [
+            ("ggc", "ggc-id", "gc-id"),
+            ("gc", "gc-id", "c-id"),
+            ("c", "c-id", "p-id"),
+        ]:
+            await event_service.ingest(
+                session,
+                auth_subject,
+                EventsIngest(
+                    events=[
+                        EventCreateExternalCustomer(
+                            name=name,
+                            external_customer_id="test-customer-123",
+                            external_id=external_id,
+                            parent_id=parent_id,
+                        ),
+                    ]
+                ),
+            )
+
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        assert len(events) == 3
+        by_name = {e.name: e for e in events}
+        # ggc and gc are linked to their parent rows as those rows now exist,
+        # but root_id stays None until the real root arrives.
+        assert by_name["ggc"].parent_id == by_name["gc"].id
+        assert by_name["ggc"].pending_parent_external_id is None
+        assert by_name["ggc"].root_id is None
+        assert by_name["gc"].parent_id == by_name["c"].id
+        assert by_name["gc"].pending_parent_external_id is None
+        assert by_name["gc"].root_id is None
+        # c references "p-id" which doesn't exist yet.
+        assert by_name["c"].parent_id is None
+        assert by_name["c"].pending_parent_external_id == "p-id"
+        assert by_name["c"].root_id is None
+
+        await event_service.ingest(
+            session,
+            auth_subject,
+            EventsIngest(
+                events=[
+                    EventCreateExternalCustomer(
+                        name="p",
+                        external_customer_id="test-customer-123",
+                        external_id="p-id",
+                    ),
+                ]
+            ),
+        )
+
+        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        by_name = {e.name: e for e in events}
+        p = by_name["p"]
+        c = by_name["c"]
+        gc = by_name["gc"]
+        ggc = by_name["ggc"]
+
+        for e in events:
+            await session.refresh(e)
+
+        assert p.parent_id is None
+        assert p.root_id == p.id
+
+        assert c.parent_id == p.id
+        assert c.root_id == p.id
+        assert c.pending_parent_external_id is None
+
+        assert gc.parent_id == c.id
+        assert gc.root_id == p.id
+        assert gc.pending_parent_external_id is None
+
+        assert ggc.parent_id == gc.id
+        assert ggc.root_id == p.id
+        assert ggc.pending_parent_external_id is None
+
+        final_call_args = set(enqueue_events_mock.call_args_list[-1][0])
+        assert {p.id, c.id, gc.id, ggc.id} == final_call_args
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_ingest_with_member_id(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
1. Update pending_parent_id to parent_id if it exists
2. Set root_id where we have the full chain

Since we allow parent ingestion to happen after the child we can now move this to the worker to avoid doing heavy work in the ingestion flow.

This re-applies the tests from #11160 but simplifies the SQL and splits it into querying by id and external_id instead of an `OR` which forces postgres into a bitmap scan.