### PR TITLE
Add country-specific minimum payout amounts

### DIFF
--- a/clients/apps/app/app/(authenticated)/finance/index.tsx
+++ b/clients/apps/app/app/(authenticated)/finance/index.tsx
@@ -142,7 +142,7 @@ export default function Finance() {
             Withdraw
           </Button>
         </Box>
-        <Text color="subtext">You may only withdraw amounts above $10.</Text>
+        <Text color="subtext">Minimum withdrawal amounts apply.</Text>
       </Box>
 
       <Box flexDirection="column" gap="spacing-16">

--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -45,7 +45,7 @@ The minimum balance required to issue a payout varies based out the payout curre
 | COP      | $50.00              |
 | Other currencies | $10.00 (default) |
 
-A handful of countries also enforce a higher minimum on top of the per-currency floor above, because Stripe applies their local minimum even when payouts are denominated in USD or another currency:
+A handful of countries also enforce a higher minimum:
 
 | Country | Minimum Balance (USD) |
 |---------|----------------------|

--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -45,6 +45,14 @@ The minimum balance required to issue a payout varies based out the payout curre
 | COP      | $50.00              |
 | Other currencies | $10.00 (default) |
 
+A handful of countries also enforce a higher minimum on top of the per-currency floor above, because Stripe applies their local minimum even when payouts are denominated in USD or another currency:
+
+| Country | Minimum Balance (USD) |
+|---------|----------------------|
+| Bahamas      | $30.00 |
+| El Salvador  | $30.00 |
+| Panama       | $50.00 |
+
 ## Manual Withdrawal
 
 We require this to be done manually since:

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -397,35 +397,18 @@ class Settings(BaseSettings):
         "usd": _DEFAULT_ACCOUNT_PAYOUT_MINIMUM_BALANCE,
     }
 
-    # Stripe enforces per-country minimum payout amounts (in the recipient's
-    # local currency). Since we trigger payouts in USD, these have been
-    # converted using current FX rates and rounded up to the next multiple
-    # of $5 USD to give us headroom against FX fluctuations. Values are in
-    # USD cents and indexed by ISO 3166-1 alpha-2 country code. Only
-    # countries whose USD-equivalent minimum is meaningful (i.e., greater
-    # than the default $10 minimum) are listed here. See:
+    # Stripe enforces per-country minimum payout amounts in the recipient's
+    # local currency. For most countries the per-currency minimum above
+    # already exceeds the country minimum after FX conversion, but a few
+    # don't fit that pattern: USD-denominated countries with a higher local
+    # minimum than the default $10, and BSD (not listed per-currency above).
+    # Values are in USD cents and indexed by ISO 3166-1 alpha-2 country
+    # code, rounded up to the next multiple of $5 USD for FX headroom. See:
     # https://docs.stripe.com/global-payouts/send-money
     ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY: dict[str, int] = {
-        "AL": 3500,  # Albania: 3000 ALL
-        "AM": 3500,  # Armenia: 12100 AMD
         "BS": 3000,  # Bahamas: 25 BSD
-        "BT": 3500,  # Bhutan: 2500 BTN
-        "BA": 3000,  # Bosnia and Herzegovina: 50 BAM
         "SV": 3000,  # El Salvador: 30 USD
-        "GM": 3000,  # Gambia: 1900 GMD
-        "GY": 3500,  # Guyana: 6300 GYD
-        "MG": 3000,  # Madagascar: 132300 MGA
-        "MY": 3000,  # Malaysia: 133 MYR
-        "MD": 3000,  # Moldova: 500 MDL
-        "MN": 3500,  # Mongolia: 105000 MNT
-        "MZ": 3000,  # Mozambique: 1600 MZN
-        "NA": 3000,  # Namibia: 500 NAD
-        "MK": 3000,  # North Macedonia: 1500 MKD
         "PA": 5000,  # Panama: 50 USD
-        "RS": 3000,  # Serbia: 3000 RSD
-        "TW": 3000,  # Taiwan: 800 TWD
-        "TH": 2000,  # Thailand: 600 THB
-        "UZ": 3000,  # Uzbekistan: 343000 UZS
     }
     PLATFORM_FEE_BASIS_POINTS: int = 400
     PLATFORM_FEE_FIXED: int = 40

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -404,7 +404,7 @@ class Settings(BaseSettings):
     # USD cents and indexed by ISO 3166-1 alpha-2 country code. Only
     # countries whose USD-equivalent minimum is meaningful (i.e., greater
     # than the default $10 minimum) are listed here. See:
-    # https://docs.stripe.com/payouts/minimum-and-maximum-payout-amounts
+    # https://docs.stripe.com/global-payouts/send-money
     ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY: dict[str, int] = {
         "AL": 3500,  # Albania: 3000 ALL
         "AM": 3500,  # Armenia: 12100 AMD

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -396,6 +396,37 @@ class Settings(BaseSettings):
         # USD, default
         "usd": _DEFAULT_ACCOUNT_PAYOUT_MINIMUM_BALANCE,
     }
+
+    # Stripe enforces per-country minimum payout amounts (in the recipient's
+    # local currency). Since we trigger payouts in USD, these have been
+    # converted using current FX rates and rounded up to the next multiple
+    # of $5 USD to give us headroom against FX fluctuations. Values are in
+    # USD cents and indexed by ISO 3166-1 alpha-2 country code. Only
+    # countries whose USD-equivalent minimum is meaningful (i.e., greater
+    # than the default $10 minimum) are listed here. See:
+    # https://docs.stripe.com/payouts/minimum-and-maximum-payout-amounts
+    ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY: dict[str, int] = {
+        "AL": 3500,  # Albania: 3000 ALL
+        "AM": 3500,  # Armenia: 12100 AMD
+        "BS": 3000,  # Bahamas: 25 BSD
+        "BT": 3500,  # Bhutan: 2500 BTN
+        "BA": 3000,  # Bosnia and Herzegovina: 50 BAM
+        "SV": 3000,  # El Salvador: 30 USD
+        "GM": 3000,  # Gambia: 1900 GMD
+        "GY": 3500,  # Guyana: 6300 GYD
+        "MG": 3000,  # Madagascar: 132300 MGA
+        "MY": 3000,  # Malaysia: 133 MYR
+        "MD": 3000,  # Moldova: 500 MDL
+        "MN": 3500,  # Mongolia: 105000 MNT
+        "MZ": 3000,  # Mozambique: 1600 MZN
+        "NA": 3000,  # Namibia: 500 NAD
+        "MK": 3000,  # North Macedonia: 1500 MKD
+        "PA": 5000,  # Panama: 50 USD
+        "RS": 3000,  # Serbia: 3000 RSD
+        "TW": 3000,  # Taiwan: 800 TWD
+        "TH": 2000,  # Thailand: 600 THB
+        "UZ": 3000,  # Uzbekistan: 343000 UZS
+    }
     PLATFORM_FEE_BASIS_POINTS: int = 400
     PLATFORM_FEE_FIXED: int = 40
 
@@ -553,10 +584,18 @@ class Settings(BaseSettings):
     def stripe_descriptor_suffix_max_length(self) -> int:
         return 22 - len("* ") - len(self.STRIPE_STATEMENT_DESCRIPTOR)
 
-    def get_minimum_payout_for_currency(self, currency: str) -> int:
-        return self.ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_CURRENCY.get(
+    def get_minimum_payout(self, currency: str, country: str | None = None) -> int:
+        currency_minimum = self.ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_CURRENCY.get(
             currency.lower(), self._DEFAULT_ACCOUNT_PAYOUT_MINIMUM_BALANCE
         )
+        country_minimum = (
+            self.ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY.get(
+                country.upper(), 0
+            )
+            if country is not None
+            else 0
+        )
+        return max(currency_minimum, country_minimum)
 
     def get_pydantic_gateway_model(
         self, model: str | None = None

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -584,16 +584,12 @@ class Settings(BaseSettings):
     def stripe_descriptor_suffix_max_length(self) -> int:
         return 22 - len("* ") - len(self.STRIPE_STATEMENT_DESCRIPTOR)
 
-    def get_minimum_payout(self, currency: str, country: str | None = None) -> int:
+    def get_minimum_payout(self, currency: str, country: str) -> int:
         currency_minimum = self.ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_CURRENCY.get(
             currency.lower(), self._DEFAULT_ACCOUNT_PAYOUT_MINIMUM_BALANCE
         )
-        country_minimum = (
-            self.ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY.get(
-                country.upper(), 0
-            )
-            if country is not None
-            else 0
+        country_minimum = self.ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY.get(
+            country.upper(), 0
         )
         return max(currency_minimum, country_minimum)
 

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -262,8 +262,8 @@ class PayoutService:
         balance_amount = await transaction_service.get_transactions_sum(
             session, account.id
         )
-        minimum_amount = settings.get_minimum_payout_for_currency(
-            payout_account.currency
+        minimum_amount = settings.get_minimum_payout(
+            payout_account.currency, payout_account.country
         )
         if balance_amount < minimum_amount:
             raise InsufficientBalance(
@@ -306,8 +306,8 @@ class PayoutService:
             balance_amount = await transaction_service.get_transactions_sum(
                 session, account.id
             )
-            minimum_amount = settings.get_minimum_payout_for_currency(
-                payout_account.currency
+            minimum_amount = settings.get_minimum_payout(
+                payout_account.currency, payout_account.country
             )
             if balance_amount < minimum_amount:
                 raise InsufficientBalance(

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -66,19 +66,23 @@ create_balance_transaction = partial(ro.create_balance_transaction, amount=10000
 @pytest.mark.asyncio
 class TestCreate:
     @pytest.mark.parametrize(
-        ("currency", "balance"),
+        ("currency", "country", "balance"),
         [
-            ("usd", -1000),
-            ("usd", 0),
-            ("usd", settings.get_minimum_payout_for_currency("usd") - 1),
-            ("eur", -1000),
-            ("eur", 0),
-            ("eur", settings.get_minimum_payout_for_currency("eur") - 1),
+            ("usd", "US", -1000),
+            ("usd", "US", 0),
+            ("usd", "US", settings.get_minimum_payout("usd", "US") - 1),
+            ("eur", "FR", -1000),
+            ("eur", "FR", 0),
+            ("eur", "FR", settings.get_minimum_payout("eur", "FR") - 1),
+            # Country-specific minimum (Panama: $50 USD) dominates the
+            # currency-based USD default ($10).
+            ("usd", "PA", settings.get_minimum_payout("usd", "PA") - 1),
         ],
     )
     async def test_insufficient_balance(
         self,
         currency: str,
+        country: str,
         balance: int,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -88,7 +92,7 @@ class TestCreate:
         user: User,
     ) -> None:
         payout_account = await create_payout_account(
-            save_fixture, organization, user, currency=currency
+            save_fixture, organization, user, currency=currency, country=country
         )
         await create_balance_transaction(save_fixture, account=account, amount=balance)
 


### PR DESCRIPTION
## Summary

[Stripe docs for reference](https://docs.stripe.com/global-payouts/send-money)

Implement country-specific minimum payout amounts for Stripe payouts, which vary by recipient country and currency. This ensures compliance with Stripe's per-country payout minimums.

## What

- Added `ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY` configuration mapping ISO 3166-1 alpha-2 country codes to USD-equivalent minimum payout amounts (in cents)
- Refactored `get_minimum_payout_for_currency()` to `get_minimum_payout()` to accept an optional `country` parameter
- Updated the method to return the maximum of currency-based and country-based minimums
- Updated payout service (`estimate()` and `create()` methods) to pass country information when checking minimum payout amounts
- Updated frontend text to reflect that minimum withdrawal amounts vary by location

## Why

Stripe enforces per-country minimum payout amounts in the recipient's local currency. The previous implementation only considered currency-based minimums (e.g., $10 USD default), which could be insufficient for certain countries. For example, Panama requires a $50 USD minimum, which is higher than the default. This change ensures payouts respect all applicable minimums.

## How

1. Added a new configuration dictionary with country-specific minimums, converted from local currencies to USD using current FX rates and rounded up to the nearest $5 for safety margin
2. Extended the minimum payout calculation logic to consider both currency and country
3. Updated all call sites in the payout service to pass the payout account's country
4. Updated tests to verify country-specific minimums are enforced correctly
5. Updated UI text to be more generic since minimums now vary by location

## Checklist

- [x] This PR addresses a single concern (implementing country-specific payout minimums)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (parametrized test cases added for country-specific scenarios)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_013PFnuei5WneNUKfHyFhXoy