### PR TITLE
chore: Dedicated queue for PDF generation jobs step 7

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -186,7 +186,7 @@ module "production" {
       dramatiq_prom_port = "10000"
     }
     "worker" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority invoices_and_receipts"
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority"
       image_url          = data.render_web_service.production_worker["worker"].runtime_source.image.image_url
       image_digest       = data.render_web_service.production_worker["worker"].runtime_source.image.digest
       custom_domains     = [{ name = "worker.polar.sh" }]


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. ~Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue~ **Done**
3. ~Create a new worker in sandbox that consumes only `invoices_and_receipts`~ **Done**
  3.1 ~terraform wiring~ **Done**
4. ~Update the regular worker in sandbox so it stops consuming the new queue~ **Done**
5. ~Verify this solves OOM issues in sandbox~ **Done**
6. ~Create a new worker in production that consumes only `invoices_and_receipts`~ **Done**
  6.1 ~terraform wiring - ensure the new worker has correct image and is deployed properly~ **Done**
7. Update the low priority worker in production so it stops consuming the new queue (**this step**)
8. Verify this solves OOM issues in production
9. Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs)
10. Remove `.v2` entirely