### PR TITLE
Chore: use correct image for worker-sandbox-invoices-receipts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
       environment: sandbox
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-crkocgbtq21c73ddsdbg"
-      render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng"
+      render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng,srv-d7unnjhj2pic73c2vr60"
       docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d089jj7diees73934kgg"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -148,7 +148,7 @@ module "sandbox" {
       dramatiq_prom_port = "10002"
     }
     worker-sandbox-invoices-receipts = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 4 --queues invoices_and_receipts"
+      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
       image_url          = data.render_web_service.sandbox_worker["worker-sandbox-invoices-receipts"].runtime_source.image.image_url
       image_digest       = data.render_web_service.sandbox_worker["worker-sandbox-invoices-receipts"].runtime_source.image.digest


### PR DESCRIPTION
Changes:
- Ensure `worker-sandbox-invoices-receipts` is (re)deployed on deployments
- Switch `worker-sandbox-invoices-receipts` to the playwright-less image
- Switch `worker-sandbox-invoices-receipts` to 3 threads instead of 4 - to actually fit its machine