### PR TITLE
server/order: fix product_billing_type filter in list endpoint

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -14,6 +14,7 @@ from polar.auth.models import (
     is_organization,
     is_user,
 )
+from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
     Options,
     RepositoryBase,
@@ -189,6 +190,15 @@ class OrderRepository(
         """Release a payment lock for an order."""
         return await self.update(
             order, update_dict={"payment_lock_acquired_at": None}, flush=flush
+        )
+
+    def get_statement_by_org_ids(
+        self, org_ids: set[AccessibleOrganizationID]
+    ) -> Select[tuple[Order]]:
+        return (
+            self.get_base_statement()
+            .join(Customer, Order.customer_id == Customer.id)
+            .where(Customer.organization_id.in_(org_ids))
         )
 
     def get_readable_statement(

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.account.repository import AccountRepository
 from polar.auth.models import AuthSubject
+from polar.authz.service import get_accessible_org_ids
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
 from polar.checkout.guard import has_product_checkout
@@ -311,7 +312,8 @@ class OrderService:
         ],
     ) -> tuple[Sequence[Order], int]:
         repository = OrderRepository.from_session(session)
-        statement = repository.get_readable_statement(auth_subject)
+        accessible_org_ids = await get_accessible_org_ids(session, auth_subject)
+        statement = repository.get_statement_by_org_ids(accessible_org_ids)
 
         statement = (
             statement.join(Order.discount, isouter=True)
@@ -333,13 +335,12 @@ class OrderService:
 
         if product_billing_type is not None:
             product_repository = ProductRepository.from_session(session)
-            matching_product_ids = await product_repository.get_ids_by_billing_type(
-                product_billing_type,
-                organization_ids=organization_id,
+            product_subquery = (
+                product_repository.get_statement_by_org_ids(accessible_org_ids)
+                .with_only_columns(Product.id)
+                .where(Product.billing_type.in_(product_billing_type))
             )
-            if not matching_product_ids:
-                return [], 0
-            statement = statement.where(Order.product_id.in_(matching_product_ids))
+            statement = statement.where(Order.product_id.in_(product_subquery))
 
         if discount_id is not None:
             statement = statement.where(Order.discount_id.in_(discount_id))

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -21,7 +21,6 @@ from polar.models import (
     ProductPriceCustom,
     ProductPriceFixed,
 )
-from polar.models.product import ProductBillingType
 from polar.models.product_price import ProductPriceAmountType, ProductPriceSource
 from polar.postgres import sql
 
@@ -137,21 +136,6 @@ class ProductRepository(
                         ProductPriceFixed.price_amount,
                     ),
                 )
-
-    async def get_ids_by_billing_type(
-        self,
-        billing_types: Sequence[ProductBillingType],
-        *,
-        organization_ids: Sequence[UUID] | None = None,
-    ) -> Sequence[UUID]:
-        statement = select(Product.id).where(
-            Product.billing_type.in_(billing_types),
-            Product.deleted_at.is_(None),
-        )
-        if organization_ids is not None:
-            statement = statement.where(Product.organization_id.in_(organization_ids))
-        result = await self.session.execute(statement)
-        return result.scalars().all()
 
     async def get_products_without_currency(
         self, organization_id: UUID, currency: PresentmentCurrency


### PR DESCRIPTION

The previous implementaion was loading _all_ the products in the whole DB to pass it to the query, without pre-filtering on the accessible organizations.

It wasn't a security issue since the whole statement was still gated by the organization filter, but it was a performance issue and a bug since we would blow up Postgres maximum number of parameters.
