### PR TITLE
Try to download OTA updates on boot

### DIFF
--- a/clients/apps/app/app.config.js
+++ b/clients/apps/app/app.config.js
@@ -113,6 +113,8 @@ module.exports = {
     },
     updates: {
       url: 'https://u.expo.dev/0c79977b-c070-4416-8878-d8b8febe2e25',
+      checkAutomatically: 'ON_LOAD',
+      fallbackToCacheTimeout: 15000,
     },
   },
 }

--- a/clients/apps/app/app.config.js
+++ b/clients/apps/app/app.config.js
@@ -114,7 +114,7 @@ module.exports = {
     updates: {
       url: 'https://u.expo.dev/0c79977b-c070-4416-8878-d8b8febe2e25',
       checkAutomatically: 'ON_LOAD',
-      fallbackToCacheTimeout: 15000,
+      fallbackToCacheTimeout: 20000,
     },
   },
 }


### PR DESCRIPTION
The default behavior when pushing an OTA update for our users is:

1. App boots
2. Expo checks for updates, finds it and downloads it
3. App is still running on old JS bundle
4. App restarts
5. New update is applied

However when dealing with critical bugs in production, we always want the user to download the latest OTA. This PR fixes that by setting `fallbackToCacheTimeout` to `20s` (it defaults to `0s`). Meaning the new flow will be:

1. App boots
2. Expo checks for updates, finds it, and waits `20s` for the download to finish (if the downloads doesn't finish in time it aborts and uses the old JS bundle)
3. App now has the latest OTA update

-----------

Regarding the `20s` wait time, we could potentially set this up to `3min` but that feels a bit excessive. Our bundle size is roughly `5MB` which should take around `10s` to download on a average 4G connection.