### PR TITLE
server/refund: swallow tax transaction already reverted error

### DIFF
--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -27,7 +27,6 @@ from polar.models import (
     Order,
     Organization,
     Payment,
-    Transaction,
     User,
 )
 from polar.models.dispute import DisputeAlertProcessor
@@ -38,6 +37,7 @@ from polar.order.repository import OrderRepository
 from polar.order.service import order as order_service
 from polar.payment.repository import PaymentRepository
 from polar.tax.calculation import tax_calculation as tax_calculation_service
+from polar.tax.calculation.base import AlreadyRevertedError
 from polar.transaction.service.refund import (
     RefundTransactionAlreadyExistsError,
     RefundTransactionDoesNotExistError,
@@ -364,7 +364,19 @@ class RefundService:
             RefundStatus.failed,
         }
         if reverted:
-            await self._revert_refund_transaction(session, refund)
+            try:
+                await refund_transaction_service.revert(session, refund)
+            except RefundTransactionDoesNotExistError:
+                pass
+
+            order = refund.order
+            if order:
+                await order_service.update_refunds(
+                    session,
+                    order,
+                    refunded_amount=-refund.amount,
+                    refunded_tax_amount=-refund.tax_amount,
+                )
 
         return refund
 
@@ -441,18 +453,18 @@ class RefundService:
                 order=order,
             )
 
-    async def _create_refund_transaction(
-        self, session: AsyncSession, refund: Refund
-    ) -> Transaction | None:
+    async def _on_succeeded(
+        self,
+        session: AsyncSession,
+        refund: Refund,
+    ) -> None:
         try:
-            transaction = await refund_transaction_service.create(
-                session, refund=refund
-            )
+            await refund_transaction_service.create(session, refund=refund)
         except RefundTransactionAlreadyExistsError:
-            return None
+            pass
 
         order = refund.order
-        if order:
+        if order is not None:
             await order_service.update_refunds(
                 session,
                 order,
@@ -469,48 +481,25 @@ class RefundService:
                 assert order.tax_processor is not None
                 assert order.billing_address is not None
                 assert order.product is not None
-                transaction_id = await tax_calculation_service.revert(
-                    order.tax_processor,
-                    order.tax_transaction_processor_id,
-                    reference=str(refund.id),
-                    address=order.billing_address,
-                    tax_code=order.product.tax_code,
-                    currency=order.currency,
-                    total_amount=order.total_amount,
-                    reverted_amount=refund.total_amount,
-                    reverted_tax_amount=refund.tax_amount,
-                )
-                refund.tax_transaction_processor_id = transaction_id
-                session.add(refund)
+                try:
+                    transaction_id = await tax_calculation_service.revert(
+                        order.tax_processor,
+                        order.tax_transaction_processor_id,
+                        reference=str(refund.id),
+                        address=order.billing_address,
+                        tax_code=order.product.tax_code,
+                        currency=order.currency,
+                        total_amount=order.total_amount,
+                        reverted_amount=refund.total_amount,
+                        reverted_tax_amount=refund.tax_amount,
+                    )
+                    refund.tax_transaction_processor_id = transaction_id
+                    session.add(refund)
+                # Case where we retry a failed refund:
+                # the tax is already reverted, so we can ignore the error.
+                except AlreadyRevertedError:
+                    pass
 
-        return transaction
-
-    async def _revert_refund_transaction(
-        self, session: AsyncSession, refund: Refund
-    ) -> None:
-        try:
-            await refund_transaction_service.revert(session, refund)
-        except RefundTransactionDoesNotExistError:
-            return None
-
-        order = refund.order
-        if order:
-            await order_service.update_refunds(
-                session,
-                order,
-                refunded_amount=-refund.amount,
-                refunded_tax_amount=-refund.tax_amount,
-            )
-
-    async def _on_succeeded(
-        self,
-        session: AsyncSession,
-        refund: Refund,
-    ) -> None:
-        await self._create_refund_transaction(session, refund)
-
-        order = refund.order
-        if order is not None:
             # Reduce positive customer balance
             customer_balance = await wallet_service.get_billing_wallet_balance(
                 session, order.customer, order.currency

--- a/server/polar/tax/calculation/__init__.py
+++ b/server/polar/tax/calculation/__init__.py
@@ -12,6 +12,7 @@ from polar.observability import TAX_CALCULATION_TOTAL
 
 from ..tax_id import TaxID
 from .base import (
+    AlreadyRevertedError,
     CalculationExpiredError,
     InvalidTaxIDError,
     TaxabilityReason,
@@ -20,6 +21,7 @@ from .base import (
     TaxCalculationLogicalError,
     TaxCalculationTechnicalError,
     TaxCode,
+    TaxRevertError,
     TaxServiceProtocol,
 )
 from .numeral import numeral_tax_service
@@ -204,6 +206,7 @@ class TaxCalculationService:
 tax_calculation = TaxCalculationService()
 
 __all__ = [
+    "AlreadyRevertedError",
     "CalculationExpiredError",
     "InvalidTaxIDError",
     "TaxBreakdownItem",
@@ -211,6 +214,7 @@ __all__ = [
     "TaxCalculationLogicalError",
     "TaxCalculationTechnicalError",
     "TaxCode",
+    "TaxRevertError",
     "TaxabilityReason",
     "tax_calculation",
 ]

--- a/server/polar/tax/calculation/base.py
+++ b/server/polar/tax/calculation/base.py
@@ -39,14 +39,29 @@ class InvalidTaxIDError(TaxCalculationLogicalError):
 
 
 class TaxRecordError(TaxError):
-    def __init__(self) -> None:
-        message = "An error occurred while recording the tax calculation."
+    def __init__(
+        self, message: str = "An error occurred while recording the tax calculation."
+    ) -> None:
+
         super().__init__(message)
 
 
-class CalculationExpiredError(TaxError):
+class CalculationExpiredError(TaxRecordError):
     def __init__(self) -> None:
         message = "The tax calculation has expired and cannot be recorded."
+        super().__init__(message)
+
+
+class TaxRevertError(TaxError):
+    def __init__(
+        self, message: str = "An error occurred while reverting the tax record."
+    ) -> None:
+        super().__init__(message)
+
+
+class AlreadyRevertedError(TaxRevertError):
+    def __init__(self) -> None:
+        message = "The tax record has already been reverted."
         super().__init__(message)
 
 

--- a/server/polar/tax/calculation/stripe.py
+++ b/server/polar/tax/calculation/stripe.py
@@ -14,12 +14,14 @@ from polar.logging import Logger
 
 from ..tax_id import TaxID, to_stripe_tax_id
 from .base import (
+    AlreadyRevertedError,
     TaxabilityReason,
     TaxBreakdownItem,
     TaxCalculation,
     TaxCalculationLogicalError,
     TaxCalculationTechnicalError,
     TaxCode,
+    TaxRevertError,
     TaxServiceProtocol,
 )
 
@@ -196,15 +198,29 @@ class StripeTaxService(TaxServiceProtocol):
         reverted_amount: int | None = None,
         reverted_tax_amount: int | None = None,
     ) -> str:
-        if reverted_amount is None and reverted_tax_amount is None:
-            transaction = await stripe_service.revert_tax_transaction(
-                transaction_id, "full", reference
+        try:
+            if reverted_amount is None and reverted_tax_amount is None:
+                transaction = await stripe_service.revert_tax_transaction(
+                    transaction_id, "full", reference
+                )
+            else:
+                assert reverted_amount is not None
+                transaction = await stripe_service.revert_tax_transaction(
+                    transaction_id, "partial", reference, -reverted_amount
+                )
+        except stripe_lib.InvalidRequestError as e:
+            error = e.error
+            if error and error.message and "fully reversed" in error.message.lower():
+                raise AlreadyRevertedError() from e
+            log.error(
+                "Failed to revert tax transaction",
+                transaction_id=transaction_id,
+                reference=reference,
+                reverted_amount=reverted_amount,
+                reverted_tax_amount=reverted_tax_amount,
+                error=str(e),
             )
-        else:
-            assert reverted_amount is not None
-            transaction = await stripe_service.revert_tax_transaction(
-                transaction_id, "partial", reference, -reverted_amount
-            )
+            raise TaxRevertError() from e
         return transaction.id
 
     async def backfill(

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -7,12 +7,13 @@ from pytest_mock import MockerFixture
 from polar.benefit.grant.service import BenefitGrantService
 from polar.dispute.service import DisputePaymentNotFoundError
 from polar.dispute.service import dispute as dispute_service
-from polar.enums import PaymentProcessor
+from polar.enums import PaymentProcessor, TaxProcessor
 from polar.integrations.chargeback_stop.types import ChargebackStopAlert
 from polar.models import Customer, Organization, Product
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
 from polar.postgres import AsyncSession
 from polar.refund.service import RefundService
+from polar.tax.calculation.base import AlreadyRevertedError
 from polar.transaction.service.dispute import DisputeTransactionService
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -418,6 +419,69 @@ class TestUpsertFromStripe:
 
         dispute_transaction_service_mock.create_dispute.assert_not_awaited()
         refund_service_mock.create_from_dispute.assert_not_awaited()
+
+    async def test_update_closed_rapid_resolution_dispute_with_failed_refund(
+        self,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+        refund_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            tax_amount=100,
+            tax_processor=TaxProcessor.stripe,
+            tax_transaction_processor_id="TAX_TRANSACTION_ID",
+        )
+        charge_id = "STRIPE_CHARGE_ID"
+        payment = await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        stripe_dispute_balance_transaction = build_stripe_balance_transaction(
+            amount=-order.due_amount,
+            reporting_category="dispute",
+            fee=0,  # Our heuristic to detect RDR disputes
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="lost",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[stripe_dispute_balance_transaction],
+        )
+        dispute = await create_dispute(
+            save_fixture,
+            order,
+            payment,
+            status=DisputeStatus.needs_response,
+            payment_processor=PaymentProcessor.stripe,
+            payment_processor_id=stripe_dispute.id,
+        )
+        failed_refund = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            dispute=dispute,
+            status="failed",
+            processor_id="REFUND_ID",
+        )
+
+        mocker.patch(
+            "polar.refund.service.tax_calculation_service.revert",
+            side_effect=AlreadyRevertedError(),
+        )
+
+        updated_dispute = await dispute_service.upsert_from_stripe(
+            session, stripe_dispute
+        )
+
+        assert updated_dispute.status == DisputeStatus.prevented
+
+        dispute_transaction_service_mock.create_dispute.assert_not_awaited()
+        refund_service_mock.create_from_dispute.assert_awaited()
 
     async def test_revoke_order(
         self,

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -910,6 +910,8 @@ async def create_order(
     discount: Discount | None = None,
     next_payment_attempt_at: datetime | None = None,
     payment_lock_acquired_at: datetime | None = None,
+    tax_processor: TaxProcessor | None = None,
+    tax_transaction_processor_id: str | None = None,
 ) -> Order:
     if order_items is None:
         order_items = [
@@ -951,6 +953,8 @@ async def create_order(
         user_metadata=user_metadata or {},
         next_payment_attempt_at=next_payment_attempt_at,
         payment_lock_acquired_at=payment_lock_acquired_at,
+        tax_processor=tax_processor,
+        tax_transaction_processor_id=tax_transaction_processor_id,
     )
     await save_fixture(order)
     return order
@@ -964,6 +968,9 @@ async def create_order_and_payment(
     subtotal_amount: int,
     tax_amount: int,
     applied_balance_amount: int = 0,
+    tax_processor: TaxProcessor | None = None,
+    tax_transaction_processor_id: str | None = None,
+    billing_address: Address | None = None,
 ) -> tuple[Order, Payment, Transaction]:
     order = await create_order(
         save_fixture,
@@ -972,6 +979,9 @@ async def create_order_and_payment(
         subtotal_amount=subtotal_amount,
         tax_amount=tax_amount,
         applied_balance_amount=applied_balance_amount,
+        billing_address=billing_address,
+        tax_processor=tax_processor,
+        tax_transaction_processor_id=tax_transaction_processor_id,
     )
     payment = await create_payment(
         save_fixture,

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -6,7 +6,9 @@ import stripe as stripe_lib
 from httpx import AsyncClient, Response
 from pytest_mock import MockerFixture
 
+from polar.enums import TaxProcessor
 from polar.integrations.stripe.service import StripeService
+from polar.kit.address import Address, CountryAlpha2
 from polar.models import (
     Customer,
     Order,
@@ -24,6 +26,8 @@ from polar.postgres import AsyncSession
 from polar.refund.schemas import RefundCreate
 from polar.refund.service import MissingRelatedDispute, RefundedAlready
 from polar.refund.service import refund as refund_service
+from polar.tax.calculation import TaxCalculationService
+from polar.tax.calculation.base import AlreadyRevertedError
 from polar.wallet.service import wallet as wallet_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -41,6 +45,13 @@ from tests.fixtures.stripe import build_stripe_refund
 def stripe_service_mock(mocker: MockerFixture) -> MagicMock:
     mock = MagicMock(spec=StripeService)
     mocker.patch("polar.refund.service.stripe_service", new=mock)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def tax_calculation_service_service_mock(mocker: MockerFixture) -> MagicMock:
+    mock = MagicMock(spec=TaxCalculationService)
+    mocker.patch("polar.refund.service.tax_calculation_service", new=mock)
     return mock
 
 
@@ -669,6 +680,51 @@ class TestCreateFromDispute:
         assert order.refundable_tax_amount == 0
         assert order.refunded_amount == 1050
         assert order.refunded_tax_amount == 300
+
+        assert refund_transaction_service_mock.create.call_count == 1
+
+    async def test_valid_tax_already_reverted(
+        self,
+        session: AsyncSession,
+        tax_calculation_service_service_mock: MagicMock,
+        refund_transaction_service_mock: MagicMock,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order, payment, transaction = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+            tax_processor=TaxProcessor.stripe,
+            tax_transaction_processor_id="TAX_TRANSACTION_ID",
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        dispute = await create_dispute(
+            save_fixture,
+            order,
+            payment,
+            amount=1000,
+            tax_amount=250,
+        )
+
+        tax_calculation_service_service_mock.revert.side_effect = AlreadyRevertedError()
+
+        refund = await refund_service.create_from_dispute(
+            session, dispute, "DISPUTE_BALANCE_TRANSACTION_ID"
+        )
+        assert refund.status == RefundStatus.succeeded
+        assert refund.reason == RefundReason.dispute_prevention
+        assert refund.amount == dispute.amount
+        assert refund.currency == dispute.currency
+        assert refund.tax_amount == dispute.tax_amount
+        assert refund.dispute_id == dispute.id
+        assert refund.order_id == order.id
+        assert refund.processor == dispute.payment_processor
+        assert refund.processor_id == dispute.payment_processor_id
+        assert refund.revoke_benefits is True
 
         assert refund_transaction_service_mock.create.call_count == 1
 


### PR DESCRIPTION
Fix #11390


In some complex cases with early disputes warnings and preventions, we might be in a situation where:

- A refund is created and the tax transaction is reverted to prevent a dispute
- Stripe then opens the dispute and mark it as lost (which is the expected behavior, with Verifi RDR), but also mark the refund as failed

In this case, we still need to record the dispute prevention with a proper refund, but need to account for that early refund that was marked as failed. To do so, we allow the tax transaction reversion to be skipped.
