### PR TITLE
refactor(organization): drop refunds_blocked column (Phase B)

### DIFF
--- a/server/migrations/versions/2026-04-22-1328_drop_organization_refunds_blocked_column.py
+++ b/server/migrations/versions/2026-04-22-1328_drop_organization_refunds_blocked_column.py
@@ -1,0 +1,54 @@
+"""drop organization refunds_blocked column
+
+Revision ID: d3f5e1a7b2c4
+Revises: befcfa872c35
+Create Date: 2026-04-22 13:28:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "d3f5e1a7b2c4"
+down_revision = "befcfa872c35"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Fail fast on lock contention. Requires `backfill_org_capabilities.py
+    # --execute` to have run first; otherwise SET NOT NULL errors.
+    op.execute("SET lock_timeout = '2s'")
+
+    op.alter_column("organizations", "capabilities", nullable=False)
+    op.drop_column("organizations", "refunds_blocked")
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '2s'")
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "refunds_blocked",
+            sa.Boolean(),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE organizations
+        SET refunds_blocked = NOT (capabilities->>'refunds')::boolean
+        """
+    )
+    op.alter_column("organizations", "refunds_blocked", nullable=False)
+    op.alter_column(
+        "organizations",
+        "capabilities",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -3553,7 +3553,7 @@ async def set_capability(
     if organization is None:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    current_value = organization.get_effective_capabilities()[capability_name]
+    current_value = organization.capabilities[capability_name]
 
     settings_url = str(
         request.url_for(

--- a/server/polar/backoffice/organizations_v2/views/modals/set_capability_modal.py
+++ b/server/polar/backoffice/organizations_v2/views/modals/set_capability_modal.py
@@ -30,7 +30,7 @@ class SetCapabilityModal:
 
     @contextlib.contextmanager
     def render(self) -> Generator[None]:
-        current_value = self.organization.get_effective_capabilities()[self.capability]
+        current_value = self.organization.capabilities[self.capability]
         status_default = STATUS_CAPABILITIES[self.organization.status][self.capability]
 
         action_word = "Enable" if self.target_value else "Disable"

--- a/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
@@ -336,7 +336,7 @@ class SettingsSection:
                     with tag.div(classes="text-xs text-base-content/60"):
                         text("Overrides reset on the next status change.")
 
-                current_caps = self.org.get_effective_capabilities()
+                current_caps = self.org.capabilities
                 status_defaults = STATUS_CAPABILITIES[self.org.status]
 
                 with tag.div(classes="space-y-3"):

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -505,18 +505,9 @@ class Organization(RateLimitGroupMixin, RecordModel):
         TIMESTAMP(timezone=True), nullable=True, default=None
     )
 
-    # DEPRECATED: use `capabilities["refunds"]` instead.
-    # `deferred=True` so default SELECTs don't include it, allowing the
-    # column to be dropped in a follow-up migration without a CD race.
-    refunds_blocked: Mapped[bool] = mapped_column(
-        nullable=False,
-        default=False,
-        deferred=True,
-    )
-
-    capabilities: Mapped[OrganizationCapabilities | None] = mapped_column(
+    capabilities: Mapped[OrganizationCapabilities] = mapped_column(
         JSONB,
-        nullable=True,
+        nullable=False,
         default=lambda: {**STATUS_CAPABILITIES[OrganizationStatus.CREATED]},
     )
 
@@ -599,13 +590,8 @@ class Organization(RateLimitGroupMixin, RecordModel):
     # End: Fields synced from GitHub
     #
 
-    def get_effective_capabilities(self) -> OrganizationCapabilities:
-        """Return capabilities, falling back to the status defaults for rows
-        that pre-date the backfill."""
-        return self.capabilities or STATUS_CAPABILITIES[self.status]
-
     def _capability(self, name: CapabilityName) -> bool:
-        return self.get_effective_capabilities()[name]
+        return self.capabilities[name]
 
     @hybrid_property
     def can_authenticate(self) -> bool:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1207,7 +1207,7 @@ class OrganizationService:
         resets `capabilities` from `STATUS_CAPABILITIES`.
         """
         current: OrganizationCapabilities = dict(  # type: ignore[assignment]
-            organization.get_effective_capabilities()
+            organization.capabilities
         )
         if current[capability] == value:
             return organization

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -899,7 +899,7 @@ class TestOrganizationRefundsBlocked:
             organization,
             update_dict={
                 "capabilities": {
-                    **organization.get_effective_capabilities(),
+                    **organization.capabilities,
                     "refunds": False,
                 },
             },


### PR DESCRIPTION
## Summary

Phase B of the `refunds_blocked` → `capabilities["refunds"]` migration. Drops the deferred column now that all app code reads from `capabilities`, and makes `capabilities` NOT NULL.

Follow-up to #11163 (Phase A, which deferred the column and removed all reads/writes).

## What

- New migration `d3f5e1a7b2c4` — `SET NOT NULL` on `capabilities`, `DROP COLUMN refunds_blocked`. Uses `SET lock_timeout = '2s'` to fail fast on contention.
- Model: drop `refunds_blocked` column, `capabilities` becomes non-nullable, remove `get_effective_capabilities()` fallback.
- Callers switched to direct `.capabilities` access:
  - `organization/service.py` (`set_capability`)
  - `backoffice/organizations_v2/endpoints.py` (`set_capability` endpoint)
  - `backoffice/organizations_v2/views/sections/settings_section.py`
  - `backoffice/organizations_v2/views/modals/set_capability_modal.py`
  - `tests/refund/test_service.py`

## Why

Phase A made `capabilities["refunds"]` the sole source of truth but left the column in place to avoid a CD race. That has now shipped and soaked — this PR cleans up the deprecated column and eliminates the nullable-capabilities fallback.

## How

**Migration safety on the hot `organizations` table** (77k rows / 177MB in prod):

- `SET lock_timeout = '2s'` prevents pileup behind long-running DDL on a table heavily joined from checkouts/orders/subscriptions.
- No defensive inline backfill — `ALTER COLUMN SET NOT NULL` will fail loudly if any NULL rows remain, which is a better signal than silent heal.
- Reversible downgrade: recreates `refunds_blocked` from `NOT (capabilities->>'refunds')::boolean` and reverts `capabilities` to nullable.

**Deploy order**:
1. `uv run python -m scripts.backfill_org_capabilities --execute` against prod (confirm zero NULLs with `--verify`).
2. Apply this migration.

## How to verify

- Local cycle: `uv run alembic upgrade head && uv run alembic downgrade -1 && uv run alembic upgrade head` — clean
- Targeted tests: `uv run pytest tests/organization tests/refund tests/backoffice` — 327 passed
- Broader capability-adjacent flows: `uv run pytest tests/checkout tests/order tests/subscription tests/payment tests/customer` — 883 passed

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included