### PR TITLE
Document customer IP address handling for checkout sessions

### DIFF
--- a/docs/features/checkout/session.mdx
+++ b/docs/features/checkout/session.mdx
@@ -112,6 +112,49 @@ Quite often, you'll have your own users management system in your application, w
 
 After a successful checkout, we'll create a Customer on Polar with the external ID you provided. It'll be provided through the `customer.external_id` property in webhooks you may have configured.
 
+## Customer IP address
+
+When you create a checkout session, Polar uses the IP address of the request to detect the customer's country. This drives features like:
+
+- **Currency auto-detection** for [products with multiple payment currencies](/features/products)
+- **Tax computation** based on the customer's location
+- **Pre-filling the billing country** on the checkout page
+
+If you create checkout sessions directly from the customer's browser, this works automatically. But if you create them from a **backend, proxy, or edge function** (e.g. your own API, a Cloudflare Worker, a Next.js route handler), Polar will see *your server's* IP — not the customer's — and the detection will be wrong.
+
+In that case, forward the customer's IP address as `customer_ip_address` in the request body:
+
+<CodeGroup>
+```ts TypeScript
+import { Polar } from "@polar-sh/sdk";
+
+const polar = new Polar({
+  accessToken: process.env["POLAR_ACCESS_TOKEN"] ?? "",
+});
+
+const checkout = await polar.checkouts.create({
+  products: ["productId"],
+  customerIpAddress: request.headers.get("CF-Connecting-IP") ?? undefined,
+});
+```
+
+```py Python
+from polar_sdk import Polar
+
+with Polar(access_token="<YOUR_BEARER_TOKEN_HERE>") as polar:
+    checkout = polar.checkouts.create(request={
+        "products": ["<product_id>"],
+        "customer_ip_address": request.client.host,
+    })
+```
+</CodeGroup>
+
+The exact way to read the connecting IP depends on your runtime — for example, `CF-Connecting-IP` on Cloudflare Workers, `x-forwarded-for` behind most proxies, or `request.client.host` in FastAPI.
+
+<Note>
+  When `customer_ip_address` is provided, you don't need to set `customer_billing_address.country` yourself — Polar will derive both the country and the currency from the IP.
+</Note>
+
 ## SDK examples
 
 Using our SDK, creating a checkout session is quite straightforward.

--- a/docs/features/checkout/session.mdx
+++ b/docs/features/checkout/session.mdx
@@ -117,10 +117,9 @@ After a successful checkout, we'll create a Customer on Polar with the external 
 When you create a checkout session, Polar uses the IP address of the request to detect the customer's country. This drives features like:
 
 - **Currency auto-detection** for [products with multiple payment currencies](/features/products)
-- **Tax computation** based on the customer's location
-- **Pre-filling the billing country** on the checkout page
+- **Pre-filling the billing country** on the checkout page, which is also used to compute taxes
 
-If you create checkout sessions directly from the customer's browser, this works automatically. But if you create them from a **backend, proxy, or edge function** (e.g. your own API, a Cloudflare Worker, a Next.js route handler), Polar will see *your server's* IP — not the customer's — and the detection will be wrong.
+If you use [checkout links](/features/checkout/links), this works automatically. But if you create sessions through the API from a **backend, proxy, or edge function** (e.g. your own API, a Cloudflare Worker, a Next.js route handler), Polar will see *your server's* IP — not the customer's — and the detection will be wrong.
 
 In that case, forward the customer's IP address as `customer_ip_address` in the request body:
 

--- a/docs/features/products.mdx
+++ b/docs/features/products.mdx
@@ -57,6 +57,12 @@ Determine how you want to charge your customers for this product.
 
     When enabled, customers will see prices in their preferred currency during checkout. Polar automatically determines the best currency for each customer based on their geographical location. If the detected currency is available for the product, it will be used. Otherwise, the system falls back to your organization's default payment currency.
 
+    <Warning>
+      **Creating checkout sessions from a backend or proxy?** Polar detects the customer's geolocation from the IP address of the request that creates the checkout session. If you create sessions server-side (e.g. from your API, a Cloudflare Worker, or any backend), Polar will see *your server's* IP — not the customer's — and may pick the wrong currency.
+
+      To fix this, forward the customer's IP address as [`customer_ip_address`](/features/checkout/session#customer-ip-address) when creating the checkout session.
+    </Warning>
+
     <Accordion title="Available Payment Currencies">
 
     The following currencies are currently supported for multiple payment currencies:


### PR DESCRIPTION
## Summary

Adds documentation about the `customer_ip_address` parameter for checkout sessions and its importance for accurate currency and country detection.

## What

Added a new "Customer IP address" section to the checkout session documentation that explains:
- How Polar uses the request IP address to detect customer location for currency auto-detection and tax computation
- Why this matters when creating sessions from a backend/proxy/edge function
- How to forward the customer's IP address using the `customer_ip_address` parameter with code examples in TypeScript and Python
- A warning in the products documentation linking to this new section

## Why

When checkout sessions are created server-side (from a backend API, Cloudflare Worker, Next.js route handler, etc.), Polar sees the server's IP address instead of the customer's, causing incorrect currency and country detection. This documentation helps developers understand the issue and provides clear guidance on how to fix it by forwarding the customer's IP address.

## How

- Added comprehensive documentation section with explanation of the problem and solution
- Provided practical code examples showing how to extract and forward the customer IP in different contexts (Cloudflare Workers, FastAPI, etc.)
- Added a cross-reference warning in the products documentation to guide users who enable multi-currency payments
- Included a note clarifying that when `customer_ip_address` is provided, developers don't need to manually set the billing country

## Checklist

- [x] This PR addresses a single concern (documentation for IP address handling)
- [x] The diff is reasonably sized and easy to review
- [x] No code changes requiring tests
- [x] Documentation only change

https://claude.ai/code/session_01JuG2L9QdWrAj7jRyVSN2qP