### PR TITLE
fix(member): forbid role=owner on public member create endpoint

### DIFF
--- a/server/polar/member/schemas.py
+++ b/server/polar/member/schemas.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 
 from annotated_types import MaxLen
 from fastapi import Path
@@ -61,9 +61,14 @@ class MemberCreate(Schema):
         description=_external_id_description,
         examples=[_external_id_example],
     )
-    role: MemberRole = Field(
+    # Owner is excluded: ownership is established via `MemberOwnerCreate` on
+    # customer creation, or transferred via the update endpoint.
+    role: Literal[MemberRole.member, MemberRole.billing_manager] = Field(
         default=MemberRole.member,
-        description="The role of the member within the customer.",
+        description=(
+            "The role of the member within the customer. To assign or transfer "
+            "ownership, use the member update endpoint."
+        ),
         examples=[MemberRole.member],
     )
 

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -442,6 +442,24 @@ class TestCreateMember:
         assert response.status_code == 404
 
     @pytest.mark.auth
+    async def test_create_member_rejects_owner_role(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Owner role is rejected at the schema layer."""
+        response = await client.post(
+            "/v1/members/",
+            json={
+                "customer_id": "00000000-0000-0000-0000-000000000000",
+                "email": "another-owner@example.com",
+                "role": "owner",
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
     async def test_create_member_default_role(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -6,10 +6,12 @@ from pytest_mock import MockerFixture
 from sqlalchemy.exc import IntegrityError
 
 from polar.auth.models import AuthSubject
+from polar.exceptions import NotPermitted
 from polar.kit.pagination import PaginationParams
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
 from polar.models import Customer, Member, Organization, User, UserOrganization
+from polar.models.customer import CustomerType
 from polar.models.member import MemberRole
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
@@ -436,9 +438,6 @@ class TestCreate:
         user_organization: UserOrganization,
     ) -> None:
         """Test that individual customers can only have 1 member (the owner)."""
-        from polar.exceptions import NotPermitted
-        from polar.models.customer import CustomerType
-
         organization.feature_settings = {"member_model_enabled": True}
         await save_fixture(organization)
 
@@ -486,8 +485,6 @@ class TestCreate:
         user_organization: UserOrganization,
     ) -> None:
         """Test that team customers can have multiple members."""
-        from polar.models.customer import CustomerType
-
         organization.feature_settings = {"member_model_enabled": True}
         await save_fixture(organization)
 


### PR DESCRIPTION
## Summary

- Narrow `MemberCreate.role` to `Literal[MemberRole.member, MemberRole.billing_manager]` so the public `POST /v1/members/` endpoint rejects `role=owner` with a 422 at the schema layer.
- Add an endpoint test that asserts the 422.

## Why

Owners are established at customer creation time via the optional `owner` field on `CustomerCreate` (or auto-provisioned on first interaction), and ownership is changed via the member update endpoint — there is no legitimate reason for a caller to insert a second owner via the public create endpoint. Accepting `role=owner` here let clients hit the partial unique index `members_customer_id_owner_active_key`, which surfaced as a `PendingRollbackError` 500 because the `IntegrityError` recovery path touched an expired ORM attribute on a poisoned session.

Forbidding the value at the boundary makes the bug structurally impossible: the request never reaches the service, and the database is never touched.

## Test plan

- [x] `cd server && uv run pytest tests/member/` — 97 tests pass
- [x] `cd server && uv run task lint`
- [x] `cd server && uv run task lint_types`
- [x] New test `test_create_member_rejects_owner_role` asserts 422 on `role=owner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)