### PR TITLE
feat(organization): enable receipts by default for new organizations

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -222,6 +222,7 @@ class OrganizationService:
         feature_settings = create_data.get("feature_settings", {})
         feature_settings["member_model_enabled"] = True
         feature_settings["seat_based_pricing_enabled"] = True
+        feature_settings["receipts_enabled"] = True
         create_data["feature_settings"] = feature_settings
 
         if settings.is_sandbox():

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -138,6 +138,7 @@ class TestCreate:
         assert organization.feature_settings == {
             "member_model_enabled": True,
             "seat_based_pricing_enabled": True,
+            "receipts_enabled": True,
         }
 
         user_organization = await user_organization_service.get_by_user_and_org(
@@ -200,6 +201,7 @@ class TestCreate:
             "issue_funding_enabled": False,
             "member_model_enabled": True,
             "seat_based_pricing_enabled": True,
+            "receipts_enabled": True,
         }
 
     @pytest.mark.auth


### PR DESCRIPTION
## Summary
- New organizations now have `receipts_enabled` set to `true` in `feature_settings` on creation, alongside the existing `member_model_enabled` and `seat_based_pricing_enabled` defaults.
- Existing organizations are unaffected; the dedicated backfill script remains the path for flipping the flag on legacy orgs.

## Test plan
- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run pytest tests/organization/test_service.py -k TestCreate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)