### PR TITLE
fix(receipt): allow rendering without billing_name or billing_address

### DIFF
--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -71,7 +71,7 @@ class Invoice(BaseModel):
     seller_address: Address
     seller_additional_info: str | None = None
     customer_name: str
-    customer_address: Address
+    customer_address: Address | None = None
     customer_additional_info: str | None = None
     customer_locale: str | None = None
     subtotal_amount: int
@@ -394,7 +394,9 @@ class InvoiceGenerator(FPDF):
         # customer locale/country first, and then all other scripts.
         customer_script = self.cjk_script_from_locale(
             data.customer_locale
-        ) or self.resolve_cjk_script(data.customer_address.country)
+        ) or self.resolve_cjk_script(
+            data.customer_address.country if data.customer_address else None
+        )
 
         fallback_fonts = [
             family
@@ -562,13 +564,14 @@ class InvoiceGenerator(FPDF):
             new_y=YPos.NEXT,
         )
         self.set_font(style="")
-        self.multi_cell(
-            80,
-            self.cell_height(),
-            self._shape_text(self.data.customer_address.to_text()),
-            new_x=XPos.LEFT,
-            new_y=YPos.NEXT,
-        )
+        if self.data.customer_address is not None:
+            self.multi_cell(
+                80,
+                self.cell_height(),
+                self._shape_text(self.data.customer_address.to_text()),
+                new_x=XPos.LEFT,
+                new_y=YPos.NEXT,
+            )
         if self.data.customer_additional_info:
             self.multi_cell(
                 80,

--- a/server/polar/receipt/generator.py
+++ b/server/polar/receipt/generator.py
@@ -102,8 +102,11 @@ class Receipt(Invoice):
         refunds: list["Refund"],
     ) -> Self:
         assert order.receipt_number is not None
-        assert order.billing_name is not None
-        assert order.billing_address is not None
+
+        customer_name = (
+            order.billing_name or order.customer.name or order.customer.email
+        )
+        assert customer_name is not None
 
         sorted_payments = sorted(payments, key=lambda p: p.created_at)
         paid_at = sorted_payments[0].created_at if sorted_payments else None
@@ -111,7 +114,7 @@ class Receipt(Invoice):
         additional_info_parts: list[str] = []
         if order.tax_id:
             additional_info_parts.append(order.tax_id[0])
-        if order.customer.email:
+        if order.customer.email and order.customer.email != customer_name:
             additional_info_parts.append(order.customer.email)
         customer_additional_info = (
             "\n".join(additional_info_parts) if additional_info_parts else None
@@ -125,7 +128,7 @@ class Receipt(Invoice):
             seller_name=settings.INVOICES_NAME,
             seller_address=settings.INVOICES_ADDRESS,
             seller_additional_info=settings.INVOICES_ADDITIONAL_INFO,
-            customer_name=order.billing_name,
+            customer_name=customer_name,
             customer_additional_info=customer_additional_info,
             customer_address=order.billing_address,
             customer_locale=order.customer.locale,

--- a/server/tests/receipt/test_generator.py
+++ b/server/tests/receipt/test_generator.py
@@ -145,6 +145,16 @@ class TestReceiptGenerator:
 
         assert bytes(output).startswith(b"%PDF-")
 
+    def test_renders_without_customer_address(self) -> None:
+        receipt = _build_receipt().model_copy(update={"customer_address": None})
+        generator = ReceiptGenerator(
+            receipt, heading_title="Receipt", add_sandbox_warning=False
+        )
+        generator.generate()
+        output = generator.output()
+
+        assert bytes(output).startswith(b"%PDF-")
+
 
 class TestReceiptPayment:
     def test_card_with_brand_and_last4(self) -> None:

--- a/server/tests/receipt/test_service.py
+++ b/server/tests/receipt/test_service.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from polar.kit.address import Address, CountryAlpha2
 from polar.kit.db.postgres import AsyncSession
 from polar.locker import Locker
-from polar.models import Account, Customer, Organization
+from polar.models import Account, Customer, Order, Organization
 from polar.receipt.service import receipt as receipt_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -16,6 +16,52 @@ from tests.fixtures.random_objects import (
     create_payment,
     create_refund,
 )
+
+_US_ADDRESS = Address(
+    line1="1 Test Way",
+    city="SF",
+    state="CA",
+    postal_code="94104",
+    country=CountryAlpha2("US"),
+)
+
+
+async def _allocated_order(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    account: Account,
+    *,
+    customer_email: str,
+    customer_name: str | None = "Customer",
+    billing_name: str | None,
+    billing_address: Address | None,
+) -> Order:
+    organization = await create_organization(
+        save_fixture, account, feature_settings={"receipts_enabled": True}
+    )
+    customer = await create_customer(
+        save_fixture,
+        organization=organization,
+        email=customer_email,
+        name=customer_name,  # type: ignore[arg-type]
+    )
+    order = await create_order(
+        save_fixture,
+        customer=customer,
+        billing_name=billing_name,
+        billing_address=billing_address,
+    )
+    await create_payment(save_fixture, organization, order=order)
+    await receipt_service.allocate(session, order)
+    return order
+
+
+def _mock_render(mocker: MockerFixture):  # type: ignore[no-untyped-def]
+    mocker.patch("polar.receipt.service.S3Service")
+    return mocker.patch(
+        "polar.receipt.service.render_receipt_pdf",
+        return_value=b"%PDF-fake",
+    )
 
 
 @pytest.mark.asyncio
@@ -197,6 +243,75 @@ class TestDoRender:
         receipt_arg = render_mock.call_args.args[0]
         assert len(receipt_arg.refunds) == 1
         assert receipt_arg.refunds[0].amount == 500
+
+    async def test_falls_back_to_customer_name_when_billing_name_missing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await _allocated_order(
+            save_fixture,
+            session,
+            account,
+            customer_email="fallback-name@example.com",
+            customer_name="Fallback Customer",
+            billing_name=None,
+            billing_address=_US_ADDRESS,
+        )
+        render_mock = _mock_render(mocker)
+
+        await receipt_service._create_order_receipt(session, order)
+
+        assert render_mock.call_args.args[0].customer_name == "Fallback Customer"
+
+    async def test_falls_back_to_customer_email_when_name_missing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await _allocated_order(
+            save_fixture,
+            session,
+            account,
+            customer_email="fallback-email@example.com",
+            customer_name=None,
+            billing_name=None,
+            billing_address=_US_ADDRESS,
+        )
+        render_mock = _mock_render(mocker)
+
+        await receipt_service._create_order_receipt(session, order)
+
+        assert (
+            render_mock.call_args.args[0].customer_name == "fallback-email@example.com"
+        )
+
+    async def test_renders_when_billing_address_missing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await _allocated_order(
+            save_fixture,
+            session,
+            account,
+            customer_email="no-address@example.com",
+            billing_name="Buyer",
+            billing_address=None,
+        )
+        render_mock = _mock_render(mocker)
+
+        await receipt_service._create_order_receipt(session, order)
+
+        receipt_arg = render_mock.call_args.args[0]
+        assert receipt_arg.customer_address is None
+        assert receipt_arg.customer_name == "Buyer"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- The `receipt.render` Dramatiq task was crashing with `AssertionError` on orders that were missing `billing_name` or `billing_address`. With receipts enabled by default for new organizations, paid orders whose customer hadn't filled in billing details started failing the render job — retrying up to 20 times each before escalating.
- `Receipt.from_order` now falls back through `order.billing_name → order.customer.name → order.customer.email` for the displayed customer name. The PDF renderer skips the address line when `customer_address` is absent. Only `receipt_number` remains a hard requirement.
- Deduped the email when it's already used as the customer name (the email line was previously printed twice in the worst-case fallback).

## Test plan

- [x] Unit + integration tests in `server/tests/receipt/` cover the three fallback levels and the missing-address case.
- [x] Manually rendered the four edge-case PDFs (full / email-only name / no address / email + no address) — layouts hold up.
- [x] `uv run task lint` passes.
- [x] `uv run task lint_types` passes.
- [x] `uv run pytest tests/receipt/ tests/invoice/` — 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)