### PR TITLE
refactor(member): atomic ownership transfer via single CASE-based UPDATE

### DIFF
--- a/server/polar/member/repository.py
+++ b/server/polar/member/repository.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, case, func, select, update
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
@@ -136,6 +136,36 @@ class MemberRepository(
             statement = statement.where(Member.is_deleted.is_(False))
         result = await session.execute(statement)
         return result.unique().scalar_one_or_none()
+
+    async def transfer_ownership(
+        self,
+        session: AsyncSession,
+        *,
+        current_owner: Member,
+        new_owner: Member,
+    ) -> None:
+        """Swap the `owner` role from one member to another in a single UPDATE,
+        and refresh both instances so their in-memory `role` matches the DB.
+
+        The partial unique index on `(customer_id) WHERE role = 'owner'` is
+        evaluated at statement end, so running demote+promote as two separate
+        statements would briefly expose two owners and trip the constraint.
+        A single CASE-based UPDATE moves both rows atomically.
+        """
+        statement = (
+            update(Member)
+            .where(Member.id.in_([current_owner.id, new_owner.id]))
+            .values(
+                role=case(
+                    (Member.id == new_owner.id, MemberRole.owner),
+                    (Member.id == current_owner.id, MemberRole.billing_manager),
+                    else_=Member.role,
+                )
+            )
+        )
+        await session.execute(statement)
+        await session.refresh(current_owner, attribute_names=["role"])
+        await session.refresh(new_owner, attribute_names=["role"])
 
     async def list_by_email_and_organization(
         self,

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -668,6 +668,7 @@ class MemberService:
             - When promoting to owner, the existing owner is automatically demoted to billing_manager
         """
         repository = MemberRepository.from_session(session)
+        transferred = False
 
         if role is not None and member.role != role:
             members = await repository.list_by_customer(session, member.customer_id)
@@ -696,35 +697,22 @@ class MemberService:
                         ]
                     )
 
-                # Find and demote the current owner
-                if caller_is_owner and caller_member is not None:
-                    # Customer portal: demote the caller (who is the owner)
-                    await repository.update(
-                        caller_member, update_dict={"role": MemberRole.billing_manager}
-                    )
-                    log.info(
-                        "member.update.ownership_transfer",
-                        old_owner_id=caller_member.id,
-                        new_owner_id=member.id,
-                        customer_id=member.customer_id,
-                    )
-                else:
-                    # Admin API: find and demote the existing owner
-                    current_owner = next(
-                        (m for m in members if m.role == MemberRole.owner), None
-                    )
-                    if current_owner:
-                        await repository.update(
-                            current_owner,
-                            update_dict={"role": MemberRole.billing_manager},
-                        )
-                        log.info(
-                            "member.update.ownership_transfer",
-                            old_owner_id=current_owner.id,
-                            new_owner_id=member.id,
-                            customer_id=member.customer_id,
-                            admin_transfer=True,
-                        )
+                current_owner = (
+                    caller_member
+                    if caller_is_owner and caller_member is not None
+                    else next(m for m in members if m.role == MemberRole.owner)
+                )
+                await repository.transfer_ownership(
+                    session, current_owner=current_owner, new_owner=member
+                )
+                transferred = True
+                log.info(
+                    "member.update.ownership_transfer",
+                    old_owner_id=current_owner.id,
+                    new_owner_id=member.id,
+                    customer_id=member.customer_id,
+                    transfer_kind="admin" if allow_ownership_transfer else "portal",
+                )
 
             # Prevent removing the last owner
             if is_losing_owner_role and owner_count <= 1:
@@ -742,13 +730,17 @@ class MemberService:
         update_dict = {}
         if name is not None:
             update_dict["name"] = name
-        if role is not None:
+        if role is not None and not transferred:
             update_dict["role"] = role
 
-        if not update_dict:
+        if not update_dict and not transferred:
             return member
 
-        updated_member = await repository.update(member, update_dict=update_dict)
+        updated_member = (
+            await repository.update(member, update_dict=update_dict)
+            if update_dict
+            else member
+        )
         log.info(
             "member.update.success",
             member_id=member.id,

--- a/server/tests/customer_portal/endpoints/test_member.py
+++ b/server/tests/customer_portal/endpoints/test_member.py
@@ -353,42 +353,6 @@ class TestUpdateMember:
 
     @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
     @pytest.mark.keep_session_state
-    async def test_cannot_demote_only_owner(
-        self,
-        client: AsyncClient,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        customer: Customer,
-        member_owner: Member,
-    ) -> None:
-        """Cannot demote the only owner via another endpoint."""
-        customer.type = CustomerType.team
-        await save_fixture(customer)
-
-        # Create another member to try to demote
-        member2 = Member(
-            customer_id=customer.id,
-            organization_id=organization.id,
-            email="other-owner@example.com",
-            name="Other Owner",
-            role=MemberRole.owner,
-        )
-        await save_fixture(member2)
-
-        # Try to demote the other owner - should fail because there can only be one owner
-        response = await client.patch(
-            f"/v1/customer-portal/members/{member2.id}",
-            json={"role": "member"},
-        )
-        # This should work because we're not demoting ourselves and there are multiple owners
-        # Wait, looking at the code again, the logic prevents multiple owners, so this should fail
-        # Actually let me re-read the logic - we allow demoting if owner_count > 1
-        # Since we now have 2 owners (member_owner and member2), demoting member2 should succeed
-        assert response.status_code == 200
-
-    @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
-    @pytest.mark.keep_session_state
     async def test_valid_update(
         self,
         client: AsyncClient,
@@ -538,37 +502,6 @@ class TestRemoveMember:
         response = await client.delete(f"/v1/customer-portal/members/{member_owner.id}")
         assert response.status_code == 422
         assert "cannot remove yourself" in response.json()["detail"][0]["msg"].lower()
-
-    @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
-    @pytest.mark.keep_session_state
-    async def test_cannot_remove_only_owner(
-        self,
-        client: AsyncClient,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        customer: Customer,
-        member_owner: Member,
-    ) -> None:
-        """Cannot remove the only owner (even if trying to remove another owner)."""
-        customer.type = CustomerType.team
-        await save_fixture(customer)
-
-        # There's only one owner (member_owner), can't remove them
-        # But we're testing self-removal which is blocked by a different check
-        # Let's create a scenario with 2 owners and remove one
-        member2 = Member(
-            customer_id=customer.id,
-            organization_id=organization.id,
-            email="other-owner@example.com",
-            name="Other Owner",
-            role=MemberRole.owner,
-        )
-        await save_fixture(member2)
-
-        # Now try to remove member2 - this should work because there are 2 owners
-        response = await client.delete(f"/v1/customer-portal/members/{member2.id}")
-        assert response.status_code == 204
 
     @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
     @pytest.mark.keep_session_state

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -17,6 +17,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_account,
     create_customer,
+    create_member,
     create_organization,
 )
 
@@ -690,6 +691,80 @@ class TestUpdate:
             await member_service.update(session, member, role=MemberRole.owner)
 
         assert "only the owner can transfer ownership" in str(exc_info.value).lower()
+
+    @pytest.mark.auth
+    async def test_update_ownership_transfer_customer_portal(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Regression: the partial unique index on (customer_id) WHERE role='owner'
+        would trip if demote+promote ran as two separate UPDATEs."""
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="owner@example.com",
+        )
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.member,
+            email="member@example.com",
+        )
+
+        updated = await member_service.update(
+            session, member, role=MemberRole.owner, caller_member=owner
+        )
+
+        assert updated.role == MemberRole.owner
+
+        await session.refresh(owner)
+        await session.refresh(member)
+        assert owner.role == MemberRole.billing_manager
+        assert member.role == MemberRole.owner
+
+    @pytest.mark.auth
+    async def test_update_ownership_transfer_admin(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="owner@example.com",
+        )
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.member,
+            email="member@example.com",
+        )
+
+        updated = await member_service.update(
+            session, member, role=MemberRole.owner, allow_ownership_transfer=True
+        )
+
+        assert updated.role == MemberRole.owner
+
+        await session.refresh(owner)
+        await session.refresh(member)
+        assert owner.role == MemberRole.billing_manager
+        assert member.role == MemberRole.owner
 
     @pytest.mark.auth
     async def test_update_no_changes(


### PR DESCRIPTION
## Summary

Replaces the two-step demote-then-promote ownership transfer with a single CASE-based `UPDATE` via a new `MemberRepository.transfer_ownership` helper. The repository method also refreshes the in-memory role on both instances so the webhook payload stays accurate after the raw UPDATE.

This is a prerequisite for a follow-up PR that adds a partial unique index `members(customer_id) WHERE deleted_at IS NULL AND role = 'owner'`: once that index exists, the previous two-statement transfer would briefly expose two owners between UPDATEs and trip the constraint. Landing this refactor first means the follow-up migration can be deployed safely — old code running against the new index would otherwise break during the deploy window.

Also removes two misnamed tests in `tests/customer_portal/endpoints/test_member.py` whose docstrings claimed they tested "cannot demote/remove only owner" but whose bodies instead created two owners and asserted that demoting/removing one succeeded — a scenario the service-level invariant already forbids. Proper "only owner" coverage is already provided by `test_cannot_modify_self` and `test_cannot_remove_self` in the same file.

## Test plan

- [x] `uv run task lint` clean
- [x] `uv run task lint_types` clean
- [x] `uv run pytest tests/member` — 96/96 passing, including two new tests covering the atomic ownership transfer for both the customer-portal and admin-API paths
- [x] `uv run pytest tests/customer_portal/endpoints/test_member.py` — passes after removing the two broken tests
- [ ] Follow-up PR adds the migration + model `Index` once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)