### PR TITLE
fix(subscription): clear stale pending seats update on no-op

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1405,7 +1405,18 @@ class SubscriptionService:
         old_seats = subscription.seats or 1
         old_amount = subscription.amount
 
+        subscription_update_repository = SubscriptionUpdateRepository.from_session(
+            session
+        )
+
         if old_seats == seats:
+            # No-op for the seat count itself, but a stale next-period
+            # SubscriptionUpdate would otherwise survive — clear it so the
+            # subscription doesn't change at the next billing cycle.
+            pending = subscription.pending_update
+            if pending is not None and pending.seats is not None:
+                await subscription_update_repository.soft_delete(pending)
+                subscription.pending_update = None
             return subscription
 
         event = await event_service.create_event(
@@ -1430,9 +1441,6 @@ class SubscriptionService:
         previous_status = subscription.status
         previous_is_canceled = subscription.canceled
 
-        subscription_update_repository = SubscriptionUpdateRepository.from_session(
-            session
-        )
         if proration_behavior == SubscriptionProrationBehavior.next_period:
             subscription.pending_update = await subscription_update_repository.upsert(
                 subscription_update

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4309,6 +4309,75 @@ class TestUpdateSeats:
         )
         assert updated_subscription_update is None
 
+    async def test_next_period_revert_to_current_clears_pending_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        # Reproduces customer flow:
+        # subscription has 3 seats → set pending=1 → set pending=2 →
+        # set pending=3 (= current) should clear the pending update.
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=3,
+        )
+
+        subscription_update_repository = SubscriptionUpdateRepository.from_session(
+            session
+        )
+
+        await subscription_service.update_seats(
+            session,
+            subscription,
+            seats=1,
+            proration_behavior=SubscriptionProrationBehavior.next_period,
+        )
+        await session.flush()
+        pending = await subscription_update_repository.get_unapplied_by_subscription_id(
+            subscription.id
+        )
+        assert pending is not None
+        assert pending.seats == 1
+
+        await subscription_service.update_seats(
+            session,
+            subscription,
+            seats=2,
+            proration_behavior=SubscriptionProrationBehavior.next_period,
+        )
+        await session.flush()
+        pending = await subscription_update_repository.get_unapplied_by_subscription_id(
+            subscription.id
+        )
+        assert pending is not None
+        assert pending.seats == 2
+
+        # Reverting to current seat count must clear the pending update
+        updated = await subscription_service.update_seats(
+            session,
+            subscription,
+            seats=3,
+            proration_behavior=SubscriptionProrationBehavior.next_period,
+        )
+        await session.flush()
+
+        assert updated.seats == 3
+        assert updated.pending_update is None
+        pending = await subscription_update_repository.get_unapplied_by_subscription_id(
+            subscription.id
+        )
+        assert pending is None
+
     async def test_seat_increase_with_fixed_discount(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

`SubscriptionService.update_seats` early-returned when the requested seat count matched the current count, leaving any next-period `SubscriptionUpdate` untouched. A flow that set a pending seat change and later attempted to revert to the current count by re-issuing the original value left a stale pending update in place — so the subscription silently changed at the next billing cycle.

The fix soft-deletes the pending `SubscriptionUpdate` on the no-op path when it carries a seats change, using the already-eager-loaded `subscription.pending_update` relationship to avoid an extra query.

## Test plan

- [x] New regression test `TestUpdateSeats::test_next_period_revert_to_current_clears_pending_update` reproduces the reported flow (3 → pending=1 → pending=2 → revert to 3) and asserts the pending update is cleared
- [x] All existing `TestUpdateSeats` tests pass (34 tests)
- [x] Backend lint and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)