### PR TITLE
fix: show all organization members in backoffice v2 team section

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -583,7 +583,6 @@ async def get_organization_detail(
             UserOrganization.is_deleted.is_(False),
             User.is_deleted.is_(False),
         )
-        .limit(10)
     )
     members_result = await session.execute(members_stmt)
     members = list(members_result.scalars().unique().all())


### PR DESCRIPTION
Removes the hardcoded 10-member limit on the team section of the backoffice v2 organization detail view, so the full members list is rendered.