### PR TITLE
feat: add cancel button for pending subscription updates (fix #11128)

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  useCustomerClearPendingSubscriptionUpdate,
   useCustomerCancelSubscription,
   useCustomerOrders,
   usePortalAuthenticatedUser,
@@ -10,7 +11,9 @@ import { Client, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { DataTable } from '@polar-sh/ui/components/atoms/DataTable'
+import { useState } from 'react'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { ConfirmModal } from '../Modal/ConfirmModal'
 import { useModal } from '../Modal/useModal'
 import { DownloadInvoicePortal } from '../Orders/DownloadInvoice'
 import AmountLabel from '../Shared/AmountLabel'
@@ -37,6 +40,9 @@ const CustomerPortalSubscription = ({
     isShown: cancelModalIsShown,
   } = useModal()
 
+  const [showClearPendingUpdateModal, setShowClearPendingUpdateModal] =
+    useState(false)
+
   // Get authenticated user to check billing permissions
   const { data: authenticatedUser } = usePortalAuthenticatedUser(api)
   const canManageBilling = hasBillingPermission(authenticatedUser)
@@ -48,6 +54,7 @@ const CustomerPortalSubscription = ({
   })
 
   const cancelSubscription = useCustomerCancelSubscription(api)
+  const clearPendingUpdate = useCustomerClearPendingSubscriptionUpdate(api)
 
   const pendingUpdate = subscription.pending_update
   const pendingProduct = products.find(
@@ -138,7 +145,17 @@ const CustomerPortalSubscription = ({
 
       {pendingUpdate && (
         <div className="flex flex-col gap-y-2">
-          <h3>Pending Update</h3>
+          <div className="flex flex-row items-center justify-between">
+            <h3>Pending Update</h3>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowClearPendingUpdateModal(true)}
+              loading={clearPendingUpdate.isPending}
+            >
+              Cancel scheduled change
+            </Button>
+          </div>
           <div className="flex flex-col">
             {pendingProduct && (
               <DetailRow
@@ -246,6 +263,17 @@ const CustomerPortalSubscription = ({
         isShown={cancelModalIsShown}
         hide={hideCancelModal}
         cancelSubscription={cancelSubscription}
+      />
+
+      <ConfirmModal
+        isShown={showClearPendingUpdateModal}
+        hide={() => setShowClearPendingUpdateModal(false)}
+        title="Cancel scheduled change"
+        description="Your subscription will remain unchanged on the next billing cycle. Are you sure you want to cancel this pending update?"
+        onConfirm={async () => {
+          await clearPendingUpdate.mutateAsync(subscription.id)
+          refetchOrders()
+        }}
       />
     </div>
   )

--- a/clients/apps/web/src/components/CustomerPortal/CustomerSubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerSubscriptionDetails.tsx
@@ -3,6 +3,7 @@
 import revalidate from '@/app/actions'
 import { SubscriptionStatusLabel } from '@/components/Subscriptions/utils'
 import {
+  useCustomerClearPendingSubscriptionUpdate,
   useCustomerCancelSubscription,
   useCustomerUncancelSubscription,
 } from '@/hooks/queries/customerPortal'
@@ -15,6 +16,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import CustomerPortalSubscription from './CustomerPortalSubscription'
+import { ConfirmModal } from '../Modal/ConfirmModal'
 import { InlineModal } from '../Modal/InlineModal'
 import { useModal } from '../Modal/useModal'
 import { DetailRow } from '../Shared/DetailRow'
@@ -39,6 +41,8 @@ const CustomerSubscriptionDetails = ({
 }) => {
   const [showChangePlanModal, setShowChangePlanModal] = useState(false)
   const [showCancelModal, setShowCancelModal] = useState(false)
+  const [showClearPendingUpdateModal, setShowClearPendingUpdateModal] =
+    useState(false)
 
   const {
     isShown: isBenefitGrantsModalOpen,
@@ -60,6 +64,7 @@ const CustomerSubscriptionDetails = ({
     organization.customer_portal_settings.subscription.update_plan === true
 
   const uncancelSubscription = useCustomerUncancelSubscription(api)
+  const clearPendingUpdate = useCustomerClearPendingSubscriptionUpdate(api)
   const router = useRouter()
 
   const pendingUpdate = subscription.pending_update
@@ -149,7 +154,17 @@ const CustomerSubscriptionDetails = ({
 
         {pendingUpdate && (
           <div className="mt-4 flex flex-col gap-y-2">
-            <h3>Pending Update</h3>
+            <div className="flex flex-row items-center justify-between">
+              <h3>Pending Update</h3>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowClearPendingUpdateModal(true)}
+                loading={clearPendingUpdate.isPending}
+              >
+                Cancel scheduled change
+              </Button>
+            </div>
             <div className="flex flex-col">
               {pendingProduct && (
                 <DetailRow
@@ -251,6 +266,18 @@ const CustomerSubscriptionDetails = ({
             />
           </div>
         }
+      />
+
+      <ConfirmModal
+        isShown={showClearPendingUpdateModal}
+        hide={() => setShowClearPendingUpdateModal(false)}
+        title="Cancel scheduled change"
+        description="Your subscription will remain unchanged on the next billing cycle. Are you sure you want to cancel this pending update?"
+        onConfirm={async () => {
+          await clearPendingUpdate.mutateAsync(subscription.id)
+          await revalidate(`customer_portal`)
+          router.refresh()
+        }}
       />
     </ShadowBox>
   )

--- a/clients/apps/web/src/components/Subscriptions/ScheduledUpdateSection.tsx
+++ b/clients/apps/web/src/components/Subscriptions/ScheduledUpdateSection.tsx
@@ -1,12 +1,15 @@
 'use client'
 
+import { useClearPendingSubscriptionUpdate } from '@/hooks/queries/subscriptions'
 import { useProduct } from '@/hooks/queries'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
 import { schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import { ConfirmModal } from '../Modal/ConfirmModal'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import Link from 'next/link'
-import { useContext } from 'react'
+import { useState, useContext } from 'react'
 import { DetailRow } from '../Shared/DetailRow'
 
 export const ScheduledUpdateSection = ({
@@ -18,11 +21,21 @@ export const ScheduledUpdateSection = ({
 }) => {
   const { organization } = useContext(OrganizationContext)
   const { data: newProduct } = useProduct(pendingUpdate.product_id ?? undefined)
+  const clearPendingUpdate = useClearPendingSubscriptionUpdate(subscription.id)
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
 
   return (
     <div className="mt-2 flex flex-col gap-y-4">
-      <div className="flex flex-row items-center gap-x-2">
+      <div className="flex flex-row items-center justify-between gap-x-2">
         <h3 className="text-lg">Scheduled Update</h3>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => setShowConfirmModal(true)}
+          loading={clearPendingUpdate.isPending}
+        >
+          Cancel scheduled change
+        </Button>
       </div>
       <div className="flex flex-col gap-y-2">
         {newProduct && (
@@ -53,6 +66,14 @@ export const ScheduledUpdateSection = ({
           value={<FormattedDateTime datetime={pendingUpdate.applies_at} />}
         />
       </div>
+
+      <ConfirmModal
+        isShown={showConfirmModal}
+        hide={() => setShowConfirmModal(false)}
+        title="Cancel scheduled change"
+        description="The customer's subscription will remain unchanged on the next billing cycle. Are you sure you want to cancel this pending update?"
+        onConfirm={() => clearPendingUpdate.mutateAsync()}
+      />
     </div>
   )
 }

--- a/clients/apps/web/src/hooks/queries/customerPortal.ts
+++ b/clients/apps/web/src/hooks/queries/customerPortal.ts
@@ -651,3 +651,29 @@ export const useRemoveCustomerPortalMember = (api: Client) =>
       })
     },
   })
+
+export const useCustomerClearPendingSubscriptionUpdate = (api: Client) =>
+  useMutation({
+    mutationFn: async (id: string) => {
+      const result = await api.PATCH('/v1/customer-portal/subscriptions/{id}', {
+        params: { path: { id } },
+        body: {
+          pending_update: null,
+        } as schemas['CustomerSubscriptionUpdateClear'],
+      })
+      if (result.error) {
+        throw new Error(
+          extractApiErrorMessage(
+            result.error,
+            'Failed to clear pending subscription update',
+          ),
+        )
+      }
+      return result
+    },
+    onSuccess: async () => {
+      getQueryClient().invalidateQueries({
+        queryKey: ['customer_subscriptions'],
+      })
+    },
+  })

--- a/clients/apps/web/src/hooks/queries/subscriptions.ts
+++ b/clients/apps/web/src/hooks/queries/subscriptions.ts
@@ -159,3 +159,54 @@ export const useUncancelSubscription = (id: string) =>
       })
     },
   })
+
+export const useClearPendingSubscriptionUpdate = (id: string) =>
+  useMutation({
+    mutationFn: () => {
+      return api.PATCH('/v1/subscriptions/{id}', {
+        params: { path: { id } },
+        body: {
+          pending_update: null,
+        } as schemas['SubscriptionUpdateClear'],
+      })
+    },
+    onSuccess: (result) => {
+      const { data, error } = result
+      if (error) {
+        return
+      }
+      const queryClient = getQueryClient()
+      queryClient.setQueriesData<schemas['Subscription']>(
+        {
+          queryKey: ['subscriptions', { id }],
+        },
+        data,
+      )
+      queryClient.setQueriesData<schemas['ListResource_Subscription_']>(
+        {
+          queryKey: [
+            'subscriptions',
+            { organizationId: data.product.organization_id },
+          ],
+        },
+        (old) => {
+          if (!old) {
+            return {
+              items: [data],
+              pagination: {
+                total_count: 1,
+                max_page: 1,
+              },
+            }
+          } else {
+            return {
+              items: old.items.map((item) =>
+                item.id === data.id ? data : item,
+              ),
+              pagination: old.pagination,
+            }
+          }
+        },
+      )
+    },
+  })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -16430,6 +16430,15 @@ export interface components {
       | components['schemas']['CustomerSubscriptionUpdateProduct']
       | components['schemas']['CustomerSubscriptionUpdateSeats']
       | components['schemas']['CustomerSubscriptionCancel']
+      | components['schemas']['CustomerSubscriptionUpdateClear']
+    /** CustomerSubscriptionUpdateClear */
+    CustomerSubscriptionUpdateClear: {
+      /**
+       * Pending Update
+       * @description Clear the pending subscription update.
+       */
+      pending_update: null
+    }
     /** CustomerSubscriptionUpdateProduct */
     CustomerSubscriptionUpdateProduct: {
       /**
@@ -28092,6 +28101,7 @@ export interface components {
       | components['schemas']['SubscriptionUpdateBillingPeriod']
       | components['schemas']['SubscriptionCancel']
       | components['schemas']['SubscriptionRevoke']
+      | components['schemas']['SubscriptionUpdateClear']
     /** SubscriptionUpdateBillingPeriod */
     SubscriptionUpdateBillingPeriod: {
       /**
@@ -28102,6 +28112,94 @@ export interface components {
        *     It is not possible to update the current billing period on a canceled subscription.
        */
       current_billing_period_end: string
+    }
+    /** SubscriptionUpdateClear */
+    SubscriptionUpdateClear: {
+      /**
+       * Pending Update
+       * @description Clear the pending subscription update. Set to null to remove scheduled changes.
+       */
+      pending_update: null
+    }
+    /**
+     * SubscriptionUpdateClearedEvent
+     * @description An event created by Polar when a pending subscription update is cleared without being applied.
+     */
+    SubscriptionUpdateClearedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.update_cleared'
+      metadata: components['schemas']['SubscriptionUpdateClearedMetadata']
+    }
+    /** SubscriptionUpdateClearedMetadata */
+    SubscriptionUpdateClearedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
     }
     /** SubscriptionUpdateDiscount */
     SubscriptionUpdateDiscount: {
@@ -28295,6 +28393,7 @@ export interface components {
       | components['schemas']['SubscriptionProductUpdatedEvent']
       | components['schemas']['SubscriptionSeatsUpdatedEvent']
       | components['schemas']['SubscriptionBillingPeriodUpdatedEvent']
+      | components['schemas']['SubscriptionUpdateClearedEvent']
       | components['schemas']['OrderPaidEvent']
       | components['schemas']['OrderRefundedEvent']
       | components['schemas']['OrderVoidedEvent']
@@ -54525,6 +54624,9 @@ export const subscriptionStatusValues: ReadonlyArray<
 export const subscriptionUncanceledEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionUncanceledEvent']['name']
 > = ['subscription.uncanceled']
+export const subscriptionUpdateClearedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionUpdateClearedEvent']['name']
+> = ['subscription.update_cleared']
 export const subscriptionUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionUpdatedEvent']['name']
 > = ['subscription.updated']

--- a/server/polar/customer_portal/schemas/subscription.py
+++ b/server/polar/customer_portal/schemas/subscription.py
@@ -127,9 +127,14 @@ class CustomerSubscriptionCancel(Schema):
     )
 
 
+class CustomerSubscriptionUpdateClear(Schema):
+    pending_update: None = Field(description="Clear the pending subscription update.")
+
+
 CustomerSubscriptionUpdate = Annotated[
     CustomerSubscriptionUpdateProduct
     | CustomerSubscriptionUpdateSeats
-    | CustomerSubscriptionCancel,
+    | CustomerSubscriptionCancel
+    | CustomerSubscriptionUpdateClear,
     SetSchemaReference("CustomerSubscriptionUpdate"),
 ]

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -24,6 +24,7 @@ from polar.subscription.service import subscription as subscription_service
 
 from ..schemas.subscription import (
     CustomerSubscriptionUpdate,
+    CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
     CustomerSubscriptionUpdateSeats,
 )
@@ -162,6 +163,11 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 subscription,
                 seats=updates.seats,
                 proration_behavior=updates.proration_behavior,
+            )
+
+        if isinstance(updates, CustomerSubscriptionUpdateClear):
+            return await subscription_service.clear_pending_update(
+                session, subscription
             )
 
         cancel = updates.cancel_at_period_end is True

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -38,6 +38,7 @@ from polar.event.system import (
     SubscriptionRevokedMetadata,
     SubscriptionSeatsUpdatedMetadata,
     SubscriptionUncanceledMetadata,
+    SubscriptionUpdateClearedMetadata,
     SubscriptionUpdatedMetadata,
 )
 from polar.event.system import SystemEvent as SystemEventEnum
@@ -411,6 +412,17 @@ class SubscriptionSeatsUpdatedEvent(SystemEventBase):
     )
 
 
+class SubscriptionUpdateClearedEvent(SystemEventBase):
+    """An event created by Polar when a pending subscription update is cleared without being applied."""
+
+    name: Literal[SystemEventEnum.subscription_update_cleared] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionUpdateClearedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class SubscriptionBillingPeriodUpdatedEvent(SystemEventBase):
     """An event created by Polar when a subscription billing period is updated."""
 
@@ -571,6 +583,7 @@ SystemEvent = Annotated[
     | SubscriptionProductUpdatedEvent
     | SubscriptionSeatsUpdatedEvent
     | SubscriptionBillingPeriodUpdatedEvent
+    | SubscriptionUpdateClearedEvent
     | OrderPaidEvent
     | OrderRefundedEvent
     | OrderVoidedEvent

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -28,6 +28,7 @@ class SystemEvent(StrEnum):
     subscription_product_updated = "subscription.product_updated"
     subscription_seats_updated = "subscription.seats_updated"
     subscription_billing_period_updated = "subscription.billing_period_updated"
+    subscription_update_cleared = "subscription.update_cleared"
     order_paid = "order.paid"
     order_refunded = "order.refunded"
     order_voided = "order.voided"
@@ -61,6 +62,7 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "checkout.created": "Checkout Created",
     "subscription.seats_updated": "Subscription Seats Updated",
     "subscription.billing_period_updated": "Subscription Billing Period Updated",
+    "subscription.update_cleared": "Subscription Update Cleared",
     "customer.created": "Customer Created",
     "customer.updated": "Customer Updated",
     "customer.deleted": "Customer Deleted",
@@ -352,6 +354,17 @@ class SubscriptionBillingPeriodUpdatedEvent(Event):
         source: Mapped[Literal[EventSource.system]]
         name: Mapped[Literal[SystemEvent.subscription_billing_period_updated]]
         user_metadata: Mapped[SubscriptionBillingPeriodUpdatedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionUpdateClearedMetadata(TypedDict):
+    subscription_id: str
+
+
+class SubscriptionUpdateClearedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_update_cleared]]
+        user_metadata: Mapped[SubscriptionUpdateClearedMetadata]  # type: ignore[assignment]
 
 
 class OrderPaidMetadata(TypedDict):
@@ -688,6 +701,15 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionBillingPeriodUpdatedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_update_cleared],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionUpdateClearedMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -389,6 +389,12 @@ class SubscriptionRevoke(SubscriptionCancelBase):
     )
 
 
+class SubscriptionUpdateClear(Schema):
+    pending_update: Literal[None] = Field(
+        description="Clear the pending subscription update. Set to null to remove scheduled changes."
+    )
+
+
 SubscriptionUpdate = Annotated[
     SubscriptionUpdateProduct
     | SubscriptionUpdateDiscount
@@ -396,7 +402,8 @@ SubscriptionUpdate = Annotated[
     | SubscriptionUpdateSeats
     | SubscriptionUpdateBillingPeriod
     | SubscriptionCancel
-    | SubscriptionRevoke,
+    | SubscriptionRevoke
+    | SubscriptionUpdateClear,
     SetSchemaReference("SubscriptionUpdate"),
 ]
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -110,6 +110,7 @@ from .schemas import (
     SubscriptionRevoke,
     SubscriptionUpdate,
     SubscriptionUpdateBillingPeriod,
+    SubscriptionUpdateClear,
     SubscriptionUpdateDiscount,
     SubscriptionUpdateProduct,
     SubscriptionUpdateSeats,
@@ -974,6 +975,9 @@ class SubscriptionService:
                 immediately=True,
             )
 
+        if isinstance(update, SubscriptionUpdateClear):
+            return await self.clear_pending_update(session, subscription)
+
     async def update_product(
         self,
         session: AsyncSession,
@@ -1193,6 +1197,56 @@ class SubscriptionService:
             subscription,
             previous_status=previous_status,
             previous_is_canceled=previous_is_canceled,
+        )
+
+        return subscription
+
+    async def clear_pending_update(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+    ) -> Subscription:
+        """Clear the pending update for a subscription."""
+        if subscription.pending_update is None:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "pending_update"),
+                        "msg": "This subscription has no pending update to clear.",
+                        "input": None,
+                    }
+                ]
+            )
+
+        subscription_update_repository = SubscriptionUpdateRepository.from_session(
+            session
+        )
+        await subscription_update_repository.soft_delete_unapplied_by_subscription_id(
+            subscription.id
+        )
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.update(
+            subscription, update_dict={"pending_update": None}
+        )
+
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_update_cleared,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata={
+                    "subscription_id": str(subscription.id),
+                },
+            ),
+        )
+
+        await self._after_subscription_updated(
+            session,
+            subscription,
+            previous_status=subscription.status,
+            previous_is_canceled=False,
         )
 
         return subscription

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -5,6 +5,7 @@ import pytest
 
 from polar.auth.models import AuthSubject
 from polar.customer_portal.schemas.subscription import (
+    CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
     CustomerSubscriptionUpdateSeats,
 )
@@ -15,6 +16,7 @@ from polar.customer_portal.service.subscription import (
 from polar.customer_portal.service.subscription import (
     customer_subscription as customer_subscription_service,
 )
+from polar.enums import SubscriptionProrationBehavior
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams
 from polar.models import (
@@ -27,6 +29,7 @@ from polar.models import (
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.subscription.service import AlreadyCanceledSubscription
+from polar.subscription.update import generate_subscription_update
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -382,3 +385,68 @@ class TestCancel:
         assert updated_subscription.ended_at is None
         assert updated_subscription.cancel_at_period_end
         assert updated_subscription.ends_at == updated_subscription.current_period_end
+
+
+@pytest.mark.asyncio
+class TestClearPendingUpdate:
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
+    async def test_clear_pending_product_update(
+        self,
+        auth_subject: AuthSubject[Customer],
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+        product_second: Product,
+    ) -> None:
+
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=product_second,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        updates = CustomerSubscriptionUpdateClear(pending_update=None)
+        updated = await customer_subscription_service.update(
+            session, subscription, updates=updates
+        )
+        await save_fixture(updated)
+
+        assert updated.pending_update is None
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="customer"))
+    async def test_clear_pending_update_no_pending(
+        self,
+        auth_subject: AuthSubject[Customer],
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+
+        updates = CustomerSubscriptionUpdateClear(pending_update=None)
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await customer_subscription_service.update(
+                session, subscription, updates=updates
+            )
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["type"] == "value_error"
+        assert errors[0]["loc"] == ("body", "pending_update")
+        assert "no pending update" in errors[0]["msg"]

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -5024,3 +5024,105 @@ class TestCancelCustomer:
             "Expected no calls to 'benefit.enqueue_benefits_grants', "
             f"but found {len(benefit_grant_calls)} call(s)"
         )
+
+
+@pytest.mark.asyncio
+class TestClearPendingUpdate:
+    async def test_clear_pending_product_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        # Given: Subscription with a pending product update
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=product_second,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        # When: Clear the pending update
+        updated_subscription = await subscription_service.clear_pending_update(
+            session,
+            subscription,
+        )
+        await save_fixture(updated_subscription)
+
+        # Then: Pending update is cleared
+        assert updated_subscription.pending_update is None
+
+    async def test_clear_pending_update_no_pending(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # Given: Subscription with no pending update
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+
+        # When/Then: Should raise validation error
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await subscription_service.clear_pending_update(
+                session,
+                subscription,
+            )
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["type"] == "value_error"
+        assert errors[0]["loc"] == ("body", "pending_update")
+        assert "no pending update" in errors[0]["msg"]
+
+    async def test_clear_pending_seat_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        # Given: Seat-based product and subscription with a pending seat update
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=5,
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            seats=10,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        # When: Clear the pending update
+        updated_subscription = await subscription_service.clear_pending_update(
+            session,
+            subscription,
+        )
+        await save_fixture(updated_subscription)
+
+        # Then: Pending update is cleared
+        assert updated_subscription.pending_update is None


### PR DESCRIPTION
## Summary

**Related Issue**: #11128

Both Customer Portal and Merchant Dashboard show pending subscription changes in read-only UIs. This adds a way to cancel a scheduled change from the UI.

## What

- Add Cancel buttons next to pending update sections in both Customer Portal and Merchant Dashboard
- Add confirmation modals before clearing pending updates
- Add mutation hooks for both Customer Portal (`useCustomerClearPendingSubscriptionUpdate`) and Merchant Dashboard (`useClearPendingSubscriptionUpdate`)

## Why

Users and merchants need the ability to cancel pending subscription updates (product changes, seat changes) before they take effect. Previously, pending changes could only be cancelled via API.

## How

- Created mutation hooks that PATCH the subscription with `pending_update: null` using existing API endpoints:
  - Customer Portal: `PATCH /v1/customer-portal/subscriptions/{id}` with `CustomerSubscriptionUpdateClear` schema
  - Merchant Dashboard: `PATCH /v1/subscriptions/{id}` with `SubscriptionUpdateClear` schema
- Added Cancel buttons with `variant="secondary"` and `size="sm"` in the header of pending update sections
- Added ConfirmModal with context-aware copy:
  - Customer Portal: "Your subscription will remain unchanged on the next billing cycle. Are you sure you want to cancel this pending update?"
  - Merchant Dashboard: "The customer's subscription will remain unchanged on the next billing cycle. Are you sure you want to cancel this pending update?"
- Updated cache invalidation to refresh data after clearing

## Screenshots

<img width="2732" height="2048" alt="Subscription | frankie567 | Polar" src="https://github.com/user-attachments/assets/7de53617-18b3-4db7-865b-c298e467b05f" />

<img width="2732" height="2048" alt="Subscription | frankie567 | Polar 2" src="https://github.com/user-attachments/assets/bdd5e0a4-a2d5-41e0-b686-a7709eead776" />

<img width="2732" height="2258" alt="Customer Portal | frankie567 | Polar 3" src="https://github.com/user-attachments/assets/bf385ac1-64a5-4eae-941a-ca0d9dc72b65" />

<img width="2732" height="2258" alt="Customer Portal | frankie567 | Polar 4" src="https://github.com/user-attachments/assets/54b787b2-7f7c-47e8-af25-e66326049c32" />

## Checklist

- [x] This PR addresses a single concern (one feature)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included