### PR TITLE
docker: Copy backoffice pnpm workspace for build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 
 COPY ./polar/backoffice/pnpm-lock.yaml .
 COPY ./polar/backoffice/package.json .
+COPY ./polar/backoffice/pnpm-workspace.yaml .
 RUN pnpm install --frozen-lockfile
 
 COPY ./polar/backoffice/ .


### PR DESCRIPTION
Now that the allow builds moved to the workspace we need to copy it
