### PR TITLE
docs: add OpenCode MCP configuration example

### DIFF
--- a/docs/integrate/mcp.mdx
+++ b/docs/integrate/mcp.mdx
@@ -157,6 +157,36 @@ For sandbox:
 claude mcp add --transport http "Polar-Sandbox" "https://mcp.polar.sh/mcp/polar-sandbox"
 ```
 
+### OpenCode
+
+In `opencode.jsonc`, add:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "Polar": {
+      "type": "remote",
+      "url": "https://mcp.polar.sh/mcp/polar-mcp"
+    }
+  }
+}
+```
+
+For sandbox:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "Polar Sandbox": {
+      "type": "remote",
+      "url": "https://mcp.polar.sh/mcp/polar-sandbox"
+    }
+  }
+}
+```
+
 ### ChatGPT
 
 MCP is only available for paid users in beta on ChatGPT web, by enabling Developer Mode.


### PR DESCRIPTION
## Summary

- Adds an OpenCode section to the MCP integration docs (`docs/integrate/mcp.mdx`) with `opencode.jsonc` configuration examples for both production and sandbox.

Closes #9083

## Test plan

- [ ] Verify the new section renders correctly on the docs site
- [ ] Confirm the JSONC example matches OpenCode's expected `opencode.jsonc` schema


---
_Generated by [Claude Code](https://claude.ai/code/session_01XrVe3iUtZWpNVkwdfqH1AH)_