### PR TITLE
ci: Wrap each preview PR in a caddy route

### DIFF
--- a/infra/preview/caddy-preview.template
+++ b/infra/preview/caddy-preview.template
@@ -1,30 +1,32 @@
-handle /pr-__PR_NUM__/v1/* {
-	uri strip_prefix /pr-__PR_NUM__
-	reverse_proxy 127.0.0.1:__API_PORT__
-}
-@backoffice__PR_NUM__ path /pr-__PR_NUM__/backoffice /pr-__PR_NUM__/backoffice/*
-handle @backoffice__PR_NUM__ {
-	uri strip_prefix /pr-__PR_NUM__
-	reverse_proxy 127.0.0.1:__API_PORT__
-}
-handle /pr-__PR_NUM__/healthz {
-	uri strip_prefix /pr-__PR_NUM__
-	reverse_proxy 127.0.0.1:__API_PORT__
-}
-handle /pr-__PR_NUM__/openapi.json {
-	uri strip_prefix /pr-__PR_NUM__
-	reverse_proxy 127.0.0.1:__API_PORT__
-}
-handle_path /pr-__PR_NUM__/_logs/* {
-	rewrite * /pr-__PR_NUM__{path}
-	reverse_proxy 127.0.0.1:9999
-}
-@vercel__PR_NUM__ path /pr-__PR_NUM__ /pr-__PR_NUM__/*
-handle @vercel__PR_NUM__ {
-	reverse_proxy __VERCEL_PREVIEW_URL__ {
-		header_up Host __VERCEL_PREVIEW_HOST__
-		header_up X-Forwarded-Host __TS_HOSTNAME__
-		header_up X-Forwarded-Proto https
-		header_up x-vercel-protection-bypass {$VERCEL_BYPASS_SECRET}
+route {
+	handle /pr-__PR_NUM__/v1/* {
+		uri strip_prefix /pr-__PR_NUM__
+		reverse_proxy 127.0.0.1:__API_PORT__
+	}
+	@backoffice__PR_NUM__ path /pr-__PR_NUM__/backoffice /pr-__PR_NUM__/backoffice/*
+	handle @backoffice__PR_NUM__ {
+		uri strip_prefix /pr-__PR_NUM__
+		reverse_proxy 127.0.0.1:__API_PORT__
+	}
+	handle /pr-__PR_NUM__/healthz {
+		uri strip_prefix /pr-__PR_NUM__
+		reverse_proxy 127.0.0.1:__API_PORT__
+	}
+	handle /pr-__PR_NUM__/openapi.json {
+		uri strip_prefix /pr-__PR_NUM__
+		reverse_proxy 127.0.0.1:__API_PORT__
+	}
+	handle_path /pr-__PR_NUM__/_logs/* {
+		rewrite * /pr-__PR_NUM__{path}
+		reverse_proxy 127.0.0.1:9999
+	}
+	@vercel__PR_NUM__ path /pr-__PR_NUM__ /pr-__PR_NUM__/*
+	handle @vercel__PR_NUM__ {
+		reverse_proxy __VERCEL_PREVIEW_URL__ {
+			header_up Host __VERCEL_PREVIEW_HOST__
+			header_up X-Forwarded-Host __TS_HOSTNAME__
+			header_up X-Forwarded-Proto https
+			header_up x-vercel-protection-bypass {$VERCEL_BYPASS_SECRET}
+		}
 	}
 }

--- a/infra/preview/process-preview-triggers.sh
+++ b/infra/preview/process-preview-triggers.sh
@@ -23,7 +23,6 @@ while true; do
                 if [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
                     "$PREVIEW_TOOLS_DIR/regenerate-caddyfile.sh"
                     systemctl reload caddy
-                    systemctl enable "polar-preview-backend@${PR_NUM}"
                     systemctl restart "polar-preview-backend@${PR_NUM}" || echo "[trigger] Failed to restart pr-${PR_NUM}"
                 fi
                 ;;


### PR DESCRIPTION
To ensure the specificity for the route matches is consistent
