### PR TITLE
feat(organization): configurable review snooze with two modes

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 import stripe as stripe_lib
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import UUID4, BaseModel, ValidationError, field_validator
+from pydantic import UUID4, BaseModel, Field, ValidationError, field_validator
 from pydantic_core import PydanticCustomError
 from sqlalchemy import Select, and_, func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
@@ -67,6 +67,7 @@ from polar.models.organization import (
     CAPABILITY_NAMES,
     CapabilityName,
     OrganizationStatus,
+    SnoozeType,
 )
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
@@ -75,6 +76,7 @@ from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
 from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import OrganizationFeatureSettings
+from polar.organization.service import SNOOZE_MAX_DAYS, SNOOZE_MIN_DAYS
 from polar.organization.service import organization as organization_service
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import (
@@ -147,6 +149,16 @@ class SetCapabilityForm(BaseModel):
 
     @classmethod
     def model_validate_form(cls, data: Any) -> "SetCapabilityForm":
+        return cls.model_validate(dict(data))
+
+
+class SnoozeForm(BaseModel):
+    snooze_type: SnoozeType
+    days: int = Field(ge=SNOOZE_MIN_DAYS, le=SNOOZE_MAX_DAYS)
+    reason: str | None = None
+
+    @classmethod
+    def model_validate_form(cls, data: Any) -> "SnoozeForm":
         return cls.model_validate(dict(data))
 
 
@@ -1722,7 +1734,13 @@ async def snooze_dialog(
 
     if request.method == "POST":
         form_data = await request.form()
-        reason = str(form_data.get("reason", "")).strip() or None
+        try:
+            form = SnoozeForm.model_validate_form(form_data)
+        except ValidationError as e:
+            detail = [{"loc": err["loc"], "msg": err["msg"]} for err in e.errors()]
+            raise HTTPException(status_code=400, detail=detail) from e
+
+        reason = (form.reason or "").strip() or None
 
         review_repo = OrganizationReviewRepository(session)
         await review_repo.record_human_decision(
@@ -1733,7 +1751,11 @@ async def snooze_dialog(
         )
 
         await organization_service.snooze_organization(
-            session, organization, reason=reason
+            session,
+            organization,
+            days=form.days,
+            snooze_type=form.snooze_type,
+            reason=reason,
         )
 
         return HXRedirectResponse(
@@ -1778,8 +1800,59 @@ async def snooze_dialog(
                         text("Payouts remain blocked")
                     with tag.li():
                         text(
-                            "Org returns to Review automatically when a sale occurs 24h+ after snoozing"
+                            "Org returns to Review based on the trigger you "
+                            "select below"
                         )
+
+            snooze_options = [
+                (
+                    SnoozeType.NEXT_SALE,
+                    "On next sale after X days",
+                    "Stays snoozed past the deadline until the next sale arrives.",
+                ),
+                (
+                    SnoozeType.TIME_BASED,
+                    "Auto re-review after X days",
+                    "Pops back into the queue automatically once the deadline passes.",
+                ),
+            ]
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text font-semibold"):
+                        text("Re-review trigger")
+                with tag.div(classes="flex flex-col gap-2"):
+                    for option_type, option_label, option_desc in snooze_options:
+                        with tag.label(classes="flex items-start gap-2 cursor-pointer"):
+                            input_attrs: dict[str, Any] = {
+                                "type": "radio",
+                                "name": "snooze_type",
+                                "value": option_type.value,
+                                "classes": "radio radio-sm mt-0.5",
+                            }
+                            if option_type == SnoozeType.NEXT_SALE:
+                                input_attrs["checked"] = "checked"
+                            with tag.input(**input_attrs):
+                                pass
+                            with tag.div(classes="flex flex-col"):
+                                with tag.span(classes="text-sm font-medium"):
+                                    text(option_label)
+                                with tag.span(classes="text-xs text-base-content/70"):
+                                    text(option_desc)
+
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text font-semibold"):
+                        text(f"Days ({SNOOZE_MIN_DAYS}–{SNOOZE_MAX_DAYS})")
+                with tag.input(
+                    type="number",
+                    name="days",
+                    value=str(SNOOZE_MIN_DAYS),
+                    min=str(SNOOZE_MIN_DAYS),
+                    max=str(SNOOZE_MAX_DAYS),
+                    required="required",
+                    classes="input input-bordered w-full",
+                ):
+                    pass
 
             with tag.div(classes="form-control"):
                 with tag.label(classes="label"):

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -10,8 +10,7 @@ from fastapi import Request
 from tagflow import tag, text
 
 from polar.models import Organization, User
-from polar.models.organization import OrganizationStatus
-from polar.organization.service import SNOOZE_GRACE_PERIOD
+from polar.models.organization import OrganizationStatus, SnoozeType
 from polar.organization_review.schemas import ReviewVerdict
 
 from ...components import (
@@ -505,29 +504,35 @@ class OrganizationDetailView:
                         self._render_create_review_ticket_button(request)
 
                     elif self.org.status == OrganizationStatus.SNOOZED:
-                        if self.org.status_updated_at:
-                            grace_end = self.org.status_updated_at + SNOOZE_GRACE_PERIOD
+                        deadline = self.org.snoozed_until
+                        snooze_type = self.org.snooze_type or SnoozeType.NEXT_SALE
+                        if deadline is not None:
                             now = datetime.now(UTC)
                             with tag.div(
                                 classes="bg-warning/10 border border-warning/20 p-3 rounded-lg text-xs mb-2"
                             ):
                                 with tag.p(classes="font-semibold"):
                                     text(f"Snoozed {self.org.snooze_count} time(s)")
-                                if now < grace_end:
-                                    remaining = grace_end - now
-                                    hours = int(remaining.total_seconds() // 3600)
-                                    minutes = int(
-                                        (remaining.total_seconds() % 3600) // 60
-                                    )
+                                with tag.p(classes="text-base-content/70"):
+                                    text(snooze_type.get_display_name())
+                                if now < deadline:
+                                    remaining = deadline - now
+                                    hours, seconds = divmod(remaining.seconds, 3600)
+                                    minutes = seconds // 60
+                                    if remaining.days > 0:
+                                        countdown = f"{remaining.days}d {hours}h"
+                                    else:
+                                        countdown = f"{hours}h {minutes}m"
+                                    with tag.p():
+                                        text(f"Time remaining: {countdown}")
+                                elif snooze_type == SnoozeType.NEXT_SALE:
                                     with tag.p():
                                         text(
-                                            f"Grace period: {hours}h {minutes}m remaining"
+                                            "Deadline passed — next sale triggers re-review"
                                         )
                                 else:
                                     with tag.p():
-                                        text(
-                                            "Grace period ended — next sale triggers re-review"
-                                        )
+                                        text("Deadline passed — auto re-review pending")
 
                         with tag.div(classes="w-full"):
                             with button(

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import Select, func, select, update
@@ -29,11 +30,15 @@ from polar.models.discount import (
     DiscountPercentage,
     DiscountType,
 )
-from polar.models.organization import OrganizationStatus
+from polar.models.organization import OrganizationStatus, SnoozeType
 from polar.models.organization_review import OrganizationReview
 from polar.models.subscription import SubscriptionStatus
 
 from .sorting import OrganizationSortProperty
+
+# Maximum orgs the unsnooze cron processes per run. Bounds worst-case
+# transaction size when many time-based snoozes expire in the same window.
+UNSNOOZE_EXPIRED_BATCH_SIZE = 500
 
 
 class OrganizationRepository(
@@ -153,6 +158,23 @@ class OrganizationRepository(
                 Organization.status != OrganizationStatus.BLOCKED,
             )
             .options(*options)
+        )
+        return await self.get_all(statement)
+
+    async def get_expired_time_based_snoozes(
+        self, now: datetime, *, limit: int = UNSNOOZE_EXPIRED_BATCH_SIZE
+    ) -> Sequence[Organization]:
+        """Snoozed orgs whose TIME_BASED deadline has passed."""
+        statement = (
+            self.get_base_statement()
+            .where(
+                Organization.status == OrganizationStatus.SNOOZED,
+                Organization.snooze_type == SnoozeType.TIME_BASED,
+                Organization.snoozed_until.is_not(None),
+                Organization.snoozed_until <= now,
+            )
+            .order_by(Organization.snoozed_until.asc())
+            .limit(limit)
         )
         return await self.get_all(statement)
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -45,6 +45,7 @@ from polar.models.organization import (
     OrganizationCapabilities,
     OrganizationDetails,
     OrganizationStatus,
+    SnoozeType,
 )
 from polar.models.organization_review import OrganizationReview
 from polar.models.transaction import TransactionType
@@ -88,7 +89,8 @@ from .sorting import OrganizationSortProperty
 log = structlog.get_logger()
 
 _MIN_REVIEW_THRESHOLD = 10_000
-SNOOZE_GRACE_PERIOD = timedelta(hours=24)
+SNOOZE_MIN_DAYS = 1
+SNOOZE_MAX_DAYS = 7
 
 
 def _website_domain(website: str | None) -> str | None:
@@ -820,16 +822,16 @@ class OrganizationService:
         if settings.is_sandbox():
             return organization
 
-        # If snoozed and grace period has passed, a sale triggers re-review
+        # Time-based snoozes are handled exclusively by
+        # ``organization.unsnooze_expired``; only next-sale snoozes
+        # transition here when their deadline has passed.
         if (
             organization.status == OrganizationStatus.SNOOZED
-            and organization.status_updated_at is not None
-            and datetime.now(UTC) - organization.status_updated_at
-            >= SNOOZE_GRACE_PERIOD
+            and organization.snooze_type == SnoozeType.NEXT_SALE
+            and organization.snoozed_until is not None
+            and datetime.now(UTC) >= organization.snoozed_until
         ):
-            organization.set_status(OrganizationStatus.REVIEW)
-            session.add(organization)
-            enqueue_job("organization.under_review", organization_id=organization.id)
+            await self._exit_snooze_to_review(session, organization)
             return organization
 
         if organization.status != OrganizationStatus.ACTIVE:
@@ -1113,23 +1115,47 @@ class OrganizationService:
         session: AsyncSession,
         organization: Organization,
         *,
+        days: int,
+        snooze_type: SnoozeType,
         reason: str | None = None,
     ) -> Organization:
-        """Snooze an organization under review.
+        """Snooze an organization under review for ``days`` days.
 
-        The org stays snoozed until a sale occurs 24h+ after being snoozed,
-        which triggers a transition back to REVIEW via check_review_threshold().
+        Two modes are supported via ``snooze_type``:
+
+        * ``TIME_BASED``: the org returns to REVIEW automatically once the
+          deadline passes (handled by the ``organization.unsnooze_expired``
+          periodic task).
+        * ``NEXT_SALE``: the org stays snoozed past the deadline until the
+          next sale arrives, which triggers re-review via
+          ``check_review_threshold``.
         """
         if organization.status != OrganizationStatus.REVIEW:
             raise OrganizationError(
                 "Only organizations under review can be snoozed.", 403
             )
 
+        if not SNOOZE_MIN_DAYS <= days <= SNOOZE_MAX_DAYS:
+            raise OrganizationError(
+                f"Snooze duration must be between {SNOOZE_MIN_DAYS} and "
+                f"{SNOOZE_MAX_DAYS} days.",
+                400,
+            )
+
         organization.set_status(OrganizationStatus.SNOOZED)
         organization.snooze_count += 1
+        organization.snoozed_until = datetime.now(UTC) + timedelta(days=days)
+        organization.snooze_type = snooze_type
+
+        trigger = (
+            "auto re-review afterwards"
+            if snooze_type == SnoozeType.TIME_BASED
+            else "re-review on next sale afterwards"
+        )
         _append_internal_note(
             organization,
-            f"Organization snoozed (#{organization.snooze_count}).",
+            f"Organization snoozed (#{organization.snooze_count}) "
+            f"for {days} day(s) — {trigger}.",
             reason=reason,
         )
         session.add(organization)
@@ -1144,10 +1170,41 @@ class OrganizationService:
         if organization.status != OrganizationStatus.SNOOZED:
             raise OrganizationError("Only snoozed organizations can be unsnoozed.", 403)
 
+        await self._exit_snooze_to_review(session, organization)
+        return organization
+
+    async def unsnooze_expired_organizations(
+        self, session: AsyncSession
+    ) -> Sequence[Organization]:
+        """Auto-unsnooze TIME_BASED snoozes whose deadline has passed.
+
+        Run periodically by a worker. Returns the orgs transitioned.
+        """
+        repository = OrganizationRepository.from_session(session)
+        candidates = await repository.get_expired_time_based_snoozes(datetime.now(UTC))
+        transitioned: list[Organization] = []
+        for organization in candidates:
+            # Skip if a concurrent admin action already moved the org out of
+            # SNOOZED — set_status would raise InvalidStatusTransitionError
+            # and abort the whole batch otherwise.
+            if organization.status != OrganizationStatus.SNOOZED:
+                continue
+            _append_internal_note(
+                organization,
+                "Auto-unsnoozed: time-based snooze deadline reached.",
+            )
+            await self._exit_snooze_to_review(session, organization)
+            transitioned.append(organization)
+        return transitioned
+
+    async def _exit_snooze_to_review(
+        self, session: AsyncSession, organization: Organization
+    ) -> None:
         organization.set_status(OrganizationStatus.REVIEW)
+        organization.snoozed_until = None
+        organization.snooze_type = None
         session.add(organization)
         enqueue_job("organization.under_review", organization_id=organization.id)
-        return organization
 
     async def set_organization_under_review(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1189,10 +1189,6 @@ class OrganizationService:
             # and abort the whole batch otherwise.
             if organization.status != OrganizationStatus.SNOOZED:
                 continue
-            _append_internal_note(
-                organization,
-                "Auto-unsnoozed: time-based snooze deadline reached.",
-            )
             await self._exit_snooze_to_review(session, organization)
             transitioned.append(organization)
         return transitioned

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -16,9 +16,16 @@ from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
-from polar.worker import AsyncSessionMaker, TaskPriority, actor, enqueue_job
+from polar.worker import (
+    AsyncSessionMaker,
+    CronTrigger,
+    TaskPriority,
+    actor,
+    enqueue_job,
+)
 
 from .repository import OrganizationRepository
+from .service import organization as organization_service
 
 log = structlog.get_logger()
 
@@ -56,6 +63,18 @@ async def organization_created(organization_id: uuid.UUID) -> None:
         organization = await repository.get_by_id(organization_id)
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
+
+
+@actor(
+    actor_name="organization.unsnooze_expired",
+    cron_trigger=CronTrigger.from_crontab("0 * * * *"),
+    priority=TaskPriority.LOW,
+    max_retries=0,
+)
+async def organization_unsnooze_expired() -> None:
+    """Auto-unsnooze TIME_BASED snoozed orgs whose deadline has passed."""
+    async with AsyncSessionMaker() as session:
+        await organization_service.unsnooze_expired_organizations(session)
 
 
 @actor(actor_name="organization.under_review", priority=TaskPriority.LOW)

--- a/server/scripts/snooze_stale_reviews.py
+++ b/server/scripts/snooze_stale_reviews.py
@@ -136,6 +136,8 @@ async def _run_snooze(
         SET status = :snoozed_status,
             status_updated_at = now(),
             snooze_count = snooze_count + 1,
+            snoozed_until = now() + INTERVAL '24 hours',
+            snooze_type = 'next_sale',
             internal_notes = CASE
                 WHEN internal_notes IS NULL OR internal_notes = ''
                 THEN :note

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -24,6 +24,7 @@ from polar.models.organization import (
     OrganizationNotificationSettings,
     OrganizationStatus,
     OrganizationSubscriptionSettings,
+    SnoozeType,
 )
 from polar.models.organization import (
     OrganizationDetails as OrganizationDetailsDict,
@@ -740,9 +741,11 @@ class TestCheckReviewThreshold:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: snoozed less than 24h ago
+        # Given: NEXT_SALE snooze with deadline still in the future
         organization.status = OrganizationStatus.SNOOZED
         organization.status_updated_at = datetime.now(UTC) - timedelta(hours=12)
+        organization.snoozed_until = datetime.now(UTC) + timedelta(hours=12)
+        organization.snooze_type = SnoozeType.NEXT_SALE
         organization.next_review_threshold = 1000
 
         mocker.patch(
@@ -763,9 +766,11 @@ class TestCheckReviewThreshold:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: snoozed more than 24h ago (grace period expired)
+        # Given: NEXT_SALE snooze with deadline already passed
         organization.status = OrganizationStatus.SNOOZED
         organization.status_updated_at = datetime.now(UTC) - timedelta(hours=25)
+        organization.snoozed_until = datetime.now(UTC) - timedelta(hours=1)
+        organization.snooze_type = SnoozeType.NEXT_SALE
         organization.next_review_threshold = 1000
 
         mocker.patch(
@@ -781,19 +786,24 @@ class TestCheckReviewThreshold:
         # Then: transitions back to REVIEW and enqueues review job
         assert result.status == OrganizationStatus.REVIEW
         assert result.status_updated_at is not None
+        assert result.snoozed_until is None
+        assert result.snooze_type is None
         enqueue_job_mock.assert_called_once_with(
             "organization.under_review", organization_id=organization.id
         )
 
-    async def test_snoozed_without_status_updated_at_stays_snoozed(
+    async def test_time_based_snooze_does_not_trigger_on_sale(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: snoozed but status_updated_at is None (edge case)
+        # Given: TIME_BASED snooze with deadline already passed — sales must
+        # NOT pull it back into review (that's the cron task's job).
         organization.status = OrganizationStatus.SNOOZED
-        organization.status_updated_at = None
+        organization.status_updated_at = datetime.now(UTC) - timedelta(hours=25)
+        organization.snoozed_until = datetime.now(UTC) - timedelta(hours=1)
+        organization.snooze_type = SnoozeType.TIME_BASED
         organization.next_review_threshold = 1000
 
         mocker.patch(
@@ -805,7 +815,30 @@ class TestCheckReviewThreshold:
             session, organization
         )
 
-        # Then: stays snoozed (can't compute grace period)
+        assert result.status == OrganizationStatus.SNOOZED
+
+    async def test_snoozed_without_deadline_stays_snoozed(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Given: a SNOOZED org with no snoozed_until (defensive — the
+        # migration backfills this field, but be safe).
+        organization.status = OrganizationStatus.SNOOZED
+        organization.snoozed_until = None
+        organization.snooze_type = SnoozeType.NEXT_SALE
+        organization.next_review_threshold = 1000
+
+        mocker.patch(
+            "polar.organization.service.transaction_service.get_transactions_sum",
+            return_value=5000,
+        )
+
+        result = await organization_service.check_review_threshold(
+            session, organization
+        )
+
         assert result.status == OrganizationStatus.SNOOZED
 
     async def test_offboarding_over_threshold_stays_offboarding(
@@ -2847,11 +2880,34 @@ class TestSnoozeOrganization:
         organization.status = OrganizationStatus.REVIEW
         organization.snooze_count = 0
 
-        result = await organization_service.snooze_organization(session, organization)
+        result = await organization_service.snooze_organization(
+            session, organization, days=7, snooze_type=SnoozeType.NEXT_SALE
+        )
 
         assert result.status == OrganizationStatus.SNOOZED
         assert result.snooze_count == 1
         assert result.status_updated_at is not None
+        assert result.snoozed_until is not None
+        assert result.snooze_type == SnoozeType.NEXT_SALE
+
+    async def test_time_based_sets_deadline(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        organization.snooze_count = 0
+
+        before = datetime.now(UTC)
+        result = await organization_service.snooze_organization(
+            session, organization, days=5, snooze_type=SnoozeType.TIME_BASED
+        )
+        after = datetime.now(UTC)
+
+        assert result.snooze_type == SnoozeType.TIME_BASED
+        assert result.snoozed_until is not None
+        assert before + timedelta(days=5) <= result.snoozed_until
+        assert result.snoozed_until <= after + timedelta(days=5)
 
     async def test_increments_snooze_count(
         self,
@@ -2861,7 +2917,9 @@ class TestSnoozeOrganization:
         organization.status = OrganizationStatus.REVIEW
         organization.snooze_count = 3
 
-        result = await organization_service.snooze_organization(session, organization)
+        result = await organization_service.snooze_organization(
+            session, organization, days=7, snooze_type=SnoozeType.NEXT_SALE
+        )
 
         assert result.snooze_count == 4
 
@@ -2873,7 +2931,21 @@ class TestSnoozeOrganization:
         organization.status = OrganizationStatus.ACTIVE
 
         with pytest.raises(Exception, match="Only organizations under review"):
-            await organization_service.snooze_organization(session, organization)
+            await organization_service.snooze_organization(
+                session, organization, days=7, snooze_type=SnoozeType.NEXT_SALE
+            )
+
+    async def test_invalid_days_raises(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+
+        with pytest.raises(Exception, match="Snooze duration must be"):
+            await organization_service.snooze_organization(
+                session, organization, days=0, snooze_type=SnoozeType.NEXT_SALE
+            )
 
     async def test_with_reason_appends_internal_notes(
         self,
@@ -2885,7 +2957,11 @@ class TestSnoozeOrganization:
         organization.internal_notes = None
 
         result = await organization_service.snooze_organization(
-            session, organization, reason="Merchant not responding"
+            session,
+            organization,
+            days=7,
+            snooze_type=SnoozeType.NEXT_SALE,
+            reason="Merchant not responding",
         )
 
         assert result.internal_notes is not None
@@ -2901,7 +2977,9 @@ class TestSnoozeOrganization:
         organization.snooze_count = 0
         organization.internal_notes = "Previous note"
 
-        result = await organization_service.snooze_organization(session, organization)
+        result = await organization_service.snooze_organization(
+            session, organization, days=7, snooze_type=SnoozeType.NEXT_SALE
+        )
 
         assert result.internal_notes is not None
         assert "Previous note" in result.internal_notes
@@ -2917,12 +2995,16 @@ class TestUnsnoozeOrganization:
         organization: Organization,
     ) -> None:
         organization.status = OrganizationStatus.SNOOZED
+        organization.snoozed_until = datetime.now(UTC) + timedelta(days=7)
+        organization.snooze_type = SnoozeType.NEXT_SALE
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
         result = await organization_service.unsnooze_organization(session, organization)
 
         assert result.status == OrganizationStatus.REVIEW
         assert result.status_updated_at is not None
+        assert result.snoozed_until is None
+        assert result.snooze_type is None
         enqueue_job_mock.assert_called_once_with(
             "organization.under_review", organization_id=organization.id
         )
@@ -2936,6 +3018,89 @@ class TestUnsnoozeOrganization:
 
         with pytest.raises(Exception, match="Only snoozed organizations"):
             await organization_service.unsnooze_organization(session, organization)
+
+
+@pytest.mark.asyncio
+class TestUnsnoozeExpiredOrganizations:
+    async def test_expired_time_based_transitions(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.SNOOZED
+        organization.snoozed_until = datetime.now(UTC) - timedelta(hours=1)
+        organization.snooze_type = SnoozeType.TIME_BASED
+        await save_fixture(organization)
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.unsnooze_expired_organizations(session)
+
+        assert len(result) == 1
+        assert result[0].id == organization.id
+        assert result[0].status == OrganizationStatus.REVIEW
+        assert result[0].snoozed_until is None
+        assert result[0].snooze_type is None
+        enqueue_job_mock.assert_called_once_with(
+            "organization.under_review", organization_id=organization.id
+        )
+
+    async def test_future_deadline_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.SNOOZED
+        organization.snoozed_until = datetime.now(UTC) + timedelta(days=1)
+        organization.snooze_type = SnoozeType.TIME_BASED
+        await save_fixture(organization)
+
+        result = await organization_service.unsnooze_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.SNOOZED
+
+    async def test_next_sale_snooze_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        # NEXT_SALE snoozes are handled by check_review_threshold, not the cron.
+        organization.status = OrganizationStatus.SNOOZED
+        organization.snoozed_until = datetime.now(UTC) - timedelta(hours=1)
+        organization.snooze_type = SnoozeType.NEXT_SALE
+        await save_fixture(organization)
+
+        result = await organization_service.unsnooze_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.SNOOZED
+
+    async def test_status_changed_concurrently_is_skipped(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Simulate the race: the candidate query returns an org whose status
+        # has flipped to ACTIVE between SELECT and UPDATE. The guard must
+        # skip without raising InvalidStatusTransitionError.
+        organization.status = OrganizationStatus.ACTIVE
+        mocker.patch.object(
+            OrganizationRepository,
+            "get_expired_time_based_snoozes",
+            return_value=[organization],
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.unsnooze_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.ACTIVE
+        enqueue_job_mock.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two snooze modes for orgs under review, replacing the fixed 24h-and-next-sale rule:

- **Auto re-review after X days** — hourly cron pops the org back into the queue once the deadline passes.
- **Re-review on next sale after X days** — stays snoozed past the deadline until the next sale arrives.

Reviewers pick the trigger and duration (1–7 days, default 1) from the snooze dialog; the detail sidebar shows the mode and a live countdown.

Builds on the schema landed in #11510.

## Test plan

- [x] Backend lint + mypy clean
- [ ] CI: org service tests (incl. new `TestUnsnoozeExpiredOrganizations`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)