### PR TITLE
Fix UI overflow issue on home

### DIFF
--- a/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
+++ b/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
@@ -61,7 +61,7 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
         <h2 className="text-2xl font-medium text-gray-900 dark:text-white">
           Overview
         </h2>
-        <div className="flex items-center gap-x-4">
+        <div className="flex items-center justify-between md:gap-x-4">
           <SegmentedControl
             options={(
               Object.entries(CHART_RANGES) as [ChartRange, string][]
@@ -75,9 +75,10 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
             variant="secondary"
             size="sm"
             wrapperClassNames="gap-x-2"
+            aria-label="Customize"
           >
             <Settings2 className="h-3.5 w-3.5" />
-            Customize
+            <span className="hidden md:inline">Customize</span>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Fixes: https://github.com/polarsource/polar/issues/9957

| Before | After  |
|--------|--------|
| <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/0f3f44d7-aeb7-40ad-8f93-a36edc9d13ae" /> | <img width="1170" height="2532" alt="127 0 0 1_3000_dashboard_admin-org(iPhone 12 Pro) (3)" src="https://github.com/user-attachments/assets/a8122be6-eecc-4139-8013-5ce90422e5e9" /> |







