### PR TITLE
Fix app error boundary

### DIFF
--- a/clients/apps/app/app/(authenticated)/_layout.tsx
+++ b/clients/apps/app/app/(authenticated)/_layout.tsx
@@ -12,21 +12,13 @@ import { UserProvider } from '@/providers/UserProvider'
 import { DarkTheme, ThemeProvider } from '@react-navigation/native'
 import { useQueryClient } from '@tanstack/react-query'
 import { Redirect, Stack, useRouter } from 'expo-router'
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { ErrorBoundary as ErrorBoundaryComponent } from 'react-error-boundary'
 import { StatusBar } from 'react-native'
 
-const RootLayout = () => {
-  const theme = useTheme()
-  const { session } = useSession()
+const AuthenticatedErrorBoundary = ({ children }: PropsWithChildren) => {
   const queryClient = useQueryClient()
   const router = useRouter()
-
-  useAppOpenTracking()
-
-  if (!session) {
-    return <Redirect href="/" />
-  }
 
   return (
     <ErrorBoundaryComponent
@@ -38,23 +30,38 @@ const RootLayout = () => {
         <ErrorFallback error={error} resetErrorBoundary={resetErrorBoundary} />
       )}
     >
-      <>
-        <StatusBar barStyle="light-content" />
-        <Stack
-          screenOptions={{
-            headerStyle: {
-              backgroundColor: theme.colors.background,
-            },
-            headerTitleStyle: {
-              color: theme.colors.text,
-              fontSize: 18,
-            },
-            contentStyle: { backgroundColor: theme.colors.background },
-            headerShadowVisible: false,
-          }}
-        />
-      </>
+      {children}
     </ErrorBoundaryComponent>
+  )
+}
+
+const RootLayout = () => {
+  const theme = useTheme()
+  const { session } = useSession()
+
+  useAppOpenTracking()
+
+  if (!session) {
+    return <Redirect href="/" />
+  }
+
+  return (
+    <>
+      <StatusBar barStyle="light-content" />
+      <Stack
+        screenOptions={{
+          headerStyle: {
+            backgroundColor: theme.colors.background,
+          },
+          headerTitleStyle: {
+            color: theme.colors.text,
+            fontSize: 18,
+          },
+          contentStyle: { backgroundColor: theme.colors.background },
+          headerShadowVisible: false,
+        }}
+      />
+    </>
   )
 }
 
@@ -63,17 +70,19 @@ export default function Providers() {
     <ThemeProvider value={DarkTheme}>
       <PolarClientProvider>
         <PolarQueryClientProvider>
-          <UserProvider>
-            <DeepLinkProvider>
-              <NotificationsProvider>
-                <PolarOrganizationProvider>
-                  <ToastProvider>
-                    <RootLayout />
-                  </ToastProvider>
-                </PolarOrganizationProvider>
-              </NotificationsProvider>
-            </DeepLinkProvider>
-          </UserProvider>
+          <DeepLinkProvider>
+            <NotificationsProvider>
+              <AuthenticatedErrorBoundary>
+                <UserProvider>
+                  <PolarOrganizationProvider>
+                    <ToastProvider>
+                      <RootLayout />
+                    </ToastProvider>
+                  </PolarOrganizationProvider>
+                </UserProvider>
+              </AuthenticatedErrorBoundary>
+            </NotificationsProvider>
+          </DeepLinkProvider>
         </PolarQueryClientProvider>
       </PolarClientProvider>
     </ThemeProvider>


### PR DESCRIPTION
<img width="325" align="right" alt="" src="https://github.com/user-attachments/assets/2fbc6977-b5da-4e8a-b822-d55221c8906b" />

Our `<ErrorBoundary />` was placed _inside_ of `<PolarOrganizationProvider />` and `<UserProvider />` meaning if they throw an error, the boundary won't catch it.

This PR fixes that by moving up the boundary, so if we get 400/500 errors on org/user queries we'll see this instead of a crash 👉 