### PR TITLE
polar: Buffer self event ingestion

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -216,6 +216,37 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
 
         return newly_rooted
 
+    async def get_latest_polar_self_ingestion_timestamp(
+        self, organization_id: UUID
+    ) -> datetime | None:
+        statement = select(func.max(Event.timestamp)).where(
+            Event.organization_id == organization_id,
+            Event.name == "event_ingestion",
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    async def count_user_events_by_organization(
+        self,
+        *,
+        after: datetime | None,
+        until: datetime,
+        exclude_organization_id: UUID,
+    ) -> dict[UUID, int]:
+        statement = (
+            select(Event.organization_id, func.count(Event.id))
+            .where(
+                Event.source == EventSource.user,
+                Event.organization_id != exclude_organization_id,
+                Event.ingested_at <= until,
+            )
+            .group_by(Event.organization_id)
+        )
+        if after is not None:
+            statement = statement.where(Event.ingested_at > after)
+        result = await self.session.execute(statement)
+        return {row[0]: row[1] for row in result.all()}
+
     async def get_latest_meter_reset(
         self, customer: Customer, meter_id: UUID
     ) -> Event | None:

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -20,7 +20,6 @@ from polar.customer_meter.repository import CustomerMeterRepository
 from polar.event.tinybird_repository import TinybirdEventRepository
 from polar.event_type.repository import EventTypeRepository
 from polar.exceptions import PolarError, PolarRequestValidationError, ValidationError
-from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.integrations.tinybird.service import (
     TinybirdTimeseriesStats,
     events_to_tinybird,
@@ -1015,8 +1014,6 @@ class EventService:
 
         tinybird_events = events_to_tinybird(events, ancestors_by_event)
         enqueue_job("tinybird.ingest", tinybird_events)
-
-        polar_self_service.enqueue_event_ingestion(events)
 
     async def _create_meter_events(
         self, session: AsyncSession, events: Sequence[Event]

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, NoReturn
+from uuid import UUID
 
 import httpx
 import logfire
@@ -199,6 +202,43 @@ class PolarSelfClient:
                 _raise_error(span, e, "delete_customer")
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "delete_customer")
+
+    async def track_event_ingestion(
+        self, *, counts: Mapping[UUID, int], cutoff: datetime
+    ) -> None:
+        from polar_sdk.models import (
+            EventCreateCustomer,
+            EventCreateExternalCustomer,
+            EventsIngest,
+        )
+        from polar_sdk.models.polarerror import PolarError
+
+        cutoff_epoch = int(cutoff.timestamp())
+        events: list[EventCreateCustomer | EventCreateExternalCustomer] = [
+            EventCreateExternalCustomer(
+                name="event_ingestion",
+                external_customer_id=str(org_id),
+                external_id=f"events_ingested-{org_id}-{cutoff_epoch}",
+                timestamp=cutoff,
+                metadata={"count": count},
+            )
+            for org_id, count in counts.items()
+        ]
+
+        with logfire.span(
+            "polar.track_event_ingestion",
+            org_count=len(events),
+            cutoff=cutoff.isoformat(),
+        ) as span:
+            try:
+                await self._sdk.events.ingest_async(request=EventsIngest(events=events))
+            except PolarError as e:
+                if e.status_code == 409:
+                    span.set_attribute("conflict", True)
+                    return
+                _raise_error(span, e, "track_event_ingestion")
+            except httpx.RequestError as e:
+                _raise_network_error(span, e, "track_event_ingestion")
 
     async def track_event_ingestion(
         self, *, external_customer_id: str, count: int

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -240,37 +240,6 @@ class PolarSelfClient:
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "track_event_ingestion")
 
-    async def track_event_ingestion(
-        self, *, external_customer_id: str, count: int
-    ) -> None:
-        from polar_sdk.models import EventCreateExternalCustomer, EventsIngest
-        from polar_sdk.models.polarerror import PolarError
-
-        with logfire.span(
-            "polar.track_event_ingestion",
-            external_customer_id=external_customer_id,
-            event_count=count,
-        ) as span:
-            try:
-                await self._sdk.events.ingest_async(
-                    request=EventsIngest(
-                        events=[
-                            EventCreateExternalCustomer(
-                                name="event_ingestion",
-                                external_customer_id=external_customer_id,
-                                metadata={"count": count},
-                            )
-                        ]
-                    )
-                )
-            except PolarError as e:
-                if e.status_code == 409:
-                    span.set_attribute("conflict", True)
-                    return
-                _raise_error(span, e, "track_event_ingestion")
-            except httpx.RequestError as e:
-                _raise_network_error(span, e, "track_event_ingestion")
-
     async def track_organization_review_usage(
         self,
         *,

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -1,11 +1,7 @@
 import uuid
-from collections import defaultdict
-from collections.abc import Sequence
 from decimal import Decimal
 
 from polar.config import settings
-from polar.models import Event
-from polar.models.event import EventSource
 from polar.worker import enqueue_job
 
 
@@ -77,16 +73,6 @@ class PolarSelfService:
             external_id=str(organization_id),
         )
 
-    def enqueue_track_ingestion(self, *, external_customer_id: str, count: int) -> None:
-        if not self.is_configured:
-            return
-        enqueue_job(
-            "polar_self.track_event_ingestion",
-            external_customer_id=external_customer_id,
-            count=count,
-            organization_id=settings.POLAR_ORGANIZATION_ID,
-        )
-
     def enqueue_track_organization_review_usage(
         self,
         *,
@@ -117,25 +103,6 @@ class PolarSelfService:
             output_tokens=output_tokens,
             cost_usd=str(cost_decimal),
         )
-
-    def enqueue_event_ingestion(self, events: Sequence[Event]) -> None:
-        if not self.is_configured:
-            return
-
-        self_organization_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
-        counts: dict[uuid.UUID, int] = defaultdict(int)
-        for event in events:
-            if event.source != EventSource.user:
-                continue
-            if event.organization_id == self_organization_id:
-                continue
-            counts[event.organization_id] += 1
-
-        for organization_id, count in counts.items():
-            self.enqueue_track_ingestion(
-                external_customer_id=str(organization_id),
-                count=count,
-            )
 
 
 polar_self = PolarSelfService()

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -1,8 +1,19 @@
+import uuid
+from datetime import timedelta
 from decimal import Decimal
 
 from dramatiq import Retry
 
-from polar.worker import TaskPriority, actor, can_retry
+from polar.config import settings
+from polar.event.repository import EventRepository
+from polar.kit.utils import utc_now
+from polar.worker import (
+    AsyncSessionMaker,
+    CronTrigger,
+    TaskPriority,
+    actor,
+    can_retry,
+)
 
 from .client import get_client
 
@@ -89,14 +100,29 @@ async def delete_customer(external_id: str) -> None:
     await get_client().delete_customer(external_id=external_id)
 
 
-@actor(actor_name="polar_self.track_event_ingestion", priority=TaskPriority.LOW)
-async def track_event_ingestion(
-    external_customer_id: str, count: int, organization_id: str
-) -> None:
-    await get_client().track_event_ingestion(
-        external_customer_id=external_customer_id,
-        count=count,
-    )
+@actor(
+    actor_name="polar_self.track_event_ingestion_v2",
+    cron_trigger=CronTrigger.from_crontab("*/5 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def track_event_ingestion() -> None:
+    if not settings.POLAR_SELF_ENABLED:
+        return
+    self_organization_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
+    cutoff = utc_now() - timedelta(seconds=30)
+    async with AsyncSessionMaker() as session:
+        repository = EventRepository.from_session(session)
+        last_flush = await repository.get_latest_polar_self_ingestion_timestamp(
+            self_organization_id
+        )
+        counts = await repository.count_user_events_by_organization(
+            after=last_flush,
+            until=cutoff,
+            exclude_organization_id=self_organization_id,
+        )
+    if not counts:
+        return
+    await get_client().track_event_ingestion(counts=counts, cutoff=cutoff)
 
 
 @actor(

--- a/server/tests/event/test_repository.py
+++ b/server/tests/event/test_repository.py
@@ -1,0 +1,263 @@
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from polar.event.repository import EventRepository
+from polar.kit.utils import utc_now
+from polar.models import Event, Organization
+from polar.models.event import EventSource
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+async def _create_event(
+    save_fixture: SaveFixture,
+    *,
+    organization: Organization,
+    ingested_at: datetime,
+    timestamp: datetime | None = None,
+    source: EventSource = EventSource.user,
+    name: str = "test_event",
+) -> Event:
+    event_id = uuid.uuid4()
+    event = Event(
+        id=event_id,
+        ingested_at=ingested_at,
+        timestamp=timestamp or ingested_at,
+        source=source,
+        name=name,
+        organization=organization,
+        root_id=event_id,
+        user_metadata={},
+    )
+    await save_fixture(event)
+    return event
+
+
+@pytest.mark.asyncio
+class TestCountUserEventsByOrganization:
+    async def test_groups_counts_per_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(save_fixture, organization=organization, ingested_at=now)
+        await _create_event(save_fixture, organization=organization, ingested_at=now)
+        await _create_event(
+            save_fixture, organization=organization_second, ingested_at=now
+        )
+
+        repository = EventRepository.from_session(session)
+        counts = await repository.count_user_events_by_organization(
+            after=now - timedelta(minutes=1),
+            until=now + timedelta(minutes=1),
+            exclude_organization_id=uuid.uuid4(),
+        )
+
+        assert counts == {organization.id: 2, organization_second.id: 1}
+
+    async def test_excludes_system_events(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(save_fixture, organization=organization, ingested_at=now)
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=now,
+            source=EventSource.system,
+        )
+
+        repository = EventRepository.from_session(session)
+        counts = await repository.count_user_events_by_organization(
+            after=now - timedelta(minutes=1),
+            until=now + timedelta(minutes=1),
+            exclude_organization_id=uuid.uuid4(),
+        )
+
+        assert counts == {organization.id: 1}
+
+    async def test_excludes_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(save_fixture, organization=organization, ingested_at=now)
+        await _create_event(
+            save_fixture, organization=organization_second, ingested_at=now
+        )
+
+        repository = EventRepository.from_session(session)
+        counts = await repository.count_user_events_by_organization(
+            after=now - timedelta(minutes=1),
+            until=now + timedelta(minutes=1),
+            exclude_organization_id=organization.id,
+        )
+
+        assert counts == {organization_second.id: 1}
+
+    async def test_after_is_exclusive_until_is_inclusive(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        boundary = utc_now()
+        await _create_event(
+            save_fixture, organization=organization, ingested_at=boundary
+        )
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=boundary + timedelta(milliseconds=1),
+        )
+
+        repository = EventRepository.from_session(session)
+        counts = await repository.count_user_events_by_organization(
+            after=boundary,
+            until=boundary + timedelta(milliseconds=1),
+            exclude_organization_id=uuid.uuid4(),
+        )
+
+        assert counts == {organization.id: 1}
+
+    async def test_no_lower_bound_when_after_is_none(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=now - timedelta(days=365),
+        )
+        await _create_event(save_fixture, organization=organization, ingested_at=now)
+
+        repository = EventRepository.from_session(session)
+        counts = await repository.count_user_events_by_organization(
+            after=None,
+            until=now + timedelta(minutes=1),
+            exclude_organization_id=uuid.uuid4(),
+        )
+
+        assert counts == {organization.id: 2}
+
+    async def test_returns_empty_when_no_match(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(save_fixture, organization=organization, ingested_at=now)
+
+        repository = EventRepository.from_session(session)
+        counts = await repository.count_user_events_by_organization(
+            after=now + timedelta(hours=1),
+            until=now + timedelta(hours=2),
+            exclude_organization_id=uuid.uuid4(),
+        )
+
+        assert counts == {}
+
+
+@pytest.mark.asyncio
+class TestGetLatestPolarSelfIngestionTimestamp:
+    async def test_returns_latest_for_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        earlier = utc_now() - timedelta(minutes=10)
+        later = utc_now() - timedelta(minutes=1)
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=earlier,
+            timestamp=earlier,
+            name="event_ingestion",
+        )
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=later,
+            timestamp=later,
+            name="event_ingestion",
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_latest_polar_self_ingestion_timestamp(
+            organization.id
+        )
+
+        assert result == later
+
+    async def test_returns_none_when_no_events(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repository = EventRepository.from_session(session)
+        result = await repository.get_latest_polar_self_ingestion_timestamp(
+            organization.id
+        )
+
+        assert result is None
+
+    async def test_filters_by_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(
+            save_fixture,
+            organization=organization_second,
+            ingested_at=now,
+            timestamp=now,
+            name="event_ingestion",
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_latest_polar_self_ingestion_timestamp(
+            organization.id
+        )
+
+        assert result is None
+
+    async def test_filters_by_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=now,
+            timestamp=now,
+            name="other_event",
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_latest_polar_self_ingestion_timestamp(
+            organization.id
+        )
+
+        assert result is None

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -1,25 +1,13 @@
 import uuid
 from decimal import Decimal
-from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
 from polar.integrations.polar.service import polar_self
-from polar.models.event import EventSource
 
 SELF_ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 ORG_A = uuid.UUID("00000000-0000-0000-0000-00000000000a")
-ORG_B = uuid.UUID("00000000-0000-0000-0000-00000000000b")
-
-
-def _event(
-    organization_id: uuid.UUID, source: EventSource = EventSource.user
-) -> MagicMock:
-    event = MagicMock()
-    event.organization_id = organization_id
-    event.source = source
-    return event
 
 
 @pytest.fixture
@@ -27,95 +15,6 @@ def configured(mocker: MockerFixture) -> None:
     settings = mocker.patch("polar.integrations.polar.service.settings")
     settings.POLAR_SELF_ENABLED = True
     settings.POLAR_ORGANIZATION_ID = str(SELF_ORG_ID)
-
-
-class TestEnqueueEventIngestion:
-    def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
-        settings = mocker.patch("polar.integrations.polar.service.settings")
-        settings.POLAR_SELF_ENABLED = False
-        enqueue = mocker.patch(
-            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
-        )
-
-        polar_self.enqueue_event_ingestion([_event(ORG_A)])
-
-        enqueue.assert_not_called()
-
-    def test_noop_on_empty(self, configured: None, mocker: MockerFixture) -> None:
-        enqueue = mocker.patch(
-            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
-        )
-
-        polar_self.enqueue_event_ingestion([])
-
-        enqueue.assert_not_called()
-
-    def test_aggregates_per_organization(
-        self, configured: None, mocker: MockerFixture
-    ) -> None:
-        enqueue = mocker.patch(
-            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
-        )
-
-        polar_self.enqueue_event_ingestion(
-            [
-                _event(ORG_A),
-                _event(ORG_A),
-                _event(ORG_A),
-                _event(ORG_B),
-                _event(ORG_B),
-            ]
-        )
-
-        assert enqueue.call_count == 2
-        calls = {
-            call.kwargs["external_customer_id"]: call.kwargs["count"]
-            for call in enqueue.call_args_list
-        }
-        assert calls == {str(ORG_A): 3, str(ORG_B): 2}
-
-    def test_skips_system_events(self, configured: None, mocker: MockerFixture) -> None:
-        enqueue = mocker.patch(
-            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
-        )
-
-        polar_self.enqueue_event_ingestion(
-            [
-                _event(ORG_A, source=EventSource.user),
-                _event(ORG_A, source=EventSource.system),
-                _event(ORG_A, source=EventSource.system),
-            ]
-        )
-
-        enqueue.assert_called_once_with(external_customer_id=str(ORG_A), count=1)
-
-    def test_skips_self_organization(
-        self, configured: None, mocker: MockerFixture
-    ) -> None:
-        enqueue = mocker.patch(
-            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
-        )
-
-        polar_self.enqueue_event_ingestion(
-            [
-                _event(SELF_ORG_ID),
-                _event(SELF_ORG_ID),
-                _event(ORG_A),
-            ]
-        )
-
-        enqueue.assert_called_once_with(external_customer_id=str(ORG_A), count=1)
-
-    def test_noop_when_only_self_org_events(
-        self, configured: None, mocker: MockerFixture
-    ) -> None:
-        enqueue = mocker.patch(
-            "polar.integrations.polar.service.polar_self.enqueue_track_ingestion"
-        )
-
-        polar_self.enqueue_event_ingestion([_event(SELF_ORG_ID), _event(SELF_ORG_ID)])
-
-        enqueue.assert_not_called()
 
 
 class TestEnqueueTrackOrganizationReviewUsage:

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -1,3 +1,4 @@
+import uuid
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,6 +13,7 @@ from polar.integrations.polar.tasks import (
     add_member,
     delete_customer,
     remove_member,
+    track_event_ingestion,
     track_organization_review_usage,
 )
 
@@ -184,6 +186,76 @@ class TestDeleteCustomer:
         await delete_customer(external_id="org-123")
 
         client.delete_customer.assert_called_once_with(external_id="org-123")
+
+
+@pytest.mark.asyncio
+class TestFlushEventIngestion:
+    SELF_ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+    def _patch_settings(self, mocker: MockerFixture, *, enabled: bool = True) -> None:
+        settings = mocker.patch("polar.integrations.polar.tasks.settings")
+        settings.POLAR_SELF_ENABLED = enabled
+        settings.POLAR_ORGANIZATION_ID = str(self.SELF_ORG_ID)
+
+    async def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
+        self._patch_settings(mocker, enabled=False)
+        client = AsyncMock(spec=PolarSelfClient)
+        get_client = mocker.patch(
+            "polar.integrations.polar.tasks.get_client", return_value=client
+        )
+
+        await track_event_ingestion()
+
+        get_client.assert_not_called()
+
+    async def test_noop_when_no_counts(self, mocker: MockerFixture) -> None:
+        self._patch_settings(mocker)
+        repository = MagicMock()
+        repository.get_latest_polar_self_ingestion_timestamp = AsyncMock(
+            return_value=None
+        )
+        repository.count_user_events_by_organization = AsyncMock(return_value={})
+        mocker.patch(
+            "polar.integrations.polar.tasks.EventRepository.from_session",
+            return_value=repository,
+        )
+        client = AsyncMock(spec=PolarSelfClient)
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await track_event_ingestion()
+
+        client.track_event_ingestion.assert_not_called()
+
+    async def test_calls_client_with_counts_and_cutoff(
+        self, mocker: MockerFixture
+    ) -> None:
+        self._patch_settings(mocker)
+        org_a = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+        last_flush = MagicMock()
+        counts = {org_a: 7}
+        repository = MagicMock()
+        repository.get_latest_polar_self_ingestion_timestamp = AsyncMock(
+            return_value=last_flush
+        )
+        repository.count_user_events_by_organization = AsyncMock(return_value=counts)
+        mocker.patch(
+            "polar.integrations.polar.tasks.EventRepository.from_session",
+            return_value=repository,
+        )
+        client = AsyncMock(spec=PolarSelfClient)
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await track_event_ingestion()
+
+        repository.count_user_events_by_organization.assert_called_once()
+        kwargs = repository.count_user_events_by_organization.call_args.kwargs
+        assert kwargs["after"] is last_flush
+        assert kwargs["exclude_organization_id"] == self.SELF_ORG_ID
+        cutoff = kwargs["until"]
+
+        client.track_event_ingestion.assert_called_once_with(
+            counts=counts, cutoff=cutoff
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Instead of mapping every `/ingest` call to a self ingest call (i.e. 1:1 or n:1 events in Polar), we have a cron that runs and checks all organizations that have ingested events the past 5 minutes, and logs those as an event.

This will give us a spike every 5 minutes, but it will be a lot less than what we were seeing since we will be rolling up the events.

For the past 24 hours the difference would've been ~58% fewer tasks running in this solution vs the original solution. 