### PR TITLE
fix(organization): skip review-threshold check for ineligible statuses

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -776,14 +776,7 @@ class OrganizationService:
             enqueue_job("organization.under_review", organization_id=organization.id)
             return organization
 
-        if organization.status not in {
-            OrganizationStatus.ACTIVE,
-            OrganizationStatus.REVIEW,
-            OrganizationStatus.SNOOZED,
-        }:
-            return organization
-
-        if organization.is_under_review:
+        if organization.status != OrganizationStatus.ACTIVE:
             return organization
 
         if (

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -776,6 +776,13 @@ class OrganizationService:
             enqueue_job("organization.under_review", organization_id=organization.id)
             return organization
 
+        if organization.status not in {
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+        }:
+            return organization
+
         if organization.is_under_review:
             return organization
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -548,6 +548,33 @@ class TestCheckReviewThreshold:
         # Then: stays snoozed (can't compute grace period)
         assert result.status == OrganizationStatus.SNOOZED
 
+    async def test_offboarding_over_threshold_stays_offboarding(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Given: offboarding org with threshold 0 and a positive balance
+        # (OFFBOARDING -> REVIEW is not a legal transition, so the check
+        # must skip without raising InvalidStatusTransitionError)
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.next_review_threshold = 0
+
+        mocker.patch(
+            "polar.organization.service.transaction_service.get_transactions_sum",
+            return_value=5000,
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.check_review_threshold(
+            session, organization
+        )
+
+        # Then: no status mutation, balance still synced, no review enqueued
+        assert result.status == OrganizationStatus.OFFBOARDING
+        assert result.total_balance == 5000
+        enqueue_job_mock.assert_not_called()
+
 
 @pytest.mark.asyncio
 class TestConfirmOrganizationReviewed:


### PR DESCRIPTION
## Summary

`check_review_threshold` was falling through to `set_status(REVIEW)` for OFFBOARDING orgs, raising `InvalidStatusTransitionError` and poisoning the `order.balance` worker.

Per the status diagram, the `Transfers >= threshold` edge only applies to **Active → Review**. Narrow the guard to ACTIVE; other statuses are skipped (Snooze → Review via grace period still runs in its own branch above).

OFFBOARDING currently keeps payments enabled by design, and re-reviewing doesn't change that — so there's nothing for the check to do.

## Test plan

- [x] New test: OFFBOARDING + threshold 0 + positive balance → no status change, no raise
- [x] Existing `TestCheckReviewThreshold` cases still pass
- [x] Lint + type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)