### PR TITLE
rate-limit: short-circuit blocked callers around auth + DB

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -181,6 +181,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     stop_remote_write_pusher()
 
     await redis.close(True)
+    rate_limit_redis = getattr(app.state, "rate_limit_redis", None)
+    if rate_limit_redis is not None:
+        await rate_limit_redis.close(True)
     await async_engine.dispose()
     if async_read_engine is not async_engine:
         await async_read_engine.dispose()
@@ -202,10 +205,12 @@ def create_app() -> FastAPI:
     if settings.is_sandbox():
         app.add_middleware(SandboxResponseHeaderMiddleware)
     if not settings.is_testing():
-        app.add_middleware(rate_limit.get_middleware)
-        app.add_middleware(AuthSubjectMiddleware)
+        rate_limit_redis = create_redis("rate-limit")
+        app.state.rate_limit_redis = rate_limit_redis
+        app.add_middleware(AuthSubjectMiddleware, redis=rate_limit_redis)
         app.add_middleware(FlushEnqueuedWorkerJobsMiddleware)
         app.add_middleware(AsyncSessionMiddleware)
+        app.add_middleware(rate_limit.get_middleware, redis=rate_limit_redis)
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")
     app.add_middleware(LogCorrelationIdMiddleware)
     if not settings.is_testing():

--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -40,7 +40,7 @@ from polar.personal_access_token.service import (
     personal_access_token as personal_access_token_service,
 )
 from polar.postgres import AsyncSession
-from polar.rate_limit import write_cached_identity
+from polar.rate_limit import clear_cached_identity, write_cached_identity
 from polar.redis import Redis
 from polar.sentry import set_sentry_user
 from polar.worker import enqueue_job
@@ -204,6 +204,9 @@ class AuthSubjectMiddleware:
         try:
             auth_subject = await get_auth_subject(request, session)
         except OAuth2Error as e:
+            token = get_bearer_token(request)
+            if token is not None:
+                await clear_cached_identity(self.redis, token)
             response = await oauth2_error_exception_handler(request, e)
             return await response(scope, receive, send)
 
@@ -213,7 +216,7 @@ class AuthSubjectMiddleware:
             token = get_bearer_token(request)
             if token is not None:
                 await write_cached_identity(
-                    self.redis, token.encode("ascii"), auth_subject.rate_limit_key
+                    self.redis, token, auth_subject.rate_limit_key
                 )
 
         with logfire.set_baggage(**auth_subject.log_context):

--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -40,6 +40,8 @@ from polar.personal_access_token.service import (
     personal_access_token as personal_access_token_service,
 )
 from polar.postgres import AsyncSession
+from polar.rate_limit import write_cached_identity
+from polar.redis import Redis
 from polar.sentry import set_sentry_user
 from polar.worker import enqueue_job
 
@@ -187,8 +189,9 @@ async def get_auth_subject(
 
 
 class AuthSubjectMiddleware:
-    def __init__(self, app: ASGIApp) -> None:
+    def __init__(self, app: ASGIApp, redis: Redis) -> None:
         self.app = app
+        self.redis = redis
 
     async def __call__(self, scope: ASGIScope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -205,6 +208,13 @@ class AuthSubjectMiddleware:
             return await response(scope, receive, send)
 
         scope["state"]["auth_subject"] = auth_subject
+
+        if not isinstance(auth_subject.subject, Anonymous):
+            token = get_bearer_token(request)
+            if token is not None:
+                await write_cached_identity(
+                    self.redis, token.encode("ascii"), auth_subject.rate_limit_key
+                )
 
         with logfire.set_baggage(**auth_subject.log_context):
             log.info("Authenticated subject", **auth_subject.log_context)

--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -5,6 +5,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 from starlette.types import ASGIApp, Receive, Send
 from starlette.types import Scope as ASGIScope
 
+from polar.config import settings
 from polar.customer_session.service import (
     CUSTOMER_SESSION_TOKEN_PREFIX,
 )
@@ -212,12 +213,19 @@ class AuthSubjectMiddleware:
 
         scope["state"]["auth_subject"] = auth_subject
 
+        cookie = request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
         if not isinstance(auth_subject.subject, Anonymous):
             token = get_bearer_token(request)
             if token is not None:
                 await write_cached_identity(
                     self.redis, token, auth_subject.rate_limit_key
                 )
+            if cookie is not None:
+                await write_cached_identity(
+                    self.redis, cookie, auth_subject.rate_limit_key
+                )
+        elif cookie is not None:
+            await clear_cached_identity(self.redis, cookie)
 
         with logfire.set_baggage(**auth_subject.log_context):
             log.info("Authenticated subject", **auth_subject.log_context)

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -1,4 +1,5 @@
-from collections.abc import Sequence
+import hashlib
+from collections.abc import Awaitable, Callable, Sequence
 
 from ratelimit import RateLimitMiddleware, Rule
 from ratelimit.auths import EmptyInformation
@@ -6,23 +7,81 @@ from ratelimit.auths.ip import client_ip
 from ratelimit.backends.redis import RedisBackend
 from ratelimit.types import ASGIApp, Scope
 
-from polar.auth.models import AuthSubject, Subject, is_anonymous
 from polar.config import Environment, settings
 from polar.enums import RateLimitGroup
-from polar.redis import create_redis
+from polar.redis import Redis
+
+_IDENTITY_KEY_PREFIX = "rl:ident:"
+_IDENTITY_TTL_SECONDS = 300
+
+_AUTHORIZATION_HEADER = b"authorization"
+_BEARER_PREFIX = b"bearer "
 
 
-async def _authenticate(scope: Scope) -> tuple[str, RateLimitGroup]:
-    auth_subject: AuthSubject[Subject] = scope["state"]["auth_subject"]
+def _bearer_token(scope: Scope) -> bytes | None:
+    if scope.get("type") != "http":
+        return None
+    for name, value in scope.get("headers", ()):
+        if (
+            name == _AUTHORIZATION_HEADER
+            and value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX
+        ):
+            token = value[len(_BEARER_PREFIX) :].strip()
+            return token or None
+    return None
 
-    if is_anonymous(auth_subject):
+
+def _hash_token(token: bytes) -> str:
+    return hashlib.blake2b(token, digest_size=16).hexdigest()
+
+
+def identity_cache_key(token: bytes) -> str:
+    return f"{_IDENTITY_KEY_PREFIX}{_hash_token(token)}"
+
+
+async def _read_cached_identity(
+    redis: Redis, token: bytes
+) -> tuple[str, RateLimitGroup] | None:
+    raw = await redis.get(identity_cache_key(token))
+    if raw is None:
+        return None
+    group_str, sep, user = raw.partition("|")
+    if not sep:
+        return None
+    try:
+        return user, RateLimitGroup(group_str)
+    except ValueError:
+        return None
+
+
+async def write_cached_identity(
+    redis: Redis, token: bytes, key: tuple[str, RateLimitGroup]
+) -> None:
+    user, group = key
+    await redis.set(
+        identity_cache_key(token),
+        f"{group.value}|{user}",
+        ex=_IDENTITY_TTL_SECONDS,
+    )
+
+
+def _make_authenticate(
+    redis: Redis,
+) -> Callable[[Scope], Awaitable[tuple[str, RateLimitGroup]]]:
+    async def _authenticate(scope: Scope) -> tuple[str, RateLimitGroup]:
+        token = _bearer_token(scope)
+        if token is not None:
+            cached = await _read_cached_identity(redis, token)
+            if cached is not None:
+                return cached
+
         try:
             ip, _ = await client_ip(scope)
             return ip, RateLimitGroup.default
         except (EmptyInformation, ValueError, TypeError):
-            return auth_subject.rate_limit_key
+            return "anonymous", RateLimitGroup.default
 
-    return auth_subject.rate_limit_key
+    return _authenticate
 
 
 _BASE_RULES: dict[str, Sequence[Rule]] = {
@@ -66,7 +125,7 @@ _PRODUCTION_RULES: dict[str, Sequence[Rule]] = {
 }
 
 
-def get_middleware(app: ASGIApp) -> RateLimitMiddleware:
+def get_middleware(app: ASGIApp, redis: Redis) -> RateLimitMiddleware:
     match settings.ENV:
         case Environment.production:
             rules = _PRODUCTION_RULES
@@ -75,8 +134,5 @@ def get_middleware(app: ASGIApp) -> RateLimitMiddleware:
         case _:
             rules = {}
     return RateLimitMiddleware(
-        app, _authenticate, RedisBackend(create_redis("rate-limit")), rules
+        app, _make_authenticate(redis), RedisBackend(redis), rules
     )
-
-
-__all__ = ["get_middleware"]

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -18,6 +18,7 @@ _IDENTITY_TTL_SECONDS = 300
 _ANONYMOUS_IDENTITY = "anonymous"
 
 _AUTHORIZATION_HEADER = b"authorization"
+_COOKIE_HEADER = b"cookie"
 
 
 def _bearer_token(scope: Scope) -> str | None:
@@ -34,6 +35,28 @@ def _bearer_token(scope: Scope) -> str | None:
         if not scheme or scheme.lower() != "bearer" or not token:
             return None
         return token
+    return None
+
+
+def _session_cookie(scope: Scope) -> str | None:
+    if scope.get("type") != "http":
+        return None
+    name_bytes = settings.USER_SESSION_COOKIE_KEY.encode("ascii")
+    for header_name, header_value in scope.get("headers", ()):
+        if header_name != _COOKIE_HEADER:
+            continue
+        for part in header_value.split(b";"):
+            part = part.strip()
+            equal = part.find(b"=")
+            if equal == -1:
+                continue
+            if part[:equal] != name_bytes:
+                continue
+            try:
+                value = part[equal + 1 :].decode("ascii")
+            except UnicodeDecodeError:
+                return None
+            return value or None
     return None
 
 
@@ -76,6 +99,11 @@ async def _authenticate(scope: Scope, *, redis: Redis) -> tuple[str, RateLimitGr
     token = _bearer_token(scope)
     if token is not None:
         cached = await _read_cached_identity(redis, token)
+        if cached is not None:
+            return cached
+    cookie = _session_cookie(scope)
+    if cookie is not None:
+        cached = await _read_cached_identity(redis, cookie)
         if cached is not None:
             return cached
     try:

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -1,6 +1,8 @@
 import hashlib
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Sequence
+from functools import partial
 
+from fastapi.security.utils import get_authorization_scheme_param
 from ratelimit import RateLimitMiddleware, Rule
 from ratelimit.auths import EmptyInformation
 from ratelimit.auths.ip import client_ip
@@ -13,36 +15,37 @@ from polar.redis import Redis
 
 _IDENTITY_KEY_PREFIX = "rl:ident:"
 _IDENTITY_TTL_SECONDS = 300
+_ANONYMOUS_IDENTITY = "anonymous"
 
 _AUTHORIZATION_HEADER = b"authorization"
-_BEARER_PREFIX = b"bearer "
 
 
-def _bearer_token(scope: Scope) -> bytes | None:
+def _bearer_token(scope: Scope) -> str | None:
     if scope.get("type") != "http":
         return None
     for name, value in scope.get("headers", ()):
-        if (
-            name == _AUTHORIZATION_HEADER
-            and value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX
-        ):
-            token = value[len(_BEARER_PREFIX) :].strip()
-            return token or None
+        if name != _AUTHORIZATION_HEADER:
+            continue
+        try:
+            authorization = value.decode("ascii")
+        except UnicodeDecodeError:
+            return None
+        scheme, token = get_authorization_scheme_param(authorization)
+        if not scheme or scheme.lower() != "bearer" or not token:
+            return None
+        return token
     return None
 
 
-def _hash_token(token: bytes) -> str:
-    return hashlib.blake2b(token, digest_size=16).hexdigest()
-
-
-def identity_cache_key(token: bytes) -> str:
-    return f"{_IDENTITY_KEY_PREFIX}{_hash_token(token)}"
+def _identity_cache_key(token: str) -> str:
+    digest = hashlib.blake2b(token.encode("ascii"), digest_size=16).hexdigest()
+    return f"{_IDENTITY_KEY_PREFIX}{digest}"
 
 
 async def _read_cached_identity(
-    redis: Redis, token: bytes
+    redis: Redis, token: str
 ) -> tuple[str, RateLimitGroup] | None:
-    raw = await redis.get(identity_cache_key(token))
+    raw = await redis.get(_identity_cache_key(token))
     if raw is None:
         return None
     group_str, sep, user = raw.partition("|")
@@ -55,33 +58,31 @@ async def _read_cached_identity(
 
 
 async def write_cached_identity(
-    redis: Redis, token: bytes, key: tuple[str, RateLimitGroup]
+    redis: Redis, token: str, key: tuple[str, RateLimitGroup]
 ) -> None:
     user, group = key
     await redis.set(
-        identity_cache_key(token),
+        _identity_cache_key(token),
         f"{group.value}|{user}",
         ex=_IDENTITY_TTL_SECONDS,
     )
 
 
-def _make_authenticate(
-    redis: Redis,
-) -> Callable[[Scope], Awaitable[tuple[str, RateLimitGroup]]]:
-    async def _authenticate(scope: Scope) -> tuple[str, RateLimitGroup]:
-        token = _bearer_token(scope)
-        if token is not None:
-            cached = await _read_cached_identity(redis, token)
-            if cached is not None:
-                return cached
+async def clear_cached_identity(redis: Redis, token: str) -> None:
+    await redis.delete(_identity_cache_key(token))
 
-        try:
-            ip, _ = await client_ip(scope)
-            return ip, RateLimitGroup.default
-        except (EmptyInformation, ValueError, TypeError):
-            return "anonymous", RateLimitGroup.default
 
-    return _authenticate
+async def _authenticate(scope: Scope, *, redis: Redis) -> tuple[str, RateLimitGroup]:
+    token = _bearer_token(scope)
+    if token is not None:
+        cached = await _read_cached_identity(redis, token)
+        if cached is not None:
+            return cached
+    try:
+        ip, _ = await client_ip(scope)
+        return ip, RateLimitGroup.default
+    except (EmptyInformation, ValueError, TypeError):
+        return _ANONYMOUS_IDENTITY, RateLimitGroup.default
 
 
 _BASE_RULES: dict[str, Sequence[Rule]] = {
@@ -134,5 +135,12 @@ def get_middleware(app: ASGIApp, redis: Redis) -> RateLimitMiddleware:
         case _:
             rules = {}
     return RateLimitMiddleware(
-        app, _make_authenticate(redis), RedisBackend(redis), rules
+        app, partial(_authenticate, redis=redis), RedisBackend(redis), rules
     )
+
+
+__all__ = [
+    "clear_cached_identity",
+    "get_middleware",
+    "write_cached_identity",
+]

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -6,9 +6,10 @@ from fakeredis import FakeAsyncRedis
 
 from polar.enums import RateLimitGroup
 from polar.rate_limit import (
+    _authenticate,
     _bearer_token,
-    _make_authenticate,
-    identity_cache_key,
+    _identity_cache_key,
+    clear_cached_identity,
     write_cached_identity,
 )
 from polar.redis import Redis
@@ -32,13 +33,13 @@ def _http_scope(
 
 
 class TestBearerToken:
-    def test_returns_token_bytes(self) -> None:
+    def test_returns_token(self) -> None:
         scope = _http_scope(headers=[(b"authorization", b"Bearer polar_pat_xyz")])
-        assert _bearer_token(scope) == b"polar_pat_xyz"
+        assert _bearer_token(scope) == "polar_pat_xyz"
 
     def test_case_insensitive_scheme(self) -> None:
         scope = _http_scope(headers=[(b"authorization", b"BEARER polar_pat_xyz")])
-        assert _bearer_token(scope) == b"polar_pat_xyz"
+        assert _bearer_token(scope) == "polar_pat_xyz"
 
     def test_missing_header(self) -> None:
         scope = _http_scope(headers=[])
@@ -52,6 +53,10 @@ class TestBearerToken:
         scope = _http_scope(headers=[(b"authorization", b"Bearer ")])
         assert _bearer_token(scope) is None
 
+    def test_non_ascii_header(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"Bearer \xc3\xa9token")])
+        assert _bearer_token(scope) is None
+
     def test_non_http_scope(self) -> None:
         scope: dict[str, object] = {"type": "websocket", "headers": []}
         assert _bearer_token(scope) is None
@@ -60,88 +65,70 @@ class TestBearerToken:
 @pytest.mark.asyncio
 class TestIdentityCacheRoundTrip:
     async def test_write_then_read_via_authenticate(self, redis: Redis) -> None:
-        token = b"polar_pat_round_trip"
+        token = "polar_pat_round_trip"
         await write_cached_identity(
             redis, token, ("user:abc-123", RateLimitGroup.elevated)
         )
 
-        authenticate = _make_authenticate(redis)
-        identity = await authenticate(
-            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_round_trip")])
+        identity = await _authenticate(
+            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_round_trip")]),
+            redis=redis,
         )
 
         assert identity == ("user:abc-123", RateLimitGroup.elevated)
 
     async def test_write_sets_ttl(self, redis: Redis) -> None:
-        token = b"polar_pat_ttl"
+        token = "polar_pat_ttl"
         await write_cached_identity(redis, token, ("user:1", RateLimitGroup.default))
 
-        ttl = await redis.ttl(identity_cache_key(token))
+        ttl = await redis.ttl(_identity_cache_key(token))
         assert 0 < ttl <= 300
+
+    async def test_clear_removes_entry(self, redis: Redis) -> None:
+        token = "polar_pat_clear"
+        await write_cached_identity(redis, token, ("user:1", RateLimitGroup.default))
+        assert await redis.exists(_identity_cache_key(token)) == 1
+
+        await clear_cached_identity(redis, token)
+
+        assert await redis.exists(_identity_cache_key(token)) == 0
 
 
 @pytest.mark.asyncio
 class TestAuthenticate:
     async def test_cache_miss_falls_back_to_client_ip(self, redis: Redis) -> None:
-        authenticate = _make_authenticate(redis)
-        identity = await authenticate(
+        identity = await _authenticate(
             _http_scope(
                 headers=[(b"authorization", b"Bearer polar_pat_unknown")],
                 client=("8.8.8.8", 1234),
-            )
+            ),
+            redis=redis,
         )
         assert identity == ("8.8.8.8", RateLimitGroup.default)
 
     async def test_no_token_uses_client_ip(self, redis: Redis) -> None:
-        authenticate = _make_authenticate(redis)
-        identity = await authenticate(_http_scope(client=("1.1.1.1", 80)))
+        identity = await _authenticate(_http_scope(client=("1.1.1.1", 80)), redis=redis)
         assert identity == ("1.1.1.1", RateLimitGroup.default)
 
     async def test_no_client_returns_anonymous(self, redis: Redis) -> None:
-        authenticate = _make_authenticate(redis)
-        identity = await authenticate(_http_scope(client=None))
+        identity = await _authenticate(_http_scope(client=None), redis=redis)
         assert identity == ("anonymous", RateLimitGroup.default)
 
-    async def test_malformed_cache_value_falls_back(self, redis: Redis) -> None:
-        token = b"polar_pat_corrupt"
-        await redis.set(identity_cache_key(token), "garbage-no-pipe")
-
-        authenticate = _make_authenticate(redis)
-        identity = await authenticate(
-            _http_scope(
-                headers=[(b"authorization", b"Bearer polar_pat_corrupt")],
-                client=("8.8.8.8", 1234),
-            )
-        )
-        assert identity == ("8.8.8.8", RateLimitGroup.default)
-
-    async def test_unknown_group_in_cache_falls_back(self, redis: Redis) -> None:
-        token = b"polar_pat_bad_group"
-        await redis.set(identity_cache_key(token), "not_a_group|user:abc")
-
-        authenticate = _make_authenticate(redis)
-        identity = await authenticate(
-            _http_scope(
-                headers=[(b"authorization", b"Bearer polar_pat_bad_group")],
-                client=("8.8.8.8", 1234),
-            )
-        )
-        assert identity == ("8.8.8.8", RateLimitGroup.default)
-
     async def test_distinct_tokens_get_distinct_identities(self, redis: Redis) -> None:
-        token_a = b"polar_pat_a"
-        token_b = b"polar_pat_b"
+        token_a = "polar_pat_a"
+        token_b = "polar_pat_b"
         await write_cached_identity(redis, token_a, ("user:a", RateLimitGroup.default))
         await write_cached_identity(
             redis, token_b, ("organization:b", RateLimitGroup.elevated)
         )
 
-        authenticate = _make_authenticate(redis)
-        ident_a = await authenticate(
-            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_a")])
+        ident_a = await _authenticate(
+            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_a")]),
+            redis=redis,
         )
-        ident_b = await authenticate(
-            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_b")])
+        ident_b = await _authenticate(
+            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_b")]),
+            redis=redis,
         )
 
         assert ident_a == ("user:a", RateLimitGroup.default)

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -4,11 +4,13 @@ import pytest
 import pytest_asyncio
 from fakeredis import FakeAsyncRedis
 
+from polar.config import settings
 from polar.enums import RateLimitGroup
 from polar.rate_limit import (
     _authenticate,
     _bearer_token,
     _identity_cache_key,
+    _session_cookie,
     clear_cached_identity,
     write_cached_identity,
 )
@@ -62,6 +64,37 @@ class TestBearerToken:
         assert _bearer_token(scope) is None
 
 
+class TestSessionCookie:
+    def test_returns_value(self) -> None:
+        header = f"{settings.USER_SESSION_COOKIE_KEY}=polar_us_xyz".encode("ascii")
+        scope = _http_scope(headers=[(b"cookie", header)])
+        assert _session_cookie(scope) == "polar_us_xyz"
+
+    def test_among_other_cookies(self) -> None:
+        header = (
+            f"foo=bar; {settings.USER_SESSION_COOKIE_KEY}=polar_us_xyz; baz=qux"
+        ).encode("ascii")
+        scope = _http_scope(headers=[(b"cookie", header)])
+        assert _session_cookie(scope) == "polar_us_xyz"
+
+    def test_missing_header(self) -> None:
+        scope = _http_scope(headers=[])
+        assert _session_cookie(scope) is None
+
+    def test_other_cookies_only(self) -> None:
+        scope = _http_scope(headers=[(b"cookie", b"foo=bar; baz=qux")])
+        assert _session_cookie(scope) is None
+
+    def test_empty_value(self) -> None:
+        header = f"{settings.USER_SESSION_COOKIE_KEY}=".encode("ascii")
+        scope = _http_scope(headers=[(b"cookie", header)])
+        assert _session_cookie(scope) is None
+
+    def test_non_http_scope(self) -> None:
+        scope: dict[str, object] = {"type": "websocket", "headers": []}
+        assert _session_cookie(scope) is None
+
+
 @pytest.mark.asyncio
 class TestIdentityCacheRoundTrip:
     async def test_write_then_read_via_authenticate(self, redis: Redis) -> None:
@@ -113,6 +146,48 @@ class TestAuthenticate:
     async def test_no_client_returns_anonymous(self, redis: Redis) -> None:
         identity = await _authenticate(_http_scope(client=None), redis=redis)
         assert identity == ("anonymous", RateLimitGroup.default)
+
+    async def test_cookie_cache_hit(self, redis: Redis) -> None:
+        cookie = "polar_us_session"
+        await write_cached_identity(redis, cookie, ("user:web", RateLimitGroup.web))
+
+        header = f"{settings.USER_SESSION_COOKIE_KEY}={cookie}".encode("ascii")
+        identity = await _authenticate(
+            _http_scope(headers=[(b"cookie", header)]), redis=redis
+        )
+
+        assert identity == ("user:web", RateLimitGroup.web)
+
+    async def test_cookie_cache_miss_falls_back_to_client_ip(
+        self, redis: Redis
+    ) -> None:
+        header = f"{settings.USER_SESSION_COOKIE_KEY}=polar_us_unknown".encode("ascii")
+        identity = await _authenticate(
+            _http_scope(headers=[(b"cookie", header)], client=("9.9.9.9", 1234)),
+            redis=redis,
+        )
+        assert identity == ("9.9.9.9", RateLimitGroup.default)
+
+    async def test_bearer_token_preferred_over_cookie(self, redis: Redis) -> None:
+        await write_cached_identity(
+            redis, "polar_pat_a", ("user:bearer", RateLimitGroup.elevated)
+        )
+        await write_cached_identity(
+            redis, "polar_us_b", ("user:cookie", RateLimitGroup.web)
+        )
+
+        cookie_header = f"{settings.USER_SESSION_COOKIE_KEY}=polar_us_b".encode("ascii")
+        identity = await _authenticate(
+            _http_scope(
+                headers=[
+                    (b"authorization", b"Bearer polar_pat_a"),
+                    (b"cookie", cookie_header),
+                ]
+            ),
+            redis=redis,
+        )
+
+        assert identity == ("user:bearer", RateLimitGroup.elevated)
 
     async def test_distinct_tokens_get_distinct_identities(self, redis: Redis) -> None:
         token_a = "polar_pat_a"

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -1,0 +1,148 @@
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fakeredis import FakeAsyncRedis
+
+from polar.enums import RateLimitGroup
+from polar.rate_limit import (
+    _bearer_token,
+    _make_authenticate,
+    identity_cache_key,
+    write_cached_identity,
+)
+from polar.redis import Redis
+
+
+@pytest_asyncio.fixture
+async def redis() -> AsyncIterator[Redis]:
+    yield FakeAsyncRedis(decode_responses=True)
+
+
+def _http_scope(
+    *,
+    headers: list[tuple[bytes, bytes]] | None = None,
+    client: tuple[str, int] | None = ("8.8.8.8", 1234),
+) -> dict[str, object]:
+    return {
+        "type": "http",
+        "headers": headers or [],
+        "client": client,
+    }
+
+
+class TestBearerToken:
+    def test_returns_token_bytes(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"Bearer polar_pat_xyz")])
+        assert _bearer_token(scope) == b"polar_pat_xyz"
+
+    def test_case_insensitive_scheme(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"BEARER polar_pat_xyz")])
+        assert _bearer_token(scope) == b"polar_pat_xyz"
+
+    def test_missing_header(self) -> None:
+        scope = _http_scope(headers=[])
+        assert _bearer_token(scope) is None
+
+    def test_other_scheme(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"Basic dXNlcjpwYXNz")])
+        assert _bearer_token(scope) is None
+
+    def test_empty_token(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"Bearer ")])
+        assert _bearer_token(scope) is None
+
+    def test_non_http_scope(self) -> None:
+        scope: dict[str, object] = {"type": "websocket", "headers": []}
+        assert _bearer_token(scope) is None
+
+
+@pytest.mark.asyncio
+class TestIdentityCacheRoundTrip:
+    async def test_write_then_read_via_authenticate(self, redis: Redis) -> None:
+        token = b"polar_pat_round_trip"
+        await write_cached_identity(
+            redis, token, ("user:abc-123", RateLimitGroup.elevated)
+        )
+
+        authenticate = _make_authenticate(redis)
+        identity = await authenticate(
+            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_round_trip")])
+        )
+
+        assert identity == ("user:abc-123", RateLimitGroup.elevated)
+
+    async def test_write_sets_ttl(self, redis: Redis) -> None:
+        token = b"polar_pat_ttl"
+        await write_cached_identity(redis, token, ("user:1", RateLimitGroup.default))
+
+        ttl = await redis.ttl(identity_cache_key(token))
+        assert 0 < ttl <= 300
+
+
+@pytest.mark.asyncio
+class TestAuthenticate:
+    async def test_cache_miss_falls_back_to_client_ip(self, redis: Redis) -> None:
+        authenticate = _make_authenticate(redis)
+        identity = await authenticate(
+            _http_scope(
+                headers=[(b"authorization", b"Bearer polar_pat_unknown")],
+                client=("8.8.8.8", 1234),
+            )
+        )
+        assert identity == ("8.8.8.8", RateLimitGroup.default)
+
+    async def test_no_token_uses_client_ip(self, redis: Redis) -> None:
+        authenticate = _make_authenticate(redis)
+        identity = await authenticate(_http_scope(client=("1.1.1.1", 80)))
+        assert identity == ("1.1.1.1", RateLimitGroup.default)
+
+    async def test_no_client_returns_anonymous(self, redis: Redis) -> None:
+        authenticate = _make_authenticate(redis)
+        identity = await authenticate(_http_scope(client=None))
+        assert identity == ("anonymous", RateLimitGroup.default)
+
+    async def test_malformed_cache_value_falls_back(self, redis: Redis) -> None:
+        token = b"polar_pat_corrupt"
+        await redis.set(identity_cache_key(token), "garbage-no-pipe")
+
+        authenticate = _make_authenticate(redis)
+        identity = await authenticate(
+            _http_scope(
+                headers=[(b"authorization", b"Bearer polar_pat_corrupt")],
+                client=("8.8.8.8", 1234),
+            )
+        )
+        assert identity == ("8.8.8.8", RateLimitGroup.default)
+
+    async def test_unknown_group_in_cache_falls_back(self, redis: Redis) -> None:
+        token = b"polar_pat_bad_group"
+        await redis.set(identity_cache_key(token), "not_a_group|user:abc")
+
+        authenticate = _make_authenticate(redis)
+        identity = await authenticate(
+            _http_scope(
+                headers=[(b"authorization", b"Bearer polar_pat_bad_group")],
+                client=("8.8.8.8", 1234),
+            )
+        )
+        assert identity == ("8.8.8.8", RateLimitGroup.default)
+
+    async def test_distinct_tokens_get_distinct_identities(self, redis: Redis) -> None:
+        token_a = b"polar_pat_a"
+        token_b = b"polar_pat_b"
+        await write_cached_identity(redis, token_a, ("user:a", RateLimitGroup.default))
+        await write_cached_identity(
+            redis, token_b, ("organization:b", RateLimitGroup.elevated)
+        )
+
+        authenticate = _make_authenticate(redis)
+        ident_a = await authenticate(
+            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_a")])
+        )
+        ident_b = await authenticate(
+            _http_scope(headers=[(b"authorization", b"Bearer polar_pat_b")])
+        )
+
+        assert ident_a == ("user:a", RateLimitGroup.default)
+        assert ident_b == ("organization:b", RateLimitGroup.elevated)


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- N/A — perf incident response -->

Move rate-limit checks ahead of auth so a 429 short-circuits before the request pays for a DB session and the full auth resolution stack. A high-volume customer hammering the API was driving CPU spikes despite every response being a 429, because the rate limiter ran *after* `AuthSubjectMiddleware`.

This replaces an earlier sketch in this branch (a separate fast-path middleware with its own block-state in Redis) with the lighter-weight approach Frankie suggested in review: have the existing `RateLimitMiddleware` itself run before auth, and feed it the right identity via a cached `tokenHash → rate_limit_key` mapping written by `AuthSubjectMiddleware` on successful auth.

## What

- `RateLimitMiddleware` is now positioned outside `AsyncSessionMiddleware`, `FlushEnqueuedWorkerJobsMiddleware`, and `AuthSubjectMiddleware`. A 429 returns without acquiring a DB session or running auth.
- `_authenticate` no longer reads `scope["state"]["auth_subject"]` (auth hasn't run yet at that point). Instead it parses the bearer token from raw scope headers, hashes it (blake2b), and looks up `rl:ident:<hash>` in Redis. On miss, it falls back to client IP. With no client info, it falls back to the literal `"anonymous"`.
- `AuthSubjectMiddleware` seeds the cache after successful non-anonymous auth, mapping the token hash to `(rate_limit_user, rate_limit_group)` with a 5-minute TTL.
- A single `rate-limit` Redis client is created at app build time, shared between `RateLimitMiddleware` and `AuthSubjectMiddleware`, and closed in the lifespan shutdown.

## Why

Production CPU spike: a single customer was generating enough rate-limited traffic that the per-request work *before* the 429 (auth subject resolution does up to 5 sequential token lookups, plus sentry/logfire setup and a worker enqueue for token usage tracking) was driving real cost. Returning 429 cheaply turns the bad client into a near-no-op.

## How

- Counters stay where they are: `RateLimitMiddleware`'s own `(zone, identity)` counters remain the single source of truth — no separate block-state to maintain or invalidate.
- Cold start: the very first request from a new token misses the cache, falls through to IP-based rate limiting, completes auth, and seeds the mapping. Every subsequent request from that token is identified by token hash without consulting the DB.
- Token revocation: a revoked token will keep being rate-limited under its old identity for up to the TTL, but `AuthSubjectMiddleware` still rejects with 401 — there's no way to use a revoked token to abuse fresh quota.
- Anonymous traffic and tokens that fail to authenticate keep getting IP-based rate limiting, same as before.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (`tests/test_rate_limit.py`, 14 tests)
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included