### PR TITLE
fix(authz): exclude soft-deleted orgs from accessible org IDs

### DIFF
--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -14,9 +14,14 @@ class AuthzRepository:
 
     async def get_user_org_ids(self, user_id: UUID) -> set[UUID]:
         """Get all organization IDs a user is a member of."""
-        stmt = select(UserOrganization.organization_id).where(
-            UserOrganization.user_id == user_id,
-            UserOrganization.is_deleted.is_(False),
+        stmt = (
+            select(UserOrganization.organization_id)
+            .join(Organization, UserOrganization.organization_id == Organization.id)
+            .where(
+                UserOrganization.user_id == user_id,
+                UserOrganization.is_deleted.is_(False),
+                Organization.is_deleted.is_(False),
+            )
         )
         result = await self.session.scalars(stmt)
         return set(result.all())

--- a/server/tests/authz/test_service.py
+++ b/server/tests/authz/test_service.py
@@ -98,3 +98,17 @@ class TestGetAccessibleOrgIds:
     ) -> None:
         result = await get_accessible_org_ids(session, auth_subject)
         assert result == {organization.id}
+
+    @pytest.mark.auth
+    async def test_excludes_soft_deleted_org(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.set_deleted_at()
+        await session.flush()
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == set()


### PR DESCRIPTION
## Summary

- `AuthzRepository.get_user_org_ids` only filtered `UserOrganization.is_deleted` — soft-deleted organizations still surfaced through `get_accessible_org_ids`, leaking data for ~40 services that gate authorization through it (orders list/CSV export, customers, subscriptions, etc.).
- Join `Organization` in the query and filter `is_deleted`. `get_user_org_ids` has a single caller (`get_accessible_org_ids`), so the fix is centralized.
- **BLOCKED orgs are deliberately not filtered here**: the codebase handles them explicitly downstream (`Organization.can_authenticate` checks raise `NotPermitted` → 403) so users get a clear "blocked" response instead of 404. Filtering at this layer collapsed those into 404/422 and broke that UX (caught by `tests/checkout/test_endpoints.py::test_blocked_organization`).

Detail bug: [bug_87081e0d-36bf-4470-89a8-998cb34eb49d](https://app.detail.dev/org_ecfbc7cf-6d21-4ce1-8c61-cda1d650ccf7/bugs/bug_87081e0d-36bf-4470-89a8-998cb34eb49d)

## Test plan

- [x] `uv run task test_fast` — passes
- [x] New regression test: `TestGetAccessibleOrgIds::test_excludes_soft_deleted_org`