### PR TITLE
fix: gate backoffice approval of denied orgs on Stripe onboarding

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -385,6 +385,7 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
     ),
     OrganizationStatus.DENIED: frozenset(
         {
+            OrganizationStatus.CREATED,
             OrganizationStatus.ACTIVE,
             OrganizationStatus.BLOCKED,
         }
@@ -396,6 +397,7 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
     ),
     OrganizationStatus.BLOCKED: frozenset(
         {
+            OrganizationStatus.CREATED,
             OrganizationStatus.ACTIVE,
         }
     ),

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -839,22 +839,10 @@ class OrganizationService:
             )
 
         previous_status = organization.status
-        organization.set_status(OrganizationStatus.ACTIVE)
-        organization.next_review_threshold = next_review_threshold
+        reactivation_note = reactivation_notes.get(previous_status)
 
-        if previous_status in reactivation_notes:
-            _append_internal_note(
-                organization, reactivation_notes[previous_status], reason=reason
-            )
-
-        initial_review = False
-        if organization.initially_reviewed_at is None:
-            organization.initially_reviewed_at = datetime.now(UTC)
-            initial_review = True
-
-        session.add(organization)
-
-        # If there's an appeal, mark it as approved (handles both pending and previously rejected appeals)
+        # Mark the appeal approved before the gate check so a later
+        # webhook-driven maybe_activate sees an approved review.
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
         if (
@@ -866,6 +854,36 @@ class OrganizationService:
             review.appeal_reviewed_at = datetime.now(UTC)
             session.add(review)
 
+        # Reactivations require completed Stripe onboarding to go straight to
+        # ACTIVE; otherwise revert to CREATED and let the webhook-driven
+        # maybe_activate promote them once Stripe finishes.
+        target_status = OrganizationStatus.ACTIVE
+        if reactivation_note and not await self._is_activation_ready(
+            session, organization
+        ):
+            target_status = OrganizationStatus.CREATED
+
+        organization.set_status(target_status)
+        organization.next_review_threshold = next_review_threshold
+
+        if reactivation_note:
+            suffix = (
+                " Status reverted to created — pending Stripe Identity and "
+                "Stripe Connect Express completion before activation."
+                if target_status == OrganizationStatus.CREATED
+                else ""
+            )
+            _append_internal_note(
+                organization, reactivation_note + suffix, reason=reason
+            )
+
+        initial_review = False
+        if organization.initially_reviewed_at is None:
+            organization.initially_reviewed_at = datetime.now(UTC)
+            initial_review = True
+
+        session.add(organization)
+
         enqueue_job(
             "organization.reviewed",
             organization_id=organization.id,
@@ -873,6 +891,38 @@ class OrganizationService:
             silent=silent,
         )
         return organization
+
+    async def _is_activation_ready(
+        self, session: AsyncSession, organization: Organization
+    ) -> bool:
+        """Whether onboarding gates (details, payout account, KYC) are met.
+
+        Mirrors the non-review gates checked by :meth:`maybe_activate` so the
+        backoffice approval path can decide whether a reactivation should go
+        straight to ACTIVE or revert to CREATED to finish onboarding.
+        """
+        if not organization.details_submitted_at or not organization.details:
+            return False
+
+        if organization.payout_account_id is None:
+            return False
+
+        payout_account_repository = PayoutAccountRepository.from_session(session)
+        payout_account = await payout_account_repository.get_by_id(
+            organization.payout_account_id,
+            options=(joinedload(PayoutAccount.admin),),
+        )
+        if payout_account is None or not payout_account.is_payout_ready:
+            return False
+
+        admin = payout_account.admin
+        if (
+            admin is None
+            or admin.identity_verification_status != IdentityVerificationStatus.verified
+        ):
+            return False
+
+        return True
 
     async def maybe_activate(
         self, session: AsyncSession, organization: Organization
@@ -901,30 +951,12 @@ class OrganizationService:
         ):
             return False
 
-        if not organization.details_submitted_at or not organization.details:
-            return False
-
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
         if review is None or not review.is_approved:
             return False
 
-        if organization.payout_account_id is None:
-            return False
-
-        payout_account_repository = PayoutAccountRepository.from_session(session)
-        payout_account = await payout_account_repository.get_by_id(
-            organization.payout_account_id,
-            options=(joinedload(PayoutAccount.admin),),
-        )
-        if payout_account is None or not payout_account.is_payout_ready:
-            return False
-
-        admin = payout_account.admin
-        if (
-            admin is None
-            or admin.identity_verification_status != IdentityVerificationStatus.verified
-        ):
+        if not await self._is_activation_ready(session, organization):
             return False
 
         reason: str | None = None

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -916,7 +916,6 @@ class TestConfirmOrganizationReviewed:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org denied with a rejected appeal
         organization.status = OrganizationStatus.DENIED
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
@@ -942,8 +941,7 @@ class TestConfirmOrganizationReviewed:
             session, organization, 15000, reason="Appeal re-examined"
         )
 
-        # Then: appeal decision is overridden to approved
-        assert result.status == OrganizationStatus.ACTIVE
+        assert result.status == OrganizationStatus.CREATED
         assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
         assert review.appeal_reviewed_at is not None
 
@@ -2409,7 +2407,7 @@ class TestStatusTransitions:
             (OrganizationStatus.BLOCKED, "unblocked"),
         ],
     )
-    async def test_reactivation_with_reason_succeeds(
+    async def test_reactivation_without_gates_reverts_to_created(
         self,
         current: OrganizationStatus,
         expected_note_fragment: str,
@@ -2425,10 +2423,43 @@ class TestStatusTransitions:
             session, organization, 15000, reason="Merchant provided additional docs"
         )
 
-        assert result.status == OrganizationStatus.ACTIVE
+        assert result.status == OrganizationStatus.CREATED
         assert result.internal_notes is not None
         assert expected_note_fragment in result.internal_notes
         assert "Merchant provided additional docs" in result.internal_notes
+        assert "pending Stripe Identity" in result.internal_notes
+
+    @pytest.mark.parametrize(
+        "current",
+        [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],
+    )
+    async def test_reactivation_with_gates_met_activates(
+        self,
+        current: OrganizationStatus,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.status = current
+        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        organization.details_submitted_at = datetime.now(UTC)
+        organization.details = {"about": "Test"}
+        await save_fixture(organization)
+
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+
+        await create_payout_account(save_fixture, organization, user)
+
+        mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.confirm_organization_reviewed(
+            session, organization, 15000, reason="Merchant provided additional docs"
+        )
+
+        assert result.status == OrganizationStatus.ACTIVE
 
     async def test_self_transition_is_noop(
         self,
@@ -2441,14 +2472,13 @@ class TestStatusTransitions:
     @pytest.mark.parametrize(
         "target",
         [
-            OrganizationStatus.CREATED,
             OrganizationStatus.REVIEW,
             OrganizationStatus.SNOOZED,
             OrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING,
         ],
     )
-    async def test_blocked_only_transitions_to_active(
+    async def test_blocked_only_transitions_to_active_or_created(
         self,
         target: OrganizationStatus,
         organization: Organization,
@@ -2456,6 +2486,19 @@ class TestStatusTransitions:
         organization.status = OrganizationStatus.BLOCKED
         with pytest.raises(InvalidStatusTransitionError):
             organization.set_status(target)
+
+    @pytest.mark.parametrize(
+        "previous_status",
+        [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],
+    )
+    async def test_reactivation_to_created_is_allowed(
+        self,
+        previous_status: OrganizationStatus,
+        organization: Organization,
+    ) -> None:
+        organization.status = previous_status
+        organization.set_status(OrganizationStatus.CREATED)
+        assert organization.status == OrganizationStatus.CREATED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Backoffice approval of a previously denied or blocked organization unconditionally flipped status to `ACTIVE`, granting payment and payout capabilities even when the merchant had not completed Stripe Identity (KYC) or Stripe Connect Express. This bypassed the gates enforced by `maybe_activate`.
- Reactivations now run the same onboarding gate check used by `maybe_activate`. If any gate is unmet, the org reverts to `CREATED` instead of jumping to `ACTIVE`.
- The review/appeal approval is still recorded up front, so when the merchant later completes Stripe onboarding the existing webhook-driven `maybe_activate` auto-promotes them to `ACTIVE` — no second backoffice trip needed.
- Allows `DENIED → CREATED` and `BLOCKED → CREATED` transitions and extracts the shared gate check into a `_is_activation_ready` helper used by both `confirm_organization_reviewed` and `maybe_activate`.

## Test plan
- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes
- [x] `uv run pytest tests/organization tests/organization_review tests/payout_account` — 552 passed
- [x] New tests cover: reactivation without gates met → `CREATED`, reactivation with gates met → `ACTIVE`, and the new `DENIED/BLOCKED → CREATED` transitions
- [ ] Backoffice smoke check: approve a denied org with incomplete Stripe onboarding and verify it lands in `CREATED` with capabilities stripped, then auto-activates after the merchant completes Identity + Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)