### PR TITLE
login code: Prevent code race

### DIFF
--- a/server/polar/customer_portal/repository/customer_session_code.py
+++ b/server/polar/customer_portal/repository/customer_session_code.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Select, select
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.kit.repository import RepositoryBase
@@ -9,11 +9,10 @@ from polar.models import Customer, CustomerSessionCode
 class CustomerSessionCodeRepository(RepositoryBase[CustomerSessionCode]):
     model = CustomerSessionCode
 
-    def get_valid_by_code_hash_statement(
+    async def get_valid_by_code_hash_for_update(
         self, code_hash: str
-    ) -> Select[tuple[CustomerSessionCode]]:
-        """Get a valid (non-expired) CustomerSessionCode by its hash."""
-        return (
+    ) -> CustomerSessionCode | None:
+        statement = (
             select(CustomerSessionCode)
             .where(
                 CustomerSessionCode.expires_at > utc_now(),
@@ -24,12 +23,7 @@ class CustomerSessionCodeRepository(RepositoryBase[CustomerSessionCode]):
                     Customer.organization
                 )
             )
+            .with_for_update(nowait=True, of=CustomerSessionCode)
         )
-
-    async def get_valid_by_code_hash(
-        self, code_hash: str
-    ) -> CustomerSessionCode | None:
-        """Get a valid (non-expired) CustomerSessionCode by its hash."""
-        statement = self.get_valid_by_code_hash_statement(code_hash)
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()

--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from math import ceil
 
 import structlog
+from sqlalchemy.exc import DBAPIError
 
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -16,6 +17,7 @@ from polar.email.schemas import CustomerSessionCodeEmail, CustomerSessionCodePro
 from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError
 from polar.kit.crypto import get_token_hash
+from polar.kit.db.locking import is_lock_not_available_error
 from polar.kit.utils import utc_now
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
@@ -243,7 +245,14 @@ class CustomerSessionService:
         code_hash = get_token_hash(code, secret=settings.SECRET)
 
         code_repository = CustomerSessionCodeRepository.from_session(session)
-        customer_session_code = await code_repository.get_valid_by_code_hash(code_hash)
+        try:
+            customer_session_code = (
+                await code_repository.get_valid_by_code_hash_for_update(code_hash)
+            )
+        except DBAPIError as e:
+            if is_lock_not_available_error(e):
+                raise CustomerSessionCodeInvalidOrExpired() from e
+            raise
 
         if customer_session_code is None:
             raise CustomerSessionCodeInvalidOrExpired()

--- a/server/polar/login_code/repository.py
+++ b/server/polar/login_code/repository.py
@@ -9,7 +9,9 @@ from polar.models import LoginCode
 class LoginCodeRepository(RepositoryBase[LoginCode]):
     model = LoginCode
 
-    async def get_by_code(self, code_hash: str, email: str) -> LoginCode | None:
+    async def get_by_code_for_update(
+        self, code_hash: str, email: str
+    ) -> LoginCode | None:
         statement = (
             select(LoginCode)
             .where(
@@ -18,5 +20,6 @@ class LoginCodeRepository(RepositoryBase[LoginCode]):
                 LoginCode.expires_at > utc_now(),
             )
             .options(joinedload(LoginCode.user))
+            .with_for_update(nowait=True, of=LoginCode)
         )
         return await self.get_one_or_none(statement)

--- a/server/polar/login_code/repository.py
+++ b/server/polar/login_code/repository.py
@@ -1,0 +1,22 @@
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+from polar.kit.repository import RepositoryBase
+from polar.kit.utils import utc_now
+from polar.models import LoginCode
+
+
+class LoginCodeRepository(RepositoryBase[LoginCode]):
+    model = LoginCode
+
+    async def get_by_code(self, code_hash: str, email: str) -> LoginCode | None:
+        statement = (
+            select(LoginCode)
+            .where(
+                LoginCode.code_hash == code_hash,
+                LoginCode.email == email,
+                LoginCode.expires_at > utc_now(),
+            )
+            .options(joinedload(LoginCode.user))
+        )
+        return await self.get_one_or_none(statement)

--- a/server/polar/login_code/service.py
+++ b/server/polar/login_code/service.py
@@ -4,8 +4,6 @@ import string
 from math import ceil
 
 import structlog
-from sqlalchemy import select
-from sqlalchemy.orm import joinedload
 
 from polar.config import settings
 from polar.email.schemas import LoginCodeEmail, LoginCodeProps
@@ -13,6 +11,7 @@ from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
+from polar.login_code.repository import LoginCodeRepository
 from polar.models import LoginCode, User
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
@@ -106,17 +105,8 @@ class LoginCodeService:
 
         code_hash = get_token_hash(code, secret=settings.SECRET)
 
-        statement = (
-            select(LoginCode)
-            .where(
-                LoginCode.code_hash == code_hash,
-                LoginCode.email == email,
-                LoginCode.expires_at > utc_now(),
-            )
-            .options(joinedload(LoginCode.user))
-        )
-        result = await session.execute(statement)
-        login_code = result.unique().scalar_one_or_none()
+        repository = LoginCodeRepository.from_session(session)
+        login_code = await repository.get_by_code(code_hash, email)
 
         if login_code is None:
             raise LoginCodeInvalidOrExpired()

--- a/server/polar/login_code/service.py
+++ b/server/polar/login_code/service.py
@@ -4,12 +4,14 @@ import string
 from math import ceil
 
 import structlog
+from sqlalchemy.exc import DBAPIError
 
 from polar.config import settings
 from polar.email.schemas import LoginCodeEmail, LoginCodeProps
 from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError
 from polar.kit.crypto import get_token_hash
+from polar.kit.db.locking import is_lock_not_available_error
 from polar.kit.utils import utc_now
 from polar.login_code.repository import LoginCodeRepository
 from polar.models import LoginCode, User
@@ -106,7 +108,12 @@ class LoginCodeService:
         code_hash = get_token_hash(code, secret=settings.SECRET)
 
         repository = LoginCodeRepository.from_session(session)
-        login_code = await repository.get_by_code(code_hash, email)
+        try:
+            login_code = await repository.get_by_code_for_update(code_hash, email)
+        except DBAPIError as e:
+            if is_lock_not_available_error(e):
+                raise LoginCodeInvalidOrExpired() from e
+            raise
 
         if login_code is None:
             raise LoginCodeInvalidOrExpired()

--- a/server/tests/login_code/test_race_condition.py
+++ b/server/tests/login_code/test_race_condition.py
@@ -1,0 +1,93 @@
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy.exc import DBAPIError
+
+from polar.config import settings
+from polar.kit.crypto import get_token_hash
+from polar.login_code.repository import LoginCodeRepository
+from polar.login_code.service import LoginCodeInvalidOrExpired
+from polar.login_code.service import login_code as login_code_service
+from polar.postgres import AsyncSession
+
+
+@pytest.mark.asyncio
+class TestAuthenticateConcurrency:
+    async def test_lock_not_available_raises_invalid_or_expired(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        _, code = await login_code_service.request(session, email="race@example.com")
+        await session.flush()
+
+        lock_error = DBAPIError(
+            "SELECT ...", {}, Exception("could not obtain lock on row")
+        )
+        mocker.patch.object(
+            LoginCodeRepository,
+            "get_by_code_for_update",
+            side_effect=lock_error,
+        )
+
+        with pytest.raises(LoginCodeInvalidOrExpired):
+            await login_code_service.authenticate(
+                session,
+                code=code,
+                email="race@example.com",
+            )
+
+    async def test_unrelated_dbapi_error_is_reraised(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        _, code = await login_code_service.request(session, email="race@example.com")
+        await session.flush()
+
+        other_error = DBAPIError(
+            "SELECT ...", {}, Exception("some other database failure")
+        )
+        mocker.patch.object(
+            LoginCodeRepository,
+            "get_by_code_for_update",
+            side_effect=other_error,
+        )
+
+        with pytest.raises(DBAPIError):
+            await login_code_service.authenticate(
+                session,
+                code=code,
+                email="race@example.com",
+            )
+
+    async def test_code_is_single_use(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        email = "single-use@example.com"
+        _, code = await login_code_service.request(session, email=email)
+        await session.flush()
+
+        user, _ = await login_code_service.authenticate(session, code=code, email=email)
+        assert user.email == email
+
+        with pytest.raises(LoginCodeInvalidOrExpired):
+            await login_code_service.authenticate(session, code=code, email=email)
+
+    async def test_for_update_method_is_called(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        email = "lock-acquired@example.com"
+        _, code = await login_code_service.request(session, email=email)
+        await session.flush()
+
+        spy = mocker.spy(LoginCodeRepository, "get_by_code_for_update")
+
+        await login_code_service.authenticate(session, code=code, email=email)
+
+        spy.assert_called_once()
+        code_hash = get_token_hash(code, secret=settings.SECRET)
+        assert spy.call_args.args[1] == code_hash
+        assert spy.call_args.args[2] == email


### PR DESCRIPTION
Migrate login code to repository and set `with_for_update` to ensure that it can't be used in two simultaneous sessions