### PR TITLE
rate-limit: share + close the rate-limit Redis client via lifespan

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -181,6 +181,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     stop_remote_write_pusher()
 
     await redis.close(True)
+    rate_limit_redis = getattr(app.state, "rate_limit_redis", None)
+    if rate_limit_redis is not None:
+        await rate_limit_redis.close(True)
     await async_engine.dispose()
     if async_read_engine is not async_engine:
         await async_read_engine.dispose()
@@ -202,7 +205,13 @@ def create_app() -> FastAPI:
     if settings.is_sandbox():
         app.add_middleware(SandboxResponseHeaderMiddleware)
     if not settings.is_testing():
-        app.add_middleware(rate_limit.get_middleware)
+        # One Redis client shared by both rate-limit middlewares (post-auth
+        # limiter and the fast path). Stashed on app.state so the lifespan
+        # can close it on shutdown.
+        rate_limit_redis = create_redis("rate-limit")
+        app.state.rate_limit_redis = rate_limit_redis
+
+        app.add_middleware(rate_limit.get_middleware, redis=rate_limit_redis)
         app.add_middleware(AuthSubjectMiddleware)
         app.add_middleware(FlushEnqueuedWorkerJobsMiddleware)
         app.add_middleware(AsyncSessionMiddleware)
@@ -210,7 +219,7 @@ def create_app() -> FastAPI:
         # writes the block whenever a downstream 429 is observed.
         app.add_middleware(
             rate_limit.RateLimitFastPathMiddleware,
-            redis=create_redis("rate-limit"),
+            redis=rate_limit_redis,
         )
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")
     app.add_middleware(LogCorrelationIdMiddleware)

--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -206,6 +206,12 @@ def create_app() -> FastAPI:
         app.add_middleware(AuthSubjectMiddleware)
         app.add_middleware(FlushEnqueuedWorkerJobsMiddleware)
         app.add_middleware(AsyncSessionMiddleware)
+        # Sits outside auth + DB so blocked callers cost one Redis GET, and
+        # writes the block whenever a downstream 429 is observed.
+        app.add_middleware(
+            rate_limit.RateLimitFastPathMiddleware,
+            redis=create_redis("rate-limit"),
+        )
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")
     app.add_middleware(LogCorrelationIdMiddleware)
     if not settings.is_testing():

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -146,9 +146,7 @@ def _caller_identity(scope: ASGIScope) -> str | None:
             if value[:7].lower() == b"bearer ":
                 token = value[7:].strip()
                 if token:
-                    return "t:" + hashlib.blake2b(
-                        token, digest_size=16
-                    ).hexdigest()
+                    return "t:" + hashlib.blake2b(token, digest_size=16).hexdigest()
             break
     client = scope.get("client")
     if client and client[0]:
@@ -167,9 +165,7 @@ class RateLimitFastPathMiddleware:
         self.app = app
         self.redis = redis
 
-    async def __call__(
-        self, scope: ASGIScope, receive: Receive, send: Send
-    ) -> None:
+    async def __call__(self, scope: ASGIScope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or not scope["path"].startswith("/v1"):
             await self.app(scope, receive, send)
             return
@@ -192,9 +188,7 @@ class RateLimitFastPathMiddleware:
                     ],
                 }
             )
-            await send(
-                {"type": "http.response.body", "body": b"Too Many Requests"}
-            )
+            await send({"type": "http.response.body", "body": b"Too Many Requests"})
             return
 
         start_message: Message | None = None

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -1,18 +1,24 @@
-from collections.abc import Sequence
+import hashlib
+from collections.abc import Iterable, Sequence
 
+import structlog
 from ratelimit import RateLimitMiddleware, Rule
 from ratelimit.auths import EmptyInformation
 from ratelimit.auths.ip import client_ip
 from ratelimit.backends.redis import RedisBackend
-from ratelimit.types import ASGIApp, Scope
+from starlette.types import ASGIApp, Message, Receive, Send
+from starlette.types import Scope as ASGIScope
 
 from polar.auth.models import AuthSubject, Subject, is_anonymous
 from polar.config import Environment, settings
 from polar.enums import RateLimitGroup
-from polar.redis import create_redis
+from polar.logging import Logger
+from polar.redis import Redis, create_redis
+
+log: Logger = structlog.get_logger()
 
 
-async def _authenticate(scope: Scope) -> tuple[str, RateLimitGroup]:
+async def _authenticate(scope: ASGIScope) -> tuple[str, RateLimitGroup]:
     auth_subject: AuthSubject[Subject] = scope["state"]["auth_subject"]
 
     if is_anonymous(auth_subject):
@@ -79,4 +85,144 @@ def get_middleware(app: ASGIApp) -> RateLimitMiddleware:
     )
 
 
-__all__ = ["get_middleware"]
+# --- Fast path ----------------------------------------------------------
+#
+# The post-auth limiter above runs after AuthSubjectMiddleware has already
+# done up to 5 sequential token lookups + Dramatiq enqueues. Under abuse
+# that's enough work to spike CPU even though every response is a 429.
+#
+# RateLimitFastPathMiddleware sits *outside* auth and the DB session and
+# does both halves of the same loop using a coarse caller identity (bearer
+# token hash or client IP):
+#
+#   - On the way in: one Redis GET. If a block is set, return 429
+#     immediately with no DB, no auth, no Dramatiq.
+#   - On the way out: if downstream returned 429, write a block whose TTL
+#     mirrors the response's Retry-After header (clamped to a sane range)
+#     so the block matches whatever the rate-limit rule already decided
+#     (window reset time or the rule's block_time), falling back to
+#     _DEFAULT_BLOCK_SECONDS.
+#
+# The auto-block write is gated on caller identity being trustworthy: if
+# the request presented a bearer token but AuthSubjectMiddleware did not
+# validate it to a non-anonymous subject, we skip the write. Otherwise an
+# unauthenticated attacker could supply arbitrary bearer bytes and get a
+# block keyed on that hash, which would lock out the legitimate owner of
+# any token whose hash collides (or, more realistically, lock out anyone
+# whose token they observed).
+
+_BLOCK_KEY_PREFIX = "rl:block:"
+_DEFAULT_BLOCK_SECONDS = 60
+_MAX_BLOCK_SECONDS = 3600  # ceiling for downstream-supplied Retry-After
+
+
+def _parse_retry_after(headers: Iterable[tuple[bytes, bytes]]) -> int | None:
+    """Extract a sane Retry-After value (seconds) from response headers.
+
+    Returns None if absent, unparseable, non-positive, or larger than
+    _MAX_BLOCK_SECONDS — so a misbehaving downstream component cannot pin a
+    block for an arbitrary duration.
+    """
+    for name, value in headers:
+        if name.lower() != b"retry-after":
+            continue
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+        return parsed if 0 < parsed <= _MAX_BLOCK_SECONDS else None
+    return None
+
+
+def _caller_identity(scope: ASGIScope) -> str | None:
+    """Coarse caller identity from the raw ASGI scope, no DB or auth.
+
+    Returns a hashed bearer token if present, else the client IP.
+    None when neither is available (we let the request through in that
+    case rather than block-by-default).
+    """
+    for name, value in scope.get("headers", ()):
+        if name == b"authorization":
+            if value[:7].lower() == b"bearer ":
+                token = value[7:].strip()
+                if token:
+                    return "t:" + hashlib.blake2b(
+                        token, digest_size=16
+                    ).hexdigest()
+            break
+    client = scope.get("client")
+    if client and client[0]:
+        return f"ip:{client[0]}"
+    return None
+
+
+class RateLimitFastPathMiddleware:
+    """Short-circuits blocked callers around the auth + DB stack.
+
+    Returns 429 from a single Redis GET when a block is set, and writes
+    that block whenever a downstream 429 is observed.
+    """
+
+    def __init__(self, app: ASGIApp, redis: Redis) -> None:
+        self.app = app
+        self.redis = redis
+
+    async def __call__(
+        self, scope: ASGIScope, receive: Receive, send: Send
+    ) -> None:
+        if scope["type"] != "http" or not scope["path"].startswith("/v1"):
+            await self.app(scope, receive, send)
+            return
+
+        ident = _caller_identity(scope)
+        if ident is None:
+            await self.app(scope, receive, send)
+            return
+
+        block_key = _BLOCK_KEY_PREFIX + ident
+        blocked = await self.redis.get(block_key)
+        if blocked:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 429,
+                    "headers": [
+                        (b"content-type", b"text/plain; charset=utf-8"),
+                        (b"retry-after", str(int(blocked)).encode()),
+                    ],
+                }
+            )
+            await send(
+                {"type": "http.response.body", "body": b"Too Many Requests"}
+            )
+            return
+
+        start_message: Message | None = None
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal start_message
+            if start_message is None and message["type"] == "http.response.start":
+                start_message = message
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+        if start_message is None or start_message["status"] != 429:
+            return
+
+        # If the caller presented a bearer token but auth did NOT validate
+        # it to a real subject, the token bytes are attacker-controlled —
+        # do not write a block keyed on their hash.
+        if ident.startswith("t:"):
+            auth_subject = scope.get("state", {}).get("auth_subject")
+            if auth_subject is None or is_anonymous(auth_subject):
+                return
+
+        retry_after = _parse_retry_after(start_message["headers"])
+        block_seconds = retry_after if retry_after else _DEFAULT_BLOCK_SECONDS
+        await self.redis.set(block_key, block_seconds, ex=block_seconds)
+        log.info(
+            "rate_limit.fastpath.block_set",
+            identity=ident,
+            ttl_seconds=block_seconds,
+        )

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -13,7 +13,7 @@ from polar.auth.models import AuthSubject, Subject, is_anonymous
 from polar.config import Environment, settings
 from polar.enums import RateLimitGroup
 from polar.logging import Logger
-from polar.redis import Redis, create_redis
+from polar.redis import Redis
 
 log: Logger = structlog.get_logger()
 
@@ -72,7 +72,7 @@ _PRODUCTION_RULES: dict[str, Sequence[Rule]] = {
 }
 
 
-def get_middleware(app: ASGIApp) -> RateLimitMiddleware:
+def get_middleware(app: ASGIApp, redis: Redis) -> RateLimitMiddleware:
     match settings.ENV:
         case Environment.production:
             rules = _PRODUCTION_RULES
@@ -80,9 +80,7 @@ def get_middleware(app: ASGIApp) -> RateLimitMiddleware:
             rules = _SANDBOX_RULES
         case _:
             rules = {}
-    return RateLimitMiddleware(
-        app, _authenticate, RedisBackend(create_redis("rate-limit")), rules
-    )
+    return RateLimitMiddleware(app, _authenticate, RedisBackend(redis), rules)
 
 
 # --- Fast path ----------------------------------------------------------

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -203,9 +203,7 @@ class TestRateLimitFastPathMiddlewareWriteOnTrip:
         keys = [k async for k in redis.scan_iter("rl:*")]
         assert keys == []
 
-    async def test_uses_retry_after_for_block_duration(
-        self, redis: Redis
-    ) -> None:
+    async def test_uses_retry_after_for_block_duration(self, redis: Redis) -> None:
         app = _RecordingApp(status=429, extra_headers=[(b"retry-after", b"42")])
         middleware = RateLimitFastPathMiddleware(app, redis)
         scope = _http_scope()
@@ -276,9 +274,7 @@ class TestRateLimitFastPathMiddlewareWriteOnTrip:
     ) -> None:
         # A negative ex on real Redis would raise after http.response.start
         # was already sent, corrupting the response. Clamp to the default.
-        app = _RecordingApp(
-            status=429, extra_headers=[(b"retry-after", b"-1")]
-        )
+        app = _RecordingApp(status=429, extra_headers=[(b"retry-after", b"-1")])
         middleware = RateLimitFastPathMiddleware(app, redis)
         scope = _http_scope()
         ident = _caller_identity(scope)
@@ -290,9 +286,7 @@ class TestRateLimitFastPathMiddlewareWriteOnTrip:
         assert block is not None
         assert block == str(_DEFAULT_BLOCK_SECONDS)
 
-    async def test_huge_retry_after_falls_back_to_default(
-        self, redis: Redis
-    ) -> None:
+    async def test_huge_retry_after_falls_back_to_default(self, redis: Redis) -> None:
         app = _RecordingApp(
             status=429,
             extra_headers=[(b"retry-after", str(_MAX_BLOCK_SECONDS + 1).encode())],
@@ -319,9 +313,7 @@ class TestRateLimitFastPathMiddlewareAuthGating:
     locking out the legitimate owner of any token they can observe.
     """
 
-    async def test_block_written_for_authenticated_bearer(
-        self, redis: Redis
-    ) -> None:
+    async def test_block_written_for_authenticated_bearer(self, redis: Redis) -> None:
         app = _RecordingApp(status=429, auth_subject_to_set=_AUTHED_SUBJECT)
         middleware = RateLimitFastPathMiddleware(app, redis)
         scope = _http_scope(headers=[_BEARER_HEADER])
@@ -348,9 +340,7 @@ class TestRateLimitFastPathMiddlewareAuthGating:
 
         assert await redis.get(_BLOCK_KEY_PREFIX + ident) is None
 
-    async def test_no_block_when_auth_subject_missing(
-        self, redis: Redis
-    ) -> None:
+    async def test_no_block_when_auth_subject_missing(self, redis: Redis) -> None:
         # Defensive: scope state may be empty if AuthSubjectMiddleware
         # didn't run (e.g. an earlier middleware short-circuited).
         app = _RecordingApp(status=429)  # does not set auth_subject

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -1,0 +1,401 @@
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fakeredis import FakeAsyncRedis
+from starlette.types import Message, Receive, Scope, Send
+
+from polar.auth.models import Anonymous, AuthSubject
+from polar.models import User
+from polar.rate_limit import (
+    _BLOCK_KEY_PREFIX,
+    _DEFAULT_BLOCK_SECONDS,
+    _MAX_BLOCK_SECONDS,
+    RateLimitFastPathMiddleware,
+    _caller_identity,
+)
+from polar.redis import Redis
+
+
+@pytest_asyncio.fixture
+async def redis() -> AsyncIterator[Redis]:
+    # Override the shared autouse fixture (tests/fixtures/redis.py) with
+    # decode_responses=True so .get() returns str matching the project-wide
+    # Redis type hint — letting tests assert direct string equality.
+    yield FakeAsyncRedis(decode_responses=True)
+
+
+_ANON_SUBJECT = AuthSubject(Anonymous(), set(), None)
+_AUTHED_SUBJECT = AuthSubject(MagicMock(spec=User), set(), None)
+
+
+_BEARER_HEADER = (b"authorization", b"Bearer secret-abc")
+
+
+def _http_scope(
+    *,
+    path: str = "/v1/orders",
+    headers: list[tuple[bytes, bytes]] | None = None,
+    client: tuple[str, int] | None = ("1.2.3.4", 5000),
+    auth_subject: object | None = None,
+) -> Scope:
+    scope: Scope = {
+        "type": "http",
+        "path": path,
+        "headers": headers or [],
+        "client": client,
+    }
+    if auth_subject is not None:
+        scope["state"] = {"auth_subject": auth_subject}
+    return scope
+
+
+async def _noop_receive() -> Message:
+    return {"type": "http.disconnect"}
+
+
+class _RecordingApp:
+    def __init__(
+        self,
+        status: int = 200,
+        extra_headers: list[tuple[bytes, bytes]] | None = None,
+        auth_subject_to_set: object | None = None,
+    ) -> None:
+        self.status = status
+        self.extra_headers = extra_headers or []
+        self.auth_subject_to_set = auth_subject_to_set
+        self.calls = 0
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.calls += 1
+        # Simulate AuthSubjectMiddleware populating scope state on the way in.
+        if self.auth_subject_to_set is not None:
+            scope.setdefault("state", {})["auth_subject"] = self.auth_subject_to_set
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status,
+                "headers": [
+                    (b"content-type", b"text/plain"),
+                    *self.extra_headers,
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+class _CapturingSend:
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+
+    async def __call__(self, message: Message) -> None:
+        self.messages.append(message)
+
+    @property
+    def status(self) -> int | None:
+        for msg in self.messages:
+            if msg["type"] == "http.response.start":
+                return msg["status"]
+        return None
+
+    def header(self, name: bytes) -> bytes | None:
+        for msg in self.messages:
+            if msg["type"] == "http.response.start":
+                for k, v in msg["headers"]:
+                    if k == name:
+                        return v
+        return None
+
+
+class TestCallerIdentity:
+    def test_bearer_token_hashed(self) -> None:
+        scope = _http_scope(headers=[_BEARER_HEADER])
+        ident = _caller_identity(scope)
+        assert ident is not None
+        assert ident.startswith("t:")
+        assert "secret-abc" not in ident  # raw token must not appear
+
+    def test_bearer_is_case_insensitive(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"bearer xyz")])
+        assert _caller_identity(scope) is not None
+
+    def test_non_bearer_falls_back_to_ip(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"Basic abc")])
+        assert _caller_identity(scope) == "ip:1.2.3.4"
+
+    def test_ip_when_no_auth_header(self) -> None:
+        scope = _http_scope()
+        assert _caller_identity(scope) == "ip:1.2.3.4"
+
+    def test_returns_none_without_auth_or_client(self) -> None:
+        scope = _http_scope(client=None)
+        assert _caller_identity(scope) is None
+
+    def test_empty_bearer_falls_back_to_ip(self) -> None:
+        scope = _http_scope(headers=[(b"authorization", b"Bearer   ")])
+        assert _caller_identity(scope) == "ip:1.2.3.4"
+
+
+@pytest.mark.asyncio
+class TestRateLimitFastPathMiddlewareShortCircuit:
+    """Behavior when reading an existing block on the way in."""
+
+    async def test_passes_through_when_no_block(self, redis: Redis) -> None:
+        app = _RecordingApp()
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        send = _CapturingSend()
+
+        await middleware(_http_scope(), _noop_receive, send)
+
+        assert app.calls == 1
+        assert send.status == 200
+
+    async def test_returns_429_when_blocked(self, redis: Redis) -> None:
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+        await redis.set(_BLOCK_KEY_PREFIX + ident, 300, ex=300)
+
+        app = _RecordingApp()
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        send = _CapturingSend()
+
+        await middleware(scope, _noop_receive, send)
+
+        assert app.calls == 0  # downstream never invoked
+        assert send.status == 429
+        assert send.header(b"retry-after") == b"300"
+
+    async def test_skips_non_v1_paths(self, redis: Redis) -> None:
+        scope = _http_scope(path="/healthz")
+        ident = _caller_identity(scope)
+        assert ident is not None
+        await redis.set(_BLOCK_KEY_PREFIX + ident, 300, ex=300)
+
+        app = _RecordingApp()
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        send = _CapturingSend()
+
+        await middleware(scope, _noop_receive, send)
+
+        assert app.calls == 1
+        assert send.status == 200
+
+    async def test_lifespan_passes_through(self, redis: Redis) -> None:
+        app = _RecordingApp()
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        # Lifespan scopes do not have headers/client; middleware must not crash.
+        await middleware({"type": "lifespan"}, _noop_receive, _CapturingSend())
+        assert app.calls == 1
+
+
+@pytest.mark.asyncio
+class TestRateLimitFastPathMiddlewareWriteOnTrip:
+    """Behavior when observing a downstream 429 on the way out."""
+
+    async def test_no_block_written_on_2xx(self, redis: Redis) -> None:
+        app = _RecordingApp(status=200)
+        middleware = RateLimitFastPathMiddleware(app, redis)
+
+        await middleware(_http_scope(), _noop_receive, _CapturingSend())
+
+        keys = [k async for k in redis.scan_iter("rl:*")]
+        assert keys == []
+
+    async def test_uses_retry_after_for_block_duration(
+        self, redis: Redis
+    ) -> None:
+        app = _RecordingApp(status=429, extra_headers=[(b"retry-after", b"42")])
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        block = await redis.get(_BLOCK_KEY_PREFIX + ident)
+        assert block is not None
+        assert block == "42"
+        ttl = await redis.ttl(_BLOCK_KEY_PREFIX + ident)
+        assert 0 < ttl <= 42
+
+    async def test_falls_back_to_default_when_no_retry_after(
+        self, redis: Redis
+    ) -> None:
+        app = _RecordingApp(status=429)
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        block = await redis.get(_BLOCK_KEY_PREFIX + ident)
+        assert block is not None
+        assert block == str(_DEFAULT_BLOCK_SECONDS)
+
+    async def test_ignores_unparseable_retry_after(self, redis: Redis) -> None:
+        # asgi-ratelimit always emits seconds, but RFC allows HTTP-date too.
+        # We don't parse dates; we just fall back to the default.
+        app = _RecordingApp(
+            status=429,
+            extra_headers=[(b"retry-after", b"Wed, 21 Oct 2026 07:28:00 GMT")],
+        )
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        block = await redis.get(_BLOCK_KEY_PREFIX + ident)
+        assert block is not None
+        assert block == str(_DEFAULT_BLOCK_SECONDS)
+
+    async def test_isolates_identities(self, redis: Redis) -> None:
+        app = _RecordingApp(status=429)
+        middleware = RateLimitFastPathMiddleware(app, redis)
+
+        attacker = _http_scope(client=("9.9.9.9", 1))
+        bystander = _http_scope(client=("1.1.1.1", 1))
+
+        await middleware(attacker, _noop_receive, _CapturingSend())
+        # Bystander never trips, so no entry should exist for them.
+
+        attacker_id = _caller_identity(attacker)
+        bystander_id = _caller_identity(bystander)
+        assert attacker_id is not None
+        assert bystander_id is not None
+
+        assert await redis.get(_BLOCK_KEY_PREFIX + attacker_id) is not None
+        assert await redis.get(_BLOCK_KEY_PREFIX + bystander_id) is None
+
+    async def test_negative_retry_after_falls_back_to_default(
+        self, redis: Redis
+    ) -> None:
+        # A negative ex on real Redis would raise after http.response.start
+        # was already sent, corrupting the response. Clamp to the default.
+        app = _RecordingApp(
+            status=429, extra_headers=[(b"retry-after", b"-1")]
+        )
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        block = await redis.get(_BLOCK_KEY_PREFIX + ident)
+        assert block is not None
+        assert block == str(_DEFAULT_BLOCK_SECONDS)
+
+    async def test_huge_retry_after_falls_back_to_default(
+        self, redis: Redis
+    ) -> None:
+        app = _RecordingApp(
+            status=429,
+            extra_headers=[(b"retry-after", str(_MAX_BLOCK_SECONDS + 1).encode())],
+        )
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        block = await redis.get(_BLOCK_KEY_PREFIX + ident)
+        assert block is not None
+        assert block == str(_DEFAULT_BLOCK_SECONDS)
+
+
+@pytest.mark.asyncio
+class TestRateLimitFastPathMiddlewareAuthGating:
+    """Auto-block writes are gated on the bearer token having been
+    validated by AuthSubjectMiddleware to a non-anonymous subject.
+
+    Without this gate, an unauthenticated attacker could supply arbitrary
+    bearer bytes, trigger any 429, and write a block keyed on the hash —
+    locking out the legitimate owner of any token they can observe.
+    """
+
+    async def test_block_written_for_authenticated_bearer(
+        self, redis: Redis
+    ) -> None:
+        app = _RecordingApp(status=429, auth_subject_to_set=_AUTHED_SUBJECT)
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope(headers=[_BEARER_HEADER])
+        ident = _caller_identity(scope)
+        assert ident is not None
+        assert ident.startswith("t:")
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        assert await redis.get(_BLOCK_KEY_PREFIX + ident) is not None
+
+    async def test_no_block_for_anonymous_bearer(self, redis: Redis) -> None:
+        # Bearer header present but auth resolved to Anonymous (e.g.
+        # registration-token-prefix path, or any other case where the
+        # bearer bytes were not validated as a real credential).
+        app = _RecordingApp(status=429, auth_subject_to_set=_ANON_SUBJECT)
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope(headers=[_BEARER_HEADER])
+        ident = _caller_identity(scope)
+        assert ident is not None
+        assert ident.startswith("t:")
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        assert await redis.get(_BLOCK_KEY_PREFIX + ident) is None
+
+    async def test_no_block_when_auth_subject_missing(
+        self, redis: Redis
+    ) -> None:
+        # Defensive: scope state may be empty if AuthSubjectMiddleware
+        # didn't run (e.g. an earlier middleware short-circuited).
+        app = _RecordingApp(status=429)  # does not set auth_subject
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope(headers=[_BEARER_HEADER])
+        ident = _caller_identity(scope)
+        assert ident is not None
+        assert ident.startswith("t:")
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        assert await redis.get(_BLOCK_KEY_PREFIX + ident) is None
+
+    async def test_block_written_for_ip_identity_without_auth_subject(
+        self, redis: Redis
+    ) -> None:
+        # No bearer header → identity is IP-based → gate does not apply.
+        app = _RecordingApp(status=429)
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+        ident = _caller_identity(scope)
+        assert ident is not None
+        assert ident.startswith("ip:")
+
+        await middleware(scope, _noop_receive, _CapturingSend())
+
+        assert await redis.get(_BLOCK_KEY_PREFIX + ident) is not None
+
+
+@pytest.mark.asyncio
+class TestRateLimitFastPathMiddlewareEndToEnd:
+    """First request trips downstream → second request takes the short-circuit."""
+
+    async def test_trip_then_short_circuit(self, redis: Redis) -> None:
+        app = _RecordingApp(status=429, extra_headers=[(b"retry-after", b"30")])
+        middleware = RateLimitFastPathMiddleware(app, redis)
+        scope = _http_scope()
+
+        # First request: hits downstream, gets 429, block written.
+        await middleware(scope, _noop_receive, _CapturingSend())
+        assert app.calls == 1
+
+        # Second request: short-circuited by the block, downstream not invoked.
+        send = _CapturingSend()
+        await middleware(scope, _noop_receive, send)
+        assert app.calls == 1
+        assert send.status == 429
+        assert send.header(b"retry-after") == b"30"


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- none -->

Stacked on top of #11466. Closes the Redis-client lifecycle leak flagged in that PR's review by sharing one client between both rate-limit middlewares and disposing it in the lifespan shutdown.

## What

- `rate_limit.get_middleware` now takes a `redis: Redis` parameter instead of calling `create_redis("rate-limit")` internally.
- `create_app()` creates one `rate_limit_redis` client and passes it to both `rate_limit.get_middleware` (post-auth limiter) and `RateLimitFastPathMiddleware`.
- The client is stashed on `app.state.rate_limit_redis` so the lifespan shutdown can close it alongside the existing `app` Redis client.

## Why

Before this change, both rate-limit middlewares each constructed their own `create_redis("rate-limit")` client at `create_app()` time and never closed them on shutdown — two leaked connection pools per app lifecycle. Annoying in production (slow shutdown, pool exhaustion under reload loops), noisy in tests/dev with auto-reload.

The fix is the "construct once, close in lifespan" pattern the existing `redis = create_redis("app")` already uses (`server/polar/app.py:154,183`).

## How

One Redis client is enough — both middlewares connect with the same `client_name="<env>.rate-limit"` and share the same key namespace, so a single connection pool is correct. `get_middleware` was the awkward outlier (factory hiding its Redis dependency); refactoring it to take the client as a parameter mirrors how `RateLimitFastPathMiddleware` is already wired and keeps the lifecycle visible at the call site.

Lifespan shutdown closes it via `getattr(app.state, "rate_limit_redis", None)` — testing builds skip the rate-limit middlewares entirely, so the attribute may be absent.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included