### PR TITLE
oauth2: Reject expired access tokens, except for the Polar app

### DIFF
--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -20,15 +20,15 @@ from polar.user_organization.service import (
 
 log: Logger = structlog.get_logger()
 
-# TEMPORARY: the iOS app does not refresh its access tokens and crashes on 401.
-# Until the app's auth flow is fixed, expired tokens issued to it are still
-# accepted but logged. Source of truth for these IDs:
-# clients/apps/app/hooks/oauth.ts.
-_IOS_APP_CLIENT_IDS: dict[Environment, str] = {
+# TEMPORARY: the Polar app (iOS/Android/web, @polar-sh/app) does not refresh
+# its access tokens and crashes on 401. Until the app's auth flow is fixed,
+# expired tokens issued to it are still accepted but logged. Source of truth
+# for these IDs: clients/apps/app/hooks/oauth.ts.
+_APP_CLIENT_IDS: dict[Environment, str] = {
     Environment.production: "polar_ci_yZLBGwoWZVsOdfN5CODRwVSTlJfwJhXqwg65e2CuNMZ",
     Environment.development: "polar_ci_hbFdMZZRghgdm2F4LMceQSrcQNunmjlh6ukGJ1dG0Vg",
 }
-IOS_APP_CLIENT_ID: str | None = _IOS_APP_CLIENT_IDS.get(settings.ENV)
+APP_CLIENT_ID: str | None = _APP_CLIENT_IDS.get(settings.ENV)
 
 
 class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
@@ -51,10 +51,10 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
             return None
 
         if cast(bool, token.is_expired()):
-            if token.client_id != IOS_APP_CLIENT_ID:
+            if token.client_id != APP_CLIENT_ID:
                 return None
             log.warning(
-                "Allowing expired access token from iOS app client",
+                "Allowing expired access token from Polar app client",
                 token_id=token.id,
                 client_id=token.client_id,
                 expires_at=token.expires_at,

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -5,7 +5,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
-from polar.config import settings
+from polar.config import Environment, settings
 from polar.email.schemas import OAuth2LeakedTokenEmail, OAuth2LeakedTokenProps
 from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
@@ -19,6 +19,16 @@ from polar.user_organization.service import (
 )
 
 log: Logger = structlog.get_logger()
+
+# TEMPORARY: the iOS app does not refresh its access tokens and crashes on 401.
+# Until the app's auth flow is fixed, expired tokens issued to it are still
+# accepted but logged. Source of truth for these IDs:
+# clients/apps/app/hooks/oauth.ts.
+_IOS_APP_CLIENT_IDS: dict[Environment, str] = {
+    Environment.production: "polar_ci_yZLBGwoWZVsOdfN5CODRwVSTlJfwJhXqwg65e2CuNMZ",
+    Environment.development: "polar_ci_hbFdMZZRghgdm2F4LMceQSrcQNunmjlh6ukGJ1dG0Vg",
+}
+IOS_APP_CLIENT_ID: str | None = _IOS_APP_CLIENT_IDS.get(settings.ENV)
 
 
 class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
@@ -39,6 +49,17 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
 
         if cast(bool, token.is_revoked()):
             return None
+
+        if cast(bool, token.is_expired()):
+            if token.client_id != IOS_APP_CLIENT_ID:
+                return None
+            log.warning(
+                "Allowing expired access token from iOS app client",
+                token_id=token.id,
+                client_id=token.client_id,
+                expires_at=token.expires_at,
+                expired_seconds_ago=int(time.time()) - token.expires_at,
+            )
 
         if not token.sub.can_authenticate:
             return None

--- a/server/tests/oauth2/conftest.py
+++ b/server/tests/oauth2/conftest.py
@@ -105,7 +105,15 @@ async def create_oauth2_token(
     organization: Organization | None = None,
     access_token_revoked_at: int | None = None,
     refresh_token_revoked_at: int | None = None,
+    issued_at: int | None = None,
+    expires_in: int | None = None,
 ) -> OAuth2Token:
+    extra: dict[str, int] = {}
+    if issued_at is not None:
+        extra["issued_at"] = issued_at
+    if expires_in is not None:
+        extra["expires_in"] = expires_in
+
     token = OAuth2Token(
         client_id=client.client_id,
         token_type="bearer",
@@ -114,6 +122,7 @@ async def create_oauth2_token(
         scope=" ".join(scopes),
         access_token_revoked_at=access_token_revoked_at,
         refresh_token_revoked_at=refresh_token_revoked_at,
+        **extra,
     )
     if user is not None:
         token.user_id = user.id

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -228,7 +228,7 @@ class TestGetByAccessToken:
         )
         assert result is None
 
-    async def test_expired_token_ios_app_client(
+    async def test_expired_token_app_client(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -237,7 +237,7 @@ class TestGetByAccessToken:
         mocker: MockerFixture,
     ) -> None:
         mocker.patch(
-            "polar.oauth2.service.oauth2_token.IOS_APP_CLIENT_ID",
+            "polar.oauth2.service.oauth2_token.APP_CLIENT_ID",
             oauth2_client.client_id,
         )
 

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -145,3 +146,117 @@ class TestRevokeLeaked:
         assert result is True
 
         enqueue_email_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestGetByAccessToken:
+    async def test_unknown_token(self, session: AsyncSession) -> None:
+        result = await oauth2_token_service.get_by_access_token(
+            session, "polar_at_u_unknown"
+        )
+        assert result is None
+
+    async def test_valid_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_123",
+            refresh_token="polar_rt_u_123",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()),
+            expires_in=3600,
+        )
+
+        result = await oauth2_token_service.get_by_access_token(
+            session, "polar_at_u_123"
+        )
+        assert result is not None
+        assert result.client_id == oauth2_client.client_id
+
+    async def test_revoked_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_123",
+            refresh_token="polar_rt_u_123",
+            scopes=["openid"],
+            user=user,
+            access_token_revoked_at=int(time.time()),
+            refresh_token_revoked_at=int(time.time()),
+            issued_at=int(time.time()),
+            expires_in=3600,
+        )
+
+        result = await oauth2_token_service.get_by_access_token(
+            session, "polar_at_u_123"
+        )
+        assert result is None
+
+    async def test_expired_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_123",
+            refresh_token="polar_rt_u_123",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()) - 7200,
+            expires_in=3600,
+        )
+
+        result = await oauth2_token_service.get_by_access_token(
+            session, "polar_at_u_123"
+        )
+        assert result is None
+
+    async def test_expired_token_ios_app_client(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        mocker: MockerFixture,
+    ) -> None:
+        mocker.patch(
+            "polar.oauth2.service.oauth2_token.IOS_APP_CLIENT_ID",
+            oauth2_client.client_id,
+        )
+
+        await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_123",
+            refresh_token="polar_rt_u_123",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()) - 7200,
+            expires_in=3600,
+        )
+
+        log_mock = mocker.patch("polar.oauth2.service.oauth2_token.log")
+
+        result = await oauth2_token_service.get_by_access_token(
+            session, "polar_at_u_123"
+        )
+        assert result is not None
+        assert result.client_id == oauth2_client.client_id
+        log_mock.warning.assert_called_once()


### PR DESCRIPTION
## Summary

- Re-applies the expiry check reverted in #11415: `OAuth2TokenService.get_by_access_token` once again returns `None` for expired tokens.
- Adds an exception for the Polar app's OAuth2 client (Expo app at `clients/apps/app/`, shared across iOS, Android, and web). The `client_id` is looked up by environment from a hardcoded dict in `oauth2_token.py`, sourced from `clients/apps/app/hooks/oauth.ts`. Expired tokens issued to it are still returned, but a warning is logged with `token_id`, `client_id`, `expires_at` and `expired_seconds_ago`.
- Temporary workaround: the Polar app does not refresh access tokens and crashes on 401, so a hard rejection regresses it. Once the app's auth flow is fixed, delete the `_APP_CLIENT_IDS` constant and the bypass branch.

## Test plan

- [x] `uv run pytest tests/oauth2/service/test_oauth2_token.py` (14 passed) — covers valid, revoked, expired, and expired-from-app-client cases
- [ ] Manual: hit an authenticated endpoint with an expired non-app token → 401
- [ ] Manual: hit an authenticated endpoint with an expired app token → 200, warning log row emitted