### PR TITLE
events: subscription past_due + recovered

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27680,6 +27680,98 @@ export interface components {
       meter: components['schemas']['Meter']
     }
     /**
+     * SubscriptionPastDueEvent
+     * @description An event created by Polar when a subscription becomes past due.
+     */
+    SubscriptionPastDueEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.past_due'
+      metadata: components['schemas']['SubscriptionPastDueMetadata']
+    }
+    /** SubscriptionPastDueMetadata */
+    SubscriptionPastDueMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Product Id */
+      product_id?: string
+      /** Past Due At */
+      past_due_at: string
+      /** Amount */
+      amount?: number
+      /** Currency */
+      currency?: string
+      /** Recurring Interval */
+      recurring_interval?: string
+      /** Recurring Interval Count */
+      recurring_interval_count?: number
+    }
+    /**
      * SubscriptionProductUpdatedEvent
      * @description An event created by Polar when a subscription changes the product.
      */
@@ -28418,6 +28510,7 @@ export interface components {
       | components['schemas']['SubscriptionCycledEvent']
       | components['schemas']['SubscriptionCanceledEvent']
       | components['schemas']['SubscriptionRevokedEvent']
+      | components['schemas']['SubscriptionPastDueEvent']
       | components['schemas']['SubscriptionUncanceledEvent']
       | components['schemas']['SubscriptionProductUpdatedEvent']
       | components['schemas']['SubscriptionSeatsUpdatedEvent']
@@ -54598,6 +54691,9 @@ export const subscriptionCreatedEventNameValues: ReadonlyArray<
 export const subscriptionCycledEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionCycledEvent']['name']
 > = ['subscription.cycled']
+export const subscriptionPastDueEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionPastDueEvent']['name']
+> = ['subscription.past_due']
 export const subscriptionProductUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionProductUpdatedEvent']['name']
 > = ['subscription.product_updated']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27865,6 +27865,96 @@ export interface components {
       | 'next_period'
       | 'reset'
     /**
+     * SubscriptionReactivatedEvent
+     * @description An event created by Polar when a past due subscription is recovered.
+     */
+    SubscriptionReactivatedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.reactivated'
+      metadata: components['schemas']['SubscriptionReactivatedMetadata']
+    }
+    /** SubscriptionReactivatedMetadata */
+    SubscriptionReactivatedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Product Id */
+      product_id?: string
+      /** Amount */
+      amount?: number
+      /** Currency */
+      currency?: string
+      /** Recurring Interval */
+      recurring_interval?: string
+      /** Recurring Interval Count */
+      recurring_interval_count?: number
+    }
+    /**
      * SubscriptionRecurringInterval
      * @enum {string}
      */
@@ -28511,6 +28601,7 @@ export interface components {
       | components['schemas']['SubscriptionCanceledEvent']
       | components['schemas']['SubscriptionRevokedEvent']
       | components['schemas']['SubscriptionPastDueEvent']
+      | components['schemas']['SubscriptionReactivatedEvent']
       | components['schemas']['SubscriptionUncanceledEvent']
       | components['schemas']['SubscriptionProductUpdatedEvent']
       | components['schemas']['SubscriptionSeatsUpdatedEvent']
@@ -54700,6 +54791,9 @@ export const subscriptionProductUpdatedEventNameValues: ReadonlyArray<
 export const subscriptionProrationBehaviorValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionProrationBehavior']
 > = ['invoice', 'prorate', 'next_period', 'reset']
+export const subscriptionReactivatedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionReactivatedEvent']['name']
+> = ['subscription.reactivated']
 export const subscriptionRecurringIntervalValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionRecurringInterval']
 > = ['day', 'week', 'month', 'year']

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -34,6 +34,7 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
+    SubscriptionPastDueMetadata,
     SubscriptionProductUpdatedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionSeatsUpdatedMetadata,
@@ -390,6 +391,17 @@ class SubscriptionUncanceledEvent(SystemEventBase):
     )
 
 
+class SubscriptionPastDueEvent(SystemEventBase):
+    """An event created by Polar when a subscription becomes past due."""
+
+    name: Literal[SystemEventEnum.subscription_past_due] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionPastDueMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class SubscriptionProductUpdatedEvent(SystemEventBase):
     """An event created by Polar when a subscription changes the product."""
 
@@ -579,6 +591,7 @@ SystemEvent = Annotated[
     | SubscriptionCycledEvent
     | SubscriptionCanceledEvent
     | SubscriptionRevokedEvent
+    | SubscriptionPastDueEvent
     | SubscriptionUncanceledEvent
     | SubscriptionProductUpdatedEvent
     | SubscriptionSeatsUpdatedEvent

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -36,6 +36,7 @@ from polar.event.system import (
     SubscriptionCycledMetadata,
     SubscriptionPastDueMetadata,
     SubscriptionProductUpdatedMetadata,
+    SubscriptionReactivatedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionSeatsUpdatedMetadata,
     SubscriptionUncanceledMetadata,
@@ -402,6 +403,17 @@ class SubscriptionPastDueEvent(SystemEventBase):
     )
 
 
+class SubscriptionReactivatedEvent(SystemEventBase):
+    """An event created by Polar when a past due subscription is recovered."""
+
+    name: Literal[SystemEventEnum.subscription_reactivated] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionReactivatedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class SubscriptionProductUpdatedEvent(SystemEventBase):
     """An event created by Polar when a subscription changes the product."""
 
@@ -592,6 +604,7 @@ SystemEvent = Annotated[
     | SubscriptionCanceledEvent
     | SubscriptionRevokedEvent
     | SubscriptionPastDueEvent
+    | SubscriptionReactivatedEvent
     | SubscriptionUncanceledEvent
     | SubscriptionProductUpdatedEvent
     | SubscriptionSeatsUpdatedEvent

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -25,6 +25,7 @@ class SystemEvent(StrEnum):
     subscription_cycled = "subscription.cycled"
     subscription_revoked = "subscription.revoked"
     subscription_past_due = "subscription.past_due"
+    subscription_reactivated = "subscription.reactivated"
     subscription_uncanceled = "subscription.uncanceled"
     subscription_product_updated = "subscription.product_updated"
     subscription_seats_updated = "subscription.seats_updated"
@@ -56,6 +57,7 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "subscription.cycled": "Subscription Cycled",
     "subscription.revoked": "Subscription Revoked",
     "subscription.past_due": "Subscription Past Due",
+    "subscription.reactivated": "Subscription Reactivated",
     "subscription.uncanceled": "Subscription Uncanceled",
     "subscription.product_updated": "Subscription Product Updated",
     "order.paid": "Order Paid",
@@ -317,6 +319,22 @@ class SubscriptionPastDueEvent(Event):
         source: Mapped[Literal[EventSource.system]]
         name: Mapped[Literal[SystemEvent.subscription_past_due]]
         user_metadata: Mapped[SubscriptionPastDueMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionReactivatedMetadata(TypedDict):
+    subscription_id: str
+    product_id: NotRequired[str]
+    amount: NotRequired[int]
+    currency: NotRequired[str]
+    recurring_interval: NotRequired[str]
+    recurring_interval_count: NotRequired[int]
+
+
+class SubscriptionReactivatedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_reactivated]]
+        user_metadata: Mapped[SubscriptionReactivatedMetadata]  # type: ignore[assignment]
 
 
 class SubscriptionUncanceledMetadata(TypedDict):
@@ -693,6 +711,15 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionPastDueMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_reactivated],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionReactivatedMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -24,6 +24,7 @@ class SystemEvent(StrEnum):
     subscription_canceled = "subscription.canceled"
     subscription_cycled = "subscription.cycled"
     subscription_revoked = "subscription.revoked"
+    subscription_past_due = "subscription.past_due"
     subscription_uncanceled = "subscription.uncanceled"
     subscription_product_updated = "subscription.product_updated"
     subscription_seats_updated = "subscription.seats_updated"
@@ -54,6 +55,7 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "subscription.canceled": "Subscription Canceled",
     "subscription.cycled": "Subscription Cycled",
     "subscription.revoked": "Subscription Revoked",
+    "subscription.past_due": "Subscription Past Due",
     "subscription.uncanceled": "Subscription Uncanceled",
     "subscription.product_updated": "Subscription Product Updated",
     "order.paid": "Order Paid",
@@ -298,6 +300,23 @@ class SubscriptionRevokedEvent(Event):
         source: Mapped[Literal[EventSource.system]]
         name: Mapped[Literal[SystemEvent.subscription_revoked]]
         user_metadata: Mapped[SubscriptionRevokedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionPastDueMetadata(TypedDict):
+    subscription_id: str
+    product_id: NotRequired[str]
+    past_due_at: str
+    amount: NotRequired[int]
+    currency: NotRequired[str]
+    recurring_interval: NotRequired[str]
+    recurring_interval_count: NotRequired[int]
+
+
+class SubscriptionPastDueEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_past_due]]
+        user_metadata: Mapped[SubscriptionPastDueMetadata]  # type: ignore[assignment]
 
 
 class SubscriptionUncanceledMetadata(TypedDict):
@@ -665,6 +684,15 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionRevokedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_past_due],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionPastDueMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -37,6 +37,7 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
+    SubscriptionPastDueMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionUncanceledMetadata,
     SystemEvent,
@@ -1978,6 +1979,26 @@ class SubscriptionService:
         await self._send_webhook(
             session, subscription, WebhookEventType.subscription_past_due
         )
+
+        assert subscription.past_due_at is not None
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_past_due,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=SubscriptionPastDueMetadata(
+                    subscription_id=str(subscription.id),
+                    product_id=str(subscription.product_id),
+                    past_due_at=subscription.past_due_at.isoformat(),
+                    amount=subscription.amount,
+                    currency=subscription.currency,
+                    recurring_interval=subscription.recurring_interval.value,
+                    recurring_interval_count=subscription.recurring_interval_count,
+                ),
+            ),
+        )
+
         await self.send_past_due_email(session, subscription)
 
     async def _on_subscription_uncanceled(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -38,6 +38,7 @@ from polar.event.system import (
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
     SubscriptionPastDueMetadata,
+    SubscriptionReactivatedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionUncanceledMetadata,
     SystemEvent,
@@ -1972,6 +1973,24 @@ class SubscriptionService:
         # not a past due that has been reactivated.
         if not reactivated:
             await self._send_new_subscription_notification(session, subscription)
+
+        if reactivated:
+            await event_service.create_event(
+                session,
+                build_system_event(
+                    SystemEvent.subscription_reactivated,
+                    customer=subscription.customer,
+                    organization=subscription.organization,
+                    metadata=SubscriptionReactivatedMetadata(
+                        subscription_id=str(subscription.id),
+                        product_id=str(subscription.product_id),
+                        amount=subscription.amount,
+                        currency=subscription.currency,
+                        recurring_interval=subscription.recurring_interval.value,
+                        recurring_interval_count=subscription.recurring_interval_count,
+                    ),
+                ),
+            )
 
     async def _on_subscription_past_due(
         self, session: AsyncSession, subscription: Subscription


### PR DESCRIPTION
Adds an event for subscriptions that are past due and one for subscriptions that later recover.

These events will make it easier for us to answer questions on how likely it is that a subscription recovers from having been past_due