### PR TITLE
docs(handbook): focus authorization page on architecture, not catalog

### DIFF
--- a/handbook/engineering/backend-development/authorization.mdx
+++ b/handbook/engineering/backend-development/authorization.mdx
@@ -64,19 +64,17 @@ There are three PolicyGuard variants for different resource types:
 
 ### Typed dependencies
 
-Pre-built typed dependencies are defined in `server/polar/authz/dependencies.py`:
+Each guard is paired with a policy and exposed as a named dependency in `server/polar/authz/dependencies.py`. Endpoints depend on these names rather than wiring guards and policies themselves. For example:
 
 ```python
 AuthorizeFinanceRead    # OrgPolicyGuard + finance.can_read
-AuthorizeFinanceWrite   # OrgPolicyGuard + finance.can_write
 AuthorizeMembersManage  # OrgPolicyGuard + members.can_manage (User-only)
-AuthorizeOrgDelete      # OrgPolicyGuard + organization.can_delete (User-only)
-AuthorizeOrgAccessUser  # OrgPolicyGuard + always allow (User-only)
-AuthorizeAccountRead    # AccountPolicyGuard + finance.can_read
 AuthorizeAccountWrite   # AccountPolicyGuard + finance.can_write
-AuthorizePayoutAccountRead   # PayoutAccountPolicyGuard + finance.can_read
-AuthorizePayoutAccountWrite  # PayoutAccountPolicyGuard + finance.can_write
 ```
+
+There are also "always-allow" variants for endpoints that only need authentication, scope check, and org membership — no further policy. They exist so endpoints can still benefit from centralized resource resolution (the guard fetches the org and 404s non-members) without inventing a trivial policy.
+
+See `server/polar/authz/dependencies.py` for the full list.
 
 ## Policies
 
@@ -104,13 +102,9 @@ async def can_read(
 
 The denial reason string is passed through to the `NotPermitted` exception and appears in the 403 response body.
 
-### Policy files
+### Where policies live
 
-| File | Functions | Controls access to |
-|------|-----------|-------------------|
-| `policies/finance.py` | `can_read`, `can_write` | Accounts, transactions, payouts |
-| `policies/organization.py` | `can_delete` | Organization deletion |
-| `policies/members.py` | `can_manage` | Inviting, removing, and changing members |
+Policies are grouped by the resource area they protect — one file per area in `server/polar/authz/policies/` (e.g. finance, members, organization). A file typically exposes `can_read`/`can_write` or a more specific verb when the operation has its own rules (e.g. `can_delete`, `can_manage`). New areas get a new file rather than overloading an existing one.
 
 ## Org-scoped data access
 


### PR DESCRIPTION
## Summary

Trims the `engineering/backend-development/authorization.mdx` page so that it describes how authorization is *organized* rather than maintaining an exhaustive registry of every typed dependency and policy file. Detailed catalogs in handbooks tend to rot — the source of truth lives in `server/polar/authz/`.

## What

- **Typed dependencies section**: replaces the 9-line bullet list of every `Authorize*` dependency with three illustrative examples + a brief description of the always-allow variants and a pointer to `server/polar/authz/dependencies.py` for the full list.
- **Policy files section**: replaces the per-file table with a one-paragraph description of how policies are organized (one file per resource area, `can_*` verbs, new areas get new files).

The architectural content — the auth/authz split, the five-step PolicyGuard flow, the error-behavior table, the three guard variants, the org-scoped data access pattern, scopes, and the "adding a new policy-guarded endpoint" walkthrough — is unchanged.

## Why

Two problems with the previous version:

1. **The catalog was already out of date.** It didn't mention `payout_account` policies or `AuthorizeOrgManagePayoutAccount`, both of which exist in code, and it incorrectly described `AuthorizePayoutAccountRead/Write` as delegating to `finance.can_read/write`.
2. **Even if we caught it up, it would drift again.** The handbook should explain *why* the system is shaped the way it is so that someone reading it can navigate the source confidently — not duplicate the source.

## How

Targeted edits to two subsections only. No restructuring, no new content, no removed concepts — just less detail in the two places that were trying to enumerate things.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests *(N/A — docs-only)*
- [ ] Linting and type checking pass *(N/A — docs-only)*
- [x] No unrelated changes or drive-by fixes are included