### PR TITLE
fix: do not reactivate denied orgs

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1217,7 +1217,7 @@ async def approve_denied_dialog(
             )
 
             # Approve the organization
-            await organization_service.confirm_organization_reviewed(
+            await organization_service.backoffice_approve(
                 session, organization, threshold, reason=override_reason
             )
 
@@ -1474,7 +1474,7 @@ async def unblock_approve_dialog(
             )
 
             # Approve the organization
-            await organization_service.confirm_organization_reviewed(
+            await organization_service.backoffice_approve(
                 session, organization, threshold, reason=override_reason
             )
 

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -14,7 +14,7 @@ from tagflow import tag, text
 
 from polar.models import Organization, PayoutAccount
 from polar.models.organization import (
-    FIRST_REVIEW_MAX_THRESHOLD_CENTS,
+    FIRST_REVIEW_THRESHOLD_CENTS,
     OrganizationStatus,
 )
 from polar.postgres import AsyncSession
@@ -31,7 +31,7 @@ from ...components import (
 from ..priority import Signals
 
 FIRST_REVIEW_THRESHOLD_LABEL = formatters.currency(
-    FIRST_REVIEW_MAX_THRESHOLD_CENTS, "usd"
+    FIRST_REVIEW_THRESHOLD_CENTS, "usd"
 )
 
 DeletedFilter = Literal["exclude", "include", "only"]

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -30,9 +30,7 @@ from ...components import (
 )
 from ..priority import Signals
 
-FIRST_REVIEW_THRESHOLD_LABEL = formatters.currency(
-    FIRST_REVIEW_THRESHOLD_CENTS, "usd"
-)
+FIRST_REVIEW_THRESHOLD_LABEL = formatters.currency(FIRST_REVIEW_THRESHOLD_CENTS, "usd")
 
 DeletedFilter = Literal["exclude", "include", "only"]
 

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -403,14 +403,11 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
     ),
 }
 
-# Upper bound (in cents) of `next_review_threshold` that qualifies an
-# organization as a "first review" alongside orgs still in their initial
-# review cycle (`initially_reviewed_at IS NULL`). Either condition is enough.
-FIRST_REVIEW_MAX_THRESHOLD_CENTS = 1000
-
-# Default `next_review_threshold` (in cents) used at organization creation
-# and as the fallback when reactivating from DENIED/BLOCKED.
-DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS = 1000
+# Default `next_review_threshold` (in cents). Used at organization creation,
+# as the fallback when reactivating from DENIED/BLOCKED, and as the upper
+# bound that qualifies an org as still being in its "first review" cycle
+# (alongside `initially_reviewed_at IS NULL` — either condition is enough).
+FIRST_REVIEW_THRESHOLD_CENTS = 1000
 
 
 class Organization(RateLimitGroupMixin, RecordModel):
@@ -473,7 +470,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
         default=OrganizationStatus.CREATED,
     )
     next_review_threshold: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS
+        Integer, nullable=False, default=FIRST_REVIEW_THRESHOLD_CENTS
     )
     status_updated_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
@@ -691,7 +688,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
     def is_first_review(self) -> bool:
         return self.status == OrganizationStatus.REVIEW and (
             self.initially_reviewed_at is None
-            or self.next_review_threshold <= FIRST_REVIEW_MAX_THRESHOLD_CENTS
+            or self.next_review_threshold <= FIRST_REVIEW_THRESHOLD_CENTS
         )
 
     @is_first_review.inplace.expression
@@ -701,7 +698,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
             cls.status == OrganizationStatus.REVIEW,
             or_(
                 cls.initially_reviewed_at.is_(None),
-                cls.next_review_threshold <= FIRST_REVIEW_MAX_THRESHOLD_CENTS,
+                cls.next_review_threshold <= FIRST_REVIEW_THRESHOLD_CENTS,
             ),
         )
 

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -408,6 +408,10 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
 # review cycle (`initially_reviewed_at IS NULL`). Either condition is enough.
 FIRST_REVIEW_MAX_THRESHOLD_CENTS = 1000
 
+# Default `next_review_threshold` (in cents) used at organization creation
+# and as the fallback when reactivating from DENIED/BLOCKED.
+DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS = 1000
+
 
 class Organization(RateLimitGroupMixin, RecordModel):
     __tablename__ = "organizations"
@@ -469,7 +473,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
         default=OrganizationStatus.CREATED,
     )
     next_review_threshold: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=1000
+        Integer, nullable=False, default=DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS
     )
     status_updated_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -852,17 +852,19 @@ class OrganizationService:
         session: AsyncSession,
         organization: Organization,
         next_review_threshold: int | None = None,
-        *,
-        reason: str | None = None,
     ) -> Organization:
-        reactivation_notes = {
-            OrganizationStatus.DENIED: "Organization reactivated from denied.",
-            OrganizationStatus.BLOCKED: "Organization unblocked.",
-        }
-        if organization.status in reactivation_notes and not reason:
+        """Confirm a REVIEW or SNOOZED organization and transition it to ACTIVE.
+
+        For DENIED/BLOCKED reactivation, use :meth:`backoffice_approve`. For
+        post-appeal-approval transitions, use :meth:`approve_appeal`.
+        """
+        if organization.status not in (
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+        ):
             raise OrganizationError(
-                "A reason is required when reactivating a "
-                f"{organization.status.get_display_name()} organization.",
+                "confirm_organization_reviewed requires REVIEW or SNOOZED "
+                f"status, got {organization.status.get_display_name()}.",
                 400,
             )
 
@@ -871,44 +873,8 @@ class OrganizationService:
                 organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
             )
 
-        previous_status = organization.status
-        reactivation_note = reactivation_notes.get(previous_status)
-
-        # Mark the appeal approved before the gate check so a later
-        # webhook-driven maybe_activate sees an approved review.
-        review_repository = OrganizationReviewRepository.from_session(session)
-        review = await review_repository.get_by_organization(organization.id)
-        if (
-            review
-            and review.appeal_submitted_at
-            and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
-        ):
-            review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
-            review.appeal_reviewed_at = datetime.now(UTC)
-            session.add(review)
-
-        # Reactivations require completed Stripe onboarding to go straight to
-        # ACTIVE; otherwise revert to CREATED and let the webhook-driven
-        # maybe_activate promote them once Stripe finishes.
-        target_status = OrganizationStatus.ACTIVE
-        if reactivation_note and not await self._is_activation_ready(
-            session, organization
-        ):
-            target_status = OrganizationStatus.CREATED
-
-        organization.set_status(target_status)
+        organization.set_status(OrganizationStatus.ACTIVE)
         organization.next_review_threshold = next_review_threshold
-
-        if reactivation_note:
-            suffix = (
-                " Status reverted to created — pending Stripe Identity and "
-                "Stripe Connect Express completion before activation."
-                if target_status == OrganizationStatus.CREATED
-                else ""
-            )
-            _append_internal_note(
-                organization, reactivation_note + suffix, reason=reason
-            )
 
         if organization.initially_reviewed_at is None:
             organization.initially_reviewed_at = datetime.now(UTC)
@@ -956,20 +922,19 @@ class OrganizationService:
 
         Gates:
           1. Status is CREATED.
-          2. Details submitted (details + details_submitted_at).
-          3. Review is approved: verdict PASS, or verdict FAIL with an
+          2. Review is approved: verdict PASS, or verdict FAIL with an
              APPROVED appeal.
-          4. Payout account is ready (see ``PayoutAccount.is_payout_ready``).
-          5. Payout account admin: identity verified.
+          3. Details submitted, payout account ready, admin identity
+             verified (see :meth:`_is_activation_ready`).
 
-        Idempotent — safe to call from multiple automated triggers (AI review,
-        Stripe ``account.updated``, identity verification). Returns True iff
-        the org was transitioned.
+        Idempotent — safe to call from automated triggers (AI review, Stripe
+        ``account.updated``, identity verification). Returns True iff the org
+        was transitioned.
 
-        REVIEW/SNOOZED orgs are handled by the review flow
-        (:meth:`handle_ongoing_review_verdict` or backoffice approval).
-        Re-activating a DENIED or BLOCKED organization is a manual,
-        backoffice-only operation — see :meth:`backoffice_approve`.
+        Re-activation from DENIED/BLOCKED is synchronous and explicit, via
+        :meth:`approve_appeal` (post-appeal-approval) or :meth:`backoffice_approve`
+        (admin override). Webhooks never transition out of DENIED — the org's
+        current status is the sole source of truth for what's authorized.
         """
         if organization.status != OrganizationStatus.CREATED:
             return False
@@ -982,19 +947,16 @@ class OrganizationService:
         if not await self._is_activation_ready(session, organization):
             return False
 
-        # On first activation keep the small default threshold so the next
-        # review fires quickly once the merchant starts taking payments.
-        # Reactivations fall back to confirm_organization_reviewed's doubling
-        # logic.
-        next_review_threshold: int | None = None
+        organization.set_status(OrganizationStatus.ACTIVE)
         if organization.initially_reviewed_at is None:
-            next_review_threshold = organization.next_review_threshold
-
-        await self.confirm_organization_reviewed(
-            session,
-            organization,
-            next_review_threshold=next_review_threshold,
-        )
+            # First activation: keep the small default threshold so the next
+            # review fires quickly once the merchant starts taking payments.
+            organization.initially_reviewed_at = datetime.now(UTC)
+        else:
+            organization.next_review_threshold = max(
+                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
+            )
+        session.add(organization)
         log.info(
             "organization.maybe_activate.activated",
             organization_id=str(organization.id),
@@ -1002,59 +964,103 @@ class OrganizationService:
         )
         return True
 
-    async def backoffice_approve(
-        self, session: AsyncSession, organization: Organization
-    ) -> bool:
-        """Backoffice-only re-activation of a DENIED or BLOCKED organization.
+    async def _reactivate_organization(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        *,
+        note: str,
+        reason: str | None,
+        next_review_threshold: int | None = None,
+    ) -> OrganizationStatus:
+        """Synchronously transition a DENIED/BLOCKED org to ACTIVE or CREATED.
 
-        Caller must have already verified the human authorization to
-        re-activate (e.g. an approved appeal). Returns True iff the org was
-        transitioned to ACTIVE.
+        Goes to ACTIVE if every onboarding gate passes; otherwise to CREATED so
+        the merchant can finish Stripe onboarding (a later :meth:`maybe_activate`
+        then promotes them to ACTIVE).
         """
-        if organization.status not in (
-            OrganizationStatus.DENIED,
-            OrganizationStatus.BLOCKED,
-        ):
-            return False
+        if next_review_threshold is None:
+            next_review_threshold = max(
+                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
+            )
+
+        is_ready = await self._is_activation_ready(session, organization)
+        target_status = (
+            OrganizationStatus.ACTIVE if is_ready else OrganizationStatus.CREATED
+        )
+
+        full_note = note
+        if not is_ready:
+            full_note += (
+                " Status reverted to created — pending Stripe Identity and "
+                "Stripe Connect Express completion before activation."
+            )
+
+        organization.set_status(target_status)
+        organization.next_review_threshold = next_review_threshold
+        _append_internal_note(organization, full_note, reason=reason)
+
+        if organization.initially_reviewed_at is None:
+            organization.initially_reviewed_at = datetime.now(UTC)
+
+        session.add(organization)
+        return target_status
+
+    async def backoffice_approve(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        next_review_threshold: int | None = None,
+        *,
+        reason: str,
+    ) -> Organization:
+        """Backoffice override to re-activate a DENIED or BLOCKED organization.
+
+        Use for support-contact escalations where an admin overrides a denial
+        without going through the appeal flow (or after the AI auto-rejected
+        an appeal). Synchronously transitions to ACTIVE if onboarding is
+        complete, otherwise to CREATED.
+
+        If a review with a submitted appeal exists, the appeal is recorded as
+        APPROVED so the merchant's frontend reflects the approval.
+        """
+        notes = {
+            OrganizationStatus.DENIED: "Organization reactivated from denied.",
+            OrganizationStatus.BLOCKED: "Organization unblocked.",
+        }
+        if organization.status not in notes:
+            raise OrganizationError(
+                "backoffice_approve requires DENIED or BLOCKED status, got "
+                f"{organization.status.get_display_name()}.",
+                400,
+            )
 
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
-        if review is None or not review.is_approved:
-            return False
+        if (
+            review
+            and review.appeal_submitted_at
+            and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
+        ):
+            review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
+            review.appeal_reviewed_at = datetime.now(UTC)
+            session.add(review)
 
-        if not await self._is_activation_ready(session, organization):
-            organization.set_status(OrganizationStatus.CREATED)
-            _append_internal_note(
-                organization,
-                "Appeal approved — reverted to created pending Stripe "
-                "Identity and Stripe Connect Express completion.",
-                reason=review.appeal_reason or "Appeal approved",
-            )
-            session.add(organization)
-            log.info(
-                "organization.backoffice_approve.reverted_to_created",
-                organization_id=str(organization.id),
-                slug=organization.slug,
-            )
-            return False
-
-        reason = review.appeal_reason or "Appeal approved"
-        next_review_threshold: int | None = None
-        if organization.initially_reviewed_at is None:
-            next_review_threshold = organization.next_review_threshold
-
-        await self.confirm_organization_reviewed(
+        target_status = await self._reactivate_organization(
             session,
             organization,
-            next_review_threshold=next_review_threshold,
+            note=notes[organization.status],
             reason=reason,
+            next_review_threshold=next_review_threshold,
         )
         log.info(
-            "organization.backoffice_approve.activated",
+            "organization.backoffice_approve.activated"
+            if target_status == OrganizationStatus.ACTIVE
+            else "organization.backoffice_approve.reverted_to_created",
             organization_id=str(organization.id),
             slug=organization.slug,
         )
-        return True
+        return organization
 
     async def handle_ongoing_review_verdict(
         self,
@@ -1447,14 +1453,12 @@ class OrganizationService:
     async def approve_appeal(
         self, session: AsyncSession, organization: Organization
     ) -> OrganizationReview:
-        """Approve an organization's appeal.
+        """Approve an appeal and synchronously transition the organization.
 
-        Recording the approval flips the review's ``appeal_decision`` and then
-        delegates to :meth:`backoffice_approve` — which runs the remaining
-        gates (payout account ready, admin identity verified) before
-        transitioning DENIED → ACTIVE. If a gate is still missing the org is
-        moved to CREATED so the merchant can finish Stripe onboarding; a later
-        webhook-triggered :meth:`maybe_activate` then promotes it to ACTIVE.
+        Sets ``review.appeal_decision = APPROVED`` and immediately moves the
+        org out of DENIED — to ACTIVE if every onboarding gate passes,
+        otherwise to CREATED so the merchant can finish Stripe onboarding. A
+        later :meth:`maybe_activate` then promotes a CREATED org to ACTIVE.
         """
 
         repository = OrganizationReviewRepository.from_session(session)
@@ -1473,7 +1477,20 @@ class OrganizationService:
         review.appeal_reviewed_at = datetime.now(UTC)
         session.add(review)
 
-        await self.backoffice_approve(session, organization)
+        if organization.status == OrganizationStatus.DENIED:
+            target_status = await self._reactivate_organization(
+                session,
+                organization,
+                note="Appeal approved.",
+                reason=review.appeal_reason,
+            )
+            log.info(
+                "organization.approve_appeal.activated"
+                if target_status == OrganizationStatus.ACTIVE
+                else "organization.approve_appeal.reverted_to_created",
+                organization_id=str(organization.id),
+                slug=organization.slug,
+            )
 
         return review
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -952,27 +952,27 @@ class OrganizationService:
     async def maybe_activate(
         self, session: AsyncSession, organization: Organization
     ) -> bool:
-        """Transition → ACTIVE only when every onboarding gate passes.
+        """Transition CREATED/REVIEW/SNOOZED → ACTIVE when every gate passes.
 
         Gates:
-          1. Status can currently transition to ACTIVE (not already ACTIVE,
-             not OFFBOARDING).
+          1. Status is CREATED, REVIEW, or SNOOZED.
           2. Details submitted (details + details_submitted_at).
           3. Review is approved: verdict PASS, or verdict FAIL with an
              APPROVED appeal.
           4. Payout account is ready (see ``PayoutAccount.is_payout_ready``).
           5. Payout account admin: identity verified.
 
-        Idempotent — safe to call from multiple triggers (AI review, Stripe
-        account.updated, identity verification, appeal approval). Returns True
-        iff the org was transitioned.
+        Idempotent — safe to call from multiple automated triggers (AI review,
+        Stripe ``account.updated``, identity verification). Returns True iff
+        the org was transitioned.
+
+        Re-activating a DENIED or BLOCKED organization is a manual,
+        backoffice-only operation — see :meth:`backoffice_approve`.
         """
         if organization.status not in (
             OrganizationStatus.CREATED,
             OrganizationStatus.REVIEW,
             OrganizationStatus.SNOOZED,
-            OrganizationStatus.DENIED,
-            OrganizationStatus.BLOCKED,
         ):
             return False
 
@@ -981,41 +981,8 @@ class OrganizationService:
         if review is None or not review.is_approved:
             return False
 
-        # An admin's manual deny/block must stick even if the AI verdict was PASS,
-        # so re-activation from these states requires an explicitly approved appeal.
-        if (
-            organization.status
-            in (OrganizationStatus.DENIED, OrganizationStatus.BLOCKED)
-            and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
-        ):
-            return False
-
         if not await self._is_activation_ready(session, organization):
-            if organization.status in (
-                OrganizationStatus.DENIED,
-                OrganizationStatus.BLOCKED,
-            ):
-                organization.set_status(OrganizationStatus.CREATED)
-                _append_internal_note(
-                    organization,
-                    "Appeal approved — reverted to created pending Stripe "
-                    "Identity and Stripe Connect Express completion.",
-                    reason=review.appeal_reason or "Appeal approved",
-                )
-                session.add(organization)
-                log.info(
-                    "organization.maybe_activate.reverted_to_created",
-                    organization_id=str(organization.id),
-                    slug=organization.slug,
-                )
             return False
-
-        reason: str | None = None
-        if organization.status in (
-            OrganizationStatus.DENIED,
-            OrganizationStatus.BLOCKED,
-        ):
-            reason = review.appeal_reason or "Appeal approved"
 
         # On first activation keep the small default threshold so the next
         # review fires quickly once the merchant starts taking payments.
@@ -1029,10 +996,68 @@ class OrganizationService:
             session,
             organization,
             next_review_threshold=next_review_threshold,
-            reason=reason,
         )
         log.info(
             "organization.maybe_activate.activated",
+            organization_id=str(organization.id),
+            slug=organization.slug,
+        )
+        return True
+
+    async def backoffice_approve(
+        self, session: AsyncSession, organization: Organization
+    ) -> bool:
+        """Backoffice-only re-activation of a DENIED or BLOCKED organization.
+
+        Goes straight to ACTIVE if every onboarding gate passes; otherwise
+        moves the org to CREATED so the merchant can finish Stripe Identity
+        and Stripe Connect Express, after which a webhook-driven
+        :meth:`maybe_activate` promotes them to ACTIVE.
+
+        Caller must have already verified the human authorization to
+        re-activate (e.g. an approved appeal). Returns True iff the org was
+        transitioned to ACTIVE.
+        """
+        if organization.status not in (
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+        ):
+            return False
+
+        review_repository = OrganizationReviewRepository.from_session(session)
+        review = await review_repository.get_by_organization(organization.id)
+        if review is None or not review.is_approved:
+            return False
+
+        if not await self._is_activation_ready(session, organization):
+            organization.set_status(OrganizationStatus.CREATED)
+            _append_internal_note(
+                organization,
+                "Appeal approved — reverted to created pending Stripe "
+                "Identity and Stripe Connect Express completion.",
+                reason=review.appeal_reason or "Appeal approved",
+            )
+            session.add(organization)
+            log.info(
+                "organization.backoffice_approve.reverted_to_created",
+                organization_id=str(organization.id),
+                slug=organization.slug,
+            )
+            return False
+
+        reason = review.appeal_reason or "Appeal approved"
+        next_review_threshold: int | None = None
+        if organization.initially_reviewed_at is None:
+            next_review_threshold = organization.next_review_threshold
+
+        await self.confirm_organization_reviewed(
+            session,
+            organization,
+            next_review_threshold=next_review_threshold,
+            reason=reason,
+        )
+        log.info(
+            "organization.backoffice_approve.activated",
             organization_id=str(organization.id),
             slug=organization.slug,
         )
@@ -1432,11 +1457,11 @@ class OrganizationService:
         """Approve an organization's appeal.
 
         Recording the approval flips the review's ``appeal_decision`` and then
-        delegates to :meth:`maybe_activate` — which runs the remaining gates
-        (payout account ready, admin identity verified) before transitioning
-        DENIED → ACTIVE. If a gate is still missing the org is moved to
-        CREATED so the merchant can finish Stripe onboarding; a later
-        webhook-triggered ``maybe_activate`` then promotes it to ACTIVE.
+        delegates to :meth:`backoffice_approve` — which runs the remaining
+        gates (payout account ready, admin identity verified) before
+        transitioning DENIED → ACTIVE. If a gate is still missing the org is
+        moved to CREATED so the merchant can finish Stripe onboarding; a later
+        webhook-triggered :meth:`maybe_activate` then promotes it to ACTIVE.
         """
 
         repository = OrganizationReviewRepository.from_session(session)
@@ -1455,7 +1480,7 @@ class OrganizationService:
         review.appeal_reviewed_at = datetime.now(UTC)
         session.add(review)
 
-        await self.maybe_activate(session, organization)
+        await self.backoffice_approve(session, organization)
 
         return review
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -39,7 +39,7 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.organization import (
-    DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS,
+    FIRST_REVIEW_THRESHOLD_CENTS,
     STATUS_CAPABILITIES,
     CapabilityName,
     OrganizationCapabilities,
@@ -981,7 +981,7 @@ class OrganizationService:
         then promotes them to ACTIVE).
         """
         if next_review_threshold is None:
-            next_review_threshold = DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS
+            next_review_threshold = FIRST_REVIEW_THRESHOLD_CENTS
 
         is_ready = await self._is_activation_ready(session, organization)
         target_status = (

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -981,6 +981,15 @@ class OrganizationService:
         if review is None or not review.is_approved:
             return False
 
+        # An admin's manual deny/block must stick even if the AI verdict was PASS,
+        # so re-activation from these states requires an explicitly approved appeal.
+        if (
+            organization.status
+            in (OrganizationStatus.DENIED, OrganizationStatus.BLOCKED)
+            and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
+        ):
+            return False
+
         if not await self._is_activation_ready(session, organization):
             if organization.status in (
                 OrganizationStatus.DENIED,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -952,10 +952,10 @@ class OrganizationService:
     async def maybe_activate(
         self, session: AsyncSession, organization: Organization
     ) -> bool:
-        """Transition CREATED/REVIEW/SNOOZED → ACTIVE when every gate passes.
+        """Transition CREATED → ACTIVE when every onboarding gate passes.
 
         Gates:
-          1. Status is CREATED, REVIEW, or SNOOZED.
+          1. Status is CREATED.
           2. Details submitted (details + details_submitted_at).
           3. Review is approved: verdict PASS, or verdict FAIL with an
              APPROVED appeal.
@@ -966,14 +966,12 @@ class OrganizationService:
         Stripe ``account.updated``, identity verification). Returns True iff
         the org was transitioned.
 
+        REVIEW/SNOOZED orgs are handled by the review flow
+        (:meth:`handle_ongoing_review_verdict` or backoffice approval).
         Re-activating a DENIED or BLOCKED organization is a manual,
         backoffice-only operation — see :meth:`backoffice_approve`.
         """
-        if organization.status not in (
-            OrganizationStatus.CREATED,
-            OrganizationStatus.REVIEW,
-            OrganizationStatus.SNOOZED,
-        ):
+        if organization.status != OrganizationStatus.CREATED:
             return False
 
         review_repository = OrganizationReviewRepository.from_session(session)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1007,11 +1007,6 @@ class OrganizationService:
     ) -> bool:
         """Backoffice-only re-activation of a DENIED or BLOCKED organization.
 
-        Goes straight to ACTIVE if every onboarding gate passes; otherwise
-        moves the org to CREATED so the merchant can finish Stripe Identity
-        and Stripe Connect Express, after which a webhook-driven
-        :meth:`maybe_activate` promotes them to ACTIVE.
-
         Caller must have already verified the human authorization to
         re-activate (e.g. an approved appeal). Returns True iff the org was
         transitioned to ACTIVE.

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -39,6 +39,7 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.organization import (
+    DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS,
     STATUS_CAPABILITIES,
     CapabilityName,
     OrganizationCapabilities,
@@ -855,8 +856,8 @@ class OrganizationService:
     ) -> Organization:
         """Confirm a REVIEW or SNOOZED organization and transition it to ACTIVE.
 
-        For DENIED/BLOCKED reactivation, use :meth:`backoffice_approve`. For
-        post-appeal-approval transitions, use :meth:`approve_appeal`.
+        For DENIED/BLOCKED reactivation, use `backoffice_approve`. For
+        post-appeal-approval transitions, use `approve_appeal`.
         """
         if organization.status not in (
             OrganizationStatus.REVIEW,
@@ -888,7 +889,7 @@ class OrganizationService:
     ) -> bool:
         """Whether onboarding gates (details, payout account, KYC) are met.
 
-        Mirrors the non-review gates checked by :meth:`maybe_activate` so the
+        Mirrors the non-review gates checked by `maybe_activate` so the
         backoffice approval path can decide whether a reactivation should go
         straight to ACTIVE or revert to CREATED to finish onboarding.
         """
@@ -925,14 +926,14 @@ class OrganizationService:
           2. Review is approved: verdict PASS, or verdict FAIL with an
              APPROVED appeal.
           3. Details submitted, payout account ready, admin identity
-             verified (see :meth:`_is_activation_ready`).
+             verified (see `_is_activation_ready`).
 
         Idempotent — safe to call from automated triggers (AI review, Stripe
         ``account.updated``, identity verification). Returns True iff the org
         was transitioned.
 
         Re-activation from DENIED/BLOCKED is synchronous and explicit, via
-        :meth:`approve_appeal` (post-appeal-approval) or :meth:`backoffice_approve`
+        `approve_appeal` (post-appeal-approval) or `backoffice_approve`
         (admin override). Webhooks never transition out of DENIED — the org's
         current status is the sole source of truth for what's authorized.
         """
@@ -976,13 +977,11 @@ class OrganizationService:
         """Synchronously transition a DENIED/BLOCKED org to ACTIVE or CREATED.
 
         Goes to ACTIVE if every onboarding gate passes; otherwise to CREATED so
-        the merchant can finish Stripe onboarding (a later :meth:`maybe_activate`
+        the merchant can finish Stripe onboarding (a later `maybe_activate`
         then promotes them to ACTIVE).
         """
         if next_review_threshold is None:
-            next_review_threshold = max(
-                organization.next_review_threshold * 2, _MIN_REVIEW_THRESHOLD
-            )
+            next_review_threshold = DEFAULT_NEXT_REVIEW_THRESHOLD_CENTS
 
         is_ready = await self._is_activation_ready(session, organization)
         target_status = (
@@ -1458,7 +1457,7 @@ class OrganizationService:
         Sets ``review.appeal_decision = APPROVED`` and immediately moves the
         org out of DENIED — to ACTIVE if every onboarding gate passes,
         otherwise to CREATED so the merchant can finish Stripe onboarding. A
-        later :meth:`maybe_activate` then promotes a CREATED org to ACTIVE.
+        later `maybe_activate` then promotes a CREATED org to ACTIVE.
         """
 
         repository = OrganizationReviewRepository.from_session(session)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1086,16 +1086,21 @@ class TestDenyOrganization:
 class TestMaybeActivate:
     @pytest.mark.parametrize(
         "status",
-        [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],
+        [
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+        ],
     )
-    async def test_does_not_transition_from_denied_or_blocked(
+    async def test_only_transitions_from_created(
         self,
         session: AsyncSession,
         organization: Organization,
         status: OrganizationStatus,
     ) -> None:
-        """Re-activating a DENIED/BLOCKED org is a backoffice-only operation;
-        automated triggers (webhooks, etc.) must leave the status alone."""
+        """maybe_activate only handles CREATED → ACTIVE. REVIEW/SNOOZED go
+        through the review flow; DENIED/BLOCKED require backoffice_approve."""
         organization.status = status
 
         review = OrganizationReview(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1084,14 +1084,19 @@ class TestDenyOrganization:
 
 @pytest.mark.asyncio
 class TestMaybeActivate:
-    async def test_does_not_revert_admin_denied_org_with_pass_verdict(
+    @pytest.mark.parametrize(
+        "status",
+        [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],
+    )
+    async def test_does_not_transition_from_denied_or_blocked(
         self,
         session: AsyncSession,
         organization: Organization,
+        status: OrganizationStatus,
     ) -> None:
-        """Admin denial must stick even if the AI verdict was PASS and a
-        downstream trigger (e.g. Stripe webhook) calls maybe_activate."""
-        organization.status = OrganizationStatus.DENIED
+        """Re-activating a DENIED/BLOCKED org is a backoffice-only operation;
+        automated triggers (webhooks, etc.) must leave the status alone."""
+        organization.status = status
 
         review = OrganizationReview(
             organization_id=organization.id,
@@ -1107,9 +1112,24 @@ class TestMaybeActivate:
         result = await organization_service.maybe_activate(session, organization)
 
         assert result is False
-        assert organization.status == OrganizationStatus.DENIED
+        assert organization.status == status
 
-    async def test_reverts_to_created_on_approved_appeal_when_not_ready(
+
+@pytest.mark.asyncio
+class TestBackofficeApprove:
+    async def test_noop_when_not_denied_or_blocked(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+
+        result = await organization_service.backoffice_approve(session, organization)
+
+        assert result is False
+        assert organization.status == OrganizationStatus.REVIEW
+
+    async def test_reverts_to_created_when_not_activation_ready(
         self,
         session: AsyncSession,
         organization: Organization,
@@ -1131,7 +1151,7 @@ class TestMaybeActivate:
         session.add(review)
         await session.flush()
 
-        result = await organization_service.maybe_activate(session, organization)
+        result = await organization_service.backoffice_approve(session, organization)
 
         assert result is False
         assert organization.status == OrganizationStatus.CREATED

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1099,8 +1099,6 @@ class TestMaybeActivate:
         organization: Organization,
         status: OrganizationStatus,
     ) -> None:
-        """maybe_activate only handles CREATED → ACTIVE. REVIEW/SNOOZED go
-        through the review flow; DENIED/BLOCKED require backoffice_approve."""
         organization.status = status
 
         review = OrganizationReview(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1083,6 +1083,61 @@ class TestDenyOrganization:
 
 
 @pytest.mark.asyncio
+class TestMaybeActivate:
+    async def test_does_not_revert_admin_denied_org_with_pass_verdict(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Admin denial must stick even if the AI verdict was PASS and a
+        downstream trigger (e.g. Stripe webhook) calls maybe_activate."""
+        organization.status = OrganizationStatus.DENIED
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.PASS,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="Clean",
+            model_used="test",
+        )
+        session.add(review)
+        await session.flush()
+
+        result = await organization_service.maybe_activate(session, organization)
+
+        assert result is False
+        assert organization.status == OrganizationStatus.DENIED
+
+    async def test_reverts_to_created_on_approved_appeal_when_not_ready(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=80.0,
+            violated_sections=["tos"],
+            reason="Violation",
+            model_used="test",
+            appeal_submitted_at=datetime(2025, 2, 1, tzinfo=UTC),
+            appeal_reason="Please reconsider",
+            appeal_decision=OrganizationReview.AppealDecision.APPROVED,
+            appeal_reviewed_at=datetime(2025, 2, 2, tzinfo=UTC),
+        )
+        session.add(review)
+        await session.flush()
+
+        result = await organization_service.maybe_activate(session, organization)
+
+        assert result is False
+        assert organization.status == OrganizationStatus.CREATED
+
+
+@pytest.mark.asyncio
 class TestSetOrganizationUnderReview:
     async def test_set_organization_under_review(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -899,40 +899,17 @@ class TestConfirmOrganizationReviewed:
         assert result.initially_reviewed_at == initially_reviewed_at
         assert result.next_review_threshold == 15000
 
-    async def test_overrides_rejected_appeal(
+    async def test_rejects_non_review_status(
         self,
-        mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
         organization.status = OrganizationStatus.DENIED
-        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
 
-        review = OrganizationReview(
-            organization_id=organization.id,
-            verdict=OrganizationReview.Verdict.FAIL,
-            risk_score=80.0,
-            violated_sections=["tos"],
-            reason="Violation",
-            model_used="test",
-            appeal_submitted_at=datetime(2025, 2, 1, tzinfo=UTC),
-            appeal_reason="Please reconsider",
-            appeal_decision=OrganizationReview.AppealDecision.REJECTED,
-            appeal_reviewed_at=datetime(2025, 2, 2, tzinfo=UTC),
-        )
-        session.add(review)
-        await session.flush()
-
-        mocker.patch("polar.organization.service.enqueue_job")
-
-        # When: operator manually approves the org with a reason
-        result = await organization_service.confirm_organization_reviewed(
-            session, organization, 15000, reason="Appeal re-examined"
-        )
-
-        assert result.status == OrganizationStatus.CREATED
-        assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
-        assert review.appeal_reviewed_at is not None
+        with pytest.raises(OrganizationError, match="REVIEW or SNOOZED"):
+            await organization_service.confirm_organization_reviewed(
+                session, organization, 15000
+            )
 
 
 @pytest.mark.asyncio
@@ -1117,28 +1094,17 @@ class TestMaybeActivate:
         assert result is False
         assert organization.status == status
 
-
-@pytest.mark.asyncio
-class TestBackofficeApprove:
-    async def test_noop_when_not_denied_or_blocked(
+    async def test_does_not_undo_admin_redeny_after_appeal_approval(
         self,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        organization.status = OrganizationStatus.REVIEW
+        """Edge case: appeal approved → admin re-denies → Stripe webhook fires.
 
-        result = await organization_service.backoffice_approve(session, organization)
-
-        assert result is False
-        assert organization.status == OrganizationStatus.REVIEW
-
-    async def test_reverts_to_created_when_not_activation_ready(
-        self,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
+        The webhook must not undo the admin's deny, even though the appeal is
+        still marked APPROVED on the review record.
+        """
         organization.status = OrganizationStatus.DENIED
-
         review = OrganizationReview(
             organization_id=organization.id,
             verdict=OrganizationReview.Verdict.FAIL,
@@ -1154,10 +1120,71 @@ class TestBackofficeApprove:
         session.add(review)
         await session.flush()
 
-        result = await organization_service.backoffice_approve(session, organization)
+        result = await organization_service.maybe_activate(session, organization)
 
         assert result is False
+        assert organization.status == OrganizationStatus.DENIED
+
+
+@pytest.mark.asyncio
+class TestBackofficeApprove:
+    async def test_rejects_non_denied_or_blocked(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+
+        with pytest.raises(OrganizationError, match="DENIED or BLOCKED"):
+            await organization_service.backoffice_approve(
+                session, organization, reason="Test"
+            )
+
+    async def test_reverts_to_created_when_not_activation_ready(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+
+        await organization_service.backoffice_approve(
+            session, organization, reason="Support escalation"
+        )
+
         assert organization.status == OrganizationStatus.CREATED
+
+    async def test_overrides_rejected_appeal(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Support-contact escalation: AI rejected the appeal, admin overrides."""
+        organization.status = OrganizationStatus.DENIED
+        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=80.0,
+            violated_sections=["tos"],
+            reason="Violation",
+            model_used="test",
+            appeal_submitted_at=datetime(2025, 2, 1, tzinfo=UTC),
+            appeal_reason="Please reconsider",
+            appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+            appeal_reviewed_at=datetime(2025, 2, 2, tzinfo=UTC),
+        )
+        session.add(review)
+        await session.flush()
+
+        await organization_service.backoffice_approve(
+            session, organization, 15000, reason="Appeal re-examined"
+        )
+
+        assert organization.status == OrganizationStatus.CREATED
+        assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
+        assert review.appeal_reviewed_at is not None
+        assert organization.next_review_threshold == 15000
 
 
 @pytest.mark.asyncio
@@ -2992,25 +3019,6 @@ class TestStatusTransitions:
             organization.set_status(OrganizationStatus.OFFBOARDING)
 
     @pytest.mark.parametrize(
-        "current",
-        [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],
-    )
-    async def test_reactivation_requires_reason(
-        self,
-        current: OrganizationStatus,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = current
-        mocker.patch("polar.organization.service.enqueue_job")
-
-        with pytest.raises(OrganizationError):
-            await organization_service.confirm_organization_reviewed(
-                session, organization, 15000
-            )
-
-    @pytest.mark.parametrize(
         ("current", "expected_note_fragment"),
         [
             (OrganizationStatus.DENIED, "reactivated from denied"),
@@ -3029,7 +3037,7 @@ class TestStatusTransitions:
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         mocker.patch("polar.organization.service.enqueue_job")
 
-        result = await organization_service.confirm_organization_reviewed(
+        result = await organization_service.backoffice_approve(
             session, organization, 15000, reason="Merchant provided additional docs"
         )
 
@@ -3065,7 +3073,7 @@ class TestStatusTransitions:
 
         mocker.patch("polar.organization.service.enqueue_job")
 
-        result = await organization_service.confirm_organization_reviewed(
+        result = await organization_service.backoffice_approve(
             session, organization, 15000, reason="Merchant provided additional docs"
         )
 


### PR DESCRIPTION
## Summary

When the org was denied and the Stripe account send updates, the org was enabled again. I denied those orgs manually.

The problem was that `maybe_activate` and `confirm_organization_reviewed ` was too broad and called from different places, now I split the intent actions in the backoffice so it's much clear on the flow and we avoid having this errors.