### PR TITLE
backoffice: Fix Docker build after pnpm 11 pin

### DIFF
--- a/server/polar/backoffice/scripts.mjs
+++ b/server/polar/backoffice/scripts.mjs
@@ -1,9 +1,9 @@
 import htmx from "htmx.org";
-import _hyperscript from "hyperscript.org";
+import "hyperscript.org";
 import { EventSourcePlus } from "event-source-plus";
 
 window.htmx = htmx;
-_hyperscript.browserInit();
+window._hyperscript.browserInit();
 
 const formPostSSE = (formElement, target) => {
   const eventSource = new EventSourcePlus(formElement.action, {


### PR DESCRIPTION
Work around hyperscript.org@0.9.91's broken default export by importing it for side effects and using window._hyperscript.
