### PR TITLE
Fix app notification 401 crash

### DIFF
--- a/clients/apps/app/hooks/polar/notifications.ts
+++ b/clients/apps/app/hooks/polar/notifications.ts
@@ -59,6 +59,7 @@ export const useGetNotificationRecipient = (
       return response.items?.[0] ?? null
     },
     enabled: !!expoPushToken && !!session,
+    throwOnError: false,
   })
 }
 


### PR DESCRIPTION
We fixed our error fallback in https://github.com/polarsource/polar/pull/11223, however the error fallback fired a second authenticated query in `useGetNotificationRecipient` that can 4XX, and because of the global `throwOnError: true` it throws from inside the boundary's own fallback. Setting `throwOnError: false` on that one query lets it fail silently, so the fallback renders cleanly and the user can re-authenticate.

| Before | After  |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 12 29 32" src="https://github.com/user-attachments/assets/7a00614d-a912-48eb-830a-b2aa7bcc911b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 12 41 34" src="https://github.com/user-attachments/assets/0dd078a4-27f0-4cbd-8115-c2d7db0de6ba" /> |



