### PR TITLE
refactor(organization): drop redundant session param from get_admin_user

### DIFF
--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -901,7 +901,7 @@ async def create_plain_thread(
         if not organization:
             raise HTTPException(status_code=404)
 
-        admin_user = await org_repo.get_admin_user(session, organization)
+        admin_user = await org_repo.get_admin_user(organization)
         if not admin_user:
             raise HTTPException(status_code=404, detail="No admin user found")
 
@@ -1273,10 +1273,7 @@ async def get(
                             with tag.h2(classes="card-title"):
                                 text(f"Team Members ({len(users)})")
 
-                        # Check if current organization has admin
-                        admin_user = await repository.get_admin_user(
-                            session, organization
-                        )
+                        admin_user = await repository.get_admin_user(organization)
 
                         if users:
                             # Users table
@@ -1549,7 +1546,7 @@ async def get_plain_search_url(
     if not organization:
         raise HTTPException(status_code=404)
 
-    admin_user = await org_repo.get_admin_user(session, organization)
+    admin_user = await org_repo.get_admin_user(organization)
     if not admin_user:
         raise HTTPException(status_code=404, detail="No admin user found")
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -515,7 +515,7 @@ async def get_organization_detail(
         ai_verdict = parsed.report.verdict.value
 
     # Fetch admin user email for Plain search
-    admin_user = await repository.get_admin_user(session, organization)
+    admin_user = await repository.get_admin_user(organization)
     admin_email = admin_user.email if admin_user else None
 
     # Determine impersonation target: admin, or first member as fallback
@@ -691,8 +691,6 @@ async def get_organization_detail(
                 ):
                     pass
             elif section == "team":
-                # Get admin user for the organization
-                admin_user = await repository.get_admin_user(session, organization)
                 identity_country = None
                 if admin_user:
                     identity_country = await user_service.get_identity_verified_country(
@@ -1772,7 +1770,7 @@ async def create_review_ticket(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    admin_user = await repository.get_admin_user(session, organization)
+    admin_user = await repository.get_admin_user(organization)
     if not admin_user:
         await add_toast(request, "No admin user found for this organization.", "error")
         return

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -352,7 +352,7 @@ async def members(
 
     # Get admin user to set is_admin flag
     org_repo = OrganizationRepository.from_session(session)
-    admin_user = await org_repo.get_admin_user(session, organization)
+    admin_user = await org_repo.get_admin_user(organization)
     admin_user_id = admin_user.id if admin_user else None
 
     # Build response with is_admin flag
@@ -453,9 +453,8 @@ async def leave_organization(
     organization = authz.organization
     user = authz.auth_subject.subject
 
-    # Check if user is the admin
     org_repo = OrganizationRepository.from_session(session)
-    admin_user = await org_repo.get_admin_user(session, organization)
+    admin_user = await org_repo.get_admin_user(organization)
 
     if admin_user and admin_user.id == user.id:
         raise NotPermitted("Organization admins cannot leave the organization.")

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -32,7 +32,6 @@ from polar.models.discount import (
 from polar.models.organization import OrganizationStatus
 from polar.models.organization_review import OrganizationReview
 from polar.models.subscription import SubscriptionStatus
-from polar.postgres import AsyncReadSession
 
 from .sorting import OrganizationSortProperty
 
@@ -188,9 +187,7 @@ class OrganizationRepository(
             Organization.status != OrganizationStatus.BLOCKED,
         )
 
-    async def get_admin_user(
-        self, session: AsyncReadSession, organization: Organization
-    ) -> User | None:
+    async def get_admin_user(self, organization: Organization) -> User | None:
         """Get the admin user of the organization from the associated account."""
         statement = (
             select(User)
@@ -200,7 +197,7 @@ class OrganizationRepository(
                 User.is_deleted.is_(False),
             )
         )
-        result = await session.execute(statement)
+        result = await self.session.execute(statement)
         return result.unique().scalar_one_or_none()
 
     async def count_paid_orders_by_organization(self, organization_id: UUID) -> int:

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -99,7 +99,7 @@ async def organization_reviewed(
 
         # Send an email after the initial review
         if initial_review and not silent:
-            admin_user = await repository.get_admin_user(session, organization)
+            admin_user = await repository.get_admin_user(organization)
             if admin_user:
                 email = OrganizationReviewedEmail(
                     props=OrganizationReviewedProps.model_validate(

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -197,7 +197,7 @@ async def _collect_history(organization: Organization) -> HistoryData:
         org_repository = OrganizationRepository.from_session(session)
         review_repository = OrganizationReviewRepository.from_session(session)
 
-        admin_user = await org_repository.get_admin_user(session, organization)
+        admin_user = await org_repository.get_admin_user(organization)
         admin_user_id = admin_user.id if admin_user else None
 
         user = (

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -162,8 +162,7 @@ class UserOrganizationService:
         if not user_org:
             raise UserNotMemberOfOrganization(user_id, organization_id)
 
-        # Check if the user is the organization admin
-        admin_user = await org_repo.get_admin_user(session, organization)
+        admin_user = await org_repo.get_admin_user(organization)
         if admin_user and admin_user.id == user_id:
             raise CannotRemoveOrganizationAdmin(user_id, organization_id)
 

--- a/server/scripts/appeal_review.py
+++ b/server/scripts/appeal_review.py
@@ -404,7 +404,7 @@ def _create_agent(model_name: str) -> Agent[AppealAgentDeps, AppealReviewResult]
             deps._organization_id = org.id
 
             # Find admin user
-            admin = await org_repo.get_admin_user(session, org)
+            admin = await org_repo.get_admin_user(org)
             if admin:
                 deps._admin_user_id = admin.id
                 deps._admin_email = admin.email

--- a/server/scripts/plain_comm.py
+++ b/server/scripts/plain_comm.py
@@ -188,7 +188,7 @@ async def _send_email(
     organization = await organization_repository.get_by_id(organization_id)
     if organization is None:
         raise PlainScriptError("Organization not found")
-    admin = await organization_repository.get_admin_user(session, organization)
+    admin = await organization_repository.get_admin_user(organization)
     if admin is None:
         user_repository = UserRepository.from_session(session)
         users = await user_repository.get_all_by_organization(organization_id)


### PR DESCRIPTION
## Summary

`OrganizationRepository.get_admin_user` took `session: AsyncReadSession` as a parameter even though the repository was already constructed via `from_session(session)` and holds it as `self.session`. Switched to `self.session`, dropping the redundant arg from all 13 call sites.

Also removed a duplicate `get_admin_user` call in the v2 backoffice org detail view that was re-fetching the admin user for the team section after it had already been loaded earlier in the same request.

Mirrors the recent `MemberRepository` refactor in #11359.

## Test plan

- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run task test_fast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)