### PR TITLE
fix(organization): activate org when reusing a ready payout account

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -707,11 +707,15 @@ class OrganizationService:
         payout_account: PayoutAccount,
     ) -> Organization:
         organization_repository = OrganizationRepository.from_session(session)
-        return await organization_repository.update(
+        await organization_repository.update(
             organization,
             update_dict={"payout_account_id": payout_account.id},
             flush=True,
         )
+        # Reusing an already-ready payout account doesn't fire a Stripe
+        # `account.updated` webhook, so attempt activation here too.
+        await self.maybe_activate(session, organization)
+        return organization
 
     async def add_user(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -2967,6 +2967,49 @@ class TestSetPayoutAccount:
 
         assert updated_org.payout_account_id == payout_account.id
 
+    @pytest.mark.auth
+    async def test_activates_when_all_gates_pass(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+        organization.details = {
+            "product_description": "Subscription SaaS for software teams."
+        }
+        await save_fixture(organization)
+
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.PASS,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="Clean",
+            model_used="test",
+        )
+        session.add(review)
+        await session.flush()
+
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        organization.payout_account = None
+        await save_fixture(organization)
+
+        updated_org = await organization_service.set_payout_account(
+            session, organization, payout_account
+        )
+
+        assert updated_org.payout_account_id == payout_account.id
+        assert updated_org.status == OrganizationStatus.ACTIVE
+
 
 @pytest.mark.asyncio
 class TestStatusTransitions:


### PR DESCRIPTION
## Summary

- `set_payout_account` now calls `maybe_activate` after linking, closing a gap where reusing a previously-onboarded Stripe Connect account on a fresh organization left the org stuck in `CREATED`.
- Stripe doesn't emit an `account.updated` webhook when a merchant attaches an already-ready Connect account, so none of the existing `CREATED → ACTIVE` triggers (AI review pass, Stripe account webhook, identity verification) had a chance to re-evaluate the gates after the account was attached. The merchant saw every check green in the dashboard but the "Go Live" button kept bouncing them back to verification.
- Added a regression test exercising the fix: a `CREATED` org with a `PASS` review, submitted details, and a verified admin transitions to `ACTIVE` when a ready payout account is set.

Side note: orgs already stuck in this state need a one-shot `maybe_activate` (or backoffice approve) — please flag any support tickets that match the symptoms (test-mode banner persisting after every check is green) so we can unstick them.

## Test plan

- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run pytest tests/organization/test_service.py::TestSetPayoutAccount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)