### PR TITLE
Gate design system tokens based on usage

### DIFF
--- a/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
@@ -400,7 +400,7 @@ const FrameworkCard = ({
         borderWidth={1}
         borderStyle="solid"
         borderColor={active ? 'border-secondary' : 'border-primary'}
-        backgroundColor={active ? 'text-primary' : 'background-secondary'}
+        backgroundColor={active ? 'background-card' : 'background-secondary'}
         padding="l"
       >
         {icon ?? (
@@ -408,7 +408,7 @@ const FrameworkCard = ({
             height={32}
             width={32}
             borderRadius="full"
-            backgroundColor="border-primary"
+            backgroundColor="background-secondary"
           />
         )}
         <h2 className="text-lg">{name}</h2>

--- a/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
@@ -116,8 +116,8 @@ export function OnboardingShell({
                           borderRadius="full"
                           backgroundColor={
                             i <= currentIndex
-                              ? 'text-primary'
-                              : 'border-primary'
+                              ? 'background-inverse'
+                              : 'background-card'
                           }
                         />
                       </Box>

--- a/clients/packages/orbit/src/tokens/tokens.stylex.ts
+++ b/clients/packages/orbit/src/tokens/tokens.stylex.ts
@@ -39,6 +39,10 @@ export const backgroundColors = stylex.defineVars({
     default: 'oklch(96.7% 0.003 264.54)',
     [DARK]: 'hsl(233, 4%, 9.5%)',
   },
+  'background-inverse': {
+    default: 'oklch(0.21 0.034 264.665)',
+    [DARK]: 'oklch(1.000 0.000 263.3)',
+  },
   'background-warning': {
     default: 'oklch(0.97 0.026 102.5)',
     [DARK]: 'oklch(0.445 0.1 82.5 / 0.2)',

--- a/clients/packages/orbit/src/utils/box-styles.ts
+++ b/clients/packages/orbit/src/utils/box-styles.ts
@@ -254,6 +254,9 @@ export const backgroundColorStyles = stylex.create({
     backgroundColor: backgroundColors['background-secondary'],
   },
   'background-card': { backgroundColor: backgroundColors['background-card'] },
+  'background-inverse': {
+    backgroundColor: backgroundColors['background-inverse'],
+  },
   'background-warning': {
     backgroundColor: backgroundColors['background-warning'],
   },
@@ -266,26 +269,9 @@ export const backgroundColorStyles = stylex.create({
   'background-pending': {
     backgroundColor: backgroundColors['background-pending'],
   },
-  'text-primary': { backgroundColor: textColors['text-primary'] },
-  'text-secondary': { backgroundColor: textColors['text-secondary'] },
-  'text-tertiary': { backgroundColor: textColors['text-tertiary'] },
-  'text-success': { backgroundColor: textColors['text-success'] },
-  'text-danger': { backgroundColor: textColors['text-danger'] },
-  'text-warning': { backgroundColor: textColors['text-warning'] },
-  'text-pending': { backgroundColor: textColors['text-pending'] },
-  'border-primary': { backgroundColor: borderColors['border-primary'] },
-  'border-secondary': { backgroundColor: borderColors['border-secondary'] },
-  'border-warning': { backgroundColor: borderColors['border-warning'] },
 })
 
 export const colorStyles = stylex.create({
-  'background-primary': { color: backgroundColors['background-primary'] },
-  'background-secondary': { color: backgroundColors['background-secondary'] },
-  'background-card': { color: backgroundColors['background-card'] },
-  'background-warning': { color: backgroundColors['background-warning'] },
-  'background-success': { color: backgroundColors['background-success'] },
-  'background-danger': { color: backgroundColors['background-danger'] },
-  'background-pending': { color: backgroundColors['background-pending'] },
   'text-primary': { color: textColors['text-primary'] },
   'text-secondary': { color: textColors['text-secondary'] },
   'text-tertiary': { color: textColors['text-tertiary'] },
@@ -293,28 +279,9 @@ export const colorStyles = stylex.create({
   'text-danger': { color: textColors['text-danger'] },
   'text-warning': { color: textColors['text-warning'] },
   'text-pending': { color: textColors['text-pending'] },
-  'border-primary': { color: borderColors['border-primary'] },
-  'border-secondary': { color: borderColors['border-secondary'] },
-  'border-warning': { color: borderColors['border-warning'] },
 })
 
 export const borderColorStyles = stylex.create({
-  'background-primary': { borderColor: backgroundColors['background-primary'] },
-  'background-secondary': {
-    borderColor: backgroundColors['background-secondary'],
-  },
-  'background-card': { borderColor: backgroundColors['background-card'] },
-  'background-warning': { borderColor: backgroundColors['background-warning'] },
-  'background-success': { borderColor: backgroundColors['background-success'] },
-  'background-danger': { borderColor: backgroundColors['background-danger'] },
-  'background-pending': { borderColor: backgroundColors['background-pending'] },
-  'text-primary': { borderColor: textColors['text-primary'] },
-  'text-secondary': { borderColor: textColors['text-secondary'] },
-  'text-tertiary': { borderColor: textColors['text-tertiary'] },
-  'text-success': { borderColor: textColors['text-success'] },
-  'text-danger': { borderColor: textColors['text-danger'] },
-  'text-warning': { borderColor: textColors['text-warning'] },
-  'text-pending': { borderColor: textColors['text-pending'] },
   'border-primary': { borderColor: borderColors['border-primary'] },
   'border-secondary': { borderColor: borderColors['border-secondary'] },
   'border-warning': { borderColor: borderColors['border-warning'] },

--- a/clients/packages/orbit/src/utils/resolvers.ts
+++ b/clients/packages/orbit/src/utils/resolvers.ts
@@ -5,7 +5,6 @@ import type {
   BorderColorToken,
   BorderRadiusToken,
   BreakpointKey,
-  ColorToken,
   ShadowToken,
   SpacingToken,
   TextColorToken,
@@ -173,14 +172,14 @@ function marginCss(token: SpacingToken | 'auto'): string {
   if (token === 'auto') return 'auto'
   return spacing[token] as string
 }
-function colorCss(token: ColorToken): string {
-  if (token in backgroundColors) {
-    return backgroundColors[token as BackgroundColorToken] as string
-  }
-  if (token in textColors) {
-    return textColors[token as TextColorToken] as string
-  }
-  return borderColors[token as BorderColorToken] as string
+function backgroundColorCss(token: BackgroundColorToken): string {
+  return backgroundColors[token] as string
+}
+function textColorCss(token: TextColorToken): string {
+  return textColors[token] as string
+}
+function borderColorCss(token: BorderColorToken): string {
+  return borderColors[token] as string
 }
 function radiusCss(token: BorderRadiusToken): string {
   return borderRadii[token] as string
@@ -471,10 +470,15 @@ export function resolveBoxStyles(
     backgroundColorStyles,
     'background-color',
     props.backgroundColor,
-    colorCss,
+    backgroundColorCss,
   )
-  addTokenProp(colorStyles, 'color', props.color, colorCss)
-  addTokenProp(borderColorStyles, 'border-color', props.borderColor, colorCss)
+  addTokenProp(colorStyles, 'color', props.color, textColorCss)
+  addTokenProp(
+    borderColorStyles,
+    'border-color',
+    props.borderColor,
+    borderColorCss,
+  )
 
   // --- Border radius (token-based) ---
   addTokenProp(

--- a/clients/packages/orbit/src/utils/types.ts
+++ b/clients/packages/orbit/src/utils/types.ts
@@ -1,9 +1,11 @@
 import type {
+  BackgroundColorToken,
+  BorderColorToken,
   BorderRadiusToken,
   BreakpointKey,
-  ColorToken,
   ShadowToken,
   SpacingToken,
+  TextColorToken,
 } from '../tokens/tokens.stylex'
 
 export type PseudoState =
@@ -55,9 +57,9 @@ export interface SpacingProps {
 }
 
 export interface ColorProps {
-  backgroundColor?: ResponsiveValue<ColorToken>
-  color?: ResponsiveValue<ColorToken>
-  borderColor?: ResponsiveValue<ColorToken>
+  backgroundColor?: ResponsiveValue<BackgroundColorToken>
+  color?: ResponsiveValue<TextColorToken>
+  borderColor?: ResponsiveValue<BorderColorToken>
 }
 
 export interface BorderProps {


### PR DESCRIPTION
Currently you can do something like this:

```tsx
<Box backgroundColor="text-primary" />
<Box backgroundColor="border-secondary" />
<Text color="background-success" />
```

This PR fixes that by only allowing text/bg/border specific tokens to their intended props:

```tsx
// 🚨 Error
<Box backgroundColor="text-primary" />

// ✅ All good
<Box backgroundColor="background-primary" />
```

As well as making the autocomplete easier to parse since it only contains the relevant tokens:


<img width="770" height="395" alt="Screenshot 2026-05-07 at 16 37 21" src="https://github.com/user-attachments/assets/e53d67f6-cbf4-4dab-8664-c766bf3246f0" />

