### PR TITLE
Chore: Remove unnecessary deployment delay

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ jobs:
     name: "Build Docker Image 🐳"
     concurrency:
       group: build-deploy
-      cancel-in-progress: true
 
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

Allow ongoing deployments to continue and complete regardless of new merges to `main`.

## What

Allow ongoing deployments to continue and complete regardless of new merges to `main`.

## Why

Deploys are delayed unnecessarily long due to a current setting which causes ongoing deployments to cancel if new merges to `main` occurs.

## How

Remove `cancel-in-progress: true`

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
