### PR TITLE
Upgrade to Sonnet 4.6

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts
@@ -364,12 +364,12 @@ export async function POST(req: Request) {
     : google('gemini-2.5-flash')
 
   const sonnet = phClient
-    ? withTracing(anthropic('claude-sonnet-4-5'), phClient, {
+    ? withTracing(anthropic('claude-sonnet-4-6'), phClient, {
         posthogDistinctId: user.id,
         posthogTraceId: conversationId,
         posthogGroups: { organization: organizationId },
       })
-    : anthropic('claude-sonnet-4-5')
+    : anthropic('claude-sonnet-4-6')
 
   const router = await generateObject({
     model: geminiLite,


### PR DESCRIPTION
For some reason, when we switch from Gemini to Sonnet in the AI product assistant, it stops working. Let's see if upgrading to Sonnet 4.6 helps.