### PR TITLE
Preserve license key status on benefit grant updates

### DIFF
--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -377,7 +377,6 @@ class LicenseKeyService:
             key.member_id = member_id
 
         update_attrs = [
-            "status",
             "expires_at",
             "limit_activations",
             "limit_usage",

--- a/server/tests/license_key/test_endpoints.py
+++ b/server/tests/license_key/test_endpoints.py
@@ -457,6 +457,62 @@ class TestLicenseKeyEndpoints:
         )
 
 
+@pytest.mark.asyncio
+class TestCustomerUpdateGrant:
+    @pytest.mark.parametrize(
+        "preserved_status",
+        [LicenseKeyStatus.disabled, LicenseKeyStatus.revoked],
+    )
+    async def test_preserves_status_on_benefit_update(
+        self,
+        preserved_status: LicenseKeyStatus,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        benefit, granted = await TestLicenseKey.create_benefit_and_grant(
+            session,
+            redis,
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            product=product,
+            properties=BenefitLicenseKeysCreateProperties(
+                prefix="testing",
+                activations=BenefitLicenseKeyActivationCreateProperties(
+                    limit=1, enable_customer_admin=True
+                ),
+            ),
+        )
+
+        repository = LicenseKeyRepository.from_session(session)
+        lk = await repository.get_by_id(UUID(granted["license_key_id"]))
+        assert lk is not None
+        lk.status = preserved_status
+        session.add(lk)
+        await session.flush()
+
+        benefit.properties = {
+            **benefit.properties,
+            "activations": {"limit": 5, "enable_customer_admin": True},
+        }
+        await save_fixture(benefit)
+
+        await license_key_service.customer_grant(
+            session,
+            customer=customer,
+            benefit=benefit,
+            license_key_id=lk.id,
+        )
+
+        await session.refresh(lk)
+        assert lk.status == preserved_status
+        assert lk.limit_activations == 5
+
+
 @pytest_asyncio.fixture
 async def license_key_organization_second(
     session: AsyncSession,


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Fix license key status being reset during benefit grant updates. The `customer_update_grant` method should preserve the current status (disabled/revoked) instead of overwriting it when updating other properties like activation limits.

## What

Removed `"status"` from the list of attributes updated in `customer_update_grant` method in `license_key/service.py`. This prevents the status field from being reset during benefit updates.

Added comprehensive test coverage (`TestCustomerUpdateGrant.test_preserves_status_on_benefit_update`) that verifies license key status is preserved when updating benefit properties, covering both `disabled` and `revoked` statuses.

## Why

When a benefit's properties are updated (e.g., activation limits), the associated license key's status should not be modified. Previously, the status was being included in the update attributes, causing it to be reset even when it had been explicitly set to `disabled` or `revoked`.

## How

- Removed `"status"` from the `update_attrs` list in `customer_update_grant`
- Added parameterized test that:
  1. Creates a benefit and grant with a license key
  2. Sets the license key status to `disabled` or `revoked`
  3. Updates the benefit's activation properties
  4. Calls `customer_grant` to update the grant
  5. Verifies the status is preserved while other properties are updated

## Checklist

- [x] This PR addresses a single concern (preserve status on benefit updates)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (parameterized test added)
- [ ] Linting and type checking pass (to be verified)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01VWFUsyjchHb1CtPX7CxSYh