### PR TITLE
ConfirmModal: trim whitespace when matching confirm prompt

### DIFF
--- a/clients/apps/web/src/components/Modal/ConfirmModal.tsx
+++ b/clients/apps/web/src/components/Modal/ConfirmModal.tsx
@@ -90,7 +90,7 @@ export const ConfirmModal = ({
               {confirmPrompt && (
                 <>
                   <p className="dark:text-polar-400 max-w-full text-sm text-gray-500">
-                    Please enter &quot;{confirmPrompt}&quot; to confirm:
+                    Please enter &quot;{confirmPrompt.trim()}&quot; to confirm:
                   </p>
                   <FormField
                     control={control}
@@ -108,7 +108,7 @@ export const ConfirmModal = ({
                               <Input
                                 type="input"
                                 required
-                                placeholder={confirmPrompt}
+                                placeholder={confirmPrompt.trim()}
                                 autoComplete="off"
                                 {...field}
                               />

--- a/clients/apps/web/src/components/Modal/ConfirmModal.tsx
+++ b/clients/apps/web/src/components/Modal/ConfirmModal.tsx
@@ -44,6 +44,7 @@ export const ConfirmModal = ({
   const { control, handleSubmit, reset, watch } = form
   // eslint-disable-next-line react-hooks/incompatible-library
   const prompt = watch('prompt')
+  const trimmedConfirmPrompt = confirmPrompt?.trim()
 
   const handleConfirm = useCallback(() => {
     onConfirm()
@@ -90,14 +91,14 @@ export const ConfirmModal = ({
               {confirmPrompt && (
                 <>
                   <p className="dark:text-polar-400 max-w-full text-sm text-gray-500">
-                    Please enter &quot;{confirmPrompt.trim()}&quot; to confirm:
+                    Please enter &quot;{trimmedConfirmPrompt}&quot; to confirm:
                   </p>
                   <FormField
                     control={control}
                     name="prompt"
                     rules={{
                       validate: (value) =>
-                        (value ?? '').trim() === confirmPrompt.trim() ||
+                        (value ?? '').trim() === trimmedConfirmPrompt ||
                         'Please enter the exact text to confirm',
                     }}
                     render={({ field }) => {
@@ -108,7 +109,7 @@ export const ConfirmModal = ({
                               <Input
                                 type="input"
                                 required
-                                placeholder={confirmPrompt.trim()}
+                                placeholder={trimmedConfirmPrompt}
                                 autoComplete="off"
                                 {...field}
                               />
@@ -126,8 +127,8 @@ export const ConfirmModal = ({
                   type="submit"
                   variant={destructive ? 'destructive' : 'default'}
                   disabled={
-                    confirmPrompt
-                      ? (prompt ?? '').trim() !== confirmPrompt.trim()
+                    trimmedConfirmPrompt
+                      ? (prompt ?? '').trim() !== trimmedConfirmPrompt
                       : false
                   }
                 >

--- a/clients/apps/web/src/components/Modal/ConfirmModal.tsx
+++ b/clients/apps/web/src/components/Modal/ConfirmModal.tsx
@@ -97,7 +97,7 @@ export const ConfirmModal = ({
                     name="prompt"
                     rules={{
                       validate: (value) =>
-                        value === confirmPrompt ||
+                        (value ?? '').trim() === confirmPrompt.trim() ||
                         'Please enter the exact text to confirm',
                     }}
                     render={({ field }) => {
@@ -125,7 +125,11 @@ export const ConfirmModal = ({
                 <Button
                   type="submit"
                   variant={destructive ? 'destructive' : 'default'}
-                  disabled={confirmPrompt ? prompt !== confirmPrompt : false}
+                  disabled={
+                    confirmPrompt
+                      ? (prompt ?? '').trim() !== confirmPrompt.trim()
+                      : false
+                  }
                 >
                   {destructive ? destructiveText : 'Confirm'}
                 </Button>


### PR DESCRIPTION
Customers were getting locked out of deletion flows when the source
identifier (e.g., organization slug) had trailing whitespace they didn't
type. Trim both sides of the comparison so the match is edit-proof.