### PR TITLE
Generate AUP MDX during dev up

### DIFF
--- a/dev/cli/up_steps/13_copy_aup.py
+++ b/dev/cli/up_steps/13_copy_aup.py
@@ -1,0 +1,38 @@
+"""Copy the Acceptable Use Policy file from the web app to the server."""
+
+from shared import (
+    SERVER_DIR,
+    Context,
+    console,
+    run_command,
+    step_spinner,
+    step_status,
+)
+
+NAME = "Copying acceptable use policy"
+
+AUP_PATH = (
+    SERVER_DIR / "polar" / "organization_review" / "acceptable-use-policy.mdx"
+)
+
+
+def run(ctx: Context) -> bool:
+    """Copy the AUP file used by the organization review agent."""
+    if AUP_PATH.exists() and not ctx.clean:
+        step_status(True, "Acceptable use policy", "already copied")
+        return True
+
+    with step_spinner("Copying acceptable use policy..."):
+        result = run_command(
+            ["uv", "run", "-m", "polar.organization_review.policy"],
+            cwd=SERVER_DIR,
+            capture=True,
+        )
+        if result and result.returncode == 0:
+            step_status(True, "Acceptable use policy", "copied")
+            return True
+        else:
+            step_status(False, "Acceptable use policy", "copy failed")
+            if result and result.stderr:
+                console.print(f"[dim]{result.stderr[:500]}[/dim]")
+            return False


### PR DESCRIPTION
In order to go through account review, we need a generated `acceptable-use-policy.mdx` file. If this doesn't exist the account review will fail and it's a bit tricky to understand why.

This PR will generate this file during the `dev up` setup.