### PR TITLE
ci: run openapi client check on merge_group events

### DIFF
--- a/.github/workflows/openapi-generate-check.yml
+++ b/.github/workflows/openapi-generate-check.yml
@@ -8,9 +8,10 @@ on:
       - "clients/packages/client/src/v1.ts"
       - "clients/packages/client/package.json"
       - ".github/workflows/openapi-generate-check.yml"
+  merge_group:
 
 concurrency:
-  group: openapi-generate-check-${{ github.event.pull_request.number }}
+  group: openapi-generate-check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -29,10 +30,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Merge base branch
+        if: github.event_name == 'pull_request'
         run: |
           git config user.email "actions@github.com"
           git config user.name "github-actions"
@@ -120,6 +122,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Find existing comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v4
         id: fc
         with:
@@ -127,6 +130,7 @@ jobs:
           body-includes: "<!-- __OPENAPI_CLIENT_REGEN -->"
 
       - name: Create or update PR comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
The `Check generated client` job is a required status check, but the workflow only triggered on `pull_request` events. Merge queue commits never produced a run, so the queue stalled waiting for a status that would never report.

- Add `merge_group:` to the workflow triggers.
- Fall back to `github.sha` for checkout when there is no PR head sha.
- Skip PR-only steps (manual base merge, PR comment) on `merge_group` runs.

Existing in-flight queue items won't retroactively pick up the new trigger — re-queue or emergency-merge them after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)