### PR TITLE
Exclude unset custom field values from checkout data

### DIFF
--- a/server/polar/custom_field/data.py
+++ b/server/polar/custom_field/data.py
@@ -94,7 +94,7 @@ def validate_custom_field_data(
         ]
     )
     try:
-        return schema.model_validate(data).model_dump(mode="json")
+        return schema.model_validate(data).model_dump(mode="json", exclude_unset=True)
     except ValidationError as e:
         raise PolarRequestValidationError(
             [{**err, "loc": (*error_loc_prefix, *err["loc"])} for err in e.errors()]  # pyright: ignore

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -1155,7 +1155,7 @@ class TestCreate:
             auth_subject,
         )
 
-        assert checkout.custom_field_data == {"text": "abc", "select": None}
+        assert checkout.custom_field_data == {"text": "abc"}
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),
@@ -3158,7 +3158,7 @@ class TestUpdate:
             ),
         )
 
-        assert checkout.custom_field_data == {"text": "abc", "select": None}
+        assert checkout.custom_field_data == {"text": "abc"}
 
     async def test_valid_embed_origin(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: [this comment](https://github.com/polarsource/polar/issues/9154#issuecomment-4333247337)

This PR modifies custom field data serialization to exclude unset fields, ensuring that only explicitly provided custom field values are included in checkout data.

## What

- Modified `validate_custom_field_data()` in `server/polar/custom_field/data.py` to use `exclude_unset=True` when serializing validated custom field data
- Updated test expectations in `server/tests/checkout/test_service.py` to reflect that unset fields (with `None` values) are no longer included in the serialized output

## Why

When custom fields are validated, unset optional fields are assigned `None` values by Pydantic. Previously, these `None` values were included in the serialized output, resulting in unnecessary null entries in the custom field data. By excluding unset fields, we only persist the custom field values that were explicitly provided, reducing data clutter and improving clarity about which fields were actually set.

## How

The change leverages Pydantic's `exclude_unset=True` parameter in `model_dump()`, which automatically filters out any fields that weren't explicitly set during model validation. This is a minimal, focused change that affects only the serialization behavior without altering validation logic.

## Checklist

- [x] This PR addresses a single concern (one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] Existing tests updated to reflect new behavior
- [x] No unrelated changes included

https://claude.ai/code/session_017FsYfnmyq65DZ9m8PYPFsk