### PR TITLE
chore: Dedicated queue for PDF generation jobs step 6.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
       environment: production
       docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
-      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g"
+      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g,srv-d7us9je7r5hc73be5ieg"
       docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
       has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -120,13 +120,14 @@ resource "render_redis" "redis" {
 
 locals {
   production_service_ids = {
-    api                    = "srv-ci4r87h8g3ne0dmvvl60"
-    scheduler              = "srv-d4uto5ili9vc73dd37tg"
-    worker                 = "srv-d4k6otfgi27c73cicnpg"
-    worker-medium-priority = "srv-d4k62svpm1nc73af5e3g"
-    worker-high-priority   = "srv-d3hrh1j3fgac73a1t4r0"
-    worker-webhook         = "srv-d5l0oekhg0os73clofm0"
-    worker-tinybird        = "srv-d733djuuk2gs73e98h1g"
+    api                      = "srv-ci4r87h8g3ne0dmvvl60"
+    scheduler                = "srv-d4uto5ili9vc73dd37tg"
+    worker                   = "srv-d4k6otfgi27c73cicnpg"
+    worker-medium-priority   = "srv-d4k62svpm1nc73af5e3g"
+    worker-high-priority     = "srv-d3hrh1j3fgac73a1t4r0"
+    worker-webhook           = "srv-d5l0oekhg0os73clofm0"
+    worker-tinybird          = "srv-d733djuuk2gs73e98h1g"
+    worker-invoices-receipts = "srv-d7us9je7r5hc73be5ieg"
   }
 }
 
@@ -219,8 +220,8 @@ module "production" {
     "worker-invoices-receipts" = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
-      image_url          = data.render_web_service.production_worker["worker-tinybird"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker-tinybird"].runtime_source.image.digest
+      image_url          = data.render_web_service.production_worker["worker-invoices-receipts"].runtime_source.image.image_url
+      image_digest       = data.render_web_service.production_worker["worker-invoices-receipts"].runtime_source.image.digest
       dramatiq_prom_port = "10003"
     }
   }


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. ~Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue~ **Done**
3. ~Create a new worker in sandbox that consumes only `invoices_and_receipts`~ **Done**
  3.1 ~terraform wiring~ **Done**
4. ~Update the regular worker in sandbox so it stops consuming the new queue~ **Done**
5. ~Verify this solves OOM issues in sandbox~ **Done**
6. ~Create a new worker in production that consumes only `invoices_and_receipts`~ **Done**
  6.1 terraform wiring - ensure the new worker has correct image and is deployed properly (**this step**)
8. Update the low priority worker in production so it stops consuming the new queue
9. Verify this solves OOM issues in production
10. Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs)
11. Remove `.v2` entirely