### PR TITLE
Switch to relevant currency tab on validation error

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/useAutoSwitchToErroredPriceTab.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/useAutoSwitchToErroredPriceTab.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { type FieldPath, useFormContext, useFormState } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import { hasPriceCurrency } from './utils'
+
+export const useAutoSwitchToErroredPriceTab = (
+  setSelectedCurrency: (currency: string) => void,
+) => {
+  const [autoSwitched, setAutoSwitched] = useState(false)
+  const { control, setFocus, getValues } = useFormContext<ProductFormType>()
+  const { errors } = useFormState({ control, name: 'prices' })
+
+  const priceErrors = Array.isArray(errors.prices) ? errors.prices : []
+  const erroredIndex = priceErrors.findIndex(Boolean)
+  const erroredField = Object.keys(priceErrors[erroredIndex] ?? {})[0]
+
+  if (erroredIndex >= 0 && !autoSwitched) {
+    setAutoSwitched(true)
+    const price = getValues('prices')?.[erroredIndex]
+    if (price && hasPriceCurrency(price))
+      setSelectedCurrency(price.price_currency)
+  } else if (erroredIndex < 0 && autoSwitched) {
+    setAutoSwitched(false)
+  }
+
+  useEffect(() => {
+    if (erroredIndex >= 0 && erroredField) {
+      setFocus(
+        `prices.${erroredIndex}.${erroredField}` as FieldPath<ProductFormType>,
+      )
+    }
+  }, [erroredIndex, erroredField, setFocus])
+}

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -30,6 +30,7 @@ import { twMerge } from 'tailwind-merge'
 import { Section } from '../../Layout/Section'
 import { CurrencyTabs } from './Pricing/CurrencyTabs'
 import { ProductPriceItem } from './Pricing/ProductPriceItem'
+import { useAutoSwitchToErroredPriceTab } from './Pricing/useAutoSwitchToErroredPriceTab'
 import {
   getActiveCurrencies,
   groupPricesByCurrency,
@@ -78,6 +79,8 @@ export const ProductPricingSection = ({
   const validatedSelectedCurrency = activeCurrencies.includes(selectedCurrency)
     ? selectedCurrency
     : defaultCurrency
+
+  useAutoSwitchToErroredPriceTab(setSelectedCurrency)
 
   const isLegacyRecurringProduct = useMemo(
     () => (prices as ProductPrice[]).some(isLegacyRecurringPrice),


### PR DESCRIPTION
If you add multiple prices, and one of them has a validation error (e.g missing amount) we will now:

* Scroll to the pricing section
* Switch to the currency tab with the validation error.

Fixes https://github.com/polarsource/polar/issues/11342


https://github.com/user-attachments/assets/a56c7ebf-7f27-417f-9636-bef611be5d67

