### PR TITLE
subscriptions: Re-anchor on trial conversion

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -712,6 +712,8 @@ class SubscriptionService:
             if update_cycle_dates and not pending_update_changed_interval:
                 current_period_end = subscription.current_period_end
                 subscription.current_period_start = current_period_end
+                if previous_status == SubscriptionStatus.trialing:
+                    subscription.anchor_day = current_period_end.day
                 subscription.current_period_end = (
                     subscription.recurring_interval.get_next_period(
                         current_period_end,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1314,6 +1314,38 @@ class TestCycle:
 
         enqueue_email_mock.assert_not_called()
 
+    @freeze_time("2024-04-28 12:00:00")
+    async def test_trial_end_rebases_anchor_to_trial_end_day(
+        self,
+        session: AsyncSession,
+        enqueue_job_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=7,
+            scheduler_locked_at=utc_now(),
+        )
+        assert subscription.anchor_day == 28
+        assert subscription.trial_start == datetime(2024, 4, 28, 12, 0, 0, tzinfo=UTC)
+        assert subscription.trial_end == datetime(2024, 5, 5, 12, 0, 0, tzinfo=UTC)
+        assert subscription.current_period_end == subscription.trial_end
+
+        updated_subscription = await subscription_service.cycle(session, subscription)
+
+        assert updated_subscription.status == SubscriptionStatus.active
+        assert updated_subscription.anchor_day == 5
+        assert updated_subscription.current_period_start == subscription.trial_end
+        assert updated_subscription.current_period_end == datetime(
+            2024, 6, 5, 12, 0, 0, tzinfo=UTC
+        )
+
     async def test_trial_end_with_once_discount(
         self,
         session: AsyncSession,


### PR DESCRIPTION
Fix #11450

Before 323a537a4, we used return d + relativedelta(months=leap) in get_next_period. After it we introduced the anchor_day to get the correct date to snap to. However for trials this meant that we went too far into the future.

E.g. on trial_start (subscription anchor day) 2024-04-28, with a 7 day trial we converted the trial on 2024-05-05. The get_next_period would then return 2024-06-28, making the first period 1 month + 23 days, instead of 1 month.

This change resets the anchor day to the trial conversion day, which is the same as the behaviour as it was before the anchor day was introduced. With the addition that it will stay the same (i.e. if the anchor day is 31 it will stay 31).
