### PR TITLE
docs: document order receipts

### DIFF
--- a/docs/api-reference/customer-portal/orders/get-receipt.mdx
+++ b/docs/api-reference/customer-portal/orders/get-receipt.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/customer-portal/orders/{id}/receipt
+---

--- a/docs/api-reference/orders/get-receipt.mdx
+++ b/docs/api-reference/orders/get-receipt.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/orders/{id}/receipt
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -282,7 +282,8 @@
                   "api-reference/orders/patch",
                   "api-reference/orders/list",
                   "api-reference/orders/post-invoice",
-                  "api-reference/orders/get-invoice"
+                  "api-reference/orders/get-invoice",
+                  "api-reference/orders/get-receipt"
                 ]
               },
               {
@@ -424,7 +425,8 @@
                   "api-reference/customer-portal/orders/patch",
                   "api-reference/customer-portal/orders/list",
                   "api-reference/customer-portal/orders/post-invoice",
-                  "api-reference/customer-portal/orders/get-invoice"
+                  "api-reference/customer-portal/orders/get-invoice",
+                  "api-reference/customer-portal/orders/get-receipt"
                 ]
               },
               {

--- a/docs/features/customer-portal/introduction.mdx
+++ b/docs/features/customer-portal/introduction.mdx
@@ -15,6 +15,7 @@ From the Customer Portal, your customers can:
 
 - View their **active subscriptions** and past **purchase history**
 - **Download and edit invoices** (e.g. add a company name, VAT number, or billing address)
+- **Download payment receipts** for every paid order, with the payment method and any refunds
 - **Access benefits** they're entitled to — license keys, file downloads, Discord access, etc.
 - **Cancel active subscriptions** on their own
 - **Update their default payment method** — the primary way for customers to recover from failed payments
@@ -26,7 +27,7 @@ The Customer Portal isn't just a convenience feature — it's a critical piece o
 
 - **Failed payment recovery.** When a subscription renewal fails, the portal is where customers update their card so they don't lose access. Because Polar is PCI-compliant, you never have to handle card details yourself.
 - **Self-service cancellations.** Some jurisdictions (notably California under the [Automatic Renewal Law](https://oag.ca.gov/consumers/auto-renewing-subscriptions)) legally require customers to be able to cancel a subscription the same way they signed up. The Customer Portal satisfies that requirement out of the box.
-- **Invoice access.** Customers can always retrieve and edit their invoices for bookkeeping and tax purposes, without pulling you into a support thread.
+- **Invoice and receipt access.** Customers retrieve and edit their invoices, and download a receipt for any paid order, without pulling you into a support thread.
 
 ## Next steps
 
@@ -66,8 +67,7 @@ The Customer Portal isn't just a convenience feature — it's a critical piece o
     This is a deliberate design decision. The portal is how we guarantee that
     your customers can always:
 
-    - **Access their invoices**, which they often need for tax and bookkeeping
-      reasons.
+    - **Access their invoices and payment receipts** for tax and bookkeeping.
     - **Cancel their subscriptions on their own**, which is legally required in
       some jurisdictions (for example California's [Automatic Renewal Law](https://oag.ca.gov/consumers/auto-renewing-subscriptions),
       which requires that customers be able to cancel the same way they signed
@@ -86,7 +86,8 @@ The Customer Portal isn't just a convenience feature — it's a critical piece o
     If you need a branded experience, you can build your own portal on top of
     the [Customer Portal API](/api-reference/customer-portal/get-customer),
     which covers the day-to-day actions: viewing subscriptions and orders,
-    downloading invoices, managing benefits and seats, and reading meter usage.
+    downloading invoices and receipts, managing benefits and seats, and reading
+    meter usage.
 
     <Note>
       Not every action is exposed through the Customer Portal API. Most

--- a/docs/features/orders.mdx
+++ b/docs/features/orders.mdx
@@ -58,6 +58,21 @@ Customers can download and edit their own invoices — adding a company name, VA
   their invoice from the Customer Portal, which regenerates it.
 </Note>
 
+## Receipts
+
+A **receipt** is the proof of payment for an order — what was charged, how, and what's been refunded since. Polar issues one for every paid order and assigns a per-customer number in the form `RCPT-{customer-id}-{NNNN}`.
+
+Each receipt includes:
+
+- The **payment method** used (e.g. `Visa — 4242`), the **date paid**, and the **amount**.
+- Any **customer balance** applied to the order.
+- Any **refunds** issued against the order, with dates and amounts.
+- The same line items, taxes, totals, and linked invoice number as the order's invoice.
+
+Customers download receipts from the [Customer Portal](/features/customer-portal/introduction) — a **Download Receipt** button appears on each paid order. Programmatically, use [Get Order Receipt](/api-reference/orders/get-receipt) for the merchant API or its [customer-portal counterpart](/api-reference/customer-portal/orders/get-receipt).
+
+The first request for a given order may return `202 Accepted` while the PDF renders. Retry shortly after for a presigned download URL. The Customer Portal handles this for you.
+
 ## Refunds
 
 Orders can be refunded in full or in part from the dashboard, or programmatically via the [Refunds API](/api-reference/refunds/create). Refunds are a separate resource linked to the order — see [Refunds](/features/refunds) for the rules around what's refundable and how it interacts with payouts.
@@ -84,6 +99,6 @@ If you're integrating orders into your own system, Polar emits an event on every
     List and fetch orders, update billing details, and generate invoices.
   </Card>
   <Card title="Customer Portal" icon="user" href="/features/customer-portal/introduction">
-    Where customers view their own orders and download invoices.
+    Where customers view their own orders and download invoices and receipts.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Added a Receipts section to the Orders feature page covering the receipt number format, what each receipt includes (payment method, applied customer balance, refunds, line items), and the async render behavior.
- Mentioned receipt downloads in the Customer Portal introduction alongside invoices.
- Added two new API reference pages for the receipt endpoints (merchant and customer portal) and registered them in the docs nav.

The OpenAPI spec entries for these endpoints will land via the daily `docs: update OpenAPI schema` job once the receipt endpoints are reflected in the published Speakeasy mirror — the new MDX pages will start rendering content at that point.

## Test plan
- [x] Verify the Orders page renders the new Receipts section with correct links
- [x] Verify the new API reference pages appear under Orders and Customer Portal Orders in the sidebar
- [ ] After the next OpenAPI schema update lands, confirm both receipt endpoint pages render the auto-generated request/response details

🤖 Generated with [Claude Code](https://claude.com/claude-code)