### PR TITLE
Allow specifying target organization when impersonating users

### DIFF
--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -37,6 +37,7 @@ async def start_impersonation(
     request: Request,
     admin_session: UserSession = Depends(get_admin),
     user_id: str = Form(),
+    organization_id: str | None = Form(default=None),
     session: AsyncSession = Depends(get_db_session),
 ) -> Any:  # RedirectResponse | HXRedirectResponse:
     """Start impersonating a user. Only available to admin users."""
@@ -69,8 +70,17 @@ async def start_impersonation(
     # Create response object
     org_repository = OrganizationRepository.from_session(session)
     user_orgs = await org_repository.get_all_by_user(target_user.id)
+    target_org = next(
+        (org for org in user_orgs if str(org.id) == organization_id),
+        user_orgs[0] if user_orgs else None,
+    )
+    if target_org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User has no organizations to impersonate into",
+        )
     response = HXRedirectResponse(
-        request, f"{settings.FRONTEND_BASE_URL}/dashboard/{user_orgs[0].slug}", 307
+        request, f"{settings.FRONTEND_BASE_URL}/dashboard/{target_org.slug}", 307
     )
 
     # Set admin session cookie

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -1356,13 +1356,12 @@ async def get(
                                                         if not organization.is_deleted:
                                                             with tag.button(
                                                                 classes="btn btn-primary btn-sm",
-                                                                name="user_id",
-                                                                value=str(user.id),
                                                                 hx_post=str(
                                                                     request.url_for(
                                                                         "backoffice:start_impersonation",
                                                                     )
                                                                 ),
+                                                                hx_vals=f'{{"user_id": "{user.id}", "organization_id": "{organization.id}"}}',
                                                                 hx_confirm="Are you sure you want to impersonate this user?",
                                                             ):
                                                                 text("Impersonate")

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -218,6 +218,12 @@ class OrganizationDetailView:
                             value=str(self.impersonate_user.id),
                         ):
                             pass
+                        with tag.input(
+                            type="hidden",
+                            name="organization_id",
+                            value=str(self.org.id),
+                        ):
+                            pass
                         with button(
                             variant="secondary",
                             size="sm",

--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -115,7 +115,7 @@ class TeamSection:
                                                 "backoffice:start_impersonation",
                                             )
                                         ),
-                                        hx_vals=f'{{"user_id": "{member.user_id}"}}',
+                                        hx_vals=f'{{"user_id": "{member.user_id}", "organization_id": "{self.org.id}"}}',
                                         hx_confirm="Are you sure you want to impersonate this user?",
                                     ):
                                         text("Impersonate")


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

This PR enhances the user impersonation feature to allow admins to specify which organization context to impersonate into, rather than always defaulting to the user's first organization.

## What

- Added optional `organization_id` parameter to the `start_impersonation` endpoint
- Updated impersonation logic to select the specified organization, falling back to the first organization if none is provided
- Added validation to ensure the target user has at least one organization
- Updated all impersonation UI triggers (detail view, team section, and organizations endpoints) to pass the current organization context when initiating impersonation

## Why

When impersonating a user who belongs to multiple organizations, admins should be able to choose which organization context to impersonate into. Previously, the system always redirected to the user's first organization, which may not be the intended context for the impersonation session.

## How

1. Modified the `start_impersonation` endpoint to accept an optional `organization_id` form parameter
2. Implemented logic to find the target organization by ID, with fallback to the first organization
3. Added error handling for users with no organizations
4. Updated all impersonation button implementations to include the current organization ID in the request payload using `hx_vals`

## Checklist

- [x] This PR addresses a single concern (one feature: organization-aware impersonation)
- [x] The diff is reasonably sized and easy to review
- [x] No new tests needed (existing impersonation tests cover the fallback behavior)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_016GhEHWBzPkJQBpN6jnZdQA