### PR TITLE
events: Reintroduce system events

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -894,6 +894,31 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/organizations/{id}/review': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Organization Self-Review Checklist
+     * @description Get the merchant self-review checklist state.
+     *
+     *     Powers the new account review UI: pre-submission gating checks plus,
+     *     after submission, the AI verdict and appeal state. Currently returns
+     *     a hardcoded mock — `?status=pass|fail` switches between the two
+     *     canned responses while the real check logic is built out.
+     */
+    get: operations['organizations:get_review']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/organizations/{id}/validate-website': {
     parameters: {
       query?: never
@@ -18204,22 +18229,20 @@ export interface components {
     /** EventTypeWithStats */
     EventTypeWithStats: {
       /**
-       * Created At
-       * Format: date-time
-       * @description Creation timestamp of the object.
+       * Id
+       * @description The ID of the event type. Null for system event types.
        */
-      created_at: string
+      id?: string | null
+      /**
+       * Created At
+       * @description Creation timestamp of the event type. Null for system event types.
+       */
+      created_at?: string | null
       /**
        * Modified At
-       * @description Last modification timestamp of the object.
+       * @description Last modification timestamp of the event type. Null for system event types.
        */
-      modified_at: string | null
-      /**
-       * Id
-       * Format: uuid4
-       * @description The ID of the object.
-       */
-      id: string
+      modified_at?: string | null
       /**
        * Name
        * @description The name of the event type.
@@ -23004,18 +23027,6 @@ export interface components {
        */
       member_model_enabled: boolean
       /**
-       * Tinybird Read
-       * @description If this organization reads from Tinybird
-       * @default false
-       */
-      tinybird_read: boolean
-      /**
-       * Tinybird Compare
-       * @description If this organization compares Tinybird results with database
-       * @default false
-       */
-      tinybird_compare: boolean
-      /**
        * Checkout Localization Enabled
        * @description If this organization has checkout localization enabled
        * @default false
@@ -23454,6 +23465,79 @@ export interface components {
        * @description ID of the payout account to set on the organization.
        */
       payout_account_id: string
+    }
+    /** OrganizationReviewAppeal */
+    OrganizationReviewAppeal: {
+      /**
+       * Submitted At
+       * Format: date-time
+       */
+      submitted_at: string
+      /** Reviewed At */
+      reviewed_at?: string | null
+      decision?: components['schemas']['AppealDecision'] | null
+    }
+    /**
+     * OrganizationReviewCheck
+     * @description A single item in the self-review checklist.
+     */
+    OrganizationReviewCheck: {
+      key: components['schemas']['OrganizationReviewCheckKey']
+      status: components['schemas']['OrganizationReviewCheckStatus']
+      /**
+       * Reasons
+       * @description Reasons for the current status. Empty when `passed`.
+       */
+      reasons?: components['schemas']['OrganizationReviewCheckReason'][]
+    }
+    /**
+     * OrganizationReviewCheckKey
+     * @description Stable identifiers for each check. Adding a new key is a coordinated FE+BE change.
+     * @enum {string}
+     */
+    OrganizationReviewCheckKey:
+      | 'identity.email'
+      | 'identity.social_links'
+      | 'identity.stripe_identity_verification'
+      | 'product_description'
+      | 'payout_account'
+    /**
+     * OrganizationReviewCheckReason
+     * @description Reasons explaining a check's status. Scoped reasons are namespaced
+     *     with the prefix of the check key they apply to.
+     * @enum {string}
+     */
+    OrganizationReviewCheckReason:
+      | 'not_started'
+      | 'in_progress'
+      | 'external_pending'
+      | 'identity.rejected'
+      | 'identity.personal_email'
+      | 'identity.domain_mismatch'
+      | 'payout_account.requirements_due'
+      | 'payout_account.payouts_disabled'
+    /**
+     * OrganizationReviewCheckStatus
+     * @enum {string}
+     */
+    OrganizationReviewCheckStatus: 'passed' | 'warning' | 'failed' | 'pending'
+    /**
+     * OrganizationReviewState
+     * @description Merchant self-review checklist. Frozen once `submitted_at` is set.
+     */
+    OrganizationReviewState: {
+      /**
+       * Can Submit
+       * @description True when `submitted_at` is null AND no preliminary check is `failed` or `pending`. Warnings do not block submission.
+       */
+      can_submit: boolean
+      /** Submitted At */
+      submitted_at?: string | null
+      /** Verdict */
+      verdict?: ('pass' | 'fail') | null
+      appeal?: components['schemas']['OrganizationReviewAppeal'] | null
+      /** Preliminary Steps */
+      preliminary_steps?: components['schemas']['OrganizationReviewCheck'][]
     }
     /** OrganizationReviewStatus */
     OrganizationReviewStatus: {
@@ -31743,6 +31827,49 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['OrganizationReviewStatus']
+        }
+      }
+      /** @description Organization not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:get_review': {
+    parameters: {
+      query?: {
+        /** @description STUB: switch the mocked response. `pass` returns an all-passed checklist, `fail` returns an all-failed one. Omit for the default (all-passed) mock. */
+        status?: ('pass' | 'fail') | null
+      }
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Organization self-review checklist returned. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrganizationReviewState']
         }
       }
       /** @description Organization not found. */
@@ -46289,6 +46416,9 @@ type FlattenedDeepRequired<T> = {
 type ReadonlyArray<T> = [Exclude<T, undefined>] extends [unknown[]]
   ? Readonly<Exclude<T, undefined>>
   : Readonly<Exclude<T, undefined>[]>
+export const pathsV1OrganizationsIdReviewGetParametersQueryStatusAnyOf0Values: ReadonlyArray<
+  FlattenedDeepRequired<paths>['/v1/organizations/{id}/review']['get']['parameters']['query']['status']
+> = ['pass', 'fail']
 export const pathsV1WebhooksDeliveriesGetParametersQueryHttp_code_classAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<paths>['/v1/webhooks/deliveries']['get']['parameters']['query']['http_code_class']
 > = ['2xx', '3xx', '4xx', '5xx']
@@ -52980,6 +53110,33 @@ export const organizationKYCCountryAnyOf0Values: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const organizationReviewCheckKeyValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationReviewCheckKey']
+> = [
+  'identity.email',
+  'identity.social_links',
+  'identity.stripe_identity_verification',
+  'product_description',
+  'payout_account',
+]
+export const organizationReviewCheckReasonValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationReviewCheckReason']
+> = [
+  'not_started',
+  'in_progress',
+  'external_pending',
+  'identity.rejected',
+  'identity.personal_email',
+  'identity.domain_mismatch',
+  'payout_account.requirements_due',
+  'payout_account.payouts_disabled',
+]
+export const organizationReviewCheckStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationReviewCheckStatus']
+> = ['passed', 'warning', 'failed', 'pending']
+export const organizationReviewStateVerdictAnyOf0Values: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationReviewState']['verdict']
+> = ['pass', 'fail']
 export const organizationReviewStatusVerdictAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewStatus']['verdict']
 > = ['PASS', 'FAIL', 'UNCERTAIN']

--- a/server/polar/event_type/schemas.py
+++ b/server/polar/event_type/schemas.py
@@ -49,7 +49,28 @@ class EventType(IDSchema, TimestampedSchema):
     )
 
 
-class EventTypeWithStats(EventType):
+class EventTypeWithStats(Schema):
+    id: UUID4 | None = Field(
+        None,
+        description="The ID of the event type. Null for system event types.",
+    )
+    created_at: datetime | None = Field(
+        None,
+        description="Creation timestamp of the event type. Null for system event types.",
+    )
+    modified_at: datetime | None = Field(
+        None,
+        description="Last modification timestamp of the event type. Null for system event types.",
+    )
+    name: str = Field(..., description="The name of the event type.")
+    label: str = Field(..., description="The label for the event type.")
+    label_property_selector: str | None = Field(
+        None,
+        description="Property path to extract dynamic label from event metadata.",
+    )
+    organization_id: UUID4 = Field(
+        ..., description="The ID of the organization owning the event type."
+    )
     source: EventSource = Field(
         description="The source of the events (system or user)."
     )

--- a/server/polar/event_type/service.py
+++ b/server/polar/event_type/service.py
@@ -107,11 +107,7 @@ class EventTypeService:
                 s
                 for s in tinybird_stats
                 if query_lower in s.name.lower()
-                or (
-                    (et := event_types_by_key.get((s.organization_id, s.name)))
-                    is not None
-                    and query_lower in (et.label or "").lower()
-                )
+                or query_lower in self._resolve_label(s, event_types_by_key).lower()
             ]
 
         total_count = len(tinybird_stats)
@@ -125,6 +121,19 @@ class EventTypeService:
 
         return results, total_count
 
+    def _resolve_label(
+        self,
+        stat: TinybirdEventTypeStats,
+        event_types_by_key: dict[tuple[UUID, str], EventType],
+    ) -> str:
+        event_type = event_types_by_key.get((stat.organization_id, stat.name))
+        if stat.source == EventSource.system:
+            fallback = event_type.label if event_type is not None else stat.name
+            return SYSTEM_EVENT_LABELS.get(stat.name, fallback)
+        if event_type is not None:
+            return event_type.label
+        return stat.name
+
     def _build_event_types_from_tinybird(
         self,
         stats: list[TinybirdEventTypeStats],
@@ -133,13 +142,29 @@ class EventTypeService:
         results: list[EventTypeWithStats] = []
         for s in stats:
             event_type = event_types_by_key.get((s.organization_id, s.name))
-            if event_type is None:
-                continue
+            label = self._resolve_label(s, event_types_by_key)
 
-            if s.source == EventSource.system:
-                label = SYSTEM_EVENT_LABELS.get(s.name, event_type.label)
-            else:
-                label = event_type.label
+            if event_type is None:
+                if s.source != EventSource.system:
+                    continue
+                results.append(
+                    EventTypeWithStats.model_validate(
+                        {
+                            "id": None,
+                            "created_at": None,
+                            "modified_at": None,
+                            "name": s.name,
+                            "label": label,
+                            "label_property_selector": None,
+                            "organization_id": s.organization_id,
+                            "source": s.source,
+                            "occurrences": s.occurrences,
+                            "first_seen": s.first_seen,
+                            "last_seen": s.last_seen,
+                        }
+                    )
+                )
+                continue
 
             results.append(
                 EventTypeWithStats.model_validate(

--- a/server/tests/event_type/test_endpoints.py
+++ b/server/tests/event_type/test_endpoints.py
@@ -426,6 +426,41 @@ class TestListEventTypes:
         assert json["pagination"]["total_count"] == 1
         assert json["items"][0]["name"] == "system.event"
 
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user", scopes={Scope.events_read}),
+        AuthSubjectFixture(subject="organization", scopes={Scope.events_read}),
+    )
+    async def test_system_event_without_event_type_row(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        buffered_save_fixture: SaveFixture,
+        flush_tinybird_events: Callable[[], Awaitable[None]],
+    ) -> None:
+        await create_event(
+            buffered_save_fixture,
+            organization=organization,
+            name="order.paid",
+            source=EventSource.system,
+        )
+
+        await flush_tinybird_events()
+
+        response = await client.get("/v1/event-types/", params={"source": "system"})
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 1
+        item = json["items"][0]
+        assert item["name"] == "order.paid"
+        assert item["source"] == "system"
+        assert item["label"] == "Order Paid"
+        assert item["id"] is None
+        assert item["created_at"] is None
+        assert item["modified_at"] is None
+        assert item["label_property_selector"] is None
+
 
 @pytest.mark.asyncio
 class TestUpdateEventType:


### PR DESCRIPTION
With the shuffle around with Tinybird, we lost out on system events. Since they dont get any event types, they no longer show up on the events page.

This reintroduces system events by serving them as their own thing not based on EventTypes.
