### PR TITLE
oat: validate scopes for all callers when creating tokens

### DIFF
--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import structlog
 from sqlalchemy import UnaryExpression, asc, desc
 
-from polar.auth.models import AuthSubject, Organization, is_organization, is_user
+from polar.auth.models import AuthSubject, Organization, is_user
 from polar.auth.scope import Scope
 from polar.authz.service import get_accessible_org_ids
 from polar.config import settings
@@ -165,8 +165,6 @@ class OrganizationAccessTokenService:
         auth_subject: AuthSubject[User | Organization],
         requested_scopes: Sequence[str],
     ) -> None:
-        if not is_organization(auth_subject):
-            return
         caller_scopes = auth_subject.scopes
         requested = {Scope(s) for s in requested_scopes}
         excess = requested - caller_scopes

--- a/server/tests/organization_access_token/test_service.py
+++ b/server/tests/organization_access_token/test_service.py
@@ -4,12 +4,25 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.auth.models import AuthSubject
+from polar.auth.scope import Scope
 from polar.config import settings
 from polar.email.schemas import OrganizationAccessTokenLeakedEmail
 from polar.enums import TokenType
+from polar.exceptions import PolarRequestValidationError
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
-from polar.models import Organization, OrganizationAccessToken, UserOrganization
+from polar.models import (
+    Organization,
+    OrganizationAccessToken,
+    PersonalAccessToken,
+    User,
+    UserOrganization,
+)
+from polar.organization_access_token.schemas import (
+    AvailableScope,
+    OrganizationAccessTokenCreate,
+)
 from polar.organization_access_token.service import (
     organization_access_token as organization_access_token_service,
 )
@@ -77,3 +90,29 @@ class TestRevokeLeaked:
         assert isinstance(
             enqueue_email_mock.call_args[0][0], OrganizationAccessTokenLeakedEmail
         )
+
+
+@pytest.mark.asyncio
+class TestCreateScopeValidation:
+    async def test_pat_caller_cannot_mint_broader_scope(
+        self,
+        session: AsyncSession,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        pat_session = MagicMock(spec=PersonalAccessToken)
+        auth_subject: AuthSubject[User] = AuthSubject(
+            user, {Scope.organization_access_tokens_write}, pat_session
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            await organization_access_token_service.create(
+                session,
+                auth_subject,
+                OrganizationAccessTokenCreate(
+                    organization_id=organization.id,
+                    comment="elevated",
+                    scopes=[AvailableScope("orders:write")],
+                ),
+            )


### PR DESCRIPTION
## Summary

- `_validate_scopes_within_caller` was exempting all User subjects from scope validation, which let OAuth2 tokens and PATs (which authenticate as a User with limited scopes) create Organization Access Tokens with scopes the caller didn't have.
- The exemption was based on the assumption that User subjects always have full scopes (true only for new web sessions). It silently bypassed validation for OAuth2/PAT/impersonation sessions.
- Removed the early-return entirely. Web sessions don't need a special case: new ones already get `set(Scope)` so validation is a no-op, and the limited ones (e.g. `{web_read}` impersonation) *should* be checked.

Detail bug: `bug_01c5dbf9-e101-4c60-bfdb-9d23ff6a63c0`
Introduced in #11073.

## Test plan

- [x] `uv run pytest tests/organization_access_token/` (9 passed, including new `TestCreateScopeValidation.test_pat_caller_cannot_mint_broader_scope`)
- [x] `uv run task lint_types`
- [x] `uv run task lint`
- [ ] Manual: a web user with all scopes can still create OATs with any subset of scopes
- [ ] Manual: a PAT/OAuth2 caller with limited scopes gets a 422 when requesting broader scopes