### PR TITLE
Document product_id and locale query parameters for Checkout Links

### DIFF
--- a/docs/features/checkout/links.mdx
+++ b/docs/features/checkout/links.mdx
@@ -83,6 +83,17 @@ This means that you need to make sure to always use this Checkout Link URL (as s
 
 You can pass optional query parameters to your Checkout Links.
 
+#### Preselect a product
+
+When a Checkout Link is configured with several products, you can point the
+customer directly to one of them using the `product_id` query parameter. The
+customer can still switch to another product on the checkout page.
+
+<ParamField path="product_id" type="string">
+  ID of the product to preselect on the checkout page. Must be one of the
+  products associated with the Checkout Link.
+</ParamField>
+
 #### Prepopulate fields
 
 You can prefill the checkout fields with the following query parameters:
@@ -103,6 +114,12 @@ You can prefill the checkout fields with the following query parameters:
 
 <ParamField path="amount" type="string">
   Prefill amount in case of Pay What You Want pricing
+</ParamField>
+
+<ParamField path="locale" type="string">
+  Force the checkout page language, given as an IETF BCP 47 language tag (e.g.
+  `en`, `fr`, `pt-BR`). If omitted, the language is detected from the
+  customer's browser.
 </ParamField>
 
 <ParamField path="custom_field_data.{slug}" type="string">

--- a/docs/features/checkout/links.mdx
+++ b/docs/features/checkout/links.mdx
@@ -119,7 +119,7 @@ You can prefill the checkout fields with the following query parameters:
 <ParamField path="locale" type="string">
   Force the checkout page language, given as an IETF BCP 47 language tag (e.g.
   `en`, `fr`, `pt-BR`). If omitted, the language is detected from the
-  customer's browser. Checkout localization is opt-in — see
+  customer's browser. Checkout localization is in beta — see
   [Checkout Localization](/features/checkout/localization) for details on how
   to enable it.
 </ParamField>

--- a/docs/features/checkout/links.mdx
+++ b/docs/features/checkout/links.mdx
@@ -119,7 +119,9 @@ You can prefill the checkout fields with the following query parameters:
 <ParamField path="locale" type="string">
   Force the checkout page language, given as an IETF BCP 47 language tag (e.g.
   `en`, `fr`, `pt-BR`). If omitted, the language is detected from the
-  customer's browser.
+  customer's browser. Checkout localization is opt-in — see
+  [Checkout Localization](/features/checkout/localization) for details on how
+  to enable it.
 </ParamField>
 
 <ParamField path="custom_field_data.{slug}" type="string">


### PR DESCRIPTION
## Summary

This PR adds documentation for two query parameters that can be used with Checkout Links: `product_id` for preselecting a product and `locale` for forcing the checkout page language.

## What

Added documentation for two optional query parameters in the Checkout Links documentation:

1. **`product_id`**: Allows preselecting a specific product when a Checkout Link is configured with multiple products. Customers can still switch to other products on the checkout page.

2. **`locale`**: Allows forcing the checkout page language using IETF BCP 47 language tags (e.g., `en`, `fr`, `pt-BR`). Includes a note that checkout localization is in beta with a link to the localization feature documentation.

## Why

These parameters are useful features for Checkout Links that were not previously documented. Documenting them helps users understand how to customize the checkout experience for their customers.

## How

Added two new parameter documentation sections to `docs/features/checkout/links.mdx`:
- A new "Preselect a product" section before the "Prepopulate fields" section
- Added `locale` parameter documentation within the "Prepopulate fields" section

## Checklist

- [x] This PR addresses a single concern (documentation of two related query parameters)
- [x] The diff is reasonably sized and easy to review
- [x] No testing needed (documentation only)
- [x] No unrelated changes included

https://claude.ai/code/session_018c1iDwCn6QaLL9q6AfNS3T