### PR TITLE
feat(backoffice): Add ignore action for external events

### DIFF
--- a/server/polar/backoffice/external_events/endpoints.py
+++ b/server/polar/backoffice/external_events/endpoints.py
@@ -106,6 +106,12 @@ async def list(
                         target="#modal",
                         hidden=lambda _, i: i.is_handled,
                     ),
+                    datatable.DatatableActionHTMX[ExternalEvent](
+                        "Ignore",
+                        lambda r, i: str(r.url_for("external_events:ignore", id=i.id)),
+                        target="#modal",
+                        hidden=lambda _, i: i.is_handled,
+                    ),
                 ),
                 datatable.DatatableAttrColumn("id", "ID", clipboard=True),
                 datatable.DatatableDateTimeColumn(
@@ -173,3 +179,46 @@ async def resend(
                     hx_target="#modal",
                 ):
                     text("Resend")
+
+
+@router.api_route(
+    "/{id}/ignore", name="external_events:ignore", methods=["GET", "POST"]
+)
+async def ignore(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    repository = ExternalEventRepository.from_session(session)
+    external_event = await repository.get_by_id(id)
+
+    if external_event is None:
+        raise HTTPException(status_code=404)
+
+    if request.method == "POST":
+        await repository.update(
+            external_event,
+            update_dict={"handled_at": external_event.created_at},
+            flush=True,
+        )
+        await add_toast(request, "Event has been ignored.", "success")
+        return
+
+    with modal(f"Ignore Event {external_event.id}", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.p():
+                text("Are you sure you want to ignore this event? ")
+                text(
+                    "It will be marked as handled and hidden from the unhandled filter."
+                )
+            with tag.div(classes="modal-action"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(
+                    type="button",
+                    variant="primary",
+                    hx_post=str(request.url),
+                    hx_target="#modal",
+                ):
+                    text("Ignore")


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Add an 'Ignore' action to the external events backoffice that allows marking events as handled by setting the handled_at timestamp to created_at.

## What

- Added 'Ignore' action to the contextual menu in the external events datatable
- Added new endpoint for ignore that handles both GET (show confirmation modal) and POST (perform ignore action)
- The action is only visible for unhandled events (same pattern as Resend)

## Why

This allows backoffice users to easily mark external events as handled when they want to ignore them, without having to manually update the database. This is useful for events that are not relevant or have been processed outside of the normal flow.

## How

- Added a new DatatableActionHTMX to the actions column in the list endpoint
- Created a new route with GET and POST handlers following the existing resend pattern
- On POST, updates the external event using repository.update() with handled_at = created_at
- Shows a confirmation modal before performing the action
- Displays a success toast notification upon completion

## Checklist

- [x] This PR addresses a single concern (one feature)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (uv run task lint && uv run task lint_types)
- [x] No unrelated changes or drive-by fixes are included
