### PR TITLE
chore: Dedicated queue for PDF generation jobs step 9

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -468,7 +468,7 @@ class OrderService:
         if order.billing_name is None or order.billing_address is None:
             raise MissingInvoiceBillingDetails(order)
 
-        enqueue_job("order.invoice.v2", order_id=order.id)
+        enqueue_job("order.invoice", order_id=order.id)
 
     async def generate_invoice(self, session: AsyncSession, order: Order) -> Order:
         invoice_path = await invoice_service.create_order_invoice(order)

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -225,13 +225,17 @@ async def _run_order_invoice(order_id: uuid.UUID) -> None:
         await order_service.generate_invoice(session, order)
 
 
-# Kept temporarily to drain in-flight messages enqueued before the v2 cutover.
-# Remove once the queue is empty and rename `order.invoice.v2` back to `order.invoice`.
-@actor(actor_name="order.invoice", priority=TaskPriority.LOW)
+@actor(
+    actor_name="order.invoice",
+    priority=TaskPriority.LOW,
+    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
+)
 async def order_invoice(order_id: uuid.UUID) -> None:
     await _run_order_invoice(order_id)
 
 
+# Kept temporarily to drain in-flight `order.invoice.v2` messages still in the
+# `invoices_and_receipts` queue from before the rename. Remove once drained.
 @actor(
     actor_name="order.invoice.v2",
     priority=TaskPriority.LOW,

--- a/server/polar/receipt/service.py
+++ b/server/polar/receipt/service.py
@@ -116,7 +116,7 @@ class ReceiptService:
 
     async def get_pdf_url_or_status(self, order: Order) -> tuple[str, datetime] | None:
         if order.receipt_path is None:
-            enqueue_job("receipt.render.v2", order_id=order.id)
+            enqueue_job("receipt.render", order_id=order.id)
             return None
 
         s3 = S3Service(settings.S3_CUSTOMER_RECEIPTS_BUCKET_NAME)

--- a/server/polar/receipt/tasks.py
+++ b/server/polar/receipt/tasks.py
@@ -51,20 +51,21 @@ async def _run_receipt_render(order_id: uuid.UUID) -> None:
                 "receipt render: lock contention, re-enqueueing",
                 order_id=str(order_id),
             )
-            enqueue_job("receipt.render.v2", order_id, delay=RENDER_RETRY_DELAY_MS)
+            enqueue_job("receipt.render", order_id, delay=RENDER_RETRY_DELAY_MS)
 
 
-# Kept temporarily to drain in-flight messages enqueued before the v2 cutover.
-# Remove once the queue is empty and rename `receipt.render.v2` back to `receipt.render`.
 @actor(
     actor_name="receipt.render",
     priority=TaskPriority.LOW,
+    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
     time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
 )
 async def receipt_render(order_id: uuid.UUID) -> None:
     await _run_receipt_render(order_id)
 
 
+# Kept temporarily to drain in-flight `receipt.render.v2` messages still in the
+# `invoices_and_receipts` queue from before the rename. Remove once drained.
 @actor(
     actor_name="receipt.render.v2",
     priority=TaskPriority.LOW,

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -536,7 +536,7 @@ class RefundService:
             )
 
             if order.receipt_number is not None:
-                enqueue_job("receipt.render.v2", order.id)
+                enqueue_job("receipt.render", order.id)
 
     async def _on_updated(self, session: AsyncSession, refund: Refund) -> None:
         if refund.organization is not None:

--- a/server/tests/customer_portal/endpoints/test_order.py
+++ b/server/tests/customer_portal/endpoints/test_order.py
@@ -501,7 +501,7 @@ class TestGetOrderReceipt:
         response = await client.get(f"/v1/customer-portal/orders/{order.id}/receipt")
 
         assert response.status_code == 202
-        enqueue_mock.assert_called_once_with("receipt.render.v2", order_id=order.id)
+        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
 
     @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
     async def test_200_when_receipt_ready(

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -437,7 +437,7 @@ class TestGetOrderReceipt:
         response = await client.get(f"/v1/orders/{order.id}/receipt")
 
         assert response.status_code == 202
-        enqueue_mock.assert_called_once_with("receipt.render.v2", order_id=order.id)
+        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
     async def test_200_when_receipt_ready(

--- a/server/tests/receipt/test_service.py
+++ b/server/tests/receipt/test_service.py
@@ -409,7 +409,7 @@ class TestGetPdfUrlOrStatus:
         result = await receipt_service.get_pdf_url_or_status(order)
 
         assert result is None
-        enqueue_mock.assert_called_once_with("receipt.render.v2", order_id=order.id)
+        enqueue_mock.assert_called_once_with("receipt.render", order_id=order.id)
 
     async def test_returns_url_when_path_set(
         self,

--- a/server/tests/receipt/test_tasks.py
+++ b/server/tests/receipt/test_tasks.py
@@ -73,7 +73,7 @@ class TestReceiptRender:
         await receipt_render(order.id)
 
         enqueue_job_mock.assert_called_once_with(
-            "receipt.render.v2", order.id, delay=5_000
+            "receipt.render", order.id, delay=5_000
         )
 
     async def test_delegates_to_service(


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. ~Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue~ **Done**
3. ~Create a new worker in sandbox that consumes only `invoices_and_receipts`~ **Done**
  3.1 ~terraform wiring~ **Done**
4. ~Update the regular worker in sandbox so it stops consuming the new queue~ **Done**
5. ~Verify this solves OOM issues in sandbox~ **Done**
6. ~Create a new worker in production that consumes only `invoices_and_receipts`~ **Done**
  6.1 ~terraform wiring - ensure the new worker has correct image and is deployed properly~ **Done**
7. ~Update the low priority worker in production so it stops consuming the new queue~ **Done**
8. ~Verify this solves OOM issues in production~ **Done**
9. Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs) (**this step**)
10. Remove `.v2` entirely