### PR TITLE
openapi: Use python tzdata for timezones

### DIFF
--- a/dev/docker/Dockerfile.api.dev
+++ b/dev/docker/Dockerfile.api.dev
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y \
     fonts-noto-cjk \
     libpq-dev \
     curl \
-    tzdata-legacy \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -68,8 +68,6 @@ RUN --mount=type=bind,source=uv.lock,target=uv.lock \
   redis \
   fonts-noto-cjk \
   libpq-dev \
-  # tzdata-legacy is needed to accept legacy timezone names in Python like "Asia/Calcutta"
-  tzdata-legacy \
   && uv sync --no-group dev --frozen \
   && uv tool install tinybird --python 3.13 \
   && apt-get autoremove -y build-essential

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
   "polar-sdk==0.31.3",
   "anyio>=4.13.0",
   "markdown-it-py>=4.0.0",
+  "tzdata>=2025.3",
 ]
 
 [dependency-groups]

--- a/server/scripts/generate_openapi.py
+++ b/server/scripts/generate_openapi.py
@@ -1,5 +1,10 @@
 import json
+import os
 import sys
+
+# Force `zoneinfo` to ignore system tzdata and use the bundled `tzdata` PyPI
+# package, so the OpenAPI timezone enum is identical across CI and dev machines.
+os.environ["PYTHONTZPATH"] = ""
 
 from polar.app import create_app
 

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14.0"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-04-22T11:14:11.319152Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -2135,6 +2135,7 @@ dependencies = [
     { name = "taskipy" },
     { name = "trafilatura" },
     { name = "typer" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2227,6 +2228,7 @@ requires-dist = [
     { name = "taskipy", specifier = ">=1.10.3" },
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.12.5" },
+    { name = "tzdata", specifier = ">=2025.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.42.0" },
 ]
 


### PR DESCRIPTION
Instead of relying on the operating system timezones.

This will help us decrease spread when someone in the team upgrades their OS, but also between local and CI environments.
