### PR TITLE
refactor(authz): migrate custom_field to PolicyGuard pattern

### DIFF
--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -14,6 +14,10 @@ from polar.models import Organization as OrganizationModel
 from polar.models import PayoutAccount as PayoutAccountModel
 from polar.models.account import Account as AccountModel
 from polar.organization.repository import OrganizationRepository
+from polar.organization.resolver import (
+    OrganizationIDModel,
+    get_payload_organization,
+)
 from polar.organization.schemas import OrganizationID
 from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import AsyncSession, get_db_session
@@ -22,7 +26,7 @@ from .policies import finance, members
 from .policies import organization as org_policy
 from .policies import payout_account as pa_policy
 from .service import get_accessible_org_ids, get_accessible_organization
-from .types import PolicyFn, PolicyResult
+from .types import AccessibleOrganizationID, PolicyFn, PolicyResult
 
 
 @dataclass(frozen=True)
@@ -126,6 +130,91 @@ class AuthorizedResource[R]:
     resource: R
     organization: OrganizationModel
     auth_subject: AuthSubject[User | Organization]
+
+
+@dataclass(frozen=True)
+class AuthorizedList:
+    """Result of an OrgListGuard dependency.
+
+    Contains the set of organization IDs the subject can access plus the
+    auth subject. Services receive these IDs and never see ``auth_subject``
+    for filtering.
+    """
+
+    accessible_org_ids: set[AccessibleOrganizationID]
+    auth_subject: AuthSubject[User | Organization]
+
+
+@dataclass(frozen=True)
+class AuthorizedCreate[B]:
+    """Result of an org-payload create guard.
+
+    Contains the parsed request body, the resolved target organization
+    (already access-checked), and the auth subject.
+    """
+
+    body: B
+    organization: OrganizationModel
+    auth_subject: AuthSubject[User | Organization]
+
+
+def OrgListGuard(
+    *,
+    required_scopes: set[Scope],
+    allowed_subjects: set[type] | None = None,
+) -> Any:
+    """Dependency: authenticate + resolve accessible organization IDs.
+
+    For list endpoints whose only access check is ``filter by org membership``.
+    The service receives ``accessible_org_ids`` and never sees the auth
+    subject — pure data access.
+
+    Raises:
+        Unauthorized (401): No valid credentials.
+        InsufficientScopeError (403): Token lacks required scopes.
+    """
+    _allowed = allowed_subjects or {User, Organization}
+    _authenticator = Authenticator(
+        allowed_subjects=_allowed,
+        required_scopes=required_scopes,
+    )
+
+    async def dependency(
+        auth_subject: Annotated[
+            AuthSubject[User | Organization], Depends(_authenticator)
+        ],
+        session: AsyncSession = Depends(get_db_session),
+    ) -> AuthorizedList:
+        org_ids = await get_accessible_org_ids(session, auth_subject)
+        return AuthorizedList(
+            accessible_org_ids=org_ids,
+            auth_subject=auth_subject,
+        )
+
+    return dependency
+
+
+async def authorize_create_payload[B: OrganizationIDModel](
+    *,
+    session: AsyncSession,
+    auth_subject: AuthSubject[User | Organization],
+    body: B,
+    policy_fn: PolicyFn,
+) -> AuthorizedCreate[B]:
+    """Helper for per-module create deps.
+
+    Resolves the target organization from ``body.organization_id`` (or
+    falls back to the org auth subject), checks subject access, and runs
+    the create policy. Modules wrap this in a small dep that declares the
+    concrete body type so FastAPI can introspect it.
+    """
+    organization = await get_payload_organization(session, auth_subject, body)
+    await _check_policy(policy_fn, session, auth_subject, organization)
+    return AuthorizedCreate(
+        body=body,
+        organization=organization,
+        auth_subject=auth_subject,
+    )
 
 
 def ResourcePolicyGuard[R](

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -115,6 +115,76 @@ async def _check_policy(
         raise NotPermitted(result if isinstance(result, str) else "Not permitted")
 
 
+@dataclass(frozen=True)
+class AuthorizedResource[R]:
+    """Result of a ResourcePolicyGuard dependency.
+
+    Contains the resolved resource, its owning organization (already
+    access-checked against the auth subject), and the auth subject.
+    """
+
+    resource: R
+    organization: OrganizationModel
+    auth_subject: AuthSubject[User | Organization]
+
+
+def ResourcePolicyGuard[R](
+    *,
+    resolve: Callable[[AsyncSession, UUID], Awaitable[R | None]],
+    get_organization_id: Callable[[R], UUID],
+    policy_fn: PolicyFn,
+    required_scopes: set[Scope],
+    allowed_subjects: set[type] | None = None,
+) -> Any:
+    """Generic policy guard for resources owned by an organization.
+
+    Steps:
+    1. Authenticate the subject (token type + scope check).
+    2. Resolve the resource by ``{id}`` via ``resolve``.
+    3. Extract the resource's owning organization id via ``get_organization_id``
+       and verify the subject can access it.
+    4. Evaluate the policy function against (subject, organization).
+    5. Return an ``AuthorizedResource`` wrapping resource + org + subject.
+
+    Raises:
+        Unauthorized (401): No valid credentials.
+        InsufficientScopeError (403): Token lacks required scopes.
+        ResourceNotFound (404): Resource missing, or its org is inaccessible.
+        NotPermitted (403): Subject is a member but the policy denied access.
+    """
+    _allowed = allowed_subjects or {User, Organization}
+    _authenticator = Authenticator(
+        allowed_subjects=_allowed,
+        required_scopes=required_scopes,
+    )
+
+    async def dependency(
+        id: UUID,
+        auth_subject: Annotated[
+            AuthSubject[User | Organization], Depends(_authenticator)
+        ],
+        session: AsyncSession = Depends(get_db_session),
+    ) -> AuthorizedResource[R]:
+        resource = await resolve(session, id)
+        if resource is None:
+            raise ResourceNotFound()
+
+        organization = await get_accessible_organization(
+            session, auth_subject, get_organization_id(resource)
+        )
+        if organization is None:
+            raise ResourceNotFound()
+
+        await _check_policy(policy_fn, session, auth_subject, organization)
+        return AuthorizedResource(
+            resource=resource,
+            organization=organization,
+            auth_subject=auth_subject,
+        )
+
+    return dependency
+
+
 AuthorizeFinanceRead = Annotated[
     AuthzContext[User | Organization],
     Depends(

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -14,10 +14,6 @@ from polar.models import Organization as OrganizationModel
 from polar.models import PayoutAccount as PayoutAccountModel
 from polar.models.account import Account as AccountModel
 from polar.organization.repository import OrganizationRepository
-from polar.organization.resolver import (
-    OrganizationIDModel,
-    get_payload_organization,
-)
 from polar.organization.schemas import OrganizationID
 from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import AsyncSession, get_db_session
@@ -26,7 +22,7 @@ from .policies import finance, members
 from .policies import organization as org_policy
 from .policies import payout_account as pa_policy
 from .service import get_accessible_org_ids, get_accessible_organization
-from .types import AccessibleOrganizationID, PolicyFn, PolicyResult
+from .types import PolicyFn, PolicyResult
 
 
 @dataclass(frozen=True)
@@ -130,91 +126,6 @@ class AuthorizedResource[R]:
     resource: R
     organization: OrganizationModel
     auth_subject: AuthSubject[User | Organization]
-
-
-@dataclass(frozen=True)
-class AuthorizedList:
-    """Result of an OrgListGuard dependency.
-
-    Contains the set of organization IDs the subject can access plus the
-    auth subject. Services receive these IDs and never see ``auth_subject``
-    for filtering.
-    """
-
-    accessible_org_ids: set[AccessibleOrganizationID]
-    auth_subject: AuthSubject[User | Organization]
-
-
-@dataclass(frozen=True)
-class AuthorizedCreate[B]:
-    """Result of an org-payload create guard.
-
-    Contains the parsed request body, the resolved target organization
-    (already access-checked), and the auth subject.
-    """
-
-    body: B
-    organization: OrganizationModel
-    auth_subject: AuthSubject[User | Organization]
-
-
-def OrgListGuard(
-    *,
-    required_scopes: set[Scope],
-    allowed_subjects: set[type] | None = None,
-) -> Any:
-    """Dependency: authenticate + resolve accessible organization IDs.
-
-    For list endpoints whose only access check is ``filter by org membership``.
-    The service receives ``accessible_org_ids`` and never sees the auth
-    subject — pure data access.
-
-    Raises:
-        Unauthorized (401): No valid credentials.
-        InsufficientScopeError (403): Token lacks required scopes.
-    """
-    _allowed = allowed_subjects or {User, Organization}
-    _authenticator = Authenticator(
-        allowed_subjects=_allowed,
-        required_scopes=required_scopes,
-    )
-
-    async def dependency(
-        auth_subject: Annotated[
-            AuthSubject[User | Organization], Depends(_authenticator)
-        ],
-        session: AsyncSession = Depends(get_db_session),
-    ) -> AuthorizedList:
-        org_ids = await get_accessible_org_ids(session, auth_subject)
-        return AuthorizedList(
-            accessible_org_ids=org_ids,
-            auth_subject=auth_subject,
-        )
-
-    return dependency
-
-
-async def authorize_create_payload[B: OrganizationIDModel](
-    *,
-    session: AsyncSession,
-    auth_subject: AuthSubject[User | Organization],
-    body: B,
-    policy_fn: PolicyFn,
-) -> AuthorizedCreate[B]:
-    """Helper for per-module create deps.
-
-    Resolves the target organization from ``body.organization_id`` (or
-    falls back to the org auth subject), checks subject access, and runs
-    the create policy. Modules wrap this in a small dep that declares the
-    concrete body type so FastAPI can introspect it.
-    """
-    organization = await get_payload_organization(session, auth_subject, body)
-    await _check_policy(policy_fn, session, auth_subject, organization)
-    return AuthorizedCreate(
-        body=body,
-        organization=organization,
-        auth_subject=auth_subject,
-    )
 
 
 def ResourcePolicyGuard[R](

--- a/server/polar/authz/policies/custom_field.py
+++ b/server/polar/authz/policies/custom_field.py
@@ -1,0 +1,22 @@
+from polar.auth.models import AuthSubject, Organization, User
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+
+
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Any subject with access to the org can read its custom fields."""
+    return True
+
+
+async def can_write(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Any subject with access to the org can write its custom fields."""
+    return True

--- a/server/polar/custom_field/auth.py
+++ b/server/polar/custom_field/auth.py
@@ -6,16 +6,14 @@ from fastapi import Depends
 from polar.auth.dependencies import Authenticator
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
-from polar.authz.dependencies import (
-    AuthorizedCreate,
-    AuthorizedList,
-    AuthorizedResource,
-    OrgListGuard,
-    ResourcePolicyGuard,
-    authorize_create_payload,
-)
+from polar.authz.dependencies import AuthorizedResource, ResourcePolicyGuard
 from polar.authz.policies import custom_field as custom_field_policy
+from polar.authz.service import get_accessible_org_ids
+from polar.authz.types import AccessibleOrganizationID
+from polar.exceptions import NotPermitted
 from polar.models import CustomField
+from polar.models import Organization as OrganizationModel
+from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncSession, get_db_session
 
 from .repository import CustomFieldRepository
@@ -25,38 +23,51 @@ _LIST_SCOPES = {Scope.custom_fields_read, Scope.custom_fields_write}
 _WRITE_SCOPES = {Scope.custom_fields_write}
 
 
-# List endpoint — authenticate + resolve accessible org IDs at the dep layer.
+# List endpoint — authenticate + resolve accessible org IDs.
+_list_authenticator = Authenticator(
+    allowed_subjects={User, Organization},
+    required_scopes=_LIST_SCOPES,
+)
+
+
+async def _authorize_list(
+    auth_subject: Annotated[
+        AuthSubject[User | Organization], Depends(_list_authenticator)
+    ],
+    session: AsyncSession = Depends(get_db_session),
+) -> set[AccessibleOrganizationID]:
+    return await get_accessible_org_ids(session, auth_subject)
+
+
 AuthorizeCustomFieldList = Annotated[
-    AuthorizedList, Depends(OrgListGuard(required_scopes=_LIST_SCOPES))
+    set[AccessibleOrganizationID], Depends(_authorize_list)
 ]
 
 
-# Create endpoint — parse body, resolve target org from payload, run can_write.
+# Create endpoint — authenticate + parse body + resolve target org + run policy.
 _create_authenticator = Authenticator(
     allowed_subjects={User, Organization},
     required_scopes=_WRITE_SCOPES,
 )
 
 
-async def _authorize_custom_field_create(
+async def _authorize_create(
     custom_field_create: CustomFieldCreate,
     auth_subject: Annotated[
         AuthSubject[User | Organization], Depends(_create_authenticator)
     ],
     session: AsyncSession = Depends(get_db_session),
-) -> AuthorizedCreate[CustomFieldCreate]:
-    return await authorize_create_payload(
-        session=session,
-        auth_subject=auth_subject,
-        body=custom_field_create,
-        policy_fn=custom_field_policy.can_write,
+) -> OrganizationModel:
+    organization = await get_payload_organization(
+        session, auth_subject, custom_field_create
     )
+    result = await custom_field_policy.can_write(session, auth_subject, organization)
+    if result is not True:
+        raise NotPermitted(result if isinstance(result, str) else "Not permitted")
+    return organization
 
 
-AuthorizeCustomFieldCreate = Annotated[
-    AuthorizedCreate[CustomFieldCreate],
-    Depends(_authorize_custom_field_create),
-]
+AuthorizeCustomFieldCreate = Annotated[OrganizationModel, Depends(_authorize_create)]
 
 
 # Per-id endpoints — full PolicyGuard (resolve resource → check org access → policy).

--- a/server/polar/custom_field/auth.py
+++ b/server/polar/custom_field/auth.py
@@ -6,34 +6,65 @@ from fastapi import Depends
 from polar.auth.dependencies import Authenticator
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
-from polar.authz.dependencies import AuthorizedResource, ResourcePolicyGuard
+from polar.authz.dependencies import (
+    AuthorizedCreate,
+    AuthorizedList,
+    AuthorizedResource,
+    OrgListGuard,
+    ResourcePolicyGuard,
+    authorize_create_payload,
+)
 from polar.authz.policies import custom_field as custom_field_policy
 from polar.models import CustomField
-from polar.postgres import AsyncSession
+from polar.postgres import AsyncSession, get_db_session
 
 from .repository import CustomFieldRepository
+from .schemas import CustomFieldCreate
 
-# List/create endpoints — scope check only; service applies the
-# accessible-org filter for list, and the policy is enforced at create
-# time once the target organization is resolved from the payload.
-_CustomFieldListCreate = Authenticator(
-    required_scopes={
-        Scope.custom_fields_read,
-        Scope.custom_fields_write,
-    },
-    allowed_subjects={User, Organization},
-)
-CustomFieldListCreate = Annotated[
-    AuthSubject[User | Organization], Depends(_CustomFieldListCreate)
+_LIST_SCOPES = {Scope.custom_fields_read, Scope.custom_fields_write}
+_WRITE_SCOPES = {Scope.custom_fields_write}
+
+
+# List endpoint — authenticate + resolve accessible org IDs at the dep layer.
+AuthorizeCustomFieldList = Annotated[
+    AuthorizedList, Depends(OrgListGuard(required_scopes=_LIST_SCOPES))
 ]
 
 
+# Create endpoint — parse body, resolve target org from payload, run can_write.
+_create_authenticator = Authenticator(
+    allowed_subjects={User, Organization},
+    required_scopes=_WRITE_SCOPES,
+)
+
+
+async def _authorize_custom_field_create(
+    custom_field_create: CustomFieldCreate,
+    auth_subject: Annotated[
+        AuthSubject[User | Organization], Depends(_create_authenticator)
+    ],
+    session: AsyncSession = Depends(get_db_session),
+) -> AuthorizedCreate[CustomFieldCreate]:
+    return await authorize_create_payload(
+        session=session,
+        auth_subject=auth_subject,
+        body=custom_field_create,
+        policy_fn=custom_field_policy.can_write,
+    )
+
+
+AuthorizeCustomFieldCreate = Annotated[
+    AuthorizedCreate[CustomFieldCreate],
+    Depends(_authorize_custom_field_create),
+]
+
+
+# Per-id endpoints — full PolicyGuard (resolve resource → check org access → policy).
 async def _resolve(session: AsyncSession, id: UUID) -> CustomField | None:
     repository = CustomFieldRepository.from_session(session)
     return await repository.get_by_id(id)
 
 
-# Per-id endpoints — full PolicyGuard (resolve resource → check org access → policy).
 AuthorizeCustomFieldRead = Annotated[
     AuthorizedResource[CustomField],
     Depends(
@@ -41,10 +72,7 @@ AuthorizeCustomFieldRead = Annotated[
             resolve=_resolve,
             get_organization_id=lambda cf: cf.organization_id,
             policy_fn=custom_field_policy.can_read,
-            required_scopes={
-                Scope.custom_fields_read,
-                Scope.custom_fields_write,
-            },
+            required_scopes=_LIST_SCOPES,
         )
     ),
 ]
@@ -56,7 +84,7 @@ AuthorizeCustomFieldWrite = Annotated[
             resolve=_resolve,
             get_organization_id=lambda cf: cf.organization_id,
             policy_fn=custom_field_policy.can_write,
-            required_scopes={Scope.custom_fields_write},
+            required_scopes=_WRITE_SCOPES,
         )
     ),
 ]

--- a/server/polar/custom_field/auth.py
+++ b/server/polar/custom_field/auth.py
@@ -1,27 +1,62 @@
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import Depends
 
 from polar.auth.dependencies import Authenticator
-from polar.auth.models import AuthSubject, User
+from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
-from polar.models.organization import Organization
+from polar.authz.dependencies import AuthorizedResource, ResourcePolicyGuard
+from polar.authz.policies import custom_field as custom_field_policy
+from polar.models import CustomField
+from polar.postgres import AsyncSession
 
-_CustomFieldRead = Authenticator(
+from .repository import CustomFieldRepository
+
+# List/create endpoints — scope check only; service applies the
+# accessible-org filter for list, and the policy is enforced at create
+# time once the target organization is resolved from the payload.
+_CustomFieldListCreate = Authenticator(
     required_scopes={
         Scope.custom_fields_read,
         Scope.custom_fields_write,
     },
     allowed_subjects={User, Organization},
 )
-CustomFieldRead = Annotated[AuthSubject[User | Organization], Depends(_CustomFieldRead)]
+CustomFieldListCreate = Annotated[
+    AuthSubject[User | Organization], Depends(_CustomFieldListCreate)
+]
 
-_CustomFieldWrite = Authenticator(
-    required_scopes={
-        Scope.custom_fields_write,
-    },
-    allowed_subjects={User, Organization},
-)
-CustomFieldWrite = Annotated[
-    AuthSubject[User | Organization], Depends(_CustomFieldWrite)
+
+async def _resolve(session: AsyncSession, id: UUID) -> CustomField | None:
+    repository = CustomFieldRepository.from_session(session)
+    return await repository.get_by_id(id)
+
+
+# Per-id endpoints — full PolicyGuard (resolve resource → check org access → policy).
+AuthorizeCustomFieldRead = Annotated[
+    AuthorizedResource[CustomField],
+    Depends(
+        ResourcePolicyGuard(
+            resolve=_resolve,
+            get_organization_id=lambda cf: cf.organization_id,
+            policy_fn=custom_field_policy.can_read,
+            required_scopes={
+                Scope.custom_fields_read,
+                Scope.custom_fields_write,
+            },
+        )
+    ),
+]
+
+AuthorizeCustomFieldWrite = Annotated[
+    AuthorizedResource[CustomField],
+    Depends(
+        ResourcePolicyGuard(
+            resolve=_resolve,
+            get_organization_id=lambda cf: cf.organization_id,
+            policy_fn=custom_field_policy.can_write,
+            required_scopes={Scope.custom_fields_write},
+        )
+    ),
 ]

--- a/server/polar/custom_field/endpoints.py
+++ b/server/polar/custom_field/endpoints.py
@@ -18,7 +18,12 @@ from polar.postgres import (
 )
 from polar.routing import APIRouter
 
-from . import auth, sorting
+from . import sorting
+from .auth import (
+    AuthorizeCustomFieldRead,
+    AuthorizeCustomFieldWrite,
+    CustomFieldListCreate,
+)
 from .schemas import CustomField as CustomFieldSchema
 from .schemas import CustomFieldAdapter, CustomFieldCreate, CustomFieldUpdate
 from .service import custom_field as custom_field_service
@@ -37,7 +42,7 @@ CustomFieldNotFound = {
     "/", summary="List Custom Fields", response_model=ListResource[CustomFieldSchema]
 )
 async def list(
-    auth_subject: auth.CustomFieldRead,
+    auth_subject: CustomFieldListCreate,
     pagination: PaginationParamsQuery,
     sorting: sorting.ListSorting,
     organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
@@ -74,17 +79,10 @@ async def list(
     responses={404: CustomFieldNotFound},
 )
 async def get(
-    id: CustomFieldID,
-    auth_subject: auth.CustomFieldRead,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    authz: AuthorizeCustomFieldRead,
 ) -> CustomField:
     """Get a custom field by ID."""
-    custom_field = await custom_field_service.get_by_id(session, auth_subject, id)
-
-    if custom_field is None:
-        raise ResourceNotFound()
-
-    return custom_field
+    return authz.resource
 
 
 @router.post(
@@ -96,7 +94,7 @@ async def get(
 )
 async def create(
     custom_field_create: CustomFieldCreate,
-    auth_subject: auth.CustomFieldWrite,
+    auth_subject: CustomFieldListCreate,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomField:
     """Create a custom field."""
@@ -113,18 +111,14 @@ async def create(
     },
 )
 async def update(
-    id: CustomFieldID,
     custom_field_update: CustomFieldUpdate,
-    auth_subject: auth.CustomFieldWrite,
+    authz: AuthorizeCustomFieldWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomField:
     """Update a custom field."""
-    custom_field = await custom_field_service.get_by_id(session, auth_subject, id)
-
-    if custom_field is None:
-        raise ResourceNotFound()
-
-    return await custom_field_service.update(session, custom_field, custom_field_update)
+    return await custom_field_service.update(
+        session, authz.resource, custom_field_update
+    )
 
 
 @router.delete(
@@ -137,14 +131,8 @@ async def update(
     },
 )
 async def delete(
-    id: CustomFieldID,
-    auth_subject: auth.CustomFieldWrite,
+    authz: AuthorizeCustomFieldWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     """Delete a custom field."""
-    custom_field = await custom_field_service.get_by_id(session, auth_subject, id)
-
-    if custom_field is None:
-        raise ResourceNotFound()
-
-    await custom_field_service.delete(session, custom_field)
+    await custom_field_service.delete(session, authz.resource)

--- a/server/polar/custom_field/endpoints.py
+++ b/server/polar/custom_field/endpoints.py
@@ -20,12 +20,13 @@ from polar.routing import APIRouter
 
 from . import sorting
 from .auth import (
+    AuthorizeCustomFieldCreate,
+    AuthorizeCustomFieldList,
     AuthorizeCustomFieldRead,
     AuthorizeCustomFieldWrite,
-    CustomFieldListCreate,
 )
 from .schemas import CustomField as CustomFieldSchema
-from .schemas import CustomFieldAdapter, CustomFieldCreate, CustomFieldUpdate
+from .schemas import CustomFieldAdapter, CustomFieldUpdate
 from .service import custom_field as custom_field_service
 
 router = APIRouter(prefix="/custom-fields", tags=["custom-fields", APITag.public])
@@ -42,7 +43,7 @@ CustomFieldNotFound = {
     "/", summary="List Custom Fields", response_model=ListResource[CustomFieldSchema]
 )
 async def list(
-    auth_subject: CustomFieldListCreate,
+    authz: AuthorizeCustomFieldList,
     pagination: PaginationParamsQuery,
     sorting: sorting.ListSorting,
     organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
@@ -57,7 +58,7 @@ async def list(
     """List custom fields."""
     results, count = await custom_field_service.list(
         session,
-        auth_subject,
+        authz,
         organization_id=organization_id,
         query=query,
         type=type,
@@ -93,12 +94,11 @@ async def get(
     responses={201: {"description": "Custom field created."}},
 )
 async def create(
-    custom_field_create: CustomFieldCreate,
-    auth_subject: CustomFieldListCreate,
+    authz: AuthorizeCustomFieldCreate,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomField:
     """Create a custom field."""
-    return await custom_field_service.create(session, custom_field_create, auth_subject)
+    return await custom_field_service.create(session, authz)
 
 
 @router.patch(

--- a/server/polar/custom_field/endpoints.py
+++ b/server/polar/custom_field/endpoints.py
@@ -26,7 +26,7 @@ from .auth import (
     AuthorizeCustomFieldWrite,
 )
 from .schemas import CustomField as CustomFieldSchema
-from .schemas import CustomFieldAdapter, CustomFieldUpdate
+from .schemas import CustomFieldAdapter, CustomFieldCreate, CustomFieldUpdate
 from .service import custom_field as custom_field_service
 
 router = APIRouter(prefix="/custom-fields", tags=["custom-fields", APITag.public])
@@ -43,7 +43,7 @@ CustomFieldNotFound = {
     "/", summary="List Custom Fields", response_model=ListResource[CustomFieldSchema]
 )
 async def list(
-    authz: AuthorizeCustomFieldList,
+    accessible_org_ids: AuthorizeCustomFieldList,
     pagination: PaginationParamsQuery,
     sorting: sorting.ListSorting,
     organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
@@ -58,7 +58,7 @@ async def list(
     """List custom fields."""
     results, count = await custom_field_service.list(
         session,
-        authz,
+        accessible_org_ids,
         organization_id=organization_id,
         query=query,
         type=type,
@@ -94,11 +94,12 @@ async def get(
     responses={201: {"description": "Custom field created."}},
 )
 async def create(
-    authz: AuthorizeCustomFieldCreate,
+    custom_field_create: CustomFieldCreate,
+    organization: AuthorizeCustomFieldCreate,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomField:
     """Create a custom field."""
-    return await custom_field_service.create(session, authz)
+    return await custom_field_service.create(session, custom_field_create, organization)
 
 
 @router.patch(

--- a/server/polar/custom_field/repository.py
+++ b/server/polar/custom_field/repository.py
@@ -1,0 +1,121 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import Select, delete, func, or_, select, update
+from sqlalchemy.orm import contains_eager
+
+from polar.authz.types import AccessibleOrganizationID
+from polar.kit.repository import (
+    RepositoryBase,
+    RepositorySoftDeletionIDMixin,
+    RepositorySoftDeletionMixin,
+    RepositorySortingMixin,
+    SortingClause,
+)
+from polar.models import CustomField, Organization
+from polar.models.custom_field import CustomFieldType
+
+from .attachment import attached_custom_fields_models
+from .data import custom_field_data_models
+from .sorting import CustomFieldSortProperty
+
+
+class CustomFieldRepository(
+    RepositorySortingMixin[CustomField, CustomFieldSortProperty],
+    RepositorySoftDeletionIDMixin[CustomField, UUID],
+    RepositorySoftDeletionMixin[CustomField],
+    RepositoryBase[CustomField],
+):
+    model = CustomField
+
+    def get_base_statement(
+        self, *, include_deleted: bool = False
+    ) -> Select[tuple[CustomField]]:
+        return (
+            super()
+            .get_base_statement(include_deleted=include_deleted)
+            .join(Organization, Organization.id == CustomField.organization_id)
+            .options(contains_eager(CustomField.organization))
+        )
+
+    def get_by_org_ids_statement(
+        self, org_ids: set[AccessibleOrganizationID]
+    ) -> Select[tuple[CustomField]]:
+        """Filter to custom fields owned by the given organizations."""
+        return self.get_base_statement().where(CustomField.organization_id.in_(org_ids))
+
+    def apply_query_filter(
+        self,
+        statement: Select[tuple[CustomField]],
+        *,
+        organization_id: Sequence[UUID] | None = None,
+        query: str | None = None,
+        type: Sequence[CustomFieldType] | None = None,
+    ) -> Select[tuple[CustomField]]:
+        if organization_id is not None:
+            statement = statement.where(
+                CustomField.organization_id.in_(organization_id)
+            )
+        if query is not None:
+            statement = statement.where(
+                or_(
+                    CustomField.name.ilike(f"%{query}%"),
+                    CustomField.slug.ilike(f"%{query}%"),
+                )
+            )
+        if type is not None:
+            statement = statement.where(CustomField.type.in_(type))
+        return statement
+
+    async def get_by_organization_id_and_slug(
+        self, organization_id: UUID, slug: str
+    ) -> CustomField | None:
+        statement = select(CustomField).where(
+            CustomField.organization_id == organization_id,
+            CustomField.slug == slug,
+        )
+        return await self.get_one_or_none(statement)
+
+    async def rename_slug_in_attached_data(
+        self,
+        custom_field: CustomField,
+        previous_slug: str,
+    ) -> None:
+        """Rename ``previous_slug`` to ``custom_field.slug`` inside every
+        ``custom_field_data`` JSONB column on attached models for the same org."""
+        for model in custom_field_data_models:
+            statement = (
+                update(model)
+                .where(
+                    model.organization == custom_field.organization,
+                    model.custom_field_data.has_key(previous_slug),
+                )
+                .values(
+                    custom_field_data=(
+                        model.custom_field_data.op("-")(previous_slug)
+                    ).op("||")(
+                        func.jsonb_build_object(
+                            custom_field.slug,
+                            model.custom_field_data[previous_slug],
+                        )
+                    )
+                )
+            )
+            await self.session.execute(statement)
+
+    async def detach_from_all(self, custom_field_id: UUID) -> None:
+        """Remove every association-table row pointing at this custom field."""
+        for model in attached_custom_fields_models:
+            statement = delete(model).where(model.custom_field_id == custom_field_id)
+            await self.session.execute(statement)
+
+    def get_sorting_clause(self, property: CustomFieldSortProperty) -> SortingClause:
+        if property == CustomFieldSortProperty.created_at:
+            return CustomField.created_at
+        if property == CustomFieldSortProperty.slug:
+            return CustomField.slug
+        if property == CustomFieldSortProperty.custom_field_name:
+            return CustomField.name
+        if property == CustomFieldSortProperty.type:
+            return CustomField.type
+        raise NotImplementedError(property)

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -1,12 +1,12 @@
 import uuid
 from collections.abc import Sequence
 
-from polar.authz.dependencies import AuthorizedCreate, AuthorizedList
+from polar.authz.types import AccessibleOrganizationID
 from polar.custom_field.sorting import CustomFieldSortProperty
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.sorting import Sorting
-from polar.models import CustomField
+from polar.models import CustomField, Organization
 from polar.models.custom_field import CustomFieldType
 from polar.postgres import AsyncReadSession, AsyncSession
 
@@ -18,7 +18,7 @@ class CustomFieldService:
     async def list(
         self,
         session: AsyncReadSession,
-        authz: AuthorizedList,
+        accessible_org_ids: set[AccessibleOrganizationID],
         *,
         organization_id: Sequence[uuid.UUID] | None = None,
         query: str | None = None,
@@ -29,7 +29,7 @@ class CustomFieldService:
         ],
     ) -> tuple[Sequence[CustomField], int]:
         repository = CustomFieldRepository.from_session(session)
-        statement = repository.get_by_org_ids_statement(authz.accessible_org_ids)
+        statement = repository.get_by_org_ids_statement(accessible_org_ids)
         statement = repository.apply_query_filter(
             statement,
             organization_id=organization_id,
@@ -42,11 +42,12 @@ class CustomFieldService:
     async def create(
         self,
         session: AsyncSession,
-        authz: AuthorizedCreate[CustomFieldCreate],
+        custom_field_create: CustomFieldCreate,
+        organization: Organization,
     ) -> CustomField:
         repository = CustomFieldRepository.from_session(session)
         existing_field = await repository.get_by_organization_id_and_slug(
-            authz.organization.id, authz.body.slug
+            organization.id, custom_field_create.slug
         )
         if existing_field is not None:
             raise PolarRequestValidationError(
@@ -55,14 +56,16 @@ class CustomFieldService:
                         "type": "value_error",
                         "loc": ("body", "slug"),
                         "msg": "Custom field with this slug already exists.",
-                        "input": authz.body.slug,
+                        "input": custom_field_create.slug,
                     }
                 ]
             )
 
         custom_field = CustomField(
-            **authz.body.model_dump(exclude={"organization_id"}, by_alias=True),
-            organization=authz.organization,
+            **custom_field_create.model_dump(
+                exclude={"organization_id"}, by_alias=True
+            ),
+            organization=organization,
         )
         return await repository.create(custom_field)
 

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -1,37 +1,22 @@
 import uuid
 from collections.abc import Sequence
-from typing import Any
 
-from sqlalchemy import (
-    Select,
-    UnaryExpression,
-    asc,
-    delete,
-    desc,
-    func,
-    or_,
-    select,
-    update,
-)
-from sqlalchemy.orm import contains_eager
-
-from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.models import AuthSubject, Organization, User
+from polar.authz.service import get_accessible_org_ids
 from polar.custom_field.sorting import CustomFieldSortProperty
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams, paginate
-from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
-from polar.models import CustomField, Organization, User, UserOrganization
+from polar.models import CustomField
 from polar.models.custom_field import CustomFieldType
 from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncReadSession, AsyncSession
 
-from .attachment import attached_custom_fields_models
-from .data import custom_field_data_models
+from .repository import CustomFieldRepository
 from .schemas import CustomFieldCreate, CustomFieldUpdate
 
 
-class CustomFieldService(ResourceServiceReader[CustomField]):
+class CustomFieldService:
     async def list(
         self,
         session: AsyncReadSession,
@@ -45,54 +30,17 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
             (CustomFieldSortProperty.slug, False)
         ],
     ) -> tuple[Sequence[CustomField], int]:
-        statement = self._get_readable_custom_field_statement(auth_subject)
-
-        if organization_id is not None:
-            statement = statement.where(
-                CustomField.organization_id.in_(organization_id)
-            )
-
-        if query is not None:
-            statement = statement.where(
-                or_(
-                    CustomField.name.ilike(f"%{query}%"),
-                    CustomField.slug.ilike(f"%{query}%"),
-                )
-            )
-
-        if type is not None:
-            statement = statement.where(CustomField.type.in_(type))
-
-        order_by_clauses: list[UnaryExpression[Any]] = []
-        for criterion, is_desc in sorting:
-            clause_function = desc if is_desc else asc
-            if criterion == CustomFieldSortProperty.created_at:
-                order_by_clauses.append(
-                    clause_function(CustomFieldSortProperty.created_at)
-                )
-            elif criterion == CustomFieldSortProperty.slug:
-                order_by_clauses.append(clause_function(CustomFieldSortProperty.slug))
-            elif criterion == CustomFieldSortProperty.custom_field_name:
-                order_by_clauses.append(
-                    clause_function(CustomFieldSortProperty.custom_field_name)
-                )
-            elif criterion == CustomFieldSortProperty.type:
-                order_by_clauses.append(clause_function(CustomFieldSortProperty.type))
-        statement = statement.order_by(*order_by_clauses)
-
-        return await paginate(session, statement, pagination=pagination)
-
-    async def get_by_id(
-        self,
-        session: AsyncReadSession,
-        auth_subject: AuthSubject[User | Organization],
-        id: uuid.UUID,
-    ) -> CustomField | None:
-        statement = self._get_readable_custom_field_statement(auth_subject).where(
-            CustomField.id == id
+        repository = CustomFieldRepository.from_session(session)
+        org_ids = await get_accessible_org_ids(session, auth_subject)
+        statement = repository.get_by_org_ids_statement(org_ids)
+        statement = repository.apply_query_filter(
+            statement,
+            organization_id=organization_id,
+            query=query,
+            type=type,
         )
-        result = await session.execute(statement)
-        return result.scalar_one_or_none()
+        statement = repository.apply_sorting(statement, sorting)
+        return await paginate(session, statement, pagination=pagination)
 
     async def create(
         self,
@@ -104,8 +52,9 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
             session, auth_subject, custom_field_create
         )
 
-        existing_field = await self._get_by_organization_id_and_slug(
-            session, organization.id, custom_field_create.slug
+        repository = CustomFieldRepository.from_session(session)
+        existing_field = await repository.get_by_organization_id_and_slug(
+            organization.id, custom_field_create.slug
         )
         if existing_field is not None:
             raise PolarRequestValidationError(
@@ -125,9 +74,7 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
             ),
             organization=organization,
         )
-        session.add(custom_field)
-
-        return custom_field
+        return await repository.create(custom_field)
 
     async def update(
         self,
@@ -147,12 +94,14 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
                 ]
             )
 
+        repository = CustomFieldRepository.from_session(session)
+
         if (
             custom_field_update.slug is not None
             and custom_field.slug != custom_field_update.slug
         ):
-            existing_field = await self._get_by_organization_id_and_slug(
-                session, custom_field.organization_id, custom_field_update.slug
+            existing_field = await repository.get_by_organization_id_and_slug(
+                custom_field.organization_id, custom_field_update.slug
             )
             if existing_field is not None and existing_field.id != custom_field.id:
                 raise PolarRequestValidationError(
@@ -167,98 +116,31 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
                 )
 
         previous_slug = custom_field.slug
-        for attr, value in custom_field_update.model_dump(
-            exclude_unset=True, by_alias=True
-        ).items():
-            setattr(custom_field, attr, value)
+        update_dict = custom_field_update.model_dump(exclude_unset=True, by_alias=True)
+        custom_field = await repository.update(custom_field, update_dict=update_dict)
 
-        # Update the slug from all custom_field_data JSONB
         if previous_slug != custom_field.slug:
-            for model in custom_field_data_models:
-                update_statement = (
-                    update(model)
-                    .where(
-                        model.organization == custom_field.organization,
-                        model.custom_field_data.has_key(previous_slug),
-                    )
-                    .values(
-                        custom_field_data=(
-                            model.custom_field_data.op("-")(previous_slug)
-                        ).op("||")(
-                            func.jsonb_build_object(
-                                custom_field.slug,
-                                model.custom_field_data[previous_slug],
-                            )
-                        )
-                    )
-                )
-                await session.execute(update_statement)
+            await repository.rename_slug_in_attached_data(custom_field, previous_slug)
 
-        session.add(custom_field)
         return custom_field
 
     async def delete(
         self, session: AsyncSession, custom_field: CustomField
     ) -> CustomField:
-        custom_field.set_deleted_at()
-        session.add(custom_field)
-
-        # Delete row with this custom field from all association tables
-        for model in attached_custom_fields_models:
-            delete_statement = delete(model).where(
-                model.custom_field_id == custom_field.id
-            )
-            await session.execute(delete_statement)
-
+        repository = CustomFieldRepository.from_session(session)
+        custom_field = await repository.soft_delete(custom_field)
+        await repository.detach_from_all(custom_field.id)
         return custom_field
 
     async def get_by_organization_and_id(
         self, session: AsyncSession, id: uuid.UUID, organization_id: uuid.UUID
     ) -> CustomField | None:
-        statement = select(CustomField).where(
-            CustomField.is_deleted.is_(False),
+        repository = CustomFieldRepository.from_session(session)
+        statement = repository.get_base_statement().where(
             CustomField.organization_id == organization_id,
             CustomField.id == id,
         )
-        result = await session.execute(statement)
-        return result.scalar_one_or_none()
-
-    async def _get_by_organization_id_and_slug(
-        self, session: AsyncSession, organization_id: uuid.UUID, slug: str
-    ) -> CustomField | None:
-        statement = select(CustomField).where(
-            CustomField.organization_id == organization_id,
-            CustomField.slug == slug,
-        )
-        result = await session.execute(statement)
-        return result.scalar_one_or_none()
-
-    def _get_readable_custom_field_statement(
-        self, auth_subject: AuthSubject[User | Organization]
-    ) -> Select[tuple[CustomField]]:
-        statement = (
-            select(CustomField)
-            .where(CustomField.is_deleted.is_(False))
-            .join(Organization, Organization.id == CustomField.organization_id)
-            .options(contains_eager(CustomField.organization))
-        )
-
-        if is_user(auth_subject):
-            user = auth_subject.subject
-            statement = statement.where(
-                CustomField.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
-                    )
-                )
-            )
-        elif is_organization(auth_subject):
-            statement = statement.where(
-                CustomField.organization_id == auth_subject.subject.id,
-            )
-
-        return statement
+        return await repository.get_one_or_none(statement)
 
 
-custom_field = CustomFieldService(CustomField)
+custom_field = CustomFieldService()

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -1,15 +1,13 @@
 import uuid
 from collections.abc import Sequence
 
-from polar.auth.models import AuthSubject, Organization, User
-from polar.authz.service import get_accessible_org_ids
+from polar.authz.dependencies import AuthorizedCreate, AuthorizedList
 from polar.custom_field.sorting import CustomFieldSortProperty
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.sorting import Sorting
 from polar.models import CustomField
 from polar.models.custom_field import CustomFieldType
-from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncReadSession, AsyncSession
 
 from .repository import CustomFieldRepository
@@ -20,7 +18,7 @@ class CustomFieldService:
     async def list(
         self,
         session: AsyncReadSession,
-        auth_subject: AuthSubject[User | Organization],
+        authz: AuthorizedList,
         *,
         organization_id: Sequence[uuid.UUID] | None = None,
         query: str | None = None,
@@ -31,8 +29,7 @@ class CustomFieldService:
         ],
     ) -> tuple[Sequence[CustomField], int]:
         repository = CustomFieldRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
-        statement = repository.get_by_org_ids_statement(org_ids)
+        statement = repository.get_by_org_ids_statement(authz.accessible_org_ids)
         statement = repository.apply_query_filter(
             statement,
             organization_id=organization_id,
@@ -45,16 +42,11 @@ class CustomFieldService:
     async def create(
         self,
         session: AsyncSession,
-        custom_field_create: CustomFieldCreate,
-        auth_subject: AuthSubject[User | Organization],
+        authz: AuthorizedCreate[CustomFieldCreate],
     ) -> CustomField:
-        organization = await get_payload_organization(
-            session, auth_subject, custom_field_create
-        )
-
         repository = CustomFieldRepository.from_session(session)
         existing_field = await repository.get_by_organization_id_and_slug(
-            organization.id, custom_field_create.slug
+            authz.organization.id, authz.body.slug
         )
         if existing_field is not None:
             raise PolarRequestValidationError(
@@ -63,16 +55,14 @@ class CustomFieldService:
                         "type": "value_error",
                         "loc": ("body", "slug"),
                         "msg": "Custom field with this slug already exists.",
-                        "input": custom_field_create.slug,
+                        "input": authz.body.slug,
                     }
                 ]
             )
 
         custom_field = CustomField(
-            **custom_field_create.model_dump(
-                exclude={"organization_id"}, by_alias=True
-            ),
-            organization=organization,
+            **authz.body.model_dump(exclude={"organization_id"}, by_alias=True),
+            organization=authz.organization,
         )
         return await repository.create(custom_field)
 


### PR DESCRIPTION
## Summary

Reference implementation of the authorization model described in [`handbook/engineering/backend-development/authorization.mdx`](handbook/engineering/backend-development/authorization.mdx) for a module that previously relied on a scope-only `Authenticator` dep. Drafted to evaluate the shape before migrating other modules.

**Goal:** by the time an endpoint body executes, every authorization decision is already made. Endpoint handlers contain business logic only — no `if resource is None: raise 404`, no membership checks, no `get_payload_organization` calls, no auth subject inspection inside services.

## What

All five `custom_field` endpoints (list, create, get, update, delete) now resolve authorization in the dependency layer.

**One new factory in `polar/authz/dependencies.py`:**
- `ResourcePolicyGuard[R]` — for per-id endpoints. Resolves the resource, verifies its owning org is accessible, runs a policy, returns `AuthorizedResource[R]` (resource + organization + auth_subject). Generalizes the existing `AccountPolicyGuard` / `PayoutAccountPolicyGuard` shape (~70 lines).

**Inline deps in `polar/custom_field/auth.py`** for the list and create shapes — no factory, no wrapper dataclass:
- list dep returns `set[AccessibleOrganizationID]` directly.
- create dep takes the request body, resolves the target organization via `get_payload_organization`, runs the create policy, returns `Organization`.

If a second module's list or create dep ends up with the same shape we'll extract a factory then.

**`polar/authz/policies/custom_field.py`** — `can_read` / `can_write` returning `True` (any org member; matches existing behavior).

**`polar/custom_field/repository.py`** (new) — pure data access: `get_by_org_ids_statement(set[AccessibleOrganizationID])`, `apply_query_filter`, `get_by_organization_id_and_slug`, plus `rename_slug_in_attached_data` and `detach_from_all` (the JSONB rename and association-table cleanup that previously sat in the service as raw `session.execute(...)` calls).

**`polar/custom_field/service.py`** rewritten: `list` takes `set[AccessibleOrganizationID]`, `create` takes `(body, organization)`, `update`/`delete` take `CustomField` (already resolved by the guard). No more `auth_subject` parameter, no more `get_accessible_org_ids` call, no more `get_payload_organization` call inside the service. 264 → 134 lines.

**`polar/custom_field/auth.py`** — typed deps: `AuthorizeCustomFieldList`, `AuthorizeCustomFieldCreate`, `AuthorizeCustomFieldRead`, `AuthorizeCustomFieldWrite`.

**`polar/custom_field/endpoints.py`** — every handler is business logic only:

```python
@router.get("/{id}", ...)
async def get(authz: AuthorizeCustomFieldRead) -> CustomField:
    return authz.resource

@router.post("/", ...)
async def create(
    custom_field_create: CustomFieldCreate,
    organization: AuthorizeCustomFieldCreate,
    session,
) -> CustomField:
    return await custom_field_service.create(session, custom_field_create, organization)
```

## Why

`Authenticator` is currently doing both authentication and authorization in most modules — token-type gate plus scope gate, with no policy layer. The handbook describes a clean two-layer model (`Authenticator` for authn, `PolicyGuard` for authz, with policies in `polar/authz/policies/` and repositories taking org IDs rather than `auth_subject`), but the code only matches it for finance, members, organization, and payout-account.

Most modules diverge in two ways:
1. Per-id endpoints fetch the resource inside the service and check `if None: raise 404` — authz happening inside the handler.
2. List/create do `get_accessible_org_ids` and `get_payload_organization` inside the service — also authz happening after the body has started executing.

This PR is the smallest end-to-end migration we can do for a non-finance module to:
1. validate that the handbook's pattern is ergonomic for all five endpoint shapes,
2. show what `OrgPolicyGuard` / `AccountPolicyGuard` / `PayoutAccountPolicyGuard` need to be generalized into (answer: a single `ResourcePolicyGuard`; list and create stay inline until we have a second example),
3. give us a template the rest of the modules can be migrated against opportunistically.

## How

- `ResourcePolicyGuard` takes an explicit `get_organization_id` callable rather than a Protocol on `Mapped[UUID]` — mypy doesn't reliably understand the SQLAlchemy descriptor unwrap, and a one-line lambda at the call site is clearer.
- The create dep inlines body parsing + org resolution + policy check (~12 lines). FastAPI parses the body once and passes it to both the dep and the endpoint, so the endpoint declares `custom_field_create: CustomFieldCreate` normally.
- The pre-tool `check-patterns` hook caught a `session.execute(...)` left in the service mid-edit and forced both queries (JSONB slug rename, association-table delete) into named repository methods.
- All 29 existing custom_field tests pass without modification — external contract is identical.

## Open questions for review

1. **Trivial-policy boilerplate.** 22 lines of `return True` per simple module is friction. Accept it (explicit), or add a shared `default_policy.allow_org_members`?
2. **Should `AccountPolicyGuard` / `PayoutAccountPolicyGuard` collapse into `ResourcePolicyGuard`?** They could; left for a follow-up.
3. **Naming.** `AuthorizeCustomFieldRead` (handbook) vs `CustomFieldRead` (existing module convention). I went with `Authorize…` for all four custom_field deps to be uniform.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (existing 29 tests cover the contract; no behavior change)
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)