### PR TITLE
feat(receipts): add render worker

### DIFF
--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -43,6 +43,7 @@ x-common-backend-env: &common-backend-env
   POLAR_S3_FILES_BUCKET_NAME: ${POLAR_S3_FILES_BUCKET_NAME:-polar-s3}
   POLAR_S3_FILES_PUBLIC_BUCKET_NAME: ${POLAR_S3_FILES_PUBLIC_BUCKET_NAME:-polar-s3-public}
   POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME: ${POLAR_S3_FILES_BUCKET_NAME:-polar-s3}
+  POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME: ${POLAR_S3_FILES_BUCKET_NAME:-polar-s3}
   POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME: ${POLAR_S3_FILES_BUCKET_NAME:-polar-s3}
   # CORS and allowed hosts - configured for Docker networking
   POLAR_CORS_ORIGINS: '["http://localhost:${WEB_PORT:-3000}", "http://127.0.0.1:${WEB_PORT:-3000}", "http://web:3000"]'

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -341,6 +341,7 @@ class Settings(BaseSettings):
 
     # Invoices
     S3_CUSTOMER_INVOICES_BUCKET_NAME: str = "polar-customer-invoices"
+    S3_CUSTOMER_RECEIPTS_BUCKET_NAME: str = "polar-customer-receipts"
     S3_PAYOUT_INVOICES_BUCKET_NAME: str = "polar-payout-invoices"
     INVOICES_NAME: str = "Polar Software, Inc."
     INVOICES_ADDRESS: Address = Address(

--- a/server/polar/integrations/aws/s3/service.py
+++ b/server/polar/integrations/aws/s3/service.py
@@ -46,6 +46,7 @@ class S3Service:
         path: str,
         mime_type: str,
         checksum_sha256_base64: str | None = None,
+        cache_control: str | None = None,
     ) -> str:
         """
         Uploads a file directly to S3.
@@ -64,6 +65,9 @@ class S3Service:
 
         if checksum_sha256_base64:
             request["ChecksumSHA256"] = checksum_sha256_base64
+
+        if cache_control is not None:
+            request["CacheControl"] = cache_control
 
         response = self.client.put_object(**request)
         return path

--- a/server/polar/receipt/service.py
+++ b/server/polar/receipt/service.py
@@ -1,10 +1,27 @@
+import asyncio
+
+from polar.config import settings
 from polar.customer.repository import CustomerRepository
+from polar.integrations.aws.s3 import S3Service
 from polar.kit.db.postgres import AsyncSession
+from polar.kit.utils import utc_now
+from polar.locker import Locker
 from polar.models import Order
 from polar.order.repository import OrderRepository
 from polar.payment.repository import PaymentRepository
+from polar.refund.repository import RefundRepository
+
+from .generator import Receipt
+from .render import render_receipt_pdf
 
 RECEIPT_NUMBER_PREFIX = "RCPT"
+# `private` keeps PII out of shared caches; the unique S3 key per render
+# makes `immutable` safe for the browser cache.
+RECEIPT_CACHE_CONTROL = "private, max-age=31536000, immutable"
+# 120s covers the worst-case render+upload; 1s acquire window means a
+# concurrent render triggers a retry rather than tying up workers.
+RECEIPT_RENDER_LOCK_TIMEOUT = 120
+RECEIPT_RENDER_LOCK_BLOCKING_TIMEOUT = 1
 
 
 class ReceiptService:
@@ -42,6 +59,54 @@ class ReceiptService:
         )
 
         return order
+
+    async def _create_order_receipt(self, session: AsyncSession, order: Order) -> str:
+        """Render the receipt PDF and upload it to S3, returning the new key."""
+        payment_repository = PaymentRepository.from_session(session)
+        payment = await payment_repository.get_succeeded_by_order(order.id)
+        payments = [payment] if payment is not None else []
+
+        refund_repository = RefundRepository.from_session(session)
+        refunds = list(await refund_repository.get_succeeded_by_order(order.id))
+
+        receipt = Receipt.from_order(order, payments, refunds)
+        pdf_bytes = await render_receipt_pdf(receipt)
+
+        timestamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
+        key = f"{order.organization_id}/{order.id}/{timestamp}.pdf"
+
+        s3 = S3Service(settings.S3_CUSTOMER_RECEIPTS_BUCKET_NAME)
+        await asyncio.to_thread(
+            s3.upload,
+            pdf_bytes,
+            key,
+            "application/pdf",
+            cache_control=RECEIPT_CACHE_CONTROL,
+        )
+        return key
+
+    async def generate_order_receipt(
+        self, session: AsyncSession, locker: Locker, order: Order
+    ) -> Order:
+        """Render the receipt under a cross-process lock and persist
+        ``Order.receipt_path``. Raises ``TimeoutLockError`` when another
+        worker is already rendering — caller decides whether to retry.
+        """
+        if order.receipt_number is None:
+            return order
+
+        lock_name = f"receipt:render:{order.id}"
+        async with locker.lock(
+            lock_name,
+            timeout=RECEIPT_RENDER_LOCK_TIMEOUT,
+            blocking_timeout=RECEIPT_RENDER_LOCK_BLOCKING_TIMEOUT,
+        ):
+            key = await self._create_order_receipt(session, order)
+            order_repository = OrderRepository.from_session(session)
+            order = await order_repository.update(
+                order, update_dict={"receipt_path": key}
+            )
+            return order
 
 
 receipt = ReceiptService()

--- a/server/polar/receipt/tasks.py
+++ b/server/polar/receipt/tasks.py
@@ -1,0 +1,58 @@
+import uuid
+
+import structlog
+
+from polar.exceptions import PolarTaskError
+from polar.locker import Locker, TimeoutLockError
+from polar.logging import Logger
+from polar.order.repository import OrderRepository
+from polar.worker import (
+    AsyncSessionMaker,
+    RedisMiddleware,
+    TaskPriority,
+    actor,
+    enqueue_job,
+)
+
+from .service import receipt as receipt_service
+
+log: Logger = structlog.get_logger()
+
+RENDER_RETRY_DELAY_MS = 5_000
+
+
+class ReceiptTaskError(PolarTaskError): ...
+
+
+class ReceiptOrderDoesNotExist(ReceiptTaskError):
+    def __init__(self, order_id: uuid.UUID) -> None:
+        self.order_id = order_id
+        super().__init__(f"Order {order_id} does not exist.")
+
+
+@actor(
+    actor_name="receipt.render",
+    priority=TaskPriority.LOW,
+    time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
+)
+async def receipt_render(order_id: uuid.UUID) -> None:
+    locker = Locker(RedisMiddleware.get())
+    async with AsyncSessionMaker() as session:
+        repository = OrderRepository.from_session(session)
+        order = await repository.get_by_id(
+            order_id, options=repository.get_eager_options()
+        )
+        if order is None:
+            raise ReceiptOrderDoesNotExist(order_id)
+
+        try:
+            await receipt_service.generate_order_receipt(session, locker, order)
+        except TimeoutLockError:
+            # Another worker is already rendering. Re-enqueue with a delay
+            # so the latest refund state isn't lost when their render
+            # completes against an older snapshot.
+            log.info(
+                "receipt render: lock contention, re-enqueueing",
+                order_id=str(order_id),
+            )
+            enqueue_job("receipt.render", order_id, delay=RENDER_RETRY_DELAY_MS)

--- a/server/polar/refund/repository.py
+++ b/server/polar/refund/repository.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import Select
@@ -13,6 +14,7 @@ from polar.kit.repository import (
     SortingClause,
 )
 from polar.models import Refund
+from polar.models.refund import RefundStatus
 
 from .sorting import RefundSortProperty
 
@@ -34,6 +36,17 @@ class RefundRepository(
             .options(*options)
         )
         return await self.get_one_or_none(statement)
+
+    async def get_succeeded_by_order(self, order_id: UUID) -> Sequence[Refund]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Refund.order_id == order_id,
+                Refund.status == RefundStatus.succeeded,
+            )
+            .order_by(Refund.created_at.asc())
+        )
+        return await self.get_all(statement)
 
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -47,6 +47,7 @@ from polar.transaction.service.refund import (
 )
 from polar.wallet.service import wallet as wallet_service
 from polar.webhook.service import webhook as webhook_service
+from polar.worker import enqueue_job
 
 from .repository import RefundRepository
 from .schemas import RefundCreate
@@ -544,6 +545,9 @@ class RefundService:
             await webhook_service.send(
                 session, order.organization, WebhookEventType.order_refunded, order
             )
+
+            if order.receipt_number is not None:
+                enqueue_job("receipt.render", order.id)
 
     async def _on_updated(self, session: AsyncSession, refund: Refund) -> None:
         if refund.organization is not None:

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -27,6 +27,7 @@ from polar.organization_review import tasks as organization_review
 from polar.payout import tasks as payout
 from polar.personal_access_token import tasks as personal_access_token
 from polar.processor_transaction import tasks as processor_transaction
+from polar.receipt import tasks as receipt
 from polar.subscription import tasks as subscription
 from polar.transaction import tasks as transaction
 from polar.user import tasks as user
@@ -59,6 +60,7 @@ __all__ = [
     "personal_access_token",
     "polar_self",
     "processor_transaction",
+    "receipt",
     "slo_report",
     "stripe",
     "subscription",

--- a/server/tests/receipt/test_service.py
+++ b/server/tests/receipt/test_service.py
@@ -1,6 +1,9 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.db.postgres import AsyncSession
+from polar.locker import Locker
 from polar.models import Account, Customer, Organization
 from polar.receipt.service import receipt as receipt_service
 from tests.fixtures.database import SaveFixture
@@ -9,6 +12,7 @@ from tests.fixtures.random_objects import (
     create_order,
     create_organization,
     create_payment,
+    create_refund,
 )
 
 
@@ -97,3 +101,157 @@ class TestAllocate:
         await session.refresh(customer)
         # Counter only advanced once.
         assert customer.receipt_next_number == 2
+
+
+@pytest.mark.asyncio
+class TestDoRender:
+    async def test_renders_and_uploads(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"receipts_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="render@example.com"
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            billing_name="Render Buyer",
+            billing_address=Address(
+                line1="1 Test Way",
+                city="SF",
+                state="CA",
+                postal_code="94104",
+                country=CountryAlpha2("US"),
+            ),
+        )
+        await create_payment(save_fixture, organization, order=order)
+        await receipt_service.allocate(session, order)
+        assert order.receipt_number is not None
+
+        render_mock = mocker.patch(
+            "polar.receipt.service.render_receipt_pdf",
+            return_value=b"%PDF-fake",
+        )
+        s3_class_mock = mocker.patch("polar.receipt.service.S3Service")
+        upload_mock = s3_class_mock.return_value.upload
+
+        key = await receipt_service._create_order_receipt(session, order)
+
+        render_mock.assert_called_once()
+        upload_mock.assert_called_once_with(
+            b"%PDF-fake",
+            key,
+            "application/pdf",
+            cache_control="private, max-age=31536000, immutable",
+        )
+        assert key.startswith(f"{order.organization_id}/{order.id}/")
+        assert key.endswith(".pdf")
+
+    async def test_renders_with_refunds(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"receipts_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="ref@example.com"
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            billing_name="Refund Buyer",
+            billing_address=Address(
+                line1="1 Test Way",
+                city="SF",
+                state="CA",
+                postal_code="94104",
+                country=CountryAlpha2("US"),
+            ),
+        )
+        payment = await create_payment(save_fixture, organization, order=order)
+        await receipt_service.allocate(session, order)
+
+        await create_refund(save_fixture, order=order, payment=payment, amount=500)
+
+        render_mock = mocker.patch(
+            "polar.receipt.service.render_receipt_pdf",
+            return_value=b"%PDF-fake",
+        )
+        mocker.patch("polar.receipt.service.S3Service")
+
+        await receipt_service._create_order_receipt(session, order)
+
+        render_mock.assert_called_once()
+        receipt_arg = render_mock.call_args.args[0]
+        assert len(receipt_arg.refunds) == 1
+        assert receipt_arg.refunds[0].amount == 500
+
+
+@pytest.mark.asyncio
+class TestGenerateOrderReceipt:
+    async def test_no_op_when_no_receipt_number(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        locker: Locker,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        assert order.receipt_number is None
+
+        create_mock = mocker.patch.object(receipt_service, "_create_order_receipt")
+
+        result = await receipt_service.generate_order_receipt(session, locker, order)
+
+        create_mock.assert_not_called()
+        assert result.receipt_path is None
+
+    async def test_persists_receipt_path(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        locker: Locker,
+        mocker: MockerFixture,
+    ) -> None:
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"receipts_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="generate@example.com"
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            billing_name="Buyer",
+            billing_address=Address(
+                line1="1 Test Way",
+                city="SF",
+                state="CA",
+                postal_code="94104",
+                country=CountryAlpha2("US"),
+            ),
+        )
+        await create_payment(save_fixture, organization, order=order)
+        await receipt_service.allocate(session, order)
+
+        mocker.patch.object(
+            receipt_service,
+            "_create_order_receipt",
+            new=mocker.AsyncMock(return_value="org/order/ts.pdf"),
+        )
+
+        result = await receipt_service.generate_order_receipt(session, locker, order)
+
+        assert result.receipt_path == "org/order/ts.pdf"

--- a/server/tests/receipt/test_tasks.py
+++ b/server/tests/receipt/test_tasks.py
@@ -1,0 +1,119 @@
+import uuid
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.kit.address import Address, CountryAlpha2
+from polar.kit.db.postgres import AsyncSession
+from polar.locker import TimeoutLockError
+from polar.models import Account
+from polar.receipt.service import receipt as receipt_service
+from polar.receipt.tasks import ReceiptOrderDoesNotExist, receipt_render
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_customer,
+    create_order,
+    create_organization,
+    create_payment,
+)
+
+
+def _patch_locker(mocker: MockerFixture, *, raises_timeout: bool = False) -> None:
+    cm = mocker.MagicMock()
+    cm.__aenter__ = mocker.AsyncMock(
+        side_effect=TimeoutLockError() if raises_timeout else None
+    )
+    cm.__aexit__ = mocker.AsyncMock(return_value=None)
+    locker = mocker.MagicMock()
+    locker.lock = mocker.MagicMock(return_value=cm)
+    mocker.patch("polar.receipt.tasks.Locker", return_value=locker)
+    mocker.patch("polar.receipt.tasks.RedisMiddleware.get")
+
+
+@pytest.mark.asyncio
+class TestReceiptRender:
+    async def test_raises_when_order_missing(self, mocker: MockerFixture) -> None:
+        _patch_locker(mocker)
+
+        with pytest.raises(ReceiptOrderDoesNotExist):
+            await receipt_render(uuid.uuid4())
+
+    async def test_re_enqueues_on_timeout_lock_error(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"receipts_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="rcpt-task-tle@example.com",
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            billing_name="Buyer",
+            billing_address=Address(
+                line1="1 Test Way",
+                city="SF",
+                state="CA",
+                postal_code="94104",
+                country=CountryAlpha2("US"),
+            ),
+        )
+        await create_payment(save_fixture, organization, order=order)
+        await receipt_service.allocate(session, order)
+        await session.flush()
+
+        enqueue_job_mock = mocker.patch("polar.receipt.tasks.enqueue_job")
+        _patch_locker(mocker, raises_timeout=True)
+
+        await receipt_render(order.id)
+
+        enqueue_job_mock.assert_called_once_with(
+            "receipt.render", order.id, delay=5_000
+        )
+
+    async def test_delegates_to_service(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"receipts_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="rcpt-task-ok@example.com",
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            billing_name="Buyer",
+            billing_address=Address(
+                line1="1 Test Way",
+                city="SF",
+                state="CA",
+                postal_code="94104",
+                country=CountryAlpha2("US"),
+            ),
+        )
+        await create_payment(save_fixture, organization, order=order)
+        await receipt_service.allocate(session, order)
+        await session.flush()
+
+        generate_mock = mocker.patch.object(
+            receipt_service, "generate_order_receipt", new=mocker.AsyncMock()
+        )
+        _patch_locker(mocker)
+
+        await receipt_render(order.id)
+
+        generate_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Adds a Dramatiq `receipt.render` actor that renders an order's receipt PDF under a Redis lock and persists the S3 key on `Order.receipt_path`. Lock contention re-enqueues with a short delay so the most recent refund state is captured.
- Wires the actor into the refund success path so refunds re-render the receipt against the latest data.
- Extends the S3 service with an optional `cache_control` kwarg and adds a dedicated customer-receipts bucket setting (already provisioned in the sandbox/production terraform configs).

Builds on PR4a (#11304) which introduced the renderer.

## Test plan

- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run pytest tests/receipt/ tests/refund/test_service.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)