### PR TITLE
Fix mobile layouts with contextView

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/CostsEventsTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/CostsEventsTable.tsx
@@ -174,7 +174,7 @@ export default function CostsEventsTable({
       <div ref={sentinelRef} />
     </div>
   ) : (
-    <div className="dark:border-polar-700 flex min-h-96 w-full flex-col items-center justify-center gap-4 rounded-4xl border border-gray-200 p-24">
+    <div className="dark:border-polar-700 flex min-h-96 w-full flex-col items-center justify-center gap-4 rounded-4xl border border-gray-200 p-8 text-center md:p-24">
       <h1 className="text-2xl font-normal">No events found</h1>
       <p className="dark:text-polar-500 text-gray-500">
         There are no events matching these filters

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/CostsSpanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/CostsSpanPage.tsx
@@ -386,7 +386,7 @@ export default function SpanDetailPage({
               />
             </div>
           ) : (
-            <div className="dark:border-polar-700 flex min-h-96 w-full flex-col items-center justify-center gap-4 rounded-4xl border border-gray-200 p-24">
+            <div className="dark:border-polar-700 fl ex min-h-96 w-full flex-col items-center justify-center gap-4 rounded-4xl border border-gray-200 p-24">
               <h1 className="text-2xl font-normal">No data</h1>
               <p className="dark:text-polar-500 text-gray-500">
                 No metrics available for this period

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/layout.tsx
@@ -23,6 +23,7 @@ export default async function Layout({
     <DashboardBody
       title={null}
       contextViewPlacement="left"
+      contextViewTitle="Spans"
       contextViewClassName="w-full lg:max-w-[320px] xl:max-w-[320px] h-full overflow-y-hidden"
       contextView={
         <div className="flex h-full flex-col gap-y-4">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/EventsPage.tsx
@@ -188,6 +188,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         </h3>
       }
       contextViewPlacement="left"
+      contextViewTitle="Events"
       contextViewClassName="w-full lg:max-w-[320px] xl:max-w-[320px] h-full overflow-y-hidden"
       contextView={
         <div className="flex h-full flex-col gap-y-4">
@@ -365,7 +366,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     >
       <div className="flex h-full flex-col gap-y-4">
         {events.length === 0 && !isFetching ? (
-          <div className="dark:border-polar-700 flex min-h-96 w-full flex-col items-center justify-center gap-4 rounded-4xl border border-gray-200 p-24">
+          <div className="dark:border-polar-700 flex min-h-96 w-full flex-col items-center justify-center gap-4 rounded-4xl border border-gray-200 p-8 text-center md:p-24">
             <h1 className="text-2xl font-normal">No Events Found</h1>
             <p className="dark:text-polar-500 text-gray-500">
               There are no events matching your current filters

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
@@ -119,6 +119,7 @@ export default function EventDetailPage({
       }
       className="flex flex-col gap-y-12"
       contextViewPlacement="right"
+      contextViewTitle="Customer"
       contextView={
         event.customer ? (
           <CustomerContextView
@@ -127,7 +128,7 @@ export default function EventDetailPage({
           />
         ) : undefined
       }
-      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:block hidden md:shadow-none"
+      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:shadow-none"
     >
       <div className="grid grid-cols-1 items-start gap-16 md:grid-cols-[1fr_360px]">
         {/* Left column — event rows */}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/layout.tsx
@@ -1,6 +1,10 @@
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { DashboardsListSidebar } from '@/components/Metrics/dashboards/DashboardsListSidebar'
-import { DashboardViewHeader } from '@/components/Metrics/dashboards/DashboardViewHeader'
+import {
+  DashboardViewActions,
+  DashboardViewTitle,
+} from '@/components/Metrics/dashboards/DashboardViewHeader'
+import { MetricsHeader } from '@/components/Metrics/dashboards/MetricsHeader'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { METRIC_GROUPS } from '@/utils/metrics'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
@@ -47,12 +51,25 @@ export default async function Layout(props: {
   return (
     <DashboardBody
       wide
-      title={null}
-      header={
-        <DashboardViewHeader
+      title={<DashboardViewTitle organization={organization} />}
+      titleActions={
+        <DashboardViewActions
           organization={organization}
           earliestDateISOString={limits.min_date}
         />
+      }
+      header={
+        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-center md:gap-x-6">
+          <MetricsHeader
+            organization={organization}
+            earliestDateISOString={limits.min_date}
+          />
+          <DashboardViewActions
+            organization={organization}
+            earliestDateISOString={limits.min_date}
+            className="hidden md:flex"
+          />
+        </div>
       }
       contextView={
         <DashboardsListSidebar
@@ -61,6 +78,7 @@ export default async function Layout(props: {
         />
       }
       contextViewPlacement="left"
+      contextViewTitle="Dashboards"
       contextViewClassName="md:max-w-[300px] xl:max-w-[320px]"
     >
       {props.children}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -107,13 +107,14 @@ const ClientPage: React.FC<ClientPageProps> = ({
         ) : undefined
       }
       className="gap-y-12"
+      contextViewTitle="Customer"
       contextView={
         <CustomerContextView
           organization={organization}
           customer={order.customer}
         />
       }
-      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:block hidden md:shadow-none"
+      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:shadow-none"
     >
       <ShadowBox className="dark:divide-polar-700 flex flex-col divide-y divide-gray-200 border-gray-200 bg-transparent p-0 md:rounded-3xl!">
         <div className="flex flex-col gap-6 p-4 md:p-8">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/[id]/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/[id]/CheckoutsPage.tsx
@@ -40,6 +40,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization, checkout }) => {
       }
       className="gap-y-8"
       contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none"
+      contextViewTitle="Customer"
       contextView={
         customer ? (
           <CustomerContextView

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
@@ -138,7 +138,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
           )}
         </div>
       }
-      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:block hidden"
+      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none"
+      contextViewTitle="Customer"
       contextView={
         <CustomerContextView
           organization={organization}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -164,6 +164,7 @@ export default function ClientPage({
         </div>
       }
       contextView={<WebhookContextView endpoint={endpoint} />}
+      contextViewTitle="Webhook"
       className="gap-y-8"
       wide
     >

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -1,10 +1,14 @@
 'use client'
 
 import LogoIcon from '@/components/Brand/logos/LogoIcon'
+import { Modal } from '@/components/Modal'
+import { useModal } from '@/components/Modal/useModal'
 import { useAuth } from '@/hooks/auth'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import { setLastVisitedOrg } from '@/utils/cookies'
+import ViewSidebarOutlined from '@mui/icons-material/ViewSidebarOutlined'
 import { schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
 import {
   SidebarTrigger,
   useSidebar,
@@ -17,6 +21,7 @@ import {
   PropsWithChildren,
   useContext,
   useEffect,
+  useRef,
   useState,
   type JSX,
 } from 'react'
@@ -161,7 +166,9 @@ export interface DashboardBodyProps {
   contextView?: React.ReactNode
   contextViewClassName?: string
   contextViewPlacement?: 'left' | 'right'
+  contextViewTitle?: string
   header?: JSX.Element
+  titleActions?: React.ReactNode
   wide?: boolean
 }
 
@@ -173,7 +180,9 @@ export const DashboardBody = ({
   contextView,
   contextViewClassName,
   contextViewPlacement = 'right',
+  contextViewTitle = 'Details',
   header,
+  titleActions,
   wide = false,
 }: DashboardBodyProps) => {
   const { currentRoute, currentSubRoute } = useRoute()
@@ -185,6 +194,21 @@ export const DashboardBody = ({
   const current = currentSubRoute ?? currentRoute
 
   const parsedTitle = title ?? current?.title
+
+  const pathname = usePathname()
+  const {
+    isShown: isContextShown,
+    show: showContext,
+    hide: hideContext,
+  } = useModal()
+  const lastPathnameRef = useRef(pathname)
+
+  useEffect(() => {
+    if (lastPathnameRef.current !== pathname) {
+      lastPathnameRef.current = pathname
+      hideContext()
+    }
+  }, [pathname, hideContext])
 
   return (
     <motion.div
@@ -204,16 +228,39 @@ export const DashboardBody = ({
             wide ? '' : 'max-w-(--breakpoint-xl)',
           )}
         >
-          {(title !== null || !!header) && (
+          {(title !== null || !!header || contextView) && (
             <div className="flex flex-col gap-y-4 md:flex-row md:items-center md:justify-between md:gap-x-4">
-              {title !== null &&
-                (!title || typeof parsedTitle === 'string' ? (
-                  <h4 className="text-2xl font-medium whitespace-nowrap dark:text-white">
-                    {title ?? current?.title}
-                  </h4>
-                ) : (
-                  parsedTitle
-                ))}
+              {(title !== null || contextView || titleActions) && (
+                <div className="flex items-center gap-x-2 md:contents">
+                  {title !== null &&
+                    (!title || typeof parsedTitle === 'string' ? (
+                      <h4 className="text-2xl font-medium whitespace-nowrap dark:text-white">
+                        {title ?? current?.title}
+                      </h4>
+                    ) : (
+                      parsedTitle
+                    ))}
+                  {titleActions && (
+                    <div className="ml-auto flex items-center gap-x-2 md:hidden">
+                      {titleActions}
+                    </div>
+                  )}
+                  {contextView && (
+                    <Button
+                      size="icon"
+                      variant="secondary"
+                      className={twMerge(
+                        'h-8 w-8 md:hidden',
+                        titleActions ? '' : 'ml-auto',
+                      )}
+                      onClick={showContext}
+                      aria-label={`Open ${contextViewTitle}`}
+                    >
+                      <ViewSidebarOutlined fontSize="small" />
+                    </Button>
+                  )}
+                </div>
+              )}
 
               {header ? (
                 header
@@ -243,13 +290,21 @@ export const DashboardBody = ({
             exit: { opacity: 0, transition: { duration: 0.3 } },
           }}
           className={twMerge(
-            'dark:bg-polar-900 dark:border-polar-800 w-full flex-1 overflow-y-auto rounded-2xl border border-gray-200 bg-white md:max-w-[320px] md:shadow-xs xl:max-w-[440px]',
+            'dark:bg-polar-900 dark:border-polar-800 hidden w-full flex-1 overflow-y-auto rounded-2xl border border-gray-200 bg-white md:block md:max-w-[320px] md:shadow-xs xl:max-w-[440px]',
             contextViewClassName,
           )}
         >
           {contextView}
         </motion.div>
       ) : null}
+      {contextView && (
+        <Modal
+          title={contextViewTitle}
+          isShown={isContextShown}
+          hide={hideContext}
+          modalContent={<div>{contextView}</div>}
+        />
+      )}
     </motion.div>
   )
 }

--- a/clients/apps/web/src/components/Metrics/IntervalPicker.tsx
+++ b/clients/apps/web/src/components/Metrics/IntervalPicker.tsx
@@ -113,7 +113,7 @@ const IntervalPicker = ({
 
   return (
     <Select value={interval} onValueChange={onChange}>
-      <SelectTrigger>
+      <SelectTrigger className="text-sm">
         <SelectValue placeholder="Select an interval" />
       </SelectTrigger>
       <SelectContent>

--- a/clients/apps/web/src/components/Metrics/dashboards/DashboardViewHeader.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/DashboardViewHeader.tsx
@@ -23,7 +23,7 @@ import {
 } from '@polar-sh/ui/components/atoms/DropdownMenu'
 import { usePathname, useRouter } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
-import { MetricsHeader } from './MetricsHeader'
+import { twMerge } from 'tailwind-merge'
 import { useMetricsFilters } from './useMetricsFilters'
 
 const BUILT_IN_NAMES: Record<string, string> = {
@@ -40,22 +40,9 @@ const BUILT_IN_NAMES: Record<string, string> = {
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-interface DashboardViewHeaderProps {
-  organization: schemas['Organization']
-  earliestDateISOString: string
-}
-
-export function DashboardViewHeader({
-  organization,
-  earliestDateISOString,
-}: DashboardViewHeaderProps) {
+function useCurrentDashboard(organization: schemas['Organization']) {
   const pathname = usePathname()
   const { data: customDashboards } = useMetricDashboards(organization.id)
-  const { isShown: isEditShown, show: showEdit, hide: hideEdit } = useModal()
-
-  const { interval, startDate, endDate, productId } = useMetricsFilters(
-    earliestDateISOString,
-  )
 
   const currentSlug = useMemo(() => {
     const parts = pathname.split('/')
@@ -82,6 +69,43 @@ export function DashboardViewHeader({
     if (BUILT_IN_NAMES[currentSlug]) return BUILT_IN_NAMES[currentSlug]
     return currentDashboard?.name ?? null
   }, [currentSlug, currentDashboard])
+
+  return { currentSlug, isCustomDashboard, currentDashboard, dashboardName }
+}
+
+export function DashboardViewTitle({
+  organization,
+}: {
+  organization: schemas['Organization']
+}) {
+  const { dashboardName } = useCurrentDashboard(organization)
+  if (!dashboardName) return null
+  return (
+    <h3 className="text-xl font-medium whitespace-nowrap dark:text-white">
+      {dashboardName}
+    </h3>
+  )
+}
+
+interface DashboardViewActionsProps {
+  organization: schemas['Organization']
+  earliestDateISOString: string
+  className?: string
+}
+
+export function DashboardViewActions({
+  organization,
+  earliestDateISOString,
+  className,
+}: DashboardViewActionsProps) {
+  const { isShown: isEditShown, show: showEdit, hide: hideEdit } = useModal()
+
+  const { interval, startDate, endDate, productId } = useMetricsFilters(
+    earliestDateISOString,
+  )
+
+  const { currentSlug, isCustomDashboard, currentDashboard } =
+    useCurrentDashboard(organization)
 
   const metricsForExport = useMemo(() => {
     if (isCustomDashboard && currentDashboard) {
@@ -119,30 +143,17 @@ export function DashboardViewHeader({
   ])
 
   return (
-    <div className="flex w-full items-center justify-between gap-x-4">
-      {dashboardName ? (
-        <h3 className="text-xl font-medium whitespace-nowrap dark:text-white">
-          {dashboardName}
-        </h3>
-      ) : (
-        <span />
-      )}
-      <div className="flex items-center gap-x-6">
-        <MetricsHeader
+    <div className={twMerge('flex items-center', className)}>
+      {isCustomDashboard && currentDashboard ? (
+        <DashboardDotMenu
           organization={organization}
-          earliestDateISOString={earliestDateISOString}
+          dashboard={currentDashboard}
+          onEdit={showEdit}
+          onExport={handleExport}
         />
-        {isCustomDashboard && currentDashboard ? (
-          <DashboardDotMenu
-            organization={organization}
-            dashboard={currentDashboard}
-            onEdit={showEdit}
-            onExport={handleExport}
-          />
-        ) : (
-          <ExportMenu onExport={handleExport} />
-        )}
-      </div>
+      ) : (
+        <ExportMenu onExport={handleExport} />
+      )}
       {currentDashboard && (
         <Modal
           title="Edit Dashboard"


### PR DESCRIPTION
This PR fixes multiple issues with the mobile layout in our `<DashboardBody  />` component.

### Examples

#### `/analytics/metrics/revenue`

| Before | After  |
|--------|--------|
| <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org_analytics_metrics_revenue(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/e4e6bb3c-8c18-4044-955e-460021573f2f" /> | <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org_analytics_metrics_revenue(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/ef08b4cd-7249-4810-8c47-58692977eb13" /> |


#### `/analytics/events`

| Before | After  |
|--------|--------|
| <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org_analytics_events(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/59660b72-789b-4f84-b961-b6118e098f4a" /> | <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org_analytics_events(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/b8c2f314-cfaf-4ec7-bca1-ce6c3a8118b3" /> |


#### New modals

| Events | Revenue  |
|--------|--------|
| <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org_analytics_events(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/df74659e-1ca9-4894-943c-a1264b6f3be3" /> | <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org_analytics_metrics_revenue(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/b11721ee-4248-4c6a-82c3-1e290f3014bf" /> |


This one's for my you Pieter my brother





