### PR TITLE
ci: Let OpenAPI differ merge in main before checking

### DIFF
--- a/.github/workflows/openapi-generate-check.yml
+++ b/.github/workflows/openapi-generate-check.yml
@@ -28,6 +28,20 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Merge base branch
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          if ! git merge --no-edit origin/${{ github.event.pull_request.base.ref }}; then
+            git merge --abort
+            echo "::error::Could not merge ${{ github.event.pull_request.base.ref }} into the PR cleanly. Please update your branch locally and push."
+            exit 1
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0


### PR DESCRIPTION
So if you are basing your PR on an older main, it shouldn't break the openapi differ
