### PR TITLE
Fix PWYW amount validation

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceCustomItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceCustomItem.tsx
@@ -99,10 +99,6 @@ export const ProductPriceCustomItem: React.FC<ProductPriceCustomItemProps> = ({
 
               return true
             },
-            max: {
-              value: 1_000_000,
-              message: 'Price cannot be greater than 10,000',
-            },
           }}
           render={({ field }) => {
             return (

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -194,7 +194,6 @@ class ProductPriceCustomCreate(ProductPriceCreateBase):
     )
     maximum_amount: PriceAmount | None = Field(
         default=None,
-        le=1_000_000,  # $10K
         description="The maximum amount the customer can pay.",
     )
     preset_amount: PriceAmount | None = Field(
@@ -208,7 +207,7 @@ class ProductPriceCustomCreate(ProductPriceCreateBase):
         ),
     )
 
-    @field_validator("minimum_amount", "preset_amount")
+    @field_validator("minimum_amount", "preset_amount", "maximum_amount")
     @classmethod
     def validate_amount_not_in_minimum_gap(
         cls, v: int | None, info: ValidationInfo

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -11,6 +11,7 @@ from polar.product.schemas import (
     ProductCreate,
     ProductCreateOneTime,
     ProductCreateRecurring,
+    ProductPriceCustomCreate,
     ProductPriceFixedCreate,
     ProductPriceMeteredUnitCreate,
 )
@@ -277,6 +278,35 @@ class TestProductPriceFixedCurrencyMinimums:
         # PydanticCustomError produces clean messages without "Value error, " prefix
         assert errors[0]["type"] == "minimum_price"
         assert not errors[0]["msg"].startswith("Value error")
+
+
+class TestProductPriceCustomCurrency:
+    """Test currency-specific validation on ProductPriceCustomCreate (PWYW)."""
+
+    def test_inr_maximum_amount_above_old_usd_ceiling(self) -> None:
+        """Regression: INR maximum_amount above the old hardcoded $10K ceiling
+        (1_000_000 paise = ₹10,000) must be accepted."""
+        price = ProductPriceCustomCreate(
+            amount_type=ProductPriceAmountType.custom,
+            price_currency=PresentmentCurrency.inr,
+            minimum_amount=6000,
+            preset_amount=50000,
+            maximum_amount=5_000_000,
+        )
+        assert price.maximum_amount == 5_000_000
+
+    def test_maximum_amount_below_currency_minimum_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ProductPriceCustomCreate(
+                amount_type=ProductPriceAmountType.custom,
+                price_currency=PresentmentCurrency.inr,
+                maximum_amount=400,
+            )
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("maximum_amount",)
+        assert errors[0]["type"] == "minimum_price"
 
 
 class TestProductCreateDiscriminator:


### PR DESCRIPTION
We had a hardcoded maximum in client-side validation that wasn't currency-aware. This PR drops that.

We also have an unused field `maximum_amount` that still had a matching ceiling that was currency un-aware. That doesn't really matter, but I made it re-use the existing `validate_price_amount` just as a clean house kind of thing.