### PR TITLE
feat: activate sandbox organizations by default

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -561,9 +561,7 @@ async def get_organization_detail(
         payouts_enabled = await setup_analytics.check_payout_account_enabled(
             organization
         )
-        payment_ready = organization_service.is_organization_ready_for_payment(
-            organization
-        )
+        payment_ready = organization.can_accept_payments
 
         setup_score = OrganizationSetupAnalyticsService.calculate_setup_score(
             checkout_links_count,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -85,7 +85,6 @@ from polar.observability.checkout_metrics import (
     CHECKOUT_SUCCEEDED_TOTAL,
 )
 from polar.order.service import order as order_service
-from polar.organization.service import organization as organization_service
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.posthog import posthog
 from polar.product.guard import (
@@ -959,9 +958,7 @@ class CheckoutService:
                 }
             )
 
-        if not organization_service.is_organization_ready_for_payment(
-            checkout.organization
-        ):
+        if not checkout.organization.can_accept_payments:
             if checkout.is_payment_required:
                 raise PaymentNotReady()
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -32,6 +32,7 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.organization import (
+    STATUS_CAPABILITIES,
     CapabilityName,
     OrganizationCapabilities,
     OrganizationDetails,
@@ -212,6 +213,13 @@ class OrganizationService:
         feature_settings["member_model_enabled"] = True
         feature_settings["seat_based_pricing_enabled"] = True
         create_data["feature_settings"] = feature_settings
+
+        if settings.is_sandbox():
+            create_data["status"] = OrganizationStatus.ACTIVE
+            create_data["capabilities"] = {
+                **STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]
+            }
+            create_data["status_updated_at"] = datetime.now(UTC)
 
         organization = await repository.create(
             Organization(
@@ -745,6 +753,9 @@ class OrganizationService:
         organization.total_balance = transfers_sum
         session.add(organization)
 
+        if settings.is_sandbox():
+            return organization
+
         # If snoozed and grace period has passed, a sale triggers re-review
         if (
             organization.status == OrganizationStatus.SNOOZED
@@ -1051,13 +1062,9 @@ class OrganizationService:
     def get_payment_status(self, organization: Organization) -> PaymentStatusResponse:
         """Get payment status and onboarding steps for an organization."""
         return PaymentStatusResponse(
-            payment_ready=self.is_organization_ready_for_payment(organization),
+            payment_ready=organization.can_accept_payments,
             organization_status=organization.status,
         )
-
-    def is_organization_ready_for_payment(self, organization: Organization) -> bool:
-        """Whether the org can accept payments. Sandbox bypasses the capability."""
-        return settings.is_sandbox() or organization.can_accept_payments
 
     async def get_ai_review(
         self, session: AsyncSession, organization: Organization

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -205,6 +205,51 @@ class TestCreate:
 
         assert organization.subscription_settings is not None
 
+    @pytest.mark.auth
+    async def test_sandbox_creates_active_organization(
+        self,
+        mocker: MockerFixture,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+    ) -> None:
+        mocker.patch(
+            "polar.organization.service.settings.is_sandbox", return_value=True
+        )
+
+        organization = await organization_service.create(
+            session,
+            OrganizationCreate(name="Sandbox Org", slug="sandbox-org"),
+            auth_subject,
+        )
+
+        assert organization.status == OrganizationStatus.ACTIVE
+        assert (
+            organization.capabilities == STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]
+        )
+        assert organization.status_updated_at is not None
+
+    @pytest.mark.auth
+    async def test_non_sandbox_creates_organization_with_default_status(
+        self,
+        mocker: MockerFixture,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+    ) -> None:
+        mocker.patch(
+            "polar.organization.service.settings.is_sandbox", return_value=False
+        )
+
+        organization = await organization_service.create(
+            session,
+            OrganizationCreate(name="Prod Org", slug="prod-org"),
+            auth_subject,
+        )
+
+        assert organization.status == OrganizationStatus.CREATED
+        assert (
+            organization.capabilities == STATUS_CAPABILITIES[OrganizationStatus.CREATED]
+        )
+
 
 @pytest.mark.asyncio
 async def test_get_next_invoice_number_organization(
@@ -574,6 +619,31 @@ class TestCheckReviewThreshold:
         assert result.total_balance == 5000
         enqueue_job_mock.assert_not_called()
 
+    async def test_sandbox_skips_review_transition(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.ACTIVE
+        organization.next_review_threshold = 0
+        mocker.patch(
+            "polar.organization.service.settings.is_sandbox", return_value=True
+        )
+        mocker.patch(
+            "polar.organization.service.transaction_service.get_transactions_sum",
+            return_value=5000,
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.check_review_threshold(
+            session, organization
+        )
+
+        assert result.status == OrganizationStatus.ACTIVE
+        assert result.total_balance == 5000
+        enqueue_job_mock.assert_not_called()
+
 
 @pytest.mark.asyncio
 class TestConfirmOrganizationReviewed:
@@ -891,21 +961,15 @@ class TestGetPaymentStatus:
         payment_status = organization_service.get_payment_status(organization)
         assert payment_status.payment_ready is True
 
-    def test_sandbox_environment_allows_payments(
+    def test_blocked_org_is_not_payment_ready(
         self,
         organization: Organization,
-        mocker: MockerFixture,
     ) -> None:
-        # An org with the capability disabled is normally not payment-ready,
-        # but sandbox bypasses every gate.
         organization.set_status(OrganizationStatus.BLOCKED)
-        mocker.patch(
-            "polar.organization.service.settings.is_sandbox", return_value=True
-        )
 
         payment_status = organization_service.get_payment_status(organization)
 
-        assert payment_status.payment_ready is True
+        assert payment_status.payment_ready is False
 
 
 @pytest.mark.asyncio
@@ -2230,10 +2294,6 @@ class TestCapabilityOverrides:
         }
 
         assert organization.can_accept_payments is False
-        assert (
-            organization_service.is_organization_ready_for_payment(organization)
-            is False
-        )
 
     async def test_can_authenticate_follows_api_access_capability(
         self,


### PR DESCRIPTION
## Summary

- Sandbox organizations are now created with `status=ACTIVE` and full transaction capabilities so end-to-end flows (checkout, subscriptions, payouts, refunds) work without going through review.
- `check_review_threshold` short-circuits in sandbox after syncing `total_balance`, so orgs stay ACTIVE instead of auto-transitioning to REVIEW.
- Removed `is_organization_ready_for_payment` wrapper. Callers (checkout service, backoffice setup analytics) now use `organization.can_accept_payments` directly since the prior sandbox bypass is no longer needed.

## Follow-up

A separate PR will add a backfill script for existing sandbox orgs stuck in non-ACTIVE statuses (branch: \`psincraian/sandbox-org-active-backfill\`).

## Test plan

- [x] \`uv run task lint\` passes
- [x] \`uv run task lint_types\` passes
- [x] \`tests/organization/test_service.py\` — 159 tests pass (+3 new sandbox tests)
- [x] \`tests/checkout/test_service.py\` — 308 tests pass
- [ ] Manual: create a new org in a sandbox deployment and confirm checkout works without details submission / review

🤖 Generated with [Claude Code](https://claude.com/claude-code)