### PR TITLE
Surface email validation errors in checkout

### DIFF
--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
@@ -1,0 +1,72 @@
+import { act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithCheckout } from '../test-utils/renderWithCheckout'
+import type { CheckoutContextProps } from './CheckoutProvider'
+
+type UpdateResult = Awaited<ReturnType<CheckoutContextProps['update']>>
+
+describe('CheckoutFormProvider', () => {
+  it('surfaces RequestValidationError as field-level form errors', async () => {
+    const update = vi.fn<CheckoutContextProps['update']>(
+      async () =>
+        ({
+          ok: false,
+          error: {
+            error: 'RequestValidationError',
+            detail: [
+              {
+                type: 'value_error',
+                loc: ['body', 'customer_email'],
+                msg: 'foo@example.com is not a valid email address: The domain name example.com does not accept email.',
+                input: 'foo@example.com',
+              },
+            ],
+          },
+        }) as UpdateResult,
+    )
+
+    const getCtx = renderWithCheckout({ update })
+
+    await act(async () => {
+      await expect(
+        getCtx().update({ customer_email: 'foo@example.com' }),
+      ).rejects.toBeDefined()
+    })
+
+    expect(getCtx().form.formState.errors.customer_email?.message).toContain(
+      'The domain name example.com does not accept email.',
+    )
+  })
+
+  it('surfaces PolarRequestValidationError as field-level form errors', async () => {
+    const update = vi.fn<CheckoutContextProps['update']>(
+      async () =>
+        ({
+          ok: false,
+          error: {
+            error: 'PolarRequestValidationError',
+            detail: [
+              {
+                type: 'value_error',
+                loc: ['body', 'customer_email'],
+                msg: 'Email is already taken',
+                input: 'taken@example.com',
+              },
+            ],
+          },
+        }) as UpdateResult,
+    )
+
+    const getCtx = renderWithCheckout({ update })
+
+    await act(async () => {
+      await expect(
+        getCtx().update({ customer_email: 'taken@example.com' }),
+      ).rejects.toBeDefined()
+    })
+
+    expect(getCtx().form.formState.errors.customer_email?.message).toBe(
+      'Email is already taken',
+    )
+  })
+})

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -83,6 +83,7 @@ export const CheckoutFormProvider = ({
         if (error) {
           switch (error.error) {
             case 'PolarRequestValidationError':
+            case 'RequestValidationError':
               setValidationErrors(error.detail, setError)
               break
             case 'AlreadyActiveSubscriptionError':
@@ -114,6 +115,7 @@ export const CheckoutFormProvider = ({
       if (error) {
         switch (error.error) {
           case 'PolarRequestValidationError':
+          case 'RequestValidationError':
             setValidationErrors(error.detail, setError)
             break
           case 'PaymentError':

--- a/clients/packages/checkout/src/providers/CheckoutProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutProvider.tsx
@@ -43,8 +43,8 @@ type APIError<T extends keyof operations> = {
 }
 
 type ValidationError = {
-  error: 'PolarRequestValidationError'
-  detail: { input: number; loc: string[]; msg: string; type: string }[]
+  error: 'PolarRequestValidationError' | 'RequestValidationError'
+  detail: { input: unknown; loc: string[]; msg: string; type: string }[]
 }
 
 export type ErrorResponse<T extends keyof operations> =

--- a/clients/packages/checkout/src/test-utils/renderWithCheckout.tsx
+++ b/clients/packages/checkout/src/test-utils/renderWithCheckout.tsx
@@ -1,0 +1,65 @@
+import type { Client } from '@polar-sh/client'
+import type { AcceptedLocale } from '@polar-sh/i18n'
+import { render } from '@testing-library/react'
+import { useEffect } from 'react'
+import { vi } from 'vitest'
+import type { ProductCheckoutPublic } from '../guards'
+import {
+  CheckoutFormProvider,
+  useCheckoutForm,
+  type CheckoutFormContextProps,
+} from '../providers/CheckoutFormProvider'
+import {
+  CheckoutContext,
+  type CheckoutContextProps,
+} from '../providers/CheckoutProvider'
+import { createCheckout } from './makeCheckout'
+
+interface RenderWithCheckoutOptions {
+  checkout?: Partial<ProductCheckoutPublic>
+  update: CheckoutContextProps['update']
+  confirm?: CheckoutContextProps['confirm']
+  locale?: AcceptedLocale
+}
+
+export const renderWithCheckout = ({
+  checkout: checkoutOverrides,
+  update,
+  confirm = vi.fn(),
+  locale,
+}: RenderWithCheckoutOptions) => {
+  const checkout = createCheckout({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    payment_processor: 'dummy' as any,
+    ...checkoutOverrides,
+  })
+
+  const ctxRef: { current: CheckoutFormContextProps | null } = { current: null }
+
+  const Capture = () => {
+    const ctx = useCheckoutForm()
+    useEffect(() => {
+      ctxRef.current = ctx
+    })
+    void ctx.form.formState.errors
+    return null
+  }
+
+  render(
+    <CheckoutContext.Provider
+      value={{
+        checkout,
+        refresh: vi.fn(),
+        update,
+        confirm,
+        client: {} as Client,
+      }}
+    >
+      <CheckoutFormProvider locale={locale}>
+        <Capture />
+      </CheckoutFormProvider>
+    </CheckoutContext.Provider>,
+  )
+
+  return () => ctxRef.current!
+}


### PR DESCRIPTION
<img width="325" align="right" alt="" src="https://github.com/user-attachments/assets/12bcdc42-ea26-417e-a45c-cbb68fea6798" />


Currently if you enter an invalid email in the checkout the backend will throw an error, but we're not exposing that in the UI. This PR fixes that and adds tests to prevent it from happening again, as well as a test helper.