### PR TITLE
Add copy-to-clipboard button for webhook delivery payloads

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
@@ -2,6 +2,7 @@
 
 import { DateRange } from '@/components/Metrics/DateRangePicker'
 import { toast } from '@/components/Toast/use-toast'
+import { useSafeCopy } from '@/hooks/clipboard'
 import {
   useListWebhooksDeliveries,
   useRedeliverWebhookEvent,
@@ -295,6 +296,15 @@ const ExpandedRow = (props: CellContext<DeliveryRow, unknown>) => {
     : null
 
   const redeliver = useRedeliverWebhookEvent()
+  const safeCopy = useSafeCopy(toast)
+
+  const handleCopyPayload = useCallback(async () => {
+    if (!payload) return
+    await safeCopy(payload)
+    toast({
+      title: 'Payload copied to clipboard',
+    })
+  }, [payload, safeCopy])
 
   const handleRedeliver = useCallback(
     async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -348,7 +358,14 @@ const ExpandedRow = (props: CellContext<DeliveryRow, unknown>) => {
         )}
       </div>
       <hr />
-      <div className="font-medium">Payload</div>
+      <div className="flex items-center justify-between">
+        <div className="font-medium">Payload</div>
+        {payload && (
+          <Button variant="secondary" size="sm" onClick={handleCopyPayload}>
+            Copy payload
+          </Button>
+        )}
+      </div>
       {payload ? (
         <pre className="text-xs whitespace-pre-wrap">{payload}</pre>
       ) : (


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Adds a "Copy payload" button to the webhook delivery details view, allowing users to easily copy the payload JSON to their clipboard.

## What

- Added `useSafeCopy` hook import from the clipboard utilities
- Created `handleCopyPayload` callback that copies the payload to clipboard and shows a toast confirmation
- Added a flex container with the "Payload" label and a conditional "Copy payload" button that appears when payload data exists
- The button uses secondary styling and small size to maintain visual hierarchy

## Why

Users viewing webhook delivery details often need to copy the payload for debugging, testing, or documentation purposes. This change eliminates the need to manually select and copy the text, improving the user experience.

## How

Leveraged the existing `useSafeCopy` hook (which handles clipboard operations safely) and the toast notification system to provide user feedback. The button is conditionally rendered only when payload data is available, and uses the existing Button component for consistency.

## Checklist

- [x] This PR addresses a single concern (one feature)
- [x] The diff is reasonably sized and easy to review
- [x] No new tests needed (uses existing hooks and components)
- [x] No linting or type checking issues introduced
- [x] No unrelated changes included

https://claude.ai/code/session_01NXwBa1srurh5yqRr9fHvNT