### PR TITLE
subscription: Relax current product recurring assertion

### DIFF
--- a/server/polar/subscription/update.py
+++ b/server/polar/subscription/update.py
@@ -141,7 +141,10 @@ def _generate_product_subscription_update(
     subscription = subscription_update.subscription
 
     current_product = subscription.product
-    assert is_recurring_product(current_product)
+    # We are checking for current_product.is_recurring instead of is_recurring_product
+    # because legacy products will have is_recurring but not be of type RecurringProduct
+    # which is_recurring_product asserts.
+    assert current_product.is_recurring
 
     new_product = subscription_update.product
     assert new_product is not None

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -57,7 +57,7 @@ from polar.models.customer import CustomerType
 from polar.models.customer_seat import SeatStatus
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.order import OrderBillingReasonInternal
-from polar.models.product_price import ProductPriceSeatUnit
+from polar.models.product_price import ProductPriceAmountType, ProductPriceSeatUnit
 from polar.models.subscription import SubscriptionStatus
 from polar.order.service import PaymentFailed, PaymentFailedReason
 from polar.postgres import AsyncSession
@@ -96,6 +96,7 @@ from tests.fixtures.random_objects import (
     create_customer_seat,
     create_discount,
     create_event,
+    create_legacy_recurring_product_price,
     create_meter,
     create_product,
     create_subscription,
@@ -2612,6 +2613,57 @@ class TestUpdateProduct:
                 subscription,
                 product_id=seat_product.id,
             )
+
+    async def test_upgrade_from_legacy_recurring_product_to_new_recurring_product(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+
+        legacy_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[],
+        )
+        legacy_price = await create_legacy_recurring_product_price(
+            save_fixture,
+            amount_type=ProductPriceAmountType.fixed,
+            product=legacy_product,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            amount=1000,
+        )
+        legacy_product.prices.append(legacy_price)
+        legacy_product.all_prices.append(legacy_price)
+        await save_fixture(legacy_product)
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(2000, "usd")],
+        )
+
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=legacy_product,
+            customer=customer,
+        )
+
+        updated_subscription = await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=new_product.id,
+            proration_behavior=SubscriptionProrationBehavior.prorate,
+        )
+
+        assert updated_subscription.product == new_product
 
     async def test_next_period_behavior_new_update(
         self,


### PR DESCRIPTION
Similar as we did in 0b3d753eb26492d776e1cc932d46ab958114a515 it needs to be done in the update as well
