### PR TITLE
invoices: CJK font rendering in browser reader

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -44,7 +44,40 @@ RUN --mount=type=secret,id=IPINFO_ACCESS_TOKEN \
   curl -fsSL "https://ipinfo.io/data/free/country_asn.mmdb?token=${TOKEN}" -o /data/country_asn.mmdb && \
   echo "${EXPECTED_SHA256}  /data/country_asn.mmdb" | sha256sum -c -
 
-# Stage 4: Final production image
+# Stage 4: Download per-script Noto Sans CJK .ttf fonts with checksum validation.
+# URLs are pinned to versioned (v39/v40/v56) gstatic.com paths returned by
+# https://fonts.googleapis.com/css2; those paths are immutable for a given
+# version. We use TrueType (glyf) builds because PDF.js (Firefox) does not
+# render glyphs from the CFF/OTF subsets that ship in fonts-noto-cjk.
+FROM alpine:3.21 AS download-cjk-fonts
+
+RUN apk add --no-cache curl
+
+RUN <<EOF
+set -eu
+mkdir /fonts
+cd /fonts
+curl -fsSLo NotoSansTC-Regular.ttf 'https://fonts.gstatic.com/s/notosanstc/v39/-nFuOG829Oofr2wohFbTp9ifNAn722rq0MXz76Cy_Co.ttf'
+curl -fsSLo NotoSansTC-Bold.ttf    'https://fonts.gstatic.com/s/notosanstc/v39/-nFuOG829Oofr2wohFbTp9ifNAn722rq0MXz70e1_Co.ttf'
+curl -fsSLo NotoSansSC-Regular.ttf 'https://fonts.gstatic.com/s/notosanssc/v40/k3kCo84MPvpLmixcA63oeAL7Iqp5IZJF9bmaG9_FnYw.ttf'
+curl -fsSLo NotoSansSC-Bold.ttf    'https://fonts.gstatic.com/s/notosanssc/v40/k3kCo84MPvpLmixcA63oeAL7Iqp5IZJF9bmaGzjCnYw.ttf'
+curl -fsSLo NotoSansJP-Regular.ttf 'https://fonts.gstatic.com/s/notosansjp/v56/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEj75s.ttf'
+curl -fsSLo NotoSansJP-Bold.ttf    'https://fonts.gstatic.com/s/notosansjp/v56/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFPYk75s.ttf'
+curl -fsSLo NotoSansKR-Regular.ttf 'https://fonts.gstatic.com/s/notosanskr/v39/PbyxFmXiEBPT4ITbgNA5Cgms3VYcOA-vvnIzzuoyeLQ.ttf'
+curl -fsSLo NotoSansKR-Bold.ttf    'https://fonts.gstatic.com/s/notosanskr/v39/PbyxFmXiEBPT4ITbgNA5Cgms3VYcOA-vvnIzzg01eLQ.ttf'
+sha256sum -c <<CHECKSUMS
+619662a0583f38311e92666927e5edbfd30f2a1fbe8593685660bd11bdd46a10  NotoSansTC-Regular.ttf
+33e8464f3432fd9eba5fa6ff74f5fb9ee612cad703877bd71c36e6f167c0a7e3  NotoSansTC-Bold.ttf
+450625c8d46ab3df97b7904ded955ec2746d17ec76740cb1e91d1ba63a0f89af  NotoSansSC-Regular.ttf
+0066a522a1ac007c1d72bc4fccb114f80ff7294641c78cead9715bd14d43b9ea  NotoSansSC-Bold.ttf
+4593dfcdc70ee68852606c90d75dfc6e022feda12780a55615239c53c54ef086  NotoSansJP-Regular.ttf
+a3910e15eea0451ffbea62e894e951ea9f7c812c8b4b5e947593b6ecc2d4b057  NotoSansJP-Bold.ttf
+c733940a7dc687142848b30a491e97138ed58dc58c4cae33c44e3ee52da411cb  NotoSansKR-Regular.ttf
+5ebb0def0fe9e7c853253eca8ec9c1066adc479f2e248533b412ed0c6a663abc  NotoSansKR-Bold.ttf
+CHECKSUMS
+EOF
+
+# Stage 5: Final production image
 FROM --platform=$BUILDPLATFORM python:3.14-slim AS production
 LABEL org.opencontainers.image.source=https://github.com/polarsource/polar
 LABEL org.opencontainers.image.description="Polar"
@@ -66,7 +99,6 @@ RUN --mount=type=bind,source=uv.lock,target=uv.lock \
   git \
   build-essential \
   redis \
-  fonts-noto-cjk \
   libpq-dev \
   && uv sync --no-group dev --frozen \
   && uv tool install tinybird --python 3.13 \
@@ -84,12 +116,14 @@ COPY --from=download-ipinfo /data /data
 ENV POLAR_IP_GEOLOCATION_DATABASE_DIRECTORY_PATH=/data
 ENV POLAR_IP_GEOLOCATION_DATABASE_NAME=country_asn.mmdb
 
+COPY --from=download-cjk-fonts /fonts/ /app/server/polar/invoice/fonts/
+
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}
 
 CMD ["uv", "run", "uvicorn", "polar.app:app", "--host", "0.0.0.0", "--port", "10000", "--limit-max-requests", "50000", "--limit-max-requests-jitter", "10000", "--timeout-graceful-shutdown", "30"]
 
-# Stage 5: Playwright image (for browser automation workers)
+# Stage 6: Playwright image (for browser automation workers)
 FROM production AS playwright
 
 RUN uv run playwright install --with-deps chromium

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -289,21 +289,6 @@ class InvoiceGenerator(FPDF):
     cjk_font_name: ClassVar[str] = "notosanscjk"
     """Font family name for CJK fallback glyphs."""
 
-    cjk_subfont_index_by_country: ClassVar[dict[str, int]] = {
-        "JP": 0,
-        "KR": 1,
-        "CN": 2,
-        "SG": 2,
-        "MY": 2,
-        "TW": 3,
-        "MO": 3,
-        "HK": 4,
-    }
-    """Sub-font index in NotoSansCJK-Regular.ttc per ISO 3166-1 alpha-2 country."""
-
-    cjk_subfont_default_index: ClassVar[int] = 2
-    """Default CJK sub-font index (Simplified Chinese) when country is unmapped."""
-
     base_font_size: ClassVar[int] = 10
     """Base font size in points."""
 
@@ -339,14 +324,6 @@ class InvoiceGenerator(FPDF):
     def has_cjk_fallback_fonts(cls) -> bool:
         return cls.resolve_font_file(cls.cjk_regular_font_files) is not None
 
-    @classmethod
-    def resolve_cjk_subfont_index(cls, country: str | None) -> int:
-        if country is None:
-            return cls.cjk_subfont_default_index
-        return cls.cjk_subfont_index_by_country.get(
-            country, cls.cjk_subfont_default_index
-        )
-
     def __init__(
         self,
         data: Invoice,
@@ -368,22 +345,10 @@ class InvoiceGenerator(FPDF):
         fallback_fonts = [self.hebrew_font_name, self.arabic_font_name]
         cjk_regular_font_file = self.resolve_font_file(self.cjk_regular_font_files)
         if cjk_regular_font_file is not None:
-            cjk_subfont_index = self.resolve_cjk_subfont_index(
-                data.customer_address.country
-            )
-            self.add_font(
-                self.cjk_font_name,
-                fname=cjk_regular_font_file,
-                collection_font_number=cjk_subfont_index,
-            )
+            self.add_font(self.cjk_font_name, fname=cjk_regular_font_file)
             cjk_bold_font_file = self.resolve_font_file(self.cjk_bold_font_files)
             if cjk_bold_font_file is not None:
-                self.add_font(
-                    self.cjk_font_name,
-                    fname=cjk_bold_font_file,
-                    style="B",
-                    collection_font_number=cjk_subfont_index,
-                )
+                self.add_font(self.cjk_font_name, fname=cjk_bold_font_file, style="B")
             fallback_fonts.append(self.cjk_font_name)
         self.set_fallback_fonts(fallback_fonts, exact_match=False)
         self.set_font(self.font_name, size=self.base_font_size)

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -247,56 +247,53 @@ class InvoiceGenerator(FPDF):
     logo: ClassVar[Path] = Path(__file__).parent / "invoice-logo.svg"
     """Path to the logo image for the invoice."""
 
-    regular_font_file = Path(__file__).parent / "fonts/Inter-Regular.ttf"
-    """Path to the regular font file."""
-
-    bold_font_file = Path(__file__).parent / "fonts/Inter-Bold.ttf"
-    """Path to the bold font file."""
-
     font_name: ClassVar[str] = "inter"
-    """Font family name."""
-
-    hebrew_regular_font_file = (
-        Path(__file__).parent / "fonts/NotoSansHebrew-Regular.ttf"
-    )
-    """Path to the Hebrew regular fallback font file."""
-
-    hebrew_bold_font_file = Path(__file__).parent / "fonts/NotoSansHebrew-Bold.ttf"
-    """Path to the Hebrew bold fallback font file."""
+    """Default font family name."""
 
     hebrew_font_name: ClassVar[str] = "notosanshebrew"
     """Font family name for Hebrew fallback glyphs."""
 
-    arabic_regular_font_file = (
-        Path(__file__).parent / "fonts/NotoSansArabic-Regular.ttf"
-    )
-    """Path to the Arabic regular fallback font file."""
-
-    arabic_bold_font_file = Path(__file__).parent / "fonts/NotoSansArabic-Bold.ttf"
-    """Path to the Arabic bold fallback font file."""
-
     arabic_font_name: ClassVar[str] = "notosansarabic"
     """Font family name for Arabic fallback glyphs."""
 
-    cjk_script_font_files: ClassVar[dict[str, tuple[Path, Path]]] = {
-        "tc": (
+    cjk_font_name_prefix: ClassVar[str] = "notosans"
+    """Prefix used to derive the fpdf font family name for each CJK script."""
+
+    cjk_scripts: ClassVar[tuple[str, ...]] = ("tc", "sc", "jp", "kr")
+    """CJK script families we ship per-script TTFs for."""
+
+    font_files: ClassVar[dict[str, tuple[Path, Path]]] = {
+        font_name: (
+            Path(__file__).parent / "fonts/Inter-Regular.ttf",
+            Path(__file__).parent / "fonts/Inter-Bold.ttf",
+        ),
+        hebrew_font_name: (
+            Path(__file__).parent / "fonts/NotoSansHebrew-Regular.ttf",
+            Path(__file__).parent / "fonts/NotoSansHebrew-Bold.ttf",
+        ),
+        arabic_font_name: (
+            Path(__file__).parent / "fonts/NotoSansArabic-Regular.ttf",
+            Path(__file__).parent / "fonts/NotoSansArabic-Bold.ttf",
+        ),
+        # Per-script TTFs, not the unified TTC: PDF.js can't decode the CFF subsets fpdf2 emits.
+        f"{cjk_font_name_prefix}tc": (
             Path(__file__).parent / "fonts/NotoSansTC-Regular.ttf",
             Path(__file__).parent / "fonts/NotoSansTC-Bold.ttf",
         ),
-        "sc": (
+        f"{cjk_font_name_prefix}sc": (
             Path(__file__).parent / "fonts/NotoSansSC-Regular.ttf",
             Path(__file__).parent / "fonts/NotoSansSC-Bold.ttf",
         ),
-        "jp": (
+        f"{cjk_font_name_prefix}jp": (
             Path(__file__).parent / "fonts/NotoSansJP-Regular.ttf",
             Path(__file__).parent / "fonts/NotoSansJP-Bold.ttf",
         ),
-        "kr": (
+        f"{cjk_font_name_prefix}kr": (
             Path(__file__).parent / "fonts/NotoSansKR-Regular.ttf",
             Path(__file__).parent / "fonts/NotoSansKR-Bold.ttf",
         ),
     }
-    """Per-script CJK fallback font files (regular, bold) keyed by short name."""
+    """Font files (regular, bold) keyed by fpdf family name."""
 
     cjk_script_country_map: ClassVar[dict[str, str]] = {
         "JP": "jp",
@@ -312,9 +309,6 @@ class InvoiceGenerator(FPDF):
 
     cjk_default_script: ClassVar[str] = "sc"
     """Default CJK script family when the customer's country is not mapped."""
-
-    cjk_font_name_prefix: ClassVar[str] = "notosans"
-    """Prefix used to derive the fpdf font family name for each script."""
 
     base_font_size: ClassVar[int] = 10
     """Base font size in points."""
@@ -341,22 +335,16 @@ class InvoiceGenerator(FPDF):
     """Height of each row in the totals table in points."""
 
     @classmethod
-    def resolve_font_file(cls, candidates: tuple[Path, ...]) -> Path | None:
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate
-        return None
+    def cjk_font_name_for_script(cls, script: str) -> str:
+        return f"{cls.cjk_font_name_prefix}{script}"
 
     @classmethod
     def has_cjk_fallback_fonts(cls) -> bool:
         return all(
-            regular.exists() and bold.exists()
-            for regular, bold in cls.cjk_script_font_files.values()
+            p.exists()
+            for s in cls.cjk_scripts
+            for p in cls.font_files[cls.cjk_font_name_for_script(s)]
         )
-
-    @classmethod
-    def cjk_font_name_for_script(cls, script: str) -> str:
-        return f"{cls.cjk_font_name_prefix}{script}"
 
     @classmethod
     def resolve_cjk_script(cls, country: str | None) -> str:
@@ -389,31 +377,39 @@ class InvoiceGenerator(FPDF):
     ) -> None:
         super().__init__()
 
-        self.add_font(self.font_name, fname=self.regular_font_file)
-        self.add_font(self.font_name, fname=self.bold_font_file, style="B")
-        self.add_font(self.hebrew_font_name, fname=self.hebrew_regular_font_file)
-        self.add_font(
-            self.hebrew_font_name, fname=self.hebrew_bold_font_file, style="B"
-        )
-        self.add_font(self.arabic_font_name, fname=self.arabic_regular_font_file)
-        self.add_font(
-            self.arabic_font_name, fname=self.arabic_bold_font_file, style="B"
-        )
-        fallback_fonts = [self.hebrew_font_name, self.arabic_font_name]
-        if self.has_cjk_fallback_fonts():
-            for script, (regular, bold) in self.cjk_script_font_files.items():
-                family = self.cjk_font_name_for_script(script)
-                self.add_font(family, fname=regular)
-                self.add_font(family, fname=bold, style="B")
+        # To use a font we first add the font to fpdf, and then we set the
+        # fallback order. Here we load all of the fonts. CJK fonts are
+        # downloaded in the Dockerfile build stage and may be absent in
+        # dev/CI, so skip any family whose files aren't present.
+        self.loaded_font_families: set[str] = set()
+        for family, (regular, bold) in self.font_files.items():
+            if not (regular.exists() and bold.exists()):
+                continue
+            self.add_font(family, fname=regular)
+            self.add_font(family, fname=bold, style="B")
+            self.loaded_font_families.add(family)
 
-            customer_script = self.cjk_script_from_locale(
-                data.customer_locale
-            ) or self.resolve_cjk_script(data.customer_address.country)
-            customer_family = self.cjk_font_name_for_script(customer_script)
-            fallback_fonts.append(customer_family)
-            for script in self.cjk_script_font_files:
-                if script != customer_script:
-                    fallback_fonts.append(self.cjk_font_name_for_script(script))
+        # Fallback order: Hebrew, Arabic, then CJK with the customer's script
+        # first so shared Han chars get the right regional glyph form.
+        # customer locale/country first, and then all other scripts.
+        customer_script = self.cjk_script_from_locale(
+            data.customer_locale
+        ) or self.resolve_cjk_script(data.customer_address.country)
+
+        fallback_fonts = [
+            family
+            for family in [
+                self.hebrew_font_name,
+                self.arabic_font_name,
+                self.cjk_font_name_for_script(customer_script),
+                *(
+                    self.cjk_font_name_for_script(s)
+                    for s in self.cjk_scripts
+                    if s != customer_script
+                ),
+            ]
+            if family in self.loaded_font_families
+        ]
         self.set_fallback_fonts(fallback_fonts, exact_match=False)
         self.set_font(self.font_name, size=self.base_font_size)
 

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -289,6 +289,21 @@ class InvoiceGenerator(FPDF):
     cjk_font_name: ClassVar[str] = "notosanscjk"
     """Font family name for CJK fallback glyphs."""
 
+    cjk_subfont_index_by_country: ClassVar[dict[str, int]] = {
+        "JP": 0,
+        "KR": 1,
+        "CN": 2,
+        "SG": 2,
+        "MY": 2,
+        "TW": 3,
+        "MO": 3,
+        "HK": 4,
+    }
+    """Sub-font index in NotoSansCJK-Regular.ttc per ISO 3166-1 alpha-2 country."""
+
+    cjk_subfont_default_index: ClassVar[int] = 2
+    """Default CJK sub-font index (Simplified Chinese) when country is unmapped."""
+
     base_font_size: ClassVar[int] = 10
     """Base font size in points."""
 
@@ -324,6 +339,14 @@ class InvoiceGenerator(FPDF):
     def has_cjk_fallback_fonts(cls) -> bool:
         return cls.resolve_font_file(cls.cjk_regular_font_files) is not None
 
+    @classmethod
+    def resolve_cjk_subfont_index(cls, country: str | None) -> int:
+        if country is None:
+            return cls.cjk_subfont_default_index
+        return cls.cjk_subfont_index_by_country.get(
+            country, cls.cjk_subfont_default_index
+        )
+
     def __init__(
         self,
         data: Invoice,
@@ -345,10 +368,22 @@ class InvoiceGenerator(FPDF):
         fallback_fonts = [self.hebrew_font_name, self.arabic_font_name]
         cjk_regular_font_file = self.resolve_font_file(self.cjk_regular_font_files)
         if cjk_regular_font_file is not None:
-            self.add_font(self.cjk_font_name, fname=cjk_regular_font_file)
+            cjk_subfont_index = self.resolve_cjk_subfont_index(
+                data.customer_address.country
+            )
+            self.add_font(
+                self.cjk_font_name,
+                fname=cjk_regular_font_file,
+                collection_font_number=cjk_subfont_index,
+            )
             cjk_bold_font_file = self.resolve_font_file(self.cjk_bold_font_files)
             if cjk_bold_font_file is not None:
-                self.add_font(self.cjk_font_name, fname=cjk_bold_font_file, style="B")
+                self.add_font(
+                    self.cjk_font_name,
+                    fname=cjk_bold_font_file,
+                    style="B",
+                    collection_font_number=cjk_subfont_index,
+                )
             fallback_fonts.append(self.cjk_font_name)
         self.set_fallback_fonts(fallback_fonts, exact_match=False)
         self.set_font(self.font_name, size=self.base_font_size)

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -10,7 +10,7 @@ from babel.numbers import format_decimal as _format_decimal
 from babel.numbers import format_percent as _format_percent
 from bidi.algorithm import get_display
 from fpdf import FPDF
-from fpdf.enums import Align, TableBordersLayout, XPos, YPos
+from fpdf.enums import Align, TableBordersLayout, TextEmphasis, XPos, YPos
 from fpdf.fonts import FontFace
 from pydantic import BaseModel
 
@@ -73,6 +73,7 @@ class Invoice(BaseModel):
     customer_name: str
     customer_address: Address
     customer_additional_info: str | None = None
+    customer_locale: str | None = None
     subtotal_amount: int
     applied_balance_amount: int | None = None
     discount_amount: int
@@ -220,6 +221,7 @@ class Invoice(BaseModel):
             customer_name=order.billing_name,
             customer_additional_info=order.tax_id[0] if order.tax_id else None,
             customer_address=order.billing_address,
+            customer_locale=order.customer.locale,
             subtotal_amount=order.subtotal_amount,
             applied_balance_amount=order.applied_balance_amount,
             discount_amount=order.discount_amount,
@@ -362,6 +364,23 @@ class InvoiceGenerator(FPDF):
             return cls.cjk_default_script
         return cls.cjk_script_country_map.get(country, cls.cjk_default_script)
 
+    @classmethod
+    def cjk_script_from_locale(cls, locale: str | None) -> str | None:
+        if not locale:
+            return None
+        parts = locale.replace("_", "-").lower().split("-")
+        language = parts[0]
+        if language == "ja":
+            return "jp"
+        if language == "ko":
+            return "kr"
+        if language == "zh":
+            for tag in parts[1:]:
+                if tag in {"hant", "tw", "hk", "mo"}:
+                    return "tc"
+            return "sc"
+        return None
+
     def __init__(
         self,
         data: Invoice,
@@ -387,7 +406,9 @@ class InvoiceGenerator(FPDF):
                 self.add_font(family, fname=regular)
                 self.add_font(family, fname=bold, style="B")
 
-            customer_script = self.resolve_cjk_script(data.customer_address.country)
+            customer_script = self.cjk_script_from_locale(
+                data.customer_locale
+            ) or self.resolve_cjk_script(data.customer_address.country)
             customer_family = self.cjk_font_name_for_script(customer_script)
             fallback_fonts.append(customer_family)
             for script in self.cjk_script_font_files:
@@ -400,6 +421,26 @@ class InvoiceGenerator(FPDF):
         self.data = data
         self.heading_title = heading_title
         self.add_sandbox_warning = add_sandbox_warning
+
+    def set_font(
+        self,
+        family: str | None = None,
+        style: str | TextEmphasis = "",
+        size: float = 0,
+    ) -> None:
+        # fpdf2's set_font short-circuits when family/style/size match the
+        # currently tracked values. But `current_font` can drift to a
+        # fallback font during fragment rendering (fpdf.py sets
+        # `current_font = frag.font` per fragment), so the next set_font call
+        # for the same family is a no-op and `current_font` stays stale —
+        # causing subsequent ASCII cells to render with the CJK font's
+        # cmap. Re-resolve `current_font` from the canonical font_family +
+        # font_style after delegating, so it always matches the logical
+        # font selection.
+        super().set_font(family, style, size)
+        fontkey = self.font_family + self.font_style
+        if fontkey in self.fonts:
+            self.current_font = self.fonts[fontkey]
 
     def _shape_text(self, text: str) -> str:
         lines = text.split("\n")

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -276,18 +276,43 @@ class InvoiceGenerator(FPDF):
     arabic_font_name: ClassVar[str] = "notosansarabic"
     """Font family name for Arabic fallback glyphs."""
 
-    cjk_regular_font_files: ClassVar[tuple[Path, ...]] = (
-        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
-    )
-    """Candidate paths to the CJK regular fallback font file."""
+    cjk_script_font_files: ClassVar[dict[str, tuple[Path, Path]]] = {
+        "tc": (
+            Path(__file__).parent / "fonts/NotoSansTC-Regular.ttf",
+            Path(__file__).parent / "fonts/NotoSansTC-Bold.ttf",
+        ),
+        "sc": (
+            Path(__file__).parent / "fonts/NotoSansSC-Regular.ttf",
+            Path(__file__).parent / "fonts/NotoSansSC-Bold.ttf",
+        ),
+        "jp": (
+            Path(__file__).parent / "fonts/NotoSansJP-Regular.ttf",
+            Path(__file__).parent / "fonts/NotoSansJP-Bold.ttf",
+        ),
+        "kr": (
+            Path(__file__).parent / "fonts/NotoSansKR-Regular.ttf",
+            Path(__file__).parent / "fonts/NotoSansKR-Bold.ttf",
+        ),
+    }
+    """Per-script CJK fallback font files (regular, bold) keyed by short name."""
 
-    cjk_bold_font_files: ClassVar[tuple[Path, ...]] = (
-        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc"),
-    )
-    """Candidate paths to the CJK bold fallback font file."""
+    cjk_script_country_map: ClassVar[dict[str, str]] = {
+        "JP": "jp",
+        "KR": "kr",
+        "CN": "sc",
+        "SG": "sc",
+        "MY": "sc",
+        "TW": "tc",
+        "MO": "tc",
+        "HK": "tc",
+    }
+    """Map ISO 3166-1 alpha-2 country to the preferred CJK script family."""
 
-    cjk_font_name: ClassVar[str] = "notosanscjk"
-    """Font family name for CJK fallback glyphs."""
+    cjk_default_script: ClassVar[str] = "sc"
+    """Default CJK script family when the customer's country is not mapped."""
+
+    cjk_font_name_prefix: ClassVar[str] = "notosans"
+    """Prefix used to derive the fpdf font family name for each script."""
 
     base_font_size: ClassVar[int] = 10
     """Base font size in points."""
@@ -322,7 +347,20 @@ class InvoiceGenerator(FPDF):
 
     @classmethod
     def has_cjk_fallback_fonts(cls) -> bool:
-        return cls.resolve_font_file(cls.cjk_regular_font_files) is not None
+        return all(
+            regular.exists() and bold.exists()
+            for regular, bold in cls.cjk_script_font_files.values()
+        )
+
+    @classmethod
+    def cjk_font_name_for_script(cls, script: str) -> str:
+        return f"{cls.cjk_font_name_prefix}{script}"
+
+    @classmethod
+    def resolve_cjk_script(cls, country: str | None) -> str:
+        if country is None:
+            return cls.cjk_default_script
+        return cls.cjk_script_country_map.get(country, cls.cjk_default_script)
 
     def __init__(
         self,
@@ -343,13 +381,18 @@ class InvoiceGenerator(FPDF):
             self.arabic_font_name, fname=self.arabic_bold_font_file, style="B"
         )
         fallback_fonts = [self.hebrew_font_name, self.arabic_font_name]
-        cjk_regular_font_file = self.resolve_font_file(self.cjk_regular_font_files)
-        if cjk_regular_font_file is not None:
-            self.add_font(self.cjk_font_name, fname=cjk_regular_font_file)
-            cjk_bold_font_file = self.resolve_font_file(self.cjk_bold_font_files)
-            if cjk_bold_font_file is not None:
-                self.add_font(self.cjk_font_name, fname=cjk_bold_font_file, style="B")
-            fallback_fonts.append(self.cjk_font_name)
+        if self.has_cjk_fallback_fonts():
+            for script, (regular, bold) in self.cjk_script_font_files.items():
+                family = self.cjk_font_name_for_script(script)
+                self.add_font(family, fname=regular)
+                self.add_font(family, fname=bold, style="B")
+
+            customer_script = self.resolve_cjk_script(data.customer_address.country)
+            customer_family = self.cjk_font_name_for_script(customer_script)
+            fallback_fonts.append(customer_family)
+            for script in self.cjk_script_font_files:
+                if script != customer_script:
+                    fallback_fonts.append(self.cjk_font_name_for_script(script))
         self.set_fallback_fonts(fallback_fonts, exact_match=False)
         self.set_font(self.font_name, size=self.base_font_size)
 

--- a/server/polar/receipt/generator.py
+++ b/server/polar/receipt/generator.py
@@ -128,6 +128,7 @@ class Receipt(Invoice):
             customer_name=order.billing_name,
             customer_additional_info=customer_additional_info,
             customer_address=order.billing_address,
+            customer_locale=order.customer.locale,
             subtotal_amount=order.subtotal_amount,
             applied_balance_amount=order.applied_balance_amount,
             discount_amount=order.discount_amount,

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -233,23 +233,6 @@ Thank you for your business!
                 reason="CJK fallback fonts are not installed",
             ),
         ),
-        pytest.param(
-            {
-                "customer_name": "鳴眾科技股份有限公司",
-                "customer_address": Address(
-                    line1="10 F., No. 201",
-                    line2="Sec. 3, Nanjing E. Rd., Zhongshan Dist.",
-                    city="Taipei City",
-                    postal_code="104",
-                    country=CountryAlpha2("TW"),
-                ),
-            },
-            "unicode_cjk_traditional",
-            marks=pytest.mark.skipif(
-                not InvoiceGenerator.has_cjk_fallback_fonts(),
-                reason="CJK fallback fonts are not installed",
-            ),
-        ),
     ],
 )
 def test_generator(overrides: dict[str, Any], id: str, invoice: Invoice) -> None:
@@ -261,23 +244,6 @@ def test_generator(overrides: dict[str, Any], id: str, invoice: Invoice) -> None
     generator.output(str(path))
 
     assert path.exists()
-
-
-@pytest.mark.parametrize(
-    ("country", "expected_index"),
-    [
-        ("JP", 0),
-        ("KR", 1),
-        ("CN", 2),
-        ("SG", 2),
-        ("TW", 3),
-        ("HK", 4),
-        ("US", 2),
-        (None, 2),
-    ],
-)
-def test_resolve_cjk_subfont_index(country: str | None, expected_index: int) -> None:
-    assert InvoiceGenerator.resolve_cjk_subfont_index(country) == expected_index
 
 
 def test_generator_registers_unicode_fallback_fonts(invoice: Invoice) -> None:

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -1,4 +1,6 @@
 import datetime
+import re
+import zlib
 from pathlib import Path
 from typing import Any
 
@@ -316,3 +318,144 @@ def test_generator_uses_traditional_chinese_for_tw_customer(invoice: Invoice) ->
     tc_family = generator.cjk_font_name_for_script("tc")
     assert generator.get_fallback_font("範") == tc_family
     assert generator.get_fallback_font("範", style="B") == f"{tc_family}B"
+
+
+@pytest.mark.skipif(
+    not InvoiceGenerator.has_cjk_fallback_fonts(),
+    reason="CJK fallback fonts are not installed",
+)
+def test_generator_locale_overrides_country_for_cjk_script(invoice: Invoice) -> None:
+    generator = InvoiceGenerator(
+        invoice.model_copy(
+            update={
+                "customer_name": "山田太郎",
+                "customer_locale": "ja-JP",
+                "customer_address": Address(
+                    line1="123 Example St",
+                    city="Taipei City",
+                    postal_code="100",
+                    country=CountryAlpha2("TW"),
+                ),
+            }
+        )
+    )
+
+    jp_family = generator.cjk_font_name_for_script("jp")
+    assert generator.get_fallback_font("山") == jp_family
+    assert generator.get_fallback_font("山", style="B") == f"{jp_family}B"
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("en-US", None),
+        ("ja", "jp"),
+        ("ja-JP", "jp"),
+        ("ko", "kr"),
+        ("ko-KR", "kr"),
+        ("zh", "sc"),
+        ("zh-CN", "sc"),
+        ("zh-Hans", "sc"),
+        ("zh-SG", "sc"),
+        ("zh-TW", "tc"),
+        ("zh-HK", "tc"),
+        ("zh-MO", "tc"),
+        ("zh-Hant", "tc"),
+        ("zh_TW", "tc"),
+        ("ZH-tw", "tc"),
+    ],
+)
+def test_cjk_script_from_locale(locale: str | None, expected: str | None) -> None:
+    assert InvoiceGenerator.cjk_script_from_locale(locale) == expected
+
+
+@pytest.mark.skipif(
+    not InvoiceGenerator.has_cjk_fallback_fonts(),
+    reason="CJK fallback fonts are not installed",
+)
+def test_generator_renders_amounts_in_primary_font_after_cjk(
+    invoice: Invoice, tmp_path: Path
+) -> None:
+    """fpdf2's set_font short-circuits when family/style/size match, but
+    current_font can drift to a fallback after a CJK fragment renders. The
+    set_font override on InvoiceGenerator force-resolves current_font so
+    subsequent ASCII cells (quantity, unit price, amount) render with Inter
+    and not the CJK font that was used for the description.
+    """
+    generator = InvoiceGenerator(
+        invoice.model_copy(
+            update={
+                "customer_name": "Yamada Taro",
+                "customer_locale": "ja-JP",
+                "customer_address": Address(
+                    line1="1-1 Chiyoda",
+                    city="Tokyo",
+                    postal_code="100-0001",
+                    country=CountryAlpha2("JP"),
+                ),
+                "currency": "jpy",
+                "items": [
+                    InvoiceItem(
+                        description="年間プラン",
+                        quantity=1,
+                        unit_amount=10_000,
+                        amount=10_000,
+                    ),
+                ],
+            }
+        )
+    )
+    generator.generate()
+    path = tmp_path / "amounts.pdf"
+    generator.output(str(path))
+
+    raw = path.read_bytes()
+
+    font_objs: dict[int, str] = {}
+    for obj_match in re.finditer(rb"(\d+) 0 obj\b(.*?)endobj", raw, re.DOTALL):
+        body = obj_match.group(2)
+        if not re.search(rb"/Type\s*/Font\b", body):
+            continue
+        base_font = re.search(rb"/BaseFont\s*/([^\s/<>]+)", body)
+        if base_font:
+            font_objs[int(obj_match.group(1))] = base_font.group(1).decode()
+
+    font_alias_to_basefont: dict[str, str] = {}
+    for entry in re.finditer(rb"/(F\d+)\s+(\d+)\s+0\s+R", raw):
+        alias = entry.group(1).decode()
+        ref = int(entry.group(2))
+        if ref in font_objs:
+            font_alias_to_basefont.setdefault(alias, font_objs[ref])
+
+    page_stream_match = re.search(rb"\b4 0 obj\b(.*?)endobj", raw, re.DOTALL)
+    assert page_stream_match is not None
+    obj_body = page_stream_match.group(1)
+    stream_start = re.search(rb"stream\r?\n", obj_body)
+    stream_end = obj_body.rfind(b"\nendstream")
+    assert stream_start is not None
+    assert stream_end > 0
+    decompressed = zlib.decompress(obj_body[stream_start.end() : stream_end]).decode(
+        "latin1", errors="replace"
+    )
+
+    cjk_basefont_substrings = ("NotoSansTC", "NotoSansSC", "NotoSansJP", "NotoSansKR")
+    cjk_aliases = {
+        alias
+        for alias, base_font in font_alias_to_basefont.items()
+        if any(token in base_font for token in cjk_basefont_substrings)
+    }
+
+    cjk_tf_ops = [
+        tf_match.group(1)
+        for tf_match in re.finditer(r"/(F\d+)\s+[\d.]+\s+Tf", decompressed)
+        if tf_match.group(1) in cjk_aliases
+    ]
+    assert cjk_tf_ops, "Expected the CJK font to be used for the description cell"
+    assert len(cjk_tf_ops) == 1, (
+        f"Expected the CJK font to be selected exactly once (for the "
+        f"description cell), but got {len(cjk_tf_ops)} Tf ops referencing "
+        f"{cjk_tf_ops}. This means current_font drifted after the "
+        f"description cell and amounts rendered in the CJK font."
+    )

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -233,6 +233,23 @@ Thank you for your business!
                 reason="CJK fallback fonts are not installed",
             ),
         ),
+        pytest.param(
+            {
+                "customer_name": "鳴眾科技股份有限公司",
+                "customer_address": Address(
+                    line1="10 F., No. 201",
+                    line2="Sec. 3, Nanjing E. Rd., Zhongshan Dist.",
+                    city="Taipei City",
+                    postal_code="104",
+                    country=CountryAlpha2("TW"),
+                ),
+            },
+            "unicode_cjk_traditional",
+            marks=pytest.mark.skipif(
+                not InvoiceGenerator.has_cjk_fallback_fonts(),
+                reason="CJK fallback fonts are not installed",
+            ),
+        ),
     ],
 )
 def test_generator(overrides: dict[str, Any], id: str, invoice: Invoice) -> None:
@@ -244,6 +261,23 @@ def test_generator(overrides: dict[str, Any], id: str, invoice: Invoice) -> None
     generator.output(str(path))
 
     assert path.exists()
+
+
+@pytest.mark.parametrize(
+    ("country", "expected_index"),
+    [
+        ("JP", 0),
+        ("KR", 1),
+        ("CN", 2),
+        ("SG", 2),
+        ("TW", 3),
+        ("HK", 4),
+        ("US", 2),
+        (None, 2),
+    ],
+)
+def test_resolve_cjk_subfont_index(country: str | None, expected_index: int) -> None:
+    assert InvoiceGenerator.resolve_cjk_subfont_index(country) == expected_index
 
 
 def test_generator_registers_unicode_fallback_fonts(invoice: Invoice) -> None:

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -273,15 +273,46 @@ def test_generator_registers_unicode_fallback_fonts(invoice: Invoice) -> None:
         f"{generator.arabic_font_name}B"
     )
     if InvoiceGenerator.has_cjk_fallback_fonts():
-        assert generator.get_fallback_font("你") == generator.cjk_font_name
-        assert generator.get_fallback_font("안") == generator.cjk_font_name
-        assert generator.get_fallback_font("日") == generator.cjk_font_name
-        assert generator.get_fallback_font("你", style="B") == (
-            f"{generator.cjk_font_name}B"
+        # Default invoice has a US customer, so the SC family is preferred
+        # first; characters shared across scripts (Han) resolve to it. KR is
+        # the only family with Hangul.
+        sc_family = generator.cjk_font_name_for_script("sc")
+        kr_family = generator.cjk_font_name_for_script("kr")
+        assert generator.get_fallback_font("你") == sc_family
+        assert generator.get_fallback_font("日") == sc_family
+        assert generator.get_fallback_font("안") == kr_family
+        assert generator.get_fallback_font("你", style="B") == f"{sc_family}B"
+        assert generator.get_fallback_font("日", style="B") == f"{sc_family}B"
+        assert generator.get_fallback_font("안", style="B") == f"{kr_family}B"
+
+
+@pytest.mark.skipif(
+    not InvoiceGenerator.has_cjk_fallback_fonts(),
+    reason="CJK fallback fonts are not installed",
+)
+def test_generator_uses_traditional_chinese_for_tw_customer(invoice: Invoice) -> None:
+    generator = InvoiceGenerator(
+        invoice.model_copy(
+            update={
+                "customer_name": "範例股份有限公司",
+                "customer_address": Address(
+                    line1="123 Example St",
+                    city="Taipei City",
+                    postal_code="100",
+                    country=CountryAlpha2("TW"),
+                ),
+                "items": [
+                    InvoiceItem(
+                        description="年度訂閱",
+                        quantity=1,
+                        unit_amount=100_00,
+                        amount=100_00,
+                    ),
+                ],
+            }
         )
-        assert generator.get_fallback_font("안", style="B") == (
-            f"{generator.cjk_font_name}B"
-        )
-        assert generator.get_fallback_font("日", style="B") == (
-            f"{generator.cjk_font_name}B"
-        )
+    )
+
+    tc_family = generator.cjk_font_name_for_script("tc")
+    assert generator.get_fallback_font("範") == tc_family
+    assert generator.get_fallback_font("範", style="B") == f"{tc_family}B"


### PR DESCRIPTION
Currently it the PDFs render glyphs correctly in PDF readers that support it (e.g. Preview). With this change it should also work in other readers such as PDF.js in Firefox