### PR TITLE
Hide feature flag benefits from customer-facing views

### DIFF
--- a/clients/apps/web/src/components/Benefit/utils.tsx
+++ b/clients/apps/web/src/components/Benefit/utils.tsx
@@ -5,6 +5,14 @@ import GitHubIcon from '../Icons/GitHubIcon'
 
 export type CreatableBenefit = schemas['BenefitType']
 
+const CUSTOMER_HIDDEN_BENEFIT_TYPES: ReadonlyArray<schemas['BenefitType']> = [
+  'feature_flag',
+]
+
+export const isCustomerVisibleBenefitType = (
+  type: schemas['BenefitType'],
+): boolean => !CUSTOMER_HIDDEN_BENEFIT_TYPES.includes(type)
+
 const resolveBenefitCategoryIcon = (
   type?: schemas['BenefitType'],
   className?: string,

--- a/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
@@ -8,8 +8,9 @@ import {
   type AcceptedLocale,
 } from '@polar-sh/i18n'
 import { List, ListItem } from '@polar-sh/ui/components/atoms/List'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { BenefitGrant } from '../Benefit/BenefitGrant'
+import { isCustomerVisibleBenefitType } from '../Benefit/utils'
 import { SpinnerNoMargin } from '../Shared/Spinner'
 
 interface CheckoutBenefitsProps {
@@ -30,7 +31,16 @@ const CheckoutBenefits = ({
   const { data: benefitGrants, refetch } = useCustomerBenefitGrants(api, {
     checkout_id: checkout.id,
   })
-  const expectedBenefits = checkout.product.benefits.length
+  const visibleBenefitGrants = useMemo(
+    () =>
+      benefitGrants?.items.filter((grant) =>
+        isCustomerVisibleBenefitType(grant.benefit.type),
+      ) ?? [],
+    [benefitGrants],
+  )
+  const expectedBenefits = checkout.product.benefits.filter((benefit) =>
+    isCustomerVisibleBenefitType(benefit.type),
+  ).length
 
   const customerEvents = useCustomerSSE(customerSessionToken)
   useEffect(() => {
@@ -41,19 +51,25 @@ const CheckoutBenefits = ({
   }, [customerEvents, refetch])
 
   useEffect(() => {
-    if (benefitGrants && benefitGrants.items.length >= expectedBenefits) {
+    if (benefitGrants && visibleBenefitGrants.length >= expectedBenefits) {
       return
     }
     const intervalId = setInterval(() => {
       refetch()
     }, maxWaitingTimeMs)
     return () => clearInterval(intervalId)
-  }, [benefitGrants, expectedBenefits, maxWaitingTimeMs, refetch])
+  }, [
+    benefitGrants,
+    visibleBenefitGrants,
+    expectedBenefits,
+    maxWaitingTimeMs,
+    refetch,
+  ])
 
   return (
     <div className="flex w-full flex-col gap-4 text-left">
       <List className="rounded-3xl">
-        {benefitGrants?.items.map((benefitGrant) => (
+        {visibleBenefitGrants.map((benefitGrant) => (
           <ListItem
             key={benefitGrant.id}
             className="dark:bg-polar-800 dark:hover:bg-polar-800 bg-white p-4 hover:bg-white"
@@ -65,7 +81,7 @@ const CheckoutBenefits = ({
             />
           </ListItem>
         ))}
-        {benefitGrants && benefitGrants.items.length < expectedBenefits && (
+        {benefitGrants && visibleBenefitGrants.length < expectedBenefits && (
           <ListItem className="flex flex-row items-center justify-center gap-2">
             <SpinnerNoMargin className="h-4 w-4" />
             <p className="dark:text-polar-500 text-gray-500">

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalGrants.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalGrants.tsx
@@ -1,5 +1,6 @@
 import { useCustomerBenefitGrants } from '@/hooks/queries/customerPortal'
 import { Client, schemas } from '@polar-sh/client'
+import { isCustomerVisibleBenefitType } from '../Benefit/utils'
 import { CustomerPortalGrantsComplex } from './CustomerPortalGrantsComplex'
 import { CustomerPortalGrantsSimple } from './CustomerPortalGrantsSimple'
 
@@ -34,11 +35,17 @@ export const CustomerPortalGrants = ({
     initialResponse?.pagination?.total_count ??
     initialResponse?.items?.length ??
     0
-  const initialBenefitGrants = initialResponse?.items ?? []
+  const initialBenefitGrants = (initialResponse?.items ?? []).filter((grant) =>
+    isCustomerVisibleBenefitType(grant.benefit.type),
+  )
 
   const isSimplifiedView = totalBenefitGrantCount <= SIMPLIFIED_VIEW_THRESHOLD
 
   if (totalBenefitGrantCount === 0) {
+    return null
+  }
+
+  if (isSimplifiedView && initialBenefitGrants.length === 0) {
     return null
   }
 

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalGrantsComplex.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalGrantsComplex.tsx
@@ -5,8 +5,9 @@ import { Client } from '@polar-sh/client'
 import Input from '@polar-sh/ui/components/atoms/Input'
 import { List, ListItem } from '@polar-sh/ui/components/atoms/List'
 import { Loader2, Search } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { BenefitGrant } from '../Benefit/BenefitGrant'
+import { isCustomerVisibleBenefitType } from '../Benefit/utils'
 import { Pagination } from './Pagination'
 
 export interface CustomerPortalGrantsComplexProps {
@@ -50,7 +51,13 @@ export const CustomerPortalGrantsComplex = ({
     ...filterParams,
   })
 
-  const grants = benefitGrants?.items ?? []
+  const grants = useMemo(
+    () =>
+      (benefitGrants?.items ?? []).filter((grant) =>
+        isCustomerVisibleBenefitType(grant.benefit.type),
+      ),
+    [benefitGrants],
+  )
   const pagination = benefitGrants?.pagination
 
   return (

--- a/docs/features/benefits/feature-flags.mdx
+++ b/docs/features/benefits/feature-flags.mdx
@@ -6,12 +6,17 @@ description: "Gate access to features using simple, API-driven feature flags"
 
 The Feature Flag benefit is a lightweight way to grant feature access to customers without any external service integration. If a customer has the benefit grant, they have access — it's that simple.
 
+<Note>
+  Feature Flag benefits are intentionally hidden from customers. They are not displayed on the checkout success page or in the customer portal's benefit grants overview. This makes them ideal for driving any feature flag, entitlement or gating logic in your own application without exposing the underlying flag to the customer.
+</Note>
+
 ## Use Cases
 
 * Gate premium features behind a subscription tier
 * Offer early access or beta features to select customers
 * Differentiate access levels across product tiers
 * Control API rate limit tiers or usage quotas in your application
+* Drive any internal feature flag or entitlement check in your application
 
 ## Create Feature Flag Benefit
 


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

This PR hides feature flag benefits from customer-facing views (checkout success page and customer portal) while keeping them functional for internal application logic.

## What

- Added `isCustomerVisibleBenefitType()` utility function to determine which benefit types should be displayed to customers
- Feature flag benefits are now filtered out from:
  - Checkout benefits display
  - Customer portal grants overview (both simple and complex views)
- Updated documentation to explain that feature flags are intentionally hidden from customers

## Why

Feature flag benefits are designed for internal application logic and entitlement checks, not for customer visibility. Hiding them from customer-facing interfaces:
- Reduces confusion by not exposing internal implementation details
- Keeps the customer experience clean and focused on customer-visible benefits
- Maintains the ability to use feature flags for backend gating without customer awareness

## How

1. Created `isCustomerVisibleBenefitType()` in `Benefit/utils.tsx` that filters out `feature_flag` type benefits
2. Applied this filter in three locations:
   - `CheckoutBenefits`: Filters both the displayed grants and expected benefit count
   - `CustomerPortalGrantsComplex`: Filters grants before display
   - `CustomerPortalGrants`: Filters initial grants and adds early return if simplified view has no visible grants
3. Updated feature flags documentation with a note explaining the hidden behavior and added a use case for internal entitlement checks

## Checklist

- [x] This PR addresses a single concern (hiding feature flags from customer views)
- [x] The diff is reasonably sized and easy to review
- [x] No new tests needed (filtering logic is straightforward; existing tests should pass)
- [x] Changes are isolated to benefit display logic

https://claude.ai/code/session_01Bsducn6u1dDkuUhYDEW44V