### PR TITLE
fix: gate subscription renewals on subscription_renewals capability

### DIFF
--- a/server/polar/models/payment.py
+++ b/server/polar/models/payment.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 
 class PaymentTrigger(StrEnum):
     purchase = "purchase"
+    subscription_cycle = "subscription_cycle"
     retry_dunning = "retry_dunning"
     retry_customer = "retry_customer"
     retry_payment_method_update = "retry_payment_method_update"
@@ -69,6 +70,7 @@ class PaymentTrigger(StrEnum):
 # attempts use up the customer's automated retry budget.
 DUNNING_COUNTING_TRIGGERS: set[PaymentTrigger] = {
     PaymentTrigger.purchase,
+    PaymentTrigger.subscription_cycle,
     PaymentTrigger.retry_dunning,
 }
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -851,7 +851,7 @@ class OrderService:
                     order,
                     payment_method,
                     payment_mode=payment_mode,
-                    payment_trigger=PaymentTrigger.purchase,
+                    payment_trigger=PaymentTrigger.subscription_cycle,
                 )
             # Async mode, allow payment to fail and be retried later
             else:
@@ -865,7 +865,7 @@ class OrderService:
                         "order.trigger_payment",
                         order_id=order.id,
                         payment_method_id=payment_method_id,
-                        payment_trigger=PaymentTrigger.purchase,
+                        payment_trigger=PaymentTrigger.subscription_cycle,
                     )
 
             await self._on_order_created(session, order)

--- a/server/tests/e2e/lifecycle/test_renewal.py
+++ b/server/tests/e2e/lifecycle/test_renewal.py
@@ -19,9 +19,11 @@ from polar.models import Organization, Product
 from tests.e2e.conftest import E2E_AUTH
 from tests.e2e.infra import DrainFn, SchedulerSimulator, StripeSimulator
 from tests.e2e.purchase.conftest import complete_purchase
+from tests.fixtures.database import SaveFixture
 
 # Purchase happens on Jan 15 → monthly sub ends Feb 15
 PURCHASE_DATE = "2024-01-15 12:00:00"
+RENEWAL_DATE = "2024-02-15 12:00:01"
 
 
 @pytest.mark.asyncio
@@ -79,3 +81,65 @@ class TestRenewal:
         sub = response.json()["items"][0]
         assert sub["current_period_start"].startswith("2024-04-15")
         assert sub["current_period_end"].startswith("2024-05-15")
+
+    @pytest.mark.parametrize(
+        ("checkout_payments", "subscription_renewals", "expect_renewal"),
+        [
+            pytest.param(True, True, True, id="both-on"),
+            pytest.param(False, True, True, id="checkout-off-renewals-on"),
+            pytest.param(True, False, False, id="renewals-off"),
+        ],
+    )
+    @E2E_AUTH
+    async def test_capability_gates_renewal(
+        self,
+        checkout_payments: bool,
+        subscription_renewals: bool,
+        expect_renewal: bool,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        stripe_sim: StripeSimulator,
+        drain: DrainFn,
+        scheduler_sim: SchedulerSimulator,
+        organization: Organization,
+        monthly_product: Product,
+    ) -> None:
+        """The org has two capabilities that govern recurring billing:
+        ``checkout_payments`` (gates first-time / non-renewal payments) and
+        ``subscription_renewals`` (gates renewal payments AND scheduler
+        picking). The ``checkout=off, renewals=on`` case used to drop
+        renewals because they were tagged with ``PaymentTrigger.purchase``."""
+        with freezegun.freeze_time(PURCHASE_DATE):
+            await complete_purchase(
+                client,
+                session,
+                stripe_sim,
+                drain,
+                organization,
+                monthly_product,
+                amount=1500,
+            )
+
+        # Flip capabilities after the initial purchase has paid — toggling
+        # checkout_payments beforehand would block the purchase itself.
+        organization.capabilities = {
+            **organization.capabilities,
+            "checkout_payments": checkout_payments,
+            "subscription_renewals": subscription_renewals,
+        }
+        await save_fixture(organization)
+        stripe_sim.mock.create_payment_intent.reset_mock()
+
+        with freezegun.freeze_time(RENEWAL_DATE):
+            assert await scheduler_sim.get_due_count() == (1 if expect_renewal else 0)
+            await scheduler_sim.trigger_due_cycles(drain)
+
+        assert stripe_sim.mock.create_payment_intent.called is expect_renewal
+        response = await client.get("/v1/orders/", params={"limit": 10})
+        cycle_orders = [
+            o
+            for o in response.json()["items"]
+            if o["billing_reason"] == "subscription_cycle"
+        ]
+        assert len(cycle_orders) == (1 if expect_renewal else 0)

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1008,7 +1008,7 @@ class TestCreateSubscriptionOrder:
             "order.trigger_payment",
             order_id=order.id,
             payment_method_id=subscription.payment_method_id,
-            payment_trigger="purchase",
+            payment_trigger="subscription_cycle",
         )
 
     async def test_cycle_discount(
@@ -1326,7 +1326,7 @@ class TestCreateSubscriptionOrder:
             "order.trigger_payment",
             order_id=order.id,
             payment_method_id=subscription.payment_method_id,
-            payment_trigger="purchase",
+            payment_trigger="subscription_cycle",
         )
 
     @pytest.mark.parametrize(
@@ -1594,7 +1594,7 @@ class TestCreateSubscriptionOrder:
                 "order.trigger_payment",
                 order_id=order.id,
                 payment_method_id=subscription.payment_method_id,
-                payment_trigger="purchase",
+                payment_trigger="subscription_cycle",
             )
             assert customer_balance == 0
         else:
@@ -3602,6 +3602,49 @@ class TestTriggerPayment:
         await order_service.trigger_payment(session, order, payment_method)
 
         stripe_service_mock.create_payment_intent.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("trigger", "expected_payment_attempted"),
+        [
+            (PaymentTrigger.subscription_cycle, True),
+            (PaymentTrigger.purchase, False),
+        ],
+    )
+    async def test_capability_gate_distinguishes_renewals_from_checkouts(
+        self,
+        trigger: PaymentTrigger,
+        expected_payment_attempted: bool,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """An org with checkout_payments off but subscription_renewals on must
+        process renewals while still blocking new checkouts."""
+        organization.capabilities = {
+            **organization.capabilities,
+            "checkout_payments": False,
+            "subscription_renewals": True,
+        }
+        await save_fixture(organization)
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+        )
+
+        await order_service.trigger_payment(
+            session, order, payment_method, payment_trigger=trigger
+        )
+
+        if expected_payment_attempted:
+            stripe_service_mock.create_payment_intent.assert_called_once()
+        else:
+            stripe_service_mock.create_payment_intent.assert_not_called()
 
     async def test_already_locked(
         self,


### PR DESCRIPTION
## Summary

`create_subscription_order` was enqueueing the renewal payment job with `PaymentTrigger.purchase`, so the capability gate in `trigger_payment` checked `checkout_payments` instead of `subscription_renewals`. Any org with checkout off but renewals on (the offboarding-style state) had its renewals silently dropped — the payment was skipped without a payment row or a retry, leaving the order stuck `pending`.

This adds `PaymentTrigger.subscription_cycle`, classifies it as a dunning-counting renewal trigger, and uses it from `create_subscription_order`.

## Test plan

- [x] `tests/order/test_service.py` — new parametrized regression in `TestTriggerPayment` covering both `subscription_cycle` (proceeds when checkout off + renewals on) and `purchase` (still blocked when checkout off).
- [x] `tests/e2e/lifecycle/test_renewal.py` — new parametrized `test_capability_gates_renewal` covering the three capability combinations end-to-end (both on, checkout off + renewals on, renewals off).
- [x] Backend `lint` and `lint_types` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)