### PR TITLE
Periodic cleanup of expired OAuth2 tokens

### DIFF
--- a/server/polar/oauth2/repository.py
+++ b/server/polar/oauth2/repository.py
@@ -1,0 +1,26 @@
+import time
+from collections.abc import Sequence
+
+from sqlalchemy import delete, or_
+
+from polar.kit.repository import RepositoryBase
+from polar.models import OAuth2Token
+
+
+class OAuth2TokenRepository(RepositoryBase[OAuth2Token]):
+    model = OAuth2Token
+
+    async def delete_expired(self, *, exclude_client_ids: Sequence[str] = ()) -> None:
+        now = int(time.time())
+        statement = delete(OAuth2Token).where(
+            OAuth2Token.issued_at + OAuth2Token.expires_in < now,
+            or_(
+                OAuth2Token.refresh_token.is_(None),
+                OAuth2Token.refresh_token_revoked_at != 0,
+            ),
+        )
+        if exclude_client_ids:
+            statement = statement.where(
+                OAuth2Token.client_id.notin_(exclude_client_ids)
+            )
+        await self.session.execute(statement)

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -13,6 +13,7 @@ from polar.kit.crypto import get_token_hash
 from polar.kit.services import ResourceServiceReader
 from polar.logging import Logger
 from polar.models import OAuth2Token, User
+from polar.oauth2.repository import OAuth2TokenRepository
 from polar.postgres import AsyncSession
 from polar.user_organization.service import (
     user_organization as user_organization_service,
@@ -65,6 +66,13 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
             return None
 
         return token
+
+    async def delete_expired(self, session: AsyncSession) -> None:
+        repository = OAuth2TokenRepository.from_session(session)
+        exclude_client_ids: list[str] = []
+        if APP_CLIENT_ID is not None:
+            exclude_client_ids.append(APP_CLIENT_ID)
+        await repository.delete_expired(exclude_client_ids=exclude_client_ids)
 
     async def revoke_leaked(
         self,

--- a/server/polar/oauth2/tasks.py
+++ b/server/polar/oauth2/tasks.py
@@ -1,0 +1,14 @@
+from polar.worker import AsyncSessionMaker, CronTrigger, TaskPriority, actor
+
+from .service.oauth2_token import oauth2_token as oauth2_token_service
+
+
+@actor(
+    actor_name="oauth2_token.delete_expired",
+    cron_trigger=CronTrigger(hour=0, minute=0),
+    priority=TaskPriority.LOW,
+    max_retries=0,
+)
+async def oauth2_token_delete_expired() -> None:
+    async with AsyncSessionMaker() as session:
+        await oauth2_token_service.delete_expired(session)

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -19,6 +19,7 @@ from polar.integrations.stripe import tasks as stripe
 from polar.integrations.tinybird import tasks as tinybird
 from polar.meter import tasks as meter
 from polar.notifications import tasks as notifications
+from polar.oauth2 import tasks as oauth2
 from polar.observability.slo_report import tasks as slo_report
 from polar.order import tasks as order
 from polar.organization import tasks as organization
@@ -52,6 +53,7 @@ __all__ = [
     "loops",
     "meter",
     "notifications",
+    "oauth2",
     "order",
     "organization",
     "organization_access_token",

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 
 from polar.email.schemas import OAuth2LeakedTokenEmail
 from polar.enums import TokenType
-from polar.models import OAuth2Client, Organization, User, UserOrganization
+from polar.models import OAuth2Client, OAuth2Token, Organization, User, UserOrganization
 from polar.oauth2.service.oauth2_token import oauth2_token as oauth2_token_service
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -260,3 +260,135 @@ class TestGetByAccessToken:
         assert result is not None
         assert result.client_id == oauth2_client.client_id
         log_mock.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestDeleteExpired:
+    async def test_deletes_expired_without_refresh_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        expired = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_expired",
+            refresh_token="polar_rt_u_expired",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()) - 7200,
+            expires_in=3600,
+        )
+        # Simulate a token without a refresh token (e.g. MCP web grant).
+        expired.refresh_token = None  # pyright: ignore
+        await save_fixture(expired)
+
+        await oauth2_token_service.delete_expired(session)
+
+        deleted = await session.get(OAuth2Token, expired.id)
+        assert deleted is None
+
+    async def test_deletes_expired_with_revoked_refresh_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        expired = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_revoked",
+            refresh_token="polar_rt_u_revoked",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()) - 7200,
+            expires_in=3600,
+            refresh_token_revoked_at=int(time.time()) - 7200,
+        )
+
+        await oauth2_token_service.delete_expired(session)
+
+        deleted = await session.get(OAuth2Token, expired.id)
+        assert deleted is None
+
+    async def test_preserves_active_refresh_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        expired = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_refreshable",
+            refresh_token="polar_rt_u_refreshable",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()) - 7200,
+            expires_in=3600,
+        )
+
+        await oauth2_token_service.delete_expired(session)
+
+        preserved = await session.get(OAuth2Token, expired.id)
+        assert preserved is not None
+
+    async def test_preserves_valid_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+    ) -> None:
+        valid = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_valid",
+            refresh_token="polar_rt_u_valid",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()),
+            expires_in=3600,
+        )
+        valid.refresh_token = None  # pyright: ignore
+        await save_fixture(valid)
+
+        await oauth2_token_service.delete_expired(session)
+
+        preserved = await session.get(OAuth2Token, valid.id)
+        assert preserved is not None
+
+    async def test_preserves_app_client_tokens(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        mocker: MockerFixture,
+    ) -> None:
+        mocker.patch(
+            "polar.oauth2.service.oauth2_token.APP_CLIENT_ID",
+            oauth2_client.client_id,
+        )
+
+        expired = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_app",
+            refresh_token="polar_rt_u_app",
+            scopes=["openid"],
+            user=user,
+            issued_at=int(time.time()) - 7200,
+            expires_in=3600,
+        )
+        expired.refresh_token = None  # pyright: ignore
+        await save_fixture(expired)
+
+        await oauth2_token_service.delete_expired(session)
+
+        preserved = await session.get(OAuth2Token, expired.id)
+        assert preserved is not None


### PR DESCRIPTION
(sorry, this shouldn't've created a PR, but wanted to ask if this is something we should/could/need to do?)

## Summary

The MCP "create product with AI" flow exchanges the user's session for a 1h OAuth2 access token via the custom `web` grant on every cache miss (cookie cached for `expires_in` seconds). The grant doesn't issue a refresh token, so each issuance is a brand-new row in `oauth2_tokens`, and there's no job that ever deletes them — `OAuth2TokenService.get_by_access_token` only checks `is_expired()` at lookup time, leaving expired rows behind forever.

This adds a daily cron actor that prunes safely-deletable expired tokens, mirroring the existing pattern from `customer_session.delete_expired` and `auth.delete_expired`.

### What gets deleted

A row is deleted only if **all** of the following hold:

1. The access token is past expiry: `issued_at + expires_in < now()` (`expires_at` is a Python property, not a column, so the SQL has to expand it).
2. There is no usable refresh path: `refresh_token IS NULL OR refresh_token_revoked_at != 0`. This preserves third-party OAuth apps that still have a valid refresh token they could use to mint a new access token.
3. The token's `client_id` is not the legacy Polar app client (`APP_CLIENT_ID`). The service intentionally accepts expired tokens from that client as a temporary workaround for an unfixed mobile auth flow — deleting those rows would break the workaround.

### Files

- `server/polar/oauth2/repository.py` (new) — `OAuth2TokenRepository.delete_expired(*, exclude_client_ids)`.
- `server/polar/oauth2/service/oauth2_token.py` — `OAuth2TokenService.delete_expired` wires the `APP_CLIENT_ID` exclusion.
- `server/polar/oauth2/tasks.py` (new) — `oauth2_token.delete_expired` cron actor (`hour=0, minute=0`, `TaskPriority.LOW`, `max_retries=0`).
- `server/polar/tasks.py` — registers the new tasks module.
- `server/tests/oauth2/service/test_oauth2_token.py` — `TestDeleteExpired` covering the four cases above.

## Test plan

- [ ] CI runs `TestDeleteExpired` (local execution blocked by a pre-existing Python 3.14rc2 / pydantic-ai import failure in this sandbox; ruff passes on all touched files).
- [ ] After deploy, confirm the cron actor appears in the scheduler logs at 00:00 UTC and that `oauth2_tokens` row count stops growing for client_id values without refresh tokens.

https://claude.ai/code/session_01LJttmtBWXZwktjxLRJnHpt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJttmtBWXZwktjxLRJnHpt)_