### PR TITLE
refactor(member): drop redundant session param from MemberRepository methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,19 @@ uv run task test              # Backend tests
 pnpm test                     # Frontend tests
 ```
 
+## Worktree Setup
+
+Fresh `.claude/worktrees/` checkouts don't carry `.env` or built artifacts. Before running tests in a new worktree:
+
+```bash
+cd server
+./dev/setup-environment       # generates .env
+uv run task generate_dev_jwks # creates .jwks.json
+uv run task emails            # builds emails/bin/react-email-pkg
+```
+
+Without these, pytest fails at config load with `JWKS` and `EMAIL_RENDERER_BINARY_PATH` validation errors.
+
 ## Documentation
 
 - **Handbook**: https://handbook.polar.sh/engineering/

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -79,12 +79,14 @@ class ResourceRepository(
 **Key methods from base:**
 - `get_base_statement()` - Returns `select(self.model)`
 - `get_one(statement)` - Single result, raises if not found
-- `get_one_or_none(statement)` - Single result or None
-- `get_all(statement)` - All matching results
+- `get_one_or_none(statement)` - Single result or None (calls `.unique()` — safe with `joinedload`)
+- `get_all(statement)` - All matching results (calls `.unique()` — safe with `joinedload`)
 - `paginate(statement, limit, page)` - Returns (results, count)
 - `create(object, flush=False)` - Add to session
 - `update(object, update_dict)` - Update fields
 - `from_session(session)` - Factory method
+
+**Repository methods use `self.session`, not a `session` parameter.** Once constructed via `from_session(session)`, the session lives on the instance. Don't add a `session` arg to repository methods — pass domain args only. Use `self.session.execute(...)` for raw queries (writes, refreshes), or the base helpers above for selects.
 
 **Subqueries must project explicit columns.** `select(Model).subquery()` re-materializes every mapped column — `deferred=True` does NOT propagate. For count subqueries, use `count_subquery(statement)` from `polar.kit.pagination`; otherwise narrow with `.with_only_columns(...)` before calling `.subquery()`. Enforced by `uv run task lint_subquery`.
 

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -123,7 +123,7 @@ async def resolve_member(
         raise MemberIdRequired()
 
     member = await member_repository.get_owner_by_customer_id(
-        session, customer_id, include_deleted=include_deleted
+        customer_id, include_deleted=include_deleted
     )
     if member is None:
         # Auto-create owner member (graceful fallback during migration)

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -570,7 +570,7 @@ class CheckoutService:
             ):
                 member_repository = MemberRepository.from_session(session)
                 owner_member = await member_repository.get_owner_by_customer_id(
-                    session, checkout.customer.id
+                    checkout.customer.id
                 )
                 if owner_member is not None and owner_member.email is not None:
                     checkout.customer_email = owner_member.email

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -616,7 +616,7 @@ class CustomerService:
         is_team = customer.type == CustomerType.team
         if is_team:
             member_repository = MemberRepository.from_session(session)
-            members = await member_repository.list_by_customer(session, customer.id)
+            members = await member_repository.list_by_customer(customer.id)
             for m in members:
                 if (
                     m.email is not None
@@ -691,7 +691,7 @@ class CustomerService:
 
         member_repository = MemberRepository.from_session(session)
         member = await member_repository.get_by_customer_and_email(
-            session, customer, recipient_email
+            customer, recipient_email
         )
         if member is None:
             return None

--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -120,7 +120,7 @@ class CustomerSessionService:
         """
         member_repository = MemberRepository.from_session(session)
         members = await member_repository.list_by_email_and_organization(
-            session, email, organization.id
+            email, organization.id
         )
 
         if not members:
@@ -268,7 +268,7 @@ class CustomerSessionService:
 
             # Look up member by (customer, email) - unique combination
             member = await member_repository.get_by_customer_and_email(
-                session, customer, customer_session_code.email
+                customer, customer_session_code.email
             )
 
             if member is None:

--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -151,7 +151,7 @@ class SeatService:
         if customer.email is not None:
             return customer.email
         owner = await MemberRepository.from_session(session).get_owner_by_customer_id(
-            session, customer.id
+            customer.id
         )
         return (owner.email if owner else None) or customer.display_name
 

--- a/server/polar/customer_session/service.py
+++ b/server/polar/customer_session/service.py
@@ -183,7 +183,7 @@ class CustomerSessionService(ResourceServiceReader[CustomerSession]):
         member_repository: MemberRepository,
         customer: Customer,
     ) -> Member:
-        member = await member_repository.get_owner_by_customer_id(session, customer.id)
+        member = await member_repository.get_owner_by_customer_id(customer.id)
         if member is None:
             # create_owner_member doesn't set the customer relationship,
             # set it for response serialization

--- a/server/polar/member/repository.py
+++ b/server/polar/member/repository.py
@@ -12,7 +12,6 @@ from polar.kit.repository import (
 )
 from polar.models.customer import Customer
 from polar.models.member import Member, MemberRole
-from polar.postgres import AsyncReadSession, AsyncSession
 
 
 class MemberRepository(
@@ -24,7 +23,6 @@ class MemberRepository(
 
     async def get_by_customer_and_email(
         self,
-        session: AsyncSession,
         customer: Customer,
         email: str | None = None,
     ) -> Member | None:
@@ -42,8 +40,7 @@ class MemberRepository(
             func.lower(Member.email) == email.lower(),
             Member.is_deleted.is_(False),
         )
-        result = await session.execute(statement)
-        return result.scalar_one_or_none()
+        return await self.get_one_or_none(statement)
 
     async def get_by_customer_id_and_email(
         self,
@@ -101,19 +98,16 @@ class MemberRepository(
 
     async def list_by_customer(
         self,
-        session: AsyncReadSession,
         customer_id: UUID,
     ) -> Sequence[Member]:
         statement = select(Member).where(
             Member.customer_id == customer_id,
             Member.is_deleted.is_(False),
         )
-        result = await session.execute(statement)
-        return result.scalars().all()
+        return await self.get_all(statement)
 
     async def get_owner_by_customer_id(
         self,
-        session: AsyncReadSession,
         customer_id: UUID,
         *,
         include_deleted: bool = False,
@@ -133,12 +127,10 @@ class MemberRepository(
         )
         if not include_deleted:
             statement = statement.where(Member.is_deleted.is_(False))
-        result = await session.execute(statement)
-        return result.unique().scalar_one_or_none()
+        return await self.get_one_or_none(statement)
 
     async def transfer_ownership(
         self,
-        session: AsyncSession,
         *,
         current_owner: Member,
         new_owner: Member,
@@ -153,22 +145,21 @@ class MemberRepository(
         the customer briefly has zero owners (allowed by the partial index),
         then promote the new owner.
         """
-        await session.execute(
+        await self.session.execute(
             update(Member)
             .where(Member.id == current_owner.id)
             .values(role=MemberRole.billing_manager)
         )
-        await session.execute(
+        await self.session.execute(
             update(Member)
             .where(Member.id == new_owner.id)
             .values(role=MemberRole.owner)
         )
-        await session.refresh(current_owner, attribute_names=["role"])
-        await session.refresh(new_owner, attribute_names=["role"])
+        await self.session.refresh(current_owner, attribute_names=["role"])
+        await self.session.refresh(new_owner, attribute_names=["role"])
 
     async def list_by_email_and_organization(
         self,
-        session: AsyncReadSession,
         email: str,
         organization_id: UUID,
     ) -> Sequence[Member]:
@@ -186,12 +177,10 @@ class MemberRepository(
             )
             .options(joinedload(Member.customer))
         )
-        result = await session.execute(statement)
-        return result.scalars().unique().all()
+        return await self.get_all(statement)
 
     async def list_by_customers(
         self,
-        session: AsyncReadSession,
         customer_ids: Sequence[UUID],
     ) -> Sequence[Member]:
         """
@@ -204,8 +193,7 @@ class MemberRepository(
             Member.customer_id.in_(customer_ids),
             Member.is_deleted.is_(False),
         )
-        result = await session.execute(statement)
-        return result.scalars().all()
+        return await self.get_all(statement)
 
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -132,7 +132,7 @@ class MemberService:
 
         # Prevent deleting the only owner
         if member.role == MemberRole.owner:
-            members = await repository.list_by_customer(session, member.customer_id)
+            members = await repository.list_by_customer(member.customer_id)
             owner_count = sum(1 for m in members if m.role == MemberRole.owner)
             if owner_count <= 1:
                 raise PolarRequestValidationError(
@@ -184,7 +184,7 @@ class MemberService:
         )
 
         repository = MemberRepository.from_session(session)
-        members = await repository.list_by_customer(session, customer_id)
+        members = await repository.list_by_customer(customer_id)
 
         if not members:
             return []
@@ -233,7 +233,7 @@ class MemberService:
             return
 
         repository = MemberRepository.from_session(session)
-        owner = await repository.get_owner_by_customer_id(session, customer.id)
+        owner = await repository.get_owner_by_customer_id(customer.id)
         if owner is None or owner.email.lower() == customer.email.lower():
             return
 
@@ -307,7 +307,7 @@ class MemberService:
         # regardless of email — if we only dedupe by (customer_id, email), a drifted
         # owner.email (e.g., typo in original email that was later corrected on the
         # customer) produces a duplicate owner on the next sign-in.
-        existing_owner = await repository.get_owner_by_customer_id(session, customer.id)
+        existing_owner = await repository.get_owner_by_customer_id(customer.id)
         if existing_owner is not None:
             log.debug(
                 "member.create_owner_member.skipped",
@@ -351,9 +351,7 @@ class MemberService:
                 error=str(e),
                 reason="Likely race condition - member already exists",
             )
-            existing_owner = await repository.get_owner_by_customer_id(
-                session, customer.id
-            )
+            existing_owner = await repository.get_owner_by_customer_id(customer.id)
             if existing_owner is not None:
                 log.info(
                     "member.create_owner_member.found_existing",
@@ -466,7 +464,7 @@ class MemberService:
         customer_id: UUID,
     ) -> Sequence[Member]:
         repository = MemberRepository.from_session(session)
-        return await repository.list_by_customer(session, customer_id)
+        return await repository.list_by_customer(customer_id)
 
     async def get_by_customer_and_id(
         self,
@@ -518,7 +516,7 @@ class MemberService:
         Get all members for multiple customers (batch loading to avoid N+1 queries).
         """
         repository = MemberRepository.from_session(session)
-        return await repository.list_by_customers(session, customer_ids)
+        return await repository.list_by_customers(customer_ids)
 
     async def create(
         self,
@@ -577,7 +575,7 @@ class MemberService:
         # NULL type is treated as 'individual' (legacy customers)
         customer_type = customer.type or CustomerType.individual
         if customer_type == CustomerType.individual:
-            existing_members = await repository.list_by_customer(session, customer_id)
+            existing_members = await repository.list_by_customer(customer_id)
             active_members = [m for m in existing_members if not m.is_deleted]
             if len(active_members) >= 1:
                 raise NotPermitted(
@@ -586,7 +584,7 @@ class MemberService:
                 )
 
         existing_member = await repository.get_by_customer_and_email(
-            session, customer, email=email
+            customer, email=email
         )
         if existing_member:
             log.info(
@@ -632,7 +630,7 @@ class MemberService:
                 error=str(e),
             )
             existing_member = await repository.get_by_customer_and_email(
-                session, customer, email=email
+                customer, email=email
             )
             if existing_member:
                 log.info(
@@ -674,7 +672,7 @@ class MemberService:
         transferred = False
 
         if role is not None and member.role != role:
-            members = await repository.list_by_customer(session, member.customer_id)
+            members = await repository.list_by_customer(member.customer_id)
             owner_count = sum(1 for m in members if m.role == MemberRole.owner)
 
             is_current_owner = member.role == MemberRole.owner
@@ -706,7 +704,7 @@ class MemberService:
                     else next(m for m in members if m.role == MemberRole.owner)
                 )
                 await repository.transfer_ownership(
-                    session, current_owner=current_owner, new_owner=member
+                    current_owner=current_owner, new_owner=member
                 )
                 transferred = True
                 log.info(

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -296,9 +296,7 @@ async def _backfill_seats(
 
     async def _get_owner_member(customer_id: uuid.UUID) -> Member | None:
         if customer_id not in owner_members_map:
-            owner = await member_repository.get_owner_by_customer_id(
-                session, customer_id
-            )
+            owner = await member_repository.get_owner_by_customer_id(customer_id)
             if owner is not None:
                 owner_members_map[customer_id] = owner
         return owner_members_map.get(customer_id)
@@ -559,7 +557,7 @@ async def _backfill_benefit_grants(
             else:
                 if grant.customer_id not in owner_members_map:
                     owner = await member_repository.get_owner_by_customer_id(
-                        session, grant.customer_id
+                        grant.customer_id
                     )
                     if owner is not None:
                         owner_members_map[grant.customer_id] = owner
@@ -733,7 +731,7 @@ async def _cleanup_orphaned_seat_customers(
             continue
 
         # Soft-delete members first (FK restrict on customer_id)
-        members = await member_repository.list_by_customer(session, customer_id)
+        members = await member_repository.list_by_customer(customer_id)
         for member in members:
             await member_repository.soft_delete(member)
 
@@ -851,9 +849,7 @@ async def _prepare_seats(
 
     async def _get_owner_member(customer_id: uuid.UUID) -> Member | None:
         if customer_id not in owner_members_map:
-            owner = await member_repository.get_owner_by_customer_id(
-                session, customer_id
-            )
+            owner = await member_repository.get_owner_by_customer_id(customer_id)
             if owner is not None:
                 owner_members_map[customer_id] = owner
         return owner_members_map.get(customer_id)
@@ -1058,7 +1054,7 @@ async def _prepare_benefit_grants(
             if target_member_id is None:
                 if grant.customer_id not in owner_members_map:
                     owner = await member_repository.get_owner_by_customer_id(
-                        session, grant.customer_id
+                        grant.customer_id
                     )
                     if owner is not None:
                         owner_members_map[grant.customer_id] = owner

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -362,9 +362,7 @@ class TestCreateCustomer:
         assert json["external_id"] == "customer_ext_123"
 
         member_repository = MemberRepository.from_session(session)
-        owner = await member_repository.get_owner_by_customer_id(
-            session, uuid.UUID(json["id"])
-        )
+        owner = await member_repository.get_owner_by_customer_id(uuid.UUID(json["id"]))
         assert owner is not None
         assert owner.email == "owner@polar.sh"
         assert owner.name == "Owner Name"

--- a/server/tests/customer/test_service.py
+++ b/server/tests/customer/test_service.py
@@ -205,7 +205,7 @@ class TestCreate:
         assert customer.name == "Test Customer"
 
         member_repository = MemberRepository.from_session(session)
-        member = await member_repository.get_by_customer_and_email(session, customer)
+        member = await member_repository.get_by_customer_and_email(customer)
         assert member is not None
         assert member.customer_id == customer.id
         assert member.email == customer.email
@@ -239,7 +239,7 @@ class TestCreate:
         assert customer.email == "customer.without.member@example.com"
 
         member_repository = MemberRepository.from_session(session)
-        member = await member_repository.get_by_customer_and_email(session, customer)
+        member = await member_repository.get_by_customer_and_email(customer)
         assert member is None
 
     @pytest.mark.auth(
@@ -280,7 +280,7 @@ class TestCreate:
         assert customer.external_id == "customer_ext_123"
 
         member_repository = MemberRepository.from_session(session)
-        member = await member_repository.get_owner_by_customer_id(session, customer.id)
+        member = await member_repository.get_owner_by_customer_id(customer.id)
         assert member is not None
         assert member.customer_id == customer.id
         assert member.email == "owner@polar.sh"
@@ -1065,7 +1065,7 @@ class TestDelete:
         await session.flush()
 
         repository = MemberRepository.from_session(session)
-        active_members = await repository.list_by_customer(session, customer.id)
+        active_members = await repository.list_by_customer(customer.id)
         assert len(active_members) == 0
 
     async def test_delete_prevents_duplicate_members_on_recreate(
@@ -1110,7 +1110,7 @@ class TestDelete:
 
         repository = MemberRepository.from_session(session)
         active_members = await repository.list_by_email_and_organization(
-            session, "duplicate-test@example.com", organization.id
+            "duplicate-test@example.com", organization.id
         )
         assert len(active_members) == 1
         assert active_members[0].id == member2.id
@@ -1141,7 +1141,7 @@ class TestDelete:
         await session.flush()
 
         repository = MemberRepository.from_session(session)
-        active_members = await repository.list_by_customer(session, customer.id)
+        active_members = await repository.list_by_customer(customer.id)
         assert len(active_members) == 0
 
     async def test_delete_with_multiple_members(
@@ -1175,7 +1175,7 @@ class TestDelete:
         await session.flush()
 
         repository = MemberRepository.from_session(session)
-        active_members = await repository.list_by_customer(session, customer.id)
+        active_members = await repository.list_by_customer(customer.id)
         assert len(active_members) == 0
 
 

--- a/server/tests/customer_email_update/test_service.py
+++ b/server/tests/customer_email_update/test_service.py
@@ -373,5 +373,5 @@ class TestVerify:
 
         assert owner.email == "verified@example.com"
         repository = MemberRepository.from_session(session)
-        members = await repository.list_by_customer(session, customer.id)
+        members = await repository.list_by_customer(customer.id)
         assert len([m for m in members if m.role == MemberRole.owner]) == 1

--- a/server/tests/member/test_repository.py
+++ b/server/tests/member/test_repository.py
@@ -27,7 +27,7 @@ class TestListByEmailAndOrganization:
         repository = MemberRepository.from_session(session)
 
         members = await repository.list_by_email_and_organization(
-            session, "nonexistent@example.com", organization.id
+            "nonexistent@example.com", organization.id
         )
 
         assert len(members) == 0
@@ -53,7 +53,7 @@ class TestListByEmailAndOrganization:
 
         repository = MemberRepository.from_session(session)
         members = await repository.list_by_email_and_organization(
-            session, "test@example.com", organization.id
+            "test@example.com", organization.id
         )
 
         assert len(members) == 1
@@ -94,7 +94,7 @@ class TestListByEmailAndOrganization:
 
         repository = MemberRepository.from_session(session)
         members = await repository.list_by_email_and_organization(
-            session, shared_email, organization.id
+            shared_email, organization.id
         )
 
         assert len(members) == 2
@@ -124,14 +124,14 @@ class TestListByEmailAndOrganization:
 
         # Test uppercase
         members_upper = await repository.list_by_email_and_organization(
-            session, "USER@EXAMPLE.COM", organization.id
+            "USER@EXAMPLE.COM", organization.id
         )
         assert len(members_upper) == 1
         assert members_upper[0].id == member.id
 
         # Test mixed case
         members_mixed = await repository.list_by_email_and_organization(
-            session, "User@Example.Com", organization.id
+            "User@Example.Com", organization.id
         )
         assert len(members_mixed) == 1
         assert members_mixed[0].id == member.id
@@ -157,7 +157,7 @@ class TestListByEmailAndOrganization:
 
         repository = MemberRepository.from_session(session)
         members = await repository.list_by_email_and_organization(
-            session, "deleted@example.com", organization.id
+            "deleted@example.com", organization.id
         )
 
         assert len(members) == 0
@@ -201,14 +201,14 @@ class TestListByEmailAndOrganization:
 
         # Query primary organization
         members_org1 = await repository.list_by_email_and_organization(
-            session, "shared@example.com", organization.id
+            "shared@example.com", organization.id
         )
         assert len(members_org1) == 1
         assert members_org1[0].id == member1.id
 
         # Query other organization
         members_org2 = await repository.list_by_email_and_organization(
-            session, "shared@example.com", other_org.id
+            "shared@example.com", other_org.id
         )
         assert len(members_org2) == 1
         assert members_org2[0].id == member2.id
@@ -236,7 +236,7 @@ class TestListByEmailAndOrganization:
 
         repository = MemberRepository.from_session(session)
         members = await repository.list_by_email_and_organization(
-            session, "test@example.com", organization.id
+            "test@example.com", organization.id
         )
 
         assert len(members) == 1
@@ -294,7 +294,7 @@ class TestTransferOwnership:
 
         repository = MemberRepository.from_session(session)
         await repository.transfer_ownership(
-            session, current_owner=current_owner, new_owner=new_owner
+            current_owner=current_owner, new_owner=new_owner
         )
 
         assert new_owner.role == MemberRole.owner

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -420,7 +420,7 @@ class TestCreateOwnerMember:
         assert member is not None
         assert member.id == existing.id
         repository = MemberRepository.from_session(session)
-        members = await repository.list_by_customer(session, customer.id)
+        members = await repository.list_by_customer(customer.id)
         assert len([m for m in members if m.role == MemberRole.owner]) == 1
 
 


### PR DESCRIPTION
## Summary

- `MemberRepository` methods previously took an explicit `session: AsyncSession` / `AsyncReadSession` parameter even though `RepositoryBase.from_session(session)` already stores it on `self.session`. Normalized 6 methods (`get_owner_by_customer_id`, `get_by_customer_and_email`, `list_by_customer`, `transfer_ownership`, `list_by_email_and_organization`, `list_by_customers`) to use `self.session` and updated all callers.
- Behavior-preserving: every call site already constructed the repository with the same session it then passed to the method.
- Read methods now use the `get_one_or_none` / `get_all` base helpers where applicable; writes (`transfer_ownership`) and joinedload-free reads use `self.session` directly.
- Documented the convention in `server/CLAUDE.md` and added a worktree-setup note to root `CLAUDE.md`.

The `MemberRepository` API now matches the convention used by sibling repositories (`CustomerRepository`, `OrderRepository`, etc.).

## Test plan

- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes (mypy clean across 1291 source files)
- [x] `uv run pytest tests/customer tests/member tests/customer_session tests/customer_seat tests/checkout tests/organization tests/benefit tests/customer_portal tests/customer_email_update -p no:logfire` passes (1472+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)