### PR TITLE
Payout Delays logic

### DIFF
--- a/clients/apps/app/app/(authenticated)/finance/index.tsx
+++ b/clients/apps/app/app/(authenticated)/finance/index.tsx
@@ -26,11 +26,9 @@ export default function Finance() {
     refetch: refetchAccount,
     isRefetching: isRefetchingAccount,
   } = useOrganizationAccount(organization?.id)
-  const {
-    data: payoutAccount,
-    refetch: refetchPayoutAccount,
-    isRefetching: isRefetchingPayoutAccount,
-  } = usePayoutAccount(organization?.payout_account_id || undefined)
+  const { data: payoutAccount } = usePayoutAccount(
+    organization?.payout_account_id || undefined,
+  )
 
   const {
     data: summary,
@@ -54,8 +52,12 @@ export default function Finance() {
   const canWithdraw =
     payoutAccount &&
     payoutAccount.is_payout_ready &&
-    summary?.balance?.amount &&
-    summary.balance.amount >= 1000
+    summary?.available_balance?.amount &&
+    summary.available_balance.amount >= 1000
+  const availableBalance = formatCurrency('accounting')(
+    summary?.available_balance.amount ?? 0,
+    summary?.available_balance.currency ?? 'usd',
+  )
 
   if (!account) {
     return (
@@ -125,13 +127,8 @@ export default function Finance() {
         padding="spacing-16"
         backgroundColor="card"
       >
-        <Text color="subtext">Account Balance</Text>
-        <Text variant="headlineLarge">
-          {formatCurrency('accounting')(
-            summary?.balance.amount ?? 0,
-            summary.balance.currency,
-          )}
-        </Text>
+        <Text color="subtext">Available balance</Text>
+        <Text variant="headlineLarge">{availableBalance}</Text>
       </Box>
       <Box flexDirection="column" alignItems="center" gap="spacing-16">
         <Box width="100%">

--- a/clients/apps/app/components/Home/FinanceTile.tsx
+++ b/clients/apps/app/components/Home/FinanceTile.tsx
@@ -28,15 +28,19 @@ export const FinanceTile = ({ loading }: FinanceTileProps) => {
   const canWithdraw =
     payoutAccount &&
     payoutAccount.is_payout_ready &&
-    summary?.balance?.amount &&
-    summary.balance.amount >= 1000
+    summary?.available_balance?.amount &&
+    summary.available_balance.amount >= 1000
+  const availableBalance = formatCurrency('compact')(
+    summary?.available_balance.amount ?? 0,
+    summary?.available_balance.currency ?? 'usd',
+  )
 
   return (
     <Tile href="/finance">
       <Box flex={1} flexDirection="column" justifyContent="space-between">
         <Box flexDirection="column" gap="spacing-4">
           <Text variant="body" color="subtext">
-            Account Balance
+            Available balance
           </Text>
           <Text
             variant="headline"
@@ -44,10 +48,7 @@ export const FinanceTile = ({ loading }: FinanceTileProps) => {
             loading={loading}
             placeholderText="$1,234"
           >
-            {formatCurrency('compact')(
-              summary?.balance.amount ?? 0,
-              summary?.balance.currency ?? 'usd',
-            )}
+            {availableBalance}
           </Text>
         </Box>
         <Box flexDirection="row" justifyContent="flex-start">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/(wide)/income/IncomePage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/(wide)/income/IncomePage.tsx
@@ -10,6 +10,7 @@ import {
   getAPIParams,
   serializeSearchParams,
 } from '@/utils/datatable'
+import { ISODuration } from '@/utils/duration'
 import { ClientResponseError, schemas } from '@polar-sh/client'
 import { usePathname, useRouter } from 'next/navigation'
 
@@ -60,6 +61,9 @@ export default function ClientPage({
     isLoading: accountIsLoading,
     error: accountError,
   } = useOrganizationAccount(organization.id)
+  const payoutTransactionDelay = account?.payout_transaction_delay
+    ? new ISODuration(account.payout_transaction_delay)
+    : null
 
   const isNotAdmin =
     accountError &&
@@ -103,6 +107,7 @@ export default function ClientPage({
         sorting={sorting}
         onSortingChange={setSorting}
         isLoading={accountIsLoading || balancesHook.isLoading}
+        payoutTransactionDelay={payoutTransactionDelay}
       />
     </div>
   )

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -5,6 +5,13 @@ import { Modal } from '@/components/Modal'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import Button from '@polar-sh/ui/components/atoms/Button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@polar-sh/ui/components/ui/tooltip'
+import InfoOutlined from '@mui/icons-material/InfoOutlined'
+import { ISODuration } from '@/utils/duration'
 import React, { useCallback } from 'react'
 import { useModal } from '../Modal/useModal'
 import { Well, WellContent, WellFooter, WellHeader } from '../Shared/Well'
@@ -70,11 +77,27 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
     showCreatePayoutAccountModal()
   }, [hideManagePayoutAccountModal, showCreatePayoutAccountModal])
 
+  const delay = new ISODuration(account.payout_transaction_delay)
+  const hasDelay = delay.isNonZero()
+  const delayLabel = delay.format()
+  const availableBalance = summary
+    ? formatCurrency('accounting')(
+        summary.available_balance.amount,
+        summary.available_balance.currency,
+      )
+    : null
+  const totalBalance = summary
+    ? formatCurrency('accounting')(
+        summary.balance.amount,
+        summary.balance.currency,
+      )
+    : null
+
   return (
     <div className="flex flex-col gap-8 md:flex-row">
       <Well className="flex-1 justify-between rounded-2xl bg-gray-50 p-6">
         <WellHeader className="flex flex-row items-center justify-between gap-x-6">
-          <h2 className="text-lg font-medium capitalize">Balance</h2>
+          <h2 className="text-lg font-medium capitalize">Available balance</h2>
           <Button className="self-start" onClick={showPayoutConfirmModal}>
             Withdraw
           </Button>
@@ -83,16 +106,31 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           <div className="text-4xl">
             {isLoading ? (
               <div className="animate-pulse rounded-lg bg-gray-200 text-gray-200">
-                &nbps;
+                &nbsp;
               </div>
             ) : (
-              summary &&
-              formatCurrency('accounting')(
-                summary.balance.amount,
-                summary.balance.currency,
-              )
+              availableBalance
             )}
           </div>
+          {summary &&
+          summary.available_balance.amount !== summary.balance.amount ? (
+            <div className="dark:text-polar-500 flex items-center gap-2 text-gray-500">
+              <span>Total balance: {totalBalance}</span>
+              {hasDelay && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <InfoOutlined fontSize="small" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Transactions are available for withdrawal after{' '}
+                      {delayLabel}.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          ) : null}
         </WellContent>
         <WellFooter>
           <p className="dark:text-polar-500 text-gray-500">
@@ -115,7 +153,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           <div className="text-4xl">
             {isLoading ? (
               <div className="animate-pulse rounded-lg bg-gray-200 text-gray-200">
-                &nbps;
+                &nbsp;
               </div>
             ) : (
               summary &&

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -5,12 +5,7 @@ import { Modal } from '@/components/Modal'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import Button from '@polar-sh/ui/components/atoms/Button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@polar-sh/ui/components/ui/tooltip'
-import InfoOutlined from '@mui/icons-material/InfoOutlined'
+
 import { ISODuration } from '@/utils/duration'
 import React, { useCallback } from 'react'
 import { useModal } from '../Modal/useModal'
@@ -114,20 +109,16 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           </div>
           {summary &&
           summary.available_balance.amount !== summary.balance.amount ? (
-            <div className="dark:text-polar-500 flex items-center gap-2 text-gray-500">
-              <span>Total balance: {totalBalance}</span>
+            <div className="dark:text-polar-500 space-y-1 text-gray-500">
+              <div>Total balance: {totalBalance}</div>
               {hasDelay && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <InfoOutlined fontSize="small" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>
-                      Transactions are available for withdrawal after{' '}
-                      {delayLabel}.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
+                <div>
+                  Available in {delayLabel}:{' '}
+                  {formatCurrency('accounting')(
+                    summary.balance.amount - summary.available_balance.amount,
+                    summary.balance.currency,
+                  )}
+                </div>
               )}
             </div>
           ) : null}

--- a/clients/apps/web/src/components/Transactions/TransactionAvailabilityStatus.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionAvailabilityStatus.tsx
@@ -1,0 +1,103 @@
+import { schemas } from '@polar-sh/client'
+import { Status } from '@polar-sh/ui/components/atoms/Status'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@polar-sh/ui/components/ui/tooltip'
+import { ISODuration } from '@/utils/duration'
+import { twMerge } from 'tailwind-merge'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+
+const TransactionAvailabilityStatusColor: Record<
+  'on_hold' | 'available' | 'paid_out',
+  string
+> = {
+  on_hold: 'bg-blue-100 text-blue-600 dark:bg-blue-950 dark:text-blue-400',
+  available: 'bg-emerald-100 text-emerald-500 dark:bg-emerald-950',
+  paid_out: 'bg-gray-100 text-gray-600 dark:bg-polar-700 dark:text-polar-400',
+}
+
+const TransactionAvailabilityStatusTitle: Record<
+  'on_hold' | 'available' | 'paid_out',
+  string
+> = {
+  on_hold: 'On hold',
+  available: 'Available',
+  paid_out: 'Paid out',
+}
+
+const getTransactionAvailability = (
+  transaction: schemas['Transaction'] | schemas['TransactionEmbedded'],
+  delay: ISODuration | null,
+): {
+  status: 'on_hold' | 'available' | 'paid_out'
+  availableAt?: Date
+} => {
+  // Check if this transaction has been paid out
+  if (
+    'payout_transaction_id' in transaction &&
+    transaction.payout_transaction_id
+  ) {
+    return { status: 'paid_out' }
+  }
+
+  // Payout transactions are always available
+  if ('type' in transaction && transaction.type === 'payout') {
+    return { status: 'available' }
+  }
+
+  // If no delay is configured, all transactions are available
+  if (!delay || !delay.isNonZero()) {
+    return { status: 'available' }
+  }
+
+  const createdAt = new Date(transaction.created_at)
+  const availableAt = delay.addToDate(createdAt)
+  const now = new Date()
+
+  if (availableAt <= now) {
+    return { status: 'available' }
+  }
+
+  return { status: 'on_hold', availableAt }
+}
+
+export const TransactionAvailabilityStatus = ({
+  transaction,
+  delay,
+}: {
+  transaction: schemas['Transaction'] | schemas['TransactionEmbedded']
+  delay: ISODuration | null
+}) => {
+  const { status, availableAt } = getTransactionAvailability(transaction, delay)
+
+  if (status === 'on_hold' && availableAt) {
+    return (
+      <Tooltip>
+        <TooltipTrigger className="cursor-help">
+          <Status
+            status={TransactionAvailabilityStatusTitle[status]}
+            className={twMerge(
+              'w-fit',
+              TransactionAvailabilityStatusColor[status],
+            )}
+          />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Available on{' '}
+            <FormattedDateTime datetime={availableAt} dateStyle="medium" />
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Status
+      status={TransactionAvailabilityStatusTitle[status]}
+      className={twMerge('w-fit', TransactionAvailabilityStatusColor[status])}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -4,6 +4,7 @@ import {
   DataTableSortingState,
 } from '@/utils/datatable'
 import { isTransaction, platformFeesDisplayNames } from '@/utils/transaction'
+import { ISODuration } from '@/utils/duration'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import {
@@ -19,6 +20,7 @@ import {
   TooltipTrigger,
 } from '@polar-sh/ui/components/ui/tooltip'
 import TransactionMeta from './TransactionMeta'
+import { TransactionAvailabilityStatus } from './TransactionAvailabilityStatus'
 
 interface TransactionsListProps {
   transactions: schemas['Transaction'][]
@@ -28,10 +30,8 @@ interface TransactionsListProps {
   onPaginationChange?: DataTableOnChangeFn<DataTablePaginationState>
   sorting: DataTableSortingState
   onSortingChange?: DataTableOnChangeFn<DataTableSortingState>
-  extraColumns?: DataTableColumnDef<
-    schemas['Transaction'] | schemas['TransactionEmbedded']
-  >[]
   isLoading: boolean | ReactQueryLoading
+  payoutTransactionDelay: ISODuration | null
 }
 
 const TransactionsList = ({
@@ -42,8 +42,8 @@ const TransactionsList = ({
   onPaginationChange,
   sorting,
   onSortingChange,
-  extraColumns,
   isLoading,
+  payoutTransactionDelay,
 }: TransactionsListProps) => {
   const columns: DataTableColumnDef<
     schemas['Transaction'] | schemas['TransactionEmbedded']
@@ -56,7 +56,11 @@ const TransactionsList = ({
       ),
       cell: (props) => {
         const datetime = props.getValue() as string
-        return <FormattedDateTime datetime={datetime} resolution="time" />
+        return (
+          <div className="whitespace-nowrap">
+            <FormattedDateTime datetime={datetime} resolution="time" />
+          </div>
+        )
       },
     },
     {
@@ -275,7 +279,28 @@ const TransactionsList = ({
         )
       },
     },
-    ...(extraColumns || []),
+    {
+      id: 'status',
+      enableSorting: false,
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          column={column}
+          title="Status"
+          className="flex justify-end"
+        />
+      ),
+      cell: (props) => {
+        const transaction = props.row.original
+        return (
+          <div className="flex justify-end">
+            <TransactionAvailabilityStatus
+              transaction={transaction}
+              delay={payoutTransactionDelay}
+            />
+          </div>
+        )
+      },
+    },
   ]
 
   return (

--- a/clients/apps/web/src/components/Widgets/AccountWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/AccountWidget.tsx
@@ -31,18 +31,15 @@ export const AccountWidget = ({ className }: AccountWidgetProps) => {
   }
 
   const allPayouts = payouts?.items ?? []
+  const availableBalance = formatCurrency('compact')(
+    summary?.available_balance.amount ?? 0,
+    summary?.available_balance.currency ?? 'usd',
+  )
 
   return (
     <WidgetContainer
-      title="Balance"
-      action={
-        <h2 className="text-lg">
-          {formatCurrency('compact')(
-            summary?.balance.amount ?? 0,
-            summary?.balance.currency ?? 'usd',
-          )}
-        </h2>
-      }
+      title="Available balance"
+      action={<h2 className="text-lg">{availableBalance}</h2>}
       className={className}
     >
       {allPayouts.length > 0 ? (

--- a/clients/apps/web/src/utils/duration.ts
+++ b/clients/apps/web/src/utils/duration.ts
@@ -1,0 +1,69 @@
+import { formatDuration, add } from 'date-fns'
+
+export class ISODuration {
+  protected years?: number
+  protected months?: number
+  protected weeks?: number
+  protected days?: number
+  protected hours?: number
+  protected minutes?: number
+  protected seconds?: number
+
+  constructor(duration: string) {
+    const dateMatch = duration.match(
+      /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?/i,
+    )
+    const timeMatch = duration.match(
+      /(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/i,
+    )
+
+    if (!dateMatch) return
+
+    const [, yearsStr, monthsStr, weeksStr, daysStr] = dateMatch
+    const [, hoursStr, minutesStr, secondsStr] = timeMatch || []
+
+    if (yearsStr) this.years = parseInt(yearsStr, 10)
+    if (monthsStr) this.months = parseInt(monthsStr, 10)
+    if (weeksStr) this.weeks = parseInt(weeksStr, 10)
+    if (daysStr) this.days = parseInt(daysStr, 10)
+    if (hoursStr) this.hours = parseInt(hoursStr, 10)
+    if (minutesStr) this.minutes = parseInt(minutesStr, 10)
+    if (secondsStr) this.seconds = parseFloat(secondsStr)
+  }
+
+  public format(): string {
+    return formatDuration({
+      years: this.years,
+      months: this.months,
+      weeks: this.weeks,
+      days: this.days,
+      hours: this.hours,
+      minutes: this.minutes,
+      seconds: this.seconds,
+    })
+  }
+
+  public isNonZero(): boolean {
+    return !!(
+      this.years ||
+      this.months ||
+      this.weeks ||
+      this.days ||
+      this.hours ||
+      this.minutes ||
+      this.seconds
+    )
+  }
+
+  public addToDate(date: Date): Date {
+    return add(date, {
+      years: this.years,
+      months: this.months,
+      weeks: this.weeks,
+      days: this.days,
+      hours: this.hours,
+      minutes: this.minutes,
+      seconds: this.seconds,
+    })
+  }
+}

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5589,6 +5589,12 @@ export interface components {
        * @description Minimum delay, in seconds, between two payout requests.
        */
       payout_interval: number
+      /**
+       * Payout Transaction Delay
+       * Format: duration
+       * @description Delay after which a transaction becomes available for payout.
+       */
+      payout_transaction_delay: string
     }
     /** AccountCredit */
     AccountCredit: {
@@ -29237,6 +29243,7 @@ export interface components {
     /** TransactionsSummary */
     TransactionsSummary: {
       balance: components['schemas']['TransactionsBalance']
+      available_balance: components['schemas']['TransactionsBalance']
       payout: components['schemas']['TransactionsBalance']
     }
     /** TrialAlreadyRedeemed */

--- a/server/polar/account/schemas.py
+++ b/server/polar/account/schemas.py
@@ -16,6 +16,9 @@ class Account(TimestampedSchema, IDSchema):
     payout_interval: int = Field(
         description="Minimum delay, in seconds, between two payout requests.",
     )
+    payout_transaction_delay: timedelta = Field(
+        description="Delay after which a transaction becomes available for payout."
+    )
 
     @field_validator("payout_interval", mode="before")
     @classmethod

--- a/server/polar/backoffice/forms.py
+++ b/server/polar/backoffice/forms.py
@@ -155,7 +155,7 @@ class InputField(FormField):
             if errors:
                 classes("input-error")
         if description:
-            with tag.div(classes="label"):
+            with tag.div(classes="label text-wrap"):
                 text(description)
         for error in errors:
             with tag.div(classes="label text-error"):

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -17,12 +17,13 @@ import stripe as stripe_lib
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import UUID4, BaseModel, Field, ValidationError, field_validator
-from pydantic_core import PydanticCustomError
+from pydantic_core import PydanticCustomError, SchemaSerializer, core_schema
 from sqlalchemy import Select, and_, func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
 from sse_starlette.sse import EventSourceResponse
 from tagflow import tag, text
 
+from polar.account.repository import AccountRepository
 from polar.account.service import account as account_service
 from polar.account_credit.repository import AccountCreditRepository
 from polar.account_credit.service import account_credit_service
@@ -98,6 +99,7 @@ from ..layout import layout
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
 from . import priority as review_priority
+from .forms import UpdateAccountSettingsForm
 from .priority import Signals
 from .views.detail_view import OrganizationDetailView
 from .views.list_view import (
@@ -2766,6 +2768,81 @@ async def edit_checkout_settings(
                     type="submit",
                     variant="primary",
                 ):
+                    text("Save Changes")
+
+    return None
+
+
+@router.api_route(
+    "/{organization_id}/edit-account-settings",
+    name="organizations:edit_account_settings",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def edit_account_settings(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> HXRedirectResponse | None:
+    """Edit organization account settings (e.g., payout_transaction_delay)."""
+    repository = OrganizationRepository(session)
+
+    organization = await repository.get_by_id(
+        organization_id,
+        include_blocked=True,
+        options=(joinedload(Organization.account),),
+    )
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    validation_error: ValidationError | None = None
+
+    if request.method == "POST":
+        data = await request.form()
+        try:
+            form = UpdateAccountSettingsForm.model_validate_form(data)
+            account_repository = AccountRepository.from_session(session)
+            await account_repository.update(
+                organization.account,
+                update_dict={"payout_transaction_delay": form.payout_transaction_delay},
+            )
+            return HXRedirectResponse(
+                request,
+                str(
+                    request.url_for(
+                        "organizations:detail", organization_id=organization_id
+                    )
+                )
+                + "?section=settings",
+            )
+        except ValidationError as e:
+            validation_error = e
+
+    timedelta_serializer = SchemaSerializer(core_schema.timedelta_schema())
+    prefill_data = {
+        "payout_transaction_delay": timedelta_serializer.to_python(
+            organization.account.payout_transaction_delay, mode="json"
+        )
+    }
+
+    with modal("Edit Account Settings", open=True):
+        with UpdateAccountSettingsForm.render(
+            data=prefill_data,
+            hx_post=str(
+                request.url_for(
+                    "organizations:edit_account_settings",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            validation_error=validation_error,
+            classes="flex flex-col",
+        ):
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(type="submit", variant="primary"):
                     text("Save Changes")
 
     return None

--- a/server/polar/backoffice/organizations_v2/forms.py
+++ b/server/polar/backoffice/organizations_v2/forms.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+from typing import Annotated
+
+from pydantic import Field
+
+from polar.backoffice import forms
+
+
+class UpdateAccountSettingsForm(forms.BaseForm):
+    """Form for editing account settings including payout_transaction_delay."""
+
+    payout_transaction_delay: Annotated[timedelta, forms.InputField(type="text")] = (
+        Field(
+            title="Payout Transaction Delay",
+            description=(
+                "Expected format is ISO8601 duration format "
+                "(e.g., 'P3D' for 3 days, or 'PT12H' for 12 hours)."
+            ),
+        )
+    )

--- a/server/polar/backoffice/organizations_v2/views/sections/account_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/account_section.py
@@ -4,6 +4,7 @@ import contextlib
 from collections.abc import Generator, Sequence
 from datetime import UTC, datetime
 
+from babel.dates import format_timedelta
 from fastapi import Request
 from tagflow import tag, text
 
@@ -85,9 +86,6 @@ class AccountSection:
 
                     # Fees row
                     with tag.div(classes="pt-4 border-t border-base-300"):
-                        with tag.div(classes="text-sm font-semibold mb-3"):
-                            text("Platform Fees")
-
                         with tag.div(classes="grid grid-cols-2 gap-4"):
                             with tag.div():
                                 with tag.div(
@@ -109,6 +107,19 @@ class AccountSection:
                                 with tag.div(classes="font-semibold"):
                                     text(
                                         f"{basis_points / 100:.2f}% + {_format_cents(fixed_cents)}"
+                                    )
+
+                            # Payout Transaction Delay - span both columns
+                            with tag.div(classes="col-span-2"):
+                                with tag.div(
+                                    classes="text-sm text-base-content/60 mb-1"
+                                ):
+                                    text("Payout Transaction Delay")
+                                with tag.div(classes="font-semibold"):
+                                    text(
+                                        format_timedelta(
+                                            account.payout_transaction_delay
+                                        )
                                     )
 
             # Fee Credits section (only if account exists)

--- a/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
@@ -3,6 +3,7 @@
 import contextlib
 from collections.abc import Generator
 
+from babel.dates import format_timedelta
 from fastapi import Request
 from tagflow import tag, text
 
@@ -152,6 +153,36 @@ class SettingsSection:
                             text("Group")
                         with tag.div(classes="text-sm"):
                             text(self.org.rate_limit_group.value.title())
+
+            # Account settings card
+            with card(bordered=True):
+                with tag.div(classes="flex items-center justify-between mb-4"):
+                    with tag.h2(classes="text-lg font-bold"):
+                        text("Account Settings")
+                    with button(
+                        variant="secondary",
+                        size="sm",
+                        ghost=True,
+                        hx_get=str(
+                            request.url_for(
+                                "organizations:edit_account_settings",
+                                organization_id=self.org.id,
+                            )
+                        ),
+                        hx_target="#modal",
+                    ):
+                        text("Edit")
+
+                with tag.div(classes="space-y-4"):
+                    with tag.div():
+                        with tag.div(classes="text-sm text-base-content/60 mb-1"):
+                            text("Payout Transaction Delay")
+                        with tag.div(classes="font-semibold"):
+                            text(
+                                format_timedelta(
+                                    self.org.account.payout_transaction_delay
+                                )
+                            )
 
             # Feature flags card
             with card(bordered=True):

--- a/server/polar/invoice/service.py
+++ b/server/polar/invoice/service.py
@@ -70,11 +70,9 @@ class InvoiceService:
         for transaction in payout_transactions:
             if transaction.platform_fee_type is None:
                 gross_amount += transaction.amount
-            elif transaction.platform_fee_type not in {
-                PlatformFeeType.account,
-                PlatformFeeType.payout,
-                PlatformFeeType.cross_border_transfer,
-            }:
+            elif (
+                transaction.platform_fee_type not in PlatformFeeType.payout_fee_types()
+            ):
                 payment_fees_amount += transaction.amount
             else:
                 payout_fees_amount += transaction.amount

--- a/server/polar/models/transaction.py
+++ b/server/polar/models/transaction.py
@@ -187,6 +187,10 @@ class PlatformFeeType(StrEnum):
     **Deprecated: we no longer have a generic platform fee. They're always associated with a specific reason.**
     """
 
+    @classmethod
+    def payout_fee_types(cls) -> set["PlatformFeeType"]:
+        return {cls.cross_border_transfer, cls.payout, cls.account}
+
 
 class Transaction(RecordModel):
     """

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -269,9 +269,8 @@ class PayoutService:
         account = organization.account
         payout_account = organization.get_ready_payout_account()
 
-        balance_amount = await transaction_service.get_transactions_sum(
-            session, account.id
-        )
+        summary = await transaction_service.get_summary(session, account)
+        balance_amount = summary.available_balance.amount
         minimum_amount = settings.get_minimum_payout(
             payout_account.currency, payout_account.country
         )
@@ -335,9 +334,8 @@ class PayoutService:
 
             payout_account = organization.get_ready_payout_account()
 
-            balance_amount = await transaction_service.get_transactions_sum(
-                session, account.id
-            )
+            summary = await transaction_service.get_summary(session, account)
+            balance_amount = summary.available_balance.amount
             minimum_amount = settings.get_minimum_payout(
                 payout_account.currency, payout_account.country
             )

--- a/server/polar/transaction/repository.py
+++ b/server/polar/transaction/repository.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import Select, update
+from sqlalchemy import Select, func, or_, update
 from sqlalchemy.orm import selectinload
 
 from polar.kit.repository import (
@@ -10,8 +10,8 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import Order, Payment, Transaction
-from polar.models.transaction import TransactionType
+from polar.models import Account, Order, Payment, Transaction
+from polar.models.transaction import PlatformFeeType, TransactionType
 
 
 class TransactionRepository(
@@ -71,10 +71,18 @@ class BalanceTransactionRepository(TransactionRepository):
     async def get_all_unpaid_by_account(self, account: UUID) -> Sequence[Transaction]:
         statement = (
             self.get_base_statement()
+            .join(Account, Account.id == Transaction.account_id)
             .where(
                 Transaction.type == TransactionType.balance,
                 Transaction.account_id == account,
                 Transaction.payout_transaction_id.is_(None),
+                or_(
+                    Transaction.created_at + Account.payout_transaction_delay
+                    <= func.now(),
+                    Transaction.platform_fee_type.in_(
+                        PlatformFeeType.payout_fee_types()
+                    ),
+                ),
             )
             .options(
                 selectinload(Transaction.balance_reversal_transaction),

--- a/server/polar/transaction/schemas.py
+++ b/server/polar/transaction/schemas.py
@@ -86,4 +86,5 @@ class TransactionsBalance(Schema):
 
 class TransactionsSummary(Schema):
     balance: TransactionsBalance
+    available_balance: TransactionsBalance
     payout: TransactionsBalance

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -18,7 +18,7 @@ from polar.models import (
     User,
 )
 from polar.models.organization import Organization
-from polar.models.transaction import TransactionType
+from polar.models.transaction import PlatformFeeType, TransactionType
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncReadSession, AsyncSession
 
@@ -177,12 +177,12 @@ class TransactionService(BaseTransactionService):
                         func.sum(Transaction.amount).filter(
                             or_(
                                 Transaction.type == TransactionType.payout,
-                                and_(
-                                    Transaction.type != TransactionType.payout,
-                                    Transaction.created_at
-                                    + Account.payout_transaction_delay
-                                    <= func.now(),
+                                Transaction.platform_fee_type.in_(
+                                    PlatformFeeType.payout_fee_types()
                                 ),
+                                Transaction.created_at
+                                + Account.payout_transaction_delay
+                                <= func.now(),
                             )
                         ),
                         0,
@@ -206,8 +206,8 @@ class TransactionService(BaseTransactionService):
                     ),
                 ),
             )
-            .where(Transaction.account_id == account.id)
             .join(Account, Account.id == Transaction.account_id)
+            .where(Transaction.account_id == account.id)
         )
 
         result = await session.execute(statement)

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from enum import StrEnum
 from typing import Any, cast
 
-from sqlalchemy import Select, UnaryExpression, asc, desc, func, or_, select
+from sqlalchemy import Select, UnaryExpression, and_, asc, desc, func, or_, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import aliased, joinedload, subqueryload
 
@@ -146,28 +146,69 @@ class TransactionService(BaseTransactionService):
     async def get_summary(
         self, session: AsyncReadSession, account: Account
     ) -> TransactionsSummary:
-        statement = select(
-            cast(type[int], func.coalesce(func.sum(Transaction.amount), 0)),
-            cast(type[int], func.coalesce(func.sum(Transaction.account_amount), 0)),
-            cast(
-                type[int],
-                func.coalesce(
-                    func.sum(Transaction.amount).filter(
-                        Transaction.type == TransactionType.payout
+        statement = (
+            select(
+                # Total balance (all transactions)
+                cast(type[int], func.coalesce(func.sum(Transaction.amount), 0)),
+                cast(type[int], func.coalesce(func.sum(Transaction.account_amount), 0)),
+                # Payout balance
+                cast(
+                    type[int],
+                    func.coalesce(
+                        func.sum(Transaction.amount).filter(
+                            Transaction.type == TransactionType.payout
+                        ),
+                        0,
                     ),
-                    0,
                 ),
-            ),
-            cast(
-                type[int],
-                func.coalesce(
-                    func.sum(Transaction.account_amount).filter(
-                        Transaction.type == TransactionType.payout
+                cast(
+                    type[int],
+                    func.coalesce(
+                        func.sum(Transaction.account_amount).filter(
+                            Transaction.type == TransactionType.payout
+                        ),
+                        0,
                     ),
-                    0,
                 ),
-            ),
-        ).where(Transaction.account_id == account.id)
+                # Available balance (payouts + aged non-payouts)
+                cast(
+                    type[int],
+                    func.coalesce(
+                        func.sum(Transaction.amount).filter(
+                            or_(
+                                Transaction.type == TransactionType.payout,
+                                and_(
+                                    Transaction.type != TransactionType.payout,
+                                    Transaction.created_at
+                                    + Account.payout_transaction_delay
+                                    <= func.now(),
+                                ),
+                            )
+                        ),
+                        0,
+                    ),
+                ),
+                cast(
+                    type[int],
+                    func.coalesce(
+                        func.sum(Transaction.account_amount).filter(
+                            or_(
+                                Transaction.type == TransactionType.payout,
+                                and_(
+                                    Transaction.type != TransactionType.payout,
+                                    Transaction.created_at
+                                    + Account.payout_transaction_delay
+                                    <= func.now(),
+                                ),
+                            )
+                        ),
+                        0,
+                    ),
+                ),
+            )
+            .where(Transaction.account_id == account.id)
+            .join(Account, Account.id == Transaction.account_id)
+        )
 
         result = await session.execute(statement)
 
@@ -181,12 +222,16 @@ class TransactionService(BaseTransactionService):
                 account_amount,
                 payout_amount,
                 account_payout_amount,
+                available_amount,
+                available_account_amount,
             ) = result.one()._tuple()
         except NoResultFound:
             amount = 0
             account_amount = 0
             payout_amount = 0
             account_payout_amount = 0
+            available_amount = 0
+            available_account_amount = 0
 
         return TransactionsSummary(
             balance=TransactionsBalance(
@@ -194,6 +239,12 @@ class TransactionService(BaseTransactionService):
                 amount=amount,
                 account_currency=account_currency,
                 account_amount=account_amount,
+            ),
+            available_balance=TransactionsBalance(
+                currency=currency,
+                amount=available_amount,
+                account_currency=account_currency,
+                account_amount=available_account_amount,
             ),
             payout=TransactionsBalance(
                 currency=currency,

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1884,6 +1884,7 @@ async def create_payment_transaction(
     pledge: Pledge | None = None,
     order: Order | None = None,
     issue_reward: IssueReward | None = None,
+    created_at: datetime | None = None,
 ) -> Transaction:
     transaction = Transaction(
         type=TransactionType.payment,
@@ -1900,6 +1901,7 @@ async def create_payment_transaction(
         issue_reward=issue_reward,
         presentment_currency="usd",
         presentment_amount=amount,
+        created_at=created_at,
     )
     await save_fixture(transaction)
     return transaction
@@ -1915,6 +1917,7 @@ async def create_refund_transaction(
     pledge: Pledge | None = None,
     order: Order | None = None,
     issue_reward: IssueReward | None = None,
+    created_at: datetime | None = None,
 ) -> Transaction:
     transaction = Transaction(
         type=TransactionType.refund,
@@ -1932,6 +1935,7 @@ async def create_refund_transaction(
         issue_reward=issue_reward,
         presentment_currency="usd",
         presentment_amount=amount,
+        created_at=created_at,
     )
     await save_fixture(transaction)
     return transaction
@@ -1979,6 +1983,7 @@ async def create_balance_transaction(
     payment_transaction: Transaction | None = None,
     balance_reversal_transaction: Transaction | None = None,
     payout_transaction: Transaction | None = None,
+    created_at: datetime | None = None,
 ) -> Transaction:
     transaction = Transaction(
         type=TransactionType.balance,
@@ -1992,6 +1997,7 @@ async def create_balance_transaction(
         payment_transaction=payment_transaction,
         balance_reversal_transaction=balance_reversal_transaction,
         payout_transaction=payout_transaction,
+        created_at=created_at,
     )
     await save_fixture(transaction)
     return transaction

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timedelta
 from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -59,9 +60,16 @@ def stripe_service_mock(mocker: MockerFixture) -> MagicMock:
     return mock
 
 
-create_payment_transaction = partial(ro.create_payment_transaction, amount=10000)
-create_refund_transaction = partial(ro.create_refund_transaction, amount=-10000)
-create_balance_transaction = partial(ro.create_balance_transaction, amount=10000)
+ten_days_ago = utc_now() - timedelta(days=10)
+create_payment_transaction = partial(
+    ro.create_payment_transaction, amount=10000, created_at=ten_days_ago
+)
+create_refund_transaction = partial(
+    ro.create_refund_transaction, amount=-10000, created_at=ten_days_ago
+)
+create_balance_transaction = partial(
+    ro.create_balance_transaction, amount=10000, created_at=ten_days_ago
+)
 
 
 @pytest.mark.asyncio
@@ -206,6 +214,56 @@ class TestCreate:
         assert payout.fees_amount > 0
         assert payout.account_currency == "usd"
         assert payout.account_amount > 0
+
+        payout_transaction_service_mock.create.assert_called_once()
+
+    async def test_available_balance_with_delay(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        user: User,
+        account: Account,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        payout_account = await create_payout_account(save_fixture, organization, user)
+
+        now = utc_now()
+
+        # Create an old balance transaction (8 days ago - should be available)
+        payment_transaction_old = await create_payment_transaction(
+            save_fixture, created_at=now - timedelta(days=8)
+        )
+        balance_transaction_old = await create_balance_transaction(
+            save_fixture,
+            account=account,
+            payment_transaction=payment_transaction_old,
+            created_at=now - timedelta(days=8),
+        )
+
+        # Create a recent balance transaction (2 days ago - should NOT be available)
+        payment_transaction_recent = await create_payment_transaction(
+            save_fixture, created_at=now - timedelta(days=2)
+        )
+        balance_transaction_recent = await create_balance_transaction(
+            save_fixture,
+            account=account,
+            payment_transaction=payment_transaction_recent,
+            created_at=now - timedelta(days=2),
+        )
+
+        payout_transaction_service_mock.create.return_value = Transaction()
+
+        payout = await payout_service.create(session, locker, organization)
+
+        assert payout.account == account
+        assert payout.payout_account == payout_account
+        # The payout amount should only include the old balance (10000) that's available
+        # The recent balance (10000) is excluded because it's only 2 days old (< 7 days)
+        # So we expect payout amount to be based on available_balance = 10000 (from old balance only)
+        assert payout.amount == 10000 - payout.fees_amount
+        assert payout.account_amount == 10000 - payout.fees_amount
 
         payout_transaction_service_mock.create.assert_called_once()
 

--- a/server/tests/transaction/service/test_payout.py
+++ b/server/tests/transaction/service/test_payout.py
@@ -1,8 +1,10 @@
+from datetime import timedelta
 from functools import partial
 
 import pytest
 
 from polar.enums import PayoutAccountType
+from polar.kit.utils import utc_now
 from polar.models import (
     Account,
     Organization,
@@ -25,9 +27,16 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_account, create_payout_account
 from tests.fixtures.random_objects import create_payout as _create_payout
 
-create_payment_transaction = partial(ro.create_payment_transaction, amount=10000)
-create_refund_transaction = partial(ro.create_refund_transaction, amount=-10000)
-create_balance_transaction = partial(ro.create_balance_transaction, amount=10000)
+ten_days_ago = utc_now() - timedelta(days=10)
+create_payment_transaction = partial(
+    ro.create_payment_transaction, amount=10000, created_at=ten_days_ago
+)
+create_refund_transaction = partial(
+    ro.create_refund_transaction, amount=-10000, created_at=ten_days_ago
+)
+create_balance_transaction = partial(
+    ro.create_balance_transaction, amount=10000, created_at=ten_days_ago
+)
 
 
 async def create_payout(
@@ -75,6 +84,7 @@ class TestCreate:
             save_fixture, organization, user, type=PayoutAccountType.stripe
         )
 
+        # Transactions available for payouts
         payment_transaction_1 = await create_payment_transaction(save_fixture)
         balance_transaction_1 = await create_balance_transaction(
             save_fixture, account=account, payment_transaction=payment_transaction_1
@@ -83,6 +93,17 @@ class TestCreate:
         payment_transaction_2 = await create_payment_transaction(save_fixture)
         balance_transaction_2 = await create_balance_transaction(
             save_fixture, account=account, payment_transaction=payment_transaction_2
+        )
+
+        # Transactions not available for payouts
+        payment_transaction_3 = await create_payment_transaction(
+            save_fixture, created_at=utc_now()
+        )
+        balance_transaction_3 = await create_balance_transaction(
+            save_fixture,
+            account=account,
+            payment_transaction=payment_transaction_3,
+            created_at=utc_now(),
         )
 
         payout, fees = await create_payout(

--- a/server/tests/transaction/service/test_transaction.py
+++ b/server/tests/transaction/service/test_transaction.py
@@ -1,13 +1,17 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams
+from polar.kit.utils import utc_now
 from polar.models import Account, Organization, Transaction, User, UserOrganization
 from polar.models.transaction import TransactionType
 from polar.postgres import AsyncSession
 from polar.transaction.service.transaction import transaction as transaction_service
+from tests.fixtures.database import SaveFixture
+from tests.transaction.conftest import create_transaction
 
 
 @pytest.mark.asyncio
@@ -160,11 +164,7 @@ class TestSearch:
 @pytest.mark.asyncio
 class TestGetSummary:
     async def test_no_transaction(
-        self,
-        session: AsyncSession,
-        account: Account,
-        user: User,
-        user_organization: UserOrganization,
+        self, session: AsyncSession, account: Account
     ) -> None:
         summary = await transaction_service.get_summary(session, account)
 
@@ -179,32 +179,59 @@ class TestGetSummary:
         assert summary.payout.account_amount == 0
 
     async def test_valid(
-        self,
-        session: AsyncSession,
-        account: Account,
-        user: User,
-        user_organization: UserOrganization,
-        account_transactions: list[Transaction],
+        self, session: AsyncSession, save_fixture: SaveFixture, account: Account
     ) -> None:
+        now = utc_now()
+
+        # Create an old balance transaction (8 days ago - should be available)
+        # Using account_currency="usd" so account_amount = amount
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=1000,
+            currency="usd",
+            account_currency="usd",
+            created_at=now - timedelta(days=8),
+        )
+
+        # Create a recent balance transaction (2 days ago - should NOT be available)
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=500,
+            currency="usd",
+            account_currency="usd",
+            created_at=now - timedelta(days=2),
+        )
+
+        # Create a payout transaction (2 days ago - should ALWAYS be available)
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.payout,
+            account=account,
+            amount=-2000,
+            currency="usd",
+            account_currency="usd",
+            created_at=now - timedelta(days=2),
+        )
+
         summary = await transaction_service.get_summary(session, account)
 
-        assert summary.balance.currency == "usd"
-        assert summary.balance.account_currency == "usd"
-        assert summary.balance.amount == sum(t.amount for t in account_transactions)
-        assert summary.balance.account_amount == sum(
-            t.account_amount for t in account_transactions
-        )
+        # Total balance should include all transactions
+        assert summary.balance.amount == 1000 + 500 - 2000
+        assert summary.balance.account_amount == 1000 + 500 - 2000
 
-        assert summary.payout.currency == "usd"
-        assert summary.payout.account_currency == "usd"
-        assert summary.payout.amount == sum(
-            t.amount for t in account_transactions if t.type == TransactionType.payout
-        )
-        assert summary.payout.account_amount == sum(
-            t.account_amount
-            for t in account_transactions
-            if t.type == TransactionType.payout
-        )
+        # Available balance should exclude recent non-payout transactions
+        # old_balance (1000) + payout (-2000) = -1000
+        # recent_balance (500) is excluded because it's only 2 days old (< 7 days)
+        assert summary.available_balance.amount == 1000 - 2000
+        assert summary.available_balance.account_amount == 1000 - 2000
+
+        # Payout balance should include all payouts
+        assert summary.payout.amount == -2000
+        assert summary.payout.account_amount == -2000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

Part of #11424

- Logic for locking payout of transactions that are more recent than the configured Account delay
- API to return the Account delay and the current available balance
- UI to show the available balance, configured delay and state on each transaction (see video below). **Feedback welcome 🙏**

<div>
    <a href="https://www.loom.com/share/b4c3892281f043beac7994f1ee941609">
      <p>UI Review: Payout Delays and Statuses - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/b4c3892281f043beac7994f1ee941609">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b4c3892281f043beac7994f1ee941609-2bea789e2a15b774-full-play.gif#t=0.1">
    </a>
  </div>
