### PR TITLE
ci: serialize sandbox and production deploys per environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,9 @@ jobs:
 
   deploy-sandbox:
     name: "Deploy to Sandbox 🧪"
+    concurrency:
+      group: deploy-sandbox
+      cancel-in-progress: false
     needs: [changes, build]
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
@@ -144,6 +147,9 @@ jobs:
 
   deploy-production:
     name: "Deploy to Production 🚀"
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     needs: [changes, build, deploy-sandbox]
     if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml


### PR DESCRIPTION
## Summary

Two main-branch workflow runs could interleave their deploy jobs in the same environment, letting an older image overwrite a newer one (e.g. PR1's prod backend landing after PR2's). The job-level concurrency inside `deploy-environment.yml` only protected individual jobs, not the overall ordering.

This adds a `concurrency` group on `deploy-sandbox` and `deploy-production` so only one run per environment is in flight at a time. `cancel-in-progress: false` keeps in-flight deploys from being interrupted.

## Test plan

- [ ] Merge two PRs to `main` in quick succession; the second `deploy-production` waits for the first.
- [ ] A single-PR deploy still completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)