### PR TITLE
server/authz: proper policy guard for payout accounts

### DIFF
--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -19,8 +19,9 @@ from polar.postgres import AsyncSession, get_db_session
 
 from .policies import finance, members
 from .policies import organization as org_policy
+from .policies import payout_account as pa_policy
 from .service import get_accessible_org_ids, get_accessible_organization
-from .types import PolicyFn
+from .types import PayoutAccountPolicyFn, PolicyFn
 
 
 @dataclass(frozen=True)
@@ -179,7 +180,7 @@ class AuthorizedPayoutAccount:
     """Result of a PayoutAccountPolicyGuard dependency."""
 
     payout_account: "PayoutAccountModel"
-    auth_subject: AuthSubject[User | Organization]
+    auth_subject: AuthSubject[User]
 
 
 def AccountPolicyGuard(policy_fn: PolicyFn) -> Any:
@@ -223,14 +224,17 @@ def AccountPolicyGuard(policy_fn: PolicyFn) -> Any:
     return dependency
 
 
-def PayoutAccountPolicyGuard(policy_fn: PolicyFn) -> Any:
-    """FastAPI dependency: resolve payout account by {id}, find owning org, check policy.
+def PayoutAccountPolicyGuard(policy_fn: PayoutAccountPolicyFn) -> Any:
+    """FastAPI dependency: resolve payout account by {id}, check policy.
+
+    Payout accounts are user-owned resources (via ``admin_id``).
+    The policy receives the authenticated user and the payout account
+    instead of an organization.
 
     Raises:
         Unauthorized (401): No valid credentials.
-        ResourceNotFound (404): Payout account not found or subject has no
-            access to the owning organization.
-        NotPermitted (403): Subject is a member but the policy denied access.
+        ResourceNotFound (404): Payout account not found or policy denied
+            access.
     """
 
     _authenticator = Authenticator(
@@ -248,11 +252,9 @@ def PayoutAccountPolicyGuard(policy_fn: PolicyFn) -> Any:
         if payout_account is None:
             raise ResourceNotFound()
 
-        # Check that the user is admin of this payout account's organization
-        if payout_account.admin_id != auth_subject.subject.id:
+        if not await policy_fn(auth_subject, payout_account):
             raise ResourceNotFound()
 
-        # await _check_policy(policy_fn, session, auth_subject, organization)
         return AuthorizedPayoutAccount(
             payout_account=payout_account,
             auth_subject=auth_subject,
@@ -269,9 +271,9 @@ AuthorizeAccountWrite = Annotated[
     Depends(AccountPolicyGuard(finance.can_write)),
 ]
 AuthorizePayoutAccountRead = Annotated[
-    AuthorizedPayoutAccount, Depends(PayoutAccountPolicyGuard(finance.can_read))
+    AuthorizedPayoutAccount, Depends(PayoutAccountPolicyGuard(pa_policy.can_read))
 ]
 AuthorizePayoutAccountWrite = Annotated[
     AuthorizedPayoutAccount,
-    Depends(PayoutAccountPolicyGuard(finance.can_write)),
+    Depends(PayoutAccountPolicyGuard(pa_policy.can_write)),
 ]

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -1,3 +1,4 @@
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Annotated, Any
 from uuid import UUID
@@ -21,7 +22,7 @@ from .policies import finance, members
 from .policies import organization as org_policy
 from .policies import payout_account as pa_policy
 from .service import get_accessible_org_ids, get_accessible_organization
-from .types import PayoutAccountPolicyFn, PolicyFn
+from .types import PolicyFn
 
 
 @dataclass(frozen=True)
@@ -224,7 +225,9 @@ def AccountPolicyGuard(policy_fn: PolicyFn) -> Any:
     return dependency
 
 
-def PayoutAccountPolicyGuard(policy_fn: PayoutAccountPolicyFn) -> Any:
+def PayoutAccountPolicyGuard(
+    policy_fn: Callable[[AuthSubject[User], "PayoutAccountModel"], Awaitable[bool]],
+) -> Any:
     """FastAPI dependency: resolve payout account by {id}, check policy.
 
     Payout accounts are user-owned resources (via ``admin_id``).

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -22,7 +22,7 @@ from .policies import finance, members
 from .policies import organization as org_policy
 from .policies import payout_account as pa_policy
 from .service import get_accessible_org_ids, get_accessible_organization
-from .types import PolicyFn
+from .types import PolicyFn, PolicyResult
 
 
 @dataclass(frozen=True)
@@ -226,7 +226,7 @@ def AccountPolicyGuard(policy_fn: PolicyFn) -> Any:
 
 
 def PayoutAccountPolicyGuard(
-    policy_fn: Callable[[AuthSubject[User], "PayoutAccountModel"], Awaitable[bool]],
+    policy_fn: Callable[[AuthSubject[User], "PayoutAccountModel"], Awaitable[PolicyResult]],
 ) -> Any:
     """FastAPI dependency: resolve payout account by {id}, check policy.
 
@@ -255,7 +255,8 @@ def PayoutAccountPolicyGuard(
         if payout_account is None:
             raise ResourceNotFound()
 
-        if not await policy_fn(auth_subject, payout_account):
+        result = await policy_fn(auth_subject, payout_account)
+        if result is not True:
             raise ResourceNotFound()
 
         return AuthorizedPayoutAccount(

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -144,6 +144,16 @@ AuthorizeOrgDelete = Annotated[
         )
     ),
 ]
+AuthorizeOrgManagePayoutAccount = Annotated[
+    AuthzContext[User],
+    Depends(
+        OrgPolicyGuard(
+            org_policy.can_manage_payout_account,
+            allowed_subjects={User},
+            required_scopes={Scope.web_write, Scope.organizations_write},
+        )
+    ),
+]
 AuthorizeOrgAccess = Annotated[
     AuthzContext[User | Organization], Depends(OrgPolicyGuard(_always_allow))
 ]
@@ -226,7 +236,9 @@ def AccountPolicyGuard(policy_fn: PolicyFn) -> Any:
 
 
 def PayoutAccountPolicyGuard(
-    policy_fn: Callable[[AuthSubject[User], "PayoutAccountModel"], Awaitable[PolicyResult]],
+    policy_fn: Callable[
+        [AuthSubject[User], "PayoutAccountModel"], Awaitable[PolicyResult]
+    ],
 ) -> Any:
     """FastAPI dependency: resolve payout account by {id}, check policy.
 

--- a/server/polar/authz/policies/members.py
+++ b/server/polar/authz/policies/members.py
@@ -1,14 +1,9 @@
-from polar.account.service import account as account_service
-from polar.auth.models import (
-    AuthSubject,
-    Organization,
-    User,
-    is_organization,
-    is_user,
-)
+from polar.auth.models import AuthSubject, Organization, User
 from polar.authz.types import PolicyResult
 from polar.models import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
+
+from .organization import _require_account_admin
 
 
 async def can_manage(
@@ -16,20 +11,10 @@ async def can_manage(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject invite/remove/change members?
-
-    - Organization tokens: always allowed (the org is the subject)
-    - Users: if the org has an account, only the account admin can manage.
-      If no account, any member can manage.
-    """
-    if is_organization(auth_subject):
-        return True
-    if is_user(auth_subject):
-        if organization.account_id is None:
-            return True
-        if await account_service.is_user_admin(
-            session, organization.account_id, auth_subject.subject
-        ):
-            return True
-        return "Only organization admins can manage members"
-    return "Not permitted"
+    """Can the subject invite/remove/change members?"""
+    return await _require_account_admin(
+        session,
+        auth_subject,
+        organization,
+        "Only the account admin can manage members",
+    )

--- a/server/polar/authz/policies/organization.py
+++ b/server/polar/authz/policies/organization.py
@@ -11,28 +11,41 @@ from polar.models import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
 
 
+async def _require_account_admin(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+    denied_msg: str,
+) -> PolicyResult:
+    """Check that the subject is the account admin of the organization.
+
+    Organizations always have a billing account. Only the account admin
+    (the user whose ``admin_id`` matches the account) is allowed.
+    Organization-token subjects are always permitted.
+    """
+    if is_organization(auth_subject):
+        return True
+    if is_user(auth_subject):
+        if await account_service.is_user_admin(
+            session, organization.account_id, auth_subject.subject
+        ):
+            return True
+        return denied_msg
+    return "Not permitted"
+
+
 async def can_delete(
     session: AsyncReadSession,
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject delete this organization?
-
-    - Organization tokens: always allowed (the org is the subject)
-    - Users: if the org has an account, only the account admin can delete.
-      If no account, any member can delete.
-    """
-    if is_organization(auth_subject):
-        return True
-    if is_user(auth_subject):
-        if organization.account_id is None:
-            return True
-        if await account_service.is_user_admin(
-            session, organization.account_id, auth_subject.subject
-        ):
-            return True
-        return "Only the account admin can delete an organization with an account"
-    return "Not permitted"
+    """Can the subject delete this organization?"""
+    return await _require_account_admin(
+        session,
+        auth_subject,
+        organization,
+        "Only the account admin can delete the organization",
+    )
 
 
 async def can_manage_payout_account(
@@ -40,20 +53,10 @@ async def can_manage_payout_account(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject set or change the payout account for this organization?
-
-    - Organization tokens: always allowed (the org is the subject)
-    - Users: if the org has an account, only the account admin can manage.
-      If no account, any member can manage.
-    """
-    if is_organization(auth_subject):
-        return True
-    if is_user(auth_subject):
-        if organization.account_id is None:
-            return True
-        if await account_service.is_user_admin(
-            session, organization.account_id, auth_subject.subject
-        ):
-            return True
-        return "Only organization admins can manage the payout account"
-    return "Not permitted"
+    """Can the subject set or change the payout account for this organization?"""
+    return await _require_account_admin(
+        session,
+        auth_subject,
+        organization,
+        "Only the account admin can manage the payout account",
+    )

--- a/server/polar/authz/policies/organization.py
+++ b/server/polar/authz/policies/organization.py
@@ -33,3 +33,27 @@ async def can_delete(
             return True
         return "Only the account admin can delete an organization with an account"
     return "Not permitted"
+
+
+async def can_manage_payout_account(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject set or change the payout account for this organization?
+
+    - Organization tokens: always allowed (the org is the subject)
+    - Users: if the org has an account, only the account admin can manage.
+      If no account, any member can manage.
+    """
+    if is_organization(auth_subject):
+        return True
+    if is_user(auth_subject):
+        if organization.account_id is None:
+            return True
+        if await account_service.is_user_admin(
+            session, organization.account_id, auth_subject.subject
+        ):
+            return True
+        return "Only organization admins can manage the payout account"
+    return "Not permitted"

--- a/server/polar/authz/policies/payout_account.py
+++ b/server/polar/authz/policies/payout_account.py
@@ -5,10 +5,12 @@ from polar.models import PayoutAccount as PayoutAccountModel
 async def can_read(
     auth_subject: AuthSubject[User], payout_account: PayoutAccountModel
 ) -> bool:
+    """Can the subject view this payout account?"""
     return payout_account.admin_id == auth_subject.subject.id
 
 
 async def can_write(
     auth_subject: AuthSubject[User], payout_account: PayoutAccountModel
 ) -> bool:
-    return payout_account.admin_id == auth_subject.subject.id
+    """Can the subject manage this payout account?"""
+    return await can_read(auth_subject, payout_account)

--- a/server/polar/authz/policies/payout_account.py
+++ b/server/polar/authz/policies/payout_account.py
@@ -1,16 +1,19 @@
 from polar.auth.models import AuthSubject, User
+from polar.authz.types import PolicyResult
 from polar.models import PayoutAccount as PayoutAccountModel
 
 
 async def can_read(
     auth_subject: AuthSubject[User], payout_account: PayoutAccountModel
-) -> bool:
+) -> PolicyResult:
     """Can the subject view this payout account?"""
-    return payout_account.admin_id == auth_subject.subject.id
+    if payout_account.admin_id == auth_subject.subject.id:
+        return True
+    return "Only the payout account admin can access this resource"
 
 
 async def can_write(
     auth_subject: AuthSubject[User], payout_account: PayoutAccountModel
-) -> bool:
+) -> PolicyResult:
     """Can the subject manage this payout account?"""
     return await can_read(auth_subject, payout_account)

--- a/server/polar/authz/policies/payout_account.py
+++ b/server/polar/authz/policies/payout_account.py
@@ -1,0 +1,14 @@
+from polar.auth.models import AuthSubject, User
+from polar.models import PayoutAccount as PayoutAccountModel
+
+
+async def can_read(
+    auth_subject: AuthSubject[User], payout_account: PayoutAccountModel
+) -> bool:
+    return payout_account.admin_id == auth_subject.subject.id
+
+
+async def can_write(
+    auth_subject: AuthSubject[User], payout_account: PayoutAccountModel
+) -> bool:
+    return payout_account.admin_id == auth_subject.subject.id

--- a/server/polar/authz/types.py
+++ b/server/polar/authz/types.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.models import Organization as OrganizationModel
-from polar.models import PayoutAccount as PayoutAccountModel
 from polar.postgres import AsyncSession
 
 # A UUID that has been verified as accessible by the current auth subject.
@@ -17,10 +16,4 @@ PolicyResult = bool | str
 PolicyFn = Callable[
     [AsyncSession, AuthSubject[User | Organization], OrganizationModel],
     Awaitable[PolicyResult],
-]
-
-# Policy functions for payout-account guards (no org context).
-PayoutAccountPolicyFn = Callable[
-    [AuthSubject[User], PayoutAccountModel],
-    Awaitable[bool],
 ]

--- a/server/polar/authz/types.py
+++ b/server/polar/authz/types.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.models import Organization as OrganizationModel
+from polar.models import PayoutAccount as PayoutAccountModel
 from polar.postgres import AsyncSession
 
 # A UUID that has been verified as accessible by the current auth subject.
@@ -16,4 +17,10 @@ PolicyResult = bool | str
 PolicyFn = Callable[
     [AsyncSession, AuthSubject[User | Organization], OrganizationModel],
     Awaitable[PolicyResult],
+]
+
+# Policy functions for payout-account guards (no org context).
+PayoutAccountPolicyFn = Callable[
+    [AuthSubject[User], PayoutAccountModel],
+    Awaitable[bool],
 ]

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -11,6 +11,7 @@ from polar.authz.dependencies import (
     AuthorizeMembersManage,
     AuthorizeOrgAccessUser,
     AuthorizeOrgDelete,
+    AuthorizeOrgManagePayoutAccount,
 )
 from polar.authz.policies import payout_account as pa_policy
 from polar.config import settings
@@ -164,34 +165,18 @@ async def get_account(
     tags=[APITag.private],
 )
 async def set_payout_account(
-    id: OrganizationID,
+    authz: AuthorizeOrgManagePayoutAccount,
     body: OrganizationPayoutAccountSet,
-    auth_subject: auth.OrganizationsWriteUser,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Set the payout account for an organization."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
     # Resolve payout account and check admin ownership
     pa_repo = PayoutAccountRepository.from_session(session)
     payout_account = await pa_repo.get_by_id(body.payout_account_id)
-    if payout_account is None:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "value_error",
-                    "loc": ("body", "payout_account_id"),
-                    "msg": "Payout account not found or not accessible.",
-                    "input": str(body.payout_account_id),
-                }
-            ]
-        )
-
-    result = await pa_policy.can_write(auth_subject, payout_account)
-    if result is not True:
+    if (
+        payout_account is None
+        or await pa_policy.can_write(authz.auth_subject, payout_account) is not True
+    ):
         raise PolarRequestValidationError(
             [
                 {
@@ -204,7 +189,7 @@ async def set_payout_account(
         )
 
     return await organization_service.set_payout_account(
-        session, organization, payout_account
+        session, authz.organization, payout_account
     )
 
 

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -12,6 +12,7 @@ from polar.authz.dependencies import (
     AuthorizeOrgAccessUser,
     AuthorizeOrgDelete,
 )
+from polar.authz.policies import payout_account as pa_policy
 from polar.config import settings
 from polar.email.schemas import OrganizationInviteEmail, OrganizationInviteProps
 from polar.email.sender import enqueue_email_template
@@ -31,6 +32,7 @@ from polar.organization.repository import (
     OrganizationRepository,
     OrganizationReviewRepository,
 )
+from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import (
     AsyncReadSession,
     AsyncSession,
@@ -173,8 +175,36 @@ async def set_payout_account(
     if organization is None:
         raise ResourceNotFound()
 
+    # Resolve payout account and check admin ownership
+    pa_repo = PayoutAccountRepository.from_session(session)
+    payout_account = await pa_repo.get_by_id(body.payout_account_id)
+    if payout_account is None:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "payout_account_id"),
+                    "msg": "Payout account not found or not accessible.",
+                    "input": str(body.payout_account_id),
+                }
+            ]
+        )
+
+    result = await pa_policy.can_write(auth_subject, payout_account)
+    if result is not True:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "payout_account_id"),
+                    "msg": "Payout account not found or not accessible.",
+                    "input": str(body.payout_account_id),
+                }
+            ]
+        )
+
     return await organization_service.set_payout_account(
-        session, auth_subject, organization, body.payout_account_id
+        session, organization, payout_account
     )
 
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -67,8 +67,6 @@ from .schemas import (
 )
 from .sorting import OrganizationSortProperty
 
-
-
 log = structlog.get_logger()
 
 _MIN_REVIEW_THRESHOLD = 10_000

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -640,25 +640,9 @@ class OrganizationService:
     async def set_payout_account(
         self,
         session: AsyncSession,
-        auth_subject: AuthSubject[User],
         organization: Organization,
-        payout_account_id: uuid.UUID,
+        payout_account: PayoutAccount,
     ) -> Organization:
-        payout_account = await payout_account_service.get_by_id_and_admin(
-            session, payout_account_id, auth_subject.subject
-        )
-        if payout_account is None:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "payout_account_id"),
-                        "msg": "Payout account not found or not accessible.",
-                        "input": str(payout_account_id),
-                    }
-                ]
-            )
-
         organization_repository = OrganizationRepository.from_session(session)
         return await organization_repository.update(
             organization,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 from uuid import UUID
 
 import structlog
@@ -67,8 +67,7 @@ from .schemas import (
 )
 from .sorting import OrganizationSortProperty
 
-if TYPE_CHECKING:
-    pass
+
 
 log = structlog.get_logger()
 

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -100,20 +100,6 @@ class PayoutAccountService:
         )
         return await repository.get_one_or_none(statement)
 
-    async def get_by_id_and_admin(
-        self,
-        session: AsyncReadSession,
-        payout_account_id: uuid.UUID,
-        user: User,
-    ) -> PayoutAccount | None:
-        """Look up a payout account by ID, checking that the user is its admin."""
-        repository = PayoutAccountRepository.from_session(session)
-        statement = repository.get_base_statement().where(
-            PayoutAccount.id == payout_account_id,
-            PayoutAccount.admin_id == user.id,
-        )
-        return await repository.get_one_or_none(statement)
-
     async def create(
         self,
         auth_subject: AuthSubject[User],

--- a/server/tests/authz/test_endpoints.py
+++ b/server/tests/authz/test_endpoints.py
@@ -118,7 +118,7 @@ class TestPolicyGuardDeleteOrganization:
         assert response.status_code == 403
         assert (
             response.json()["detail"]
-            == "Only the account admin can delete an organization with an account"
+            == "Only the account admin can delete the organization"
         )
 
 
@@ -164,7 +164,7 @@ class TestPolicyGuardInviteMember:
         )
         assert response.status_code == 403
         assert (
-            response.json()["detail"] == "Only organization admins can manage members"
+            response.json()["detail"] == "Only the account admin can manage members"
         )
 
 

--- a/server/tests/authz/test_endpoints.py
+++ b/server/tests/authz/test_endpoints.py
@@ -163,9 +163,7 @@ class TestPolicyGuardInviteMember:
             json={"email": "newmember@example.com"},
         )
         assert response.status_code == 403
-        assert (
-            response.json()["detail"] == "Only the account admin can manage members"
-        )
+        assert response.json()["detail"] == "Only the account admin can manage members"
 
 
 @pytest.mark.asyncio

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -113,7 +113,7 @@ class TestOrgCanDelete:
         assert isinstance(result, str)
         assert (
             result
-            == "Only the account admin can delete an organization with an account"
+            == "Only the account admin can delete the organization"
         )
 
 
@@ -151,7 +151,7 @@ class TestMembersCanManage:
 
         result = await members.can_manage(session, auth_subject, organization)
         assert isinstance(result, str)
-        assert result == "Only organization admins can manage members"
+        assert result == "Only the account admin can manage members"
 
 
 @pytest.mark.asyncio

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -182,7 +182,8 @@ class TestPayoutAccountCanRead:
         )
 
         result = await pa_policy.can_read(auth_subject, payout_account)
-        assert result is False
+        assert isinstance(result, str)
+        assert "admin" in result.lower()
 
 
 @pytest.mark.asyncio
@@ -217,4 +218,5 @@ class TestPayoutAccountCanWrite:
         )
 
         result = await pa_policy.can_write(auth_subject, payout_account)
-        assert result is False
+        assert isinstance(result, str)
+        assert "admin" in result.lower()

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -3,12 +3,13 @@ import pytest
 from polar.auth.models import AuthSubject
 from polar.authz.policies import finance, members
 from polar.authz.policies import organization as org_policy
-from polar.models import Organization, User
+from polar.authz.policies import payout_account as pa_policy
+from polar.models import Organization, PayoutAccount, User
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_account
+from tests.fixtures.random_objects import create_account, create_payout_account, create_user
 
 
 @pytest.mark.asyncio
@@ -147,3 +148,73 @@ class TestMembersCanManage:
         result = await members.can_manage(session, auth_subject, organization)
         assert isinstance(result, str)
         assert result == "Only organization admins can manage members"
+
+
+@pytest.mark.asyncio
+class TestPayoutAccountCanRead:
+    @pytest.mark.auth
+    async def test_admin_allowed(
+        self,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+
+        result = await pa_policy.can_read(auth_subject, payout_account)
+        assert result is True
+
+    @pytest.mark.auth
+    async def test_non_admin_denied(
+        self,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        other_user = await create_user(save_fixture)
+        payout_account = await create_payout_account(
+            save_fixture, organization, other_user
+        )
+
+        result = await pa_policy.can_read(auth_subject, payout_account)
+        assert result is False
+
+
+@pytest.mark.asyncio
+class TestPayoutAccountCanWrite:
+    @pytest.mark.auth
+    async def test_admin_allowed(
+        self,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+
+        result = await pa_policy.can_write(auth_subject, payout_account)
+        assert result is True
+
+    @pytest.mark.auth
+    async def test_non_admin_denied(
+        self,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        other_user = await create_user(save_fixture)
+        payout_account = await create_payout_account(
+            save_fixture, organization, other_user
+        )
+
+        result = await pa_policy.can_write(auth_subject, payout_account)
+        assert result is False

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -4,12 +4,16 @@ from polar.auth.models import AuthSubject
 from polar.authz.policies import finance, members
 from polar.authz.policies import organization as org_policy
 from polar.authz.policies import payout_account as pa_policy
-from polar.models import Organization, PayoutAccount, User
+from polar.models import Organization, User
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_account, create_payout_account, create_user
+from tests.fixtures.random_objects import (
+    create_account,
+    create_payout_account,
+    create_user,
+)
 
 
 @pytest.mark.asyncio
@@ -161,9 +165,7 @@ class TestPayoutAccountCanRead:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
 
         result = await pa_policy.can_read(auth_subject, payout_account)
         assert result is True
@@ -197,9 +199,7 @@ class TestPayoutAccountCanWrite:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
 
         result = await pa_policy.can_write(auth_subject, payout_account)
         assert result is True

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -111,10 +111,7 @@ class TestOrgCanDelete:
 
         result = await org_policy.can_delete(session, auth_subject, organization)
         assert isinstance(result, str)
-        assert (
-            result
-            == "Only the account admin can delete the organization"
-        )
+        assert result == "Only the account admin can delete the organization"
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -831,5 +831,5 @@ class TestDeleteOrganization:
         json = response.json()
         assert (
             json["detail"]
-            == "Only the account admin can delete an organization with an account"
+            == "Only the account admin can delete the organization"
         )

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -829,7 +829,4 @@ class TestDeleteOrganization:
 
         assert response.status_code == 403
         json = response.json()
-        assert (
-            json["detail"]
-            == "Only the account admin can delete the organization"
-        )
+        assert json["detail"] == "Only the account admin can delete the organization"

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -548,9 +548,7 @@ class TestSetPayoutAccount:
         organization.account = await create_account(save_fixture, user=other_user)
         await save_fixture(organization)
 
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
         organization.payout_account = None
         await save_fixture(organization)
 
@@ -573,9 +571,7 @@ class TestSetPayoutAccount:
         organization.account = await create_account(save_fixture, user=user)
         await save_fixture(organization)
 
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
         organization.payout_account = None
         await save_fixture(organization)
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -21,7 +21,9 @@ from tests.fixtures.random_objects import (
     create_account,
     create_customer,
     create_order,
+    create_payout_account,
     create_subscription,
+    create_user,
 )
 
 
@@ -507,6 +509,126 @@ class TestGetPaymentStatus:
         json = response.json()
         # Should be payment ready even without completing steps
         assert json["payment_ready"] is True
+
+
+@pytest.mark.asyncio
+class TestSetPayoutAccount:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/payout-account",
+            json={"payout_account_id": str(uuid.uuid4())},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_non_member_returns_404(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/payout-account",
+            json={"payout_account_id": str(uuid.uuid4())},
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_non_admin_member_returns_403(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        """A regular org member (not admin) cannot set the payout account."""
+        other_user = await create_user(save_fixture)
+        organization.account = await create_account(save_fixture, user=other_user)
+        await save_fixture(organization)
+
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+        organization.payout_account = None
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/payout-account",
+            json={"payout_account_id": str(payout_account.id)},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_admin_can_set_own_payout_account(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        """An org admin can set the payout account to one they own."""
+        organization.account = await create_account(save_fixture, user=user)
+        await save_fixture(organization)
+
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+        organization.payout_account = None
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/payout-account",
+            json={"payout_account_id": str(payout_account.id)},
+        )
+        assert response.status_code == 200
+        assert response.json()["id"] == str(organization.id)
+
+    @pytest.mark.auth
+    async def test_admin_cannot_set_other_users_payout_account(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        """An org admin cannot assign a payout account they don't own."""
+        organization.account = await create_account(save_fixture, user=user)
+        await save_fixture(organization)
+
+        other_user = await create_user(save_fixture)
+        payout_account = await create_payout_account(
+            save_fixture, organization, other_user
+        )
+        organization.payout_account = None
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/payout-account",
+            json={"payout_account_id": str(payout_account.id)},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_unknown_payout_account_returns_422(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        organization.account = await create_account(save_fixture, user=user)
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/payout-account",
+            json={"payout_account_id": str(uuid.uuid4())},
+        )
+        assert response.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -2042,7 +2041,6 @@ class TestSetPayoutAccount:
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
-        auth_subject: AuthSubject[User],
         organization: Organization,
         user_organization: UserOrganization,
         user: User,
@@ -2056,25 +2054,10 @@ class TestSetPayoutAccount:
         await save_fixture(organization)
 
         updated_org = await organization_service.set_payout_account(
-            session, auth_subject, organization, payout_account.id
+            session, organization, payout_account
         )
 
         assert updated_org.payout_account_id == payout_account.id
-
-    @pytest.mark.auth
-    async def test_set_unknown_payout_account_raises_error(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        auth_subject: AuthSubject[User],
-        organization: Organization,
-        user: User,
-    ) -> None:
-        """Raises PolarRequestValidationError for unknown payout account."""
-        with pytest.raises(PolarRequestValidationError):
-            await organization_service.set_payout_account(
-                session, auth_subject, organization, uuid.uuid4()
-            )
 
 
 @pytest.mark.asyncio

--- a/server/tests/payout_account/test_endpoints.py
+++ b/server/tests/payout_account/test_endpoints.py
@@ -1,9 +1,11 @@
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
+from polar.integrations.stripe.service import StripeService
 from polar.models import Organization, PayoutAccount, User, UserOrganization
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -171,6 +173,35 @@ class TestDeletePayoutAccount:
         assert response.status_code == 401
 
     @pytest.mark.auth
+    async def test_admin_can_delete_unlinked_account(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MagicMock,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+        # Unlink from organization so delete is allowed
+        organization.payout_account = None
+        await save_fixture(organization)
+
+        mock = mocker.MagicMock(spec=StripeService)
+        mock.account_exists.return_value = True
+        mock.retrieve_balance.return_value = ("usd", 0)
+        mock.delete_account.return_value = None
+        mocker.patch("polar.payout_account.service.stripe", new=mock)
+
+        response = await client.delete(
+            f"/v1/payout-accounts/{payout_account.id}"
+        )
+
+        assert response.status_code == 204
+
+    @pytest.mark.auth
     async def test_user_cannot_delete_other_organization_account(
         self,
         client: AsyncClient,
@@ -195,6 +226,34 @@ class TestOnboardingLink:
         assert response.status_code == 401
 
     @pytest.mark.auth
+    async def test_admin_can_get_onboarding_link(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MagicMock,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+
+        mock = mocker.MagicMock(spec=StripeService)
+        account_link = MagicMock()
+        account_link.url = "https://connect.stripe.com/setup/test"
+        mock.create_account_link.return_value = account_link
+        mocker.patch("polar.payout_account.service.stripe", new=mock)
+
+        response = await client.post(
+            f"/v1/payout-accounts/{payout_account.id}/onboarding-link",
+            params={"return_path": "/finance/account"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["url"] == "https://connect.stripe.com/setup/test"
+
+    @pytest.mark.auth
     async def test_user_cannot_access_other_organization_account(
         self,
         client: AsyncClient,
@@ -217,6 +276,33 @@ class TestDashboardLink:
         )
 
         assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_admin_can_get_dashboard_link(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MagicMock,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+
+        mock = mocker.MagicMock(spec=StripeService)
+        login_link = MagicMock()
+        login_link.url = "https://connect.stripe.com/login/test"
+        mock.create_login_link.return_value = login_link
+        mocker.patch("polar.payout_account.service.stripe", new=mock)
+
+        response = await client.post(
+            f"/v1/payout-accounts/{payout_account.id}/dashboard-link"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["url"] == "https://connect.stripe.com/login/test"
 
     @pytest.mark.auth
     async def test_user_cannot_access_other_organization_account(

--- a/server/tests/payout_account/test_endpoints.py
+++ b/server/tests/payout_account/test_endpoints.py
@@ -6,7 +6,12 @@ from httpx import AsyncClient
 
 from polar.models import Organization, PayoutAccount, User, UserOrganization
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_payout_account
+from tests.fixtures.random_objects import (
+    create_account,
+    create_organization,
+    create_payout_account,
+    create_user,
+)
 
 
 @pytest_asyncio.fixture
@@ -70,6 +75,79 @@ class TestGetPayoutAccount:
         response = await client.get(f"/v1/payout-accounts/{uuid.uuid4()}")
 
         assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_found(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/payout-accounts/{uuid.uuid4()}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_admin_can_access(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+
+        response = await client.get(f"/v1/payout-accounts/{payout_account.id}")
+
+        assert response.status_code == 200
+        assert response.json()["id"] == str(payout_account.id)
+
+    @pytest.mark.auth
+    async def test_admin_can_access_with_multiple_orgs(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """A payout account linked to multiple organizations is accessible
+        by its admin regardless of which org it's linked to."""
+        payout_account = await create_payout_account(
+            save_fixture, organization, user
+        )
+
+        # Create a second organization owned by the same user, sharing the
+        # same payout account.
+        second_account = await create_account(save_fixture, user)
+        second_org = await create_organization(save_fixture, second_account)
+        second_org.payout_account = payout_account
+        await save_fixture(second_org)
+        second_membership = UserOrganization(user=user, organization=second_org)
+        await save_fixture(second_membership)
+
+        response = await client.get(f"/v1/payout-accounts/{payout_account.id}")
+
+        assert response.status_code == 200
+        assert response.json()["id"] == str(payout_account.id)
+
+    @pytest.mark.auth
+    async def test_non_admin_member_cannot_access(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """A user who is a member of an org that uses a payout account
+        but is NOT the payout account admin cannot access it."""
+        other_user = await create_user(save_fixture)
+        payout_account = await create_payout_account(
+            save_fixture, organization, other_user
+        )
+
+        response = await client.get(f"/v1/payout-accounts/{payout_account.id}")
+
+        assert response.status_code == 404
 
     @pytest.mark.auth
     async def test_user_cannot_access_other_organization_account(

--- a/server/tests/payout_account/test_endpoints.py
+++ b/server/tests/payout_account/test_endpoints.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
 
 from polar.integrations.stripe.service import StripeService
 from polar.models import Organization, PayoutAccount, User, UserOrganization
@@ -177,7 +178,7 @@ class TestDeletePayoutAccount:
         self,
         client: AsyncClient,
         save_fixture: SaveFixture,
-        mocker: MagicMock,
+        mocker: MockerFixture,
         user: User,
         organization: Organization,
         user_organization: UserOrganization,
@@ -230,7 +231,7 @@ class TestOnboardingLink:
         self,
         client: AsyncClient,
         save_fixture: SaveFixture,
-        mocker: MagicMock,
+        mocker: MockerFixture,
         user: User,
         organization: Organization,
         user_organization: UserOrganization,
@@ -282,7 +283,7 @@ class TestDashboardLink:
         self,
         client: AsyncClient,
         save_fixture: SaveFixture,
-        mocker: MagicMock,
+        mocker: MockerFixture,
         user: User,
         organization: Organization,
         user_organization: UserOrganization,

--- a/server/tests/payout_account/test_endpoints.py
+++ b/server/tests/payout_account/test_endpoints.py
@@ -1,12 +1,9 @@
 import uuid
-from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from pytest_mock import MockerFixture
 
-from polar.integrations.stripe.service import StripeService
 from polar.models import Organization, PayoutAccount, User, UserOrganization
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -170,31 +167,6 @@ class TestDeletePayoutAccount:
         assert response.status_code == 401
 
     @pytest.mark.auth
-    async def test_admin_can_delete_unlinked_account(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        user: User,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        payout_account = await create_payout_account(save_fixture, organization, user)
-        # Unlink from organization so delete is allowed
-        organization.payout_account = None
-        await save_fixture(organization)
-
-        mock = mocker.MagicMock(spec=StripeService)
-        mock.account_exists.return_value = True
-        mock.retrieve_balance.return_value = ("usd", 0)
-        mock.delete_account.return_value = None
-        mocker.patch("polar.payout_account.service.stripe", new=mock)
-
-        response = await client.delete(f"/v1/payout-accounts/{payout_account.id}")
-
-        assert response.status_code == 204
-
-    @pytest.mark.auth
     async def test_user_cannot_delete_other_organization_account(
         self,
         client: AsyncClient,
@@ -219,32 +191,6 @@ class TestOnboardingLink:
         assert response.status_code == 401
 
     @pytest.mark.auth
-    async def test_admin_can_get_onboarding_link(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        user: User,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        payout_account = await create_payout_account(save_fixture, organization, user)
-
-        mock = mocker.MagicMock(spec=StripeService)
-        account_link = MagicMock()
-        account_link.url = "https://connect.stripe.com/setup/test"
-        mock.create_account_link.return_value = account_link
-        mocker.patch("polar.payout_account.service.stripe", new=mock)
-
-        response = await client.post(
-            f"/v1/payout-accounts/{payout_account.id}/onboarding-link",
-            params={"return_path": "/finance/account"},
-        )
-
-        assert response.status_code == 200
-        assert response.json()["url"] == "https://connect.stripe.com/setup/test"
-
-    @pytest.mark.auth
     async def test_user_cannot_access_other_organization_account(
         self,
         client: AsyncClient,
@@ -267,31 +213,6 @@ class TestDashboardLink:
         )
 
         assert response.status_code == 401
-
-    @pytest.mark.auth
-    async def test_admin_can_get_dashboard_link(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        user: User,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        payout_account = await create_payout_account(save_fixture, organization, user)
-
-        mock = mocker.MagicMock(spec=StripeService)
-        login_link = MagicMock()
-        login_link.url = "https://connect.stripe.com/login/test"
-        mock.create_login_link.return_value = login_link
-        mocker.patch("polar.payout_account.service.stripe", new=mock)
-
-        response = await client.post(
-            f"/v1/payout-accounts/{payout_account.id}/dashboard-link"
-        )
-
-        assert response.status_code == 200
-        assert response.json()["url"] == "https://connect.stripe.com/login/test"
 
     @pytest.mark.auth
     async def test_user_cannot_access_other_organization_account(

--- a/server/tests/payout_account/test_endpoints.py
+++ b/server/tests/payout_account/test_endpoints.py
@@ -94,9 +94,7 @@ class TestGetPayoutAccount:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
 
         response = await client.get(f"/v1/payout-accounts/{payout_account.id}")
 
@@ -114,9 +112,7 @@ class TestGetPayoutAccount:
     ) -> None:
         """A payout account linked to multiple organizations is accessible
         by its admin regardless of which org it's linked to."""
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
 
         # Create a second organization owned by the same user, sharing the
         # same payout account.
@@ -183,9 +179,7 @@ class TestDeletePayoutAccount:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
         # Unlink from organization so delete is allowed
         organization.payout_account = None
         await save_fixture(organization)
@@ -196,9 +190,7 @@ class TestDeletePayoutAccount:
         mock.delete_account.return_value = None
         mocker.patch("polar.payout_account.service.stripe", new=mock)
 
-        response = await client.delete(
-            f"/v1/payout-accounts/{payout_account.id}"
-        )
+        response = await client.delete(f"/v1/payout-accounts/{payout_account.id}")
 
         assert response.status_code == 204
 
@@ -236,9 +228,7 @@ class TestOnboardingLink:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
 
         mock = mocker.MagicMock(spec=StripeService)
         account_link = MagicMock()
@@ -288,9 +278,7 @@ class TestDashboardLink:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        payout_account = await create_payout_account(
-            save_fixture, organization, user
-        )
+        payout_account = await create_payout_account(save_fixture, organization, user)
 
         mock = mocker.MagicMock(spec=StripeService)
         login_link = MagicMock()


### PR DESCRIPTION
## Summary

- Replace the broken `PayoutAccountPolicyGuard` that used org-based finance policies (assuming 1:1 org-payout account relationship) with dedicated payout account policies checking `admin_id` ownership
- Add `organization.can_manage_payout_account` policy requiring org admin role to set the payout account on an organization — previously any org member could do this
- Move payout account authorization from the service layer (`get_by_id_and_admin`) to the endpoint layer, keeping authz in guards/policies where it belongs
- Remove unused `payout_account_service.get_by_id_and_admin`

Fixes #11195

## Test plan

- [x] Policy unit tests: `can_read`/`can_write` for admin (allowed) and non-admin (denied) — `tests/authz/test_policies.py`
- [x] Payout account endpoint tests: admin access, multi-org admin access, non-admin member denied, cross-org denied, happy-path for delete/onboarding-link/dashboard-link — `tests/payout_account/test_endpoints.py`
- [x] Set payout account endpoint tests: anonymous (401), non-member (404), non-admin member (403), admin with own account (200), admin with other user's account (422), unknown account (422) — `tests/organization/test_endpoints.py`
- [x] mypy passes, linter passes, all 65+ tests green
