### PR TITLE
feat(backoffice): add Priority sort to organization Review queue

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -18,7 +18,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import UUID4, BaseModel, ValidationError, field_validator
 from pydantic_core import PydanticCustomError
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import Select, and_, func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
 from sse_starlette.sse import EventSourceResponse
 from tagflow import tag, text
@@ -95,6 +95,8 @@ from ..dependencies import get_admin
 from ..layout import layout
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
+from . import priority as review_priority
+from .priority import Signals
 from .views.detail_view import OrganizationDetailView
 from .views.list_view import (
     DeletedFilter,
@@ -195,6 +197,105 @@ async def count_test_sales(
     return orders_count, unrefunded_orders_count
 
 
+# Defensive cap on the Review-tab in-memory cohort when sorting by priority.
+REVIEW_TAB_MAX_COHORT = 2000
+
+
+async def _build_review_signals(
+    session: AsyncSession, orgs: Sequence[Organization]
+) -> dict[uuid.UUID, Signals]:
+    """Fetch each org's latest agent review, parse it, run ``priority.compute``."""
+    if not orgs:
+        return {}
+
+    org_ids = [o.id for o in orgs]
+    latest_review_stmt = (
+        select(OrganizationAgentReview)
+        .where(
+            OrganizationAgentReview.organization_id.in_(org_ids),
+            OrganizationAgentReview.deleted_at.is_(None),
+        )
+        .order_by(
+            OrganizationAgentReview.organization_id,
+            OrganizationAgentReview.reviewed_at.desc(),
+        )
+        .distinct(OrganizationAgentReview.organization_id)
+    )
+    result = await session.execute(latest_review_stmt)
+    latest_by_org: dict[uuid.UUID, OrganizationAgentReview] = {
+        ar.organization_id: ar for ar in result.scalars()
+    }
+
+    signals: dict[uuid.UUID, Signals] = {}
+    for org in orgs:
+        metrics = None
+        risk_score = org.review.risk_score if org.review else None
+        agent_review = latest_by_org.get(org.id)
+        if agent_review is not None:
+            try:
+                report = agent_review.parsed_report
+            except Exception:
+                logger.exception(
+                    "agent_review_parse_failed", organization_id=str(org.id)
+                )
+                report = None
+            if report is not None:
+                metrics = report.data_snapshot.metrics
+                risk_score = report.report.overall_risk_score
+        signals[org.id] = review_priority.compute(
+            org, metrics=metrics, risk_score=risk_score
+        )
+    return signals
+
+
+def _apply_sql_sort(stmt: Select[Any], sort: str, direction: str) -> Select[Any]:
+    is_desc = direction == "desc"
+    if sort == "name":
+        return stmt.order_by(
+            Organization.name.desc() if is_desc else Organization.name.asc()
+        )
+    if sort == "country":
+        return stmt.order_by(
+            PayoutAccount.country.desc().nullslast()
+            if is_desc
+            else PayoutAccount.country.asc().nullslast()
+        )
+    if sort == "created":
+        return stmt.order_by(
+            Organization.created_at.desc() if is_desc else Organization.created_at.asc()
+        )
+    if sort == "updated":
+        return stmt.order_by(
+            Organization.modified_at.desc()
+            if is_desc
+            else Organization.modified_at.asc()
+        )
+    if sort == "status_duration":
+        return stmt.order_by(
+            Organization.status_updated_at.desc().nullslast()
+            if is_desc
+            else Organization.status_updated_at.asc().nullsfirst()
+        )
+    if sort == "risk":
+        return stmt.join(Organization.review).order_by(
+            OrganizationReview.risk_score.asc().nullsfirst()
+            if is_desc
+            else OrganizationReview.risk_score.desc().nullslast()
+        )
+    if sort == "total_balance":
+        return stmt.order_by(
+            Organization.total_balance.desc().nullslast()
+            if is_desc
+            else Organization.total_balance.asc().nullsfirst()
+        )
+    if sort == "priority":
+        return stmt.order_by(
+            Organization.status.desc(),
+            Organization.status_updated_at.asc().nullsfirst(),
+        )
+    return stmt
+
+
 @router.get("/", name="organizations:list")
 async def list_organizations(
     request: Request,
@@ -202,7 +303,7 @@ async def list_organizations(
     status: str | None = Query(None),
     q: str | None = Query(None),
     sort: str = Query("priority"),
-    direction: str = Query("asc"),
+    direction: str | None = Query(None),
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
     # Advanced filters
@@ -348,69 +449,49 @@ async def list_organizations(
 
     stmt = apply_deleted_filter(stmt, deleted_filter)
 
-    # Apply sorting
-    is_desc = direction == "desc"
+    is_review_tab = status_filter == OrganizationStatus.REVIEW
+    priority_sort = is_review_tab and sort == "priority"
 
-    if sort == "name":
-        stmt = stmt.order_by(
-            Organization.name.desc() if is_desc else Organization.name.asc()
-        )
-    elif sort == "country":
-        country_order = (
-            PayoutAccount.country.desc().nullslast()
-            if is_desc
-            else PayoutAccount.country.asc().nullslast()
-        )
-        stmt = stmt.order_by(country_order)
-    elif sort == "created":
-        stmt = stmt.order_by(
-            Organization.created_at.desc() if is_desc else Organization.created_at.asc()
-        )
-    elif sort == "updated":
-        stmt = stmt.order_by(
-            Organization.modified_at.desc()
-            if is_desc
-            else Organization.modified_at.asc()
-        )
-    elif sort == "status_duration":
-        status_order = (
-            Organization.status_updated_at.desc().nullslast()
-            if is_desc
-            else Organization.status_updated_at.asc().nullsfirst()
-        )
-        stmt = stmt.order_by(status_order)
-    elif sort == "risk":
-        risk_order = (
-            OrganizationReview.risk_score.asc().nullsfirst()
-            if is_desc
-            else OrganizationReview.risk_score.desc().nullslast()
-        )
-        stmt = stmt.join(Organization.review).order_by(risk_order)
-    elif sort == "total_balance":
-        balance_order = (
-            Organization.total_balance.desc().nullslast()
-            if is_desc
-            else Organization.total_balance.asc().nullsfirst()
-        )
-        stmt = stmt.order_by(balance_order)
-    elif sort == "priority":
-        # Priority: Under Review > Denied > Others, then by days in status
-        stmt = stmt.order_by(
-            Organization.status.desc(),
-            Organization.status_updated_at.asc().nullsfirst(),
-        )
+    # Priority sort defaults to "desc" (highest urgency first); other sorts
+    # keep the historical "asc" default.
+    if direction is None:
+        direction = "desc" if priority_sort else "asc"
 
-    # Pagination
-    offset = (page - 1) * limit
-    stmt = stmt.offset(offset).limit(limit + 1)
+    signals_by_org: dict[uuid.UUID, Signals] = {}
+    organizations: list[Organization]
 
-    result = await session.execute(stmt)
-    organizations = list(result.scalars().unique().all())
-
-    # Check if there are more results
-    has_more = len(organizations) > limit
-    if has_more:
-        organizations = organizations[:limit]
+    if priority_sort:
+        # Priority is a Python-computed composite, so we load the cohort,
+        # build signals, sort, and paginate in memory.
+        result = await session.execute(stmt.limit(REVIEW_TAB_MAX_COHORT + 1))
+        all_orgs = list(result.scalars().unique().all())
+        if len(all_orgs) > REVIEW_TAB_MAX_COHORT:
+            logger.warning(
+                "review_tab_cohort_truncated",
+                count=len(all_orgs),
+                cap=REVIEW_TAB_MAX_COHORT,
+            )
+            all_orgs = all_orgs[:REVIEW_TAB_MAX_COHORT]
+        signals_by_org = await _build_review_signals(session, all_orgs)
+        all_orgs.sort(
+            key=lambda o: signals_by_org[o.id].priority,
+            reverse=direction == "desc",
+        )
+        offset = (page - 1) * limit
+        page_slice = all_orgs[offset : offset + limit + 1]
+        has_more = len(page_slice) > limit
+        organizations = page_slice[:limit] if has_more else page_slice
+    else:
+        stmt = _apply_sql_sort(stmt, sort, direction)
+        offset = (page - 1) * limit
+        stmt = stmt.offset(offset).limit(limit + 1)
+        result = await session.execute(stmt)
+        organizations = list(result.scalars().unique().all())
+        has_more = len(organizations) > limit
+        if has_more:
+            organizations = organizations[:limit]
+        if is_review_tab:
+            signals_by_org = await _build_review_signals(session, organizations)
 
     is_htmx_table_request = request.headers.get("HX-Target") == "org-list"
 
@@ -423,6 +504,7 @@ async def list_organizations(
             has_more,
             sort,
             direction,
+            signals_by_org=signals_by_org,
         ):
             pass
     else:
@@ -450,6 +532,7 @@ async def list_organizations(
                 selected_days_in_status=days_in_status,
                 selected_has_appeal=has_appeal,
                 selected_deleted=deleted_filter,
+                signals_by_org=signals_by_org,
             ):
                 pass
 

--- a/server/polar/backoffice/organizations_v2/priority.py
+++ b/server/polar/backoffice/organizations_v2/priority.py
@@ -1,0 +1,138 @@
+"""Composite priority score for the Review queue.
+
+Sum of four components. Risk, payment health, and fast-mover are each
+capped at 25 — they're "tie-breaker" signals on top of the queue's main
+sort, which is age in status. Aging is uncapped at 25 (50pts max) so
+orgs sitting in the queue past ~10 days naturally outrank fresh orgs
+that lack other signals — but a fresh dispute-heavy merchant can still
+surface if its other signals stack up. ``compute`` is pure over
+primitives — fetching and JSONB parsing live in the caller.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from polar.models import Organization
+from polar.organization_review.schemas import PaymentMetrics
+
+# Aging: 2.5 pts per day, capped at 50.
+# 10d → 25, 14d → 35, 20d → 50 (cap). Beats any single non-aging signal,
+# so a quietly-stale org will rise above an active-but-fresh one.
+AGING_DAILY_PTS = 2.5
+AGING_MAX_PTS = 50.0
+
+# Other components share this cap; the sum stays meaningful at [0, 125].
+SIGNAL_CAP = 25.0
+
+# Risk: AI overall_risk_score is 0..100 (LOW=15, MEDIUM=50, HIGH=85).
+# Below MEDIUM, contribute 0 — those are typically re-reviews of approved orgs.
+HIGH_RISK_SCORE = 50.0
+
+# Payment health: denominator guards prevent noise on tiny merchants.
+MIN_PAYMENTS_FOR_AUTH = 5
+MIN_PAYMENTS_FOR_REFUND = 5
+LOW_AUTH_RATE = 0.70
+HIGH_REFUND_RATE = 0.10
+
+# Fast mover: new org with meaningful volume.
+# Log ramp: $1k → 0, $3k → ~12, $10k → 25 (cap).
+NEW_ORG_DAYS = 30
+FAST_MOVER_MIN_REVENUE_CENTS = 100_000  # $1,000
+FAST_MOVER_MIN_PAYMENTS = 25
+
+
+@dataclass
+class Signals:
+    aging_pts: float = 0.0
+    risk_pts: float = 0.0
+    payment_pts: float = 0.0
+    fast_mover_pts: float = 0.0
+
+    @property
+    def priority(self) -> float:
+        return self.aging_pts + self.risk_pts + self.payment_pts + self.fast_mover_pts
+
+
+def _days_between(later: datetime, earlier: datetime) -> float:
+    return max(0.0, (later - earlier).total_seconds() / 86400.0)
+
+
+def _days_in_status(org: Organization, now: datetime) -> float:
+    return _days_between(now, org.status_updated_at or org.created_at)
+
+
+def _aging_component(org: Organization, now: datetime) -> float:
+    return min(_days_in_status(org, now) * AGING_DAILY_PTS, AGING_MAX_PTS)
+
+
+def _risk_component(risk_score: float | None) -> float:
+    # LOW-risk orgs are typically threshold-triggered re-reviews of already-
+    # approved orgs — the agent confirming "still fine" shouldn't add priority.
+    if risk_score is None or risk_score < HIGH_RISK_SCORE:
+        return 0.0
+    return (risk_score / 100.0) * SIGNAL_CAP
+
+
+def _payment_component(metrics: PaymentMetrics | None) -> float:
+    if metrics is None:
+        return 0.0
+
+    pts = 0.0
+    if metrics.total_payments >= MIN_PAYMENTS_FOR_AUTH:
+        auth_rate = metrics.succeeded_payments / metrics.total_payments
+        if auth_rate < LOW_AUTH_RATE:
+            pts += 10.0
+    if metrics.total_payments >= MIN_PAYMENTS_FOR_REFUND:
+        refund_rate = metrics.refund_count / metrics.total_payments
+        if refund_rate >= HIGH_REFUND_RATE:
+            pts += 10.0
+    if metrics.dispute_count > 0:
+        # Disputes are rare and load-bearing on their own.
+        pts += 15.0
+
+    return min(pts, SIGNAL_CAP)
+
+
+def _fast_mover_component(
+    org: Organization, metrics: PaymentMetrics | None, now: datetime
+) -> float:
+    # ``total_balance`` ticks up on every payment (freshest); the agent's
+    # ``total_amount_cents`` snapshot can be hours stale — take the larger.
+    if metrics is None:
+        return 0.0
+    age_days = _days_between(now, org.created_at)
+    if age_days > NEW_ORG_DAYS:
+        return 0.0
+
+    revenue = max(org.total_balance or 0, metrics.total_amount_cents)
+    if (
+        revenue < FAST_MOVER_MIN_REVENUE_CENTS
+        and metrics.total_payments < FAST_MOVER_MIN_PAYMENTS
+    ):
+        return 0.0
+
+    revenue_for_ramp = max(revenue, FAST_MOVER_MIN_REVENUE_CENTS)
+    ramp = math.log10(revenue_for_ramp / FAST_MOVER_MIN_REVENUE_CENTS)
+    return min(ramp, 1.0) * SIGNAL_CAP
+
+
+def compute(
+    org: Organization,
+    *,
+    metrics: PaymentMetrics | None = None,
+    risk_score: float | None = None,
+    now: datetime | None = None,
+) -> Signals:
+    """Compute the priority breakdown for an org in the Review queue."""
+    if now is None:
+        now = datetime.now(UTC)
+
+    return Signals(
+        aging_pts=_aging_component(org, now),
+        risk_pts=_risk_component(risk_score),
+        payment_pts=_payment_component(metrics),
+        fast_mover_pts=_fast_mover_component(org, metrics, now),
+    )

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import uuid
 from collections.abc import Generator
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -27,6 +28,7 @@ from ...components import (
     status_badge,
     tab_nav,
 )
+from ..priority import Signals
 
 FIRST_REVIEW_THRESHOLD_LABEL = formatters.currency(
     FIRST_REVIEW_MAX_THRESHOLD_CENTS, "usd"
@@ -192,8 +194,18 @@ class OrganizationListView:
                 _nav_button(page + 1, "Next →", disabled=not has_more)
 
     @contextlib.contextmanager
-    def organization_row(self, request: Request, org: Organization) -> Generator[None]:
-        """Render a single organization row in the table."""
+    def organization_row(
+        self,
+        request: Request,
+        org: Organization,
+        *,
+        signals: Signals | None = None,
+    ) -> Generator[None]:
+        """Render a single organization row in the table.
+
+        When ``signals`` is non-None the Review-tab Priority cell is rendered
+        so the column count matches ``_render_org_list``'s Review-only header.
+        """
         days_in_status = self.calculate_days_in_status(org)
 
         with tag.tr(classes="hover:bg-base-100"):
@@ -241,6 +253,18 @@ class OrganizationListView:
                         with tag.span(classes="badge badge-info badge-xs mt-1"):
                             text("Appeal Pending")
 
+            # Priority — Review tab only, sits next to Organization
+            if signals is not None:
+                tooltip = (
+                    f"Aging {signals.aging_pts:.0f} + "
+                    f"Risk {signals.risk_pts:.0f} + "
+                    f"Payments {signals.payment_pts:.0f} + "
+                    f"Fast Mover {signals.fast_mover_pts:.0f}"
+                )
+                with tag.td(classes="text-sm font-bold text-center"):
+                    with tag.span(title=tooltip):
+                        text(f"{signals.priority:.0f}")
+
             # Country
             with tag.td(classes="text-sm"):
                 if org.payout_account:
@@ -258,21 +282,22 @@ class OrganizationListView:
             with tag.td(classes="text-sm font-semibold text-center"):
                 text(f"{days_in_status}d")
 
-            # Risk score
-            with tag.td(classes="text-sm text-center"):
-                if org.review and org.review.risk_score is not None:
-                    risk = org.review.risk_score
-                    if risk >= 75:
-                        color = "text-error"
-                    elif risk >= 50:
-                        color = "text-warning"
+            # Risk — hidden on Review tab (encoded in Priority breakdown)
+            if signals is None:
+                with tag.td(classes="text-sm text-center"):
+                    if org.review and org.review.risk_score is not None:
+                        risk = org.review.risk_score
+                        if risk >= 75:
+                            color = "text-error"
+                        elif risk >= 50:
+                            color = "text-warning"
+                        else:
+                            color = "text-success"
+                        with tag.span(classes=f"font-bold {color}"):
+                            text(str(risk))
                     else:
-                        color = "text-success"
-                    with tag.span(classes=f"font-bold {color}"):
-                        text(str(risk))
-                else:
-                    with tag.span(classes="text-base-content/40"):
-                        text("—")
+                        with tag.span(classes="text-base-content/40"):
+                            text("—")
 
             # Total balance
             with tag.td(classes="text-sm text-right"):
@@ -313,6 +338,7 @@ class OrganizationListView:
         selected_days_in_status: str | None = None,
         selected_has_appeal: str | None = None,
         selected_deleted: DeletedFilter = "exclude",
+        signals_by_org: dict[uuid.UUID, Signals] | None = None,
     ) -> Generator[None]:
         """Render the complete list view."""
 
@@ -613,7 +639,38 @@ class OrganizationListView:
                                         with tag.option(**first_review_attrs):
                                             text("First Reviews")
 
-        # Organization table
+        self._render_org_list(
+            request,
+            organizations,
+            status_filter,
+            page,
+            has_more,
+            current_sort,
+            current_direction,
+            signals_by_org,
+        )
+
+        yield
+
+    def _render_org_list(
+        self,
+        request: Request,
+        organizations: list[Organization],
+        status_filter: OrganizationStatus | None,
+        page: int,
+        has_more: bool,
+        current_sort: str,
+        current_direction: str,
+        signals_by_org: dict[uuid.UUID, Signals] | None = None,
+    ) -> None:
+        """Render the ``#org-list`` block — table with Review-only columns.
+
+        Shared by ``render`` (full page) and ``render_table_only`` (HTMX
+        partial swap), so both paths agree on column count.
+        """
+        signals_by_org = signals_by_org or {}
+        is_review_tab = status_filter == OrganizationStatus.REVIEW
+
         with tag.div(id="org-list", classes="overflow-x-auto"):
             if not organizations:
                 with empty_state(
@@ -634,6 +691,20 @@ class OrganizationListView:
                                 status_filter=status_filter,
                             ):
                                 pass
+
+                            # Priority sits next to Organization on the Review
+                            # tab — primary sort, eye lands here second.
+                            if is_review_tab:
+                                with self.sortable_header(
+                                    request,
+                                    "Priority",
+                                    "priority",
+                                    current_sort,
+                                    current_direction,
+                                    "center",
+                                    status_filter=status_filter,
+                                ):
+                                    pass
 
                             with self.sortable_header(
                                 request,
@@ -666,16 +737,19 @@ class OrganizationListView:
                             ):
                                 pass
 
-                            with self.sortable_header(
-                                request,
-                                "Risk",
-                                "risk",
-                                current_sort,
-                                current_direction,
-                                "center",
-                                status_filter=status_filter,
-                            ):
-                                pass
+                            # Risk hidden on Review tab — it's already
+                            # encoded in the Priority breakdown tooltip.
+                            if not is_review_tab:
+                                with self.sortable_header(
+                                    request,
+                                    "Risk",
+                                    "risk",
+                                    current_sort,
+                                    current_direction,
+                                    "center",
+                                    status_filter=status_filter,
+                                ):
+                                    pass
 
                             with self.sortable_header(
                                 request,
@@ -693,7 +767,11 @@ class OrganizationListView:
 
                     with tag.tbody():
                         for org in organizations:
-                            with self.organization_row(request, org):
+                            with self.organization_row(
+                                request,
+                                org,
+                                signals=signals_by_org.get(org.id),
+                            ):
                                 pass
 
                 self.pagination_controls(
@@ -704,8 +782,6 @@ class OrganizationListView:
                     current_direction,
                     status_filter,
                 )
-
-        yield
 
     @contextlib.contextmanager
     def render_table_only(
@@ -717,100 +793,21 @@ class OrganizationListView:
         has_more: bool,
         current_sort: str = "priority",
         current_direction: str = "asc",
+        *,
+        signals_by_org: dict[uuid.UUID, Signals] | None = None,
     ) -> Generator[None]:
         """Render only the organization table (for HTMX updates)."""
 
-        # Organization table
-        with tag.div(id="org-list", classes="overflow-x-auto"):
-            if not organizations:
-                with empty_state(
-                    "No Organizations Found",
-                    "No organizations match your current filters.",
-                ):
-                    pass
-            else:
-                with tag.table(classes="table table-zebra w-full"):
-                    with tag.thead():
-                        with tag.tr():
-                            with self.sortable_header(
-                                request,
-                                "Organization",
-                                "name",
-                                current_sort,
-                                current_direction,
-                                status_filter=status_filter,
-                            ):
-                                pass
-
-                            with self.sortable_header(
-                                request,
-                                "Country",
-                                "country",
-                                current_sort,
-                                current_direction,
-                                status_filter=status_filter,
-                            ):
-                                pass
-
-                            with self.sortable_header(
-                                request,
-                                "Created",
-                                "created",
-                                current_sort,
-                                current_direction,
-                                status_filter=status_filter,
-                            ):
-                                pass
-
-                            with self.sortable_header(
-                                request,
-                                "In Status",
-                                "status_duration",
-                                current_sort,
-                                current_direction,
-                                "center",
-                                status_filter=status_filter,
-                            ):
-                                pass
-
-                            with self.sortable_header(
-                                request,
-                                "Risk",
-                                "risk",
-                                current_sort,
-                                current_direction,
-                                "center",
-                                status_filter=status_filter,
-                            ):
-                                pass
-
-                            with self.sortable_header(
-                                request,
-                                "Balance",
-                                "total_balance",
-                                current_sort,
-                                current_direction,
-                                "right",
-                                status_filter=status_filter,
-                            ):
-                                pass
-
-                            with tag.th(classes="text-right"):
-                                text("Actions")
-
-                    with tag.tbody():
-                        for org in organizations:
-                            with self.organization_row(request, org):
-                                pass
-
-                self.pagination_controls(
-                    request,
-                    page,
-                    has_more,
-                    current_sort,
-                    current_direction,
-                    status_filter,
-                )
+        self._render_org_list(
+            request,
+            organizations,
+            status_filter,
+            page,
+            has_more,
+            current_sort,
+            current_direction,
+            signals_by_org,
+        )
 
         yield
 

--- a/server/tests/backoffice/organizations_v2/test_priority.py
+++ b/server/tests/backoffice/organizations_v2/test_priority.py
@@ -1,0 +1,249 @@
+"""Pure unit tests for the Review queue priority module.
+
+These tests build synthetic Organization objects in memory and pass
+``PaymentMetrics`` directly — no DB session, no JSONB, no fixtures.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from polar.backoffice.organizations_v2.priority import (
+    AGING_DAILY_PTS,
+    AGING_MAX_PTS,
+    compute,
+)
+from polar.organization_review.schemas import PaymentMetrics
+
+
+def _metrics(
+    *,
+    total_payments: int = 0,
+    succeeded_payments: int = 0,
+    refund_count: int = 0,
+    dispute_count: int = 0,
+    total_amount_cents: int = 0,
+) -> PaymentMetrics:
+    return PaymentMetrics(
+        total_payments=total_payments,
+        succeeded_payments=succeeded_payments,
+        total_amount_cents=total_amount_cents,
+        refund_count=refund_count,
+        refund_amount_cents=0,
+        dispute_count=dispute_count,
+        dispute_amount_cents=0,
+    )
+
+
+NOW = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
+
+
+def _org(
+    *,
+    created_days_ago: int = 100,
+    days_in_status: int = 0,
+    total_balance: int | None = 0,
+) -> Any:
+    """Build a fake Organization with just the timestamps the formula reads.
+
+    Timestamps are anchored at module-level ``NOW`` so the test's ``now=NOW``
+    parameter to ``compute`` produces an exact aging value.
+    """
+    org = MagicMock()
+    org.id = uuid4()
+    org.created_at = NOW - timedelta(days=created_days_ago)
+    org.status_updated_at = NOW - timedelta(days=days_in_status)
+    org.total_balance = total_balance
+    return org
+
+
+class TestAgingComponent:
+    def test_linear_ramp(self) -> None:
+        s = compute(_org(days_in_status=4), now=NOW)
+        assert s.aging_pts == pytest.approx(4 * AGING_DAILY_PTS)
+
+    def test_outranks_single_signal_at_ten_days(self) -> None:
+        # Aging at 10d = 25 — equal to any single non-aging component cap,
+        # so a 10d-stale org ties (and beyond, beats) one with HIGH risk only.
+        s = compute(_org(days_in_status=10), now=NOW)
+        assert s.aging_pts == pytest.approx(25.0)
+
+    def test_caps_at_max_after_long_wait(self) -> None:
+        s = compute(_org(days_in_status=100), now=NOW)
+        assert s.aging_pts == pytest.approx(AGING_MAX_PTS)
+
+    def test_aging_dominates_combined_signals_when_truly_stale(self) -> None:
+        # 20d in status: aging=50 alone outranks any fresh org's risk(25)+payment(25).
+        aged = compute(_org(days_in_status=20), now=NOW)
+        fresh = compute(
+            _org(days_in_status=2),
+            metrics=_metrics(
+                total_payments=100, succeeded_payments=100, dispute_count=5
+            ),
+            risk_score=100.0,
+            now=NOW,
+        )
+        assert aged.priority > fresh.priority
+
+
+class TestRiskComponent:
+    def test_low_risk_no_points(self) -> None:
+        # LOW-risk orgs are typically threshold re-reviews of already-approved
+        # merchants — the agent confirming "still fine" shouldn't add priority.
+        s = compute(_org(), risk_score=15.0, now=NOW)
+        assert s.risk_pts == 0.0
+
+    def test_medium_risk(self) -> None:
+        s = compute(_org(), risk_score=50.0, now=NOW)
+        assert s.risk_pts == pytest.approx(12.5)
+
+    def test_high_risk(self) -> None:
+        s = compute(_org(), risk_score=85.0, now=NOW)
+        assert s.risk_pts == pytest.approx(25.0 * 0.85)
+
+    def test_no_risk_score_no_points(self) -> None:
+        s = compute(_org(), now=NOW)
+        assert s.risk_pts == 0.0
+
+
+class TestPaymentHealthComponent:
+    def test_low_auth_below_sample_size_does_not_fire(self) -> None:
+        s = compute(
+            _org(),
+            metrics=_metrics(total_payments=4, succeeded_payments=1),
+            now=NOW,
+        )
+        assert s.payment_pts == 0.0
+
+    def test_low_auth_fires(self) -> None:
+        s = compute(
+            _org(),
+            metrics=_metrics(total_payments=10, succeeded_payments=5),
+            now=NOW,
+        )
+        assert s.payment_pts == pytest.approx(10.0)
+
+    def test_high_refund_fires(self) -> None:
+        # 15% refund, 100% auth
+        s = compute(
+            _org(),
+            metrics=_metrics(total_payments=20, succeeded_payments=20, refund_count=3),
+            now=NOW,
+        )
+        assert s.payment_pts == pytest.approx(10.0)
+
+    def test_dispute_fires_strongly(self) -> None:
+        s = compute(
+            _org(),
+            metrics=_metrics(
+                total_payments=100, succeeded_payments=100, dispute_count=2
+            ),
+            now=NOW,
+        )
+        assert s.payment_pts == pytest.approx(15.0)
+
+    def test_payment_component_caps_at_25(self) -> None:
+        s = compute(
+            _org(),
+            metrics=_metrics(
+                total_payments=100,
+                succeeded_payments=20,  # 20% auth (10pts)
+                refund_count=20,  # 20% refund (10pts)
+                dispute_count=5,  # disputes (15pts) → raw 35, capped at 25
+            ),
+            now=NOW,
+        )
+        assert s.payment_pts == pytest.approx(25.0)
+
+
+class TestFastMoverComponent:
+    def test_old_org_does_not_fire(self) -> None:
+        s = compute(
+            _org(created_days_ago=120),
+            metrics=_metrics(total_amount_cents=1_000_000, total_payments=100),
+            now=NOW,
+        )
+        assert s.fast_mover_pts == 0.0
+
+    def test_new_org_below_threshold_does_not_fire(self) -> None:
+        s = compute(
+            _org(created_days_ago=10),
+            metrics=_metrics(total_amount_cents=50_000, total_payments=5),
+            now=NOW,
+        )
+        assert s.fast_mover_pts == 0.0
+
+    def test_new_org_log_ramp(self) -> None:
+        # $3k → ~11.9 pts (mid-ramp)
+        s3k = compute(
+            _org(created_days_ago=10),
+            metrics=_metrics(total_amount_cents=300_000, total_payments=20),
+            now=NOW,
+        )
+        assert s3k.fast_mover_pts == pytest.approx(11.9, abs=0.2)
+        # $10k → 25 pts (cap)
+        s10k = compute(
+            _org(created_days_ago=10),
+            metrics=_metrics(total_amount_cents=1_000_000, total_payments=20),
+            now=NOW,
+        )
+        assert s10k.fast_mover_pts == pytest.approx(25.0)
+
+    def test_total_balance_overrides_stale_agent_metrics(self) -> None:
+        # Agent snapshot is stale ($106) but the live balance shows $2,500 of
+        # recent activity. Fast Mover should use the larger.
+        s = compute(
+            _org(created_days_ago=12, total_balance=250_000),
+            metrics=_metrics(total_amount_cents=10_600, total_payments=3),
+            now=NOW,
+        )
+        # log10(2500/1000) ≈ 0.40 → ~10 pts
+        assert 9.0 < s.fast_mover_pts < 11.0
+
+    def test_payment_count_threshold_fires_without_revenue(self) -> None:
+        s = compute(
+            _org(created_days_ago=10),
+            metrics=_metrics(
+                total_amount_cents=0, total_payments=30, succeeded_payments=30
+            ),
+            now=NOW,
+        )
+        # Threshold met by payment count alone; ramp pinned at 0 (revenue floor)
+        assert s.fast_mover_pts == pytest.approx(0.0, abs=0.5)
+
+
+class TestPriorityComposite:
+    def test_zero_signals(self) -> None:
+        s = compute(_org(days_in_status=0, created_days_ago=200), now=NOW)
+        assert s.priority == 0.0
+
+    def test_priority_is_sum_of_components(self) -> None:
+        s = compute(
+            _org(days_in_status=14, created_days_ago=200),
+            metrics=_metrics(total_payments=10, succeeded_payments=5),  # 50% auth
+            risk_score=85.0,
+            now=NOW,
+        )
+        # aging 14d * 2.5 (35) + risk 85% (21.25) + payment auth (10) + no fast
+        assert s.priority == pytest.approx(66.25, abs=0.1)
+
+    def test_max_priority_bounded(self) -> None:
+        s = compute(
+            _org(days_in_status=30, created_days_ago=10),
+            metrics=_metrics(
+                total_payments=100,
+                succeeded_payments=10,
+                refund_count=30,
+                dispute_count=5,
+                total_amount_cents=100_000_000,  # $1M, hits log ramp cap
+            ),
+            risk_score=100.0,
+            now=NOW,
+        )
+        # aging max (50) + risk (25) + payment cap (25) + fast cap (25) = 125
+        assert s.priority <= 125.0


### PR DESCRIPTION
## Summary

Backoffice Review tab gets a composite **Priority** score so reviewers can triage from the top down instead of scanning manually.

Score = aging (2.5pts/day, capped at 50) + risk (≥MEDIUM only) + payment health (auth / refund / dispute) + fast mover (new orgs with volume). Aged orgs naturally rise to the top; fresh orgs with strong signals still appear when warranted.

UI: new **Priority** column on the Review tab, sortable, hover shows the breakdown. Risk column hidden on Review (it's encoded inside the score).

## Test plan
- [ ] Open the Review tab — orgs sorted by priority desc by default
- [ ] Hover a Priority cell — tooltip shows component breakdown
- [ ] Click another column header — sort updates, Priority column persists
- [ ] Other tabs (Active / Snoozed / Denied) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)