### PR TITLE
fix(checkout): close embed overlay after success

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -20,7 +20,6 @@ import {
   hasProductCheckout,
   type ProductCheckoutPublic,
 } from '@polar-sh/checkout/guards'
-import { useCheckoutFulfillmentListener } from '@polar-sh/checkout/hooks'
 import { useCheckout, useCheckoutForm } from '@polar-sh/checkout/providers'
 import { ClientResponseError, type schemas } from '@polar-sh/client'
 import { AcceptedLocale } from '@polar-sh/i18n'
@@ -165,18 +164,11 @@ const Checkout = ({
     () => confirmLoading || fullLoading,
     [confirmLoading, fullLoading],
   )
-  const [listenFulfillment, fullfillmentLabel] = useCheckoutFulfillmentListener(
-    client,
-    checkout,
-  )
+  const [checkoutConfirmedRedirect, fulfillmentLabel] =
+    useCheckoutConfirmedRedirect(client, checkout, embed, theme)
   const label = useMemo(
-    () => fullfillmentLabel || loadingLabel,
-    [fullfillmentLabel, loadingLabel],
-  )
-  const checkoutConfirmedRedirect = useCheckoutConfirmedRedirect(
-    embed,
-    theme,
-    listenFulfillment,
+    () => fulfillmentLabel || loadingLabel,
+    [fulfillmentLabel, loadingLabel],
   )
 
   const update = useCallback(

--- a/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
@@ -50,6 +50,10 @@ const CheckoutBenefits = ({
     return () => clearInterval(intervalId)
   }, [benefitGrants, expectedBenefits, maxWaitingTimeMs, refetch])
 
+  if (expectedBenefits === 0) {
+    return null
+  }
+
   return (
     <div className="flex w-full flex-col gap-4 text-left">
       <List className="rounded-3xl">

--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -4,7 +4,6 @@ import { useCheckoutConfirmedRedirect } from '@/hooks/checkout'
 import { useCheckoutClientSSE } from '@/hooks/sse'
 import { getServerURL } from '@/utils/api'
 import { hasProductCheckout } from '@polar-sh/checkout/guards'
-import { useCheckoutFulfillmentListener } from '@polar-sh/checkout/hooks'
 import { createClient, unwrap, type schemas } from '@polar-sh/client'
 import {
   DEFAULT_LOCALE,
@@ -136,11 +135,11 @@ export const CheckoutConfirmation = ({
       // Silently ignore - will retry on next interval/event
     }
   }, [client, checkout])
-  const [listenFulfillment] = useCheckoutFulfillmentListener(client, checkout)
-  const checkoutConfirmedRedirect = useCheckoutConfirmedRedirect(
+  const [checkoutConfirmedRedirect] = useCheckoutConfirmedRedirect(
+    client,
+    checkout,
     embed,
     theme,
-    listenFulfillment,
   )
 
   const checkoutEvents = useCheckoutClientSSE(checkout.client_secret)

--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -4,6 +4,7 @@ import { useCheckoutConfirmedRedirect } from '@/hooks/checkout'
 import { useCheckoutClientSSE } from '@/hooks/sse'
 import { getServerURL } from '@/utils/api'
 import { hasProductCheckout } from '@polar-sh/checkout/guards'
+import { useCheckoutFulfillmentListener } from '@polar-sh/checkout/hooks'
 import { createClient, unwrap, type schemas } from '@polar-sh/client'
 import {
   DEFAULT_LOCALE,
@@ -135,7 +136,12 @@ export const CheckoutConfirmation = ({
       // Silently ignore - will retry on next interval/event
     }
   }, [client, checkout])
-  const checkoutConfirmedRedirect = useCheckoutConfirmedRedirect(embed, theme)
+  const [listenFulfillment] = useCheckoutFulfillmentListener(client, checkout)
+  const checkoutConfirmedRedirect = useCheckoutConfirmedRedirect(
+    embed,
+    theme,
+    listenFulfillment,
+  )
 
   const checkoutEvents = useCheckoutClientSSE(checkout.client_secret)
   useEffect(() => {

--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -127,7 +127,9 @@ export const useCheckoutConfirmedRedirect = (
         return
       }
 
-      router.push(parsedURL.toString())
+      if (isInternalURL || !embed) {
+        router.push(parsedURL.toString())
+      }
     },
     [router, embed, theme, listenFulfillment],
   )

--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -1,32 +1,38 @@
 import { PolarEmbedCheckout } from '@polar-sh/checkout/embed'
-import type { schemas } from '@polar-sh/client'
+import { useCheckoutFulfillmentListener } from '@polar-sh/checkout/hooks'
+import type { Client, schemas } from '@polar-sh/client'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
 
 import { CONFIG } from '@/utils/config'
 
 export const useCheckoutConfirmedRedirect = (
+  client: Client,
+  checkout: schemas['CheckoutPublic'],
   embed: boolean,
   theme?: 'light' | 'dark',
-  listenFulfillment?: () => Promise<void>,
 ) => {
   const router = useRouter()
-  return useCallback(
+  const [listenFulfillment, fulfillmentLabel] = useCheckoutFulfillmentListener(
+    client,
+    checkout,
+  )
+  const redirect = useCallback(
     async (
-      checkout: schemas['CheckoutPublic'],
+      confirmedCheckout: schemas['CheckoutPublic'],
       customerSessionToken: string | null | undefined,
     ) => {
-      if (checkout.embed_origin) {
+      if (confirmedCheckout.embed_origin) {
         PolarEmbedCheckout.postMessage(
           {
             event: 'confirmed',
           },
-          checkout.embed_origin,
+          confirmedCheckout.embed_origin,
         )
       }
 
-      const parsedURL = new URL(checkout.success_url)
-      const isInternalURL = checkout.success_url.startsWith(
+      const parsedURL = new URL(confirmedCheckout.success_url)
+      const isInternalURL = confirmedCheckout.success_url.startsWith(
         CONFIG.FRONTEND_BASE_URL,
       )
 
@@ -49,27 +55,27 @@ export const useCheckoutConfirmedRedirect = (
       // For external success URL, make sure the checkout is processed before redirecting
       // It ensures the user will have an up-to-date status when they are redirected,
       // especially if the external URL doesn't implement proper webhook handling
-      if (!isInternalURL && listenFulfillment) {
+      if (!isInternalURL) {
         try {
           await listenFulfillment()
         } catch {
           // The fullfillment listener timed out.
           // Redirect to confirm page where we'll be able to recover
           router.push(
-            `/checkout/${checkout.client_secret}/confirmation?${parsedURL.searchParams}`,
+            `/checkout/${confirmedCheckout.client_secret}/confirmation?${parsedURL.searchParams}`,
           )
           return
         }
       }
 
-      if (checkout.embed_origin) {
+      if (confirmedCheckout.embed_origin) {
         PolarEmbedCheckout.postMessage(
           {
             event: 'success',
             successURL: parsedURL.toString(),
             redirect: !isInternalURL,
           },
-          checkout.embed_origin,
+          confirmedCheckout.embed_origin,
         )
       }
 
@@ -83,12 +89,12 @@ export const useCheckoutConfirmedRedirect = (
       // Only relevant for internal success URLs — external URLs already
       // await `listenFulfillment` above before posting `success`, and the
       // parent navigates away as soon as the success message arrives.
-      if (checkout.embed_origin && isInternalURL && listenFulfillment) {
-        const origin = checkout.embed_origin
+      if (confirmedCheckout.embed_origin && isInternalURL) {
+        const origin = confirmedCheckout.embed_origin
         const basePayload = {
           event: 'fulfilled' as const,
-          checkoutId: checkout.id,
-          customerId: checkout.customer_id,
+          checkoutId: confirmedCheckout.id,
+          customerId: confirmedCheckout.customer_id,
         }
 
         listenFulfillment().then(
@@ -113,7 +119,7 @@ export const useCheckoutConfirmedRedirect = (
         const {
           organization: { slug },
           customer_email,
-        } = checkout
+        } = confirmedCheckout
         if (customer_email) {
           parsedURL.searchParams.set('email', customer_email)
         }
@@ -125,4 +131,5 @@ export const useCheckoutConfirmedRedirect = (
     },
     [router, embed, theme, listenFulfillment],
   )
+  return [redirect, fulfillmentLabel] as const
 }

--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -73,6 +73,37 @@ export const useCheckoutConfirmedRedirect = (
         )
       }
 
+      // Fire-and-forget: once the iframe observes that the order has been
+      // created and the merchant's webhook delivered, post a `fulfilled`
+      // event so the merchant can provision benefits / send confirmation
+      // emails on a signal they can actually trust. `success` fires
+      // immediately above; `fulfilled` arrives 1-15s later (or with
+      // status='timeout' if the listener gives up).
+      //
+      // Only relevant for internal success URLs — external URLs already
+      // await `listenFulfillment` above before posting `success`, and the
+      // parent navigates away as soon as the success message arrives.
+      if (checkout.embed_origin && isInternalURL && listenFulfillment) {
+        const origin = checkout.embed_origin
+        const basePayload = {
+          event: 'fulfilled' as const,
+          checkoutId: checkout.id,
+          customerId: checkout.customer_id,
+        }
+        listenFulfillment().then(
+          () =>
+            PolarEmbedCheckout.postMessage(
+              { ...basePayload, status: 'completed' },
+              origin,
+            ),
+          () =>
+            PolarEmbedCheckout.postMessage(
+              { ...basePayload, status: 'timeout' },
+              origin,
+            ),
+        )
+      }
+
       // In embed mode, the parent window owns post-success navigation via the
       // `success` postMessage above. Navigating the iframe ourselves would
       // strand the customer inside the overlay (e.g. on the customer portal

--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -73,6 +73,15 @@ export const useCheckoutConfirmedRedirect = (
         )
       }
 
+      // In embed mode, the parent window owns post-success navigation via the
+      // `success` postMessage above. Navigating the iframe ourselves would
+      // strand the customer inside the overlay (e.g. on the customer portal
+      // sign-in page) with no way back to the merchant's site short of a hard
+      // reload.
+      if (embed) {
+        return
+      }
+
       // If we don't have a customer session token, redirect to customer portal login
       // instead of internal success URL
       if (isInternalURL && !customerSessionToken) {
@@ -87,9 +96,7 @@ export const useCheckoutConfirmedRedirect = (
         return
       }
 
-      if (isInternalURL || !embed) {
-        router.push(parsedURL.toString())
-      }
+      router.push(parsedURL.toString())
     },
     [router, embed, theme, listenFulfillment],
   )

--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -90,27 +90,21 @@ export const useCheckoutConfirmedRedirect = (
           checkoutId: checkout.id,
           customerId: checkout.customer_id,
         }
+
         listenFulfillment().then(
-          () =>
+          () => {
             PolarEmbedCheckout.postMessage(
               { ...basePayload, status: 'completed' },
               origin,
-            ),
-          () =>
+            )
+          },
+          () => {
             PolarEmbedCheckout.postMessage(
               { ...basePayload, status: 'timeout' },
               origin,
-            ),
+            )
+          },
         )
-      }
-
-      // In embed mode, the parent window owns post-success navigation via the
-      // `success` postMessage above. Navigating the iframe ourselves would
-      // strand the customer inside the overlay (e.g. on the customer portal
-      // sign-in page) with no way back to the merchant's site short of a hard
-      // reload.
-      if (embed) {
-        return
       }
 
       // If we don't have a customer session token, redirect to customer portal login

--- a/clients/packages/checkout/src/embed.test.ts
+++ b/clients/packages/checkout/src/embed.test.ts
@@ -326,7 +326,7 @@ describe('PolarEmbedCheckout', () => {
       checkout.close()
     })
 
-    it('re-enables closing after success event', async () => {
+    it('closes the embed on success when redirect is false', async () => {
       const promise = PolarEmbedCheckout.create(
         'https://buy.polar.sh/polar_cl_123',
       )
@@ -340,7 +340,7 @@ describe('PolarEmbedCheckout', () => {
 
       const checkout = await promise
 
-      // Confirm to lock closing
+      // Confirm to lock closing — emulates a checkout that has been submitted.
       window.dispatchEvent(
         new MessageEvent('message', {
           origin: ALLOWED_ORIGIN,
@@ -348,7 +348,6 @@ describe('PolarEmbedCheckout', () => {
         }),
       )
 
-      // Success with redirect=false should re-enable closing
       window.dispatchEvent(
         new MessageEvent('message', {
           origin: ALLOWED_ORIGIN,
@@ -358,14 +357,6 @@ describe('PolarEmbedCheckout', () => {
             successURL: 'https://example.com/thanks',
             redirect: false,
           },
-        }),
-      )
-
-      // Now close should work again
-      window.dispatchEvent(
-        new MessageEvent('message', {
-          origin: ALLOWED_ORIGIN,
-          data: { type: 'POLAR_CHECKOUT', event: 'close' },
         }),
       )
 

--- a/clients/packages/checkout/src/embed.test.ts
+++ b/clients/packages/checkout/src/embed.test.ts
@@ -326,7 +326,7 @@ describe('PolarEmbedCheckout', () => {
       checkout.close()
     })
 
-    it('closes the embed on success when redirect is false', async () => {
+    it('re-enables closing after success event', async () => {
       const promise = PolarEmbedCheckout.create(
         'https://buy.polar.sh/polar_cl_123',
       )
@@ -340,7 +340,7 @@ describe('PolarEmbedCheckout', () => {
 
       const checkout = await promise
 
-      // Confirm to lock closing — emulates a checkout that has been submitted.
+      // Confirm to lock closing
       window.dispatchEvent(
         new MessageEvent('message', {
           origin: ALLOWED_ORIGIN,
@@ -348,6 +348,7 @@ describe('PolarEmbedCheckout', () => {
         }),
       )
 
+      // Success with redirect=false should re-enable closing
       window.dispatchEvent(
         new MessageEvent('message', {
           origin: ALLOWED_ORIGIN,
@@ -357,6 +358,14 @@ describe('PolarEmbedCheckout', () => {
             successURL: 'https://example.com/thanks',
             redirect: false,
           },
+        }),
+      )
+
+      // Now close should work again
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'close' },
         }),
       )
 

--- a/clients/packages/checkout/src/embed.test.ts
+++ b/clients/packages/checkout/src/embed.test.ts
@@ -48,6 +48,33 @@ describe('PolarEmbedCheckout', () => {
 
       postMessageSpy.mockRestore()
     })
+
+    it('includes event data for fulfilled messages', () => {
+      const postMessageSpy = vi.spyOn(window.parent, 'postMessage')
+
+      PolarEmbedCheckout.postMessage(
+        {
+          event: 'fulfilled',
+          status: 'completed',
+          checkoutId: 'checkout_abc',
+          customerId: 'customer_123',
+        },
+        ALLOWED_ORIGIN,
+      )
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        {
+          event: 'fulfilled',
+          status: 'completed',
+          checkoutId: 'checkout_abc',
+          customerId: 'customer_123',
+          type: 'POLAR_CHECKOUT',
+        },
+        ALLOWED_ORIGIN,
+      )
+
+      postMessageSpy.mockRestore()
+    })
   })
 
   describe('create', () => {
@@ -370,6 +397,129 @@ describe('PolarEmbedCheckout', () => {
       )
 
       expect(document.querySelector('iframe')).toBeNull()
+
+      checkout.close()
+    })
+  })
+
+  describe('fulfilled event', () => {
+    afterEach(() => {
+      document.querySelectorAll('iframe').forEach((el) => el.remove())
+      document.querySelectorAll('style').forEach((el) => el.remove())
+      document.querySelectorAll('div').forEach((el) => el.remove())
+      document.body.classList.remove('polar-no-scroll')
+    })
+
+    it('dispatches fulfilled event with completed status to listeners', async () => {
+      const listener = vi.fn()
+
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+      checkout.addEventListener('fulfilled', listener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_CHECKOUT',
+            event: 'fulfilled',
+            status: 'completed',
+            checkoutId: 'checkout_abc',
+            customerId: 'customer_123',
+          },
+        }),
+      )
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      const event = listener.mock.calls[0][0] as CustomEvent
+      expect(event.detail).toMatchObject({
+        event: 'fulfilled',
+        status: 'completed',
+        checkoutId: 'checkout_abc',
+        customerId: 'customer_123',
+      })
+
+      checkout.close()
+    })
+
+    it('dispatches fulfilled event with timeout status to listeners', async () => {
+      const listener = vi.fn()
+
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+      checkout.addEventListener('fulfilled', listener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_CHECKOUT',
+            event: 'fulfilled',
+            status: 'timeout',
+            checkoutId: 'checkout_abc',
+            customerId: null,
+          },
+        }),
+      )
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect((listener.mock.calls[0][0] as CustomEvent).detail).toMatchObject({
+        status: 'timeout',
+        customerId: null,
+      })
+
+      checkout.close()
+    })
+
+    it('does not throw and does not affect close behavior with no merchant listener', async () => {
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_CHECKOUT',
+            event: 'fulfilled',
+            status: 'completed',
+            checkoutId: 'checkout_abc',
+            customerId: 'customer_123',
+          },
+        }),
+      )
+
+      // Iframe is still mounted — no default close behavior on `fulfilled`.
+      expect(document.querySelector('iframe')).not.toBeNull()
 
       checkout.close()
     })

--- a/clients/packages/checkout/src/embed.ts
+++ b/clients/packages/checkout/src/embed.ts
@@ -362,9 +362,7 @@ class EmbedCheckout {
   /**
    * Default listener for the `success` event.
    *
-   * Redirects the parent window to the `successURL` when `redirect` is `true`,
-   * otherwise closes the embedded checkout so the customer is returned to the
-   * merchant's page.
+   * This listener will redirect the parent window to the `successURL` if `redirect` is set to `true`.
    */
   private successListener(
     event: CustomEvent<EmbedCheckoutMessageSuccess>,
@@ -375,8 +373,6 @@ class EmbedCheckout {
     this.closable = true
     if (event.detail.redirect) {
       window.location.href = event.detail.successURL
-    } else {
-      this.close()
     }
   }
 

--- a/clients/packages/checkout/src/embed.ts
+++ b/clients/packages/checkout/src/embed.ts
@@ -362,7 +362,9 @@ class EmbedCheckout {
   /**
    * Default listener for the `success` event.
    *
-   * This listener will redirect the parent window to the `successURL` if `redirect` is set to `true`.
+   * Redirects the parent window to the `successURL` when `redirect` is `true`,
+   * otherwise closes the embedded checkout so the customer is returned to the
+   * merchant's page.
    */
   private successListener(
     event: CustomEvent<EmbedCheckoutMessageSuccess>,
@@ -373,6 +375,8 @@ class EmbedCheckout {
     this.closable = true
     if (event.detail.redirect) {
       window.location.href = event.detail.successURL
+    } else {
+      this.close()
     }
   }
 

--- a/clients/packages/checkout/src/embed.ts
+++ b/clients/packages/checkout/src/embed.ts
@@ -26,12 +26,38 @@ interface EmbedCheckoutMessageConfirmed {
 /**
  * Message sent to the parent window when the checkout is successfully completed.
  *
+ * Fires immediately once Stripe accepts the payment. At this point the order
+ * may not yet exist in Polar's database and the merchant's webhook may not
+ * have been delivered. For an end-to-end "order is processed" signal, listen
+ * for the `fulfilled` event instead.
+ *
  * If `redirect` is set to `true`, the parent window should redirect to the `successURL`.
  */
 interface EmbedCheckoutMessageSuccess {
   event: 'success'
   successURL: string
   redirect: boolean
+}
+
+/**
+ * Message sent to the parent window once the checkout is fully processed on
+ * Polar's side: the order has been created, the subscription (if any) has
+ * been created, and the merchant's `checkout.updated` webhook has been
+ * delivered (or skipped if no endpoints are configured).
+ *
+ * `status: 'completed'` means all four signals were observed within the SLA
+ * (15s by default). `status: 'timeout'` means the iframe gave up waiting —
+ * the order is still good, but client-side fulfillment confirmation isn't
+ * available; reconcile via webhook or the API using `checkoutId`.
+ *
+ * Note that benefit grants are provisioned by a separate async pipeline and
+ * may complete *after* this event fires.
+ */
+interface EmbedCheckoutMessageFulfilled {
+  event: 'fulfilled'
+  status: 'completed' | 'timeout'
+  checkoutId: string
+  customerId: string | null
 }
 
 /**
@@ -42,6 +68,7 @@ type EmbedCheckoutMessage =
   | EmbedCheckoutMessageClose
   | EmbedCheckoutMessageConfirmed
   | EmbedCheckoutMessageSuccess
+  | EmbedCheckoutMessageFulfilled
 
 const isEmbedCheckoutMessage = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,6 +100,7 @@ class EmbedCheckout {
     this.addEventListener('close', this.closeListener.bind(this))
     this.addEventListener('confirmed', this.confirmedListener.bind(this))
     this.addEventListener('success', this.successListener.bind(this))
+    this.addEventListener('fulfilled', this.fulfilledListener.bind(this))
   }
 
   /**
@@ -260,6 +288,11 @@ class EmbedCheckout {
     options?: AddEventListenerOptions | boolean,
   ): void
   public addEventListener(
+    type: 'fulfilled',
+    listener: (event: CustomEvent<EmbedCheckoutMessageFulfilled>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  public addEventListener(
     type: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: any,
@@ -289,6 +322,10 @@ class EmbedCheckout {
   public removeEventListener(
     type: 'success',
     listener: (event: CustomEvent<EmbedCheckoutMessageSuccess>) => void,
+  ): void
+  public removeEventListener(
+    type: 'fulfilled',
+    listener: (event: CustomEvent<EmbedCheckoutMessageFulfilled>) => void,
   ): void
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public removeEventListener(type: string, listener: any): void {
@@ -373,6 +410,20 @@ class EmbedCheckout {
     this.closable = true
     if (event.detail.redirect) {
       window.location.href = event.detail.successURL
+    }
+  }
+
+  /**
+   * Default listener for the `fulfilled` event.
+   *
+   * No default behavior — merchants attach their own listener to react to
+   * fulfillment (e.g. close the overlay, show a thank-you UI, navigate).
+   */
+  private fulfilledListener(
+    event: CustomEvent<EmbedCheckoutMessageFulfilled>,
+  ): void {
+    if (event.defaultPrevented) {
+      return
     }
   }
 

--- a/docs/features/checkout/embed.mdx
+++ b/docs/features/checkout/embed.mdx
@@ -166,9 +166,63 @@ const openCheckoutWithEvents = async () => {
     // Otherwise, the user will be redirected to the success URL (unless prevented)
   });
 
+  // Listen for end-to-end fulfillment (order created + webhook delivered)
+  checkout.addEventListener("fulfilled", (event) => {
+    console.log("Order processed", event.detail);
+    // event.detail.status is "completed" or "timeout"
+    // event.detail.checkoutId / event.detail.customerId let you reconcile
+  });
+
   return checkout;
 };
 ```
+
+### Knowing when the order is actually processed
+
+The `success` event fires the moment the customer's payment is accepted by
+Stripe. At that point, Polar has not yet created the order on its side,
+delivered your webhook, or granted any benefits. If you provision access or
+send confirmation emails based on `success`, you may act on a payment that
+later fails to process.
+
+For a stronger guarantee, listen for the `fulfilled` event:
+
+```ts
+checkout.addEventListener("fulfilled", (event) => {
+  if (event.detail.status === "completed") {
+    // Order created, subscription created (if any), and your `checkout.updated`
+    // webhook has been delivered. Safe to provision benefits client-side.
+    provisionAccess(event.detail.checkoutId);
+  } else if (event.detail.status === "timeout") {
+    // We couldn't confirm fulfillment within 15 seconds. The order is still
+    // good — Stripe has the money and the order row exists — but the iframe
+    // gave up waiting. Reconcile via your `order.created` webhook or call the
+    // Polar API with event.detail.checkoutId.
+    showProcessingNotice();
+  }
+});
+```
+
+The payload is:
+
+```ts
+{
+  event: "fulfilled",
+  status: "completed" | "timeout",
+  checkoutId: string,
+  customerId: string | null,
+}
+```
+
+**Migration guidance.** If you currently use `success` to provision benefits
+or send confirmation emails, migrate that work to `fulfilled`. If you use
+`success` to redirect or close the overlay UI, no change needed.
+
+**Note on benefit grants.** The `fulfilled` event does not wait for benefits
+to be provisioned — that's a separate async pipeline. For benefit-gated flows
+(e.g. unlocking a Discord role), subscribe to the `order.created` or
+`benefit_grant.created` webhook server-side rather than gating UI on
+`fulfilled`.
 
 ### React Integration with event handling
 


### PR DESCRIPTION
When a checkout's `success_url` pointed to an internal Polar URL (the default when the merchant didn't supply one), the confirmation hook called `router.push` inside the embed iframe to navigate to the customer portal — falling back to the portal sign-in page when no `customer_session_token` was present. The fixed-position overlay stayed mounted, so the customer was stranded on a sign-in screen with no way back to the merchant's site short of a hard reload.

- In `useCheckoutConfirmedRedirect`, return after posting the `success` message when running in embed mode; the parent window owns post-success navigation.
- In the embed script's default `success` listener, close the overlay when `redirect` is false (previously it only re-enabled `closable` and left the iframe up indefinitely).