### PR TITLE
Add feedback management interface to backoffice

### DIFF
--- a/server/polar/backoffice/__init__.py
+++ b/server/polar/backoffice/__init__.py
@@ -10,6 +10,7 @@ from .customers.endpoints import router as customers_router
 from .dependencies import get_admin
 from .email_logs.endpoints import router as email_logs_router
 from .external_events.endpoints import router as external_events_router
+from .feedbacks.endpoints import router as feedbacks_router
 from .impersonation.endpoints import router as impersonation_router
 from .layout import layout
 from .middlewares import SecurityHeadersMiddleware, TagflowMiddleware
@@ -60,6 +61,7 @@ app.include_router(orders_router, prefix="/orders")
 app.include_router(payouts_router, prefix="/payouts")
 app.include_router(impersonation_router, prefix="/impersonation")
 app.include_router(webhooks_router, prefix="/webhooks")
+app.include_router(feedbacks_router, prefix="/feedbacks")
 
 
 @app.get("/", name="index")

--- a/server/polar/backoffice/feedbacks/_markdown.py
+++ b/server/polar/backoffice/feedbacks/_markdown.py
@@ -1,0 +1,31 @@
+"""Render plain-text Markdown messages into the active tagflow document."""
+
+import xml.etree.ElementTree as ET
+
+from markdown_it import MarkdownIt
+from tagflow.tagflow import node
+
+_md = MarkdownIt(
+    "commonmark",
+    {"breaks": True, "html": False, "linkify": True, "xhtmlOut": True},
+)
+
+
+def render_markdown(source: str) -> None:
+    """Append the rendered Markdown of `source` to the current tagflow node.
+
+    Raw HTML in the source is disabled and `xhtmlOut` is enabled so the
+    output is well-formed XML that ElementTree can parse without choking
+    on void tags like `<br>`.
+    """
+    rendered = _md.render(source).strip()
+    parsed = ET.fromstring(f"<root>{rendered}</root>")
+    current = node.get()
+    if parsed.text:
+        if len(current) == 0:
+            current.text = (current.text or "") + parsed.text
+        else:
+            last = current[-1]
+            last.tail = (last.tail or "") + parsed.text
+    for child in parsed:
+        current.append(child)

--- a/server/polar/backoffice/feedbacks/endpoints.py
+++ b/server/polar/backoffice/feedbacks/endpoints.py
@@ -312,8 +312,17 @@ async def get(
                 # Internal note
                 with tag.div(classes="card card-border w-full shadow-sm"):
                     with tag.div(classes="card-body"):
-                        with tag.h2(classes="card-title"):
-                            text("Internal note")
+                        with tag.div(classes="flex items-center justify-between gap-2"):
+                            with tag.h2(classes="card-title"):
+                                text("Internal note")
+                            if feedback.internal_note and feedback.modified_at:
+                                with tag.span(classes="text-xs text-gray-500"):
+                                    text(
+                                        "Updated "
+                                        + feedback.modified_at.strftime(
+                                            "%Y-%m-%d %H:%M UTC"
+                                        )
+                                    )
                         with UpdateFeedbackNoteForm.render(
                             data={"internal_note": feedback.internal_note or ""},
                             hx_post=str(
@@ -321,11 +330,24 @@ async def get(
                             ),
                             classes="flex flex-col gap-2",
                         ):
-                            with tag.div(classes="flex justify-end"):
+                            with tag.div(classes="flex justify-end gap-2"):
                                 with button(
-                                    type="submit", variant="primary", size="sm"
+                                    type="submit",
+                                    name="action",
+                                    value="save",
+                                    size="sm",
+                                    ghost=True,
                                 ):
                                     text("Save note")
+                                if feedback.status == FeedbackStatus.new:
+                                    with button(
+                                        type="submit",
+                                        name="action",
+                                        value="save_and_triage",
+                                        variant="primary",
+                                        size="sm",
+                                    ):
+                                        text("Save & Mark as triaged")
 
 
 def _format_context_value(value: Any) -> str:
@@ -375,8 +397,21 @@ async def update_note(
         )
 
     note = form.internal_note.strip() or None
-    await repository.update(feedback, update_dict={"internal_note": note})
-    await add_toast(request, "Note saved.", "success")
+    update_dict: dict[str, Any] = {"internal_note": note}
+
+    triage = (
+        form_data.get("action") == "save_and_triage"
+        and feedback.status == FeedbackStatus.new
+    )
+    if triage:
+        update_dict["status"] = FeedbackStatus.triaged
+
+    await repository.update(feedback, update_dict=update_dict)
+    await add_toast(
+        request,
+        "Note saved and feedback marked as triaged." if triage else "Note saved.",
+        "success",
+    )
     return HXRedirectResponse(
         request, str(request.url_for("feedbacks:get", id=feedback.id))
     )

--- a/server/polar/backoffice/feedbacks/endpoints.py
+++ b/server/polar/backoffice/feedbacks/endpoints.py
@@ -109,7 +109,13 @@ def _render_table(request: Request, items: Sequence[Feedback]) -> None:
         with tag.table(classes="table table-zebra"):
             with tag.thead():
                 with tag.tr():
-                    for header in ("Type", "Message", "Organization", "User", "Submitted"):
+                    for header in (
+                        "Type",
+                        "Message",
+                        "Organization",
+                        "User",
+                        "Submitted",
+                    ):
                         with tag.th():
                             text(header)
             with tag.tbody():
@@ -119,7 +125,9 @@ def _render_table(request: Request, items: Sequence[Feedback]) -> None:
 
 def _render_row(request: Request, feedback: Feedback) -> None:
     detail_url = str(request.url_for("feedbacks:get", id=feedback.id))
-    with tag.tr(classes="hover cursor-pointer", onclick=f"window.location='{detail_url}'"):
+    with tag.tr(
+        classes="hover cursor-pointer", onclick=f"window.location='{detail_url}'"
+    ):
         with tag.td():
             _type_badge(feedback.type)
         with tag.td(classes="max-w-md truncate"):
@@ -224,9 +232,7 @@ async def get(
                         ):
                             text("Mark as triaged")
                     with button(
-                        hx_get=str(
-                            request.url_for("feedbacks:delete", id=feedback.id)
-                        ),
+                        hx_get=str(request.url_for("feedbacks:delete", id=feedback.id)),
                         hx_target="#modal",
                         variant="error",
                         ghost=True,
@@ -326,9 +332,7 @@ async def triage(
     if feedback is None:
         raise HTTPException(status_code=404)
     if feedback.status != FeedbackStatus.new:
-        raise HTTPException(
-            status_code=400, detail="Feedback is already triaged."
-        )
+        raise HTTPException(status_code=400, detail="Feedback is already triaged.")
 
     await repository.update(feedback, update_dict={"status": FeedbackStatus.triaged})
     await add_toast(request, "Feedback marked as triaged.", "success")
@@ -379,9 +383,7 @@ async def delete(
     if request.method == "POST":
         await repository.soft_delete(feedback)
         await add_toast(request, "Feedback deleted.", "success")
-        return HXRedirectResponse(
-            request, str(request.url_for("feedbacks:list"))
-        )
+        return HXRedirectResponse(request, str(request.url_for("feedbacks:list")))
 
     with document() as doc:
         with tag.div(id="modal"):

--- a/server/polar/backoffice/feedbacks/endpoints.py
+++ b/server/polar/backoffice/feedbacks/endpoints.py
@@ -1,0 +1,401 @@
+from collections.abc import Sequence
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from pydantic import UUID4, Field, ValidationError
+from sqlalchemy.orm import joinedload
+from tagflow import attr, document, tag, text
+
+from polar.feedback.repository import FeedbackRepository
+from polar.kit.pagination import PaginationParamsQuery
+from polar.models import Feedback
+from polar.models.feedback import FeedbackStatus, FeedbackType
+from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+
+from .. import forms
+from ..components import button, confirmation_dialog, datatable, description_list
+from ..components._tab_nav import Tab, tab_nav
+from ..layout import layout
+from ..responses import HXRedirectResponse
+from ..toast import add_toast
+from ._markdown import render_markdown
+
+
+class UpdateFeedbackNoteForm(forms.BaseForm):
+    internal_note: Annotated[
+        str,
+        forms.TextAreaField(
+            rows=4,
+            placeholder=(
+                "Triage notes — e.g. link to the GitHub issue this feedback "
+                "spawned, or any context for whoever picks it up next."
+            ),
+        ),
+        Field(default="", title="Internal note"),
+    ]
+
+
+router = APIRouter()
+
+
+def _type_badge(feedback_type: FeedbackType) -> None:
+    with tag.div(classes="badge badge-outline"):
+        text(feedback_type.value)
+
+
+def _status_badge(status: FeedbackStatus) -> None:
+    variant = "badge-warning" if status == FeedbackStatus.new else "badge-success"
+    with tag.div(classes=f"badge {variant}"):
+        text(status.value)
+
+
+def _list_tabs(request: Request, *, active: FeedbackStatus) -> list[Tab]:
+    return [
+        Tab(
+            "Inbox",
+            url=str(request.url_for("feedbacks:list")),
+            active=active == FeedbackStatus.new,
+        ),
+        Tab(
+            "Triaged",
+            url=str(request.url_for("feedbacks:list_triaged")),
+            active=active == FeedbackStatus.triaged,
+        ),
+    ]
+
+
+async def _render_list(
+    request: Request,
+    session: AsyncSession,
+    pagination: PaginationParamsQuery,
+    *,
+    status: FeedbackStatus,
+    route_name: str,
+    breadcrumb_label: str,
+) -> None:
+    repository = FeedbackRepository.from_session(session)
+    statement = repository.get_by_status_statement(status).options(
+        joinedload(Feedback.user), joinedload(Feedback.organization)
+    )
+    items, count = await repository.paginate(
+        statement, limit=pagination.limit, page=pagination.page
+    )
+
+    with layout(
+        request,
+        [
+            (breadcrumb_label, str(request.url)),
+            ("Feedback", str(request.url_for("feedbacks:list"))),
+        ],
+        route_name,
+    ):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.h1(classes="text-4xl"):
+                text("Feedback")
+            with tab_nav(_list_tabs(request, active=status)):
+                pass
+            if items:
+                _render_table(request, items)
+            else:
+                with tag.div(classes="text-center py-12 text-gray-500"):
+                    text("No feedback in this view.")
+            with datatable.pagination(request, pagination, count):
+                pass
+
+
+def _render_table(request: Request, items: Sequence[Feedback]) -> None:
+    with tag.div(classes="overflow-x-auto"):
+        with tag.table(classes="table table-zebra"):
+            with tag.thead():
+                with tag.tr():
+                    for header in ("Type", "Message", "Organization", "User", "Submitted"):
+                        with tag.th():
+                            text(header)
+            with tag.tbody():
+                for feedback in items:
+                    _render_row(request, feedback)
+
+
+def _render_row(request: Request, feedback: Feedback) -> None:
+    detail_url = str(request.url_for("feedbacks:get", id=feedback.id))
+    with tag.tr(classes="hover cursor-pointer", onclick=f"window.location='{detail_url}'"):
+        with tag.td():
+            _type_badge(feedback.type)
+        with tag.td(classes="max-w-md truncate"):
+            with tag.a(href=detail_url, classes="link"):
+                text(feedback.message[:120])
+        with tag.td():
+            with tag.a(
+                href=str(
+                    request.url_for(
+                        "organizations:detail", organization_id=feedback.organization_id
+                    )
+                ),
+                classes="link",
+            ):
+                text(feedback.organization.name)
+        with tag.td():
+            with tag.a(
+                href=str(request.url_for("users:get", id=feedback.user_id)),
+                classes="link",
+            ):
+                text(feedback.user.email)
+        with tag.td():
+            text(feedback.created_at.strftime("%Y-%m-%d %H:%M"))
+
+
+@router.get("/", name="feedbacks:list")
+async def list_inbox(
+    request: Request,
+    pagination: PaginationParamsQuery,
+    session: AsyncSession = Depends(get_db_read_session),
+) -> None:
+    await _render_list(
+        request,
+        session,
+        pagination,
+        status=FeedbackStatus.new,
+        route_name="feedbacks:list",
+        breadcrumb_label="Inbox",
+    )
+
+
+@router.get("/triaged", name="feedbacks:list_triaged")
+async def list_triaged(
+    request: Request,
+    pagination: PaginationParamsQuery,
+    session: AsyncSession = Depends(get_db_read_session),
+) -> None:
+    await _render_list(
+        request,
+        session,
+        pagination,
+        status=FeedbackStatus.triaged,
+        route_name="feedbacks:list_triaged",
+        breadcrumb_label="Triaged",
+    )
+
+
+async def _get_or_404(session: AsyncSession, id: UUID4) -> Feedback:
+    repository = FeedbackRepository.from_session(session)
+    feedback = await repository.get_by_id(
+        id,
+        options=(joinedload(Feedback.user), joinedload(Feedback.organization)),
+    )
+    if feedback is None:
+        raise HTTPException(status_code=404)
+    return feedback
+
+
+@router.get("/{id}", name="feedbacks:get")
+async def get(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_read_session),
+) -> None:
+    feedback = await _get_or_404(session, id)
+
+    with layout(
+        request,
+        [
+            (str(feedback.id)[:8], str(request.url)),
+            ("Feedback", str(request.url_for("feedbacks:list"))),
+        ],
+        "feedbacks:get",
+    ):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.div(classes="flex justify-between items-start gap-4"):
+                with tag.div(classes="flex flex-col gap-2"):
+                    with tag.h1(classes="text-4xl"):
+                        text("Feedback")
+                    with tag.div(classes="flex items-center gap-2"):
+                        _type_badge(feedback.type)
+                        _status_badge(feedback.status)
+                        with tag.span(classes="text-sm text-gray-500"):
+                            text(feedback.created_at.strftime("%Y-%m-%d %H:%M UTC"))
+                with tag.div(classes="flex items-center gap-2"):
+                    if feedback.status == FeedbackStatus.new:
+                        with button(
+                            hx_post=str(
+                                request.url_for("feedbacks:triage", id=feedback.id)
+                            ),
+                            variant="primary",
+                        ):
+                            text("Mark as triaged")
+                    with button(
+                        hx_get=str(
+                            request.url_for("feedbacks:delete", id=feedback.id)
+                        ),
+                        hx_target="#modal",
+                        variant="error",
+                        ghost=True,
+                    ):
+                        text("Delete")
+
+            with tag.div(classes="grid grid-cols-1 lg:grid-cols-3 gap-4"):
+                # Message (rendered Markdown) — wider column
+                with tag.div(classes="card card-border w-full shadow-sm lg:col-span-2"):
+                    with tag.div(classes="card-body"):
+                        with tag.h2(classes="card-title"):
+                            text("Message")
+                        with tag.div(classes="prose max-w-none"):
+                            render_markdown(feedback.message)
+
+                # Submitted by
+                with tag.div(classes="card card-border w-full shadow-sm"):
+                    with tag.div(classes="card-body"):
+                        with tag.h2(classes="card-title"):
+                            text("Submitted by")
+                        with description_list.DescriptionList[Feedback](
+                            description_list.DescriptionListLinkItem[Feedback](
+                                "user.email",
+                                "User",
+                                href_getter=lambda r, i: str(
+                                    r.url_for("users:get", id=i.user_id)
+                                ),
+                            ),
+                            description_list.DescriptionListLinkItem[Feedback](
+                                "organization.name",
+                                "Organization",
+                                href_getter=lambda r, i: str(
+                                    r.url_for(
+                                        "organizations:detail",
+                                        organization_id=i.organization_id,
+                                    )
+                                ),
+                            ),
+                            description_list.DescriptionListAttrItem(
+                                "organization.slug", "Slug"
+                            ),
+                        ).render(request, feedback):
+                            pass
+
+            # Internal note
+            with tag.div(classes="card card-border w-full shadow-sm"):
+                with tag.div(classes="card-body"):
+                    with tag.h2(classes="card-title"):
+                        text("Internal note")
+                    with UpdateFeedbackNoteForm.render(
+                        data={"internal_note": feedback.internal_note or ""},
+                        hx_post=str(
+                            request.url_for("feedbacks:update_note", id=feedback.id)
+                        ),
+                        classes="flex flex-col gap-2",
+                    ):
+                        with tag.div(classes="flex justify-end"):
+                            with button(type="submit", variant="primary", size="sm"):
+                                text("Save note")
+
+            # Client context
+            with tag.div(classes="card card-border w-full shadow-sm"):
+                with tag.div(classes="card-body"):
+                    with tag.h2(classes="card-title"):
+                        text("Client context")
+                    if feedback.client_context:
+                        with tag.dl(
+                            classes=(
+                                "grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 "
+                                "text-sm"
+                            )
+                        ):
+                            for key, value in sorted(feedback.client_context.items()):
+                                with tag.dt(classes="font-semibold"):
+                                    text(key)
+                                with tag.dd(classes="font-mono break-all"):
+                                    text(_format_context_value(value))
+                    else:
+                        with tag.p(classes="text-gray-500"):
+                            text("No client context captured.")
+
+
+def _format_context_value(value: Any) -> str:
+    if isinstance(value, dict):
+        return ", ".join(f"{k}: {v}" for k, v in value.items())
+    return str(value)
+
+
+@router.post("/{id}/triage", name="feedbacks:triage")
+async def triage(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    repository = FeedbackRepository.from_session(session)
+    feedback = await repository.get_by_id(id)
+    if feedback is None:
+        raise HTTPException(status_code=404)
+    if feedback.status != FeedbackStatus.new:
+        raise HTTPException(
+            status_code=400, detail="Feedback is already triaged."
+        )
+
+    await repository.update(feedback, update_dict={"status": FeedbackStatus.triaged})
+    await add_toast(request, "Feedback marked as triaged.", "success")
+    return HXRedirectResponse(
+        request, str(request.url_for("feedbacks:get", id=feedback.id))
+    )
+
+
+@router.post("/{id}/note", name="feedbacks:update_note")
+async def update_note(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    repository = FeedbackRepository.from_session(session)
+    feedback = await repository.get_by_id(id)
+    if feedback is None:
+        raise HTTPException(status_code=404)
+
+    form_data = await request.form()
+    try:
+        form = UpdateFeedbackNoteForm.model_validate_form(form_data)
+    except ValidationError:
+        await add_toast(request, "Could not save the note.", "error")
+        return HXRedirectResponse(
+            request, str(request.url_for("feedbacks:get", id=feedback.id))
+        )
+
+    note = form.internal_note.strip() or None
+    await repository.update(feedback, update_dict={"internal_note": note})
+    await add_toast(request, "Note saved.", "success")
+    return HXRedirectResponse(
+        request, str(request.url_for("feedbacks:get", id=feedback.id))
+    )
+
+
+@router.api_route("/{id}/delete", name="feedbacks:delete", methods=["GET", "POST"])
+async def delete(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    repository = FeedbackRepository.from_session(session)
+    feedback = await repository.get_by_id(id)
+    if feedback is None:
+        raise HTTPException(status_code=404)
+
+    if request.method == "POST":
+        await repository.soft_delete(feedback)
+        await add_toast(request, "Feedback deleted.", "success")
+        return HXRedirectResponse(
+            request, str(request.url_for("feedbacks:list"))
+        )
+
+    with document() as doc:
+        with tag.div(id="modal"):
+            with confirmation_dialog(
+                "Delete feedback",
+                "This will hide the feedback from both views. It can be restored "
+                "from the database if needed.",
+                variant="error",
+                confirm_text="Delete",
+                open=True,
+            ):
+                attr(
+                    "hx-post",
+                    str(request.url_for("feedbacks:delete", id=feedback.id)),
+                )
+
+    return HTMLResponse(str(doc))

--- a/server/polar/backoffice/feedbacks/endpoints.py
+++ b/server/polar/backoffice/feedbacks/endpoints.py
@@ -41,13 +41,13 @@ router = APIRouter()
 
 def _type_badge(feedback_type: FeedbackType) -> None:
     with tag.div(classes="badge badge-outline"):
-        text(feedback_type.value)
+        text(str(feedback_type))
 
 
 def _status_badge(status: FeedbackStatus) -> None:
     variant = "badge-warning" if status == FeedbackStatus.new else "badge-success"
     with tag.div(classes=f"badge {variant}"):
-        text(status.value)
+        text(str(status))
 
 
 def _list_tabs(request: Request, *, active: FeedbackStatus) -> list[Tab]:
@@ -85,8 +85,8 @@ async def _render_list(
     with layout(
         request,
         [
-            (breadcrumb_label, str(request.url)),
             ("Feedback", str(request.url_for("feedbacks:list"))),
+            (breadcrumb_label, str(request.url)),
         ],
         route_name,
     ):
@@ -207,8 +207,8 @@ async def get(
     with layout(
         request,
         [
-            (str(feedback.id)[:8], str(request.url)),
             ("Feedback", str(request.url_for("feedbacks:list"))),
+            (str(feedback.id)[:8], str(request.url)),
         ],
         "feedbacks:get",
     ):
@@ -239,15 +239,20 @@ async def get(
                     ):
                         text("Delete")
 
-            with tag.div(classes="grid grid-cols-1 lg:grid-cols-3 gap-4"):
-                # Message (rendered Markdown) — wider column
-                with tag.div(classes="card card-border w-full shadow-sm lg:col-span-2"):
-                    with tag.div(classes="card-body"):
-                        with tag.h2(classes="card-title"):
-                            text("Message")
-                        with tag.div(classes="prose max-w-none"):
-                            render_markdown(feedback.message)
+            # Message (rendered Markdown) — full width
+            with tag.div(classes="card card-border w-full shadow-sm"):
+                with tag.div(classes="card-body"):
+                    with tag.h2(classes="card-title"):
+                        text("Message")
+                    with tag.div(
+                        classes=(
+                            "prose max-w-none "
+                            "prose-pre:whitespace-pre-wrap prose-pre:break-words"
+                        )
+                    ):
+                        render_markdown(feedback.message)
 
+            with tag.div(classes="grid grid-cols-1 lg:grid-cols-3 gap-4"):
                 # Submitted by
                 with tag.div(classes="card card-border w-full shadow-sm"):
                     with tag.div(classes="card-body"):
@@ -277,42 +282,50 @@ async def get(
                         ).render(request, feedback):
                             pass
 
-            # Internal note
-            with tag.div(classes="card card-border w-full shadow-sm"):
-                with tag.div(classes="card-body"):
-                    with tag.h2(classes="card-title"):
-                        text("Internal note")
-                    with UpdateFeedbackNoteForm.render(
-                        data={"internal_note": feedback.internal_note or ""},
-                        hx_post=str(
-                            request.url_for("feedbacks:update_note", id=feedback.id)
-                        ),
-                        classes="flex flex-col gap-2",
-                    ):
-                        with tag.div(classes="flex justify-end"):
-                            with button(type="submit", variant="primary", size="sm"):
-                                text("Save note")
+                # Client context
+                with tag.div(classes="card card-border w-full shadow-sm"):
+                    with tag.div(classes="card-body"):
+                        with tag.h2(classes="card-title"):
+                            text("Client context")
+                        if feedback.client_context:
+                            with tag.dl(
+                                classes=(
+                                    "grid grid-cols-[max-content_1fr] gap-x-4 "
+                                    "gap-y-1 text-sm"
+                                )
+                            ):
+                                for key, value in sorted(
+                                    feedback.client_context.items()
+                                ):
+                                    with tag.dt(classes="font-semibold"):
+                                        text(key)
+                                    with tag.dd(
+                                        classes=(
+                                            "font-mono whitespace-pre-wrap break-all"
+                                        )
+                                    ):
+                                        text(_format_context_value(value))
+                        else:
+                            with tag.p(classes="text-gray-500"):
+                                text("No client context captured.")
 
-            # Client context
-            with tag.div(classes="card card-border w-full shadow-sm"):
-                with tag.div(classes="card-body"):
-                    with tag.h2(classes="card-title"):
-                        text("Client context")
-                    if feedback.client_context:
-                        with tag.dl(
-                            classes=(
-                                "grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 "
-                                "text-sm"
-                            )
+                # Internal note
+                with tag.div(classes="card card-border w-full shadow-sm"):
+                    with tag.div(classes="card-body"):
+                        with tag.h2(classes="card-title"):
+                            text("Internal note")
+                        with UpdateFeedbackNoteForm.render(
+                            data={"internal_note": feedback.internal_note or ""},
+                            hx_post=str(
+                                request.url_for("feedbacks:update_note", id=feedback.id)
+                            ),
+                            classes="flex flex-col gap-2",
                         ):
-                            for key, value in sorted(feedback.client_context.items()):
-                                with tag.dt(classes="font-semibold"):
-                                    text(key)
-                                with tag.dd(classes="font-mono break-all"):
-                                    text(_format_context_value(value))
-                    else:
-                        with tag.p(classes="text-gray-500"):
-                            text("No client context captured.")
+                            with tag.div(classes="flex justify-end"):
+                                with button(
+                                    type="submit", variant="primary", size="sm"
+                                ):
+                                    text("Save note")
 
 
 def _format_context_value(value: Any) -> str:

--- a/server/polar/backoffice/navigation.py
+++ b/server/polar/backoffice/navigation.py
@@ -40,4 +40,7 @@ NAVIGATION = [
     navigation.NavigationItem(
         "Webhooks", "webhooks:list", active_route_name_prefix="webhooks:"
     ),
+    navigation.NavigationItem(
+        "Feedback", "feedbacks:list", active_route_name_prefix="feedbacks:"
+    ),
 ]

--- a/server/polar/feedback/repository.py
+++ b/server/polar/feedback/repository.py
@@ -1,9 +1,28 @@
-from polar.kit.repository import RepositoryBase, RepositorySoftDeletionMixin
+from uuid import UUID
+
+from sqlalchemy import Select
+
+from polar.kit.repository import (
+    RepositoryBase,
+    RepositorySoftDeletionIDMixin,
+    RepositorySoftDeletionMixin,
+)
 from polar.models import Feedback
+from polar.models.feedback import FeedbackStatus
 
 
 class FeedbackRepository(
+    RepositorySoftDeletionIDMixin[Feedback, UUID],
     RepositorySoftDeletionMixin[Feedback],
     RepositoryBase[Feedback],
 ):
     model = Feedback
+
+    def get_by_status_statement(
+        self, status: FeedbackStatus
+    ) -> Select[tuple[Feedback]]:
+        return (
+            self.get_base_statement()
+            .where(Feedback.status == status)
+            .order_by(Feedback.created_at.desc())
+        )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "trafilatura>=2.0.0",
   "polar-sdk==0.31.3",
   "anyio>=4.13.0",
+  "markdown-it-py>=4.0.0",
 ]
 
 [dependency-groups]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14.0"
 
 [options]
-exclude-newer = "2026-04-15T12:59:45.62691044Z"
+exclude-newer = "2026-04-20T13:55:33.598226Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -2090,6 +2090,7 @@ dependencies = [
     { name = "itsdangerous" },
     { name = "logfire", extra = ["fastapi", "httpx", "redis", "sqlalchemy"] },
     { name = "makefun" },
+    { name = "markdown-it-py" },
     { name = "plain-client" },
     { name = "playwright" },
     { name = "polar-sdk" },
@@ -2181,6 +2182,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "logfire", extras = ["fastapi", "httpx", "sqlalchemy", "redis"], specifier = ">=4.32.0" },
     { name = "makefun", specifier = ">=1.15.6" },
+    { name = "markdown-it-py", specifier = ">=4.0.0" },
     { name = "plain-client", specifier = ">=0.0.3" },
     { name = "playwright", specifier = ">=1.50.0" },
     { name = "polar-sdk", url = "https://files.pythonhosted.org/packages/ef/23/bd856ec12a8faef40bfb6b30e7add657952c7266f5f0ac7c156067fa30ea/polar_sdk-0.31.3-py3-none-any.whl" },


### PR DESCRIPTION
## Summary

Adds a complete feedback management interface to the backoffice, allowing admins to view, triage, and manage user feedback submissions.

## What

- Created new feedback endpoints module (`server/polar/backoffice/feedbacks/endpoints.py`) with:
  - List views for inbox (new feedback) and triaged feedback with pagination
  - Detail view showing feedback message, submitter info, and client context
  - Ability to mark feedback as triaged
  - Internal notes field for triage context
  - Soft delete functionality with confirmation dialog
- Added Markdown rendering utility (`server/polar/backoffice/feedbacks/_markdown.py`) to display feedback messages with proper formatting
- Extended `FeedbackRepository` with:
  - `get_by_status_statement()` method to filter feedback by status
  - Support for soft deletion by ID
- Added feedback navigation item to backoffice sidebar
- Registered feedback router in backoffice app initialization
- Added `markdown-it-py` dependency for Markdown rendering

## Why

This provides admins with a dedicated interface to manage user feedback, enabling them to:
- Triage incoming feedback into actionable items
- Add internal notes linking to GitHub issues or providing context
- Track which feedback has been reviewed
- Delete spam or duplicate feedback
- View submitter information and client context for better understanding

## How

The implementation follows the existing backoffice patterns:
- Uses tagflow for HTML generation with DaisyUI components
- Leverages existing form and layout components
- Integrates with the feedback repository for data access
- Uses HTMX for interactive features (triage, note updates, delete confirmation)
- Follows the same pagination and breadcrumb patterns as other backoffice sections

## Checklist

- [x] This PR addresses a single concern (feedback management feature)
- [x] The diff is reasonably sized and focused
- [x] No unrelated changes included

https://claude.ai/code/session_01GusgP3LS1qs6rY9hamtu82