### PR TITLE
feat(member): partial unique index to enforce one active owner per customer

### DIFF
--- a/server/migrations/versions/2026-04-22-0900_member_owner_partial_unique_index.py
+++ b/server/migrations/versions/2026-04-22-0900_member_owner_partial_unique_index.py
@@ -1,0 +1,44 @@
+"""member_owner_partial_unique_index
+
+Revision ID: befcfa872c35
+Revises: f96e4424ec70
+Create Date: 2026-04-22 09:00:00.000000
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "befcfa872c35"
+down_revision = "f96e4424ec70"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Fail fast if the brief catalog ACCESS EXCLUSIVE locks can't be
+        # acquired (e.g., another DDL or VACUUM FULL is in flight). No
+        # statement_timeout: killing CONCURRENTLY mid-build leaves an
+        # INVALID index that still enforces uniqueness.
+        op.execute("SET lock_timeout = '5s'")
+        op.create_index(
+            "members_customer_id_owner_active_key",
+            "members",
+            ["customer_id"],
+            unique=True,
+            postgresql_where="deleted_at IS NULL AND role = 'owner'",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.drop_index(
+            "members_customer_id_owner_active_key",
+            table_name="members",
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/member.py
+++ b/server/polar/models/member.py
@@ -37,6 +37,13 @@ class Member(RecordModel):
             unique=True,
             postgresql_where=text("deleted_at IS NULL AND external_id IS NOT NULL"),
         ),
+        # Partial unique index: at most one active owner per customer.
+        Index(
+            "members_customer_id_owner_active_key",
+            "customer_id",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL AND role = 'owner'"),
+        ),
     )
 
     customer_id: Mapped[UUID] = mapped_column(


### PR DESCRIPTION
## Summary

Adds a partial unique index on `members(customer_id) WHERE deleted_at IS NULL AND role = 'owner'` so the "at most one active owner per customer" invariant is enforced at the database level instead of relying solely on application-level checks. Follow-up to [#11158](https://github.com/polarsource/polar/pull/11158), which addressed one class of drift but could not close the race window at the DB layer.

## ⚠️ Deployment ordering

**Must be merged and deployed AFTER [#11179](https://github.com/polarsource/polar/pull/11179).** That PR refactors the two-statement ownership-transfer path into a single CASE-based UPDATE; the partial unique index in this PR is statement-evaluated, so the old two-statement flow would briefly expose two owners between demote and promote and trip the constraint.

## Rollout notes

- **Lock impact on checkouts: none.** `CREATE INDEX CONCURRENTLY` takes `SHARE UPDATE EXCLUSIVE`, which does not block `SELECT`/`INSERT`/`UPDATE`/`DELETE`. Same pattern was already shipped against this table on 2026-02-05.
- **Pre-flight:** verified in prod and sandbox that no customers currently have more than one active owner, so the index build will not fail on existing data.
- **Lock timeout:** `SET lock_timeout = '5s'` so the build fails fast if the brief catalog locks can't be acquired (e.g., concurrent DDL or `VACUUM FULL`). No `statement_timeout` — killing `CREATE INDEX CONCURRENTLY` mid-build leaves an `INVALID` index that still enforces uniqueness.
- **If the build fails mid-flight** and leaves an `INVALID` index: `DROP INDEX CONCURRENTLY members_customer_id_owner_active_key;` then re-run.

## Test plan

- [x] `uv run task lint` clean
- [x] `uv run task lint_types` clean
- [x] Local Postgres: `alembic upgrade head` then downgrade + re-upgrade cycle verified; index appears in `pg_indexes` with the expected predicate
- [ ] After deploy: confirm the index is `VALID` in prod (`pg_index.indisvalid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)