### PR TITLE
feat: auto-decide organization appeals with the review agent

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPage.tsx
@@ -14,7 +14,7 @@ import { useOrganizationReviewStatus } from '@/hooks/queries/org'
 import { usePayoutAccount } from '@/hooks/queries/payout_accounts'
 import { schemas } from '@polar-sh/client'
 import { loadStripe } from '@stripe/stripe-js'
-import { BanIcon, CheckIcon } from 'lucide-react'
+import { CheckIcon } from 'lucide-react'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 export default function ClientPage({
@@ -39,8 +39,6 @@ export default function ClientPage({
     reviewStatus?.reason === 'Grandfathered organization'
 
   const isDenied = organization.status === 'denied'
-
-  const canAppeal = reviewStatus?.appeal_decision !== 'rejected'
 
   const isActive = ['active', 'review', 'snoozed'].includes(organization.status)
 
@@ -168,17 +166,6 @@ export default function ClientPage({
               kyc={true}
               onSubmitted={handleDetailsSubmitted}
             />
-          ) : isDenied && !canAppeal ? (
-            <div className="dark:bg-polar-800 rounded-2xl border bg-white p-8 text-center">
-              <span className="dark:bg-polar-700 mb-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-100">
-                <BanIcon className="dark:text-polar-400 h-4 w-4 text-gray-500" />
-              </span>
-              <h4 className="mb-2 font-medium">Account denied</h4>
-              <p className="dark:text-polar-400 mx-auto max-w-sm text-sm text-balance text-gray-600">
-                You have been denied access to Polar. If you believe this is a
-                mistake, please contact support for further assistance.
-              </p>
-            </div>
           ) : isApproved ? (
             <div className="dark:bg-polar-800 rounded-2xl border bg-white p-8 text-center">
               <span className="dark:bg-polar-700 mb-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-100">

--- a/clients/apps/web/src/components/Organization/AppealForm.tsx
+++ b/clients/apps/web/src/components/Organization/AppealForm.tsx
@@ -9,7 +9,7 @@ import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { Textarea } from '@polar-sh/ui/components/ui/textarea'
 import { Loader2 } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 interface AppealFormProps {
   organization: schemas['Organization']
@@ -22,31 +22,33 @@ const AppealForm: React.FC<AppealFormProps> = ({
   reason,
   existingReviewStatus,
 }) => {
-  const [appealReason, setAppealReason] = useState(
-    () => existingReviewStatus?.appeal_reason ?? '',
-  )
-  const [isSubmitted, setIsSubmitted] = useState(
-    () => !!existingReviewStatus?.appeal_submitted_at,
-  )
+  const [appealReason, setAppealReason] = useState('')
   const [showForm, setShowForm] = useState(false)
+  const [pollingTimedOut, setPollingTimedOut] = useState(false)
 
   const appealMutation = useOrganizationAppeal(organization.id)
-  const reviewStatus = useOrganizationReviewStatus(organization.id)
+  const isAwaitingDecision =
+    !!existingReviewStatus?.appeal_submitted_at &&
+    !existingReviewStatus?.appeal_decision
+  const reviewStatus = useOrganizationReviewStatus(
+    organization.id,
+    true,
+    (appealMutation.isSuccess || isAwaitingDecision) && !pollingTimedOut
+      ? 3000
+      : undefined,
+  )
 
-  // Use existing review status if provided, otherwise use fetched data
   const currentReviewStatus = existingReviewStatus || reviewStatus.data
+  const isSubmitted =
+    appealMutation.isSuccess || !!currentReviewStatus?.appeal_submitted_at
+  const submittedReason = currentReviewStatus?.appeal_reason || appealReason
 
-  // Update state based on existing review status
-  const [prevReviewStatus, setPrevReviewStatus] = useState(currentReviewStatus)
-  if (currentReviewStatus !== prevReviewStatus) {
-    setPrevReviewStatus(currentReviewStatus)
-    if (currentReviewStatus?.appeal_submitted_at) {
-      setIsSubmitted(true)
-      if (currentReviewStatus.appeal_reason) {
-        setAppealReason(currentReviewStatus.appeal_reason)
-      }
-    }
-  }
+  // Stop polling after 2 minutes if the worker hasn't decided yet.
+  useEffect(() => {
+    if (!isAwaitingDecision || pollingTimedOut) return
+    const timeout = setTimeout(() => setPollingTimedOut(true), 120_000)
+    return () => clearTimeout(timeout)
+  }, [isAwaitingDecision, pollingTimedOut])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -57,9 +59,6 @@ const AppealForm: React.FC<AppealFormProps> = ({
 
     try {
       await appealMutation.mutateAsync({ reason: appealReason })
-      setIsSubmitted(true)
-
-      // Invalidate the review status query to refresh the data
       getQueryClient().invalidateQueries({
         queryKey: ['organizationReviewStatus', organization.id],
       })
@@ -79,19 +78,26 @@ const AppealForm: React.FC<AppealFormProps> = ({
     return (
       <div className="space-y-4">
         <div>
-          <h4 className="mb-1 font-medium">
+          <h4 className="mb-1 flex items-center gap-2 font-medium">
+            {!decision && !pollingTimedOut && (
+              <Loader2 className="dark:text-polar-400 h-4 w-4 animate-spin text-gray-500" />
+            )}
             {decision === 'approved'
               ? 'Appeal approved'
               : decision === 'rejected'
                 ? 'Appeal denied'
-                : 'Appeal under review'}
+                : pollingTimedOut
+                  ? 'Appeal still processing'
+                  : 'Appeal under review'}
           </h4>
           <p className="dark:text-polar-400 text-sm text-gray-600">
             {decision === 'approved'
               ? 'Your appeal has been approved. Payment access has been restored.'
               : decision === 'rejected'
-                ? 'Your appeal has been reviewed and denied. Please contact support for further assistance.'
-                : 'Our team will review your case and get back to you as soon as possible.'}
+                ? "Your appeal wasn't approved. If you believe this is wrong, please contact support — we can take another look."
+                : pollingTimedOut
+                  ? "This is taking longer than expected. Refresh the page in a few minutes — if it still hasn't updated, please contact support."
+                  : 'We are reviewing your appeal. This usually takes about a minute.'}
           </p>
           {submissionDate && (
             <p className="dark:text-polar-400 mt-2 text-xs text-gray-500">
@@ -102,10 +108,10 @@ const AppealForm: React.FC<AppealFormProps> = ({
           )}
         </div>
 
-        {appealReason && (
+        {submittedReason && (
           <div className="dark:bg-polar-800 rounded-lg bg-white p-3">
             <p className="dark:text-polar-300 text-sm text-gray-700">
-              {appealReason}
+              {submittedReason}
             </p>
           </div>
         )}
@@ -128,8 +134,8 @@ const AppealForm: React.FC<AppealFormProps> = ({
               className="cursor-pointer underline hover:no-underline"
             >
               submit an appeal
-            </button>{' '}
-            for manual review.
+            </button>
+            .
           </p>
         )}
       </div>

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -17,7 +17,6 @@ from polar.customer.repository import CustomerRepository
 from polar.enums import InvoiceNumbering, SubscriptionProrationBehavior
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.integrations.loops.service import loops as loops_service
-from polar.integrations.plain.service import plain as plain_service
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.anonymization import anonymize_email_for_deletion, anonymize_for_deletion
 from polar.kit.currency import PresentmentCurrency
@@ -1073,7 +1072,12 @@ class OrganizationService:
     async def submit_appeal(
         self, session: AsyncSession, organization: Organization, appeal_reason: str
     ) -> OrganizationReview:
-        """Submit an appeal for organization review and create a Plain ticket."""
+        """Submit an appeal and enqueue the AI agent to decide it.
+
+        The appeal is decisive: the agent either approves the org or rejects
+        the appeal with a "contact support" message. No Plain ticket is
+        created automatically.
+        """
 
         repository = OrganizationReviewRepository.from_session(session)
         review = await repository.get_by_organization(organization.id)
@@ -1092,7 +1096,7 @@ class OrganizationService:
 
         session.add(review)
 
-        await plain_service.create_appeal_review_thread(session, organization, review)
+        enqueue_job("organization_review.appeal_submitted", organization.id)
 
         return review
 

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -49,6 +49,8 @@ async def run_organization_review(
     session: AsyncSession,
     organization: Organization,
     context: ReviewContext = ReviewContext.THRESHOLD,
+    appeal_reason: str | None = None,
+    original_denial_reason: str | None = None,
 ) -> AgentReviewResult:
     start_time = time.monotonic()
 
@@ -61,6 +63,13 @@ async def run_organization_review(
 
     try:
         snapshot = await _collect_data(organization, context)
+        appeal_updates: dict[str, str] = {}
+        if appeal_reason is not None:
+            appeal_updates["appeal_reason"] = appeal_reason
+        if original_denial_reason is not None:
+            appeal_updates["original_denial_reason"] = original_denial_reason
+        if appeal_updates:
+            snapshot = snapshot.model_copy(update=appeal_updates)
 
         report, analyzer_usage = await review_analyzer.analyze(
             snapshot, context=context

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -56,9 +56,11 @@ Social link should be linked to the user's profile on the platform, and not the 
 Unverified identity is a red flag.
 Countries with high risk of fraud or money laundering are yellow flags that requires \
 human reviews.
-Also check if the user has other organizations on Polar, especially denied or blocked ones. \
-Prior denials are a strong signal. Re-creating an organization after denial is grounds \
-for automatic denial.
+
+Whether to weigh the user's other organizations on Polar (prior denials, blocked \
+organizations) depends on the review CONTEXT. The context-specific preamble below \
+will tell you whether to consider prior history. If the preamble does not mention it, \
+do NOT use prior denials as a signal — a fresh organization deserves a fresh look.
 
 ### 4. Financial Risk
 Assess payment risk scores, refund rates, charge back rates, authorization rate, and dispute history. \
@@ -358,7 +360,9 @@ No Stripe account, payments, or products exist yet. \
 Assess only: POLICY_COMPLIANCE, PRODUCT_LEGITIMACY, IDENTITY_TRUST. \
 Skip FINANCIAL_RISK and SETUP_READINESS — set those to LOW risk with confidence 0. \
 Identity verification is NOT expected at this stage — unverified identity is normal and should NOT be flagged. \
-For IDENTITY_TRUST at this stage, focus only on prior history (prior denials, blocked organizations).
+At submission time, do NOT use prior denied or blocked organizations as a signal — \
+the user deserves a fresh review based on this submission's content alone. Set IDENTITY_TRUST \
+to LOW with confidence 0 unless there is a concrete identity-related red flag in this submission.
 
 Website leniency: If the website is inaccessible, returns errors, or has minor discrepancies \
 with the stated business, do NOT treat this as a red flag. Many legitimate businesses have \
@@ -412,6 +416,11 @@ disputes/chargebacks at meaningful volume).
 a binding decision and do NOT override it based on the same concerns.
 - Re-flagging the same concerns wastes human reviewer time and degrades trust in the \
 agent. When in doubt, defer to the prior human decision.
+
+**Prior history (assess under IDENTITY_TRUST)**: The admin's other organizations \
+on Polar (especially denied or blocked ones) are a meaningful risk signal here. \
+Prior denials of OTHER orgs by the same admin are strong evidence — re-creating \
+an organization after denial is grounds for denial.
 
 Important information to check (assess under SETUP_READINESS):
 - **Setup readiness check**: The org is ready to sell if ANY of these is true:
@@ -495,6 +504,66 @@ Return only APPROVE or DENY.
 """
 
 
+APPEAL_PREAMBLE = """\
+This is an APPEAL review. The organization was previously DENIED at submission \
+time and the merchant has now submitted an appeal explaining why they believe \
+that decision was wrong. Their appeal text is included in the prompt under \
+"## Appeal from Merchant".
+
+Your decision here is FINAL — there is no further automated review after this. \
+A merchant who is denied at this stage is told to contact human support if they \
+disagree, but no Plain ticket is created automatically. So weigh the appeal \
+text carefully.
+
+How to evaluate the appeal:
+- The "## Original Denial Message Shown to Merchant" section (if present) is \
+the exact text the merchant read before writing their appeal. The appeal is \
+their response to THAT specific message — read both side-by-side and judge \
+whether the appeal directly addresses the stated concern.
+- The "## Prior Review Decisions" section (further down) contains the prior \
+agent's internal reasoning, which is more detailed than the merchant-facing \
+text. Use it for richer context, but anchor your assessment on the concern \
+the merchant was actually told about.
+- Treat the appeal text as NEW evidence about the business that was not \
+available at submission. The original review only saw the org's setup details \
+and website; the appeal may clarify the actual product, customer base, or \
+business model.
+- If the appeal credibly explains away the original concern (e.g., "we sell \
+Framer templates, not human consulting services"), and nothing else in the \
+data contradicts it, APPROVE.
+- If the appeal is vague, evasive, or does not address the original concern, \
+DENY.
+- If the appeal asserts something that directly contradicts hard data \
+(prohibited products visible on Polar, Stripe fraud signals), DENY \
+regardless of the appeal text. Do NOT use prior denied or blocked \
+organizations as a signal at the appeal stage — judge this organization \
+on its own merits and the appeal text.
+- A short or generic appeal ("please approve me", "I disagree") with no \
+specific information is grounds for DENY.
+
+Assess only POLICY_COMPLIANCE, PRODUCT_LEGITIMACY, IDENTITY_TRUST. \
+Skip FINANCIAL_RISK and SETUP_READINESS — set those to LOW with confidence 0.
+
+Return only APPROVE or DENY, never NEEDS_HUMAN_REVIEW.
+
+## Merchant-Facing Summary (merchant_summary)
+
+Produce a short merchant_summary (1-2 sentences) shown directly to the merchant:
+- For APPROVE: confirm that the appeal was accepted.
+- For DENY: explain in general terms why the appeal was not sufficient and \
+tell them to contact support if they believe the decision is wrong. NEVER \
+mention scraped websites, prior organizations, risk scores, or specific \
+fraud signals.
+
+Examples for DENY:
+- "Your appeal did not provide enough new information to overturn the original decision. If you believe this is wrong, please contact support."
+- "Based on the information provided, we are unable to approve your organization. Please contact support if you believe this is incorrect."
+
+Examples for APPROVE:
+- "Your appeal has been accepted. Your organization has been approved to sell on Polar."
+"""
+
+
 def _annotate_domains(domains: list[str]) -> str:
     """Join domain names, tagging known service domains for the AI agent."""
     parts = []
@@ -535,6 +604,7 @@ class ReviewAnalyzer:
             ReviewContext.SUBMISSION: SUBMISSION_PREAMBLE,
             ReviewContext.THRESHOLD: THRESHOLD_PREAMBLE,
             ReviewContext.MANUAL: MANUAL_PREAMBLE,
+            ReviewContext.APPEAL: APPEAL_PREAMBLE,
         }.get(context)
 
         try:
@@ -570,6 +640,20 @@ class ReviewAnalyzer:
         history = snapshot.history
 
         parts = []
+
+        if snapshot.context == ReviewContext.APPEAL:
+            if snapshot.original_denial_reason:
+                parts.append("## Original Denial Message Shown to Merchant")
+                parts.append(
+                    "This is the exact text the merchant saw on their dashboard "
+                    "and is now responding to:"
+                )
+                parts.append(snapshot.original_denial_reason)
+                parts.append("")
+            if snapshot.appeal_reason:
+                parts.append("## Appeal from Merchant")
+                parts.append(snapshot.appeal_reason)
+                parts.append("")
 
         # Organization details
         parts.append("## Organization Details")

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -311,6 +311,8 @@ class DataSnapshot(Schema):
     setup: SetupData = Field(default_factory=SetupData)
     website: WebsiteData | None = None
     prior_feedback: PriorFeedbackData = Field(default_factory=PriorFeedbackData)
+    appeal_reason: str | None = None
+    original_denial_reason: str | None = None
     collected_at: datetime
 
 

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -6,7 +6,7 @@ import structlog
 from polar.config import Environment, settings
 from polar.exceptions import PolarTaskError
 from polar.integrations.polar.service import polar_self
-from polar.models.organization import OrganizationStatus
+from polar.models.organization import Organization, OrganizationStatus
 from polar.models.organization_review import OrganizationReview
 from polar.organization.repository import (
     OrganizationRepository,
@@ -15,12 +15,19 @@ from polar.organization.repository import (
     OrganizationReviewRepository as OrgReviewRepository,
 )
 from polar.organization.service import organization as organization_service
+from polar.postgres import AsyncSession
 from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
 from .agent import run_organization_review
 from .report import build_agent_report
 from .repository import OrganizationReviewRepository
-from .schemas import ActorType, DecisionType, ReviewContext, ReviewVerdict
+from .schemas import (
+    ActorType,
+    AgentReviewResult,
+    DecisionType,
+    ReviewContext,
+    ReviewVerdict,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -40,6 +47,47 @@ _VERDICT_MAP: dict[ReviewVerdict, str] = {
     ReviewVerdict.APPROVE: OrganizationReview.Verdict.PASS,
     ReviewVerdict.DENY: OrganizationReview.Verdict.FAIL,
 }
+
+
+async def _persist_agent_result(
+    session: AsyncSession,
+    organization: Organization,
+    review_context: ReviewContext,
+    result: AgentReviewResult,
+) -> uuid.UUID:
+    """Log + track usage + persist OrganizationAgentReview. Returns its id."""
+    report = result.report
+    log.info(
+        "organization_review.task.complete",
+        organization_id=str(organization.id),
+        slug=organization.slug,
+        context=review_context.value,
+        verdict=report.verdict.value,
+        overall_risk_score=report.overall_risk_score,
+        summary=report.summary,
+        model_used=result.model_used,
+        duration_seconds=result.duration_seconds,
+        estimated_cost_usd=result.usage.estimated_cost_usd,
+    )
+
+    polar_self.enqueue_track_organization_review_usage(
+        external_customer_id=str(organization.id),
+        review_context=review_context.value,
+        vendor=result.model_provider,
+        model=result.model_used,
+        input_tokens=result.usage.input_tokens,
+        output_tokens=result.usage.output_tokens,
+        cost_usd=result.usage.estimated_cost_usd,
+    )
+
+    review_repository = OrganizationReviewRepository.from_session(session)
+    typed_report = build_agent_report(result, review_type=review_context.value)
+    agent_review = await review_repository.save_agent_review(
+        organization_id=organization.id,
+        report=typed_report,
+        reviewed_at=datetime.now(UTC),
+    )
+    return agent_review.id
 
 
 @actor(
@@ -86,37 +134,10 @@ async def run_review_agent(
             raise
 
         report = result.report
-        log.info(
-            "organization_review.task.complete",
-            organization_id=str(organization_id),
-            slug=organization.slug,
-            context=review_context.value,
-            verdict=report.verdict.value,
-            overall_risk_score=report.overall_risk_score,
-            summary=report.summary,
-            model_used=result.model_used,
-            duration_seconds=result.duration_seconds,
-            estimated_cost_usd=result.usage.estimated_cost_usd,
+        agent_review_id = await _persist_agent_result(
+            session, organization, review_context, result
         )
-
-        polar_self.enqueue_track_organization_review_usage(
-            external_customer_id=str(organization_id),
-            review_context=review_context.value,
-            vendor=result.model_provider,
-            model=result.model_used,
-            input_tokens=result.usage.input_tokens,
-            output_tokens=result.usage.output_tokens,
-            cost_usd=result.usage.estimated_cost_usd,
-        )
-
-        # Persist agent report to its own table (both contexts)
         review_repository = OrganizationReviewRepository.from_session(session)
-        typed_report = build_agent_report(result, review_type=review_context.value)
-        agent_review = await review_repository.save_agent_review(
-            organization_id=organization_id,
-            report=typed_report,
-            reviewed_at=datetime.now(UTC),
-        )
 
         # For THRESHOLD context with auto-approve eligibility:
         # delegate decision to the service layer
@@ -152,7 +173,7 @@ async def run_review_agent(
             if auto_approved:
                 await review_repository.record_agent_decision(
                     organization_id=organization_id,
-                    agent_review_id=agent_review.id,
+                    agent_review_id=agent_review_id,
                     decision=DecisionType.APPROVE,
                     review_context=ReviewContext.THRESHOLD,
                     verdict=report.verdict,
@@ -212,7 +233,7 @@ async def run_review_agent(
 
                 await review_repository.record_agent_decision(
                     organization_id=organization_id,
-                    agent_review_id=agent_review.id,
+                    agent_review_id=agent_review_id,
                     decision=DecisionType.DENY,
                     review_context=ReviewContext.SUBMISSION,
                     verdict=report.verdict,
@@ -227,3 +248,73 @@ async def run_review_agent(
                 )
             elif report.verdict == ReviewVerdict.APPROVE:
                 await organization_service.maybe_activate(session, organization)
+
+
+@actor(
+    actor_name="organization_review.appeal_submitted",
+    priority=TaskPriority.LOW,
+    time_limit=180_000,
+    max_retries=1,
+)
+async def review_appeal(organization_id: uuid.UUID) -> None:
+    """Auto-review a submitted appeal with the AI agent.
+
+    The merchant's appeal is decisive: APPROVE activates the org, DENY closes
+    out the appeal with a "contact support" message and no Plain ticket.
+    """
+    if settings.ENV == Environment.sandbox:
+        return
+
+    async with AsyncSessionMaker() as session:
+        repository = OrganizationRepository.from_session(session)
+        organization = await repository.get_by_id(organization_id, include_blocked=True)
+        if organization is None:
+            raise OrganizationDoesNotExist(organization_id)
+
+        org_review_repository = OrgReviewRepository.from_session(session)
+        review = await org_review_repository.get_by_organization(organization_id)
+        if review is None or review.appeal_submitted_at is None:
+            log.warning(
+                "organization_review.appeal.no_pending_appeal",
+                organization_id=str(organization_id),
+                slug=organization.slug,
+            )
+            return
+
+        if review.appeal_decision is not None:
+            log.info(
+                "organization_review.appeal.already_decided",
+                organization_id=str(organization_id),
+                slug=organization.slug,
+                decision=review.appeal_decision,
+            )
+            return
+
+        result = await run_organization_review(
+            session,
+            organization,
+            context=ReviewContext.APPEAL,
+            appeal_reason=review.appeal_reason,
+            original_denial_reason=review.reason,
+        )
+        report = result.report
+        agent_review_id = await _persist_agent_result(
+            session, organization, ReviewContext.APPEAL, result
+        )
+
+        if report.verdict == ReviewVerdict.APPROVE:
+            await organization_service.approve_appeal(session, organization)
+            decision = DecisionType.APPROVE
+        else:
+            await organization_service.deny_appeal(session, organization)
+            decision = DecisionType.DENY
+
+        agent_review_repository = OrganizationReviewRepository.from_session(session)
+        await agent_review_repository.record_agent_decision(
+            organization_id=organization_id,
+            agent_review_id=agent_review_id,
+            decision=decision,
+            review_context=ReviewContext.APPEAL,
+            verdict=report.verdict,
+            risk_score=report.overall_risk_score,
+        )

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -973,9 +973,7 @@ class TestSubmitAppeal:
         )
         await save_fixture(review)
 
-        mock_plain_service = mocker.patch(
-            "polar.organization.service.plain_service.create_appeal_review_thread"
-        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
         appeal_reason = "We selling templates and not consultancy services"
         result = await organization_service.submit_appeal(
@@ -984,7 +982,9 @@ class TestSubmitAppeal:
 
         assert result.appeal_submitted_at is not None
         assert result.appeal_reason == appeal_reason
-        mock_plain_service.assert_called_once_with(session, organization, result)
+        enqueue_job_mock.assert_called_once_with(
+            "organization_review.appeal_submitted", organization.id
+        )
 
     async def test_submit_appeal_no_review_exists(
         self, session: AsyncSession, organization: Organization
@@ -1044,7 +1044,7 @@ class TestSubmitAppeal:
                 session, organization, "New appeal reason"
             )
 
-    async def test_submit_appeal_plain_service_called(
+    async def test_submit_appeal_enqueues_ai_review(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -1062,15 +1062,15 @@ class TestSubmitAppeal:
         )
         await save_fixture(review)
 
-        mock_plain_service = mocker.patch(
-            "polar.organization.service.plain_service.create_appeal_review_thread"
-        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
-        result = await organization_service.submit_appeal(
+        await organization_service.submit_appeal(
             session, organization, "Please review again"
         )
 
-        mock_plain_service.assert_called_once_with(session, organization, result)
+        enqueue_job_mock.assert_called_once_with(
+            "organization_review.appeal_submitted", organization.id
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization_review/test_tasks.py
+++ b/server/tests/organization_review/test_tasks.py
@@ -29,13 +29,14 @@ from polar.organization_review.schemas import (
     RiskLevel,
     UsageInfo,
 )
-from polar.organization_review.tasks import run_review_agent
+from polar.organization_review.tasks import review_appeal, run_review_agent
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 
 # Access the unwrapped async function to bypass the actor decorator
 # which requires JobQueueManager / Redis / Dramatiq broker infrastructure.
 _run_review_agent = run_review_agent.__wrapped__  # type: ignore[attr-defined]
+_review_appeal = review_appeal.__wrapped__  # type: ignore[attr-defined]
 
 
 def _make_agent_result(
@@ -306,3 +307,143 @@ class TestRunReviewAgentGrandfathered:
         # Verify the org was denied
         await session.refresh(organization)
         assert organization.status == OrganizationStatus.DENIED
+
+
+@pytest.mark.asyncio
+class TestReviewAppeal:
+    async def test_approve_activates_org(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=85.0,
+            violated_sections=["policy"],
+            reason="Original denial",
+            timed_out=False,
+            model_used="test-model",
+            organization_details_snapshot={},
+            appeal_submitted_at=datetime.now(UTC),
+            appeal_reason="We sell digital templates, not consultancy.",
+        )
+        await save_fixture(review)
+
+        agent_result = _make_agent_result(
+            verdict=ReviewVerdict.APPROVE,
+            merchant_summary="Appeal approved",
+        )
+
+        approve_mock = AsyncMock()
+        deny_mock = AsyncMock()
+
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                new_callable=AsyncMock,
+                return_value=agent_result,
+            ),
+            patch(
+                "polar.organization_review.tasks.organization_service.approve_appeal",
+                approve_mock,
+            ),
+            patch(
+                "polar.organization_review.tasks.organization_service.deny_appeal",
+                deny_mock,
+            ),
+        ):
+            await _review_appeal(organization.id)
+
+        approve_mock.assert_awaited_once()
+        deny_mock.assert_not_awaited()
+
+    async def test_deny_rejects_appeal(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=85.0,
+            violated_sections=["policy"],
+            reason="Original denial",
+            timed_out=False,
+            model_used="test-model",
+            organization_details_snapshot={},
+            appeal_submitted_at=datetime.now(UTC),
+            appeal_reason="please approve",
+        )
+        await save_fixture(review)
+
+        agent_result = _make_agent_result(
+            verdict=ReviewVerdict.DENY,
+            merchant_summary="Appeal denied",
+        )
+
+        approve_mock = AsyncMock()
+        deny_mock = AsyncMock()
+
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                new_callable=AsyncMock,
+                return_value=agent_result,
+            ),
+            patch(
+                "polar.organization_review.tasks.organization_service.approve_appeal",
+                approve_mock,
+            ),
+            patch(
+                "polar.organization_review.tasks.organization_service.deny_appeal",
+                deny_mock,
+            ),
+        ):
+            await _review_appeal(organization.id)
+
+        deny_mock.assert_awaited_once()
+        approve_mock.assert_not_awaited()
+
+    async def test_no_pending_appeal_short_circuits(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=85.0,
+            violated_sections=[],
+            reason="Original denial",
+            timed_out=False,
+            model_used="test-model",
+            organization_details_snapshot={},
+        )
+        await save_fixture(review)
+
+        run_mock = AsyncMock()
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                run_mock,
+            ),
+        ):
+            await _review_appeal(organization.id)
+
+        run_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

Replaces the manual Plain ticket appeal flow with an AI auto-decision driven by the existing review agent.

When a denied org submits an appeal:
1. `submit_appeal` enqueues `organization_review.appeal_submitted` (no Plain ticket).
2. The new `review_appeal` actor runs the review agent with a new `ReviewContext.APPEAL` preamble. The merchant's appeal text and the original merchant-facing denial message are both included in the prompt so the AI can judge whether the appeal directly addresses the stated concern.
3. On `APPROVE` → `approve_appeal()` → `maybe_activate()` (payout/identity gates still apply).
4. On `DENY` → `deny_appeal()`. The merchant sees a non-final denial banner that points them at support — given that some share of denied appeals are overridden in support, the copy avoids overpromising finality.

## Frontend

- `AppealForm` polls every 3s while pending, with a 120s timeout fallback (so a stalled worker doesn't poll forever).
- Loader2 spinner inline next to the title while under review.
- Dropped the `prevReviewStatus` shadowing pattern in favor of derivation from `appealMutation.isSuccess` + server data.
- Removed a legacy banner short-circuit in `AccountPage.tsx` that was making the new copy unreachable once an appeal was rejected.

## Prompt scoping

Updated `analyzer.py` so prior denials of *other* orgs by the same admin are treated as a risk signal **only at the THRESHOLD review stage** — not at submission or appeal. A fresh organization deserves a fresh look.

## Screenshots

The four states of the appeal flow on the merchant dashboard:
- `01-denied.png` — initial denial with appeal CTA
- `02-under-review.png` — pending state with loading spinner
- `03-approved.png` — approved
- `04-denied.png` — rejected with non-final copy that points to support

_(uploading inline in this description)_

## Migration

- Denied orgs that **never appealed** pre-merge: get the new flow when they appeal — clean migration.
- Already-decided appeals: render correctly with the new banner copy.
- **In-flight appeals at deploy time** (Plain ticket exists, no decision yet): no AI task is enqueued retroactively. The existing `approve_appeal` / `deny_appeal` service methods are unchanged, so the backoffice / Plain flow still resolves them. The frontend pending copy ("AI is reviewing — about a minute") will be slightly inaccurate for these for up to 120s before falling back to "Appeal still processing".

## Test plan

- [x] Backend: `uv run task lint`, `uv run task lint_types`
- [x] Backend tests: 230 passes in `tests/organization_review/`, 5 in `TestSubmitAppeal`, 3 new in `TestReviewAppeal`
- [x] Frontend: `pnpm typecheck`, `pnpm lint`
- [x] Browser e2e (mocked AI): APPROVE path — submit → worker logs verdict=APPROVE → org flips → "Appeal approved" rendered
- [x] Browser e2e: DENY path through the real worker (gateway 503 → fallback DENY) — non-final copy renders
- [ ] Verify on staging that an in-flight Plain ticket pre-merge still resolves correctly post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)