### PR TITLE
chore: Dedicated queue for PDF generation jobs step 2

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -468,7 +468,7 @@ class OrderService:
         if order.billing_name is None or order.billing_address is None:
             raise MissingInvoiceBillingDetails(order)
 
-        enqueue_job("order.invoice", order_id=order.id)
+        enqueue_job("order.invoice.v2", order_id=order.id)
 
     async def generate_invoice(self, session: AsyncSession, order: Order) -> Order:
         invoice_path = await invoice_service.create_order_invoice(order)

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -19,6 +19,7 @@ from polar.worker import (
     AsyncSessionMaker,
     CronTrigger,
     TaskPriority,
+    TaskQueue,
     actor,
     can_retry,
     enqueue_job,
@@ -212,7 +213,11 @@ async def order_confirmation_email(order_id: uuid.UUID) -> None:
         await order_service.send_confirmation_email(session, order)
 
 
-@actor(actor_name="order.invoice", priority=TaskPriority.LOW)
+@actor(
+    actor_name="order.invoice",
+    priority=TaskPriority.LOW,
+    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
+)
 async def order_invoice(order_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = OrderRepository.from_session(session)

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -213,12 +213,7 @@ async def order_confirmation_email(order_id: uuid.UUID) -> None:
         await order_service.send_confirmation_email(session, order)
 
 
-@actor(
-    actor_name="order.invoice",
-    priority=TaskPriority.LOW,
-    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
-)
-async def order_invoice(order_id: uuid.UUID) -> None:
+async def _run_order_invoice(order_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = OrderRepository.from_session(session)
         order = await repository.get_by_id(
@@ -228,6 +223,22 @@ async def order_invoice(order_id: uuid.UUID) -> None:
             raise OrderDoesNotExist(order_id)
 
         await order_service.generate_invoice(session, order)
+
+
+# Kept temporarily to drain in-flight messages enqueued before the v2 cutover.
+# Remove once the queue is empty and rename `order.invoice.v2` back to `order.invoice`.
+@actor(actor_name="order.invoice", priority=TaskPriority.LOW)
+async def order_invoice(order_id: uuid.UUID) -> None:
+    await _run_order_invoice(order_id)
+
+
+@actor(
+    actor_name="order.invoice.v2",
+    priority=TaskPriority.LOW,
+    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
+)
+async def order_invoice_v2(order_id: uuid.UUID) -> None:
+    await _run_order_invoice(order_id)
 
 
 @actor(

--- a/server/polar/receipt/service.py
+++ b/server/polar/receipt/service.py
@@ -116,7 +116,7 @@ class ReceiptService:
 
     async def get_pdf_url_or_status(self, order: Order) -> tuple[str, datetime] | None:
         if order.receipt_path is None:
-            enqueue_job("receipt.render", order_id=order.id)
+            enqueue_job("receipt.render.v2", order_id=order.id)
             return None
 
         s3 = S3Service(settings.S3_CUSTOMER_RECEIPTS_BUCKET_NAME)

--- a/server/polar/receipt/tasks.py
+++ b/server/polar/receipt/tasks.py
@@ -31,13 +31,7 @@ class ReceiptOrderDoesNotExist(ReceiptTaskError):
         super().__init__(f"Order {order_id} does not exist.")
 
 
-@actor(
-    actor_name="receipt.render",
-    priority=TaskPriority.LOW,
-    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
-    time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
-)
-async def receipt_render(order_id: uuid.UUID) -> None:
+async def _run_receipt_render(order_id: uuid.UUID) -> None:
     locker = Locker(RedisMiddleware.get())
     async with AsyncSessionMaker() as session:
         repository = OrderRepository.from_session(session)
@@ -57,4 +51,25 @@ async def receipt_render(order_id: uuid.UUID) -> None:
                 "receipt render: lock contention, re-enqueueing",
                 order_id=str(order_id),
             )
-            enqueue_job("receipt.render", order_id, delay=RENDER_RETRY_DELAY_MS)
+            enqueue_job("receipt.render.v2", order_id, delay=RENDER_RETRY_DELAY_MS)
+
+
+# Kept temporarily to drain in-flight messages enqueued before the v2 cutover.
+# Remove once the queue is empty and rename `receipt.render.v2` back to `receipt.render`.
+@actor(
+    actor_name="receipt.render",
+    priority=TaskPriority.LOW,
+    time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
+)
+async def receipt_render(order_id: uuid.UUID) -> None:
+    await _run_receipt_render(order_id)
+
+
+@actor(
+    actor_name="receipt.render.v2",
+    priority=TaskPriority.LOW,
+    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
+    time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
+)
+async def receipt_render_v2(order_id: uuid.UUID) -> None:
+    await _run_receipt_render(order_id)

--- a/server/polar/receipt/tasks.py
+++ b/server/polar/receipt/tasks.py
@@ -10,6 +10,7 @@ from polar.worker import (
     AsyncSessionMaker,
     RedisMiddleware,
     TaskPriority,
+    TaskQueue,
     actor,
     enqueue_job,
 )
@@ -33,6 +34,7 @@ class ReceiptOrderDoesNotExist(ReceiptTaskError):
 @actor(
     actor_name="receipt.render",
     priority=TaskPriority.LOW,
+    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
     time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
 )
 async def receipt_render(order_id: uuid.UUID) -> None:

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -536,7 +536,7 @@ class RefundService:
             )
 
             if order.receipt_number is not None:
-                enqueue_job("receipt.render", order.id)
+                enqueue_job("receipt.render.v2", order.id)
 
     async def _on_updated(self, session: AsyncSession, refund: Refund) -> None:
         if refund.organization is not None:

--- a/server/polar/worker/_queues.py
+++ b/server/polar/worker/_queues.py
@@ -13,6 +13,7 @@ class TaskQueue(StrEnum):
     LOW_PRIORITY = "low_priority"
     WEBHOOKS = "webhooks"
     TINYBIRD = "tinybird"
+    INVOICES_AND_RECEIPTS = "invoices_and_receipts"
 
 
 __all__ = [

--- a/server/tests/customer_portal/endpoints/test_order.py
+++ b/server/tests/customer_portal/endpoints/test_order.py
@@ -501,7 +501,7 @@ class TestGetOrderReceipt:
         response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
 
         assert response.status_code == 202
-        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
+        enqueue_mock.assert_called_once_with("receipt.render.v2", order_id=order.id)
 
     @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
     async def test_200_when_receipt_ready(

--- a/server/tests/e2e/infra/task_drain.py
+++ b/server/tests/e2e/infra/task_drain.py
@@ -39,6 +39,7 @@ DEFAULT_IGNORED_ACTORS: frozenset[str] = frozenset(
         "order.balance",
         # Uploads invoice PDF to S3/MinIO
         "order.invoice",
+        "order.invoice.v2",
         # Loops.so CRM integration
         "loops.update_last_order_at",
         "loops.update_contact",
@@ -57,6 +58,7 @@ QUEUE_NAMES = (
     "low_priority",
     "webhooks",
     "tinybird",
+    "invoices_and_receipts",
 )
 MAX_DRAIN_ITERATIONS = 200
 MAX_UNWRAP_DEPTH = 10

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -437,7 +437,7 @@ class TestGetOrderReceipt:
         response = await client.get(f"/v1/orders/{order.id}/receipt")
 
         assert response.status_code == 202
-        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
+        enqueue_mock.assert_called_once_with("receipt.render.v2", order_id=order.id)
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
     async def test_200_when_receipt_ready(

--- a/server/tests/receipt/test_service.py
+++ b/server/tests/receipt/test_service.py
@@ -409,7 +409,7 @@ class TestGetPdfUrlOrStatus:
         result = await receipt_service.get_pdf_url_or_status(order)
 
         assert result is None
-        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
+        enqueue_mock.assert_called_once_with("receipt.render.v2", order_id=order.id)
 
     async def test_returns_url_when_path_set(
         self,

--- a/server/tests/receipt/test_tasks.py
+++ b/server/tests/receipt/test_tasks.py
@@ -73,7 +73,7 @@ class TestReceiptRender:
         await receipt_render(order.id)
 
         enqueue_job_mock.assert_called_once_with(
-            "receipt.render", order.id, delay=5_000
+            "receipt.render.v2", order.id, delay=5_000
         )
 
     async def test_delegates_to_service(


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue **(this step)**
3. Create a new worker in sandbox that consumes only `invoices_and_receipts`
4. Update the regular worker in sandbox so it stops consuming the new queue
5. Verify this solves OOM issues in sandbox
6. Create a new worker in production that consumes only `invoices_and_receipts`
7. Update the low priority worker in production so it stops consuming the new queue
8. Verify this solves OOM issues in production
9. Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs)
10. Remove `.v2` entirely