### PR TITLE
feat(organization): add snoozed_until and snooze_type schema

### DIFF
--- a/server/migrations/versions/2026-05-07-1000_add_organization_snooze_until_and_type.py
+++ b/server/migrations/versions/2026-05-07-1000_add_organization_snooze_until_and_type.py
@@ -1,0 +1,55 @@
+"""add organization snoozed_until + snooze_type columns
+
+Revision ID: 9b1f3a4c2d8e
+Revises: 01607ddf3d7f
+Create Date: 2026-05-07 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "9b1f3a4c2d8e"
+down_revision = "01607ddf3d7f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "snoozed_until",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "snooze_type",
+            sa.String(),
+            nullable=True,
+        ),
+    )
+
+    # Backfill existing snoozed organizations to preserve current behavior
+    # (re-review on next sale 24h after the snooze took effect).
+    op.execute(
+        """
+        UPDATE organizations
+        SET
+            snoozed_until = COALESCE(status_updated_at, NOW()) + INTERVAL '24 hours',
+            snooze_type = 'next_sale'
+        WHERE status = 'snoozed'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "snooze_type")
+    op.drop_column("organizations", "snoozed_until")

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -226,6 +226,17 @@ class OrganizationStatus(StrEnum):
         return {cls.REVIEW, cls.SNOOZED}  # pyright: ignore
 
 
+class SnoozeType(StrEnum):
+    TIME_BASED = "time_based"
+    NEXT_SALE = "next_sale"
+
+    def get_display_name(self) -> str:
+        return {
+            SnoozeType.TIME_BASED: "Auto re-review after X days",
+            SnoozeType.NEXT_SALE: "Re-review on next sale after X days",
+        }[self]
+
+
 class OrganizationCapabilities(TypedDict):
     checkout_payments: bool
     subscription_renewals: bool
@@ -481,6 +492,12 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     snooze_count: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
+    )
+    snoozed_until: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, default=None
+    )
+    snooze_type: Mapped[SnoozeType | None] = mapped_column(
+        StringEnum(SnoozeType), nullable=True, default=None
     )
 
     total_balance: Mapped[int | None] = mapped_column(


### PR DESCRIPTION
## Summary

Some orgs get back to the review after 24 because they have lot of sales. I plan to add a way to snooze them for X days. 

This PR adds the migration:
- Adds `snoozed_until` (nullable `TIMESTAMP`) and `snooze_type` (nullable `VARCHAR`) columns on `organizations`.
- Adds the `SnoozeType` enum with `time_based` and `next_sale` modes.
- Migration backfills existing snoozed organizations with `next_sale` and `status_updated_at + 24h` so live behavior is unchanged.

The feature code that reads/writes these columns ships in a follow-up PR. Splitting per the repo's migration-isolation policy.

## Test plan

- [x] Backend lint + mypy clean
- [x] `alembic upgrade head` resolves to a single head (`9b1f3a4c2d8e` chained off `01607ddf3d7f`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)