### PR TITLE
Display discount amount for metered pricing

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -553,7 +553,7 @@ describe('CheckoutPricingBreakdown', () => {
   })
 
   describe('metered prices in breakdown', () => {
-    it('shows additional metered usage row', () => {
+    it('shows usage pricing section and per-meter row', () => {
       const meteredPrice = createMeteredPrice({
         id: 'price_metered_1',
         meter: { id: 'meter_1', name: 'API Calls', unit: 'scalar' as const },
@@ -570,8 +570,76 @@ describe('CheckoutPricingBreakdown', () => {
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
-      expect(screen.getByText(/additional metered usage/i)).toBeInTheDocument()
+      expect(screen.getByText(/usage pricing/i)).toBeInTheDocument()
       expect(screen.getByTestId('detail-row-API Calls')).toBeInTheDocument()
+    })
+
+    it('strikes through the original rate when a percentage discount is active', () => {
+      const meteredPrice = createMeteredPrice({
+        id: 'price_metered_1',
+        unit_amount: '900',
+        meter: { id: 'meter_1', name: 'Workspaces', unit: 'scalar' as const },
+      })
+      const checkout = createCheckout({
+        amount: 999,
+        discount_amount: 500,
+        net_amount: 499,
+        tax_amount: null,
+        total_amount: 499,
+        discount: {
+          id: 'disc_1',
+          name: 'half',
+          type: 'percentage',
+          duration: 'once',
+          code: 'halfoff',
+          basis_points: 5000,
+        } satisfies schemas['CheckoutPublic']['discount'],
+        prices: {
+          prod_1: [createCheckout().product_price, meteredPrice],
+        },
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      const row = screen.getByTestId('detail-row-Workspaces')
+      expect(row).toHaveTextContent('$9.00')
+      expect(row).toHaveTextContent('$4.50')
+      expect(within(row).getByText('$9.00')).toHaveClass('line-through')
+    })
+
+    it('does not strike through the rate for fixed-amount discounts', () => {
+      const meteredPrice = createMeteredPrice({
+        id: 'price_metered_1',
+        unit_amount: '900',
+        meter: { id: 'meter_1', name: 'Workspaces', unit: 'scalar' as const },
+      })
+      const checkout = createCheckout({
+        amount: 999,
+        discount_amount: 500,
+        net_amount: 499,
+        tax_amount: null,
+        total_amount: 499,
+        discount: {
+          id: 'disc_1',
+          name: '$5 off',
+          type: 'fixed',
+          duration: 'once',
+          code: null,
+          amount: 500,
+          currency: 'usd',
+          amounts: { usd: 500 },
+        } satisfies schemas['CheckoutPublic']['discount'],
+        prices: {
+          prod_1: [createCheckout().product_price, meteredPrice],
+        },
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      const row = screen.getByTestId('detail-row-Workspaces')
+      expect(row).toHaveTextContent('$9.00')
+      expect(within(row).queryByText('$4.50')).not.toBeInTheDocument()
+      expect(row.querySelector('.line-through')).toBeNull()
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -553,7 +553,7 @@ describe('CheckoutPricingBreakdown', () => {
   })
 
   describe('metered prices in breakdown', () => {
-    it('shows usage pricing section and per-meter row', () => {
+    it('shows additional metered usage row', () => {
       const meteredPrice = createMeteredPrice({
         id: 'price_metered_1',
         meter: { id: 'meter_1', name: 'API Calls', unit: 'scalar' as const },
@@ -570,7 +570,7 @@ describe('CheckoutPricingBreakdown', () => {
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
-      expect(screen.getByText(/usage pricing/i)).toBeInTheDocument()
+      expect(screen.getByText(/additional metered usage/i)).toBeInTheDocument()
       expect(screen.getByTestId('detail-row-API Calls')).toBeInTheDocument()
     })
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -260,7 +260,14 @@ const CheckoutPricingBreakdown = ({
             />
           </DetailRow>
           {meteredPrices.length > 0 && (
-            <DetailRow title={t('checkout.pricing.additionalMeteredUsage')} />
+            <DetailRow
+              title={t('checkout.pricing.additionalMeteredUsage')}
+              subtitle={
+                checkout.discount?.type === 'percentage'
+                  ? discountEndLabel || undefined
+                  : undefined
+              }
+            />
           )}
           {meteredPrices.map((meteredPrice) => (
             <DetailRow
@@ -268,7 +275,11 @@ const CheckoutPricingBreakdown = ({
               key={meteredPrice.id}
               emphasis
             >
-              <MeteredPriceLabel price={meteredPrice} locale={locale} />
+              <MeteredPriceLabel
+                price={meteredPrice}
+                locale={locale}
+                discount={checkout.discount}
+              />
             </DetailRow>
           ))}
         </>

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -262,11 +262,7 @@ const CheckoutPricingBreakdown = ({
           {meteredPrices.length > 0 && (
             <DetailRow
               title={t('checkout.pricing.additionalMeteredUsage')}
-              subtitle={
-                checkout.discount?.type === 'percentage'
-                  ? discountEndLabel || undefined
-                  : undefined
-              }
+              className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-4"
             />
           )}
           {meteredPrices.map((meteredPrice) => (

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -1,7 +1,29 @@
-import { render } from '@testing-library/react'
+import { schemas } from '@polar-sh/client'
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { createMeteredPrice } from '../test-utils/makeCheckout'
 import MeteredPriceLabel from './MeteredPriceLabel'
+
+const percentageDiscount = (basisPoints: number) =>
+  ({
+    id: 'disc_1',
+    name: 'test',
+    type: 'percentage',
+    duration: 'once',
+    code: null,
+    basis_points: basisPoints,
+  }) satisfies schemas['CheckoutPublic']['discount']
+
+const fixedDiscount = {
+  id: 'disc_1',
+  name: '$5 off',
+  type: 'fixed',
+  duration: 'once',
+  code: null,
+  amount: 500,
+  currency: 'usd',
+  amounts: { usd: 500 },
+} satisfies schemas['CheckoutPublic']['discount']
 
 describe('MeteredPriceLabel', () => {
   describe('scalar unit (default)', () => {
@@ -134,6 +156,86 @@ describe('MeteredPriceLabel', () => {
       )
 
       expect(container.textContent).toContain('/ unit')
+    })
+  })
+
+  describe('with percentage discount', () => {
+    it('renders original rate with line-through and discounted rate alongside', () => {
+      const price = createMeteredPrice({ unit_amount: '900' })
+
+      render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={percentageDiscount(5000)}
+        />,
+      )
+
+      expect(screen.getByText('$9.00')).toHaveClass('line-through')
+      expect(screen.getByText('$4.50')).toBeInTheDocument()
+    })
+
+    it('renders $0 as the discounted rate for a 100% discount', () => {
+      const price = createMeteredPrice({ unit_amount: '900' })
+
+      render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={percentageDiscount(10000)}
+        />,
+      )
+
+      expect(screen.getByText('$9.00')).toHaveClass('line-through')
+      expect(screen.getByText('$0.00')).toBeInTheDocument()
+    })
+
+    it('applies the discount to scaled (per-1M tokens) rates', () => {
+      const price = createMeteredPrice({
+        unit_amount: '0.001',
+        meter: { id: 'meter_1', name: 'LLM Tokens', unit: 'token' },
+      })
+
+      render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={percentageDiscount(5000)}
+        />,
+      )
+
+      expect(screen.getByText('$10.00')).toHaveClass('line-through')
+      expect(screen.getByText('$5.00')).toBeInTheDocument()
+    })
+  })
+
+  describe('with fixed discount', () => {
+    it('renders the plain rate without a strike-through', () => {
+      const price = createMeteredPrice({ unit_amount: '900' })
+
+      const { container } = render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={fixedDiscount}
+        />,
+      )
+
+      expect(container.textContent).toContain('$9.00')
+      expect(container.querySelector('.line-through')).toBeNull()
+    })
+  })
+
+  describe('without discount', () => {
+    it('renders a single rate', () => {
+      const price = createMeteredPrice({ unit_amount: '900' })
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$9.00')
+      expect(container.querySelector('.line-through')).toBeNull()
     })
   })
 })

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -7,22 +7,37 @@ import { cn } from '@polar-sh/ui/lib/utils'
 interface MeteredPriceLabelProps {
   price: schemas['ProductPriceMeteredUnit']
   locale?: AcceptedLocale
+  discount?: schemas['CheckoutPublic']['discount']
 }
 
 const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   price,
   locale = DEFAULT_LOCALE,
+  discount,
 }) => {
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
     customLabel: price.meter.custom_label,
     customMultiplier: price.meter.custom_multiplier,
   })
 
+  const format = formatCurrency('subcent', locale)
+  const baseAmount = Number.parseFloat(price.unit_amount) * scale
+  const discountedAmount =
+    discount && 'basis_points' in discount
+      ? baseAmount * (1 - discount.basis_points / 10000)
+      : null
+
   return (
     <div className="flex flex-row items-baseline gap-x-1">
-      {formatCurrency('subcent', locale)(
-        Number.parseFloat(price.unit_amount) * scale,
-        price.price_currency,
+      {discountedAmount !== null ? (
+        <>
+          <span className="dark:text-polar-500 text-gray-400 line-through">
+            {format(baseAmount, price.price_currency)}
+          </span>
+          <span>{format(discountedAmount, price.price_currency)}</span>
+        </>
+      ) : (
+        format(baseAmount, price.price_currency)
       )}
       <span
         className={cn(

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -95,7 +95,7 @@ export default {
           other: 'Every # years',
         },
       },
-      additionalMeteredUsage: 'Additional metered usage',
+      additionalMeteredUsage: 'Usage pricing',
       perUnit: '/ unit',
       perSeat: 'per seat',
       seats: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -95,7 +95,7 @@ export default {
           other: 'Every # years',
         },
       },
-      additionalMeteredUsage: 'Usage pricing',
+      additionalMeteredUsage: 'Additional metered usage',
       perUnit: '/ unit',
       perSeat: 'per seat',
       seats: {


### PR DESCRIPTION
Fixes: https://github.com/polarsource/polar/issues/8093


| Before | After  |
|--------|--------|
| <img width="473" height="502" alt="Screenshot 2026-04-24 at 14 04 36" src="https://github.com/user-attachments/assets/0dba117b-2ca5-43bd-913d-a2cf55fcd7d9" /> | <img width="473" height="485" alt="Screenshot 2026-04-24 at 14 04 25" src="https://github.com/user-attachments/assets/938a4c73-12a7-48c7-ba7c-b1d4204c18d3" /> |












