### PR TITLE
feat: implement organization self-review checklist

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -905,10 +905,8 @@ export interface paths {
      * Get Organization Self-Review Checklist
      * @description Get the merchant self-review checklist state.
      *
-     *     Powers the new account review UI: pre-submission gating checks plus,
-     *     after submission, the AI verdict and appeal state. Currently returns
-     *     a hardcoded mock — `?status=pass|fail` switches between the two
-     *     canned responses while the real check logic is built out.
+     *     Powers the account review UI: pre-submission gating checks plus,
+     *     after submission, the AI verdict and appeal state.
      */
     get: operations['organizations:get_review']
     put?: never
@@ -32296,10 +32294,7 @@ export interface operations {
   }
   'organizations:get_review': {
     parameters: {
-      query?: {
-        /** @description STUB: switch the mocked response. `pass` returns an all-passed checklist, `fail` returns an all-failed one. Omit for the default (all-passed) mock. */
-        status?: ('pass' | 'fail') | null
-      }
+      query?: never
       header?: never
       path: {
         id: string
@@ -46957,9 +46952,6 @@ type FlattenedDeepRequired<T> = {
 type ReadonlyArray<T> = [Exclude<T, undefined>] extends [unknown[]]
   ? Readonly<Exclude<T, undefined>>
   : Readonly<Exclude<T, undefined>[]>
-export const pathsV1OrganizationsIdReviewGetParametersQueryStatusAnyOf0Values: ReadonlyArray<
-  FlattenedDeepRequired<paths>['/v1/organizations/{id}/review']['get']['parameters']['query']['status']
-> = ['pass', 'fail']
 export const pathsV1WebhooksDeliveriesGetParametersQueryHttp_code_classAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<paths>['/v1/webhooks/deliveries']['get']['parameters']['query']['http_code_class']
 > = ['2xx', '3xx', '4xx', '5xx']

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -1,4 +1,3 @@
-from typing import Literal
 from uuid import UUID
 
 import httpx
@@ -648,25 +647,14 @@ async def get_review_status(
 )
 async def get_review(
     authz: AuthorizeOrgAccess,
-    status: Literal["pass", "fail"] | None = Query(
-        None,
-        description=(
-            "STUB: switch the mocked response. `pass` returns an all-passed "
-            "checklist, `fail` returns an all-failed one. Omit for the default "
-            "(all-passed) mock."
-        ),
-    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewState:
     """Get the merchant self-review checklist state.
 
-    Powers the new account review UI: pre-submission gating checks plus,
-    after submission, the AI verdict and appeal state. Currently returns
-    a hardcoded mock — `?status=pass|fail` switches between the two
-    canned responses while the real check logic is built out.
+    Powers the account review UI: pre-submission gating checks plus,
+    after submission, the AI verdict and appeal state.
     """
-    return await organization_service.get_review_state(
-        authz.organization, status=status
-    )
+    return await organization_service.get_review_state(session, authz.organization)
 
 
 @router.post(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -601,6 +601,9 @@ class OrganizationReviewAppeal(Schema):
     decision: OrganizationReview.AppealDecision | None = None
 
 
+OrganizationReviewVerdict = Literal["pass", "fail"]
+
+
 class OrganizationReviewState(Schema):
     """Merchant self-review checklist. Frozen once `submitted_at` is set."""
 
@@ -611,7 +614,7 @@ class OrganizationReviewState(Schema):
         )
     )
     submitted_at: datetime | None = None
-    verdict: Literal["pass", "fail"] | None = None
+    verdict: OrganizationReviewVerdict | None = None
     appeal: OrganizationReviewAppeal | None = None
     preliminary_steps: list[OrganizationReviewCheck] = Field(default_factory=list)
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal, cast
+from typing import Any, assert_never, cast
 from uuid import UUID
 
 import structlog
@@ -68,12 +68,14 @@ from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (
     OrganizationCreate,
     OrganizationDeletionBlockedReason,
+    OrganizationReviewAppeal,
     OrganizationReviewCheck,
     OrganizationReviewCheckKey,
     OrganizationReviewCheckReason,
     OrganizationReviewCheckStatus,
     OrganizationReviewState,
     OrganizationReviewSubmissionBody,
+    OrganizationReviewVerdict,
     OrganizationUpdate,
 )
 from .sorting import OrganizationSortProperty
@@ -1163,51 +1165,171 @@ class OrganizationService:
 
     async def get_review_state(
         self,
+        session: AsyncReadSession,
         organization: Organization,
-        *,
-        status: Literal["pass", "fail"] | None = None,
     ) -> OrganizationReviewState:
         """Build the merchant self-review checklist state.
 
-        STUB: returns one of two hardcoded mocks so the new dashboard UI can
-        integrate against the contract while the real check logic is built
-        out incrementally. The shape is final; only the values are dummy.
-
-        - ``status="pass"`` (default): every check ``passed``.
-        - ``status="fail"``: every check ``failed`` with a representative reason.
+        Pre-submission, the response surfaces gating checks that block
+        submission until resolved. Once submitted, ``submitted_at`` is set
+        and the response also carries the AI verdict and any appeal state.
         """
-        is_fail = status == "fail"
-        check_status = (
-            OrganizationReviewCheckStatus.FAILED
-            if is_fail
-            else OrganizationReviewCheckStatus.PASSED
-        )
-        identity_reasons = (
-            [OrganizationReviewCheckReason.IDENTITY_REJECTED] if is_fail else []
-        )
-        payout_reasons = (
-            [OrganizationReviewCheckReason.PAYOUT_ACCOUNT_REQUIREMENTS_DUE]
-            if is_fail
-            else []
-        )
-        checks = [
-            (OrganizationReviewCheckKey.IDENTITY_EMAIL, identity_reasons),
-            (OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS, identity_reasons),
-            (OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION, identity_reasons),
-            (OrganizationReviewCheckKey.PRODUCT_DESCRIPTION, []),
-            (OrganizationReviewCheckKey.PAYOUT_ACCOUNT, payout_reasons),
-        ]
+        payout_account: PayoutAccount | None = None
+        if organization.payout_account_id is not None:
+            payout_account_repository = PayoutAccountRepository.from_session(session)
+            payout_account = await payout_account_repository.get_by_id(
+                organization.payout_account_id
+            )
+
+        organization_repository = OrganizationRepository.from_session(session)
+        admin_user = await organization_repository.get_admin_user(session, organization)
+
+        review_repository = OrganizationReviewRepository.from_session(session)
+        review = await review_repository.get_by_organization(organization.id)
+
         preliminary_steps = [
-            OrganizationReviewCheck(key=key, status=check_status, reasons=reasons)
-            for key, reasons in checks
+            self._build_email_check(organization),
+            self._build_socials_check(organization),
+            self._build_identity_verification_check(admin_user),
+            self._build_product_description_check(organization),
+            self._build_payout_account_check(payout_account),
         ]
+
+        submitted_at = organization.details_submitted_at
+        is_blocked = any(
+            step.status
+            in (
+                OrganizationReviewCheckStatus.FAILED,
+                OrganizationReviewCheckStatus.PENDING,
+            )
+            for step in preliminary_steps
+        )
+        can_submit = submitted_at is None and not is_blocked
+
+        verdict: OrganizationReviewVerdict | None = None
+        appeal: OrganizationReviewAppeal | None = None
+        if review is not None:
+            if review.verdict == OrganizationReview.Verdict.PASS:
+                verdict = "pass"
+            elif review.verdict == OrganizationReview.Verdict.FAIL:
+                verdict = "fail"
+            if review.appeal_submitted_at is not None:
+                appeal = OrganizationReviewAppeal(
+                    submitted_at=review.appeal_submitted_at,
+                    reviewed_at=review.appeal_reviewed_at,
+                    decision=review.appeal_decision,
+                )
 
         return OrganizationReviewState(
-            can_submit=not is_fail,
-            submitted_at=None,
-            verdict=None,
-            appeal=None,
+            can_submit=can_submit,
+            submitted_at=submitted_at,
+            verdict=verdict,
+            appeal=appeal,
             preliminary_steps=preliminary_steps,
+        )
+
+    @staticmethod
+    def _not_started_check(
+        key: OrganizationReviewCheckKey,
+    ) -> OrganizationReviewCheck:
+        return OrganizationReviewCheck(
+            key=key,
+            status=OrganizationReviewCheckStatus.PENDING,
+            reasons=[OrganizationReviewCheckReason.NOT_STARTED],
+        )
+
+    @staticmethod
+    def _passed_check(key: OrganizationReviewCheckKey) -> OrganizationReviewCheck:
+        return OrganizationReviewCheck(
+            key=key, status=OrganizationReviewCheckStatus.PASSED
+        )
+
+    def _build_email_check(self, organization: Organization) -> OrganizationReviewCheck:
+        key = OrganizationReviewCheckKey.IDENTITY_EMAIL
+        if not organization.email:
+            return self._not_started_check(key)
+        return self._passed_check(key)
+
+    def _build_socials_check(
+        self, organization: Organization
+    ) -> OrganizationReviewCheck:
+        key = OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS
+        if not organization.socials:
+            return self._not_started_check(key)
+        return self._passed_check(key)
+
+    def _build_identity_verification_check(
+        self, admin_user: User | None
+    ) -> OrganizationReviewCheck:
+        key = OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION
+        if admin_user is None:
+            return self._not_started_check(key)
+
+        status = admin_user.identity_verification_status
+        match status:
+            case IdentityVerificationStatus.verified:
+                return self._passed_check(key)
+            case IdentityVerificationStatus.pending:
+                return OrganizationReviewCheck(
+                    key=key,
+                    status=OrganizationReviewCheckStatus.PENDING,
+                    reasons=[OrganizationReviewCheckReason.EXTERNAL_PENDING],
+                )
+            case IdentityVerificationStatus.failed:
+                return OrganizationReviewCheck(
+                    key=key,
+                    status=OrganizationReviewCheckStatus.FAILED,
+                    reasons=[OrganizationReviewCheckReason.IDENTITY_REJECTED],
+                )
+            case IdentityVerificationStatus.unverified:
+                return self._not_started_check(key)
+            case _:
+                assert_never(status)
+
+    def _build_product_description_check(
+        self, organization: Organization
+    ) -> OrganizationReviewCheck:
+        key = OrganizationReviewCheckKey.PRODUCT_DESCRIPTION
+        description = organization.details.get("product_description")
+        # ``details`` is JSONB — defend against non-string values written by
+        # legacy migrations or backoffice tooling.
+        if not isinstance(description, str) or not description.strip():
+            return self._not_started_check(key)
+        # Mirrors OrganizationReviewSubmissionDetails: min_length=30 after strip.
+        if len(description.strip()) < 30:
+            return OrganizationReviewCheck(
+                key=key,
+                status=OrganizationReviewCheckStatus.FAILED,
+                reasons=[OrganizationReviewCheckReason.IN_PROGRESS],
+            )
+        return self._passed_check(key)
+
+    def _build_payout_account_check(
+        self, payout_account: PayoutAccount | None
+    ) -> OrganizationReviewCheck:
+        key = OrganizationReviewCheckKey.PAYOUT_ACCOUNT
+        if payout_account is None:
+            return self._not_started_check(key)
+        if payout_account.is_payout_ready:
+            return self._passed_check(key)
+        # Reserve PAYOUTS_DISABLED for the case where Stripe explicitly blocked
+        # payouts on an otherwise-complete account; everything else (incomplete
+        # onboarding, charges off, missing details) is a requirements gap that
+        # the merchant can resolve by finishing Stripe Connect.
+        stripe_blocked_payouts = (
+            payout_account.is_details_submitted
+            and payout_account.is_charges_enabled
+            and not payout_account.is_payouts_enabled
+        )
+        reason = (
+            OrganizationReviewCheckReason.PAYOUT_ACCOUNT_PAYOUTS_DISABLED
+            if stripe_blocked_payouts
+            else OrganizationReviewCheckReason.PAYOUT_ACCOUNT_REQUIREMENTS_DUE
+        )
+        return OrganizationReviewCheck(
+            key=key,
+            status=OrganizationReviewCheckStatus.FAILED,
+            reasons=[reason],
         )
 
     async def submit_appeal(

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1182,7 +1182,7 @@ class OrganizationService:
             )
 
         organization_repository = OrganizationRepository.from_session(session)
-        admin_user = await organization_repository.get_admin_user(session, organization)
+        admin_user = await organization_repository.get_admin_user(organization)
 
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -959,7 +959,7 @@ class TestGetReview:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        """Returns the v1 checklist shape: a flat list of leaf checks."""
+        """Returns the checklist shape: a flat list of leaf checks."""
         response = await client.get(f"/v1/organizations/{organization.id}/review")
 
         assert response.status_code == 200
@@ -974,43 +974,22 @@ class TestGetReview:
         ]
 
     @pytest.mark.auth
-    @pytest.mark.parametrize(
-        ("status", "expected_check_status", "expected_can_submit"),
-        [("pass", "passed", True), ("fail", "failed", False)],
-    )
-    async def test_status_mock(
+    async def test_empty_org_blocks_submission(
         self,
         client: AsyncClient,
         organization: Organization,
         user_organization: UserOrganization,
-        status: str,
-        expected_check_status: str,
-        expected_can_submit: bool,
     ) -> None:
-        response = await client.get(
-            f"/v1/organizations/{organization.id}/review",
-            params={"status": status},
-        )
+        """A freshly created org with no details has every check pending."""
+        response = await client.get(f"/v1/organizations/{organization.id}/review")
 
         assert response.status_code == 200
         json = response.json()
-        assert json["can_submit"] is expected_can_submit
-        assert len(json["preliminary_steps"]) == 5
+        assert json["can_submit"] is False
+        assert json["submitted_at"] is None
+        assert json["verdict"] is None
+        assert json["appeal"] is None
+        assert all(step["status"] == "pending" for step in json["preliminary_steps"])
         assert all(
-            step["status"] == expected_check_status
-            for step in json["preliminary_steps"]
+            "not_started" in step["reasons"] for step in json["preliminary_steps"]
         )
-
-    @pytest.mark.auth
-    async def test_status_invalid(
-        self,
-        client: AsyncClient,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        response = await client.get(
-            f"/v1/organizations/{organization.id}/review",
-            params={"status": "passed"},
-        )
-
-        assert response.status_code == 422

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -34,6 +34,11 @@ from polar.organization.schemas import (
     OrganizationCreate,
     OrganizationDetails,
     OrganizationFeatureSettings,
+    OrganizationReviewCheck,
+    OrganizationReviewCheckKey,
+    OrganizationReviewCheckReason,
+    OrganizationReviewCheckStatus,
+    OrganizationReviewState,
     OrganizationSocialLink,
     OrganizationSocialPlatforms,
     OrganizationUpdate,
@@ -1221,6 +1226,390 @@ class TestGetAIReview:
         assert result is not None
         assert result.id == review.id
         assert result.verdict == OrganizationReview.Verdict.PASS
+
+
+async def _setup_passing_org(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    user: User,
+) -> None:
+    organization.email = "support@example.com"
+    organization.website = "https://example.com"
+    organization.socials = [{"platform": "x", "url": "https://x.com/polar"}]
+    organization.details = {
+        "product_description": "Subscription SaaS for software teams and agencies."
+    }
+    await save_fixture(organization)
+
+    user.identity_verification_status = IdentityVerificationStatus.verified
+    await save_fixture(user)
+    await create_payout_account(save_fixture, organization, user)
+
+
+def _step(
+    state: OrganizationReviewState, key: OrganizationReviewCheckKey
+) -> OrganizationReviewCheck:
+    for step in state.preliminary_steps:
+        if step.key == key:
+            return step
+    raise AssertionError(f"step {key} missing from {state}")
+
+
+@pytest.mark.asyncio
+class TestGetReviewState:
+    """Test the merchant self-review checklist."""
+
+    async def test_empty_org_blocks_submission(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        state = await organization_service.get_review_state(session, organization)
+
+        assert state.can_submit is False
+        assert state.submitted_at is None
+        assert state.verdict is None
+        assert state.appeal is None
+        assert all(
+            step.status == OrganizationReviewCheckStatus.PENDING
+            for step in state.preliminary_steps
+        )
+        assert all(
+            OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+            for step in state.preliminary_steps
+        )
+
+    async def test_email_set_passes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.email = "support@example.com"
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_EMAIL)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert step.reasons == []
+
+    async def test_socials_present_passes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.socials = [{"platform": "x", "url": "https://x.com/polar"}]
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+
+    @pytest.mark.parametrize(
+        ("identity_status", "expected_status", "expected_reason"),
+        [
+            (
+                IdentityVerificationStatus.verified,
+                OrganizationReviewCheckStatus.PASSED,
+                None,
+            ),
+            (
+                IdentityVerificationStatus.pending,
+                OrganizationReviewCheckStatus.PENDING,
+                OrganizationReviewCheckReason.EXTERNAL_PENDING,
+            ),
+            (
+                IdentityVerificationStatus.failed,
+                OrganizationReviewCheckStatus.FAILED,
+                OrganizationReviewCheckReason.IDENTITY_REJECTED,
+            ),
+            (
+                IdentityVerificationStatus.unverified,
+                OrganizationReviewCheckStatus.PENDING,
+                OrganizationReviewCheckReason.NOT_STARTED,
+            ),
+        ],
+    )
+    async def test_identity_verification_branches(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        identity_status: IdentityVerificationStatus,
+        expected_status: OrganizationReviewCheckStatus,
+        expected_reason: OrganizationReviewCheckReason | None,
+    ) -> None:
+        user.identity_verification_status = identity_status
+        await save_fixture(user)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION)
+
+        assert step.status == expected_status
+        if expected_reason is None:
+            assert step.reasons == []
+        else:
+            assert expected_reason in step.reasons
+
+    async def test_product_description_missing_is_not_started(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Empty/whitespace-only string is treated the same as missing.
+        organization.details = {"product_description": "   "}
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PRODUCT_DESCRIPTION)
+
+        assert step.status == OrganizationReviewCheckStatus.PENDING
+        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+
+    async def test_product_description_too_short_is_in_progress(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Started but not yet meeting the 30-char threshold — action required,
+        # not "to do". Distinguishes the merchant who tried from one who
+        # never started.
+        organization.details = {"product_description": "too short"}
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PRODUCT_DESCRIPTION)
+
+        assert step.status == OrganizationReviewCheckStatus.FAILED
+        assert OrganizationReviewCheckReason.IN_PROGRESS in step.reasons
+
+    async def test_product_description_long_enough(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.details = {
+            "product_description": "Subscription SaaS for software teams and agencies."
+        }
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PRODUCT_DESCRIPTION)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+
+    async def test_payout_account_ready(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await create_payout_account(save_fixture, organization, user)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PAYOUT_ACCOUNT)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+
+    async def test_payout_account_payouts_disabled_when_stripe_blocked(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # Details + charges submitted, but Stripe explicitly disabled payouts.
+        # This is the only case that should surface as PAYOUTS_DISABLED.
+        await create_payout_account(
+            save_fixture, organization, user, is_payouts_enabled=False
+        )
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PAYOUT_ACCOUNT)
+
+        assert step.status == OrganizationReviewCheckStatus.FAILED
+        assert (
+            OrganizationReviewCheckReason.PAYOUT_ACCOUNT_PAYOUTS_DISABLED
+            in step.reasons
+        )
+
+    async def test_payout_account_requirements_due_when_onboarding_incomplete(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # Merchant created the Stripe Connect account but never finished
+        # onboarding. ~4.5k orgs in this state in prod — they should see
+        # "complete onboarding", NOT "Stripe disabled your payouts".
+        payout = await create_payout_account(
+            save_fixture, organization, user, is_payouts_enabled=False
+        )
+        payout.is_details_submitted = False
+        payout.is_charges_enabled = False
+        await save_fixture(payout)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PAYOUT_ACCOUNT)
+
+        assert step.status == OrganizationReviewCheckStatus.FAILED
+        assert (
+            OrganizationReviewCheckReason.PAYOUT_ACCOUNT_REQUIREMENTS_DUE
+            in step.reasons
+        )
+
+    async def test_payout_account_requirements_due_when_no_stripe_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # is_payouts_enabled=True but stripe_id is None: is_payout_ready returns
+        # False via the stripe_id check. Falls through to REQUIREMENTS_DUE.
+        await create_payout_account(save_fixture, organization, user, stripe_id=None)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PAYOUT_ACCOUNT)
+
+        assert step.status == OrganizationReviewCheckStatus.FAILED
+        assert (
+            OrganizationReviewCheckReason.PAYOUT_ACCOUNT_REQUIREMENTS_DUE
+            in step.reasons
+        )
+
+    async def test_all_checks_pass_can_submit(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+
+        state = await organization_service.get_review_state(session, organization)
+
+        assert state.can_submit is True
+        assert all(
+            step.status == OrganizationReviewCheckStatus.PASSED
+            for step in state.preliminary_steps
+        )
+
+    async def test_submitted_blocks_resubmission(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+
+        assert state.submitted_at is not None
+        assert state.can_submit is False
+
+    @pytest.mark.parametrize(
+        ("verdict", "expected"),
+        [
+            (OrganizationReview.Verdict.PASS, "pass"),
+            (OrganizationReview.Verdict.FAIL, "fail"),
+            (OrganizationReview.Verdict.UNCERTAIN, None),
+        ],
+    )
+    async def test_verdict_mapping(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        verdict: OrganizationReview.Verdict,
+        expected: str | None,
+    ) -> None:
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=verdict,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="test",
+            timed_out=False,
+            organization_details_snapshot={},
+            model_used="test-model",
+        )
+        session.add(review)
+        await session.flush()
+
+        state = await organization_service.get_review_state(session, organization)
+
+        assert state.verdict == expected
+        assert state.appeal is None
+
+    async def test_appeal_pending_decision(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        appeal_submitted = datetime.now(UTC)
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=80.0,
+            violated_sections=[],
+            reason="High risk",
+            timed_out=False,
+            organization_details_snapshot={},
+            model_used="test-model",
+            appeal_submitted_at=appeal_submitted,
+            appeal_reason="Please reconsider, here's why...",
+        )
+        session.add(review)
+        await session.flush()
+
+        state = await organization_service.get_review_state(session, organization)
+
+        assert state.appeal is not None
+        assert state.appeal.submitted_at == appeal_submitted
+        assert state.appeal.reviewed_at is None
+        assert state.appeal.decision is None
+
+    async def test_appeal_approved(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        appeal_submitted = datetime.now(UTC)
+        appeal_reviewed = datetime.now(UTC) + timedelta(hours=1)
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=80.0,
+            violated_sections=[],
+            reason="High risk",
+            timed_out=False,
+            organization_details_snapshot={},
+            model_used="test-model",
+            appeal_submitted_at=appeal_submitted,
+            appeal_reason="Please reconsider, here's why...",
+            appeal_reviewed_at=appeal_reviewed,
+            appeal_decision=OrganizationReview.AppealDecision.APPROVED,
+        )
+        session.add(review)
+        await session.flush()
+
+        state = await organization_service.get_review_state(session, organization)
+
+        assert state.appeal is not None
+        assert state.appeal.decision == OrganizationReview.AppealDecision.APPROVED
+        assert state.appeal.reviewed_at == appeal_reviewed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Replace the mocked `GET /v1/organizations/{id}/review` endpoint with a real implementation that derives the merchant self-review checklist from the organization's actual state.
- Five preliminary checks (`identity.email`, `identity.social_links`, `identity.stripe_identity_verification`, `product_description`, `payout_account`) plus, after submission, the AI verdict and any appeal status.
- Each check returns a status (`passed` / `pending` / `failed`) and, where the FE needs to distinguish sub-states, a reason. `can_submit` blocks while any check is `failed` or `pending`.
- Drop the `?status=pass|fail` mock query parameter.

### Notable behaviors

- **Product description**: missing or whitespace-only ⇒ `pending + not_started`; non-empty but under the 30-char threshold ⇒ `failed + in_progress` (distinguishes "tried but too short" from "never started"); 30+ chars ⇒ `passed`.
- **Payout account**: `payouts_disabled` is reserved for the case where Stripe explicitly blocked payouts on an otherwise-complete account (`is_details_submitted` ∧ `is_charges_enabled` ∧ ¬`is_payouts_enabled`); incomplete onboarding paths surface as `requirements_due`.
- **Identity verification**: `match` over `IdentityVerificationStatus` with `assert_never` for exhaustiveness.
- **Verdict**: AI verdict is mapped to `pass` / `fail`; `UNCERTAIN` falls through to `null` so the merchant-facing checklist only exposes resolved verdicts.

### What's not in this PR

Per the design intent, follow-ups will add (each in its own PR):
- Product URL split out as its own check
- Product configuration check (has ≥1 product)
- Setup readiness check (checkout link / API key / webhook)
- Disallowed-category detection in product description
- Website reachability

## Test plan

- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run pytest tests/organization/` — service- and endpoint-level coverage for every check branch, verdict mapping, and appeal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)