### PR TITLE
chore: Dedicated queue for PDF generation jobs step 1

### DIFF
--- a/dev/cli/commands/worker.py
+++ b/dev/cli/commands/worker.py
@@ -20,7 +20,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
         cmd = [
             "uv", "run", "dramatiq",
             "-p", "1", "-t", "1",
-            "--queues", "high_priority", "medium_priority", "low_priority", "tinybird",
+            "--queues", "high_priority", "medium_priority", "low_priority", "tinybird", "invoices_and_receipts",
             "--watch", "polar",
             "-f", "polar.worker.scheduler:start",
             "polar.worker.run",

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -185,7 +185,7 @@ module "production" {
       dramatiq_prom_port = "10000"
     }
     "worker" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority"
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority invoices_and_receipts"
       image_url          = data.render_web_service.production_worker["worker"].runtime_source.image.image_url
       image_digest       = data.render_web_service.production_worker["worker"].runtime_source.image.digest
       custom_domains     = [{ name = "worker.polar.sh" }]

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -128,7 +128,7 @@ module "sandbox" {
 
   workers = {
     worker-sandbox = {
-      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority"
+      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority invoices_and_receipts"
       image_url          = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.image_url
       image_digest       = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.digest
       dramatiq_prom_port = "10000"


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `order.receipt` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. Update existing workers to start consuming a new queue (this step)
2. Move `order.invoice` and `order.receipt` to the new queue
3. Create a new worker in sandbox that consumes only `invoices_and_receipts`
4. Update the regular worker in sandbox so it stops consuming the new queue
5. Verify this solves OOM issues in sandbox
6. Create a new worker in production that consumes only `invoices_and_receipts`
7. Update the low priority worker in production so it stops consuming the new queue
8. Verify this solves OOM issues in production 