### PR TITLE
feat: surface ad-hoc and pay-what-you-want pricing to org review agent

### DIFF
--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -123,7 +123,8 @@ async def _collect_products(
     async with AsyncReadSessionMaker() as session:
         repo = OrganizationReviewRepository.from_session(session)
         products = await repo.get_products_with_prices(organization_id)
-        return collect_products_data(products)
+        adhoc_prices_count = await repo.get_adhoc_price_count(organization_id)
+        return collect_products_data(products, adhoc_prices_count=adhoc_prices_count)
 
 
 async def _collect_setup(organization_id: UUID, context: ReviewContext) -> SetupData:

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -108,6 +108,24 @@ to prohibited content (adult sites, gambling, etc.). Any cross-domain redirect f
 checkout URL is a strong red flag and should be treated as HIGH risk unless the final \
 destination is a known service domain.
 
+**Pricing setup**: How the organization has configured its prices is part of how it's \
+set up to sell. Custom and ad-hoc pricing should be judged differently:
+
+- **Pay-what-you-want (custom amount_type)** — contextual. Not a red flag on its own.
+  - Legitimate fit: open-source sponsorship, creator/community support, donations to a \
+project, tipping. PWYW is the EXPECTED model here.
+  - Suspicious fit: SaaS subscriptions, software licenses, human services (web design, \
+consulting), or any product with a defined deliverable and market price. A SaaS that \
+charges "whatever the customer enters" doesn't make sense as a business model — flag here.
+
+- **Ad-hoc prices (catalog price overridden via API at checkout)** — edgy. The public \
+catalog price is not what's actually being charged: each checkout gets a one-off price. \
+A $1 catalog product paired with ad-hoc prices is the classic abuse pattern. If the \
+ad-hoc count is non-zero, default to DENY so a human reviews it — UNLESS the prior \
+human-approval rule applies (a previous human reviewer already approved this org with \
+the same ad-hoc pricing pattern in view). Don't re-raise a concern a human has already \
+resolved.
+
 ## Verdict Guidelines
 
 - **APPROVE**: All dimensions are LOW risk, no policy violations, \
@@ -234,6 +252,24 @@ is expected — the user is supporting the project, not buying a product. Do not
 with prohibited "donations" (which refers to charity/non-profit fundraising, not open source support).
 **Lesson**: Open source project support is always acceptable. Low volume with no benefits is \
 normal for this category — do not flag it.
+
+### Example 9b: SaaS with $1 Catalog Product + Ad-hoc Prices → DENY (human review)
+**Business**: Self-described SaaS in private beta. Catalog has a $1 fixed-price product \
+and a separate product for "human services (web development)". Many ad-hoc prices have been \
+created at checkout, billing amounts well above $1.
+**Agent concern**: Ad-hoc pricing exists on the account.
+**Correct verdict**: DENY. Ad-hoc prices alone are enough to route this to a human reviewer, \
+and the rest of the picture reinforces that decision: the $1 catalog listing is a façade \
+(the real prices are set per-checkout, hidden from the public catalog), the stated business \
+is a SaaS where defined tiers are expected, and the separate "human services" product is \
+itself unsupported (Polar does not handle pure human services). A human reviewer can confirm \
+or override; the agent should not auto-approve.
+**Lesson**: Ad-hoc prices are edgy on their own — default to DENY so a human looks at it. \
+Pay-what-you-want is contextual (fine for OSS support, suspicious for SaaS), but ad-hoc \
+prices override the catalog itself and are a structural mismatch with how a public catalog \
+is supposed to work. When in doubt, DENY and let a human approve. Exception: if a prior \
+human reviewer already approved this org while the same ad-hoc pricing was in place, \
+trust that approval and do not re-raise.
 
 ### Example 10: Small-Volume Org with High Refund Rate → APPROVE (Threshold)
 **Business**: Legitimate SaaS with 3 succeeded payments and 1 refund (33% refund rate). \
@@ -404,7 +440,8 @@ overrides agent-level concerns. Specifically:
 - Do NOT re-raise the SAME concerns that were raised in prior agent reviews and resolved \
 by a human approval. This includes: setup/integration concerns, website concerns, \
 cross-domain redirects, missing webhooks, missing checkout link benefits, domain \
-mismatches, and policy concerns the human already considered.
+mismatches, ad-hoc / pay-what-you-want pricing concerns, and policy concerns the human \
+already considered.
 - The ONLY reasons to deny an org with prior human approval are:
   1. NEW evidence of a clearly prohibited business (e.g., the org pivoted to selling \
 prohibited content like adult/gambling/financial trading).
@@ -694,6 +731,17 @@ class ReviewAnalyzer:
                         else:
                             price_strs.append(str(pr.get("amount_type", "unknown")))
                     parts.append(f"  Prices: {', '.join(price_strs)}")
+
+            if products.custom_pricing_products_count > 0:
+                parts.append(
+                    f"Pay-what-you-want products (customer enters the amount): "
+                    f"{products.custom_pricing_products_count} of {products.total_count}"
+                )
+            if products.adhoc_prices_count > 0:
+                parts.append(
+                    f"Ad-hoc prices created at checkout via the API "
+                    f"(overriding the catalog price): {products.adhoc_prices_count}"
+                )
 
         # Setup & Integration Signals (only for threshold/manual reviews)
         setup = snapshot.setup

--- a/server/polar/organization_review/collectors/products.py
+++ b/server/polar/organization_review/collectors/products.py
@@ -1,10 +1,14 @@
 from polar.models.product import Product
+from polar.models.product_price import ProductPriceAmountType
 
 from ..schemas import ProductData, ProductsData
 
 
-def collect_products_data(products: list[Product]) -> ProductsData:
+def collect_products_data(
+    products: list[Product], adhoc_prices_count: int = 0
+) -> ProductsData:
     product_data_list = []
+    custom_pricing_products_count = 0
     for product in products:
         prices = []
         for price in product.prices:
@@ -16,6 +20,9 @@ def collect_products_data(products: list[Product]) -> ProductsData:
             if hasattr(price, "price_currency"):
                 price_info["currency"] = price.price_currency
             prices.append(price_info)
+
+        if any(p.amount_type == ProductPriceAmountType.custom for p in product.prices):
+            custom_pricing_products_count += 1
 
         product_data_list.append(
             ProductData(
@@ -33,4 +40,6 @@ def collect_products_data(products: list[Product]) -> ProductsData:
     return ProductsData(
         products=product_data_list,
         total_count=len(product_data_list),
+        adhoc_prices_count=adhoc_prices_count,
+        custom_pricing_products_count=custom_pricing_products_count,
     )

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -22,6 +22,7 @@ from polar.models.organization_review_feedback import OrganizationReviewFeedback
 from polar.models.payment import Payment, PaymentStatus
 from polar.models.payout_account import PayoutAccount
 from polar.models.product import Product
+from polar.models.product_price import ProductPrice, ProductPriceSource
 from polar.models.refund import Refund, RefundStatus
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
@@ -131,6 +132,20 @@ class OrganizationReviewRepository(
         )
         result = await self.session.execute(statement)
         return list(result.scalars().unique().all())
+
+    async def get_adhoc_price_count(self, organization_id: UUID) -> int:
+        """Count prices created on-demand at checkout (overriding the catalog price)."""
+        statement = (
+            select(func.count(ProductPrice.id))
+            .join(Product, Product.id == ProductPrice.product_id)
+            .where(
+                Product.organization_id == organization_id,
+                ProductPrice.source == ProductPriceSource.ad_hoc,
+                ProductPrice.is_archived.is_(False),
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar() or 0
 
     async def get_payment_stats(self, organization_id: UUID) -> tuple[int, int, int]:
         """Returns (total_payments, succeeded_payments, total_amount_cents)."""

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -107,6 +107,20 @@ class ProductData(Schema):
 class ProductsData(Schema):
     products: list[ProductData] = Field(default_factory=list)
     total_count: int = 0
+    adhoc_prices_count: int = Field(
+        default=0,
+        description=(
+            "Number of prices created on-demand at checkout via the API, overriding "
+            "the catalog price for that checkout."
+        ),
+    )
+    custom_pricing_products_count: int = Field(
+        default=0,
+        description=(
+            "Number of active products with pay-what-you-want pricing (the customer "
+            "enters the amount at checkout)."
+        ),
+    )
 
 
 class IdentityData(Schema):

--- a/server/tests/organization_review/collectors/test_products.py
+++ b/server/tests/organization_review/collectors/test_products.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock
+
+from polar.models.product_price import ProductPriceAmountType
+from polar.organization_review.collectors.products import collect_products_data
+
+
+def _build_price(
+    amount_type: ProductPriceAmountType,
+    *,
+    price_amount: int | None = None,
+    price_currency: str | None = "usd",
+) -> MagicMock:
+    """Build a mock ProductPrice. Only attributes used by the collector are set."""
+    price = MagicMock(spec=["amount_type", "price_amount", "price_currency"])
+    price.amount_type = amount_type
+    price.price_amount = price_amount
+    price.price_currency = price_currency
+    return price
+
+
+def _build_product(
+    *,
+    name: str = "Product",
+    is_archived: bool = False,
+    prices: list[MagicMock] | None = None,
+) -> MagicMock:
+    product = MagicMock()
+    product.name = name
+    product.description = None
+    product.recurring_interval = None
+    product.visibility = None
+    product.is_archived = is_archived
+    product.prices = prices or []
+    return product
+
+
+class TestCollectProductsData:
+    def test_empty(self) -> None:
+        data = collect_products_data([])
+        assert data.total_count == 0
+        assert data.adhoc_prices_count == 0
+        assert data.custom_pricing_products_count == 0
+
+    def test_passes_through_adhoc_prices_count(self) -> None:
+        data = collect_products_data([], adhoc_prices_count=7)
+        assert data.adhoc_prices_count == 7
+
+    def test_counts_products_with_pay_what_you_want_pricing(self) -> None:
+        custom_product = _build_product(
+            name="Donate",
+            prices=[_build_price(ProductPriceAmountType.custom)],
+        )
+        fixed_product = _build_product(
+            name="Pro Plan",
+            prices=[_build_price(ProductPriceAmountType.fixed, price_amount=2000)],
+        )
+        data = collect_products_data([custom_product, fixed_product])
+        assert data.total_count == 2
+        assert data.custom_pricing_products_count == 1
+
+    def test_counts_each_custom_product_once_regardless_of_price_count(self) -> None:
+        product = _build_product(
+            prices=[
+                _build_price(ProductPriceAmountType.custom),
+                _build_price(ProductPriceAmountType.custom),
+                _build_price(ProductPriceAmountType.fixed, price_amount=500),
+            ],
+        )
+        data = collect_products_data([product])
+        assert data.custom_pricing_products_count == 1
+
+    def test_no_custom_pricing(self) -> None:
+        data = collect_products_data(
+            [
+                _build_product(
+                    prices=[
+                        _build_price(ProductPriceAmountType.fixed, price_amount=1000)
+                    ],
+                ),
+                _build_product(prices=[_build_price(ProductPriceAmountType.free)]),
+            ]
+        )
+        assert data.custom_pricing_products_count == 0

--- a/server/tests/organization_review/test_repository.py
+++ b/server/tests/organization_review/test_repository.py
@@ -2,9 +2,11 @@ from datetime import UTC, datetime
 
 import pytest
 
+from polar.models.account import Account
 from polar.models.organization import Organization
 from polar.models.payment import PaymentStatus
 from polar.models.product import Product
+from polar.models.product_price import ProductPriceSource
 from polar.models.user import User
 from polar.organization_review.report import (
     AgentReportV2,
@@ -36,7 +38,10 @@ from tests.fixtures.random_objects import (
     create_checkout_link,
     create_customer,
     create_order,
+    create_organization,
     create_payment,
+    create_product,
+    create_product_price_fixed,
     create_refund,
 )
 
@@ -1072,3 +1077,99 @@ class TestGetCheckoutLinksWithBenefits:
         repo = OrganizationReviewRepository.from_session(session)
         links = await repo.get_checkout_links_with_benefits(organization.id)
         assert links == []
+
+
+@pytest.mark.asyncio
+class TestGetAdhocPriceCount:
+    async def test_zero_when_no_prices(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repo = OrganizationReviewRepository.from_session(session)
+        assert await repo.get_adhoc_price_count(organization.id) == 0
+
+    async def test_excludes_catalog_prices(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[(1000, "usd")],
+        )
+        repo = OrganizationReviewRepository.from_session(session)
+        assert await repo.get_adhoc_price_count(organization.id) == 0
+
+    async def test_counts_adhoc_prices(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[(100, "usd")],  # $1 catalog product
+        )
+        # Two ad-hoc overrides created at checkout
+        for amount in (5000, 25000):
+            adhoc = await create_product_price_fixed(
+                save_fixture, product=product, amount=amount, currency="usd"
+            )
+            adhoc.source = ProductPriceSource.ad_hoc
+            await save_fixture(adhoc)
+
+        repo = OrganizationReviewRepository.from_session(session)
+        assert await repo.get_adhoc_price_count(organization.id) == 2
+
+    async def test_excludes_archived_adhoc_prices(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[(100, "usd")],
+        )
+        adhoc = await create_product_price_fixed(
+            save_fixture, product=product, amount=5000, currency="usd"
+        )
+        adhoc.source = ProductPriceSource.ad_hoc
+        adhoc.is_archived = True
+        await save_fixture(adhoc)
+
+        repo = OrganizationReviewRepository.from_session(session)
+        assert await repo.get_adhoc_price_count(organization.id) == 0
+
+    async def test_scoped_to_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        account_second: Account,
+    ) -> None:
+        # Ad-hoc price on a product from a DIFFERENT org should not be counted.
+        other_org = await create_organization(save_fixture, account_second)
+        other_product = await create_product(
+            save_fixture,
+            organization=other_org,
+            recurring_interval=None,
+            prices=[(100, "usd")],
+        )
+        adhoc = await create_product_price_fixed(
+            save_fixture, product=other_product, amount=5000, currency="usd"
+        )
+        adhoc.source = ProductPriceSource.ad_hoc
+        await save_fixture(adhoc)
+
+        repo = OrganizationReviewRepository.from_session(session)
+        assert await repo.get_adhoc_price_count(organization.id) == 0
+        assert await repo.get_adhoc_price_count(other_org.id) == 1


### PR DESCRIPTION
## Summary

- Org review agent now sees counts of ad-hoc prices (catalog price overridden via API at checkout) and pay-what-you-want products in the snapshot it analyzes.
- Adds prompt guidance under Setup Readiness: PWYW is contextual (fine for OSS support, suspicious for SaaS); ad-hoc pricing defaults to DENY for human review, unless the prior human-approval rule already covers it.
- Adds collector unit tests and repository integration tests for the new query.

## Test plan
- [x] Backend lint and type-check pass
- [x] New collector tests pass (5)
- [x] New repository tests pass (5)
- [ ] Manual: trigger "Run review agent" on an org with ad-hoc pricing and confirm the verdict reflects the new guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)