### PR TITLE
chore: Dedicated queue for PDF generation jobs step 4

### DIFF
--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -129,7 +129,7 @@ module "sandbox" {
 
   workers = {
     worker-sandbox = {
-      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority invoices_and_receipts"
+      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority"
       image_url          = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.image_url
       image_digest       = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.digest
       dramatiq_prom_port = "10000"


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. ~Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue~ **Done**
3. ~Create a new worker in sandbox that consumes only `invoices_and_receipts`~ **Done**
    3.1 ~terraform wiring~ **Done**
4. Update the regular worker in sandbox so it stops consuming the new queue (**this step**)
5. Verify this solves OOM issues in sandbox
6. Create a new worker in production that consumes only `invoices_and_receipts`
7. Update the low priority worker in production so it stops consuming the new queue
8. Verify this solves OOM issues in production
9. Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs)
10. Remove `.v2` entirely