### PR TITLE
feat: hide deleted organizations from backoffice list by default

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -96,7 +96,11 @@ from ..layout import layout
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
 from .views.detail_view import OrganizationDetailView
-from .views.list_view import OrganizationListView
+from .views.list_view import (
+    DeletedFilter,
+    OrganizationListView,
+    apply_deleted_filter,
+)
 from .views.modals import DeletePayoutAccountModal, SetCapabilityModal
 from .views.sections._shared import RISK_LEVEL_BADGE, VERDICT_BADGE
 from .views.sections.account_section import AccountSection
@@ -207,6 +211,7 @@ async def list_organizations(
     days_in_status: str | None = Query(""),
     has_appeal: str | None = Query(""),
     first_reviews: str | None = Query(""),
+    deleted: DeletedFilter | None = Query(None),
 ) -> None:
     """
     List organizations with enhanced filtering and smart grouping.
@@ -225,6 +230,8 @@ async def list_organizations(
     risk_level = risk_level if risk_level else None
     has_appeal = has_appeal if has_appeal else None
     days_in_status_int = int(days_in_status) if days_in_status else None
+    # When searching, include deleted so matches surface.
+    deleted_filter: DeletedFilter = deleted or ("include" if q else "exclude")
 
     # Parse status filter
     status_filter: OrganizationStatus | None = None
@@ -339,6 +346,8 @@ async def list_organizations(
     if first_reviews == "true":
         stmt = stmt.where(Organization.is_first_review.is_(True))
 
+    stmt = apply_deleted_filter(stmt, deleted_filter)
+
     # Apply sorting
     is_desc = direction == "desc"
 
@@ -417,7 +426,7 @@ async def list_organizations(
         ):
             pass
     else:
-        status_counts = await list_view.get_status_counts()
+        status_counts = await list_view.get_status_counts(deleted_filter)
         countries = await list_view.get_distinct_countries()
         with layout(
             request,
@@ -440,6 +449,7 @@ async def list_organizations(
                 selected_risk_level=risk_level,
                 selected_days_in_status=days_in_status,
                 selected_has_appeal=has_appeal,
+                selected_deleted=deleted_filter,
             ):
                 pass
 

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -4,10 +4,11 @@ import contextlib
 import json
 from collections.abc import Generator
 from datetime import UTC, datetime
+from typing import Any, Literal
 
 import pycountry
 from fastapi import Request
-from sqlalchemy import func, select
+from sqlalchemy import Select, func, select
 from tagflow import tag, text
 
 from polar.models import Organization, PayoutAccount
@@ -31,6 +32,18 @@ FIRST_REVIEW_THRESHOLD_LABEL = formatters.currency(
     FIRST_REVIEW_MAX_THRESHOLD_CENTS, "usd"
 )
 
+DeletedFilter = Literal["exclude", "include", "only"]
+
+
+def apply_deleted_filter[T: tuple[Any, ...]](
+    stmt: Select[T], deleted: DeletedFilter
+) -> Select[T]:
+    if deleted == "only":
+        return stmt.where(Organization.deleted_at.is_not(None))
+    if deleted == "exclude":
+        return stmt.where(Organization.deleted_at.is_(None))
+    return stmt
+
 
 class OrganizationListView:
     """Render the enhanced organization list view."""
@@ -38,12 +51,15 @@ class OrganizationListView:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def get_status_counts(self) -> dict[OrganizationStatus, int]:
+    async def get_status_counts(
+        self, deleted: DeletedFilter = "exclude"
+    ) -> dict[OrganizationStatus, int]:
         """Get count of organizations by status for tab badges."""
         stmt = select(
             Organization.status,
             func.count(Organization.id).label("count"),
         ).group_by(Organization.status)
+        stmt = apply_deleted_filter(stmt, deleted)
         result = await self.session.execute(stmt)
         return {row.status: row.count for row in result}  # type: ignore[misc]
 
@@ -296,6 +312,7 @@ class OrganizationListView:
         selected_risk_level: str | None = None,
         selected_days_in_status: str | None = None,
         selected_has_appeal: str | None = None,
+        selected_deleted: DeletedFilter = "exclude",
     ) -> Generator[None]:
         """Render the complete list view."""
 
@@ -550,6 +567,28 @@ class OrganizationListView:
                                     ):
                                         opt_attrs = {"value": opt_value}
                                         if (selected_has_appeal or "") == opt_value:
+                                            opt_attrs["selected"] = ""
+                                        with tag.option(**opt_attrs):
+                                            text(opt_label)
+
+                            # Deleted
+                            with tag.div():
+                                with tag.label(classes="label"):
+                                    with tag.span(
+                                        classes="label-text text-xs font-semibold"
+                                    ):
+                                        text("Deleted")
+                                with tag.select(
+                                    classes="select select-bordered select-sm w-full filter-select",
+                                    name="deleted",
+                                ):
+                                    for opt_value, opt_label in (
+                                        ("exclude", "Exclude Deleted"),
+                                        ("include", "Include Deleted"),
+                                        ("only", "Only Deleted"),
+                                    ):
+                                        opt_attrs = {"value": opt_value}
+                                        if selected_deleted == opt_value:
                                             opt_attrs["selected"] = ""
                                         with tag.option(**opt_attrs):
                                             text(opt_label)


### PR DESCRIPTION
## Summary

- Adds a **Deleted** filter to the backoffice organizations list with three options: Exclude / Include / Only.
- Default is **Exclude Deleted** so soft-deleted organizations no longer appear in the listing or in tab counts.
- When a search query is active, the default flips to **Include** so search matches still surface; admins can still pick **Exclude** or **Only** while searching.

## Test plan

- [x] Lint (`uv run task lint`) passes
- [x] Type check (`uv run task lint_types`) passes
- [x] Verified end-to-end against the local stack: deleted orgs hidden by default, surfaced when filter is changed, surfaced in search results regardless of the deleted filter default
- [x] Verified tab counts respect the active filter
- [ ] Manual check on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)