### PR TITLE
Fix falsy check for hoveredPeriodIndex in MetricChartBox

### DIFF
--- a/clients/apps/web/src/components/Metrics/MetricChartBox.tsx
+++ b/clients/apps/web/src/components/Metrics/MetricChartBox.tsx
@@ -151,12 +151,12 @@ const MetricChartBox = ({
   }, [data, metric, selectedMetric])
 
   const hoveredPeriod = useMemo(() => {
-    if (!data || !hoveredPeriodIndex) return null
+    if (!data || hoveredPeriodIndex == null) return null
     return data.periods[hoveredPeriodIndex]
   }, [data, hoveredPeriodIndex])
 
   const hoveredPreviousPeriod = useMemo(() => {
-    if (!previousData || !hoveredPeriodIndex) return null
+    if (!previousData || hoveredPeriodIndex == null) return null
     return previousData.periods[hoveredPeriodIndex]
   }, [previousData, hoveredPeriodIndex])
 


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Fix incorrect falsy checks that would fail when `hoveredPeriodIndex` is `0`, a valid array index.

## What

Changed two falsy checks (`!hoveredPeriodIndex`) to explicit null checks (`hoveredPeriodIndex == null`) in the `hoveredPeriod` and `hoveredPreviousPeriod` useMemo hooks.

## Why

The original code used `!hoveredPeriodIndex` which treats `0` as falsy. Since `0` is a valid array index, this would incorrectly return `null` when hovering over the first period in the chart, breaking the hover functionality for that data point.

## How

Replaced the falsy checks with explicit null/undefined checks using `== null`, which only returns true when the value is `null` or `undefined`, allowing `0` to be treated as a valid index.

## Checklist

- [x] This PR addresses a single concern (one bug fix)
- [x] The diff is reasonably sized and easy to review
- [x] Linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_0128YLVy2LFqhbuvjitVFHXn