### PR TITLE
feat(backoffice): surface first-review organizations in the list view

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -112,8 +112,6 @@ logger = structlog.getLogger(__name__)
 
 REVIEW_TICKET_TITLE = "Ongoing organization review"
 
-FIRST_REVIEWS_MAX_THRESHOLD_CENTS = 1000
-
 
 class DeletePayoutAccountForm(BaseModel):
     reason: str
@@ -338,11 +336,7 @@ async def list_organizations(
             stmt = stmt.where(OrganizationReview.appeal_submitted_at.is_(None))
 
     if first_reviews == "true":
-        stmt = stmt.where(
-            Organization.status == OrganizationStatus.REVIEW,
-            Organization.initially_reviewed_at.is_(None),
-            Organization.next_review_threshold <= FIRST_REVIEWS_MAX_THRESHOLD_CENTS,
-        )
+        stmt = stmt.where(Organization.is_first_review.is_(True))
 
     # Apply sorting
     is_desc = direction == "desc"

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -11,9 +11,13 @@ from sqlalchemy import func, select
 from tagflow import tag, text
 
 from polar.models import Organization, PayoutAccount
-from polar.models.organization import OrganizationStatus
+from polar.models.organization import (
+    FIRST_REVIEW_MAX_THRESHOLD_CENTS,
+    OrganizationStatus,
+)
 from polar.postgres import AsyncSession
 
+from ... import formatters
 from ...components import (
     Tab,
     action_bar,
@@ -21,6 +25,10 @@ from ...components import (
     empty_state,
     status_badge,
     tab_nav,
+)
+
+FIRST_REVIEW_THRESHOLD_LABEL = formatters.currency(
+    FIRST_REVIEW_MAX_THRESHOLD_CENTS, "usd"
 )
 
 
@@ -187,8 +195,20 @@ class OrganizationListView:
                             title=org.name,
                         ):
                             text(org.name)
-                        with status_badge(org.status):
-                            pass
+                        if org.is_first_review:
+                            with tag.span(
+                                classes="badge badge-warning",
+                                title=(
+                                    "First review — never reviewed before "
+                                    f"or next review threshold is ≤ "
+                                    f"{FIRST_REVIEW_THRESHOLD_LABEL}"
+                                ),
+                                **{"aria-label": "first review status"},
+                            ):
+                                text("First Review")
+                        else:
+                            with status_badge(org.status):
+                                pass
                     with tag.div(
                         classes="text-xs text-base-content/60 font-mono truncate max-w-[200px]",
                         title=org.slug,
@@ -535,7 +555,7 @@ class OrganizationListView:
                                         if selected_first_reviews == "true":
                                             first_review_attrs["selected"] = ""
                                         with tag.option(**first_review_attrs):
-                                            text("First Reviews (≤ $10)")
+                                            text("First Reviews")
 
         # Organization table
         with tag.div(id="org-list", classes="overflow-x-auto"):

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     UniqueConstraint,
     Uuid,
     and_,
+    or_,
 )
 from sqlalchemy.dialects.postgresql import CITEXT, JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -400,6 +401,11 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
     ),
 }
 
+# Upper bound (in cents) of `next_review_threshold` that qualifies an
+# organization as a "first review" alongside orgs still in their initial
+# review cycle (`initially_reviewed_at IS NULL`). Either condition is enough.
+FIRST_REVIEW_MAX_THRESHOLD_CENTS = 1000
+
 
 class Organization(RateLimitGroupMixin, RecordModel):
     __tablename__ = "organizations"
@@ -671,6 +677,24 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @classmethod
     def _is_under_review_expression(cls) -> ColumnElement[bool]:
         return cls.status.in_(OrganizationStatus.review_statuses())
+
+    @hybrid_property
+    def is_first_review(self) -> bool:
+        return self.status == OrganizationStatus.REVIEW and (
+            self.initially_reviewed_at is None
+            or self.next_review_threshold <= FIRST_REVIEW_MAX_THRESHOLD_CENTS
+        )
+
+    @is_first_review.inplace.expression
+    @classmethod
+    def _is_first_review_expression(cls) -> ColumnElement[bool]:
+        return and_(
+            cls.status == OrganizationStatus.REVIEW,
+            or_(
+                cls.initially_reviewed_at.is_(None),
+                cls.next_review_threshold <= FIRST_REVIEW_MAX_THRESHOLD_CENTS,
+            ),
+        )
 
     @property
     def polar_site_url(self) -> str:


### PR DESCRIPTION
## Summary
- Promote the first-review rule to an `Organization.is_first_review` hybrid_property on the model, backed by both a Python and a SQL expression so filters and view logic share one source of truth.
- Use the hybrid_property in the `first_reviews=true` filter on the organizations list endpoint (replacing the inline `WHERE` clause that duplicated the rule).
- In the v2 organizations list view, render a dedicated "First Review" badge in place of the generic Review pill when the org qualifies, keeping the same warning color so the palette stays consistent.
- Drop the misleading `(≤ $10)` suffix from the "First Reviews" filter option, since the rule now accepts either an unset `initially_reviewed_at` or a threshold below the first-review limit.

## Test plan
- [ ] Open the backoffice Organizations page and confirm qualifying orgs show "First Review" while others still show "Review".
- [ ] Toggle the "First Reviews" advanced filter and confirm the list narrows to qualifying orgs only.
- [ ] Spot-check an org with a large threshold but no `initially_reviewed_at` — it should qualify.
- [ ] Spot-check an org with a small threshold and an `initially_reviewed_at` set — it should still qualify.
- [ ] `uv run task lint` and `uv run task lint_types` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)