### PR TITLE
feat(receipts): provision S3 bucket and IAM for customer receipts

### DIFF
--- a/terraform/modules/application_access/main.tf
+++ b/terraform/modules/application_access/main.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "customer_invoices" {
 
 data "aws_iam_policy_document" "customer_receipts" {
   statement {
-    sid = "VisualEditor0"
+    sid = "Terraform"
     actions = [
       "s3:PutObject",
       "s3:GetObjectAttributes",

--- a/terraform/modules/application_access/main.tf
+++ b/terraform/modules/application_access/main.tf
@@ -42,7 +42,6 @@ data "aws_iam_policy_document" "customer_invoices" {
 
 data "aws_iam_policy_document" "customer_receipts" {
   statement {
-    sid = "Terraform"
     actions = [
       "s3:PutObject",
       "s3:GetObjectAttributes",

--- a/terraform/modules/application_access/main.tf
+++ b/terraform/modules/application_access/main.tf
@@ -18,6 +18,7 @@ variable "buckets" {
   description = "Bucket names and policy descriptions"
   type = object({
     customer_invoices = object({ name = string, description = optional(string) })
+    customer_receipts = object({ name = string, description = optional(string) })
     payout_invoices   = object({ name = string, description = optional(string) })
     files             = object({ name = string, description = optional(string) })
     public_files      = object({ name = string, description = optional(string) })
@@ -36,6 +37,20 @@ data "aws_iam_policy_document" "customer_invoices" {
       "s3:GetObjectVersionAttributes",
     ]
     resources = ["arn:aws:s3:::${var.buckets.customer_invoices.name}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "customer_receipts" {
+  statement {
+    sid = "VisualEditor0"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObjectAttributes",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAttributes",
+    ]
+    resources = ["arn:aws:s3:::${var.buckets.customer_receipts.name}/*"]
   }
 }
 
@@ -101,6 +116,12 @@ resource "aws_iam_policy" "customer_invoices" {
   policy      = data.aws_iam_policy_document.customer_invoices.json
 }
 
+resource "aws_iam_policy" "customer_receipts" {
+  name        = var.buckets.customer_receipts.name
+  description = var.buckets.customer_receipts.description
+  policy      = data.aws_iam_policy_document.customer_receipts.json
+}
+
 resource "aws_iam_policy" "payout_invoices" {
   name        = var.buckets.payout_invoices.name
   description = var.buckets.payout_invoices.description
@@ -128,6 +149,11 @@ resource "aws_iam_policy" "logs" {
 resource "aws_iam_user_policy_attachment" "customer_invoices" {
   user       = var.username
   policy_arn = aws_iam_policy.customer_invoices.arn
+}
+
+resource "aws_iam_user_policy_attachment" "customer_receipts" {
+  user       = var.username
+  policy_arn = aws_iam_policy.customer_receipts.arn
 }
 
 resource "aws_iam_user_policy_attachment" "payout_invoices" {

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -111,6 +111,7 @@ resource "render_env_group" "aws_s3" {
     POLAR_S3_FILES_PRESIGN_TTL             = { value = var.aws_s3_config.files_presign_ttl }
     POLAR_S3_FILES_PUBLIC_BUCKET_NAME      = { value = var.aws_s3_config.files_public_bucket_name }
     POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME = { value = var.aws_s3_config.customer_invoices_bucket_name }
+    POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME = { value = var.aws_s3_config.customer_receipts_bucket_name }
     POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME   = { value = var.aws_s3_config.payout_invoices_bucket_name }
     POLAR_S3_LOGS_BUCKET_NAME              = { value = var.aws_s3_config.logs_bucket_name }
     POLAR_AWS_ACCESS_KEY_ID                = { value = var.aws_s3_secrets.access_key_id }

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -169,6 +169,7 @@ variable "aws_s3_config" {
     files_presign_ttl             = string # "600"
     files_public_bucket_name      = string # "polar-public-files"
     customer_invoices_bucket_name = string # "polar-customer-invoices"
+    customer_receipts_bucket_name = string # "polar-customer-receipts"
     payout_invoices_bucket_name   = string # "polar-payout-invoices"
     logs_bucket_name              = string # "polar-logs"
   })

--- a/terraform/modules/s3_buckets/main.tf
+++ b/terraform/modules/s3_buckets/main.tf
@@ -59,6 +59,10 @@ resource "aws_s3_bucket" "customer_invoices" {
   bucket = "${local.name_prefix}-customer-invoices"
 }
 
+resource "aws_s3_bucket" "customer_receipts" {
+  bucket = "${local.name_prefix}-customer-receipts"
+}
+
 resource "aws_s3_bucket" "payout_invoices" {
   bucket = "${local.name_prefix}-payout-invoices"
 }

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -390,6 +390,7 @@ module "application_access_production" {
   username = "polar-production-files"
   buckets = {
     customer_invoices = { name = "polar-customer-invoices" }
+    customer_receipts = { name = "polar-customer-receipts" }
     payout_invoices   = { name = "polar-payout-invoices" }
     files             = { name = "polar-production-files", description = "Policy used by our app for downloadable benefits. Keep permissions to a bare minimum." }
     public_files      = { name = "polar-public-files", description = "Policy used by our app for public uploads -products medias and such-. Keep permissions to a bare minimum." }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -292,6 +292,7 @@ module "production" {
     files_presign_ttl             = "3600"
     files_public_bucket_name      = "polar-public-files"
     customer_invoices_bucket_name = "polar-customer-invoices"
+    customer_receipts_bucket_name = "polar-customer-receipts"
     payout_invoices_bucket_name   = "polar-payout-invoices"
     logs_bucket_name              = "polar-production-logs"
   }

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -7,6 +7,7 @@ module "application_access_sandbox" {
   username = "polar-sandbox-files"
   buckets = {
     customer_invoices = { name = "polar-sandbox-customer-invoices" }
+    customer_receipts = { name = "polar-sandbox-customer-receipts" }
     payout_invoices   = { name = "polar-sandbox-payout-invoices" }
     files             = { name = "polar-sandbox-files", description = "Policy used by our SANDBOX app for downloadable benefits. Keep permissions to a bare minimum." }
     public_files      = { name = "polar-public-sandbox-files", description = "Policy used by our SANDBOX app for public uploads -products medias and such-. Keep permissions to a bare minimum." }

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -204,6 +204,7 @@ module "sandbox" {
     files_presign_ttl             = "3600"
     files_public_bucket_name      = "polar-public-sandbox-files"
     customer_invoices_bucket_name = "polar-sandbox-customer-invoices"
+    customer_receipts_bucket_name = "polar-sandbox-customer-receipts"
     payout_invoices_bucket_name   = "polar-sandbox-payout-invoices"
     logs_bucket_name              = "polar-sandbox-logs"
   }

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -228,6 +228,7 @@ module "test" {
     files_presign_ttl             = "600"
     files_public_bucket_name      = "polar-public-files"
     customer_invoices_bucket_name = "polar-test-customer-invoices"
+    customer_receipts_bucket_name = "polar-test-customer-receipts"
     payout_invoices_bucket_name   = "polar-test-payout-invoices"
     logs_bucket_name              = "polar-test-logs"
   }


### PR DESCRIPTION
## Summary

PR 2 of the customer-receipts series ([design doc](handbook/engineering/design-documents/receipts.mdx)). Provisions infrastructure only — no application code reads the new env var yet, so the bucket sits empty.

- New `aws_s3_bucket "customer_receipts"` in the `s3_buckets` module, mirroring `customer_invoices`. Private bucket, no public access policy.
- New IAM policy in the `application_access` module granting the application user `PutObject` / `GetObject` (and the same read variants used by sibling buckets) on the receipts bucket, plus user attachment.
- New `customer_receipts_bucket_name` field on the `render_service` module's `aws_s3_config`, exposed as `POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME`.
- Per-env values wired through production, sandbox, and test (`polar-customer-receipts`, `polar-sandbox-customer-receipts`, `polar-test-customer-receipts`).

## Why safe to merge independently

No code path reads `POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME` yet. The bucket exists empty; the IAM grants are inert until later PRs in the series land. Forward-only.

## Test plan

- [x] `terraform fmt -recursive terraform/` — clean
- [x] `terraform validate` — passes for `production`, `sandbox`, `test`
- [ ] `terraform plan` against staging shows only the new resources (bucket + IAM policy + user attachment + env var)
- [ ] After apply: bucket exists, IAM user can write to it