### PR TITLE
Display "Back to <org>" button on mobile

### DIFF
--- a/clients/apps/web/src/app/(main)/[organization]/portal/CustomerPortalLayoutWrapper.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/CustomerPortalLayoutWrapper.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { CustomerPortalProvider } from '@/components/CustomerPortal/CustomerPortalProvider'
+import { useCustomerPortalSession } from '@/hooks/queries/customerPortal'
+import { createClientSideAPI } from '@/utils/client'
+import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined'
 import { schemas } from '@polar-sh/client'
+import Avatar from '@polar-sh/ui/components/atoms/Avatar'
+import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 
 interface CustomerPortalLayoutWrapperProps {
@@ -19,6 +24,8 @@ export function CustomerPortalLayoutWrapper({
     searchParams.get('member_session_token') ??
     ''
 
+  const { data: session } = useCustomerPortalSession(createClientSideAPI(token))
+
   return (
     <CustomerPortalProvider
       token={token}
@@ -26,6 +33,22 @@ export function CustomerPortalLayoutWrapper({
       organizationSlug={organization.slug}
       baseUrl={process.env.NEXT_PUBLIC_API_URL}
     >
+      <div className="flex flex-row items-center gap-x-3 px-4 py-4 lg:px-8 lg:py-8">
+        <Avatar
+          className="h-8 w-8 flex-none"
+          avatar_url={organization.avatar_url}
+          name={organization.name}
+        />
+        {session?.return_url && (
+          <Link
+            href={session.return_url}
+            className="dark:text-polar-500 flex min-w-0 flex-row items-center gap-x-1 text-xs text-gray-500"
+          >
+            <ArrowBackOutlined fontSize="inherit" className="flex-none" />
+            <span className="truncate">Back to {organization.name}</span>
+          </Link>
+        )}
+      </div>
       {children}
     </CustomerPortalProvider>
   )

--- a/clients/apps/web/src/app/(main)/[organization]/portal/Navigation.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/Navigation.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import {
-  useCustomerPortalSession,
-  usePortalAuthenticatedUser,
-} from '@/hooks/queries/customerPortal'
+import { usePortalAuthenticatedUser } from '@/hooks/queries/customerPortal'
 import { createClientSideAPI } from '@/utils/client'
 import { hasBillingPermission } from '@/utils/customerPortal'
-import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined'
 import { Client, schemas } from '@polar-sh/client'
 import {
   Select,
@@ -75,7 +71,6 @@ const NavigationContent = ({
   searchParams: URLSearchParams
 }) => {
   const router = useRouter()
-  const { data: customerPortalSession } = useCustomerPortalSession(api)
   const { data: authenticatedUser } = usePortalAuthenticatedUser(api)
 
   const buildPath = (path: string) => {
@@ -87,15 +82,6 @@ const NavigationContent = ({
   return (
     <>
       <nav className="sticky top-0 hidden h-fit w-40 flex-none flex-col gap-y-6 py-12 md:flex lg:w-64">
-        {customerPortalSession && customerPortalSession.return_url && (
-          <Link
-            href={customerPortalSession.return_url}
-            className="dark:text-polar-500 flex flex-row items-center gap-x-4 py-2 text-gray-500"
-          >
-            <ArrowBackOutlined fontSize="inherit" />
-            <span>Back to {organization.name}</span>
-          </Link>
-        )}
         <div className="flex flex-col">
           {authenticatedUser?.name ? <h3>{authenticatedUser?.name}</h3> : null}
           <span

--- a/clients/apps/web/src/app/(main)/[organization]/portal/layout.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/layout.tsx
@@ -1,7 +1,6 @@
 import { Toaster } from '@/components/Toast/Toaster'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { getOrganizationOrNotFound } from '@/utils/customerPortal'
-import Avatar from '@polar-sh/ui/components/atoms/Avatar'
 import { CustomerPortalLayoutWrapper } from './CustomerPortalLayoutWrapper'
 import { Navigation } from './Navigation'
 
@@ -23,15 +22,6 @@ export default async function Layout(props: {
 
   return (
     <div className="flex min-h-screen grow flex-col">
-      <div className="flex w-full flex-col">
-        <div className="flex flex-col justify-center gap-y-12 px-4 py-4 lg:px-8 lg:py-8">
-          <Avatar
-            className="h-8 w-8"
-            avatar_url={organization.avatar_url}
-            name={organization.name}
-          />
-        </div>
-      </div>
       <CustomerPortalLayoutWrapper organization={organization}>
         <div className="flex w-full flex-col items-stretch gap-6 px-4 py-8 md:mx-auto md:max-w-5xl md:flex-row md:gap-12 lg:px-0">
           <Navigation organization={organization} />


### PR DESCRIPTION
Display the `Back to <org>` button in the customer portal on mobile, similar to what we do on desktop.

Fixes: https://github.com/polarsource/polar/issues/8711

| Before | After  |
|--------|--------|
| <img width="431" height="639" alt="Screenshot 2026-04-23 at 17 12 50" src="https://github.com/user-attachments/assets/b622a64d-ac11-45b1-b243-be55ad28051d" /> | <img width="384" height="480" alt="Screenshot 2026-04-24 at 12 44 46" src="https://github.com/user-attachments/assets/a0f87c74-5faa-4372-88f7-47362bfab4c6" /> |








