### PR TITLE
feat: auto-approve first-pass threshold reviews

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1075,11 +1075,10 @@ class OrganizationService:
 
         Returns True if auto-approved, False if the org must be handled by a
         human operator in the backoffice.
-        Only auto-approves when: verdict is APPROVE and org has been initially reviewed.
+        Only auto-approves when: status is REVIEW and verdict is APPROVE.
         """
         is_eligible = (
             organization.status == OrganizationStatus.REVIEW
-            and organization.initially_reviewed_at is not None
             and verdict == ReviewVerdict.APPROVE
         )
 

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -66,10 +66,7 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
 
-        is_auto_approve_eligible = (
-            organization.status == OrganizationStatus.REVIEW
-            and organization.initially_reviewed_at is not None
-        )
+        is_auto_approve_eligible = organization.status == OrganizationStatus.REVIEW
 
         enqueue_job(
             "organization_review.run_agent",

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -999,27 +999,23 @@ class TestHandleOngoingReviewVerdict:
         assert organization.status == OrganizationStatus.ACTIVE
         assert organization.next_review_threshold == 10_000
 
-    async def test_not_eligible_no_initial_review(
+    async def test_auto_approve_without_initial_review(
         self,
-        mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: org is REVIEW without initially_reviewed_at
+        # Given: org is REVIEW without initially_reviewed_at (first-pass review)
         organization.status = OrganizationStatus.REVIEW
         organization.next_review_threshold = 50_000
 
-        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
-
-        # When: verdict is APPROVE but org hasn't been initially reviewed
+        # When: verdict is APPROVE
         result = await organization_service.handle_ongoing_review_verdict(
             session, organization, ReviewVerdict.APPROVE
         )
 
-        # Then: not eligible for auto-approval, stays under review for backoffice handling
-        assert result is False
-        assert organization.status == OrganizationStatus.REVIEW
-        enqueue_job_mock.assert_not_called()
+        # Then: auto-approved on first pass
+        assert result is True
+        assert organization.status == OrganizationStatus.ACTIVE
 
     async def test_not_eligible_wrong_status(
         self,

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import UTC, datetime
 
 import pytest
 from pytest_mock import MockerFixture
@@ -42,7 +41,7 @@ class TestOrganizationUnderReview:
         with pytest.raises(OrganizationDoesNotExist):
             await organization_under_review(uuid.uuid4())
 
-    async def test_existing_organization(
+    async def test_review_status_eligible(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -50,34 +49,8 @@ class TestOrganizationUnderReview:
         organization: Organization,
         user: User,
     ) -> None:
-        # Update organization to have under review status
+        # Org in REVIEW status → auto-approve eligible (no prior review needed)
         organization.status = OrganizationStatus.REVIEW
-        await save_fixture(organization)
-
-        # then
-        session.expunge_all()
-
-        enqueue_job_mock = mocker.patch("polar.organization.tasks.enqueue_job")
-
-        await organization_under_review(organization.id)
-
-        enqueue_job_mock.assert_called_once_with(
-            "organization_review.run_agent",
-            organization_id=organization.id,
-            auto_approve_eligible=False,
-        )
-
-    async def test_auto_approve_eligible(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user: User,
-    ) -> None:
-        # Org under review and previously reviewed → auto-approve eligible
-        organization.status = OrganizationStatus.REVIEW
-        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         await save_fixture(organization)
 
         session.expunge_all()
@@ -90,4 +63,27 @@ class TestOrganizationUnderReview:
             "organization_review.run_agent",
             organization_id=organization.id,
             auto_approve_eligible=True,
+        )
+
+    async def test_non_review_status_not_eligible(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        await save_fixture(organization)
+
+        session.expunge_all()
+
+        enqueue_job_mock = mocker.patch("polar.organization.tasks.enqueue_job")
+
+        await organization_under_review(organization.id)
+
+        enqueue_job_mock.assert_called_once_with(
+            "organization_review.run_agent",
+            organization_id=organization.id,
+            auto_approve_eligible=False,
         )


### PR DESCRIPTION
## Summary

- Drop the `initially_reviewed_at IS NOT NULL` precondition from the two auto-approval gates ([organization/tasks.py](server/polar/organization/tasks.py), [organization/service.py](server/polar/organization/service.py)). We now trust the AI verdict on first-pass reviews too: an org hitting the review threshold for the first time with verdict APPROVE flows through without needing a prior human review.
- Update tests to reflect the new behavior (REVIEW status alone is now eligible; non-REVIEW remains ineligible).

The other gates remain in place: `auto_approve_eligible` is still set per-context in the task layer, the manual-review override still short-circuits, and DENY verdicts still go to the human queue.

## Test plan

- [x] `uv run pytest tests/organization/test_tasks.py tests/organization/test_service.py::TestHandleOngoingReviewVerdict`
- [x] `uv run task lint`
- [x] `uv run task lint_types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)