### PR TITLE
Allow order override in <Box /> props

### DIFF
--- a/clients/packages/orbit/src/utils/resolvers.test.ts
+++ b/clients/packages/orbit/src/utils/resolvers.test.ts
@@ -221,6 +221,26 @@ describe('addTokenProp — breakpoint variants', () => {
     expect(responsiveCSS).toContain('padding: 16px')
     expect(responsiveCSS).toContain('gap: 8px')
   })
+
+  it('padding-top wins over padding-block at the same breakpoint', () => {
+    const { responsiveCSS } = resolveBoxStyles(
+      {
+        paddingVertical: { md: 'l' },
+        paddingTop: { md: 'none' },
+      },
+      'scope',
+    )
+    expect(responsiveCSS).toContain('@media (min-width: 768px)')
+    const mdMatch = responsiveCSS!.match(
+      /@media \(min-width: 768px\) \{[^}]+\}/,
+    )
+    expect(mdMatch).toBeTruthy()
+    const block = mdMatch![0]
+    expect(block.indexOf('padding-block')).toBeLessThan(
+      block.indexOf('padding-top'),
+    )
+    expect(block).toContain('padding-top: 0')
+  })
 })
 
 describe('addTokenProp — token-CSS translations', () => {

--- a/clients/packages/orbit/src/utils/resolvers.ts
+++ b/clients/packages/orbit/src/utils/resolvers.ts
@@ -86,6 +86,71 @@ function toKebab(str: string): string {
   return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)
 }
 
+const DECLARATION_ORDER: readonly string[] = [
+  'padding',
+  'margin',
+  'gap',
+  'padding-inline',
+  'margin-inline',
+  'padding-block',
+  'margin-block',
+  'row-gap',
+  'column-gap',
+  'padding-top',
+  'padding-right',
+  'padding-bottom',
+  'padding-left',
+  'margin-top',
+  'margin-right',
+  'margin-bottom',
+  'margin-left',
+  'border-width',
+  'border-style',
+  'border-color',
+  'border-radius',
+  'border-top-left-radius',
+  'border-top-right-radius',
+  'border-bottom-left-radius',
+  'border-bottom-right-radius',
+  'border-top-width',
+  'border-right-width',
+  'border-bottom-width',
+  'border-left-width',
+  'overflow',
+  'overflow-x',
+  'overflow-y',
+  'flex',
+  'flex-direction',
+  'flex-wrap',
+  'flex-grow',
+  'flex-shrink',
+  'flex-basis',
+  'inset',
+  'top',
+  'right',
+  'bottom',
+  'left',
+]
+
+function normalizedCssKey(key: string): string {
+  return key.includes('-') ? key : toKebab(key)
+}
+
+function sortedDeclarationEntries(
+  record: Record<string, string | number>,
+): [string, string | number][] {
+  return Object.entries(record).sort(([a], [b]) => {
+    const ka = normalizedCssKey(a)
+    const kb = normalizedCssKey(b)
+    const ia = DECLARATION_ORDER.indexOf(ka)
+    const ib = DECLARATION_ORDER.indexOf(kb)
+    const pa = ia === -1 ? 10_000 : ia
+    const pb = ib === -1 ? 10_000 : ib
+    if (pa !== pb) return pa - pb
+    return ka.localeCompare(kb)
+  })
+}
+
 function px(v: number): string {
   return v === 0 ? '0' : `${v}px`
 }
@@ -539,8 +604,8 @@ export function resolveBoxStyles(
     const parts: string[] = []
 
     for (const bp of bpKeys) {
-      const entries = Object.entries(breakpointStyles[bp])
-        .map(([k, v]) => `${toKebab(k)}: ${v}`)
+      const entries = sortedDeclarationEntries(breakpointStyles[bp])
+        .map(([k, v]) => `${normalizedCssKey(k)}: ${v}`)
         .join('; ')
       // Breakpoint 0 = base styles for responsive arbitrary props (no media query).
       // Higher breakpoints are wrapped in @media so they cascade over the base.
@@ -552,8 +617,8 @@ export function resolveBoxStyles(
     }
 
     for (const pseudo of pseudoKeys) {
-      const entries = Object.entries(pseudoStyles[pseudo])
-        .map(([k, v]) => `${toKebab(k)}: ${v}`)
+      const entries = sortedDeclarationEntries(pseudoStyles[pseudo])
+        .map(([k, v]) => `${normalizedCssKey(k)}: ${v}`)
         .join('; ')
       parts.push(`${selector}${pseudo} { ${entries} }`)
     }


### PR DESCRIPTION
This PR will allow us for prop order overrides in our `<Box />` component, similar to what you can do in CSS. Meaning this is now possible:

```tsx
const Component = ({removeTopSpacing}) => {
  return (
    <Box
      paddingVertical={{
        base: '3xl',
        md: '4xl',
      }}
      paddingTop={{ md: removeTopSpacing ? "none" : undefined  }}
    >
      Hello
    </Box>
  )
}
```