### PR TITLE
Handle 403 errors gracefully in AccountWidget

### DIFF
--- a/clients/apps/web/src/components/Widgets/AccountWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/AccountWidget.tsx
@@ -1,6 +1,7 @@
 import { useOrganizationAccount, useTransactionsSummary } from '@/hooks/queries'
 import { usePayouts } from '@/hooks/queries/payouts'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
+import { ClientResponseError } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Card } from '@polar-sh/ui/components/atoms/Card'
 import { Status } from '@polar-sh/ui/components/atoms/Status'
@@ -15,12 +16,19 @@ export interface AccountWidgetProps {
 export const AccountWidget = ({ className }: AccountWidgetProps) => {
   const { organization: org } = useContext(OrganizationContext)
 
-  const { data: account } = useOrganizationAccount(org.id)
+  const { data: account, error: accountError } = useOrganizationAccount(org.id)
   const { data: summary } = useTransactionsSummary(account?.id ?? '')
   const { data: payouts } = usePayouts(account?.id, {
     limit: 10,
     sorting: ['-created_at'],
   })
+
+  if (
+    accountError instanceof ClientResponseError &&
+    accountError.response.status === 403
+  ) {
+    return null
+  }
 
   const allPayouts = payouts?.items ?? []
 


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Handle 403 Forbidden errors in the AccountWidget component by returning null instead of attempting to render with unavailable data.

## What

Added error handling to the AccountWidget component to detect and gracefully handle 403 Forbidden responses from the `useOrganizationAccount` hook. When a 403 error occurs, the component now returns null instead of rendering.

## Why

When a user lacks permission to access organization account data (403 Forbidden), the component should not attempt to render with missing or inaccessible data. This prevents potential errors and provides a cleaner user experience by hiding the widget entirely rather than displaying broken state.

## How

- Imported `ClientResponseError` from `@polar-sh/client`
- Destructured the `error` property from the `useOrganizationAccount` hook
- Added a conditional check that returns null if the error is a `ClientResponseError` with a 403 status code

## Checklist

- [x] This PR addresses a single concern (error handling for 403 responses)
- [x] The diff is reasonably sized and easy to review
- [x] No new tests needed (error handling is straightforward conditional logic)
- [x] Linting and type checking should pass
- [x] No unrelated changes included

https://claude.ai/code/session_01LB1MgRFvv7tgeb1MT65yMP