### PR TITLE
webhook: Speed up deliveries endpoint

### DIFF
--- a/server/polar/webhook/repository.py
+++ b/server/polar/webhook/repository.py
@@ -174,3 +174,16 @@ class WebhookEndpointRepository(
         return self.get_base_statement().where(
             WebhookEndpoint.organization_id.in_(org_ids)
         )
+
+    async def get_accessible_ids(
+        self,
+        org_ids: set[AccessibleOrganizationID],
+        endpoint_ids: Sequence[UUID],
+    ) -> Sequence[UUID]:
+        statement = (
+            self.get_statement_by_org_ids(org_ids)
+            .with_only_columns(WebhookEndpoint.id)
+            .where(WebhookEndpoint.id.in_(endpoint_ids))
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -220,16 +220,22 @@ class WebhookService:
         repository = WebhookDeliveryRepository.from_session(session)
         org_ids = await get_accessible_org_ids(session, auth_subject)
 
-        statement = (
-            repository.get_statement_by_org_ids(org_ids)
-            .options(joinedload(WebhookDelivery.webhook_event))
-            .order_by(desc(WebhookDelivery.created_at))
-        )
-
         if endpoint_id is not None:
-            statement = statement.where(
-                WebhookDelivery.webhook_endpoint_id.in_(endpoint_id)
+            endpoint_repository = WebhookEndpointRepository.from_session(session)
+            allowed_endpoint_ids = await endpoint_repository.get_accessible_ids(
+                org_ids, endpoint_id
             )
+            if not allowed_endpoint_ids:
+                return [], 0
+            base_statement = repository.get_base_statement().where(
+                WebhookDelivery.webhook_endpoint_id.in_(allowed_endpoint_ids)
+            )
+        else:
+            base_statement = repository.get_statement_by_org_ids(org_ids)
+
+        statement = base_statement.options(
+            joinedload(WebhookDelivery.webhook_event)
+        ).order_by(desc(WebhookDelivery.created_at))
 
         if start_timestamp is not None:
             statement = statement.where(WebhookDelivery.created_at > start_timestamp)


### PR DESCRIPTION
By splitting the join into two separate queries we can avoid doing the join on every row and just query filter out the deliveries corresponding to the correct webhook endpoint.
