### PR TITLE
feat(server): finish migrating organization endpoints to PolicyGuard

### DIFF
--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -174,6 +174,15 @@ AuthorizeOrgManagePayoutAccount = Annotated[
 AuthorizeOrgAccess = Annotated[
     AuthzContext[User | Organization], Depends(OrgPolicyGuard(_always_allow))
 ]
+AuthorizeOrgAccessWrite = Annotated[
+    AuthzContext[User | Organization],
+    Depends(
+        OrgPolicyGuard(
+            _always_allow,
+            required_scopes={Scope.organizations_write},
+        )
+    ),
+]
 AuthorizeOrgAccessUser = Annotated[
     AuthzContext[User],
     Depends(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -9,7 +9,9 @@ from polar.account.service import account as account_service
 from polar.authz.dependencies import (
     AuthorizeFinanceRead,
     AuthorizeMembersManage,
+    AuthorizeOrgAccess,
     AuthorizeOrgAccessUser,
+    AuthorizeOrgAccessWrite,
     AuthorizeOrgDelete,
     AuthorizeOrgManagePayoutAccount,
 )
@@ -114,17 +116,10 @@ async def list(
     tags=[APITag.public],
 )
 async def get(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsRead,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    authz: AuthorizeOrgAccess,
 ) -> Organization:
     """Get an organization by ID."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    return organization
+    return authz.organization
 
 
 @router.get(
@@ -201,17 +196,10 @@ async def set_payout_account(
     tags=[APITag.private],
 )
 async def get_kyc(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsRead,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    authz: AuthorizeOrgAccess,
 ) -> Organization:
     """Get an organization's KYC/compliance details."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    return organization
+    return authz.organization
 
 
 @router.post(
@@ -246,18 +234,14 @@ async def create(
     tags=[APITag.public],
 )
 async def update(
-    id: OrganizationID,
+    authz: AuthorizeOrgAccessWrite,
     organization_update: OrganizationUpdate,
-    auth_subject: auth.OrganizationsWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Update an organization."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    return await organization_service.update(session, organization, organization_update)
+    return await organization_service.update(
+        session, authz.organization, organization_update
+    )
 
 
 @router.delete(
@@ -333,17 +317,12 @@ async def get_payment_status(
     tags=[APITag.private],
 )
 async def members(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsRead,
+    authz: AuthorizeOrgAccess,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[OrganizationMember]:
     """List members in an organization."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    members = await user_organization_service.list_by_org(session, id)
+    organization = authz.organization
+    members = await user_organization_service.list_by_org(session, organization.id)
 
     # Get admin user to set is_admin flag
     org_repo = OrganizationRepository.from_session(session)
@@ -521,17 +500,11 @@ async def remove_member(
     tags=[APITag.private],
 )
 async def validate_with_ai(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsWrite,
+    authz: AuthorizeOrgAccessWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> OrganizationReviewStatus:
     """Get the AI validation status. Review runs asynchronously in the background."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    review = await organization_service.get_ai_review(session, organization)
+    review = await organization_service.get_ai_review(session, authz.organization)
 
     if review is None:
         # Review is pending (background task not yet complete)
@@ -559,20 +532,14 @@ async def validate_with_ai(
     tags=[APITag.private],
 )
 async def submit_appeal(
-    id: OrganizationID,
+    authz: AuthorizeOrgAccessWrite,
     appeal_request: OrganizationAppealRequest,
-    auth_subject: auth.OrganizationsWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> OrganizationAppealResponse:
     """Submit an appeal for organization review after AI validation failure."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
     try:
         result = await organization_service.submit_appeal(
-            session, organization, appeal_request.reason
+            session, authz.organization, appeal_request.reason
         )
 
         return OrganizationAppealResponse(
@@ -604,17 +571,13 @@ async def submit_appeal(
     tags=[APITag.private],
 )
 async def mark_ai_onboarding_complete(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsWrite,
+    authz: AuthorizeOrgAccessWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Mark the AI onboarding as completed for this organization."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    return await organization_service.mark_ai_onboarding_complete(session, organization)
+    return await organization_service.mark_ai_onboarding_complete(
+        session, authz.organization
+    )
 
 
 @router.get(
@@ -628,18 +591,12 @@ async def mark_ai_onboarding_complete(
     tags=[APITag.private],
 )
 async def get_review_status(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsRead,
+    authz: AuthorizeOrgAccess,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewStatus:
     """Get the current review status and appeal information for an organization."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
     review_repository = OrganizationReviewRepository.from_session(session)
-    review = await review_repository.get_by_organization(organization.id)
+    review = await review_repository.get_by_organization(authz.organization.id)
 
     if review is None:
         return OrganizationReviewStatus()
@@ -665,17 +622,10 @@ async def get_review_status(
     tags=[APITag.private],
 )
 async def validate_website(
-    id: OrganizationID,
+    authz: AuthorizeOrgAccessWrite,
     body: OrganizationValidateWebsiteRequest,
-    auth_subject: auth.OrganizationsWrite,
-    session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationValidateWebsiteResponse:
     """Validate that a website URL is reachable and not targeting a private network."""
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
     try:
         validated_url = await validate_crawlable_url(body.url)
     except UnsafeCrawlableUrl as e:


### PR DESCRIPTION
## Summary

Migrates the remaining 9 endpoints in the organization module from `auth.OrganizationsRead/Write` + manual `organization_service.get(...)` onto the PolicyGuard pattern documented in the [authorization handbook](https://handbook.polar.sh/engineering/backend-development/authorization). The module is now 100% on PolicyGuard.

## What

- Adds `AuthorizeOrgAccessWrite` to `polar/authz/dependencies.py` — User|Organization, `organizations_write` scope, always-allow policy. Mirrors the existing `AuthorizeOrgAccess` (read) and `AuthorizeOrgAccessUser` (User-only write) variants.
- Migrates 9 endpoints in `polar/organization/endpoints.py`:
  - **Read → `AuthorizeOrgAccess`**: `get`, `get_kyc`, `members`, `get_review_status`
  - **Write → `AuthorizeOrgAccessWrite`**: `update`, `validate_with_ai`, `submit_appeal`, `mark_ai_onboarding_complete`, `validate_website`
- Each migrated endpoint drops its manual `organization_service.get(...) ➜ raise ResourceNotFound` block; the guard now handles resource resolution, membership check, and 404.

Untouched: `list`, `create`, `get_payment_status` — these don't take an `{id}` path param that resolves to an organization, so they don't fit the `OrgPolicyGuard` shape.

## Why

The handbook describes PolicyGuard as the standard pattern, but adoption was uneven — only 6 of ~17 organization endpoints used it. Finishing the migration:

- Removes ~40 lines of repeated "fetch + check + 404" boilerplate.
- Makes the auth contract on each endpoint visible in the signature (`authz: AuthorizeOrgAccess`) instead of hidden inside the service layer.
- Gives us a fully-migrated reference module before we tackle others.

## How

The endpoints already delegated authorization to `organization_service.get(...)`, which internally calls `get_accessible_org_ids` and returns `None` for non-members. PolicyGuard does the same membership check up front and 404s before the endpoint body runs, so the migration is purely mechanical: swap the dependency, drop the manual fetch, read `authz.organization` instead. No behavior change.

The two new "always-allow" `AuthorizeOrgAccess*` variants exist for endpoints that need authentication + scope + org membership but no further policy — they centralize resource resolution without forcing a trivial policy function.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (existing org endpoint tests cover the migrated endpoints; all pass)
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included