### PR TITLE
Chore: Add organization_id column to orders - step 2

### DIFF
--- a/server/migrations/versions/2026-04-27-1530_make_orders_organization_id_non_nullable.py
+++ b/server/migrations/versions/2026-04-27-1530_make_orders_organization_id_non_nullable.py
@@ -1,0 +1,63 @@
+"""Make orders.organization_id non nullable
+
+Revision ID: b07286a34be3
+Revises: f3a2b1c4d5e6
+Create Date: 2026-04-27 09:40:38.765100
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b07286a34be3"
+down_revision = "f3a2b1c4d5e6"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Use the NOT VALID / VALIDATE pattern to avoid a full-table ACCESS EXCLUSIVE
+    # lock when setting NOT NULL.
+    #
+    # Step 1: add the check constraint as NOT VALID — takes only SHARE UPDATE
+    #         EXCLUSIVE, so concurrent reads and writes are unblocked.
+    op.execute(
+        """
+        ALTER TABLE orders
+            ADD CONSTRAINT orders_organization_id_not_null
+            CHECK (organization_id IS NOT NULL) NOT VALID
+        """
+    )
+
+    # Step 2: validate the constraint — also SHARE UPDATE EXCLUSIVE.  Postgres
+    #         scans the table for violations here, but concurrent DML is still
+    #         allowed (it must simply not introduce new NULLs).
+    op.execute(
+        """
+        ALTER TABLE orders
+            VALIDATE CONSTRAINT orders_organization_id_not_null
+        """
+    )
+
+    # Step 3: set NOT NULL — because a validated check constraint already proves
+    #         no NULLs exist, Postgres 12+ skips the full table scan and holds
+    #         ACCESS EXCLUSIVE for only a very short time.
+    op.alter_column(
+        "orders", "organization_id", existing_type=sa.UUID(), nullable=False
+    )
+
+    # Step 4: the check constraint is now redundant — the NOT NULL column
+    #         constraint takes over.
+    op.execute(
+        """
+        ALTER TABLE orders
+            DROP CONSTRAINT orders_organization_id_not_null
+        """
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("orders", "organization_id", existing_type=sa.UUID(), nullable=True)

--- a/server/migrations/versions/2026-04-27-1530_make_orders_organization_id_non_nullable.py
+++ b/server/migrations/versions/2026-04-27-1530_make_orders_organization_id_non_nullable.py
@@ -19,6 +19,20 @@ depends_on: tuple[str] | None = None
 
 
 def upgrade() -> None:
+    # Production is expected to have been backfilled via
+    # scripts/backfill_order_organization_id.py before this migration runs;
+    # this UPDATE is a safety net for local environments where the script
+    # may not have been executed.
+    op.execute(
+        """
+        UPDATE orders
+           SET organization_id = customers.organization_id
+          FROM customers
+         WHERE orders.customer_id = customers.id
+           AND orders.organization_id IS NULL
+        """
+    )
+
     # Use the NOT VALID / VALIDATE pattern to avoid a full-table ACCESS EXCLUSIVE
     # lock when setting NOT NULL.
     #

--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -121,9 +121,10 @@ async def list(
         repository.get_base_statement()
         .join(Customer, Order.customer_id == Customer.id)
         .join(Product, Order.product_id == Product.id, isouter=True)
-        .join(Organization, Customer.organization_id == Organization.id)
+        .join(Organization, Order.organization_id == Organization.id)
         .options(
-            contains_eager(Order.customer).contains_eager(Customer.organization),
+            contains_eager(Order.customer),
+            contains_eager(Order.organization),
             contains_eager(Order.product),
         )
     )
@@ -250,7 +251,8 @@ async def get(
     order = await order_repository.get_by_id(
         id,
         options=(
-            joinedload(Order.customer).joinedload(Customer.organization),
+            joinedload(Order.customer),
+            joinedload(Order.organization),
             joinedload(Order.product),
             joinedload(Order.discount),
             joinedload(Order.subscription),

--- a/server/polar/backoffice/organizations/orders_import.py
+++ b/server/polar/backoffice/organizations/orders_import.py
@@ -266,7 +266,7 @@ async def orders_import(
                 tax_rate=None,
                 tax_calculation_processor_id=None,
                 invoice_number=invoice_number,
-                organization_id=organization.id,
+                organization=organization,
                 customer=customer,
                 product=product,
                 discount=None,

--- a/server/polar/customer_portal/repository/order.py
+++ b/server/polar/customer_portal/repository/order.py
@@ -12,9 +12,6 @@ from polar.kit.repository import (
     RepositorySoftDeletionMixin,
 )
 from polar.models import (
-    Customer as CustomerModel,
-)
-from polar.models import (
     Order,
     OrderItem,
     Product,
@@ -48,7 +45,8 @@ class CustomerOrderRepository(
         if product_load is None:
             product_load = joinedload(Order.product)
         return (
-            joinedload(Order.customer).joinedload(CustomerModel.organization),
+            joinedload(Order.customer),
+            joinedload(Order.organization),
             joinedload(Order.discount),
             joinedload(Order.subscription).joinedload(Subscription.customer),
             product_load.options(

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -8,7 +8,6 @@ from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import RepositoryBase
 from polar.kit.repository.base import Options
 from polar.models import (
-    Customer,
     CustomerSeat,
     Order,
     Product,
@@ -416,7 +415,8 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
             ),
             joinedload(CustomerSeat.order).options(
                 joinedload(Order.product).joinedload(Product.organization),
-                joinedload(Order.customer).joinedload(Customer.organization),
+                joinedload(Order.customer),
+                joinedload(Order.organization),
             ),
             joinedload(CustomerSeat.customer),
             joinedload(CustomerSeat.member),

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -38,7 +38,7 @@ from plain_client import (
     UpsertCustomerUpsertCustomer,
 )
 from sqlalchemy import func, or_, select
-from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -871,7 +871,8 @@ class PlainService:
             limit=3,
             options=(
                 contains_eager(Order.product),
-                contains_eager(Order.customer).joinedload(Customer.organization),
+                contains_eager(Order.customer),
+                joinedload(Order.organization),
             ),
         )
 
@@ -879,7 +880,7 @@ class PlainService:
             return None
 
         def _get_order_container(order: Order) -> ComponentContainerInput:
-            organization = order.customer.organization
+            organization = order.organization
 
             return ComponentContainerInput(
                 container_content=[

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -18,7 +18,6 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
-from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
@@ -192,16 +191,16 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
     def customer(cls) -> Mapped["Customer"]:
         return relationship("Customer", lazy="raise")
 
-    organization_id: Mapped[UUID | None] = mapped_column(
+    organization_id: Mapped[UUID] = mapped_column(
         Uuid,
         ForeignKey("organizations.id", ondelete="restrict"),
-        nullable=True,
+        nullable=False,
         index=True,
     )
 
-    organization: AssociationProxy["Organization"] = association_proxy(
-        "customer", "organization"
-    )
+    @declared_attr
+    def organization(cls) -> Mapped["Organization"]:
+        return relationship("Organization", lazy="raise")
 
     product_id: Mapped[UUID | None] = mapped_column(
         Uuid, ForeignKey("products.id"), nullable=True, index=True

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -99,11 +99,7 @@ class OrderRepository(
 
         statement = (
             self.get_base_statement()
-            .join(Customer, Customer.id == Order.customer_id)
-            .join(
-                Organization,
-                Organization.id == Customer.organization_id,
-            )
+            .join(Organization, Organization.id == Order.organization_id)
             .where(
                 Order.next_payment_attempt_at.is_not(None),
                 Order.next_payment_attempt_at <= utc_now(),
@@ -195,23 +191,17 @@ class OrderRepository(
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]
     ) -> Select[tuple[Order]]:
-        return (
-            self.get_base_statement()
-            .join(Customer, Order.customer_id == Customer.id)
-            .where(Customer.organization_id.in_(org_ids))
-        )
+        return self.get_base_statement().where(Order.organization_id.in_(org_ids))
 
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization | Customer | Member]
     ) -> Select[tuple[Order]]:
-        statement = self.get_base_statement().join(
-            Customer, Order.customer_id == Customer.id
-        )
+        statement = self.get_base_statement()
 
         if is_user(auth_subject):
             user = auth_subject.subject
             statement = statement.where(
-                Customer.organization_id.in_(
+                Order.organization_id.in_(
                     select(UserOrganization.organization_id).where(
                         UserOrganization.user_id == user.id,
                         UserOrganization.is_deleted.is_(False),
@@ -220,7 +210,7 @@ class OrderRepository(
             )
         elif is_organization(auth_subject):
             statement = statement.where(
-                Customer.organization_id == auth_subject.subject.id,
+                Order.organization_id == auth_subject.subject.id,
             )
         elif is_customer(auth_subject):
             customer = auth_subject.subject
@@ -245,9 +235,8 @@ class OrderRepository(
         discount_load: "_AbstractLoad | None" = None,
     ) -> Options:
         return (
-            customer_load
-            if customer_load
-            else joinedload(Order.customer).joinedload(Customer.organization),
+            customer_load if customer_load else joinedload(Order.customer),
+            joinedload(Order.organization),
             discount_load if discount_load else joinedload(Order.discount),
             product_load if product_load else joinedload(Order.product),
             joinedload(Order.subscription).joinedload(Subscription.customer),

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -316,7 +316,8 @@ class OrderService:
         statement = repository.get_statement_by_org_ids(accessible_org_ids)
 
         statement = (
-            statement.join(Order.discount, isouter=True)
+            statement.join(Customer, Order.customer_id == Customer.id)
+            .join(Order.discount, isouter=True)
             .join(Order.product, isouter=True)
             .options(
                 *repository.get_eager_options(
@@ -328,7 +329,7 @@ class OrderService:
         )
 
         if organization_id is not None:
-            statement = statement.where(Customer.organization_id.in_(organization_id))
+            statement = statement.where(Order.organization_id.in_(organization_id))
 
         if product_id is not None:
             statement = statement.where(Order.product_id.in_(product_id))
@@ -380,7 +381,6 @@ class OrderService:
             repository.get_readable_statement(auth_subject)
             .options(
                 *repository.get_eager_options(
-                    customer_load=contains_eager(Order.customer),
                     product_load=joinedload(Order.product),
                 )
             )
@@ -473,7 +473,7 @@ class OrderService:
             "order.invoice_generated",
             {"order_id": order.id},
             customer_id=order.customer_id,
-            organization_id=order.organization.id,
+            organization_id=order.organization_id,
         )
 
         await self.send_webhook(session, order, WebhookEventType.order_updated)
@@ -596,7 +596,7 @@ class OrderService:
                 tax_behavior=checkout.tax_behavior,
                 tax_rate=checkout.tax_rate,
                 invoice_number=invoice_number,
-                organization_id=organization.id,
+                organization=organization,
                 customer=customer,
                 product=checkout.product,
                 discount=checkout.discount,
@@ -775,7 +775,7 @@ class OrderService:
                     tax_processor=tax_processor,
                     tax_calculation_processor_id=tax_calculation_processor_id,
                     invoice_number=invoice_number,
-                    organization_id=subscription.organization.id,
+                    organization=subscription.organization,
                     customer=customer,
                     product=subscription.product,
                     discount=discount,
@@ -902,7 +902,7 @@ class OrderService:
                 tax_id=customer.tax_id,
                 tax_rate=None,
                 invoice_number=invoice_number,
-                organization_id=organization.id,
+                organization=organization,
                 customer=customer,
                 product=product,
                 discount=None,
@@ -956,7 +956,7 @@ class OrderService:
                 taxability_reason=wallet_transaction.taxability_reason,
                 tax_rate=wallet_transaction.tax_rate,
                 invoice_number=invoice_number,
-                organization_id=wallet.organization.id,
+                organization=wallet.organization,
                 customer=customer,
                 items=items,
                 product=None,
@@ -1078,7 +1078,7 @@ class OrderService:
         async with self.acquire_payment_lock(session, order):
             if payment_method.processor == PaymentProcessor.stripe:
                 metadata: dict[str, Any] = {
-                    "organization_id": str(order.organization.id),
+                    "organization_id": str(order.organization_id),
                     "order_id": str(order.id),
                     "payment_mode": payment_mode,
                 }
@@ -1238,7 +1238,7 @@ class OrderService:
                 )
 
         metadata: dict[str, Any] = {
-            "organization_id": str(order.organization.id),
+            "organization_id": str(order.organization_id),
             "order_id": str(order.id),
             STRIPE_METADATA_PAYMENT_TRIGGER: PaymentTrigger.retry_customer,
         }
@@ -2341,7 +2341,7 @@ class OrderService:
             log.info(
                 "Subscription renewals disabled, skipping dunning",
                 order_id=order.id,
-                organization_id=order.organization.id,
+                organization_id=order.organization_id,
             )
             return order
 

--- a/server/scripts/backfill_missing_balance_order_event.py
+++ b/server/scripts/backfill_missing_balance_order_event.py
@@ -14,7 +14,6 @@ from polar.event.system import (
 )
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Event, Order, Transaction
-from polar.models.customer import Customer
 from polar.postgres import create_async_engine
 from scripts.helper import typer_async
 
@@ -36,7 +35,8 @@ async def backfill(
             Order,
             order_id,
             options=[
-                joinedload(Order.customer).joinedload(Customer.organization),
+                joinedload(Order.customer),
+                joinedload(Order.organization),
             ],
         )
         if order is None:
@@ -81,7 +81,7 @@ async def backfill(
                 )
                 raise typer.Exit(0)
 
-        organization = order.customer.organization
+        organization = order.organization
 
         if txn is not None:
             assert txn.presentment_amount is not None

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -941,7 +941,7 @@ async def create_order(
         billing_name=billing_name,
         billing_address=billing_address,
         invoice_number=invoice_number or rstr("INV-"),
-        organization_id=customer.organization_id,
+        organization=customer.organization,
         customer=customer,
         product=product,
         subscription=subscription,


### PR DESCRIPTION
## Summary

Phase B follow-up to #11206. Makes `orders.organization_id` NOT NULL, replaces the `AssociationProxy` with a real relationship, and switches queries to filter on `Order.organization_id` directly instead of joining through `Customer`.

## What

- **Migration**: `orders.organization_id` set to NOT NULL using the safe `NOT VALID` → `VALIDATE` → `SET NOT NULL` pattern (per the precedent in `2026-04-09-1625_make_organization_account_id_non_.py`) to avoid a long ACCESS EXCLUSIVE lock.
- **Model**: dropped the `AssociationProxy` (`order.organization` previously walked through `customer.organization`); replaced with `relationship("Organization", lazy="raise")`.
- **Queries**: `OrderRepository.get_readable_statement`, `get_statement_by_org_ids`, `get_due_dunning_orders`, and `get_eager_options` no longer join `Customer` to filter/load the org. Eager loads in the customer portal repo, backoffice, customer_seat repo, plain integration, and one backfill script switched from `Order.customer.organization` to `Order.organization`.
- **Order creation**: all 5 sites now assign `organization=organization` (ORM object) rather than `organization_id=organization.id` — addresses [@frankie567's comment](https://github.com/polarsource/polar/pull/11206#discussion_r-) on PR1.
- A few `order.organization.id` accesses simplified to `order.organization_id` to avoid triggering the now-strict `lazy="raise"`.

## Why

Direct `Order.organization_id` filtering eliminates the `Customer` join for organization-scoped queries — the original motivation behind PR1.

## Deploy notes

The migration's `VALIDATE CONSTRAINT` step requires zero NULL rows in `orders.organization_id`. Backfill (`scripts/backfill_order_organization_id.py`) has been run against production and verified — 0 NULL rows remain. Old code (post-PR1) already populates `organization_id` on every Order creation, so concurrent writes during the deploy window are safe.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [x] Existing test coverage exercises the touched paths (`uv run task test_fast` — 3843 passed, no cartesian-product warnings)
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)