### PR TITLE
checkout/test: Attempt to fix flaky test

### DIFF
--- a/clients/packages/checkout/src/providers/CheckoutProvider.test.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutProvider.test.tsx
@@ -130,8 +130,8 @@ describe('CheckoutProvider', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('ready')).toBeInTheDocument()
+        expect(getCtx().checkout.id).toBe('ch_fetched')
       })
-      expect(getCtx().checkout.id).toBe('ch_fetched')
       expect(mockClient.GET).toHaveBeenCalledWith(
         '/v1/checkouts/client/{client_secret}',
         { params: { path: { client_secret: 'cs_test' } } },


### PR DESCRIPTION
The "fetches the checkout and renders children once it resolves" test asserted on ctxRef.current after waitFor saw the testid, but ctxRef is set in a post-commit useEffect, so the assertion could fire before the effect ran. Moved that one assertion inside waitFor; the GET call assertion is upstream of the testid appearing, so it can stay outside.

~waitFor can resolve before the useEffect has run, which causes the test to fail (see: https://github.com/polarsource/polar/actions/runs/24991162646/attempts/1?pr=10837)~

~This assigns the ref immediately which should avoid the race condition~