### PR TITLE
chore: serialize deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
       - ".github/workflows/deploy_server.sh"
   workflow_dispatch:
 
+concurrency:
+  group: build-deploy
+
 jobs:
   changes:
     name: "Detect Changes 🔍"
@@ -40,9 +43,6 @@ jobs:
 
   build:
     name: "Build Docker Image 🐳"
-    concurrency:
-      group: build-deploy
-
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20


### PR DESCRIPTION
Currently the build job inside our deploy workflow has a concurrency lock so only a single build can run at a time, but the rest of the deploy workflow can still run in parallel. This can result in problematic race conditions and is also harder to reason about.

This PR simplifies deployments by moving the concurrency lock from the build job to the entire workflow, so only one deploy workflow can run at a time.