### PR TITLE
feat(receipts): add receipt download button to customer portal

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
@@ -8,7 +8,7 @@ import { Status } from '@polar-sh/ui/components/atoms/Status'
 import { ThemingPresetProps } from '@polar-sh/ui/hooks/theming'
 import { useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { DownloadInvoicePortal } from '../Orders/DownloadInvoice'
+import { OrderDownloadActions } from '../Orders/OrderDownloadActions'
 import { DetailRow } from '../Shared/DetailRow'
 import { CustomerPortalGrants } from './CustomerPortalGrants'
 import { OrderPaymentRetryModal } from './OrderPaymentRetryModal'
@@ -227,13 +227,10 @@ const CustomerPortalOrder = ({
             )}
           </div>
           {order.paid && (
-            <div className="flex flex-col gap-2">
-              <DownloadInvoicePortal
-                customerSessionToken={customerSessionToken}
-                order={order}
-                onInvoiceGenerated={() => {}}
-              />
-            </div>
+            <OrderDownloadActions
+              order={order}
+              customerSessionToken={customerSessionToken}
+            />
           )}
         </div>
 

--- a/clients/apps/web/src/components/Orders/DownloadReceipt.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadReceipt.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import type { Client, schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import type EventEmitter from 'eventemitter3'
+import { useCallback, useRef, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import { useCustomerPortalContext } from '../CustomerPortal/CustomerPortalProvider'
+
+const RECEIPT_GENERATED_EVENT = 'order.receipt_generated'
+const RENDER_TIMEOUT_MS = 30_000
+
+const openInNewTab = (url: string) => {
+  const newWindow = window.open(url, '_blank')
+  if (!newWindow) {
+    window.location.href = url
+  }
+}
+
+const waitForReceipt = (
+  eventEmitter: EventEmitter,
+  orderId: string,
+  timeoutMs: number,
+) =>
+  new Promise<boolean>((resolve) => {
+    const listener = ({ order_id }: { order_id: string }) => {
+      if (order_id !== orderId) return
+      cleanup()
+      resolve(true)
+    }
+    const timer = setTimeout(() => {
+      cleanup()
+      resolve(false)
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timer)
+      eventEmitter.off(RECEIPT_GENERATED_EVENT, listener)
+    }
+    eventEmitter.on(RECEIPT_GENERATED_EVENT, listener)
+  })
+
+const DownloadReceipt = ({
+  order,
+  api,
+  eventEmitter,
+  receiptURL,
+  className,
+}: {
+  order: schemas['Order'] | schemas['CustomerOrder']
+  api: Client
+  eventEmitter: EventEmitter
+  receiptURL:
+    | '/v1/orders/{id}/receipt'
+    | '/v1/customer-portal/orders/{id}/receipt'
+  className?: string
+}) => {
+  const [loading, setLoading] = useState(false)
+  const [failed, setFailed] = useState(false)
+  const inFlightRef = useRef(false)
+
+  const fetchReceiptUrl = useCallback(async (): Promise<
+    { url: string } | { pending: true } | { failed: true }
+  > => {
+    const response = await api.GET(receiptURL, {
+      params: { path: { id: order.id } },
+    })
+    if (response.data?.url) {
+      return { url: response.data.url }
+    }
+    // 202 has no body, openapi-fetch returns data as undefined.
+    if (response.response.status === 202) {
+      return { pending: true }
+    }
+    return { failed: true }
+  }, [api, order.id, receiptURL])
+
+  const onDownload = useCallback(async () => {
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+    setLoading(true)
+    setFailed(false)
+
+    try {
+      const initial = await fetchReceiptUrl()
+      if ('url' in initial) {
+        openInNewTab(initial.url)
+        return
+      }
+      if ('failed' in initial) {
+        setFailed(true)
+        return
+      }
+
+      const arrived = await waitForReceipt(
+        eventEmitter,
+        order.id,
+        RENDER_TIMEOUT_MS,
+      )
+      if (!arrived) {
+        setFailed(true)
+        return
+      }
+
+      const ready = await fetchReceiptUrl()
+      if ('url' in ready) {
+        openInNewTab(ready.url)
+      } else {
+        setFailed(true)
+      }
+    } finally {
+      setLoading(false)
+      inFlightRef.current = false
+    }
+  }, [fetchReceiptUrl, eventEmitter, order.id])
+
+  if (failed) {
+    return (
+      <div className={twMerge('flex flex-col gap-2 lg:flex-row', className)}>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onDownload}
+          className="w-full"
+        >
+          Try again
+        </Button>
+        <Button type="button" asChild className="w-full">
+          <a href="mailto:support@polar.sh">Contact support</a>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <Button
+      type="button"
+      onClick={onDownload}
+      loading={loading}
+      disabled={loading}
+      className={twMerge('w-full', className)}
+    >
+      Download Receipt
+    </Button>
+  )
+}
+
+export const DownloadReceiptPortal = ({
+  order,
+  className,
+}: {
+  order: schemas['CustomerOrder']
+  className?: string
+}) => {
+  const { client: api, customerSSE } = useCustomerPortalContext()
+  return (
+    <DownloadReceipt
+      order={order}
+      api={api}
+      eventEmitter={customerSSE}
+      receiptURL="/v1/customer-portal/orders/{id}/receipt"
+      className={className}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Orders/OrderDownloadActions.tsx
+++ b/clients/apps/web/src/components/Orders/OrderDownloadActions.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import type { schemas } from '@polar-sh/client'
+import { useIsMobile } from '@polar-sh/ui/hooks/use-mobile'
+import { DownloadInvoicePortal } from './DownloadInvoice'
+import { DownloadReceiptPortal } from './DownloadReceipt'
+
+interface OrderDownloadActionsProps {
+  order: schemas['CustomerOrder']
+  customerSessionToken: string
+}
+
+export const OrderDownloadActions = ({
+  order,
+  customerSessionToken,
+}: OrderDownloadActionsProps) => {
+  const isMobile = useIsMobile()
+  const hasReceipt = order.receipt_number != null
+
+  if (isMobile) {
+    return (
+      <div className="flex flex-col gap-2">
+        {hasReceipt && <DownloadReceiptPortal order={order} />}
+        <DownloadInvoicePortal
+          customerSessionToken={customerSessionToken}
+          order={order}
+          onInvoiceGenerated={() => {}}
+          variant={hasReceipt ? 'secondary' : undefined}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      {hasReceipt ? (
+        <>
+          <DownloadReceiptPortal order={order} className="w-auto" />
+          <DownloadInvoicePortal
+            customerSessionToken={customerSessionToken}
+            order={order}
+            onInvoiceGenerated={() => {}}
+            dropdown
+          />
+        </>
+      ) : (
+        <DownloadInvoicePortal
+          customerSessionToken={customerSessionToken}
+          order={order}
+          onInvoiceGenerated={() => {}}
+          className="w-auto"
+        />
+      )}
+    </div>
+  )
+}

--- a/server/polar/receipt/service.py
+++ b/server/polar/receipt/service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
+from polar.eventstream.service import publish as eventstream_publish
 from polar.integrations.aws.s3 import S3Service
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.utils import utc_now
@@ -107,6 +108,12 @@ class ReceiptService:
             order_repository = OrderRepository.from_session(session)
             order = await order_repository.update(
                 order, update_dict={"receipt_path": key}
+            )
+            await eventstream_publish(
+                "order.receipt_generated",
+                {"order_id": order.id},
+                customer_id=order.customer_id,
+                organization_id=order.organization_id,
             )
             return order
 

--- a/server/tests/receipt/test_service.py
+++ b/server/tests/receipt/test_service.py
@@ -258,6 +258,54 @@ class TestGenerateOrderReceipt:
 
         assert result.receipt_path == "org/order/ts.pdf"
 
+    async def test_publishes_eventstream(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        locker: Locker,
+        mocker: MockerFixture,
+    ) -> None:
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"receipts_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="event@example.com"
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            billing_name="Buyer",
+            billing_address=Address(
+                line1="1 Test Way",
+                city="SF",
+                state="CA",
+                postal_code="94104",
+                country=CountryAlpha2("US"),
+            ),
+        )
+        await create_payment(save_fixture, organization, order=order)
+        await receipt_service.allocate(session, order)
+
+        mocker.patch.object(
+            receipt_service,
+            "_create_order_receipt",
+            new=mocker.AsyncMock(return_value="org/order/ts.pdf"),
+        )
+        publish_mock = mocker.patch(
+            "polar.receipt.service.eventstream_publish",
+            new=mocker.AsyncMock(),
+        )
+
+        await receipt_service.generate_order_receipt(session, locker, order)
+
+        publish_mock.assert_awaited_once_with(
+            "order.receipt_generated",
+            {"order_id": order.id},
+            customer_id=customer.id,
+            organization_id=organization.id,
+        )
+
 
 @pytest.mark.asyncio
 class TestGetPdfUrlOrStatus:


### PR DESCRIPTION
## Summary

Adds the customer-portal Download Receipt button.

**Server**: emits `order.receipt_generated` on the customer + org SSE channels after `receipt_path` is updated, mirroring `order.invoice_generated`.

**Frontend**: `DownloadReceipt` component on click — initial GET, then either:
- `200` → open the presigned URL,
- `202` → wait for the SSE event (30s timeout), then re-fetch and open,
- `4xx`/`5xx` → Try again / Contact support fallback.

The SSE listener is per-click (not mount-time like invoice's). Receipts also re-render on refunds; a mount-time listener would auto-open tabs the customer didn't ask for.

**Layout**: `OrderDownloadActions` toolbar:
- Desktop: receipt button + kebab dropdown (Download / Edit Invoice), right-aligned, sized to content.
- Mobile: full-width stacked buttons.

Driven by `useIsMobile` so exactly one `DownloadInvoicePortal` mounts per breakpoint — avoids duplicate SSE subscriptions on `order.invoice_generated` that would otherwise open two browser tabs.

Gated on `order.receipt_number != null`. Today every prod order has `receipt_number = NULL`, so the button stays hidden until per-org backfill + flag flip.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `uv run task lint`, `uv run task lint_types` pass
- [x] e2e on a real Stripe-paid order: 202 → `receipt.render` worker → `eventstream_publish` → SSE event delivered to the customer channel → frontend re-fetches → 200 with valid PDF
- [x] Negative case: `receipt_number = null` → button hidden, existing invoice flow unchanged
- [x] Visual states (idle / loading / failed) on desktop and mobile
- [x] New `test_publishes_eventstream` asserts the publish call shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)