### PR TITLE
server: introduct tax_breakdown column

### DIFF
--- a/server/migrations/versions/2026-04-27-1500_add_tax_breakdown_column.py
+++ b/server/migrations/versions/2026-04-27-1500_add_tax_breakdown_column.py
@@ -1,0 +1,52 @@
+"""add tax_breakdown column to orders, checkouts and wallet_transactions
+
+Revision ID: f3a2b1c4d5e6
+Revises: fe139a04f807
+Create Date: 2026-04-24 15:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "f3a2b1c4d5e6"
+down_revision = "fe139a04f807"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "orders",
+        sa.Column(
+            "tax_breakdown",
+            postgresql.JSONB(astext_type=sa.Text(), none_as_null=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "checkouts",
+        sa.Column(
+            "tax_breakdown",
+            postgresql.JSONB(astext_type=sa.Text(), none_as_null=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "wallet_transactions",
+        sa.Column(
+            "tax_breakdown",
+            postgresql.JSONB(astext_type=sa.Text(), none_as_null=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("wallet_transactions", "tax_breakdown")
+    op.drop_column("checkouts", "tax_breakdown")
+    op.drop_column("orders", "tax_breakdown")

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -35,7 +35,7 @@ from polar.product.guard import (
     is_free_price,
     is_metered_price,
 )
-from polar.tax.calculation import TaxabilityReason, TaxRate
+from polar.tax.calculation import TaxabilityReason, TaxBreakdownItem, TaxRate
 from polar.tax.tax_id import TaxID, TaxIDType
 
 from .customer import Customer
@@ -150,6 +150,9 @@ class Checkout(
     )
     taxability_reason: Mapped[TaxabilityReason | None] = mapped_column(
         String, nullable=True, default=None
+    )
+    tax_breakdown: Mapped[list[TaxBreakdownItem] | None] = mapped_column(
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     tax_behavior: Mapped[TaxBehavior | None] = mapped_column(
         StringEnum(TaxBehavior), nullable=True, default=None

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -30,7 +30,7 @@ from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.metadata import MetadataMixin
 from polar.models.order_item import OrderItem
-from polar.tax.calculation import TaxabilityReason, TaxRate
+from polar.tax.calculation import TaxabilityReason, TaxBreakdownItem, TaxRate
 from polar.tax.tax_id import TaxID, TaxIDType
 
 if TYPE_CHECKING:
@@ -145,6 +145,9 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
     )
     tax_id: Mapped[TaxID | None] = mapped_column(TaxIDType, nullable=True, default=None)
     tax_rate: Mapped[TaxRate | None] = mapped_column(
+        JSONB(none_as_null=True), nullable=True, default=None
+    )
+    tax_breakdown: Mapped[list[TaxBreakdownItem] | None] = mapped_column(
         JSONB(none_as_null=True), nullable=True, default=None
     )
     tax_processor: Mapped[TaxProcessor | None] = mapped_column(

--- a/server/polar/models/wallet_transaction.py
+++ b/server/polar/models/wallet_transaction.py
@@ -11,7 +11,7 @@ from polar.enums import TaxProcessor
 from polar.kit.db.models import IDModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.utils import utc_now
-from polar.tax.calculation import TaxabilityReason, TaxRate
+from polar.tax.calculation import TaxabilityReason, TaxBreakdownItem, TaxRate
 
 if TYPE_CHECKING:
     from .order import Order
@@ -42,6 +42,9 @@ class WalletTransaction(IDModel):
     )
     taxability_reason: Mapped[TaxabilityReason | None] = mapped_column(
         String, nullable=True, default=None
+    )
+    tax_breakdown: Mapped[list[TaxBreakdownItem] | None] = mapped_column(
+        JSONB(none_as_null=True), nullable=True, default=None
     )
     tax_calculation_processor_id: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None

--- a/server/polar/tax/calculation/__init__.py
+++ b/server/polar/tax/calculation/__init__.py
@@ -15,6 +15,7 @@ from .base import (
     CalculationExpiredError,
     InvalidTaxIDError,
     TaxabilityReason,
+    TaxBreakdownItem,
     TaxCalculation,
     TaxCalculationLogicalError,
     TaxCalculationTechnicalError,
@@ -206,6 +207,7 @@ tax_calculation = TaxCalculationService()
 __all__ = [
     "CalculationExpiredError",
     "InvalidTaxIDError",
+    "TaxBreakdownItem",
     "TaxCalculation",
     "TaxCalculationLogicalError",
     "TaxCalculationTechnicalError",

--- a/server/polar/tax/calculation/base.py
+++ b/server/polar/tax/calculation/base.py
@@ -122,6 +122,16 @@ class TaxRate(TypedDict):
     state: str | None
 
 
+class TaxBreakdownItem(TypedDict):
+    rate_type: Literal["percentage", "fixed"]
+    rate: float | None
+    display_name: str
+    country: str | None
+    state: str | None
+    amount: int
+    taxability_reason: TaxabilityReason
+
+
 class TaxCalculation(TypedDict):
     processor_id: str | None
     amount: int


### PR DESCRIPTION
First step to tackle #11210: add a `tax_breakdown` column on Checkout, Order and WalletTransaction that will in the end replace both `tax_rate` and `taxability_reason`.

Other PR will follow to actually fill and then use that column.