### PR TITLE
Check slug availability separately from organization creation

### DIFF
--- a/clients/apps/web/src/app/(main)/onboarding/validate-description/route.ts
+++ b/clients/apps/web/src/app/(main)/onboarding/validate-description/route.ts
@@ -1,10 +1,11 @@
-import { CONFIG } from '@/utils/config'
+import { getAuthenticatedUser } from '@/utils/user'
 import { createOpenAI } from '@ai-sdk/openai'
+import { withTracing } from '@posthog/ai'
 import { generateText, Output } from 'ai'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
+import { PostHog } from 'posthog-node'
 import { z } from 'zod'
 import * as Sentry from '@sentry/nextjs'
 
@@ -18,6 +19,12 @@ const openai = createOpenAI({
   baseURL: 'https://gateway-us.pydantic.dev/proxy/chat/',
 })
 
+const phClient = process.env.NEXT_PUBLIC_POSTHOG_TOKEN
+  ? new PostHog(process.env.NEXT_PUBLIC_POSTHOG_TOKEN!, {
+      host: 'https://us.i.posthog.com',
+    })
+  : null
+
 // Loaded from the local copy of the canonical MDX file.
 // The file is created by `scripts/copy-aup.mjs` (run via `prebuild`).
 const aupContent = readFileSync(
@@ -29,6 +36,7 @@ const aupContent = readFileSync(
 )
 
 const requestSchema = z.object({
+  conversation_id: z.string().min(1).max(64),
   product_description: z.string().max(MAX_DESCRIPTION_LENGTH),
   selling_categories: z
     .array(z.string().max(MAX_CATEGORY_LENGTH))
@@ -49,8 +57,8 @@ const requestSchema = z.object({
 })
 
 export async function POST(req: Request) {
-  const cookieStore = await cookies()
-  if (!cookieStore.has(CONFIG.AUTH_COOKIE_KEY)) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -70,12 +78,24 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
   }
 
-  const { product_description, selling_categories, pricing_models, history } =
-    parsed.data
+  const {
+    conversation_id,
+    product_description,
+    selling_categories,
+    pricing_models,
+    history,
+  } = parsed.data
+
+  const model = phClient
+    ? withTracing(openai('gpt-5.4-mini'), phClient, {
+        posthogDistinctId: user.id,
+        posthogTraceId: conversation_id,
+      })
+    : openai('gpt-5.4-mini')
 
   try {
     const { output } = await generateText({
-      model: openai('gpt-5.4-mini'),
+      model,
       maxOutputTokens: 256,
       output: Output.object({
         schema: z.object({
@@ -174,6 +194,10 @@ Current submission:
 Pricing models: ${pricing_models.join(', ') || 'Not specified'}
 Product description: <user_input>${product_description}</user_input>`,
     })
+
+    if (phClient) {
+      await phClient.flush()
+    }
 
     return NextResponse.json(output)
   } catch (error) {

--- a/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useAuth } from '@/hooks'
-import { useCreateOrganization } from '@/hooks/queries'
 import { useOnboardingV2Tracking } from '@/hooks/onboardingV2'
+import { api } from '@/utils/client'
 import { enums, schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import Button from '@polar-sh/ui/components/atoms/Button'
@@ -21,12 +20,27 @@ import {
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm, useFormContext, useWatch } from 'react-hook-form'
-import { setValidationErrors } from '@/utils/api/errors'
 import slugify from 'slugify'
 import { containsBlockedWord } from '@/utils/blocked-words'
 import { CurrencySelector } from '../CurrencySelector'
 import { useOnboardingData } from './OnboardingContext'
 import { OnboardingShell } from './OnboardingShell'
+
+function slugUnavailableMessage(
+  reason: schemas['OrganizationSlugAvailability']['reason'],
+): string {
+  switch (reason) {
+    case 'taken':
+      return 'This slug is already taken.'
+    case 'reserved':
+      return 'This slug is reserved.'
+    case 'blocked':
+      return 'This slug is not allowed.'
+    case 'format':
+    default:
+      return 'This slug is invalid.'
+  }
+}
 
 interface FormSchema {
   organizationType: 'individual' | 'company'
@@ -223,12 +237,8 @@ function SubmitButton({ loading }: { loading: boolean }) {
 
 export function BusinessDetailsStep() {
   const router = useRouter()
-  const { setUserOrganizations } = useAuth()
   const { trackStepViewed, trackStepCompleted } = useOnboardingV2Tracking()
-  const { data, updateData, setApiLoading, showApiResponse } =
-    useOnboardingData()
-  const createOrganization = useCreateOrganization()
-  const [submitting, setSubmitting] = useState(false)
+  const { data, updateData } = useOnboardingData()
 
   trackStepViewed('business')
   const [editedSlug, setEditedSlug] = useState(
@@ -253,12 +263,9 @@ export function BusinessDetailsStep() {
     },
   })
 
-  const { handleSubmit, setError, setValue } = form
+  const { handleSubmit, setValue } = form
 
-  const onSubmit = async (formData: FormSchema) => {
-    setSubmitting(true)
-    setApiLoading(true)
-
+  const onSubmit = (formData: FormSchema) => {
     updateData({
       organizationType: formData.organizationType,
       orgName: formData.name,
@@ -268,48 +275,7 @@ export function BusinessDetailsStep() {
       registeredBusinessName: formData.legal_entity.registered_name,
     })
 
-    const { data: organization, error } = await createOrganization.mutateAsync({
-      name: formData.name,
-      slug: formData.slug,
-      default_presentment_currency:
-        formData.default_presentment_currency as schemas['PresentmentCurrency'],
-      country: (formData.country || undefined) as
-        | schemas['OrganizationCreate']['country']
-        | undefined,
-      default_tax_behavior: 'location',
-      legal_entity:
-        formData.organizationType === 'company'
-          ? {
-              type: 'company' as const,
-              registered_name: formData.legal_entity.registered_name,
-            }
-          : { type: 'individual' as const },
-    })
-
-    if (error) {
-      setSubmitting(false)
-      if (Array.isArray(error.detail)) {
-        setValidationErrors(error.detail, setError)
-      } else {
-        setError('root', {
-          message:
-            typeof error.detail === 'string'
-              ? error.detail
-              : 'Failed to create organization',
-        })
-      }
-      await showApiResponse(400, 'Failed to create organization')
-      return
-    }
-
-    setUserOrganizations((previous) => [...previous, organization])
-    updateData({
-      organizationId: organization.id,
-      orgSlug: organization.slug,
-    })
-
-    trackStepCompleted('business', { organization_id: organization.id })
-    await showApiResponse(201, 'Created')
+    trackStepCompleted('business')
     router.push('/onboarding/product')
   }
 
@@ -399,8 +365,20 @@ export function BusinessDetailsStep() {
               name="slug"
               rules={{
                 required: 'Slug is required',
-                validate: (v) =>
-                  !containsBlockedWord(v) || 'This slug is not allowed.',
+                validate: async (v) => {
+                  if (containsBlockedWord(v)) return 'This slug is not allowed.'
+                  const { data: result, error } = await api.POST(
+                    '/v1/organizations/check-slug',
+                    { body: { slug: v } },
+                  )
+                  if (error || !result) {
+                    return 'Could not validate slug. Please try again.'
+                  }
+                  if (!result.available) {
+                    return slugUnavailableMessage(result.reason)
+                  }
+                  return true
+                },
               }}
               render={({ field }) => (
                 <FormItem className="w-full">
@@ -439,7 +417,9 @@ export function BusinessDetailsStep() {
             </p>
           )}
 
-          <SubmitButton loading={submitting} />
+          <SubmitButton
+            loading={form.formState.isValidating || form.formState.isSubmitting}
+          />
         </Box>
       </Form>
     </OnboardingShell>

--- a/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
@@ -26,22 +26,6 @@ import { CurrencySelector } from '../CurrencySelector'
 import { useOnboardingData } from './OnboardingContext'
 import { OnboardingShell } from './OnboardingShell'
 
-function slugUnavailableMessage(
-  reason: schemas['OrganizationSlugAvailability']['reason'],
-): string {
-  switch (reason) {
-    case 'taken':
-      return 'This slug is already taken.'
-    case 'reserved':
-      return 'This slug is reserved.'
-    case 'blocked':
-      return 'This slug is not allowed.'
-    case 'format':
-    default:
-      return 'This slug is invalid.'
-  }
-}
-
 interface FormSchema {
   organizationType: 'individual' | 'company'
   name: string
@@ -375,7 +359,7 @@ export function BusinessDetailsStep() {
                     return 'Could not validate slug. Please try again.'
                   }
                   if (!result.available) {
-                    return slugUnavailableMessage(result.reason)
+                    return 'This slug is not available.'
                   }
                   return true
                 },

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import * as Sentry from '@sentry/nextjs'
-import { useUpdateOrganization } from '@/hooks/queries'
+import { useAuth } from '@/hooks'
+import { useCreateOrganization } from '@/hooks/queries'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import Button from '@polar-sh/ui/components/atoms/Button'
@@ -65,10 +66,11 @@ interface FormSchema {
 
 export function ProductDetailsStep() {
   const router = useRouter()
+  const { setUserOrganizations } = useAuth()
   const { data, updateData, setApiLoading, showApiResponse } =
     useOnboardingData()
   const { trackStepViewed, trackStepCompleted } = useOnboardingV2Tracking()
-  const updateOrganization = useUpdateOrganization()
+  const createOrganization = useCreateOrganization()
   const [loading, setLoading] = useState<
     'validating' | 'submitting' | 'submitting-anyway' | null
   >(null)
@@ -130,11 +132,12 @@ export function ProductDetailsStep() {
   const submitOrg = async (formData: FormSchema) => {
     setApiLoading(true)
 
-    if (!data.organizationId) {
+    if (!data.orgName || !data.orgSlug) {
       form.setError('root', {
-        message: 'Organization setup is incomplete. Please start again.',
+        message: 'Business details are incomplete. Please start again.',
       })
-      await showApiResponse(400, 'Failed to update organization')
+      await showApiResponse(400, 'Failed to create organization')
+      router.push('/onboarding/business')
       return false
     }
 
@@ -143,22 +146,47 @@ export function ProductDetailsStep() {
       switching ? formData.currentlySellingOn[0] : null
     ) as schemas['OrganizationDetails']['switching_from']
 
-    const { error } = await updateOrganization.mutateAsync({
-      id: data.organizationId,
-      body: {
-        ...(formData.supportEmail && { email: formData.supportEmail }),
-        ...(formData.productUrl && { website: formData.productUrl }),
-        details: {
-          product_description: formData.productDescription,
-          selling_categories: formData.sellingCategories,
-          pricing_models: formData.pricingModel,
-          switching,
-          switching_from: switchingFrom,
-        } satisfies schemas['OrganizationDetails'],
-      },
+    const { data: organization, error } = await createOrganization.mutateAsync({
+      name: data.orgName,
+      slug: data.orgSlug,
+      default_presentment_currency: (data.defaultCurrency ||
+        'usd') as schemas['PresentmentCurrency'],
+      country: (data.businessCountry || undefined) as
+        | schemas['OrganizationCreate']['country']
+        | undefined,
+      default_tax_behavior: 'location',
+      legal_entity:
+        data.organizationType === 'company'
+          ? {
+              type: 'company' as const,
+              registered_name: data.registeredBusinessName ?? '',
+            }
+          : { type: 'individual' as const },
+      ...(formData.supportEmail && { email: formData.supportEmail }),
+      ...(formData.productUrl && { website: formData.productUrl }),
+      details: {
+        product_description: formData.productDescription,
+        selling_categories: formData.sellingCategories,
+        pricing_models: formData.pricingModel,
+        switching,
+        switching_from: switchingFrom,
+      } satisfies schemas['OrganizationDetails'],
     })
 
     if (error) {
+      const slugConflict =
+        Array.isArray(error.detail) &&
+        error.detail.some((e) => Array.isArray(e.loc) && e.loc.includes('slug'))
+
+      if (slugConflict) {
+        await showApiResponse(
+          409,
+          'This slug is no longer available. Please pick another.',
+        )
+        router.push('/onboarding/business')
+        return false
+      }
+
       form.setError('root', {
         message:
           typeof error.detail === 'string'
@@ -167,12 +195,18 @@ export function ProductDetailsStep() {
               ? (error.detail[0]?.msg ?? 'Validation failed')
               : 'Something went wrong, please try again.',
       })
-      await showApiResponse(400, 'Failed to update organization')
+      await showApiResponse(400, 'Failed to create organization')
       return false
     }
 
-    trackStepCompleted('product', { organization_id: data.organizationId })
-    await showApiResponse(200, 'OK')
+    setUserOrganizations((previous) => [...previous, organization])
+    updateData({
+      organizationId: organization.id,
+      orgSlug: organization.slug,
+    })
+
+    trackStepCompleted('product', { organization_id: organization.id })
+    await showApiResponse(201, 'Created')
     router.push('/onboarding/complete')
     return true
   }

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -17,6 +17,7 @@ import {
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
 import { useOnboardingV2Tracking } from '@/hooks/onboardingV2'
+import { nanoid } from 'nanoid'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -80,6 +81,7 @@ export function ProductDetailsStep() {
   const [aupHistory, setAupHistory] = useState<
     Array<{ product_description: string; verdict: string; message?: string }>
   >([])
+  const [conversationId] = useState(() => nanoid())
 
   const form = useForm<FormSchema>({
     defaultValues: {
@@ -220,6 +222,7 @@ export function ProductDetailsStep() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          conversation_id: conversationId,
           product_description: formData.productDescription,
           selling_categories: formData.sellingCategories,
           pricing_models: formData.pricingModel,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23734,11 +23734,6 @@ export interface components {
        * @description Whether the slug is available for a new organization.
        */
       available: boolean
-      /**
-       * Reason
-       * @description If unavailable, the reason why. `format` if the slug doesn't match the required format, `reserved` if it's a reserved keyword, `blocked` if it contains a disallowed word, `taken` if another organization already uses it.
-       */
-      reason?: ('format' | 'reserved' | 'blocked' | 'taken') | null
     }
     /** OrganizationSlugCheck */
     OrganizationSlugCheck: {
@@ -54065,9 +54060,6 @@ export const organizationReviewStateVerdictAnyOf0Values: ReadonlyArray<
 export const organizationReviewStatusVerdictAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewStatus']['verdict']
 > = ['PASS', 'FAIL', 'UNCERTAIN']
-export const organizationSlugAvailabilityReasonAnyOf0Values: ReadonlyArray<
-  FlattenedDeepRequired<components>['schemas']['OrganizationSlugAvailability']['reason']
-> = ['format', 'reserved', 'blocked', 'taken']
 export const organizationSocialPlatformsValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationSocialPlatforms']
 > = [

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -686,6 +686,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/organizations/check-slug': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Check Organization Slug Availability
+     * @description Check whether a slug is valid and available for a new organization.
+     *
+     *     **Scopes**: `organizations:write`
+     */
+    post: operations['organizations:check_slug']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/organizations/{id}/submit-review': {
     parameters: {
       query?: never
@@ -23705,6 +23727,27 @@ export interface components {
        */
       appeal_reviewed_at?: string | null
     }
+    /** OrganizationSlugAvailability */
+    OrganizationSlugAvailability: {
+      /**
+       * Available
+       * @description Whether the slug is available for a new organization.
+       */
+      available: boolean
+      /**
+       * Reason
+       * @description If unavailable, the reason why. `format` if the slug doesn't match the required format, `reserved` if it's a reserved keyword, `blocked` if it contains a disallowed word, `taken` if another organization already uses it.
+       */
+      reason?: ('format' | 'reserved' | 'blocked' | 'taken') | null
+    }
+    /** OrganizationSlugCheck */
+    OrganizationSlugCheck: {
+      /**
+       * Slug
+       * @description The slug to check availability for.
+       */
+      slug: string
+    }
     /** OrganizationSocialLink */
     OrganizationSocialLink: {
       /** @description The social platform of the URL */
@@ -32181,6 +32224,39 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:check_slug': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['OrganizationSlugCheck']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrganizationSlugAvailability']
         }
       }
       /** @description Validation Error */
@@ -53989,6 +54065,9 @@ export const organizationReviewStateVerdictAnyOf0Values: ReadonlyArray<
 export const organizationReviewStatusVerdictAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewStatus']['verdict']
 > = ['PASS', 'FAIL', 'UNCERTAIN']
+export const organizationSlugAvailabilityReasonAnyOf0Values: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationSlugAvailability']['reason']
+> = ['format', 'reserved', 'blocked', 'taken']
 export const organizationSocialPlatformsValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationSocialPlatforms']
 > = [

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -62,6 +62,8 @@ from .schemas import (
     OrganizationPayoutAccountSet,
     OrganizationReviewState,
     OrganizationReviewStatus,
+    OrganizationSlugAvailability,
+    OrganizationSlugCheck,
     OrganizationUpdate,
     OrganizationValidateWebsiteRequest,
     OrganizationValidateWebsiteResponse,
@@ -214,6 +216,21 @@ async def create(
 ) -> Organization:
     """Create an organization."""
     return await organization_service.create(session, organization_create, auth_subject)
+
+
+@router.post(
+    "/check-slug",
+    response_model=OrganizationSlugAvailability,
+    summary="Check Organization Slug Availability",
+    tags=[APITag.private],
+)
+async def check_slug(
+    body: OrganizationSlugCheck,
+    auth_subject: auth.OrganizationsCreate,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> OrganizationSlugAvailability:
+    """Check whether a slug is valid and available for a new organization."""
+    return await organization_service.check_slug_availability(session, body.slug)
 
 
 @router.patch(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -82,6 +82,31 @@ SlugInput = Annotated[
 ]
 
 
+class OrganizationSlugCheck(Schema):
+    slug: str = Field(description="The slug to check availability for.")
+
+
+OrganizationSlugUnavailableReason = Literal[
+    "format", "reserved", "blocked", "taken"
+]
+
+
+class OrganizationSlugAvailability(Schema):
+    available: bool = Field(
+        description="Whether the slug is available for a new organization."
+    )
+    reason: OrganizationSlugUnavailableReason | None = Field(
+        None,
+        description=(
+            "If unavailable, the reason why. "
+            "`format` if the slug doesn't match the required format, "
+            "`reserved` if it's a reserved keyword, "
+            "`blocked` if it contains a disallowed word, "
+            "`taken` if another organization already uses it."
+        ),
+    )
+
+
 def _discard_logo_dev_url(url: HttpUrl) -> HttpUrl | None:
     if url.host and url.host.endswith("logo.dev"):
         return None

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -86,9 +86,7 @@ class OrganizationSlugCheck(Schema):
     slug: str = Field(description="The slug to check availability for.")
 
 
-OrganizationSlugUnavailableReason = Literal[
-    "format", "reserved", "blocked", "taken"
-]
+OrganizationSlugUnavailableReason = Literal["format", "reserved", "blocked", "taken"]
 
 
 class OrganizationSlugAvailability(Schema):

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -86,22 +86,9 @@ class OrganizationSlugCheck(Schema):
     slug: str = Field(description="The slug to check availability for.")
 
 
-OrganizationSlugUnavailableReason = Literal["format", "reserved", "blocked", "taken"]
-
-
 class OrganizationSlugAvailability(Schema):
     available: bool = Field(
         description="Whether the slug is available for a new organization."
-    )
-    reason: OrganizationSlugUnavailableReason | None = Field(
-        None,
-        description=(
-            "If unavailable, the reason why. "
-            "`format` if the slug doesn't match the required format, "
-            "`reserved` if it's a reserved keyword, "
-            "`blocked` if it contains a disallowed word, "
-            "`taken` if another organization already uses it."
-        ),
     )
 
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -69,6 +69,8 @@ from polar.transaction.service.transaction import transaction as transaction_ser
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
 
+from slugify import slugify
+
 from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (
     OrganizationCreate,
@@ -81,7 +83,10 @@ from .schemas import (
     OrganizationReviewState,
     OrganizationReviewSubmissionBody,
     OrganizationReviewVerdict,
+    OrganizationSlugAvailability,
     OrganizationUpdate,
+    validate_blocked_words,
+    validate_reserved_keywords,
 )
 from .sorting import OrganizationSortProperty
 
@@ -212,6 +217,35 @@ class OrganizationService:
         )
 
         return await repository.get_one_or_none(statement)
+
+    async def check_slug_availability(
+        self, session: AsyncReadSession, slug: str
+    ) -> OrganizationSlugAvailability:
+        """Check whether a slug is valid and available for a new organization.
+
+        Mirrors the validation rules of the `SlugInput` type plus a
+        check against existing (and soft-deleted) organizations.
+        """
+        normalized = slug.lower()
+
+        if len(normalized) < 3 or slugify(normalized) != normalized:
+            return OrganizationSlugAvailability(available=False, reason="format")
+
+        try:
+            validate_reserved_keywords(normalized)
+        except ValueError:
+            return OrganizationSlugAvailability(available=False, reason="reserved")
+
+        try:
+            validate_blocked_words(normalized)
+        except ValueError:
+            return OrganizationSlugAvailability(available=False, reason="blocked")
+
+        repository = OrganizationRepository.from_session(session)
+        if await repository.slug_exists(normalized):
+            return OrganizationSlugAvailability(available=False, reason="taken")
+
+        return OrganizationSlugAvailability(available=True)
 
     async def create(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -9,6 +9,7 @@ import email_validator
 import structlog
 from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
+from slugify import slugify
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
@@ -68,8 +69,6 @@ from polar.product.repository import ProductRepository
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
-
-from slugify import slugify
 
 from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -228,21 +228,17 @@ class OrganizationService:
         normalized = slug.lower()
 
         if len(normalized) < 3 or slugify(normalized) != normalized:
-            return OrganizationSlugAvailability(available=False, reason="format")
+            return OrganizationSlugAvailability(available=False)
 
         try:
             validate_reserved_keywords(normalized)
-        except ValueError:
-            return OrganizationSlugAvailability(available=False, reason="reserved")
-
-        try:
             validate_blocked_words(normalized)
         except ValueError:
-            return OrganizationSlugAvailability(available=False, reason="blocked")
+            return OrganizationSlugAvailability(available=False)
 
         repository = OrganizationRepository.from_session(session)
         if await repository.slug_exists(normalized):
-            return OrganizationSlugAvailability(available=False, reason="taken")
+            return OrganizationSlugAvailability(available=False)
 
         return OrganizationSlugAvailability(available=True)
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1015,9 +1015,7 @@ class TestCheckSlugAvailability:
         assert response.json() == {"available": True, "reason": None}
 
     @pytest.mark.auth
-    async def test_taken(
-        self, client: AsyncClient, organization: Organization
-    ) -> None:
+    async def test_taken(self, client: AsyncClient, organization: Organization) -> None:
         response = await client.post(
             "/v1/organizations/check-slug", json={"slug": organization.slug}
         )

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -994,3 +994,69 @@ class TestGetReview:
         assert all(
             "not_started" in step["reasons"] for step in json["preliminary_steps"]
         )
+
+
+@pytest.mark.asyncio
+class TestCheckSlugAvailability:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "available-slug"}
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_available(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "brand-new-slug"}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"available": True, "reason": None}
+
+    @pytest.mark.auth
+    async def test_taken(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": organization.slug}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "taken"}
+
+    @pytest.mark.auth
+    async def test_too_short(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "ab"}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "format"}
+
+    @pytest.mark.auth
+    async def test_invalid_format(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "Invalid Slug!"}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "format"}
+
+    @pytest.mark.auth
+    async def test_reserved(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "dashboard"}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "reserved"}
+
+    @pytest.mark.auth
+    async def test_blocked_word(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "porn-shop"}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "blocked"}

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1012,7 +1012,7 @@ class TestCheckSlugAvailability:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": True, "reason": None}
+        assert response.json() == {"available": True}
 
     @pytest.mark.auth
     async def test_taken(self, client: AsyncClient, organization: Organization) -> None:
@@ -1021,7 +1021,7 @@ class TestCheckSlugAvailability:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": False, "reason": "taken"}
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_too_short(self, client: AsyncClient) -> None:
@@ -1030,7 +1030,7 @@ class TestCheckSlugAvailability:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": False, "reason": "format"}
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_invalid_format(self, client: AsyncClient) -> None:
@@ -1039,7 +1039,7 @@ class TestCheckSlugAvailability:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": False, "reason": "format"}
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_reserved(self, client: AsyncClient) -> None:
@@ -1048,7 +1048,7 @@ class TestCheckSlugAvailability:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": False, "reason": "reserved"}
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_blocked_word(self, client: AsyncClient) -> None:
@@ -1057,4 +1057,4 @@ class TestCheckSlugAvailability:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": False, "reason": "blocked"}
+        assert response.json() == {"available": False}


### PR DESCRIPTION
Splitting into POST + PATCH allowed users to work around the onboarding AUP validation by abandoning the onboarding on step 3 and logging back in.

Also started tracking the AUP validation results in Posthog (for now) so that I can see a bit how we're performing, we shouldn't be flying blind there.