### PR TITLE
Refresh app session

### DIFF
--- a/clients/apps/app/auth/oauthConfig.ts
+++ b/clients/apps/app/auth/oauthConfig.ts
@@ -1,0 +1,92 @@
+export const CLIENT_ID = 'polar_ci_yZLBGwoWZVsOdfN5CODRwVSTlJfwJhXqwg65e2CuNMZ'
+
+export const discovery = {
+  authorizationEndpoint: 'https://polar.sh/oauth2/authorize',
+  tokenEndpoint: 'https://api.polar.sh/v1/oauth2/token',
+  registrationEndpoint: 'https://api.polar.sh/v1/oauth2/register',
+  revocationEndpoint: 'https://api.polar.sh/v1/oauth2/revoke',
+}
+
+/*
+Uncomment these lines and update the client ID to run against a local version of the backend
+
+To get the CLIENT_ID:
+1. Create a new Oauth app at http://127.0.0.1:3000/dashboard/account/developer
+2. Select "Public Client" and give it all the scopes
+3. Set "Redirect URIs" to "polar://oauth/callback"
+
+And make sure to set the EXPO_PUBLIC_POLAR_SERVER_URL is set to "http://127.0.0.1:8000".
+
+export const CLIENT_ID = 'polar_ci_hbFdMZZRghgdm2F4LMceQSrcQNunmjlh6ukGJ1dG0Vg'
+
+export const discovery = {
+  authorizationEndpoint: 'http://127.0.0.1:3000/oauth2/authorize',
+  tokenEndpoint: `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL}/v1/oauth2/token`,
+  registrationEndpoint: `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL}/v1/oauth2/register`,
+  revocationEndpoint: `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL}/v1/oauth2/revoke`,
+*/
+
+export const scopes = [
+  'benefits:read',
+  'benefits:write',
+  'checkout_links:read',
+  'checkout_links:write',
+  'checkouts:read',
+  'checkouts:write',
+  'custom_fields:read',
+  'custom_fields:write',
+  'customer_meters:read',
+  'customer_portal:read',
+  'customer_portal:write',
+  'customer_seats:read',
+  'customer_seats:write',
+  'customer_sessions:write',
+  'customers:read',
+  'customers:write',
+  'discounts:read',
+  'discounts:write',
+  'disputes:read',
+  'email',
+  'events:read',
+  'events:write',
+  'files:read',
+  'files:write',
+  'license_keys:read',
+  'license_keys:write',
+  'member_sessions:write',
+  'members:read',
+  'members:write',
+  'meters:read',
+  'meters:write',
+  'metrics:read',
+  'metrics:write',
+  'notification_recipients:read',
+  'notification_recipients:write',
+  'notifications:read',
+  'notifications:write',
+  'openid',
+  'orders:read',
+  'orders:write',
+  'organization_access_tokens:read',
+  'organization_access_tokens:write',
+  'organizations:read',
+  'organizations:write',
+  'payments:read',
+  'payouts:read',
+  'payouts:write',
+  'products:read',
+  'products:write',
+  'profile',
+  'refunds:read',
+  'refunds:write',
+  'subscriptions:read',
+  'subscriptions:write',
+  'transactions:read',
+  'transactions:write',
+  'user:read',
+  'user:write',
+  'wallets:read',
+  'wallets:write',
+  'webhooks:read',
+  'webhooks:write',
+]

--- a/clients/apps/app/auth/refreshMiddleware.test.ts
+++ b/clients/apps/app/auth/refreshMiddleware.test.ts
@@ -1,0 +1,243 @@
+import type { refreshAsync } from 'expo-auth-session'
+import type * as RefresherModule from './refresher'
+import type * as RefreshMiddlewareModule from './refreshMiddleware'
+
+const mockRefreshAsync = jest.fn<
+  ReturnType<typeof refreshAsync>,
+  Parameters<typeof refreshAsync>
+>()
+
+jest.mock('expo-auth-session', () => ({
+  refreshAsync: mockRefreshAsync,
+}))
+
+let configureRefresher: (typeof RefresherModule)['configureRefresher']
+let refreshMiddleware: (typeof RefreshMiddlewareModule)['refreshMiddleware']
+
+const NOW = new Date('2024-01-01T00:00:00Z').getTime()
+
+const buildTokenResponse = (
+  overrides: Partial<{
+    accessToken: string
+    refreshToken: string
+    expiresIn: number
+  }> = {},
+) =>
+  ({
+    accessToken: 'AT_NEW',
+    refreshToken: 'RT_NEW',
+    expiresIn: 60,
+    ...overrides,
+  }) as unknown as Awaited<ReturnType<typeof refreshAsync>>
+
+const buildRequest = (
+  url: string,
+  init: RequestInit & { authToken?: string } = {},
+): Request => {
+  const { authToken, ...rest } = init
+  const headers = new Headers(rest.headers ?? {})
+  if (authToken !== undefined) {
+    headers.set('Authorization', `Bearer ${authToken}`)
+  }
+  return new Request(url, { ...rest, headers })
+}
+
+const middlewareOptions = {
+  baseUrl: 'http://127.0.0.1:8000',
+  parseAs: 'json' as const,
+  querySerializer: () => '',
+  bodySerializer: () => '',
+  fetch: jest.fn() as jest.MockedFunction<typeof fetch>,
+}
+
+const callOnRequest = async (request: Request) => {
+  if (typeof refreshMiddleware.onRequest !== 'function') {
+    throw new Error('onRequest is not defined on the middleware')
+  }
+  return await refreshMiddleware.onRequest({
+    request,
+    schemaPath: '/v1/foo',
+    params: {},
+    options: middlewareOptions,
+    id: 'test-id',
+  })
+}
+
+const callOnResponse = async (request: Request, response: Response) => {
+  if (typeof refreshMiddleware.onResponse !== 'function') {
+    throw new Error('onResponse is not defined on the middleware')
+  }
+  return await refreshMiddleware.onResponse({
+    request,
+    response,
+    schemaPath: '/v1/foo',
+    params: {},
+    options: middlewareOptions,
+    id: 'test-id',
+  })
+}
+
+const configureFresh = () => {
+  configureRefresher({
+    accessToken: 'AT_OLD',
+    refreshToken: 'RT_OLD',
+    expiresAt: NOW + 60_000,
+    setSession: jest.fn(),
+  })
+}
+
+const configureStale = () => {
+  configureRefresher({
+    accessToken: 'AT_OLD',
+    refreshToken: 'RT_OLD',
+    expiresAt: NOW + 60_000,
+    setSession: jest.fn(),
+  })
+  jest.setSystemTime(NOW + 50_000)
+}
+
+beforeEach(() => {
+  jest.resetModules()
+  ;({ configureRefresher } = require('./refresher') as typeof RefresherModule)
+  ;({ refreshMiddleware } =
+    require('./refreshMiddleware') as typeof RefreshMiddlewareModule)
+  mockRefreshAsync.mockReset()
+  middlewareOptions.fetch.mockReset()
+  jest.useFakeTimers().setSystemTime(NOW)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('onRequest (proactive refresh)', () => {
+  it('returns undefined when no refresh token is configured', async () => {
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when the token is fresh', async () => {
+    configureFresh()
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('skips OAuth endpoints to avoid recursive refresh', async () => {
+    configureStale()
+    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/token', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('refreshes and returns a new Request with the new auth header when stale', async () => {
+    configureStale()
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ accessToken: 'AT_NEW' }),
+    )
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+
+    expect(result).toBeInstanceOf(Request)
+    const next = result as Request
+    expect(next.headers.get('Authorization')).toBe('Bearer AT_NEW')
+    expect(next.url).toBe('http://127.0.0.1:8000/v1/orgs')
+    expect(mockRefreshAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns undefined when the proactive refresh fails', async () => {
+    configureStale()
+    mockRefreshAsync.mockRejectedValueOnce(new Error('refresh failed'))
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('onResponse (reactive refresh)', () => {
+  it('returns undefined for non-401 responses', async () => {
+    configureFresh()
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const response = new Response('{}', { status: 200 })
+    const result = await callOnResponse(request, response)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined for 401 from OAuth endpoints', async () => {
+    configureFresh()
+    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/userinfo', {
+      authToken: 'AT_OLD',
+    })
+    const response = new Response('{}', { status: 401 })
+    const result = await callOnResponse(request, response)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined for 401 when no refresh token is available', async () => {
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const response = new Response('{}', { status: 401 })
+    const result = await callOnResponse(request, response)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('on 401, refreshes and retries the request with the new token', async () => {
+    configureFresh()
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ accessToken: 'AT_NEW' }),
+    )
+    const retryResponse = new Response('{}', { status: 200 })
+    middlewareOptions.fetch.mockResolvedValueOnce(retryResponse)
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const response = new Response('{}', { status: 401 })
+
+    const result = await callOnResponse(request, response)
+
+    expect(mockRefreshAsync).toHaveBeenCalledTimes(1)
+    expect(middlewareOptions.fetch).toHaveBeenCalledTimes(1)
+    const retried = middlewareOptions.fetch.mock.calls[0][0] as Request
+    expect(retried.headers.get('Authorization')).toBe('Bearer AT_NEW')
+    expect(retried.url).toBe('http://127.0.0.1:8000/v1/orgs')
+    expect(result).toBe(retryResponse)
+  })
+
+  it('does not retry when refresh itself fails', async () => {
+    configureFresh()
+    mockRefreshAsync.mockRejectedValueOnce(new Error('rt revoked'))
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_OLD',
+    })
+    const response = new Response('{}', { status: 401 })
+
+    const result = await callOnResponse(request, response)
+
+    expect(result).toBeUndefined()
+    expect(middlewareOptions.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/clients/apps/app/auth/refreshMiddleware.test.ts
+++ b/clients/apps/app/auth/refreshMiddleware.test.ts
@@ -155,7 +155,7 @@ describe('onRequest (proactive refresh)', () => {
     expect(mockRefreshAsync).not.toHaveBeenCalled()
   })
 
-  it('skips OAuth endpoints to avoid recursive refresh', async () => {
+  it('skips the token endpoint to avoid recursive refresh', async () => {
     configureStale()
     const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/token', {
       authToken: 'AT_OLD',
@@ -163,6 +163,34 @@ describe('onRequest (proactive refresh)', () => {
     const result = await callOnRequest(request)
     expect(result).toBeUndefined()
     expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('skips the revoke endpoint to avoid recursive refresh', async () => {
+    configureStale()
+    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/revoke', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+    expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('refreshes for /v1/oauth2/userinfo when stale (it is a normal bearer-protected endpoint)', async () => {
+    configureStale()
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ accessToken: 'AT_NEW' }),
+    )
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/userinfo', {
+      authToken: 'AT_OLD',
+    })
+    const result = await callOnRequest(request)
+
+    expect(result).toBeInstanceOf(Request)
+    const next = result as Request
+    expect(next.headers.get('Authorization')).toBe('Bearer AT_NEW')
+    expect(next.url).toBe('http://127.0.0.1:8000/v1/oauth2/userinfo')
+    expect(mockRefreshAsync).toHaveBeenCalledTimes(1)
   })
 
   it('refreshes and returns a new Request with the new auth header when stale', async () => {
@@ -207,15 +235,38 @@ describe('onResponse (reactive refresh)', () => {
     expect(mockRefreshAsync).not.toHaveBeenCalled()
   })
 
-  it('returns undefined for 401 from OAuth endpoints', async () => {
+  it('returns undefined for 401 from the token endpoint (refresh itself failed)', async () => {
     configureFresh()
-    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/userinfo', {
+    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/token', {
       authToken: 'AT_OLD',
     })
     const response = new Response('{}', { status: 401 })
     const result = await callOnResponse(request, response)
     expect(result).toBeUndefined()
     expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('on 401 from /v1/oauth2/userinfo, refreshes and retries (it is a normal bearer-protected endpoint)', async () => {
+    configureFresh()
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ accessToken: 'AT_NEW' }),
+    )
+    const retryResponse = new Response('{}', { status: 200 })
+    middlewareOptions.fetch.mockResolvedValueOnce(retryResponse)
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/oauth2/userinfo', {
+      authToken: 'AT_OLD',
+    })
+    const response = new Response('{}', { status: 401 })
+
+    const result = await callOnResponse(request, response)
+
+    expect(mockRefreshAsync).toHaveBeenCalledTimes(1)
+    expect(middlewareOptions.fetch).toHaveBeenCalledTimes(1)
+    const retried = middlewareOptions.fetch.mock.calls[0][0] as Request
+    expect(retried.headers.get('Authorization')).toBe('Bearer AT_NEW')
+    expect(retried.url).toBe('http://127.0.0.1:8000/v1/oauth2/userinfo')
+    expect(result).toBe(retryResponse)
   })
 
   it('returns undefined for 401 when no refresh token is available', async () => {

--- a/clients/apps/app/auth/refreshMiddleware.test.ts
+++ b/clients/apps/app/auth/refreshMiddleware.test.ts
@@ -7,9 +7,15 @@ const mockRefreshAsync = jest.fn<
   Parameters<typeof refreshAsync>
 >()
 
-jest.mock('expo-auth-session', () => ({
-  refreshAsync: mockRefreshAsync,
-}))
+jest.mock('expo-auth-session', () => {
+  const actual = jest.requireActual<typeof import('expo-auth-session')>(
+    'expo-auth-session',
+  )
+  return {
+    ...actual,
+    refreshAsync: mockRefreshAsync,
+  }
+})
 
 let configureRefresher: (typeof RefresherModule)['configureRefresher']
 let refreshMiddleware: (typeof RefreshMiddlewareModule)['refreshMiddleware']
@@ -127,6 +133,26 @@ describe('onRequest (proactive refresh)', () => {
     })
     const result = await callOnRequest(request)
     expect(result).toBeUndefined()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('rewrites Authorization when fresh but the request still carries a stale bearer', async () => {
+    configureFresh()
+    configureRefresher({
+      accessToken: 'AT_CURRENT',
+      refreshToken: 'RT_OLD',
+      expiresAt: NOW + 60_000,
+      setSession: jest.fn(),
+    })
+
+    const request = buildRequest('http://127.0.0.1:8000/v1/orgs', {
+      authToken: 'AT_STALE',
+    })
+    const result = await callOnRequest(request)
+
+    expect(result).toBeInstanceOf(Request)
+    const next = result as Request
+    expect(next.headers.get('Authorization')).toBe('Bearer AT_CURRENT')
     expect(mockRefreshAsync).not.toHaveBeenCalled()
   })
 

--- a/clients/apps/app/auth/refreshMiddleware.test.ts
+++ b/clients/apps/app/auth/refreshMiddleware.test.ts
@@ -8,9 +8,8 @@ const mockRefreshAsync = jest.fn<
 >()
 
 jest.mock('expo-auth-session', () => {
-  const actual = jest.requireActual<typeof import('expo-auth-session')>(
-    'expo-auth-session',
-  )
+  const actual =
+    jest.requireActual<typeof import('expo-auth-session')>('expo-auth-session')
   return {
     ...actual,
     refreshAsync: mockRefreshAsync,

--- a/clients/apps/app/auth/refreshMiddleware.ts
+++ b/clients/apps/app/auth/refreshMiddleware.ts
@@ -6,7 +6,8 @@ import {
   refreshAccessToken,
 } from './refresher'
 
-const isOAuthEndpoint = (url: string): boolean => url.includes('/v1/oauth2/')
+const isOAuthEndpoint = (url: string): boolean =>
+  url.includes('/v1/oauth2/token') || url.includes('/v1/oauth2/revoke')
 
 export const refreshMiddleware: Middleware = {
   onRequest: async ({ request }) => {

--- a/clients/apps/app/auth/refreshMiddleware.ts
+++ b/clients/apps/app/auth/refreshMiddleware.ts
@@ -1,0 +1,36 @@
+import type { Middleware } from '@polar-sh/client'
+import {
+  hasRefreshToken,
+  isAccessTokenStale,
+  refreshAccessToken,
+} from './refresher'
+
+const isOAuthEndpoint = (url: string): boolean => url.includes('/v1/oauth2/')
+
+export const refreshMiddleware: Middleware = {
+  onRequest: async ({ request }) => {
+    if (isOAuthEndpoint(request.url)) return
+    if (!hasRefreshToken()) return
+    if (!isAccessTokenStale()) return
+
+    const newAccessToken = await refreshAccessToken()
+    if (!newAccessToken) return
+
+    const next = new Request(request)
+    next.headers.set('Authorization', `Bearer ${newAccessToken}`)
+    return next
+  },
+
+  onResponse: async ({ request, response, options }) => {
+    if (response.status !== 401) return
+    if (isOAuthEndpoint(request.url)) return
+    if (!hasRefreshToken()) return
+
+    const newAccessToken = await refreshAccessToken()
+    if (!newAccessToken) return
+
+    const retry = new Request(request)
+    retry.headers.set('Authorization', `Bearer ${newAccessToken}`)
+    return await options.fetch(retry)
+  },
+}

--- a/clients/apps/app/auth/refreshMiddleware.ts
+++ b/clients/apps/app/auth/refreshMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Middleware } from '@polar-sh/client'
 import {
+  getRefresherAccessToken,
   hasRefreshToken,
   isAccessTokenStale,
   refreshAccessToken,
@@ -10,15 +11,25 @@ const isOAuthEndpoint = (url: string): boolean => url.includes('/v1/oauth2/')
 export const refreshMiddleware: Middleware = {
   onRequest: async ({ request }) => {
     if (isOAuthEndpoint(request.url)) return
-    if (!hasRefreshToken()) return
-    if (!isAccessTokenStale()) return
 
-    const newAccessToken = await refreshAccessToken()
-    if (!newAccessToken) return
+    if (hasRefreshToken() && isAccessTokenStale()) {
+      const newAccessToken = await refreshAccessToken()
+      if (!newAccessToken) return
 
-    const next = new Request(request)
-    next.headers.set('Authorization', `Bearer ${newAccessToken}`)
-    return next
+      const next = new Request(request)
+      next.headers.set('Authorization', `Bearer ${newAccessToken}`)
+      return next
+    }
+
+    const latestToken = getRefresherAccessToken()
+    if (!latestToken) return
+
+    const expected = `Bearer ${latestToken}`
+    if (request.headers.get('Authorization') !== expected) {
+      const next = new Request(request)
+      next.headers.set('Authorization', expected)
+      return next
+    }
   },
 
   onResponse: async ({ request, response, options }) => {

--- a/clients/apps/app/auth/refresher.test.ts
+++ b/clients/apps/app/auth/refresher.test.ts
@@ -1,4 +1,5 @@
 import type { refreshAsync } from 'expo-auth-session'
+import { TokenError } from 'expo-auth-session'
 import type * as RefresherModule from './refresher'
 
 const mockRefreshAsync = jest.fn<
@@ -6,9 +7,15 @@ const mockRefreshAsync = jest.fn<
   Parameters<typeof refreshAsync>
 >()
 
-jest.mock('expo-auth-session', () => ({
-  refreshAsync: mockRefreshAsync,
-}))
+jest.mock('expo-auth-session', () => {
+  const actual = jest.requireActual<typeof import('expo-auth-session')>(
+    'expo-auth-session',
+  )
+  return {
+    ...actual,
+    refreshAsync: mockRefreshAsync,
+  }
+})
 
 let configureRefresher: (typeof RefresherModule)['configureRefresher']
 let hasRefreshToken: (typeof RefresherModule)['hasRefreshToken']
@@ -164,8 +171,12 @@ describe('isAccessTokenStale', () => {
 
     it('does not record a lifetime when configured with an expired token (cold start path)', () => {
       configure({ expiresAt: NOW - 5_000 })
-
       configure({ expiresAt: NOW + 30_000 })
+
+      expect(isAccessTokenStale()).toBe(false)
+
+      jest.setSystemTime(NOW + 20_001)
+      expect(isAccessTokenStale()).toBe(true)
     })
   })
 })
@@ -242,23 +253,52 @@ describe('refreshAccessToken', () => {
   })
 
   it('updates state so subsequent isAccessTokenStale uses the new lifetime', async () => {
-    configure({ expiresAt: NOW + 60_000 })
+    configure({ expiresAt: NOW + 10_000 })
     mockRefreshAsync.mockResolvedValueOnce(
-      buildTokenResponse({ expiresIn: 60 }),
+      buildTokenResponse({ expiresIn: 3_600 }),
     )
     await refreshAccessToken()
+
+    jest.setSystemTime(NOW + 3_550_000)
+
+    expect(isAccessTokenStale()).toBe(true)
   })
 
-  it('on failure, clears session and returns null', async () => {
+  it('on transport failure, returns null without clearing the session', async () => {
     const { setSession } = configure()
     mockRefreshAsync.mockRejectedValueOnce(new Error('refresh denied'))
 
     const result = await refreshAccessToken()
 
     expect(result).toBeNull()
-    expect(setSession).toHaveBeenCalledWith(null)
+    expect(setSession).not.toHaveBeenCalledWith(null)
+    expect(hasRefreshToken()).toBe(true)
+  })
 
+  it('on invalid_grant TokenError, clears session and returns null', async () => {
+    const { setSession } = configure()
+    mockRefreshAsync.mockRejectedValueOnce(
+      new TokenError({ error: 'invalid_grant' }),
+    )
+
+    const result = await refreshAccessToken()
+
+    expect(result).toBeNull()
+    expect(setSession).toHaveBeenCalledWith(null)
     expect(hasRefreshToken()).toBe(false)
+  })
+
+  it('on invalid_request TokenError, returns null without clearing the session', async () => {
+    const { setSession } = configure()
+    mockRefreshAsync.mockRejectedValueOnce(
+      new TokenError({ error: 'invalid_request' }),
+    )
+
+    const result = await refreshAccessToken()
+
+    expect(result).toBeNull()
+    expect(setSession).not.toHaveBeenCalledWith(null)
+    expect(hasRefreshToken()).toBe(true)
   })
 
   describe('concurrency dedup', () => {
@@ -320,30 +360,32 @@ describe('refreshAccessToken', () => {
 })
 
 describe('configureRefresher lifetime estimation', () => {
-  it('estimates lifetime from expiresAt on the first configure call', async () => {
+  it('estimates lifetime from expiresAt on the first configure call', () => {
     configure({ expiresAt: NOW + 30_000 })
 
     jest.setSystemTime(NOW + 19_000)
+    expect(isAccessTokenStale()).toBe(false)
 
     jest.setSystemTime(NOW + 21_000)
+    expect(isAccessTokenStale()).toBe(true)
   })
 
   it('does not overwrite a known lifetime on subsequent configure calls', async () => {
-    configure()
+    configure({ expiresAt: NOW + 120_000 })
     mockRefreshAsync.mockResolvedValueOnce(
-      buildTokenResponse({ expiresIn: 60 }),
+      buildTokenResponse({ expiresIn: 3_600 }),
     )
     await refreshAccessToken()
 
-    jest.setSystemTime(NOW + 50_000)
+    configureRefresher({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: NOW + 120_000,
+      setSession: jest.fn(),
+    })
 
-    jest.setSystemTime(NOW + 50_001)
+    jest.setSystemTime(NOW + 61_100)
 
-    mockRefreshAsync.mockResolvedValueOnce(
-      buildTokenResponse({ expiresIn: 60 }),
-    )
-    await refreshAccessToken()
-
-    expect(isAccessTokenStale()).toBe(false)
+    expect(isAccessTokenStale()).toBe(true)
   })
 })

--- a/clients/apps/app/auth/refresher.test.ts
+++ b/clients/apps/app/auth/refresher.test.ts
@@ -1,0 +1,349 @@
+import type { refreshAsync } from 'expo-auth-session'
+import type * as RefresherModule from './refresher'
+
+const mockRefreshAsync = jest.fn<
+  ReturnType<typeof refreshAsync>,
+  Parameters<typeof refreshAsync>
+>()
+
+jest.mock('expo-auth-session', () => ({
+  refreshAsync: mockRefreshAsync,
+}))
+
+let configureRefresher: (typeof RefresherModule)['configureRefresher']
+let hasRefreshToken: (typeof RefresherModule)['hasRefreshToken']
+let isAccessTokenStale: (typeof RefresherModule)['isAccessTokenStale']
+let refreshAccessToken: (typeof RefresherModule)['refreshAccessToken']
+
+const NOW = new Date('2024-01-01T00:00:00Z').getTime()
+
+const buildTokenResponse = (
+  overrides: Partial<{
+    accessToken: string
+    refreshToken: string | undefined
+    expiresIn: number | undefined
+  }> = {},
+) =>
+  ({
+    accessToken: 'new-access-token',
+    refreshToken: 'new-refresh-token',
+    expiresIn: 60,
+    ...overrides,
+  }) as unknown as Awaited<ReturnType<typeof refreshAsync>>
+
+const configure = (
+  overrides: Partial<{
+    accessToken: string | null
+    refreshToken: string | null
+    expiresAt: number | null
+    setSession: jest.Mock
+  }> = {},
+) => {
+  const setSession = overrides.setSession ?? jest.fn()
+  configureRefresher({
+    accessToken: overrides.accessToken ?? 'access-token',
+    refreshToken:
+      overrides.refreshToken !== undefined
+        ? overrides.refreshToken
+        : 'refresh-token',
+    expiresAt:
+      overrides.expiresAt !== undefined ? overrides.expiresAt : NOW + 60_000,
+    setSession,
+  })
+  return { setSession }
+}
+
+beforeEach(() => {
+  jest.resetModules()
+  ;({
+    configureRefresher,
+    hasRefreshToken,
+    isAccessTokenStale,
+    refreshAccessToken,
+  } = require('./refresher') as typeof RefresherModule)
+  mockRefreshAsync.mockReset()
+  jest.useFakeTimers().setSystemTime(NOW)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('hasRefreshToken', () => {
+  it('returns false when no refresh token is configured', () => {
+    expect(hasRefreshToken()).toBe(false)
+  })
+
+  it('returns true when a refresh token is configured', () => {
+    configure({ refreshToken: 'rt' })
+    expect(hasRefreshToken()).toBe(true)
+  })
+
+  it('returns false when refresh token is explicitly null', () => {
+    configure({ refreshToken: null })
+    expect(hasRefreshToken()).toBe(false)
+  })
+})
+
+describe('isAccessTokenStale', () => {
+  it('returns false when no refresh token is configured', () => {
+    expect(isAccessTokenStale()).toBe(false)
+  })
+
+  it('returns false when no expiresAt is set', () => {
+    configure({ expiresAt: null })
+    expect(isAccessTokenStale()).toBe(false)
+  })
+
+  describe('with adaptive margin', () => {
+    it('with a 60s lifetime, treats 30s remaining as fresh (margin = 20s)', () => {
+      configure({ expiresAt: NOW + 60_000 })
+      jest.setSystemTime(NOW + 30_000)
+      expect(isAccessTokenStale()).toBe(false)
+    })
+
+    it('with a 60s lifetime, treats 15s remaining as stale (margin = 20s)', () => {
+      configure({ expiresAt: NOW + 60_000 })
+      jest.setSystemTime(NOW + 45_000)
+      expect(isAccessTokenStale()).toBe(true)
+    })
+
+    it('with a 60s lifetime, treats already-expired token as stale', () => {
+      configure({ expiresAt: NOW + 60_000 })
+      jest.setSystemTime(NOW + 90_000)
+      expect(isAccessTokenStale()).toBe(true)
+    })
+  })
+
+  describe('with margin clamping', () => {
+    it('clamps margin to 60s ceiling for very long lifetimes', async () => {
+      configure({ expiresAt: NOW + 3_600_000 })
+
+      mockRefreshAsync.mockResolvedValueOnce(
+        buildTokenResponse({ expiresIn: 3_600 }),
+      )
+      await refreshAccessToken()
+
+      configure({ expiresAt: NOW + 90_000 })
+
+      expect(isAccessTokenStale()).toBe(false)
+
+      jest.setSystemTime(NOW + 31_000)
+      expect(isAccessTokenStale()).toBe(true)
+    })
+
+    it('clamps margin to 1s floor for very short lifetimes', async () => {
+      configure({ expiresAt: NOW + 2_000 })
+      mockRefreshAsync.mockResolvedValueOnce(
+        buildTokenResponse({ expiresIn: 2 }),
+      )
+      await refreshAccessToken()
+
+      expect(isAccessTokenStale()).toBe(false)
+
+      jest.setSystemTime(NOW + 1_100)
+      expect(isAccessTokenStale()).toBe(true)
+    })
+  })
+
+  describe('with unknown lifetime', () => {
+    it('falls back to 60s margin when no lifetime has been observed', () => {
+      configure({ expiresAt: NOW - 1_000 })
+
+      expect(isAccessTokenStale()).toBe(true)
+    })
+
+    it('estimates lifetime from a future expiresAt at first configure', () => {
+      configure({ expiresAt: NOW + 30_000 })
+
+      expect(isAccessTokenStale()).toBe(false)
+
+      jest.setSystemTime(NOW + 20_001)
+      expect(isAccessTokenStale()).toBe(true)
+    })
+
+    it('does not record a lifetime when configured with an expired token (cold start path)', () => {
+      configure({ expiresAt: NOW - 5_000 })
+
+      configure({ expiresAt: NOW + 30_000 })
+    })
+  })
+})
+
+describe('refreshAccessToken response handling', () => {
+  it('handles a response missing expiresIn gracefully (no lifetime poisoning)', async () => {
+    const { setSession } = configure()
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ expiresIn: undefined }),
+    )
+
+    await refreshAccessToken()
+
+    expect(setSession).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: null }),
+    )
+
+    expect(isAccessTokenStale()).toBe(false)
+  })
+})
+
+describe('refreshAccessToken', () => {
+  it('returns null when no refresh token is configured', async () => {
+    const setSession = jest.fn()
+    configure({ refreshToken: null, setSession })
+    const result = await refreshAccessToken()
+    expect(result).toBeNull()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+    expect(setSession).not.toHaveBeenCalled()
+  })
+
+  it('returns null when no setSession is configured', async () => {
+    const result = await refreshAccessToken()
+    expect(result).toBeNull()
+    expect(mockRefreshAsync).not.toHaveBeenCalled()
+  })
+
+  it('on success, returns new access token and persists the new bundle', async () => {
+    const { setSession } = configure({ refreshToken: 'old-rt' })
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({
+        accessToken: 'AT_NEW',
+        refreshToken: 'RT_NEW',
+        expiresIn: 60,
+      }),
+    )
+
+    const result = await refreshAccessToken()
+
+    expect(result).toBe('AT_NEW')
+    expect(mockRefreshAsync).toHaveBeenCalledTimes(1)
+    expect(mockRefreshAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: 'old-rt' }),
+      expect.any(Object),
+    )
+    expect(setSession).toHaveBeenCalledWith({
+      accessToken: 'AT_NEW',
+      refreshToken: 'RT_NEW',
+      expiresAt: NOW + 60_000,
+    })
+  })
+
+  it('falls back to the existing refresh token if the response omits one', async () => {
+    const { setSession } = configure({ refreshToken: 'old-rt' })
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ refreshToken: undefined }),
+    )
+
+    await refreshAccessToken()
+
+    expect(setSession).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: 'old-rt' }),
+    )
+  })
+
+  it('updates state so subsequent isAccessTokenStale uses the new lifetime', async () => {
+    configure({ expiresAt: NOW + 60_000 })
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ expiresIn: 60 }),
+    )
+    await refreshAccessToken()
+  })
+
+  it('on failure, clears session and returns null', async () => {
+    const { setSession } = configure()
+    mockRefreshAsync.mockRejectedValueOnce(new Error('refresh denied'))
+
+    const result = await refreshAccessToken()
+
+    expect(result).toBeNull()
+    expect(setSession).toHaveBeenCalledWith(null)
+
+    expect(hasRefreshToken()).toBe(false)
+  })
+
+  describe('concurrency dedup', () => {
+    it('shares a single in-flight refresh across N concurrent callers', async () => {
+      configure()
+      let resolveRefresh!: (
+        value: Awaited<ReturnType<typeof refreshAsync>>,
+      ) => void
+      const refreshPromise = new Promise<
+        Awaited<ReturnType<typeof refreshAsync>>
+      >((resolve) => {
+        resolveRefresh = resolve
+      })
+      mockRefreshAsync.mockReturnValueOnce(refreshPromise)
+
+      const callers = [
+        refreshAccessToken(),
+        refreshAccessToken(),
+        refreshAccessToken(),
+        refreshAccessToken(),
+      ]
+
+      expect(mockRefreshAsync).toHaveBeenCalledTimes(1)
+
+      resolveRefresh(buildTokenResponse({ accessToken: 'shared-AT' }))
+      const results = await Promise.all(callers)
+
+      expect(results).toEqual([
+        'shared-AT',
+        'shared-AT',
+        'shared-AT',
+        'shared-AT',
+      ])
+    })
+
+    it('clears the in-flight slot after success so a subsequent refresh can fire', async () => {
+      configure()
+      mockRefreshAsync
+        .mockResolvedValueOnce(buildTokenResponse({ accessToken: 'AT_1' }))
+        .mockResolvedValueOnce(buildTokenResponse({ accessToken: 'AT_2' }))
+
+      expect(await refreshAccessToken()).toBe('AT_1')
+      expect(await refreshAccessToken()).toBe('AT_2')
+      expect(mockRefreshAsync).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears the in-flight slot after failure so a subsequent refresh can fire', async () => {
+      configure()
+      mockRefreshAsync
+        .mockRejectedValueOnce(new Error('first call fails'))
+        .mockResolvedValueOnce(buildTokenResponse({ accessToken: 'AT_2' }))
+
+      expect(await refreshAccessToken()).toBeNull()
+
+      configure()
+      expect(await refreshAccessToken()).toBe('AT_2')
+    })
+  })
+})
+
+describe('configureRefresher lifetime estimation', () => {
+  it('estimates lifetime from expiresAt on the first configure call', async () => {
+    configure({ expiresAt: NOW + 30_000 })
+
+    jest.setSystemTime(NOW + 19_000)
+
+    jest.setSystemTime(NOW + 21_000)
+  })
+
+  it('does not overwrite a known lifetime on subsequent configure calls', async () => {
+    configure()
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ expiresIn: 60 }),
+    )
+    await refreshAccessToken()
+
+    jest.setSystemTime(NOW + 50_000)
+
+    jest.setSystemTime(NOW + 50_001)
+
+    mockRefreshAsync.mockResolvedValueOnce(
+      buildTokenResponse({ expiresIn: 60 }),
+    )
+    await refreshAccessToken()
+
+    expect(isAccessTokenStale()).toBe(false)
+  })
+})

--- a/clients/apps/app/auth/refresher.test.ts
+++ b/clients/apps/app/auth/refresher.test.ts
@@ -8,9 +8,8 @@ const mockRefreshAsync = jest.fn<
 >()
 
 jest.mock('expo-auth-session', () => {
-  const actual = jest.requireActual<typeof import('expo-auth-session')>(
-    'expo-auth-session',
-  )
+  const actual =
+    jest.requireActual<typeof import('expo-auth-session')>('expo-auth-session')
   return {
     ...actual,
     refreshAsync: mockRefreshAsync,

--- a/clients/apps/app/auth/refresher.ts
+++ b/clients/apps/app/auth/refresher.ts
@@ -1,0 +1,117 @@
+import { refreshAsync } from 'expo-auth-session'
+import { CLIENT_ID, discovery } from './oauthConfig'
+
+export type SessionData = {
+  accessToken: string
+  refreshToken?: string | null
+  expiresAt?: number | null
+}
+
+type SetSession = (data: SessionData | null) => void
+
+type RefresherState = {
+  accessToken: string | null
+  refreshToken: string | null
+  expiresAt: number | null
+  setSession: SetSession | null
+}
+
+const state: RefresherState = {
+  accessToken: null,
+  refreshToken: null,
+  expiresAt: null,
+  setSession: null,
+}
+
+let knownLifetimeMs: number | null = null
+
+let inFlight: Promise<string | null> | null = null
+
+const DEFAULT_LIFETIME_MS = 60_000
+const MIN_REFRESH_MARGIN_MS = 1_000
+const MAX_REFRESH_MARGIN_MS = 60_000
+
+export function configureRefresher(next: {
+  accessToken: string | null
+  refreshToken: string | null
+  expiresAt: number | null
+  setSession: SetSession
+}) {
+  state.accessToken = next.accessToken
+  state.refreshToken = next.refreshToken
+  state.expiresAt = next.expiresAt
+  state.setSession = next.setSession
+
+  if (knownLifetimeMs === null && typeof next.expiresAt === 'number') {
+    const remaining = next.expiresAt - Date.now()
+    if (remaining > 0) {
+      knownLifetimeMs = remaining
+    }
+  }
+}
+
+export function hasRefreshToken(): boolean {
+  return !!state.refreshToken
+}
+
+export function isAccessTokenStale(): boolean {
+  if (!state.refreshToken) return false
+  if (typeof state.expiresAt !== 'number') return false
+  const lifetime = knownLifetimeMs ?? DEFAULT_LIFETIME_MS
+  const marginMs = Math.max(
+    MIN_REFRESH_MARGIN_MS,
+    Math.min(MAX_REFRESH_MARGIN_MS, Math.floor(lifetime / 3)),
+  )
+  return state.expiresAt - Date.now() < marginMs
+}
+
+export async function refreshAccessToken(): Promise<string | null> {
+  if (!state.refreshToken || !state.setSession) {
+    return null
+  }
+  if (inFlight) {
+    return inFlight
+  }
+
+  const currentRefreshToken = state.refreshToken
+
+  inFlight = (async () => {
+    try {
+      const response = await refreshAsync(
+        { clientId: CLIENT_ID, refreshToken: currentRefreshToken },
+        discovery,
+      )
+
+      const next: SessionData = {
+        accessToken: response.accessToken,
+        refreshToken: response.refreshToken ?? currentRefreshToken,
+        expiresAt:
+          typeof response.expiresIn === 'number'
+            ? Date.now() + response.expiresIn * 1000
+            : null,
+      }
+
+      state.accessToken = next.accessToken
+      state.refreshToken = next.refreshToken ?? null
+      state.expiresAt = next.expiresAt ?? null
+
+      if (typeof response.expiresIn === 'number') {
+        knownLifetimeMs = response.expiresIn * 1000
+      }
+
+      state.setSession?.(next)
+      return next.accessToken
+    } catch {
+      state.accessToken = null
+      state.refreshToken = null
+      state.expiresAt = null
+      knownLifetimeMs = null
+      state.setSession?.(null)
+      return null
+    } finally {
+      inFlight = null
+    }
+  })()
+
+  return inFlight
+}

--- a/clients/apps/app/auth/refresher.ts
+++ b/clients/apps/app/auth/refresher.ts
@@ -54,6 +54,32 @@ export function hasRefreshToken(): boolean {
   return !!state.refreshToken
 }
 
+export function getRefresherAccessToken(): string | null {
+  return state.accessToken
+}
+
+function oauthTokenEndpointErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('params' in error)) {
+    return undefined
+  }
+  const params = (error as { params?: unknown }).params
+  if (typeof params !== 'object' || params === null || !('error' in params)) {
+    return undefined
+  }
+  const code = (params as { error?: unknown }).error
+  return typeof code === 'string' ? code : undefined
+}
+
+function shouldClearSessionAfterTokenRefreshFailure(error: unknown): boolean {
+  const code = oauthTokenEndpointErrorCode(error)
+  return (
+    code === 'invalid_grant' ||
+    code === 'invalid_client' ||
+    code === 'unauthorized_client' ||
+    code === 'unsupported_grant_type'
+  )
+}
+
 export function isAccessTokenStale(): boolean {
   if (!state.refreshToken) return false
   if (typeof state.expiresAt !== 'number') return false
@@ -101,7 +127,10 @@ export async function refreshAccessToken(): Promise<string | null> {
 
       state.setSession?.(next)
       return next.accessToken
-    } catch {
+    } catch (error) {
+      if (!shouldClearSessionAfterTokenRefreshFailure(error)) {
+        return null
+      }
       state.accessToken = null
       state.refreshToken = null
       state.expiresAt = null

--- a/clients/apps/app/hooks/oauth.ts
+++ b/clients/apps/app/hooks/oauth.ts
@@ -1,106 +1,21 @@
+import { CLIENT_ID, discovery, scopes } from '@/auth/oauthConfig'
 import { useSession } from '@/providers/SessionProvider'
+import * as Sentry from '@sentry/react-native'
 import {
   exchangeCodeAsync,
   makeRedirectUri,
   useAuthRequest,
 } from 'expo-auth-session'
-import * as Sentry from '@sentry/react-native'
 import * as WebBrowser from 'expo-web-browser'
 import { useEffect } from 'react'
 
 WebBrowser.maybeCompleteAuthSession()
 
-export const useOAuthConfig = () => {
-  const production = {
-    CLIENT_ID: 'polar_ci_yZLBGwoWZVsOdfN5CODRwVSTlJfwJhXqwg65e2CuNMZ',
-    discovery: {
-      authorizationEndpoint: 'https://polar.sh/oauth2/authorize',
-      tokenEndpoint: 'https://api.polar.sh/v1/oauth2/token',
-      registrationEndpoint: 'https://api.polar.sh/v1/oauth2/register',
-      revocationEndpoint: 'https://api.polar.sh/v1/oauth2/revoke',
-    },
-  }
-
-  const development = {
-    CLIENT_ID: 'polar_ci_hbFdMZZRghgdm2F4LMceQSrcQNunmjlh6ukGJ1dG0Vg',
-    discovery: {
-      authorizationEndpoint: `http://127.0.0.1:3000/oauth2/authorize`,
-      tokenEndpoint: `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL}/v1/oauth2/token`,
-      registrationEndpoint: `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL}/v1/oauth2/register`,
-      revocationEndpoint: `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL}/v1/oauth2/revoke`,
-    },
-  }
-
-  const scopes = [
-    'benefits:read',
-    'benefits:write',
-    'checkout_links:read',
-    'checkout_links:write',
-    'checkouts:read',
-    'checkouts:write',
-    'custom_fields:read',
-    'custom_fields:write',
-    'customer_meters:read',
-    'customer_portal:read',
-    'customer_portal:write',
-    'customer_seats:read',
-    'customer_seats:write',
-    'customer_sessions:write',
-    'customers:read',
-    'customers:write',
-    'discounts:read',
-    'discounts:write',
-    'disputes:read',
-    'email',
-    'events:read',
-    'events:write',
-    'files:read',
-    'files:write',
-    'license_keys:read',
-    'license_keys:write',
-    'member_sessions:write',
-    'members:read',
-    'members:write',
-    'meters:read',
-    'meters:write',
-    'metrics:read',
-    'metrics:write',
-    'notification_recipients:read',
-    'notification_recipients:write',
-    'notifications:read',
-    'notifications:write',
-    'openid',
-    'orders:read',
-    'orders:write',
-    'organization_access_tokens:read',
-    'organization_access_tokens:write',
-    'organizations:read',
-    'organizations:write',
-    'payments:read',
-    'payouts:read',
-    'payouts:write',
-    'products:read',
-    'products:write',
-    'profile',
-    'refunds:read',
-    'refunds:write',
-    'subscriptions:read',
-    'subscriptions:write',
-    'transactions:read',
-    'transactions:write',
-    'user:read',
-    'user:write',
-    'wallets:read',
-    'wallets:write',
-    'webhooks:read',
-    'webhooks:write',
-  ]
-
-  return {
-    scopes,
-    ...production,
-  }
-}
+export const useOAuthConfig = () => ({
+  CLIENT_ID,
+  discovery,
+  scopes,
+})
 
 export const useOAuth = () => {
   const { setSession } = useSession()
@@ -158,7 +73,14 @@ export const useOAuth = () => {
         discovery,
       )
 
-      setSession(token.accessToken)
+      setSession({
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken,
+        expiresAt:
+          typeof token.expiresIn === 'number'
+            ? Date.now() + token.expiresIn * 1000
+            : null,
+      })
     } catch (error) {
       Sentry.captureException(error, {
         extra: { context: 'oauth_authenticate' },

--- a/clients/apps/app/hooks/polar/notifications.ts
+++ b/clients/apps/app/hooks/polar/notifications.ts
@@ -103,58 +103,27 @@ export const useListNotifications = (): UseQueryResult<
   schemas['NotificationsList'],
   Error
 > => {
+  const { polar } = usePolarClient()
   const { session } = useSession()
 
   return useQuery({
     queryKey: ['notifications'],
-    queryFn: async () => {
-      const response = await fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/notifications`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`)
-      }
-      return response.json()
-    },
+    queryFn: () => unwrap(polar.GET('/v1/notifications')),
+    enabled: !!session,
   })
 }
 
 export const useNotificationsMarkRead = () => {
-  const { session } = useSession()
+  const { polar } = usePolarClient()
 
   return useMutation({
-    mutationFn: async (variables: { notificationId: string }) => {
-      const response = await fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/notifications/read`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-          body: JSON.stringify({
-            notification_id: variables.notificationId,
-          }),
-        },
-      )
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`)
-      }
-      return response.json()
-    },
-    onSuccess: (result, _variables, _ctx) => {
-      if (result && 'error' in result && result.error) {
-        return
-      }
-
+    mutationFn: (variables: { notificationId: string }) =>
+      unwrap(
+        polar.POST('/v1/notifications/read', {
+          body: { notification_id: variables.notificationId },
+        }),
+      ),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notifications'] })
     },
   })

--- a/clients/apps/app/hooks/polar/organizations.ts
+++ b/clients/apps/app/hooks/polar/organizations.ts
@@ -1,14 +1,8 @@
 import { usePolarClient } from '@/providers/PolarClientProvider'
-import { useSession } from '@/providers/SessionProvider'
 import { queryClient } from '@/utils/query'
 import { operations, schemas, unwrap } from '@polar-sh/client'
 import * as Sentry from '@sentry/react-native'
-import {
-  useMutation,
-  UseMutationResult,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 export const useOrganizations = (
   {
@@ -112,36 +106,15 @@ export const useUpdateOrganization = () => {
   })
 }
 
-export const useDeleteOrganization = (): UseMutationResult<
-  {
-    data?: schemas['OrganizationDeletionResponse']
-    error?: { detail: string }
-  },
-  Error,
-  string
-> => {
-  const { session } = useSession()
+export const useDeleteOrganization = () => {
+  const { polar } = usePolarClient()
 
   return useMutation({
     mutationFn: async (organizationId: string) => {
-      const response = await fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/organizations/${organizationId}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-
-      if (!response.ok) {
-        const error = await response.json()
-        return { error }
-      }
-
-      const data = await response.json()
-      return { data }
+      const { data, error } = await polar.DELETE('/v1/organizations/{id}', {
+        params: { path: { id: organizationId } },
+      })
+      return { data, error }
     },
   })
 }

--- a/clients/apps/app/providers/PolarClientProvider.tsx
+++ b/clients/apps/app/providers/PolarClientProvider.tsx
@@ -1,5 +1,11 @@
+import { refreshMiddleware } from '@/auth/refreshMiddleware'
 import { Client, createClient } from '@polar-sh/client'
-import { createContext, useContext, type PropsWithChildren } from 'react'
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type PropsWithChildren,
+} from 'react'
 import { useSession } from './SessionProvider'
 
 const PolarClientContext = createContext<{
@@ -25,17 +31,17 @@ export function usePolarClient() {
 export function PolarClientProvider({ children }: PropsWithChildren) {
   const { session } = useSession()
 
-  const polar = createClient(
-    process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh',
-    session ?? '',
-  )
+  const polar = useMemo(() => {
+    const client = createClient(
+      process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh',
+      session ?? '',
+    )
+    client.use(refreshMiddleware)
+    return client
+  }, [session])
 
   return (
-    <PolarClientContext.Provider
-      value={{
-        polar,
-      }}
-    >
+    <PolarClientContext.Provider value={{ polar }}>
       {children}
     </PolarClientContext.Provider>
   )

--- a/clients/apps/app/providers/SessionProvider.tsx
+++ b/clients/apps/app/providers/SessionProvider.tsx
@@ -1,25 +1,37 @@
+import { configureRefresher, type SessionData } from '@/auth/refresher'
 import { useStorageState } from '@/hooks/storage'
 import { ExtensionStorage } from '@bacons/apple-targets'
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   type PropsWithChildren,
 } from 'react'
 
-const storage = new ExtensionStorage('group.com.polarsource.Polar')
+const ACCESS_TOKEN_KEY = 'session'
+const REFRESH_TOKEN_KEY = 'session_refresh_token'
+const EXPIRES_AT_KEY = 'session_expires_at'
 
-const AuthContext = createContext<{
-  setSession: (session: string | null) => void
+const widgetStorage = new ExtensionStorage('group.com.polarsource.Polar')
+
+type AuthContextValue = {
+  setSession: (data: SessionData | null) => void
   session?: string | null
+  refreshToken?: string | null
+  expiresAt?: number | null
   isLoading: boolean
-}>({
+}
+
+const AuthContext = createContext<AuthContextValue>({
   setSession: () => null,
   session: null,
+  refreshToken: null,
+  expiresAt: null,
   isLoading: false,
 })
 
-// This hook can be used to access the user info.
 export function useSession() {
   const value = useContext(AuthContext)
   if (process.env.NODE_ENV !== 'production') {
@@ -27,24 +39,64 @@ export function useSession() {
       throw new Error('useSession must be wrapped in a <SessionProvider />')
     }
   }
-
   return value
 }
 
 export function SessionProvider({ children }: PropsWithChildren) {
-  const [[isLoading, session], setSession] = useStorageState('session')
+  const [[isLoadingAccess, accessToken], setAccessTokenStorage] =
+    useStorageState(ACCESS_TOKEN_KEY)
+  const [[isLoadingRefresh, refreshToken], setRefreshTokenStorage] =
+    useStorageState(REFRESH_TOKEN_KEY)
+  const [[isLoadingExpires, expiresAtRaw], setExpiresAtStorage] =
+    useStorageState(EXPIRES_AT_KEY)
+
+  const expiresAt = useMemo(() => {
+    if (!expiresAtRaw) return null
+    const parsed = Number.parseInt(expiresAtRaw, 10)
+    return Number.isFinite(parsed) ? parsed : null
+  }, [expiresAtRaw])
+
+  const isLoading = isLoadingAccess || isLoadingRefresh || isLoadingExpires
+
+  const setSession = useCallback(
+    (data: SessionData | null) => {
+      if (!data) {
+        setAccessTokenStorage(null)
+        setRefreshTokenStorage(null)
+        setExpiresAtStorage(null)
+        return
+      }
+      setAccessTokenStorage(data.accessToken)
+      setRefreshTokenStorage(data.refreshToken ?? null)
+      setExpiresAtStorage(
+        typeof data.expiresAt === 'number' ? String(data.expiresAt) : null,
+      )
+    },
+    [setAccessTokenStorage, setRefreshTokenStorage, setExpiresAtStorage],
+  )
 
   useEffect(() => {
-    if (session) {
-      storage.set('widget_api_token', session)
+    if (accessToken) {
+      widgetStorage.set('widget_api_token', accessToken)
     }
-  }, [session])
+  }, [accessToken])
+
+  useEffect(() => {
+    configureRefresher({
+      accessToken: accessToken ?? null,
+      refreshToken: refreshToken ?? null,
+      expiresAt,
+      setSession,
+    })
+  }, [accessToken, refreshToken, expiresAt, setSession])
 
   return (
     <AuthContext.Provider
       value={{
         setSession,
-        session,
+        session: accessToken,
+        refreshToken,
+        expiresAt,
         isLoading,
       }}
     >

--- a/clients/apps/app/providers/UserProvider.tsx
+++ b/clients/apps/app/providers/UserProvider.tsx
@@ -1,5 +1,6 @@
+import { usePolarClient } from '@/providers/PolarClientProvider'
 import { useSession } from '@/providers/SessionProvider'
-import { schemas } from '@polar-sh/client'
+import { schemas, unwrap } from '@polar-sh/client'
 import { useQuery } from '@tanstack/react-query'
 import { createContext, PropsWithChildren, useContext } from 'react'
 
@@ -19,24 +20,13 @@ export const useUser = () => useContext(UserContext)
 
 export function UserProvider({ children }: PropsWithChildren) {
   const { session } = useSession()
+  const { polar } = usePolarClient()
 
   const { data: user, isLoading } = useQuery({
     queryKey: ['userinfo'],
-    queryFn: async (): Promise<User> => {
-      const baseUrl =
-        process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'
-      const response = await fetch(`${baseUrl}/v1/oauth2/userinfo`, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${session}`,
-        },
-      })
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch user info')
-      }
-
-      return response.json()
+    queryFn: async () => {
+      const data = await unwrap(polar.GET('/v1/oauth2/userinfo'))
+      return data as User
     },
     enabled: !!session,
   })


### PR DESCRIPTION
This PR adds an OAuth refresh-token flow for the app so access tokens are renewed proactively and on `401`'s, while persisting refresh tokens alongside access tokens in session storage.

It also routes previously raw API calls through the authenticated client so refresh applies consistently.

**How to test**
1. Run the app against a local backend, guide is in [clients/apps/app/auth/oauthConfig.ts](https://github.com/polarsource/polar/pull/11417/changes#diff-2a4b33757c57992bea73605f1393eaf569ccb66bb78de481855d0abecc10d044)
2. Hard code the token to have a 60 second TTL in [server/polar/oauth2/constants](https://github.com/polarsource/polar/blob/main/server/polar/oauth2/constants.py#L25-L29)
3. Start the app
4. Log in
5. Wait ~40 seconds
6. Navigate to a sub page that makes a network call
7. Your token should now refresh



