### PR TITLE
feat(receipts): add receipt download endpoints

### DIFF
--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -86,6 +86,29 @@ class InvoicePDFItem(description_list.DescriptionListItem[Order]):
         return None
 
 
+class ReceiptPDFItem(description_list.DescriptionListItem[Order]):
+    def __init__(self, url: str | None):
+        super().__init__("Receipt PDF")
+        self.url = url
+
+    def render(self, request: Request, item: Order) -> Generator[None] | None:
+        with tag.div(classes="flex items-center gap-1"):
+            if self.url is not None:
+                with tag.a(href=self.url, classes="link flex flex-row gap-1"):
+                    attr("target", "_blank")
+                    attr("rel", "noopener noreferrer")
+                    text("Download PDF")
+                    with tag.div(classes="icon-external-link"):
+                        pass
+            elif item.receipt_number is not None:
+                with tag.span(classes="text-gray-500"):
+                    text("Pending render")
+            else:
+                with tag.span(classes="text-gray-500"):
+                    text("Not generated")
+        return None
+
+
 # Table Columns
 @contextlib.contextmanager
 def order_status_badge(status: OrderStatus) -> Generator[None]:
@@ -274,6 +297,15 @@ async def get(
             # If there's an error getting the URL, we'll show "Not generated"
             pass
 
+    receipt_url: str | None = None
+    if order.receipt_number is not None:
+        try:
+            receipt = await order_service.get_order_receipt(order)
+            if receipt is not None:
+                receipt_url = receipt.url
+        except Exception:
+            pass
+
     # Get all payments for this order
     payment_repository = PaymentRepository.from_session(session)
     payments = await payment_repository.get_all_by_order(order.id)
@@ -370,6 +402,10 @@ async def get(
                                 external=True,
                             ),
                             InvoicePDFItem(invoice_url),
+                            description_list.DescriptionListAttrItem(
+                                "receipt_number", "Receipt Number"
+                            ),
+                            ReceiptPDFItem(receipt_url),
                         ).render(request, order):
                             pass
 

--- a/server/polar/customer_portal/endpoints/order.py
+++ b/server/polar/customer_portal/endpoints/order.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import Depends, Query
+from fastapi import Depends, Query, Response
 
 from polar.exceptions import ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
@@ -29,6 +29,7 @@ from ..schemas.order import (
     CustomerOrderInvoice,
     CustomerOrderPaymentConfirmation,
     CustomerOrderPaymentStatus,
+    CustomerOrderReceipt,
     CustomerOrderUpdate,
 )
 from ..service.order import (
@@ -177,6 +178,33 @@ async def invoice(
         raise ResourceNotFound()
 
     return await customer_order_service.get_order_invoice(order)
+
+
+@router.get(
+    "/{id}/receipt",
+    summary="Get Order Receipt",
+    response_model=CustomerOrderReceipt,
+    responses={
+        202: {"description": "Receipt generation in progress."},
+        404: OrderNotFound,
+    },
+)
+async def receipt(
+    id: OrderID,
+    auth_subject: auth.CustomerPortalUnionBillingRead,
+    session: AsyncSession = Depends(get_db_session),
+) -> Response | CustomerOrderReceipt:
+    """Get a presigned URL to download an order's receipt PDF."""
+    order = await customer_order_service.get_by_id(session, auth_subject, id)
+
+    if order is None:
+        raise ResourceNotFound()
+
+    receipt = await customer_order_service.get_order_receipt(order)
+    if receipt is None:
+        return Response(status_code=202)
+
+    return receipt
 
 
 @router.get(

--- a/server/polar/customer_portal/schemas/order.py
+++ b/server/polar/customer_portal/schemas/order.py
@@ -64,6 +64,12 @@ class CustomerOrderInvoice(Schema):
     url: str = Field(..., description="The URL to the invoice.")
 
 
+class CustomerOrderReceipt(Schema):
+    """Order's receipt data."""
+
+    url: str = Field(..., description="The URL to the receipt PDF.")
+
+
 class CustomerOrderUpdate(OrderUpdateBase):
     """Schema to update an order."""
 

--- a/server/polar/customer_portal/service/order.py
+++ b/server/polar/customer_portal/service/order.py
@@ -15,13 +15,15 @@ from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.models import Order, Product
 from polar.models.product import ProductBillingType
-from polar.order.service import InvoiceDoesNotExist
+from polar.order.service import InvoiceDoesNotExist, ReceiptNotAllocated
 from polar.order.service import order as order_service
+from polar.receipt.service import receipt as receipt_service
 
 from ..repository.order import CustomerOrderRepository
 from ..schemas.order import (
     CustomerOrderInvoice,
     CustomerOrderPaymentConfirmation,
+    CustomerOrderReceipt,
     CustomerOrderUpdate,
 )
 
@@ -148,6 +150,16 @@ class CustomerOrderService:
 
         url, _ = await invoice_service.get_order_invoice_url(order)
         return CustomerOrderInvoice(url=url)
+
+    async def get_order_receipt(self, order: Order) -> CustomerOrderReceipt | None:
+        if order.receipt_number is None:
+            raise ReceiptNotAllocated(order)
+
+        result = await receipt_service.get_pdf_url_or_status(order)
+        if result is None:
+            return None
+        url, _ = result
+        return CustomerOrderReceipt(url=url)
 
     async def confirm_retry_payment(
         self,

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -381,6 +381,10 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
         return f"Invoice-{self.invoice_number}.pdf"
 
     @property
+    def receipt_filename(self) -> str:
+        return f"Receipt-{self.receipt_number}.pdf"
+
+    @property
     def statement_descriptor_suffix(self) -> str:
         if (
             self.billing_reason

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -26,7 +26,7 @@ from polar.subscription.schemas import SubscriptionID
 
 from . import auth, sorting
 from .schemas import Order as OrderSchema
-from .schemas import OrderID, OrderInvoice, OrderNotFound, OrderUpdate
+from .schemas import OrderID, OrderInvoice, OrderNotFound, OrderReceipt, OrderUpdate
 from .service import MissingInvoiceBillingDetails, NotPaidOrder
 from .service import order as order_service
 
@@ -252,3 +252,30 @@ async def invoice(
         raise ResourceNotFound()
 
     return await order_service.get_order_invoice(order)
+
+
+@router.get(
+    "/{id}/receipt",
+    summary="Get Order Receipt",
+    response_model=OrderReceipt,
+    responses={
+        202: {"description": "Receipt generation in progress."},
+        404: OrderNotFound,
+    },
+)
+async def receipt(
+    id: OrderID,
+    auth_subject: auth.OrdersRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> Response | OrderReceipt:
+    """Get a presigned URL to download an order's receipt PDF."""
+    order = await order_service.get(session, auth_subject, id)
+
+    if order is None:
+        raise ResourceNotFound()
+
+    receipt = await order_service.get_order_receipt(order)
+    if receipt is None:
+        return Response(status_code=202)
+
+    return receipt

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -97,6 +97,14 @@ class OrderBase(TimestampedSchema, IDSchema):
         description="Whether an invoice has been generated for this order."
     )
 
+    receipt_number: str | None = Field(
+        description=(
+            "The receipt number for this order. "
+            "Set once the order is paid for organizations with receipts enabled. "
+            "When set, a downloadable receipt PDF can be obtained via the receipt endpoint."
+        ),
+    )
+
     seats: int | None = Field(
         None, description="Number of seats purchased (for seat-based one-time orders)."
     )
@@ -263,3 +271,9 @@ class OrderInvoice(Schema):
     """Order's invoice data."""
 
     url: str = Field(..., description="The URL to the invoice.")
+
+
+class OrderReceipt(Schema):
+    """Order's receipt data."""
+
+    url: str = Field(..., description="The URL to the receipt PDF.")

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -119,7 +119,7 @@ from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
 from .repository import OrderRepository
-from .schemas import OrderInvoice, OrderUpdate
+from .schemas import OrderInvoice, OrderReceipt, OrderUpdate
 from .sorting import OrderSortProperty
 
 log: Logger = structlog.get_logger()
@@ -189,6 +189,13 @@ class InvoiceDoesNotExist(OrderError):
     def __init__(self, order: Order) -> None:
         self.order = order
         message = f"No invoice exists for order {order.id}."
+        super().__init__(message, 404)
+
+
+class ReceiptNotAllocated(OrderError):
+    def __init__(self, order: Order) -> None:
+        self.order = order
+        message = f"No receipt allocated for order {order.id}."
         super().__init__(message, 404)
 
 
@@ -488,6 +495,16 @@ class OrderService:
 
         url, _ = await invoice_service.get_order_invoice_url(order)
         return OrderInvoice(url=url)
+
+    async def get_order_receipt(self, order: Order) -> OrderReceipt | None:
+        if order.receipt_number is None:
+            raise ReceiptNotAllocated(order)
+
+        result = await receipt_service.get_pdf_url_or_status(order)
+        if result is None:
+            return None
+        url, _ = result
+        return OrderReceipt(url=url)
 
     async def create_from_checkout_one_time(
         self, session: AsyncSession, checkout: Checkout, payment: Payment | None = None

--- a/server/polar/receipt/service.py
+++ b/server/polar/receipt/service.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -10,6 +11,7 @@ from polar.models import Order
 from polar.order.repository import OrderRepository
 from polar.payment.repository import PaymentRepository
 from polar.refund.repository import RefundRepository
+from polar.worker import enqueue_job
 
 from .generator import Receipt
 from .render import render_receipt_pdf
@@ -107,6 +109,18 @@ class ReceiptService:
                 order, update_dict={"receipt_path": key}
             )
             return order
+
+    async def get_pdf_url_or_status(self, order: Order) -> tuple[str, datetime] | None:
+        if order.receipt_path is None:
+            enqueue_job("receipt.render", order_id=order.id)
+            return None
+
+        s3 = S3Service(settings.S3_CUSTOMER_RECEIPTS_BUCKET_NAME)
+        return s3.generate_presigned_download_url(
+            path=order.receipt_path,
+            filename=order.receipt_filename,
+            mime_type="application/pdf",
+        )
 
 
 receipt = ReceiptService()

--- a/server/tests/customer_portal/endpoints/test_order.py
+++ b/server/tests/customer_portal/endpoints/test_order.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -439,3 +440,90 @@ class TestConfirmRetryPayment:
             json={"confirmation_token_id": "ctoken_test"},
         )
         assert response.status_code >= 409
+
+
+@pytest.mark.asyncio
+class TestGetOrderReceipt:
+    async def test_anonymous(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, product=product, customer=customer)
+        response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
+        assert response.status_code == 401
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_other_customer_order(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer_second: Customer,
+    ) -> None:
+        order = await create_order(
+            save_fixture, product=product, customer=customer_second
+        )
+        order.receipt_number = "RCPT-FOO-0001"
+        await save_fixture(order)
+        response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
+        assert response.status_code == 404
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_404_when_no_receipt_number(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, product=product, customer=customer)
+        response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
+        assert response.status_code == 404
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_202_when_pending_render(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, product=product, customer=customer)
+        order.receipt_number = "RCPT-FOO-0001"
+        await save_fixture(order)
+
+        enqueue_mock = mocker.patch("polar.receipt.service.enqueue_job")
+
+        response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
+
+        assert response.status_code == 202
+        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_200_when_receipt_ready(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, product=product, customer=customer)
+        order.receipt_number = "RCPT-FOO-0001"
+        order.receipt_path = f"{order.organization_id}/{order.id}/receipt.pdf"
+        await save_fixture(order)
+
+        s3_mock = mocker.patch("polar.receipt.service.S3Service")
+        s3_mock.return_value.generate_presigned_download_url.return_value = (
+            "https://example.com/signed-url",
+            datetime(2030, 1, 1, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
+
+        assert response.status_code == 200
+        assert response.json() == {"url": "https://example.com/signed-url"}

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -1,8 +1,10 @@
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
 from polar.models import Customer, Order, Product, UserOrganization
@@ -138,6 +140,8 @@ class TestGetOrder:
 
         json = response.json()
         assert json["id"] == str(orders[0].id)
+        assert "receipt_number" in json
+        assert json["receipt_number"] is None
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="organization", scopes={Scope.orders_read}),
@@ -381,3 +385,81 @@ class TestGetOrderInvoice:
         )
 
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetOrderReceipt:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/orders/{uuid.uuid4()}/receipt")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_order(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        order_organization_second: Order,
+    ) -> None:
+        response = await client.get(
+            f"/v1/orders/{order_organization_second.id}/receipt"
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
+    async def test_404_when_no_receipt_number(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        orders: list[Order],
+    ) -> None:
+        order = orders[0]
+        response = await client.get(f"/v1/orders/{order.id}/receipt")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
+    async def test_202_when_pending_render(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        user_organization: UserOrganization,
+        orders: list[Order],
+    ) -> None:
+        order = orders[0]
+        order.receipt_number = "RCPT-FOO-0001"
+        await save_fixture(order)
+
+        enqueue_mock = mocker.patch("polar.receipt.service.enqueue_job")
+
+        response = await client.get(f"/v1/orders/{order.id}/receipt")
+
+        assert response.status_code == 202
+        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
+    async def test_200_when_receipt_ready(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        user_organization: UserOrganization,
+        orders: list[Order],
+    ) -> None:
+        order = orders[0]
+        order.receipt_number = "RCPT-FOO-0001"
+        order.receipt_path = f"{order.organization_id}/{order.id}/receipt.pdf"
+        await save_fixture(order)
+
+        s3_mock = mocker.patch("polar.receipt.service.S3Service")
+        s3_mock.return_value.generate_presigned_download_url.return_value = (
+            "https://example.com/signed-url",
+            datetime(2030, 1, 1, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/v1/orders/{order.id}/receipt")
+
+        assert response.status_code == 200
+        assert response.json() == {"url": "https://example.com/signed-url"}

--- a/server/tests/receipt/test_service.py
+++ b/server/tests/receipt/test_service.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -255,3 +257,50 @@ class TestGenerateOrderReceipt:
         result = await receipt_service.generate_order_receipt(session, locker, order)
 
         assert result.receipt_path == "org/order/ts.pdf"
+
+
+@pytest.mark.asyncio
+class TestGetPdfUrlOrStatus:
+    async def test_enqueues_render_when_path_missing(
+        self,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        order.receipt_number = "RCPT-FOO-0001"
+        await save_fixture(order)
+
+        enqueue_mock = mocker.patch("polar.receipt.service.enqueue_job")
+
+        result = await receipt_service.get_pdf_url_or_status(order)
+
+        assert result is None
+        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
+
+    async def test_returns_url_when_path_set(
+        self,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        order.receipt_number = "RCPT-FOO-0001"
+        order.receipt_path = f"{order.organization_id}/{order.id}/receipt.pdf"
+        await save_fixture(order)
+
+        s3_mock = mocker.patch("polar.receipt.service.S3Service")
+        expires_at = datetime(2030, 1, 1, tzinfo=UTC)
+        s3_mock.return_value.generate_presigned_download_url.return_value = (
+            "https://example.com/signed-url",
+            expires_at,
+        )
+
+        result = await receipt_service.get_pdf_url_or_status(order)
+
+        assert result == ("https://example.com/signed-url", expires_at)
+        s3_mock.return_value.generate_presigned_download_url.assert_called_once_with(
+            path=order.receipt_path,
+            filename=order.receipt_filename,
+            mime_type="application/pdf",
+        )


### PR DESCRIPTION
## Summary

PR5 of the receipts feature ([design doc](https://handbook.polar.sh/engineering/design-documents/receipts)). Adds the GET endpoints that hand back a presigned URL to download an order's receipt PDF, the `receipt_number` field on the `Order` schema, and the receipt link on the backoffice order detail page.

- `GET /v1/orders/{id}/receipt` — auth: `orders_read`
- `GET /v1/customer-portal/orders/{id}/receipt` — auth: customer portal session
- Backoffice: receipt number + PDF link on the order detail view

## Behavior

| Condition | Response |
|---|---|
| `order.receipt_path` set | `200 {url}` (presigned S3 URL, 10-minute TTL) |
| `order.receipt_number` set, `order.receipt_path` not set | `202` (no body); a `receipt.render` job is enqueued |
| `order.receipt_number` not set, order missing, or caller unauthorized | `404` |

The actor that consumes `receipt.render` is in a separate PR — it uses a Redis lock keyed by `order_id` to dedup repeated enqueues from polling clients.

## How

Receipt resolution mirrors the invoice flow:

- Endpoints call `order_service.get_order_receipt` / `customer_order_service.get_order_receipt`.
- Those delegate to `receipt_service.get_pdf_url_or_status`, which either generates a presigned URL or enqueues a render and returns `None` (the 202 signal).
- A new `ReceiptNotAllocated` exception (404) is raised when `receipt_number` is unset — matches the existing `InvoiceDoesNotExist` shape.

Other surface:
- Adds `S3_CUSTOMER_RECEIPTS_BUCKET_NAME` setting (default `polar-customer-receipts`).
- Adds `Order.receipt_filename` property (mirrors `invoice_filename`).
- Adds `receipt_number: str | None` to the public `Order` schema; the frontend uses this to gate the download button.

## Why safe to merge before the render pipeline

In production today, every order has `receipt_number = NULL`:

- The allocation step (PR3) is gated on `Organization.receipts_enabled`, which defaults to `false`.
- No org has the flag enabled yet — that's an operational step run per-cohort after a backfill.

So all three endpoints return `404`, the customer portal button stays hidden (`order.receipt_number != null` is the gate), and the backoffice column shows "Not generated". Once the render pipeline ships and the operator flips the flag, the same endpoints start returning `202` then `200`.

## Test plan

- [x] `uv run task lint` and `uv run task lint_types` pass
- [x] Unit and integration tests cover 401 / 404 / 202 / 200 for both order endpoints, the schema field appears on the `Order` resource, and the receipt service returns `None` when `receipt_path` is null
- [x] Manual end-to-end against the local dev stack: 401 on anonymous, 404 with no `receipt_number`, 202 after setting `receipt_number` (verified `receipt.render` job is enqueued), 200 with a presigned URL after setting `receipt_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)