### PR TITLE
fix: respect event.preventDefault() in checkout embed listeners

### DIFF
--- a/clients/packages/checkout/src/embed.test.ts
+++ b/clients/packages/checkout/src/embed.test.ts
@@ -326,6 +326,139 @@ describe('PolarEmbedCheckout', () => {
       checkout.close()
     })
 
+    it('skips the default loaded action when preventDefault is called', async () => {
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+        { onLoaded: (event) => event.preventDefault() },
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+
+      // Loader spinner should still be in the DOM since the default action
+      // (removing the loader) was prevented.
+      expect(document.querySelector('.polar-loader-spinner')).not.toBeNull()
+
+      checkout.close()
+    })
+
+    it('skips the default close action when preventDefault is called', async () => {
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+      checkout.addEventListener('close', (event) => event.preventDefault())
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).not.toBeNull()
+
+      checkout.close()
+    })
+
+    it('skips the default confirmed action when preventDefault is called', async () => {
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+      checkout.addEventListener('confirmed', (event) => event.preventDefault())
+
+      // Confirm — but listener prevents default, so closable should stay true.
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'confirmed' },
+        }),
+      )
+
+      // Close should still work since closable was not flipped to false.
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).toBeNull()
+    })
+
+    it('skips the default success action when preventDefault is called', async () => {
+      const promise = PolarEmbedCheckout.create(
+        'https://buy.polar.sh/polar_cl_123',
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'loaded' },
+        }),
+      )
+
+      const checkout = await promise
+
+      // Lock closing first, then dispatch success with a listener that
+      // prevents default — closing must remain locked because the default
+      // action (re-enabling closing) was skipped.
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'confirmed' },
+        }),
+      )
+
+      checkout.addEventListener('success', (event) => event.preventDefault())
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_CHECKOUT',
+            event: 'success',
+            successURL: 'https://example.com/thanks',
+            redirect: false,
+          },
+        }),
+      )
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).not.toBeNull()
+
+      checkout.close()
+    })
+
     it('re-enables closing after success event', async () => {
       const promise = PolarEmbedCheckout.create(
         'https://buy.polar.sh/polar_cl_123',

--- a/clients/packages/checkout/src/embed.ts
+++ b/clients/packages/checkout/src/embed.ts
@@ -69,10 +69,6 @@ class EmbedCheckout {
     this.eventTarget = new EventTarget()
     this.windowMessageListener = this.handleWindowMessage.bind(this)
     window.addEventListener('message', this.windowMessageListener)
-    this.addEventListener('loaded', this.loadedListener.bind(this))
-    this.addEventListener('close', this.closeListener.bind(this))
-    this.addEventListener('confirmed', this.confirmedListener.bind(this))
-    this.addEventListener('success', this.successListener.bind(this))
   }
 
   /**
@@ -319,12 +315,10 @@ class EmbedCheckout {
   }
 
   /**
-   * Default listener for the `loaded` event.
-   *
-   * This listener will remove the loader spinner when the embedded checkout is fully loaded.
+   * Default action for the `loaded` event: remove the loader spinner.
    */
-  private loadedListener(event: CustomEvent<EmbedCheckoutMessageLoaded>): void {
-    if (event.defaultPrevented || this.loaded) {
+  private handleLoaded(): void {
+    if (this.loaded) {
       return
     }
     document.body.removeChild(this.loader)
@@ -332,52 +326,39 @@ class EmbedCheckout {
   }
 
   /**
-   * Default listener for the `close` event.
-   *
-   * This listener will call the `close` method to remove the embedded checkout from the DOM.
+   * Default action for the `close` event: remove the embedded checkout from
+   * the DOM, unless closing has been locked by a prior `confirmed` event.
    */
-  private closeListener(event: CustomEvent<EmbedCheckoutMessageClose>): void {
-    if (event.defaultPrevented) {
-      return
-    }
+  private handleClose(): void {
     if (this.closable) {
       this.close()
     }
   }
 
   /**
-   * Default listener for the `confirmed` event.
-   *
-   * This listener will set a flag to prevent the parent window from closing the embedded checkout.
+   * Default action for the `confirmed` event: lock closing while the
+   * checkout is being processed.
    */
-  private confirmedListener(
-    event: CustomEvent<EmbedCheckoutMessageConfirmed>,
-  ): void {
-    if (event.defaultPrevented) {
-      return
-    }
+  private handleConfirmed(): void {
     this.closable = false
   }
 
   /**
-   * Default listener for the `success` event.
-   *
-   * This listener will redirect the parent window to the `successURL` if `redirect` is set to `true`.
+   * Default action for the `success` event: re-enable closing and, if
+   * requested, redirect the parent window to the `successURL`.
    */
-  private successListener(
-    event: CustomEvent<EmbedCheckoutMessageSuccess>,
-  ): void {
-    if (event.defaultPrevented) {
-      return
-    }
+  private handleSuccess(detail: EmbedCheckoutMessageSuccess): void {
     this.closable = true
-    if (event.detail.redirect) {
-      window.location.href = event.detail.successURL
+    if (detail.redirect) {
+      window.location.href = detail.successURL
     }
   }
 
   /**
    * Handle window message events from the embedded checkout iframe.
+   *
+   * Dispatches a cancelable `CustomEvent` to consumer listeners first, then
+   * runs the default action unless a listener called `event.preventDefault()`.
    */
   private handleWindowMessage({ data, origin }: MessageEvent): void {
     if (
@@ -392,9 +373,28 @@ class EmbedCheckout {
     if (!isEmbedCheckoutMessage(data)) {
       return
     }
-    this.eventTarget.dispatchEvent(
-      new CustomEvent(data.event, { detail: data, cancelable: true }),
-    )
+    const event = new CustomEvent(data.event, {
+      detail: data,
+      cancelable: true,
+    })
+    this.eventTarget.dispatchEvent(event)
+    if (event.defaultPrevented) {
+      return
+    }
+    switch (data.event) {
+      case 'loaded':
+        this.handleLoaded()
+        break
+      case 'close':
+        this.handleClose()
+        break
+      case 'confirmed':
+        this.handleConfirmed()
+        break
+      case 'success':
+        this.handleSuccess(data)
+        break
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- The embed checkout was registering its own default-behaviour handlers via `addEventListener` on the same `EventTarget` consumers use. Because `EventTarget` listeners fire in registration order and `event.defaultPrevented` is just a flag, calling `event.preventDefault()` from a consumer listener did not actually skip the default action — the internal listener ran and bailed out, but the order/coupling was fragile and broke depending on where the consumer's listener was attached relative to construction.
- Refactor so the message handler dispatches a single cancelable `CustomEvent` to consumer listeners, then runs the default action only if `event.defaultPrevented` is false. The default behaviours (`loaded` removes the loader, `close` removes the iframe, `confirmed` locks closing, `success` re-enables closing and redirects) are now plain methods, not registered listeners.
- Add tests covering `preventDefault()` for each of the four embed events.

## Test plan

- [x] `pnpm lint`
- [ ] Open an embed, attach `addEventListener('loaded', e => e.preventDefault())` and confirm the loader spinner stays on screen
- [ ] Same for `close` (iframe stays mounted), `confirmed` (closable not locked), and `success` (redirect skipped, closing stays locked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)