### PR TITLE
refactor(organization): flatten review checklist and add status mock switch

### DIFF
--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from uuid import UUID
 
 import httpx
@@ -648,16 +649,25 @@ async def get_review_status(
 )
 async def get_review(
     authz: AuthorizeOrgAccess,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    status: Literal["pass", "fail"] | None = Query(
+        None,
+        description=(
+            "STUB: switch the mocked response. `pass` returns an all-passed "
+            "checklist, `fail` returns an all-failed one. Omit for the default "
+            "(all-passed) mock."
+        ),
+    ),
 ) -> OrganizationReviewState:
     """Get the merchant self-review checklist state.
 
     Powers the new account review UI: pre-submission gating checks plus,
     after submission, the AI verdict and appeal state. Currently returns
-    a hardcoded all-passed snapshot — real check logic will land
-    incrementally without changing the response shape.
+    a hardcoded mock — `?status=pass|fail` switches between the two
+    canned responses while the real check logic is built out.
     """
-    return await organization_service.get_review_state(session, authz.organization)
+    return await organization_service.get_review_state(
+        authz.organization, status=status
+    )
 
 
 @router.post(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -551,7 +551,6 @@ class OrganizationReviewStatus(Schema):
 class OrganizationReviewCheckKey(StrEnum):
     """Stable identifiers for each check. Adding a new key is a coordinated FE+BE change."""
 
-    IDENTITY = "identity"
     IDENTITY_EMAIL = "identity.email"
     IDENTITY_SOCIAL_LINKS = "identity.social_links"
     IDENTITY_STRIPE_VERIFICATION = "identity.stripe_identity_verification"
@@ -586,17 +585,13 @@ class OrganizationReviewCheckReason(StrEnum):
 
 
 class OrganizationReviewCheck(Schema):
-    """A single item in the self-review checklist. Recursive via `children`."""
+    """A single item in the self-review checklist."""
 
     key: OrganizationReviewCheckKey
     status: OrganizationReviewCheckStatus
     reasons: list[OrganizationReviewCheckReason] = Field(
         default_factory=list,
         description="Reasons for the current status. Empty when `passed`.",
-    )
-    children: list["OrganizationReviewCheck"] = Field(
-        default_factory=list,
-        description="Nested sub-checks. Empty for leaves.",
     )
 
 
@@ -619,10 +614,6 @@ class OrganizationReviewState(Schema):
     verdict: Literal["pass", "fail"] | None = None
     appeal: OrganizationReviewAppeal | None = None
     preliminary_steps: list[OrganizationReviewCheck] = Field(default_factory=list)
-
-
-# Required for the recursive `children` field.
-OrganizationReviewCheck.model_rebuild()
 
 
 class OrganizationDeletionBlockedReason(StrEnum):

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
-from typing import Any, cast
+from typing import Any, Literal, cast
 from uuid import UUID
 
 import structlog
@@ -70,6 +70,7 @@ from .schemas import (
     OrganizationDeletionBlockedReason,
     OrganizationReviewCheck,
     OrganizationReviewCheckKey,
+    OrganizationReviewCheckReason,
     OrganizationReviewCheckStatus,
     OrganizationReviewState,
     OrganizationReviewSubmissionBody,
@@ -1099,45 +1100,48 @@ class OrganizationService:
         return await repository.get_by_organization(organization.id)
 
     async def get_review_state(
-        self, session: AsyncReadSession, organization: Organization
+        self,
+        organization: Organization,
+        *,
+        status: Literal["pass", "fail"] | None = None,
     ) -> OrganizationReviewState:
         """Build the merchant self-review checklist state.
 
-        STUB: returns hardcoded "all passed" data so the new dashboard UI can
+        STUB: returns one of two hardcoded mocks so the new dashboard UI can
         integrate against the contract while the real check logic is built
         out incrementally. The shape is final; only the values are dummy.
+
+        - ``status="pass"`` (default): every check ``passed``.
+        - ``status="fail"``: every check ``failed`` with a representative reason.
         """
+        is_fail = status == "fail"
+        check_status = (
+            OrganizationReviewCheckStatus.FAILED
+            if is_fail
+            else OrganizationReviewCheckStatus.PASSED
+        )
+        identity_reasons = (
+            [OrganizationReviewCheckReason.IDENTITY_REJECTED] if is_fail else []
+        )
+        payout_reasons = (
+            [OrganizationReviewCheckReason.PAYOUT_ACCOUNT_REQUIREMENTS_DUE]
+            if is_fail
+            else []
+        )
+        checks = [
+            (OrganizationReviewCheckKey.IDENTITY_EMAIL, identity_reasons),
+            (OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS, identity_reasons),
+            (OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION, identity_reasons),
+            (OrganizationReviewCheckKey.PRODUCT_DESCRIPTION, []),
+            (OrganizationReviewCheckKey.PAYOUT_ACCOUNT, payout_reasons),
+        ]
         preliminary_steps = [
-            OrganizationReviewCheck(
-                key=OrganizationReviewCheckKey.IDENTITY,
-                status=OrganizationReviewCheckStatus.PASSED,
-                children=[
-                    OrganizationReviewCheck(
-                        key=OrganizationReviewCheckKey.IDENTITY_EMAIL,
-                        status=OrganizationReviewCheckStatus.PASSED,
-                    ),
-                    OrganizationReviewCheck(
-                        key=OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS,
-                        status=OrganizationReviewCheckStatus.PASSED,
-                    ),
-                    OrganizationReviewCheck(
-                        key=OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION,
-                        status=OrganizationReviewCheckStatus.PASSED,
-                    ),
-                ],
-            ),
-            OrganizationReviewCheck(
-                key=OrganizationReviewCheckKey.PRODUCT_DESCRIPTION,
-                status=OrganizationReviewCheckStatus.PASSED,
-            ),
-            OrganizationReviewCheck(
-                key=OrganizationReviewCheckKey.PAYOUT_ACCOUNT,
-                status=OrganizationReviewCheckStatus.PASSED,
-            ),
+            OrganizationReviewCheck(key=key, status=check_status, reasons=reasons)
+            for key, reasons in checks
         ]
 
         return OrganizationReviewState(
-            can_submit=True,
+            can_submit=not is_fail,
             submitted_at=None,
             verdict=None,
             appeal=None,

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -959,20 +959,58 @@ class TestGetReview:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        """Returns the v1 checklist shape: 3 top-level checks with identity expanded."""
+        """Returns the v1 checklist shape: a flat list of leaf checks."""
         response = await client.get(f"/v1/organizations/{organization.id}/review")
 
         assert response.status_code == 200
         json = response.json()
 
         assert [step["key"] for step in json["preliminary_steps"]] == [
-            "identity",
-            "product_description",
-            "payout_account",
-        ]
-        identity = json["preliminary_steps"][0]
-        assert [child["key"] for child in identity["children"]] == [
             "identity.email",
             "identity.social_links",
             "identity.stripe_identity_verification",
+            "product_description",
+            "payout_account",
         ]
+
+    @pytest.mark.auth
+    @pytest.mark.parametrize(
+        ("status", "expected_check_status", "expected_can_submit"),
+        [("pass", "passed", True), ("fail", "failed", False)],
+    )
+    async def test_status_mock(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        status: str,
+        expected_check_status: str,
+        expected_can_submit: bool,
+    ) -> None:
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/review",
+            params={"status": status},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["can_submit"] is expected_can_submit
+        assert len(json["preliminary_steps"]) == 5
+        assert all(
+            step["status"] == expected_check_status
+            for step in json["preliminary_steps"]
+        )
+
+    @pytest.mark.auth
+    async def test_status_invalid(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/review",
+            params={"status": "passed"},
+        )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Drops the recursive `children` field on `OrganizationReviewCheck` and the `IDENTITY` parent grouping key from `OrganizationReviewCheckKey`. The frontend is now responsible for any visual grouping (using the dotted key prefixes such as `identity.email`).
- Adds a `status=pass|fail` query param to `GET /v1/organizations/{id}/review` that switches between two hardcoded mock responses (all-passed vs. all-failed) while the real check logic is being built out incrementally.
- The endpoint no longer takes a DB session dependency since the stub does no DB work — it'll be added back when the real implementation lands.

## Test plan

- [x] `uv run task lint` — passes
- [x] `uv run task lint_types` — passes
- [x] `uv run pytest tests/organization/test_endpoints.py::TestGetReview` — 7 tests pass (anonymous, not-member, valid flat-list response, parametrized pass/fail mock, invalid status → 422)