### PR TITLE
feat(receipts): show applied customer balance in payment history

### DIFF
--- a/server/polar/receipt/generator.py
+++ b/server/polar/receipt/generator.py
@@ -187,10 +187,14 @@ class ReceiptGenerator(InvoiceGenerator):
 
     def generate(self) -> None:
         super().generate()
-        if self.data.payments:
+        if self.data.payments or self._has_applied_balance:
             self._render_payment_history_section()
         if self.data.refunds:
             self._render_refunds_section()
+
+    @property
+    def _has_applied_balance(self) -> bool:
+        return (self.data.applied_balance_amount or 0) < 0
 
     def _render_section_title(self, title: str) -> None:
         self.set_y(self.get_y() + self.elements_y_margin)
@@ -217,6 +221,16 @@ class ReceiptGenerator(InvoiceGenerator):
             header.cell("Payment method")
             header.cell("Date")
             header.cell("Amount paid")
+
+            if self._has_applied_balance:
+                row = table.row()
+                row.cell(self._shape_text("Existing customer balance"))
+                row.cell(format_date(self.data.date))
+                row.cell(
+                    format_currency(
+                        -(self.data.applied_balance_amount or 0), self.data.currency
+                    )
+                )
 
             for payment in self.data.payments:
                 row = table.row()

--- a/server/tests/receipt/test_generator.py
+++ b/server/tests/receipt/test_generator.py
@@ -24,6 +24,7 @@ def _build_receipt(
     *,
     payments: list[ReceiptPayment] | None = None,
     refunds: list[ReceiptRefund] | None = None,
+    applied_balance_amount: int | None = None,
 ) -> Receipt:
     addr = Address(
         line1="123 Test St",
@@ -46,6 +47,7 @@ def _build_receipt(
         customer_address=addr,
         customer_additional_info="buyer@example.com",
         subtotal_amount=10000,
+        applied_balance_amount=applied_balance_amount,
         discount_amount=0,
         tax_breakdown=[],
         tax_amount=0,
@@ -132,6 +134,16 @@ class TestReceiptGenerator:
         receipt = _build_receipt()
         totals_labels = [t.label for t in receipt.totals_items]
         assert "Amount refunded" not in totals_labels
+
+    def test_renders_payment_history_with_only_applied_balance(self) -> None:
+        receipt = _build_receipt(payments=[], applied_balance_amount=-10000)
+        generator = ReceiptGenerator(
+            receipt, heading_title="Receipt", add_sandbox_warning=False
+        )
+        generator.generate()
+        output = generator.output()
+
+        assert bytes(output).startswith(b"%PDF-")
 
 
 class TestReceiptPayment:


### PR DESCRIPTION
## Summary

- Adds an "Existing customer balance" row to the receipt PDF's Payment history table when the order's stored customer balance was applied to reduce the amount paid.
- The row uses the order date and the absolute balance value, so payment-history rows sum to the order Total alongside the actual card/bank payment.
- The Payment history section now also renders when balance covered the entire amount (no card payment needed).

## Test plan

- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes
- [x] `tests/receipt/test_generator.py` — all 12 tests pass
- [x] Rendered a sample receipt PDF locally and visually verified:
  - Totals: Total → Applied balance → To be paid → Amount paid
  - Payment history: "Existing customer balance — \<order date\> — \<amount\>" + card row sum to Total
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)