### PR TITLE
chore: Dedicated queue for PDF generation jobs step 3.1

### DIFF
--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -68,10 +68,11 @@ locals {
 
 locals {
   sandbox_service_ids = {
-    api                     = "srv-crkocgbtq21c73ddsdbg"
-    worker-sandbox          = "srv-d089jj7diees73934kgg"
-    worker-sandbox-webhook  = "srv-d62q7vh4tr6s73fk44ng"
-    worker-sandbox-tinybird = "srv-d733cp15pdvs73f6vqng"
+    api                              = "srv-crkocgbtq21c73ddsdbg"
+    worker-sandbox                   = "srv-d089jj7diees73934kgg"
+    worker-sandbox-webhook           = "srv-d62q7vh4tr6s73fk44ng"
+    worker-sandbox-tinybird          = "srv-d733cp15pdvs73f6vqng"
+    worker-sandbox-invoices-receipts = "srv-d7unnjhj2pic73c2vr60"
   }
 }
 
@@ -149,8 +150,8 @@ module "sandbox" {
     worker-sandbox-invoices-receipts = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 4 --queues invoices_and_receipts"
       plan               = "standard"
-      image_url          = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.digest
+      image_url          = data.render_web_service.sandbox_worker["worker-sandbox-invoices-receipts"].runtime_source.image.image_url
+      image_digest       = data.render_web_service.sandbox_worker["worker-sandbox-invoices-receipts"].runtime_source.image.digest
       dramatiq_prom_port = "10003"
     }
   }


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. ~Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue~ **Done**
3. ~Create a new worker in sandbox that consumes only `invoices_and_receipts`~ **Done**
    3.1 terraform wiring (**this step**)
4. Update the regular worker in sandbox so it stops consuming the new queue
5. Verify this solves OOM issues in sandbox
6. Create a new worker in production that consumes only `invoices_and_receipts`
7. Update the low priority worker in production so it stops consuming the new queue
8. Verify this solves OOM issues in production
9. Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs)
10. Remove `.v2` entirely