### PR TITLE
feat: add product URL check and email warnings to organization review

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23606,6 +23606,11 @@ export interface components {
        * @description Reasons for the current status. Empty when `passed`.
        */
       reasons?: components['schemas']['OrganizationReviewCheckReason'][]
+      /**
+       * Value
+       * @description Optional contextual value associated with the check, e.g. the product URL for the `product_url` check.
+       */
+      value?: string | null
     }
     /**
      * OrganizationReviewCheckKey
@@ -23617,6 +23622,7 @@ export interface components {
       | 'identity.social_links'
       | 'identity.stripe_identity_verification'
       | 'product_description'
+      | 'product_url'
       | 'payout_account'
     /**
      * OrganizationReviewCheckReason
@@ -23631,6 +23637,7 @@ export interface components {
       | 'identity.rejected'
       | 'identity.personal_email'
       | 'identity.domain_mismatch'
+      | 'product_url.unreachable'
       | 'payout_account.requirements_due'
       | 'payout_account.payouts_disabled'
     /**
@@ -53761,6 +53768,7 @@ export const organizationReviewCheckKeyValues: ReadonlyArray<
   'identity.social_links',
   'identity.stripe_identity_verification',
   'product_description',
+  'product_url',
   'payout_account',
 ]
 export const organizationReviewCheckReasonValues: ReadonlyArray<
@@ -53772,6 +53780,7 @@ export const organizationReviewCheckReasonValues: ReadonlyArray<
   'identity.rejected',
   'identity.personal_email',
   'identity.domain_mismatch',
+  'product_url.unreachable',
   'payout_account.requirements_due',
   'payout_account.payouts_disabled',
 ]

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -101,6 +101,11 @@ class Settings(BaseSettings):
 
     ALLOWED_HOSTS: set[str] = {"127.0.0.1:3000", "localhost:3000"}
 
+    # User-Agent sent by Polar's outbound HTTP clients (e.g. URL reachability
+    # checks). Excludes the org review website/setup collectors, which use a
+    # browser-like UA to avoid bot detection by CDNs.
+    POLAR_USER_AGENT: str = "Polar/1.0 (+https://polar.sh)"
+
     # Base URL for the backend. Used by generate_external_url to
     # generate URLs to the backend accessible from the outside.
     BASE_URL: str = "http://127.0.0.1:8000"

--- a/server/polar/kit/http.py
+++ b/server/polar/kit/http.py
@@ -1,9 +1,11 @@
 import ipaddress
 import socket
+from dataclasses import dataclass
 from typing import Annotated
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import anyio
+import httpx
 from fastapi import Depends, Query
 from pydantic import AfterValidator, HttpUrl, PlainSerializer, ValidationError
 from safe_redirect_url import url_has_allowed_host_and_scheme
@@ -68,6 +70,51 @@ async def validate_crawlable_url(url: HttpUrl | str) -> HttpUrl:
     except SSRFBlockedError as e:
         raise UnsafeCrawlableUrl(str(e)) from e
     return url
+
+
+@dataclass
+class UrlReachability:
+    reachable: bool
+    status: int | None = None
+    error: str | None = None
+
+
+async def check_url_reachable(
+    url: HttpUrl | str, *, timeout: float = 5.0
+) -> UrlReachability:
+    """Validate the URL and HEAD it, following redirects.
+
+    The check rejects URLs that resolve to private/reserved IPs (including any
+    redirect target) and treats HTTP 2xx/3xx as reachable.
+    """
+    try:
+        validated_url = await validate_crawlable_url(url)
+    except UnsafeCrawlableUrl as e:
+        return UrlReachability(reachable=False, error=str(e))
+
+    async def _check_redirect(response: httpx.Response) -> None:
+        if response.is_redirect:
+            location = response.headers.get("location", "")
+            await validate_crawlable_url(location)
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers={"User-Agent": settings.POLAR_USER_AGENT},
+            event_hooks={"response": [_check_redirect]},
+        ) as client:
+            response = await client.head(str(validated_url))
+        return UrlReachability(
+            reachable=200 <= response.status_code < 400,
+            status=response.status_code,
+        )
+    except UnsafeCrawlableUrl as e:
+        return UrlReachability(reachable=False, error=str(e))
+    except httpx.TimeoutException:
+        return UrlReachability(reachable=False, error="Request timed out")
+    except httpx.HTTPError:
+        return UrlReachability(reachable=False, error="Unable to reach URL")
 
 
 def _unescape_checkout_id_placeholder(url: HttpUrl) -> str:

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-import httpx
 from fastapi import Depends, Query, Response, status
 from sqlalchemy.orm import joinedload
 
@@ -24,10 +23,7 @@ from polar.exceptions import (
     PolarRequestValidationError,
     ResourceNotFound,
 )
-from polar.kit.http import (
-    UnsafeCrawlableUrl,
-    validate_crawlable_url,
-)
+from polar.kit.http import check_url_reachable
 from polar.kit.pagination import ListResource, Pagination, PaginationParamsQuery
 from polar.models import Account, Organization
 from polar.openapi import APITag
@@ -672,36 +668,9 @@ async def validate_website(
     body: OrganizationValidateWebsiteRequest,
 ) -> OrganizationValidateWebsiteResponse:
     """Validate that a website URL is reachable and not targeting a private network."""
-    try:
-        validated_url = await validate_crawlable_url(body.url)
-    except UnsafeCrawlableUrl as e:
-        return OrganizationValidateWebsiteResponse(reachable=False, error=str(e))
-
-    async def _check_redirect(response: httpx.Response) -> None:
-        if response.is_redirect:
-            location = response.headers.get("location", "")
-            await validate_crawlable_url(location)
-
-    try:
-        async with httpx.AsyncClient(
-            follow_redirects=True,
-            timeout=5.0,
-            headers={"User-Agent": "Polar URL Validator/1.0"},
-            event_hooks={"response": [_check_redirect]},
-        ) as client:
-            response = await client.head(str(validated_url))
-
-        reachable = 200 <= response.status_code < 400
-        return OrganizationValidateWebsiteResponse(
-            reachable=reachable, status=response.status_code
-        )
-    except UnsafeCrawlableUrl as e:
-        return OrganizationValidateWebsiteResponse(reachable=False, error=str(e))
-    except httpx.TimeoutException:
-        return OrganizationValidateWebsiteResponse(
-            reachable=False, error="Request timed out"
-        )
-    except httpx.HTTPError:
-        return OrganizationValidateWebsiteResponse(
-            reachable=False, error="Unable to reach URL"
-        )
+    result = await check_url_reachable(body.url)
+    return OrganizationValidateWebsiteResponse(
+        reachable=result.reachable,
+        status=result.status,
+        error=result.error,
+    )

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -555,6 +555,7 @@ class OrganizationReviewCheckKey(StrEnum):
     IDENTITY_SOCIAL_LINKS = "identity.social_links"
     IDENTITY_STRIPE_VERIFICATION = "identity.stripe_identity_verification"
     PRODUCT_DESCRIPTION = "product_description"
+    PRODUCT_URL = "product_url"
     PAYOUT_ACCOUNT = "payout_account"
 
 
@@ -579,6 +580,9 @@ class OrganizationReviewCheckReason(StrEnum):
     IDENTITY_PERSONAL_EMAIL = "identity.personal_email"
     IDENTITY_DOMAIN_MISMATCH = "identity.domain_mismatch"
 
+    # Product URL
+    PRODUCT_URL_UNREACHABLE = "product_url.unreachable"
+
     # Payout account
     PAYOUT_ACCOUNT_REQUIREMENTS_DUE = "payout_account.requirements_due"
     PAYOUT_ACCOUNT_PAYOUTS_DISABLED = "payout_account.payouts_disabled"
@@ -592,6 +596,13 @@ class OrganizationReviewCheck(Schema):
     reasons: list[OrganizationReviewCheckReason] = Field(
         default_factory=list,
         description="Reasons for the current status. Empty when `passed`.",
+    )
+    value: str | None = Field(
+        default=None,
+        description=(
+            "Optional contextual value associated with the check, e.g. the "
+            "product URL for the `product_url` check."
+        ),
     )
 
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -2,6 +2,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any, assert_never, cast
+from urllib.parse import urlparse
 from uuid import UUID
 
 import structlog
@@ -25,6 +26,7 @@ from polar.integrations.loops.service import loops as loops_service
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.anonymization import anonymize_email_for_deletion, anonymize_for_deletion
 from polar.kit.currency import PresentmentCurrency
+from polar.kit.http import check_url_reachable
 from polar.kit.pagination import PaginationParams
 from polar.kit.repository import Options
 from polar.kit.sorting import Sorting
@@ -84,6 +86,14 @@ log = structlog.get_logger()
 
 _MIN_REVIEW_THRESHOLD = 10_000
 SNOOZE_GRACE_PERIOD = timedelta(hours=24)
+
+
+def _website_domain(website: str | None) -> str | None:
+    if not website:
+        return None
+    parsed = urlparse(website)
+    host = (parsed.netloc or parsed.path).split("/", 1)[0].split(":", 1)[0]
+    return host.lower().removeprefix("www.") or None
 
 
 def _append_internal_note(
@@ -1201,6 +1211,7 @@ class OrganizationService:
             self._build_socials_check(organization),
             self._build_identity_verification_check(admin_user),
             self._build_product_description_check(organization),
+            await self._build_product_url_check(organization),
             self._build_payout_account_check(payout_account),
         ]
 
@@ -1257,7 +1268,46 @@ class OrganizationService:
         key = OrganizationReviewCheckKey.IDENTITY_EMAIL
         if not organization.email:
             return self._not_started_check(key)
+
+        email_domain = organization.email.rsplit("@", 1)[-1].lower()
+        website_domain = _website_domain(organization.website)
+        reasons: list[OrganizationReviewCheckReason] = []
+
+        if email_domain in settings.PERSONAL_EMAIL_DOMAINS:
+            reasons.append(OrganizationReviewCheckReason.IDENTITY_PERSONAL_EMAIL)
+
+        if website_domain and email_domain != website_domain:
+            reasons.append(OrganizationReviewCheckReason.IDENTITY_DOMAIN_MISMATCH)
+
+        if reasons:
+            return OrganizationReviewCheck(
+                key=key,
+                status=OrganizationReviewCheckStatus.WARNING,
+                reasons=reasons,
+            )
         return self._passed_check(key)
+
+    async def _build_product_url_check(
+        self, organization: Organization
+    ) -> OrganizationReviewCheck:
+        key = OrganizationReviewCheckKey.PRODUCT_URL
+        if not organization.website:
+            return self._not_started_check(key)
+
+        result = await check_url_reachable(organization.website)
+        if not result.reachable:
+            return OrganizationReviewCheck(
+                key=key,
+                status=OrganizationReviewCheckStatus.FAILED,
+                reasons=[OrganizationReviewCheckReason.PRODUCT_URL_UNREACHABLE],
+                value=organization.website,
+            )
+
+        return OrganizationReviewCheck(
+            key=key,
+            status=OrganizationReviewCheckStatus.PASSED,
+            value=organization.website,
+        )
 
     def _build_socials_check(
         self, organization: Organization

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -5,6 +5,7 @@ from typing import Any, assert_never, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
+import email_validator
 import structlog
 from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
@@ -91,9 +92,8 @@ SNOOZE_GRACE_PERIOD = timedelta(hours=24)
 def _website_domain(website: str | None) -> str | None:
     if not website:
         return None
-    parsed = urlparse(website)
-    host = (parsed.netloc or parsed.path).split("/", 1)[0].split(":", 1)[0]
-    return host.lower().removeprefix("www.") or None
+    host = urlparse(website).hostname
+    return host.removeprefix("www.") if host else None
 
 
 def _append_internal_note(
@@ -1269,7 +1269,13 @@ class OrganizationService:
         if not organization.email:
             return self._not_started_check(key)
 
-        email_domain = organization.email.rsplit("@", 1)[-1].lower()
+        try:
+            email_domain = email_validator.validate_email(
+                organization.email, check_deliverability=False
+            ).domain
+        except email_validator.EmailNotValidError:
+            return self._passed_check(key)
+
         website_domain = _website_domain(organization.website)
         reasons: list[OrganizationReviewCheckReason] = []
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -970,6 +970,7 @@ class TestGetReview:
             "identity.social_links",
             "identity.stripe_identity_verification",
             "product_description",
+            "product_url",
             "payout_account",
         ]
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -15,6 +15,7 @@ from polar.enums import (
     SubscriptionRecurringInterval,
 )
 from polar.exceptions import PolarRequestValidationError
+from polar.kit.http import UrlReachability
 from polar.models import Customer, Organization, Product, User, UserOrganization
 from polar.models.account import Account
 from polar.models.organization import (
@@ -1261,6 +1262,15 @@ def _step(
 class TestGetReviewState:
     """Test the merchant self-review checklist."""
 
+    @pytest.fixture(autouse=True)
+    def mock_check_url_reachable(self, mocker: MockerFixture) -> AsyncMock:
+        # Default to reachable so existing tests don't make outbound requests.
+        # Individual tests can re-patch via `mocker.patch(...)` to override.
+        return mocker.patch(
+            "polar.organization.service.check_url_reachable",
+            new=AsyncMock(return_value=UrlReachability(reachable=True, status=200)),
+        )
+
     async def test_empty_org_blocks_submission(
         self,
         session: AsyncSession,
@@ -1288,6 +1298,69 @@ class TestGetReviewState:
         organization: Organization,
     ) -> None:
         organization.email = "support@example.com"
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_EMAIL)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert step.reasons == []
+
+    async def test_email_personal_domain_warns(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Free/personal email — the merchant can still submit, but we surface
+        # this as a soft warning so reviewers know the support address isn't
+        # tied to a business domain.
+        organization.email = "founder@gmail.com"
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_EMAIL)
+
+        assert step.status == OrganizationReviewCheckStatus.WARNING
+        assert OrganizationReviewCheckReason.IDENTITY_PERSONAL_EMAIL in step.reasons
+        assert state.can_submit is False  # other checks still pending
+        # Warnings alone don't block — verified by isolating the failing keys.
+        non_email_failing = [
+            s
+            for s in state.preliminary_steps
+            if s.key != OrganizationReviewCheckKey.IDENTITY_EMAIL
+            and s.status
+            in (
+                OrganizationReviewCheckStatus.FAILED,
+                OrganizationReviewCheckStatus.PENDING,
+            )
+        ]
+        assert non_email_failing  # something else is blocking, not the warning
+
+    async def test_email_domain_mismatch_warns(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.email = "support@otherdomain.com"
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_EMAIL)
+
+        assert step.status == OrganizationReviewCheckStatus.WARNING
+        assert OrganizationReviewCheckReason.IDENTITY_DOMAIN_MISMATCH in step.reasons
+
+    async def test_email_matching_website_passes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.email = "support@example.com"
+        organization.website = "https://www.example.com/products"
         await save_fixture(organization)
 
         state = await organization_service.get_review_state(session, organization)
@@ -1406,6 +1479,61 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.PRODUCT_DESCRIPTION)
 
         assert step.status == OrganizationReviewCheckStatus.PASSED
+
+    async def test_product_url_missing_is_not_started(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        mock_check_url_reachable: AsyncMock,
+    ) -> None:
+        assert organization.website is None
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PRODUCT_URL)
+
+        assert step.status == OrganizationReviewCheckStatus.PENDING
+        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+        assert step.value is None
+        mock_check_url_reachable.assert_not_called()
+
+    async def test_product_url_reachable_passes_with_value(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PRODUCT_URL)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert step.value == "https://example.com"
+
+    async def test_product_url_unreachable_fails(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+        mocker.patch(
+            "polar.organization.service.check_url_reachable",
+            new=AsyncMock(
+                return_value=UrlReachability(reachable=False, error="DNS failed")
+            ),
+        )
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.PRODUCT_URL)
+
+        assert step.status == OrganizationReviewCheckStatus.FAILED
+        assert OrganizationReviewCheckReason.PRODUCT_URL_UNREACHABLE in step.reasons
+        assert step.value == "https://example.com"
+        assert state.can_submit is False
 
     async def test_payout_account_ready(
         self,


### PR DESCRIPTION
## Summary

- Add a `product_url` preliminary check to the organization self-review checklist that verifies `organization.website` is set and reachable. 
- Add a soft warning on the support email when it's a free-mail domain (gmail, yahoo, etc.) or doesn't match the organization website domain. Uses the existing `IDENTITY_PERSONAL_EMAIL` / `IDENTITY_DOMAIN_MISMATCH` reason codes and the `WARNING` status — does not block submission.
- Factor the SSRF-safe HEAD-request logic out of the `validate_website` endpoint into a reusable `check_url_reachable` helper in `polar/kit/http.py`. The endpoint now reuses the helper.
- Add a `POLAR_USER_AGENT` setting (default `Polar/1.0 (+https://polar.sh)`) to centralize the User-Agent sent by Polar's outbound HTTP clients. The org-review website/setup collectors continue to use a browser-like UA to avoid CDN bot detection.

## Test plan

- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run pytest tests/organization/test_service.py::TestGetReviewState tests/organization/test_endpoints.py::TestGetReview tests/kit/test_http.py`
- [ ] Manually verify the merchant review checklist surfaces the new `product_url` step and the email warning in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)