### PR TITLE
openapi: Fix Discount OpenAPI specification

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -16746,15 +16746,16 @@ export interface components {
       | components['schemas']['DiscountPercentageOnceForeverDuration']
       | components['schemas']['DiscountPercentageRepeatDuration']
     DiscountCreate:
-      | components['schemas']['DiscountFixedOnceForeverDurationCreate']
-      | components['schemas']['DiscountFixedRepeatDurationCreate']
-      | components['schemas']['DiscountPercentageOnceForeverDurationCreate']
-      | components['schemas']['DiscountPercentageRepeatDurationCreate']
+      | components['schemas']['DiscountFixedCreate']
+      | components['schemas']['DiscountPercentageCreate']
     /**
      * DiscountDuration
      * @enum {string}
      */
     DiscountDuration: 'once' | 'forever' | 'repeating'
+    DiscountFixedCreate:
+      | components['schemas']['DiscountFixedOnceForeverDurationCreate']
+      | components['schemas']['DiscountFixedRepeatDurationCreate']
     /**
      * DiscountFixedOnceForeverDuration
      * @description Schema for a fixed amount discount that is applied once or forever.
@@ -16931,9 +16932,17 @@ export interface components {
      * @description Schema to create a fixed amount discount that is applied once or forever.
      */
     DiscountFixedOnceForeverDurationCreate: {
-      duration: components['schemas']['DiscountDuration']
-      /** @description Type of the discount. */
-      type: components['schemas']['DiscountType']
+      /**
+       * @description For subscriptions, determines if the discount should be applied once on the first invoice or forever. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      duration: 'forever' | 'once'
+      /**
+       * Type
+       * @default fixed
+       * @constant
+       */
+      type: 'fixed'
       /**
        * Amount
        * @deprecated
@@ -17180,7 +17189,11 @@ export interface components {
      *     for a certain number of months.
      */
     DiscountFixedRepeatDurationCreate: {
-      duration: components['schemas']['DiscountDuration']
+      /**
+       * @description For subscriptions, the discount should be applied on every invoice for a certain number of months, determined by `duration_in_months`. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      duration: 'repeating'
       /**
        * Duration In Months
        * @description Number of months the discount should be applied.
@@ -17189,8 +17202,12 @@ export interface components {
        *     For example, to apply the discount for 2 years, set this to 24.
        */
       duration_in_months: number
-      /** @description Type of the discount. */
-      type: components['schemas']['DiscountType']
+      /**
+       * Type
+       * @default fixed
+       * @constant
+       */
+      type: 'fixed'
       /**
        * Amount
        * @deprecated
@@ -17255,6 +17272,9 @@ export interface components {
        */
       organization_id?: string | null
     }
+    DiscountPercentageCreate:
+      | components['schemas']['DiscountPercentageOnceForeverDurationCreate']
+      | components['schemas']['DiscountPercentageRepeatDurationCreate']
     /**
      * DiscountPercentageOnceForeverDuration
      * @description Schema for a percentage discount that is applied once or forever.
@@ -17397,9 +17417,17 @@ export interface components {
      * @description Schema to create a percentage discount that is applied once or forever.
      */
     DiscountPercentageOnceForeverDurationCreate: {
-      duration: components['schemas']['DiscountDuration']
-      /** @description Type of the discount. */
-      type: components['schemas']['DiscountType']
+      /**
+       * @description For subscriptions, determines if the discount should be applied once on the first invoice or forever. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      duration: 'forever' | 'once'
+      /**
+       * Type
+       * @default percentage
+       * @constant
+       */
+      type: 'percentage'
       /**
        * Basis Points
        * @description Discount percentage in basis points.
@@ -17606,7 +17634,11 @@ export interface components {
      *     for a certain number of months.
      */
     DiscountPercentageRepeatDurationCreate: {
-      duration: components['schemas']['DiscountDuration']
+      /**
+       * @description For subscriptions, the discount should be applied on every invoice for a certain number of months, determined by `duration_in_months`. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      duration: 'repeating'
       /**
        * Duration In Months
        * @description Number of months the discount should be applied.
@@ -17615,8 +17647,12 @@ export interface components {
        *     For example, to apply the discount for 2 years, set this to 24.
        */
       duration_in_months: number
-      /** @description Type of the discount. */
-      type: components['schemas']['DiscountType']
+      /**
+       * Type
+       * @default percentage
+       * @constant
+       */
+      type: 'percentage'
       /**
        * Basis Points
        * @description Discount percentage in basis points.
@@ -52046,6 +52082,18 @@ export const customerWalletSortPropertyValues: ReadonlyArray<
 export const discountDurationValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DiscountDuration']
 > = ['once', 'forever', 'repeating']
+export const discountFixedOnceForeverDurationCreateDurationValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DiscountFixedOnceForeverDurationCreate']['duration']
+> = ['forever', 'once']
+export const discountFixedRepeatDurationCreateDurationValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DiscountFixedRepeatDurationCreate']['duration']
+> = ['repeating']
+export const discountPercentageOnceForeverDurationCreateDurationValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DiscountPercentageOnceForeverDurationCreate']['duration']
+> = ['forever', 'once']
+export const discountPercentageRepeatDurationCreateDurationValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DiscountPercentageRepeatDurationCreate']['duration']
+> = ['repeating']
 export const discountSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DiscountSortProperty']
 > = [

--- a/server/polar/discount/schemas.py
+++ b/server/polar/discount/schemas.py
@@ -96,24 +96,6 @@ MaxRedemptions = Annotated[
     ),
     Ge(1),
 ]
-DurationOnceForever = Annotated[
-    Literal[DiscountDuration.once, DiscountDuration.forever],
-    Field(
-        description=(
-            "For subscriptions, determines if the discount should be applied "
-            "once on the first invoice or forever."
-        )
-    ),
-]
-DurationRepeating = Annotated[
-    Literal[DiscountDuration.repeating],
-    Field(
-        description=(
-            "For subscriptions, the discount should be applied on every invoice "
-            "for a certain number of months, determined by `duration_in_months`."
-        )
-    ),
-]
 DurationInMonths = Annotated[
     int,
     Field(
@@ -171,14 +153,11 @@ ProductsList = Annotated[
 
 class DiscountCreateBase(MetadataInputMixin, Schema):
     name: Name
-    type: DiscountType = Field(description="Type of the discount.")
     code: Code = None
 
     starts_at: StartsAt = None
     ends_at: EndsAt = None
     max_redemptions: MaxRedemptions = None
-
-    duration: DiscountDuration
 
     products: ProductsList | None = None
 
@@ -196,17 +175,53 @@ class DiscountCreateBase(MetadataInputMixin, Schema):
         return self
 
 
-class DiscountOnceForeverDurationCreateBase(Schema):
-    duration: DurationOnceForever
+Duration = Annotated[
+    DiscountDuration,
+    Field(
+        description=(
+            "For subscriptions, determines if the discount should be applied "
+            "once on the first invoice, forever, or for a certain number of "
+            "months determined by `duration_in_months`."
+        ),
+    ),
+]
+DurationInMonthsOptional = Annotated[
+    int | None,
+    Field(
+        default=None,
+        description=inspect.cleandoc("""
+        Number of months the discount should be applied.
+
+        Required when `duration` is `repeating`. Must be omitted otherwise.
+
+        For this to work on yearly pricing, you should multiply this by 12.
+        For example, to apply the discount for 2 years, set this to 24.
+        """),
+        ge=1,
+        le=999,
+    ),
+]
 
 
-class DiscountRepeatDurationCreateBase(Schema):
-    duration: DurationRepeating
-    duration_in_months: DurationInMonths
+def _validate_duration_in_months(
+    duration: DiscountDuration, duration_in_months: int | None
+) -> None:
+    if duration == DiscountDuration.repeating and duration_in_months is None:
+        raise ValueError(
+            "`duration_in_months` is required when `duration` is `repeating`."
+        )
+    if duration != DiscountDuration.repeating and duration_in_months is not None:
+        raise ValueError(
+            "`duration_in_months` must be omitted when `duration` is not `repeating`."
+        )
 
 
-class DiscountFixedCreateBase(Schema):
+class DiscountFixedCreate(DiscountCreateBase):
+    """Schema to create a fixed amount discount."""
+
     type: Literal[DiscountType.fixed] = DiscountType.fixed
+    duration: Duration
+    duration_in_months: DurationInMonthsOptional = None
     amount: Amount | None = Field(
         default=None,
         deprecated="Use `amounts` instead to specify fixed discount amounts for different currencies.",
@@ -225,42 +240,24 @@ class DiscountFixedCreateBase(Schema):
             raise ValueError("Must specify either `amount` or `amounts`.")
         return self
 
+    @model_validator(mode="after")
+    def validate_duration_in_months(self) -> Self:
+        _validate_duration_in_months(self.duration, self.duration_in_months)
+        return self
 
-class DiscountPercentageCreateBase(Schema):
+
+class DiscountPercentageCreate(DiscountCreateBase):
+    """Schema to create a percentage discount."""
+
     type: Literal[DiscountType.percentage] = DiscountType.percentage
+    duration: Duration
+    duration_in_months: DurationInMonthsOptional = None
     basis_points: BasisPoints
 
-
-class DiscountFixedOnceForeverDurationCreate(
-    DiscountCreateBase, DiscountFixedCreateBase, DiscountOnceForeverDurationCreateBase
-):
-    """Schema to create a fixed amount discount that is applied once or forever."""
-
-
-class DiscountFixedRepeatDurationCreate(
-    DiscountCreateBase, DiscountFixedCreateBase, DiscountRepeatDurationCreateBase
-):
-    """
-    Schema to create a fixed amount discount that is applied on every invoice
-    for a certain number of months.
-    """
-
-
-class DiscountPercentageOnceForeverDurationCreate(
-    DiscountCreateBase,
-    DiscountPercentageCreateBase,
-    DiscountOnceForeverDurationCreateBase,
-):
-    """Schema to create a percentage discount that is applied once or forever."""
-
-
-class DiscountPercentageRepeatDurationCreate(
-    DiscountCreateBase, DiscountPercentageCreateBase, DiscountRepeatDurationCreateBase
-):
-    """
-    Schema to create a percentage discount that is applied on every invoice
-    for a certain number of months.
-    """
+    @model_validator(mode="after")
+    def validate_duration_in_months(self) -> Self:
+        _validate_duration_in_months(self.duration, self.duration_in_months)
+        return self
 
 
 class DiscountUpdate(MetadataInputMixin, Schema):
@@ -461,13 +458,8 @@ def get_discriminator_value(v: Any) -> str | None:
 
 
 DiscountCreate = Annotated[
-    Annotated[DiscountFixedOnceForeverDurationCreate, Tag("fixed.once_forever")]
-    | Annotated[DiscountFixedRepeatDurationCreate, Tag("fixed.repeat")]
-    | Annotated[
-        DiscountPercentageOnceForeverDurationCreate, Tag("percentage.once_forever")
-    ]
-    | Annotated[DiscountPercentageRepeatDurationCreate, Tag("percentage.repeat")],
-    Discriminator(get_discriminator_value),
+    DiscountFixedCreate | DiscountPercentageCreate,
+    Discriminator("type"),
 ]
 DiscountMinimal = Annotated[
     Annotated[DiscountFixedOnceForeverDurationBase, Tag("fixed.once_forever")]

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -30,7 +30,7 @@ from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncSession
 from polar.product.repository import ProductRepository
 
-from .schemas import DiscountCreate, DiscountFixedCreateBase, DiscountUpdate
+from .schemas import DiscountCreate, DiscountFixedCreate, DiscountUpdate
 from .sorting import DiscountSortProperty
 
 log = structlog.get_logger()
@@ -152,7 +152,7 @@ class DiscountService(ResourceServiceReader[Discount]):
         discount_model = discount_create.type.get_model()
         discount_id = uuid.uuid4()
 
-        if isinstance(discount_create, DiscountFixedCreateBase):
+        if isinstance(discount_create, DiscountFixedCreate):
             if (
                 discount_create.amount is not None
                 and discount_create.currency is not None

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -24,7 +24,7 @@ from polar.checkout_link.service import checkout_link as checkout_link_service
 from polar.config import settings
 from polar.customer.schemas.customer import CustomerIndividualCreate
 from polar.customer.service import customer as customer_service
-from polar.discount.schemas import DiscountPercentageOnceForeverDurationCreate
+from polar.discount.schemas import DiscountPercentageCreate
 from polar.discount.service import discount as discount_service
 from polar.enums import (
     PaymentProcessor,
@@ -1599,7 +1599,7 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
         if org_products:
             await discount_service.create(
                 session=session,
-                discount_create=DiscountPercentageOnceForeverDurationCreate(
+                discount_create=DiscountPercentageCreate(
                     name="Free",
                     code="free",
                     type=DiscountType.percentage,

--- a/server/tests/discount/test_endpoints.py
+++ b/server/tests/discount/test_endpoints.py
@@ -249,6 +249,93 @@ class TestCreateDiscount:
         assert discount.amount == 1000
         assert discount.currency == "usd"
 
+    @pytest.mark.auth
+    async def test_fixed_type_with_basis_points_rejected(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "fixed",
+                "code": "DISCOUNT",
+                "duration": "once",
+                "basis_points": 10000,
+                "organization_id": str(organization.id),
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        ("duration", "extra"),
+        [
+            pytest.param("once", {}, id="once"),
+            pytest.param("forever", {}, id="forever"),
+            pytest.param("repeating", {"duration_in_months": 3}, id="repeating"),
+        ],
+    )
+    @pytest.mark.auth
+    async def test_valid_percentage_durations(
+        self,
+        duration: str,
+        extra: dict[str, Any],
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "percentage",
+                "duration": duration,
+                "basis_points": 1000,
+                "organization_id": str(organization.id),
+                **extra,
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["type"] == "percentage"
+        assert response.json()["duration"] == duration
+
+    @pytest.mark.parametrize(
+        ("duration", "extra"),
+        [
+            pytest.param("once", {}, id="once"),
+            pytest.param("forever", {}, id="forever"),
+            pytest.param("repeating", {"duration_in_months": 3}, id="repeating"),
+        ],
+    )
+    @pytest.mark.auth
+    async def test_valid_fixed_durations(
+        self,
+        duration: str,
+        extra: dict[str, Any],
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "fixed",
+                "duration": duration,
+                "amounts": {"usd": 500},
+                "organization_id": str(organization.id),
+                **extra,
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["type"] == "fixed"
+        assert response.json()["duration"] == duration
+
 
 @pytest.mark.asyncio
 class TestGetDiscount:

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -7,7 +7,7 @@ from polar.auth.models import AuthSubject, User
 from polar.checkout.schemas import CheckoutUpdatePublic
 from polar.checkout.service import checkout as checkout_service
 from polar.discount.schemas import (
-    DiscountFixedOnceForeverDurationCreate,
+    DiscountFixedCreate,
     DiscountUpdate,
 )
 from polar.discount.service import discount as discount_service
@@ -54,7 +54,7 @@ class TestCreate:
     ) -> None:
         discount = await discount_service.create(
             session,
-            DiscountFixedOnceForeverDurationCreate(
+            DiscountFixedCreate(
                 duration=DiscountDuration.once,
                 type=DiscountType.fixed,
                 amount=1000,


### PR DESCRIPTION
The previous generation specification was incorrect / or lead the implementer into the wrong direction in regards to what was allowed for discounts.

It's not allowed to have basis_points with type fixed.

By splitting `DiscountCreate` into two schemas that's discriminated on type, and moving the validation in one step we can ensure that the OpenAPI spec becomes less confusing.

See https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01KQ32VWCHB81CR48BHSTN31MF/