### PR TITLE
docs: add handbook page for running Render one-off jobs

### DIFF
--- a/handbook/docs.json
+++ b/handbook/docs.json
@@ -87,7 +87,8 @@
               "engineering/oncall/developer-faq",
               "engineering/oncall/merge-accounts",
               "engineering/oncall/deploy-infra",
-              "engineering/oncall/trigger-webhooks"
+              "engineering/oncall/trigger-webhooks",
+              "engineering/oncall/run-one-off-jobs"
             ]
           }
         ]

--- a/handbook/engineering/oncall/introduction.mdx
+++ b/handbook/engineering/oncall/introduction.mdx
@@ -19,6 +19,10 @@ This guide contains manual procedures that on-call engineers may need to perform
   <Card title="Trigger Webhooks" icon="webhook" href="/engineering/oncall/trigger-webhooks">
     Manually trigger missed or failed webhooks
   </Card>
+
+  <Card title="Run One-Off Jobs" icon="play" href="/engineering/oncall/run-one-off-jobs">
+    Trigger backend scripts in production via Render One-Off Jobs
+  </Card>
 </CardGroup>
 
 

--- a/handbook/engineering/oncall/run-one-off-jobs.mdx
+++ b/handbook/engineering/oncall/run-one-off-jobs.mdx
@@ -1,0 +1,36 @@
+---
+title: "Run One-Off Jobs"
+description: "Trigger backend scripts in production via Render One-Off Jobs"
+---
+
+# Run One-Off Jobs
+
+[Render One-Off Jobs](https://render.com/docs/one-off-jobs) run a command in a fresh container using the same image and environment as the worker service. Use them for backfills, data migrations, and other ad-hoc scripts.
+
+<Note>
+  One-off jobs cannot be created from the dashboard. Use the [Render CLI](https://render.com/docs/cli) (`brew install render && render login`).
+</Note>
+
+## Procedure
+
+Run a dry run first (most scripts in `server/scripts/` preview without `--execute`):
+
+```bash
+render jobs create srv-d4k6otfgi27c73cicnpg \
+  --start-command "uv run python -m scripts.backfill_receipts --all" \
+  --confirm
+```
+
+Then run for real:
+
+```bash
+render jobs create srv-d4k6otfgi27c73cicnpg \
+  --start-command "uv run python -m scripts.backfill_receipts --all --execute" \
+  --confirm
+```
+
+Tail logs:
+
+```bash
+render logs --resources srv-d4k6otfgi27c73cicnpg --tail
+```


### PR DESCRIPTION
## Summary

- New on-call handbook page documenting how to trigger Render One-Off Jobs via the Render CLI for ad-hoc backend scripts (backfills, migrations, etc.)
- Wired the new page into the docs nav and the on-call landing page

## Test plan

- [ ] Handbook builds locally and the new page renders with correct nav placement
- [ ] Links from the on-call introduction card and from the related-docs section resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)