### PR TITLE
polar: Increase the query timeout for the polar event ingestion task temporarily

### DIFF
--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -6,9 +6,14 @@ from dramatiq import Retry
 
 from polar.config import settings
 from polar.event.repository import EventRepository
+from polar.kit.db.postgres import (
+    create_async_engine as _create_async_engine,
+)
+from polar.kit.db.postgres import (
+    create_async_sessionmaker,
+)
 from polar.kit.utils import utc_now
 from polar.worker import (
-    AsyncSessionMaker,
     CronTrigger,
     TaskPriority,
     actor,
@@ -16,6 +21,8 @@ from polar.worker import (
 )
 
 from .client import get_client
+
+_TRACK_EVENT_INGESTION_QUERY_TIMEOUT_SECONDS = 600.0
 
 
 @actor(actor_name="polar_self.create_customer", priority=TaskPriority.LOW)
@@ -110,16 +117,29 @@ async def track_event_ingestion() -> None:
         return
     self_organization_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
     cutoff = utc_now() - timedelta(seconds=30)
-    async with AsyncSessionMaker() as session:
-        repository = EventRepository.from_session(session)
-        last_flush = await repository.get_latest_polar_self_ingestion_timestamp(
-            self_organization_id
-        )
-        counts = await repository.count_user_events_by_organization(
-            after=last_flush,
-            until=cutoff,
-            exclude_organization_id=self_organization_id,
-        )
+    engine = _create_async_engine(
+        dsn=str(settings.get_postgres_dsn("asyncpg")),
+        application_name=f"{settings.ENV.value}.worker.track_event_ingestion",
+        pool_logging_name="worker_track_event_ingestion",
+        debug=settings.SQLALCHEMY_DEBUG,
+        pool_size=1,
+        pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+        command_timeout=_TRACK_EVENT_INGESTION_QUERY_TIMEOUT_SECONDS,
+    )
+    sessionmaker = create_async_sessionmaker(engine)
+    try:
+        async with sessionmaker() as session:
+            repository = EventRepository.from_session(session)
+            last_flush = await repository.get_latest_polar_self_ingestion_timestamp(
+                self_organization_id
+            )
+            counts = await repository.count_user_events_by_organization(
+                after=last_flush,
+                until=cutoff,
+                exclude_organization_id=self_organization_id,
+            )
+    finally:
+        await engine.dispose()
     if not counts:
         return
     await get_client().track_event_ingestion(counts=counts, cutoff=cutoff)

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -102,7 +102,7 @@ async def delete_customer(external_id: str) -> None:
 
 @actor(
     actor_name="polar_self.track_event_ingestion_v2",
-    cron_trigger=CronTrigger.from_crontab("*/5 * * * *"),
+    cron_trigger=CronTrigger.from_crontab("0 */3 * * *"),
     priority=TaskPriority.LOW,
 )
 async def track_event_ingestion() -> None:

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -197,6 +197,23 @@ class TestFlushEventIngestion:
         settings.POLAR_SELF_ENABLED = enabled
         settings.POLAR_ORGANIZATION_ID = str(self.SELF_ORG_ID)
 
+    def _patch_engine(self, mocker: MockerFixture) -> None:
+        engine = MagicMock()
+        engine.dispose = AsyncMock()
+        mocker.patch(
+            "polar.integrations.polar.tasks._create_async_engine",
+            return_value=engine,
+        )
+        session = MagicMock()
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+        sessionmaker = MagicMock(return_value=session_cm)
+        mocker.patch(
+            "polar.integrations.polar.tasks.create_async_sessionmaker",
+            return_value=sessionmaker,
+        )
+
     async def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
         self._patch_settings(mocker, enabled=False)
         client = AsyncMock(spec=PolarSelfClient)
@@ -210,6 +227,7 @@ class TestFlushEventIngestion:
 
     async def test_noop_when_no_counts(self, mocker: MockerFixture) -> None:
         self._patch_settings(mocker)
+        self._patch_engine(mocker)
         repository = MagicMock()
         repository.get_latest_polar_self_ingestion_timestamp = AsyncMock(
             return_value=None
@@ -230,6 +248,7 @@ class TestFlushEventIngestion:
         self, mocker: MockerFixture
     ) -> None:
         self._patch_settings(mocker)
+        self._patch_engine(mocker)
         org_a = uuid.UUID("00000000-0000-0000-0000-00000000000a")
         last_flush = MagicMock()
         counts = {org_a: 7}


### PR DESCRIPTION
Instead of doing something complicated for the backfill, I was thinking that we can just let it run to completion once, and then revert this PR