### PR TITLE
feat(organization): add self-review checklist endpoint stub

### DIFF
--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -62,6 +62,7 @@ from .schemas import (
     OrganizationKYC,
     OrganizationPaymentStatus,
     OrganizationPayoutAccountSet,
+    OrganizationReviewState,
     OrganizationReviewStatus,
     OrganizationUpdate,
     OrganizationValidateWebsiteRequest,
@@ -676,6 +677,36 @@ async def get_review_status(
         appeal_decision=review.appeal_decision,
         appeal_reviewed_at=review.appeal_reviewed_at,
     )
+
+
+@router.get(
+    "/{id}/review",
+    response_model=OrganizationReviewState,
+    summary="Get Organization Self-Review Checklist",
+    responses={
+        200: {"description": "Organization self-review checklist returned."},
+        404: OrganizationNotFound,
+    },
+    tags=[APITag.private],
+)
+async def get_review(
+    id: OrganizationID,
+    auth_subject: auth.OrganizationsRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> OrganizationReviewState:
+    """Get the merchant self-review checklist state.
+
+    Powers the new account review UI: pre-submission gating checks plus,
+    after submission, the AI verdict and appeal state. Currently returns
+    a hardcoded all-passed snapshot — real check logic will land
+    incrementally without changing the response shape.
+    """
+    organization = await organization_service.get(session, auth_subject, id)
+
+    if organization is None:
+        raise ResourceNotFound()
+
+    return await organization_service.get_review_state(session, organization)
 
 
 @router.post(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -9,6 +9,7 @@ from polar.account.service import account as account_service
 from polar.authz.dependencies import (
     AuthorizeFinanceRead,
     AuthorizeMembersManage,
+    AuthorizeOrgAccess,
     AuthorizeOrgAccessUser,
     AuthorizeOrgDelete,
     AuthorizeOrgManagePayoutAccount,
@@ -690,8 +691,7 @@ async def get_review_status(
     tags=[APITag.private],
 )
 async def get_review(
-    id: OrganizationID,
-    auth_subject: auth.OrganizationsRead,
+    authz: AuthorizeOrgAccess,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewState:
     """Get the merchant self-review checklist state.
@@ -701,12 +701,7 @@ async def get_review(
     a hardcoded all-passed snapshot — real check logic will land
     incrementally without changing the response shape.
     """
-    organization = await organization_service.get(session, auth_subject, id)
-
-    if organization is None:
-        raise ResourceNotFound()
-
-    return await organization_service.get_review_state(session, organization)
+    return await organization_service.get_review_state(session, authz.organization)
 
 
 @router.post(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -555,6 +555,83 @@ class OrganizationReviewStatus(Schema):
     )
 
 
+class OrganizationReviewCheckKey(StrEnum):
+    """Stable identifiers for each check. Adding a new key is a coordinated FE+BE change."""
+
+    IDENTITY = "identity"
+    IDENTITY_EMAIL = "identity.email"
+    IDENTITY_SOCIAL_LINKS = "identity.social_links"
+    IDENTITY_STRIPE_VERIFICATION = "identity.stripe_identity_verification"
+    PRODUCT_DESCRIPTION = "product_description"
+    PAYOUT_ACCOUNT = "payout_account"
+
+
+class OrganizationReviewCheckStatus(StrEnum):
+    PASSED = "passed"
+    WARNING = "warning"  # attention flag; does NOT block submission
+    FAILED = "failed"
+    PENDING = "pending"
+
+
+class OrganizationReviewCheckReason(StrEnum):
+    """Reasons explaining a check's status. Scoped reasons are namespaced
+    with the prefix of the check key they apply to."""
+
+    # Universal
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    EXTERNAL_PENDING = "external_pending"
+
+    # Identity
+    IDENTITY_REJECTED = "identity.rejected"
+    IDENTITY_PERSONAL_EMAIL = "identity.personal_email"
+    IDENTITY_DOMAIN_MISMATCH = "identity.domain_mismatch"
+
+    # Payout account
+    PAYOUT_ACCOUNT_REQUIREMENTS_DUE = "payout_account.requirements_due"
+    PAYOUT_ACCOUNT_PAYOUTS_DISABLED = "payout_account.payouts_disabled"
+
+
+class OrganizationReviewCheck(Schema):
+    """A single item in the self-review checklist. Recursive via `children`."""
+
+    key: OrganizationReviewCheckKey
+    status: OrganizationReviewCheckStatus
+    reasons: list[OrganizationReviewCheckReason] = Field(
+        default_factory=list,
+        description="Reasons for the current status. Empty when `passed`.",
+    )
+    children: list["OrganizationReviewCheck"] = Field(
+        default_factory=list,
+        description="Nested sub-checks. Empty for leaves.",
+    )
+
+
+class OrganizationReviewAppeal(Schema):
+    submitted_at: datetime
+    reviewed_at: datetime | None = None
+    decision: OrganizationReview.AppealDecision | None = None
+
+
+class OrganizationReviewState(Schema):
+    """Merchant self-review checklist. Frozen once `submitted_at` is set."""
+
+    can_submit: bool = Field(
+        description=(
+            "True when `submitted_at` is null AND no preliminary check is "
+            "`failed` or `pending`. Warnings do not block submission."
+        )
+    )
+    submitted_at: datetime | None = None
+    verdict: Literal["pass", "fail"] | None = None
+    appeal: OrganizationReviewAppeal | None = None
+    preliminary_steps: list[OrganizationReviewCheck] = Field(default_factory=list)
+
+
+# Required for the recursive `children` field.
+OrganizationReviewCheck.model_rebuild()
+
+
 class OrganizationDeletionBlockedReason(StrEnum):
     """Reasons why an organization cannot be immediately deleted."""
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -68,6 +68,10 @@ from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (
     OrganizationCreate,
     OrganizationDeletionBlockedReason,
+    OrganizationReviewCheck,
+    OrganizationReviewCheckKey,
+    OrganizationReviewCheckStatus,
+    OrganizationReviewState,
     OrganizationReviewSubmissionBody,
     OrganizationUpdate,
 )
@@ -1087,6 +1091,54 @@ class OrganizationService:
         """
         repository = OrganizationReviewRepository.from_session(session)
         return await repository.get_by_organization(organization.id)
+
+    async def get_review_state(
+        self, session: AsyncReadSession, organization: Organization
+    ) -> OrganizationReviewState:
+        """Build the merchant self-review checklist state.
+
+        STUB: returns hardcoded "all passed" data so the new dashboard UI can
+        integrate against the contract while the real check logic is built
+        out incrementally. The shape is final; only the values are dummy.
+        """
+        del session, organization  # unused in the stub
+
+        preliminary_steps = [
+            OrganizationReviewCheck(
+                key=OrganizationReviewCheckKey.IDENTITY,
+                status=OrganizationReviewCheckStatus.PASSED,
+                children=[
+                    OrganizationReviewCheck(
+                        key=OrganizationReviewCheckKey.IDENTITY_EMAIL,
+                        status=OrganizationReviewCheckStatus.PASSED,
+                    ),
+                    OrganizationReviewCheck(
+                        key=OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS,
+                        status=OrganizationReviewCheckStatus.PASSED,
+                    ),
+                    OrganizationReviewCheck(
+                        key=OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION,
+                        status=OrganizationReviewCheckStatus.PASSED,
+                    ),
+                ],
+            ),
+            OrganizationReviewCheck(
+                key=OrganizationReviewCheckKey.PRODUCT_DESCRIPTION,
+                status=OrganizationReviewCheckStatus.PASSED,
+            ),
+            OrganizationReviewCheck(
+                key=OrganizationReviewCheckKey.PAYOUT_ACCOUNT,
+                status=OrganizationReviewCheckStatus.PASSED,
+            ),
+        ]
+
+        return OrganizationReviewState(
+            can_submit=True,
+            submitted_at=None,
+            verdict=None,
+            appeal=None,
+            preliminary_steps=preliminary_steps,
+        )
 
     async def submit_appeal(
         self, session: AsyncSession, organization: Organization, appeal_reason: str

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1101,8 +1101,6 @@ class OrganizationService:
         integrate against the contract while the real check logic is built
         out incrementally. The shape is final; only the values are dummy.
         """
-        del session, organization  # unused in the stub
-
         preliminary_steps = [
             OrganizationReviewCheck(
                 key=OrganizationReviewCheckKey.IDENTITY,

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -930,3 +930,49 @@ class TestDeleteOrganization:
         assert response.status_code == 403
         json = response.json()
         assert json["detail"] == "Only the account admin can delete the organization"
+
+
+@pytest.mark.asyncio
+class TestGetReview:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(f"/v1/organizations/{organization.id}/review")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_member(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(f"/v1/organizations/{organization.id}/review")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Returns the v1 checklist shape: 3 top-level checks with identity expanded."""
+        response = await client.get(f"/v1/organizations/{organization.id}/review")
+
+        assert response.status_code == 200
+        json = response.json()
+
+        assert [step["key"] for step in json["preliminary_steps"]] == [
+            "identity",
+            "product_description",
+            "payout_account",
+        ]
+        identity = json["preliminary_steps"][0]
+        assert [child["key"] for child in identity["children"]] == [
+            "identity.email",
+            "identity.social_links",
+            "identity.stripe_identity_verification",
+        ]


### PR DESCRIPTION
## Summary

- Adds `GET /v1/organizations/{id}/review` returning the merchant self-review checklist shape (powers the new account-review UI being built in parallel — polarsource/feedback#113).
- Locks the v1 response contract: `can_submit`, `submitted_at`, `verdict`, `appeal`, and a recursive `preliminary_steps` tree where each check carries `key`, `status`, `reasons[]`, `children[]`.
- Currently serves a hardcoded all-passed snapshot so the frontend can integrate against the contract while real check logic lands incrementally.

The frontend owns all copy. The backend ships only stable enum values for `key`, `status`, and `reasons` (namespaced like `identity.personal_email`, `payout_account.requirements_due`); the FE maps `(key, reason)` pairs to copy and JSX.

V1 catalog (real check logic to follow in separate PRs, no shape changes):

```
identity
├── identity.email
├── identity.social_links
└── identity.stripe_identity_verification
product_description
payout_account
```

Capabilities, ToS acknowledgements, and AUP-gated product description are deferred to phase 2.

## Test plan

- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes
- [ ] `uv run pytest tests/organization/test_endpoints.py::TestGetReview -v` passes in CI
- [ ] Frontend can fetch the endpoint and render the checklist tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)