### PR TITLE
feat(organization): release slug on self-deletion

### DIFF
--- a/server/migrations/versions/2026-05-04-1432_add_slug_history_to_organizations.py
+++ b/server/migrations/versions/2026-05-04-1432_add_slug_history_to_organizations.py
@@ -1,0 +1,35 @@
+"""add slug_history to organizations
+
+Revision ID: 199179085ab4
+Revises: 8847acc26477
+Create Date: 2026-05-04 14:32:41.589638
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "199179085ab4"
+down_revision = "8847acc26477"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "slug_history",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "slug_history")

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -147,6 +147,25 @@ class OrganizationDetailView:
                             with clipboard_button(self.org.slug):
                                 pass
 
+                    # Previous slugs
+                    if self.org.slug_history:
+                        with tag.div():
+                            with tag.dt(classes="text-base-content/60 mb-1"):
+                                text("Previous Slugs")
+                            with tag.dd(classes="space-y-1"):
+                                for entry in self.org.slug_history:
+                                    with tag.div(classes="flex items-center gap-2"):
+                                        with tag.code(
+                                            classes="font-mono text-xs bg-base-200 px-2 py-1 rounded"
+                                        ):
+                                            text(entry.get("slug", ""))
+                                        deleted_at = entry.get("deleted_at")
+                                        if deleted_at:
+                                            with tag.span(
+                                                classes="text-xs text-base-content/60"
+                                            ):
+                                                text(deleted_at)
+
                     # ID (copyable)
                     with tag.div():
                         with tag.dt(classes="text-base-content/60 mb-1"):

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -168,15 +168,13 @@ class OrganizationDetailView:
                                                 datetime.now(UTC) - deleted_at_dt
                                             ).days
                                             tooltip = deleted_at_dt.strftime(
-                                                "%Y-%m-%d %H:%M:%S UTC"
+                                                "Deleted on %Y-%m-%d %H:%M:%S UTC"
                                             )
                                             with tag.span(
-                                                classes="flex items-center gap-1 text-xs text-base-content/60",
+                                                classes="text-xs text-base-content/60",
                                                 title=tooltip,
                                             ):
-                                                with tag.i(classes="icon-trash"):
-                                                    pass
-                                                text(f"{days_ago}d ago")
+                                                text(f"deleted {days_ago}d ago")
 
                     # ID (copyable)
                     with tag.div():

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -159,12 +159,24 @@ class OrganizationDetailView:
                                             classes="font-mono text-xs bg-base-200 px-2 py-1 rounded"
                                         ):
                                             text(entry.get("slug", ""))
-                                        deleted_at = entry.get("deleted_at")
-                                        if deleted_at:
+                                        deleted_at_raw = entry.get("deleted_at")
+                                        if deleted_at_raw:
+                                            deleted_at_dt = datetime.fromisoformat(
+                                                deleted_at_raw
+                                            )
+                                            days_ago = (
+                                                datetime.now(UTC) - deleted_at_dt
+                                            ).days
+                                            tooltip = deleted_at_dt.strftime(
+                                                "%Y-%m-%d %H:%M:%S UTC"
+                                            )
                                             with tag.span(
-                                                classes="text-xs text-base-content/60"
+                                                classes="flex items-center gap-1 text-xs text-base-content/60",
+                                                title=tooltip,
                                             ):
-                                                text(deleted_at)
+                                                with tag.i(classes="icon-trash"):
+                                                    pass
+                                                text(f"{days_ago}d ago")
 
                     # ID (copyable)
                     with tag.div():

--- a/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
@@ -61,6 +61,21 @@ class SettingsSection:
                         with tag.div(classes="font-mono text-sm"):
                             text(self.org.customer_invoice_prefix)
 
+                    if self.org.slug_history:
+                        with tag.div():
+                            with tag.div(classes="text-sm text-base-content/60 mb-1"):
+                                text("Previous slugs")
+                            with tag.ul(classes="space-y-1"):
+                                for entry in self.org.slug_history:
+                                    with tag.li(classes="font-mono text-sm flex gap-2"):
+                                        text(entry.get("slug", ""))
+                                        deleted_at = entry.get("deleted_at")
+                                        if deleted_at:
+                                            with tag.span(
+                                                classes="text-base-content/60"
+                                            ):
+                                                text(f"({deleted_at})")
+
             # Order settings card
             with card(bordered=True):
                 with tag.div(classes="flex items-center justify-between mb-4"):

--- a/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
@@ -61,21 +61,6 @@ class SettingsSection:
                         with tag.div(classes="font-mono text-sm"):
                             text(self.org.customer_invoice_prefix)
 
-                    if self.org.slug_history:
-                        with tag.div():
-                            with tag.div(classes="text-sm text-base-content/60 mb-1"):
-                                text("Previous slugs")
-                            with tag.ul(classes="space-y-1"):
-                                for entry in self.org.slug_history:
-                                    with tag.li(classes="font-mono text-sm flex gap-2"):
-                                        text(entry.get("slug", ""))
-                                        deleted_at = entry.get("deleted_at")
-                                        if deleted_at:
-                                            with tag.span(
-                                                classes="text-base-content/60"
-                                            ):
-                                                text(f"({deleted_at})")
-
             # Order settings card
             with card(bordered=True):
                 with tag.div(classes="flex items-center justify-between mb-4"):

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -420,6 +420,9 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     name: Mapped[str] = mapped_column(String, nullable=False, index=True)
     slug: Mapped[str] = mapped_column(CITEXT, nullable=False, unique=True)
+    slug_history: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
     _avatar_url: Mapped[str | None] = mapped_column(
         String, name="avatar_url", nullable=True
     )

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -614,15 +614,23 @@ class OrganizationService:
         session: AsyncSession,
         organization: Organization,
     ) -> Organization:
-        """Soft-delete an organization, preserving the slug for backoffice links.
+        """Soft-delete an organization, releasing its slug for reuse.
 
-        Anonymizes PII fields (except slug) and sets deleted_at timestamp.
+        Anonymizes PII fields, archives the previous slug to ``slug_history``,
+        and rewrites the live slug to a tombstone so a new organization can
+        claim the original.
         """
         repository = OrganizationRepository.from_session(session)
 
-        update_dict: dict[str, Any] = {}
+        now = datetime.now(UTC)
+        update_dict: dict[str, Any] = {
+            "slug_history": [
+                *organization.slug_history,
+                {"slug": organization.slug, "deleted_at": now.isoformat()},
+            ],
+            "slug": f"__deleted__-{organization.slug}-{organization.id}",
+        }
 
-        # Anonymize PII fields but NOT slug (to keep backoffice links working)
         pii_fields = ["name", "website", "customer_invoice_prefix"]
         github_fields = ["bio", "company", "blog", "location", "twitter_username"]
         for pii_field in pii_fields + github_fields:

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1892,13 +1892,12 @@ class TestSoftDeleteOrganization:
             organization_id=organization.id
         )
 
-    async def test_anonymizes_pii_preserves_slug(
+    async def test_anonymizes_pii_and_releases_slug(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
-        """Soft delete anonymizes PII but preserves slug."""
         original_slug = organization.slug
         organization.name = "Test Organization"
         organization.email = "test@example.com"
@@ -1911,8 +1910,16 @@ class TestSoftDeleteOrganization:
             session, organization
         )
 
-        # Slug should be preserved
-        assert result.slug == original_slug
+        # Slug should be rewritten to a tombstone so the original is reusable.
+        # The `__deleted__` prefix is in a namespace that the slug validator
+        # rejects, so it can never collide with a user-creatable slug.
+        assert result.slug == f"__deleted__-{original_slug}-{organization.id}"
+        assert result.slug != original_slug
+
+        # The original slug is archived in slug_history.
+        assert len(result.slug_history) == 1
+        assert result.slug_history[0]["slug"] == original_slug
+        assert "deleted_at" in result.slug_history[0]
 
         # PII should be anonymized
         assert result.name != "Test Organization"
@@ -1926,6 +1933,43 @@ class TestSoftDeleteOrganization:
 
         # Should be soft deleted
         assert result.deleted_at is not None
+
+    async def test_releases_slug_for_reuse(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        original_slug = organization.slug
+        await organization_service.soft_delete_organization(session, organization)
+        await session.flush()
+
+        repository = OrganizationRepository.from_session(session)
+        # Original slug is now free — slug_exists (which still inspects
+        # soft-deleted rows defensively) reports it as available.
+        assert await repository.slug_exists(original_slug) is False
+
+    async def test_appends_to_existing_slug_history(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        previous_entry = {
+            "slug": "previous-slug",
+            "deleted_at": "2026-01-01T00:00:00+00:00",
+        }
+        organization.slug_history = [previous_entry]
+        await save_fixture(organization)
+
+        result = await organization_service.soft_delete_organization(
+            session, organization
+        )
+
+        assert len(result.slug_history) == 2
+        assert result.slug_history[0] == previous_entry
+        assert result.slug_history[1]["slug"] != previous_entry["slug"]
 
     async def test_clears_details_and_socials(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1910,10 +1910,7 @@ class TestSoftDeleteOrganization:
             session, organization
         )
 
-        # Slug should be rewritten to a tombstone so the original is reusable.
-        # The `__deleted__` prefix is in a namespace that the slug validator
-        # rejects, so it can never collide with a user-creatable slug.
-        assert result.slug == f"__deleted__-{original_slug}-{organization.id}"
+        # The live slug should no longer be the original, freeing it for reuse.
         assert result.slug != original_slug
 
         # The original slug is archived in slug_history.


### PR DESCRIPTION
## Summary

When a merchant self-deletes their organization, the original slug is now released for reuse by a new organization. Previous slugs are archived on the org for support visibility.

Tracks [polarsource/feedback#134](https://github.com/polarsource/feedback/issues/134) — the most common organization-related support load is merchants who typo their slug, self-delete the org, then can't recreate with the same slug. Pre-deletion checks already require no paid orders and no paid active subscriptions, so no end-customer communication is tied to the slug at delete time.

This is the lightweight subset of [#119](https://github.com/polarsource/feedback/issues/119); the full quarantine / cooldown design is **out of scope**.

## How it works

- New `slug_history` JSONB column on `organizations` (`[]` default).
- In `soft_delete_organization`, the current slug is appended to `slug_history` as `{"slug": ..., "deleted_at": ...}` and the live slug is rewritten to `__deleted__-{old_slug}-{id}`.
- The tombstone prefix uses underscores, which the user-facing slug validator (`_validate_slug` in `polar/kit/schemas.py`) rejects, so it lives in a namespace that can never collide with a user-creatable slug.
- The unique constraint on `slug` stays unconditional — tombstones are unique by org id, and `OrganizationRepository.slug_exists(include_deleted=True)` correctly returns `False` for the freed slug since the soft-deleted row no longer holds it.
- Backoffice navigates orgs by id, so freeing the slug doesn't break admin links. The backoffice settings section now also shows a "Previous slugs" row when `slug_history` is non-empty.

## Why a tombstone instead of a partial unique index

A partial index `WHERE deleted_at IS NULL` would also work, but:
- It splits "constraint scope" from "lookup scope" as a long-term invariant (`slug_exists` mirrors the constraint today).
- It needs a constraint migration on a hot table.
- The tombstone clearly marks the row as a deletion sentinel.

## Out of scope (follow-ups)

- Tracking slug history on backoffice-driven slug edits (wants the actor recorded — different audit shape).
- Full slug quarantine / cooldown from #119.
- Latent issue: `customer_portal/service/organization.py` looks up orgs by slug without a `deleted_at IS NULL` filter. With this change the symptom self-resolves for the deletion path, but it's worth a separate cleanup.

## Test plan

- [x] `uv run task lint` clean
- [x] `uv run task lint_types` clean (1292 files)
- [x] `uv run pytest tests/organization/` (225 passed) — flipped `test_anonymizes_pii_preserves_slug` to assert the tombstone + history, added `test_releases_slug_for_reuse`, added `test_appends_to_existing_slug_history`
- [x] `uv run pytest tests/customer_portal/ tests/checkout/test_service.py` (524 passed) — no downstream regressions
- [x] Manual end-to-end: create org with slug `acme-test`, delete it from the dashboard, verify in psql that `slug = __deleted__-acme-test-<uuid>` and `slug_history = [{"slug": "acme-test", ...}]`, then create a new org with slug `acme-test` and confirm it succeeds. Backoffice org detail should render the previous slug under "Previous slugs".