### PR TITLE
fix(organization): unstick denied orgs with approved appeals

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -958,6 +958,23 @@ class OrganizationService:
             return False
 
         if not await self._is_activation_ready(session, organization):
+            if organization.status in (
+                OrganizationStatus.DENIED,
+                OrganizationStatus.BLOCKED,
+            ):
+                organization.set_status(OrganizationStatus.CREATED)
+                _append_internal_note(
+                    organization,
+                    "Appeal approved — reverted to created pending Stripe "
+                    "Identity and Stripe Connect Express completion.",
+                    reason=review.appeal_reason or "Appeal approved",
+                )
+                session.add(organization)
+                log.info(
+                    "organization.maybe_activate.reverted_to_created",
+                    organization_id=str(organization.id),
+                    slug=organization.slug,
+                )
             return False
 
         reason: str | None = None
@@ -1219,8 +1236,9 @@ class OrganizationService:
         Recording the approval flips the review's ``appeal_decision`` and then
         delegates to :meth:`maybe_activate` — which runs the remaining gates
         (payout account ready, admin identity verified) before transitioning
-        DENIED → ACTIVE. If a gate is still missing the org stays DENIED and
-        will activate later when the relevant webhook fires.
+        DENIED → ACTIVE. If a gate is still missing the org is moved to
+        CREATED so the merchant can finish Stripe onboarding; a later
+        webhook-triggered ``maybe_activate`` then promotes it to ACTIVE.
         """
 
         repository = OrganizationReviewRepository.from_session(session)

--- a/server/scripts/backfill_unstuck_denied_approved.py
+++ b/server/scripts/backfill_unstuck_denied_approved.py
@@ -1,0 +1,130 @@
+"""
+Re-run :meth:`maybe_activate` against organizations stuck in DENIED with an
+approved review/appeal.
+
+Two bugs left these orgs stranded:
+
+  1. The original ``approve_appeal`` ignored ``maybe_activate``'s False return
+     when onboarding gates were unmet — the appeal was recorded but the org
+     stayed DENIED instead of moving to a state from which Stripe webhooks
+     could finish the job.
+  2. Older manual-appeal flows (pre-AI auto-decide) had the same gap.
+
+With the fix in place, ``maybe_activate`` will either promote a stuck org
+to ACTIVE (gates met) or move it to CREATED (gates pending). This script
+walks every stuck org and calls ``maybe_activate`` once per row.
+
+Usage:
+    cd server
+
+    # Dry-run (default): list the candidates.
+    uv run python -m scripts.backfill_unstuck_denied_approved
+
+    # Execute:
+    uv run python -m scripts.backfill_unstuck_denied_approved --execute
+"""
+
+from collections import Counter
+
+import structlog
+import typer
+from rich.console import Console
+from rich.table import Table
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.models import Organization
+from polar.models.organization import OrganizationStatus
+from polar.models.organization_review import OrganizationReview
+from polar.organization.service import organization as organization_service
+from polar.postgres import create_async_engine
+from scripts.helper import configure_script_console_logging, typer_async
+
+cli = typer.Typer()
+console = Console()
+log = structlog.get_logger()
+
+configure_script_console_logging()
+
+
+STUCK_STATUSES = (OrganizationStatus.DENIED, OrganizationStatus.BLOCKED)
+
+
+async def _find_stuck(session: AsyncSession) -> list[Organization]:
+    statement = (
+        select(Organization)
+        .join(OrganizationReview, OrganizationReview.organization_id == Organization.id)
+        .where(
+            Organization.deleted_at.is_(None),
+            Organization.status.in_(STUCK_STATUSES),
+            OrganizationReview.appeal_decision
+            == OrganizationReview.AppealDecision.APPROVED,
+        )
+        .order_by(Organization.created_at.asc())
+    )
+    result = await session.execute(statement)
+    return list(result.scalars().all())
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    execute: bool = typer.Option(
+        False, help="Actually run the backfill (default: dry-run)"
+    ),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            stuck = await _find_stuck(session)
+            console.print(f"Found [bold]{len(stuck)}[/bold] stuck organization(s).")
+            if not stuck:
+                return
+
+            if not execute:
+                table = Table(title="Stuck candidates")
+                table.add_column("ID", style="dim")
+                table.add_column("Slug")
+                table.add_column("Status", style="yellow")
+                table.add_column("Created", style="cyan")
+                for org in stuck:
+                    table.add_row(
+                        str(org.id),
+                        org.slug,
+                        org.status.value,
+                        org.created_at.isoformat(),
+                    )
+                console.print(table)
+                console.print(
+                    "\n[yellow]Dry-run — re-run with --execute to apply.[/yellow]"
+                )
+                return
+
+            counts: Counter[OrganizationStatus] = Counter()
+            for org in stuck:
+                previous_status = org.status
+                await organization_service.maybe_activate(session, org)
+                counts[org.status] += 1
+                log.info(
+                    "backfill.row",
+                    id=str(org.id),
+                    slug=org.slug,
+                    previous_status=previous_status.value,
+                    new_status=org.status.value,
+                )
+            await session.commit()
+
+        summary = Table(title="Backfill result")
+        summary.add_column("New status", style="cyan")
+        summary.add_column("Count", justify="right")
+        for status, count in counts.most_common():
+            summary.add_row(status.value, str(count))
+        console.print(summary)
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1353,7 +1353,7 @@ class TestApproveAppeal:
         assert result.appeal_decision == OrganizationReview.AppealDecision.APPROVED
         assert result.appeal_reviewed_at is not None
 
-    async def test_approve_appeal_records_decision_but_stays_denied_when_gates_missing(
+    async def test_approve_appeal_reverts_to_created_when_gates_missing(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -1377,7 +1377,10 @@ class TestApproveAppeal:
 
         result = await organization_service.approve_appeal(session, organization)
 
-        assert organization.status == OrganizationStatus.DENIED
+        assert organization.status == OrganizationStatus.CREATED
+        assert organization.internal_notes is not None
+        assert "Appeal approved" in organization.internal_notes
+        assert "pending Stripe Identity" in organization.internal_notes
         assert result.appeal_decision == OrganizationReview.AppealDecision.APPROVED
         assert result.appeal_reviewed_at is not None
 


### PR DESCRIPTION
## Summary
- `approve_appeal` recorded the approval and called `maybe_activate`, but when onboarding gates (payout account, identity verification) were unmet the org silently stayed in `DENIED`. From `DENIED` the merchant cannot continue Stripe setup, so no webhook ever re-triggers activation — appeal-approved orgs were stranded with no path to `ACTIVE`.
- `maybe_activate` now moves `DENIED`/`BLOCKED` orgs with an approved review to `CREATED` when activation gates are unmet, restoring the onboarding flow. A later webhook-driven `maybe_activate` promotes them to `ACTIVE` once Stripe finishes.
- Adds `scripts.backfill_unstuck_denied_approved` to walk every org currently in this stuck state and call `maybe_activate` once per row, so existing rows are drained without further user action.

## Test plan
- [x] `uv run pytest tests/organization/test_service.py::TestApproveAppeal tests/organization/test_service.py::TestConfirmOrganizationReviewed tests/organization/test_service.py::TestStatusTransitions tests/organization/test_service.py::TestHandleOngoingReviewVerdict tests/organization/test_service.py::TestDenyAppeal` — 44 passed
- [x] `uv run task lint` — clean
- [x] `uv run task lint_types` — clean
- [ ] Run `uv run python -m scripts.backfill_unstuck_denied_approved` (dry-run) on prod, eyeball the candidate list, then re-run with `--execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)