### PR TITLE
orders: Performance of order listing

### DIFF
--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -158,6 +158,15 @@ class CustomerRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_ids_by_email(self, email: str) -> Sequence[UUID]:
+        statement = (
+            self.get_base_statement()
+            .with_only_columns(Customer.id)
+            .where(func.lower(Customer.email) == email.lower())
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
     async def get_by_external_id_and_organization(
         self, external_id: str, organization_id: UUID
     ) -> Customer | None:

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -42,6 +42,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import contains_eager
 
 from polar.config import settings
+from polar.customer.repository import CustomerRepository
 from polar.exceptions import PolarError
 from polar.kit.currency import format_currency
 from polar.models import (
@@ -49,11 +50,11 @@ from polar.models import (
     OAuthAccount,
     Order,
     Organization,
-    Product,
     User,
     UserOrganization,
 )
 from polar.models.organization_review import OrganizationReview
+from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
 
@@ -864,22 +865,20 @@ class PlainService:
     ) -> CustomerCard | None:
         email = request.customer.email
 
-        statement = (
-            (
-                select(Order)
-                .join(Customer, onclause=Customer.id == Order.customer_id)
-                .join(Product, onclause=Product.id == Order.product_id, isouter=True)
-                .where(func.lower(Customer.email) == email.lower())
-            )
-            .order_by(Order.created_at.desc())
-            .limit(3)
-            .options(
+        customer_repository = CustomerRepository.from_session(session)
+        customer_ids = await customer_repository.get_ids_by_email(email)
+        if not customer_ids:
+            return None
+
+        order_repository = OrderRepository.from_session(session)
+        orders = await order_repository.get_latest_by_customer_ids(
+            customer_ids,
+            limit=3,
+            options=(
                 contains_eager(Order.product),
                 contains_eager(Order.customer).joinedload(Customer.organization),
-            )
+            ),
         )
-        result = await session.execute(statement)
-        orders = result.unique().scalars().all()
 
         if len(orders) == 0:
             return None

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -135,6 +135,24 @@ class OrderRepository(
         )
         return await self.get_all(statement)
 
+    async def get_latest_by_customer_ids(
+        self,
+        customer_ids: Sequence[UUID],
+        *,
+        limit: int,
+        options: Options = (),
+    ) -> Sequence[Order]:
+        statement = (
+            self.get_base_statement()
+            .join(Customer, onclause=Customer.id == Order.customer_id)
+            .join(Product, onclause=Product.id == Order.product_id, isouter=True)
+            .where(Order.customer_id.in_(customer_ids))
+            .order_by(Order.created_at.desc())
+            .limit(limit)
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     async def get_pending_orders_for_subscription(
         self, subscription_id: UUID, *, options: Options = ()
     ) -> Sequence[Order]:

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -92,6 +92,7 @@ from polar.product.guard import (
     is_static_price,
 )
 from polar.product.price_set import PriceSet
+from polar.product.repository import ProductRepository
 from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import (
     CalculationExpiredError,
@@ -331,7 +332,14 @@ class OrderService:
             statement = statement.where(Order.product_id.in_(product_id))
 
         if product_billing_type is not None:
-            statement = statement.where(Product.billing_type.in_(product_billing_type))
+            product_repository = ProductRepository.from_session(session)
+            matching_product_ids = await product_repository.get_ids_by_billing_type(
+                product_billing_type,
+                organization_ids=organization_id,
+            )
+            if not matching_product_ids:
+                return [], 0
+            statement = statement.where(Order.product_id.in_(matching_product_ids))
 
         if discount_id is not None:
             statement = statement.where(Order.discount_id.in_(discount_id))

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -21,6 +21,7 @@ from polar.models import (
     ProductPriceCustom,
     ProductPriceFixed,
 )
+from polar.models.product import ProductBillingType
 from polar.models.product_price import ProductPriceAmountType, ProductPriceSource
 from polar.postgres import sql
 
@@ -136,6 +137,21 @@ class ProductRepository(
                         ProductPriceFixed.price_amount,
                     ),
                 )
+
+    async def get_ids_by_billing_type(
+        self,
+        billing_types: Sequence[ProductBillingType],
+        *,
+        organization_ids: Sequence[UUID] | None = None,
+    ) -> Sequence[UUID]:
+        statement = select(Product.id).where(
+            Product.billing_type.in_(billing_types),
+            Product.deleted_at.is_(None),
+        )
+        if organization_ids is not None:
+            statement = statement.where(Product.organization_id.in_(organization_ids))
+        result = await self.session.execute(statement)
+        return result.scalars().all()
 
     async def get_products_without_currency(
         self, organization_id: UUID, currency: PresentmentCurrency


### PR DESCRIPTION
Some of of our order listings are very slow. This PR handles two of them:

- Split product billing type filter into two separate queries instead of a case expression. This allows us to use indexes more precisely and allows for early termination of the query.
- The same for the Plain customer-card order lookup, split out the customer email lookup into its own initial query.