### PR TITLE
backoffice: approve native build scripts for pnpm 10 install

### DIFF
--- a/server/polar/backoffice/package.json
+++ b/server/polar/backoffice/package.json
@@ -17,5 +17,11 @@
     "hyperscript.org": "^0.9.14",
     "lucide-static": "^0.552.0",
     "tailwindcss": "^4.1.17"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
Specifically whitelist @parcel/watcher and esbuild