### PR TITLE
backoffice: Add esbuild to ignoredBuiltDependencies

### DIFF
--- a/server/polar/backoffice/package.json
+++ b/server/polar/backoffice/package.json
@@ -22,6 +22,9 @@
     "onlyBuiltDependencies": [
       "@parcel/watcher",
       "esbuild"
+    ],
+    "ignoredBuiltDependencies": [
+      "esbuild"
     ]
   }
 }


### PR DESCRIPTION
This removes the warning locally