### PR TITLE
Exclude canceled payouts from latest payout query

### DIFF
--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -38,7 +38,10 @@ class PayoutRepository(
     async def get_latest_by_account(self, account: UUID) -> Payout | None:
         statement = (
             self.get_base_statement()
-            .where(Payout.account_id == account)
+            .where(
+                Payout.account_id == account,
+                Payout.status != PayoutStatus.canceled,
+            )
             .order_by(Payout.created_at.desc())
             .limit(1)
         )


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Exclude canceled payouts when retrieving the latest payout for an account.

## What

Modified `get_latest_by_account()` in the payout repository to filter out payouts with `canceled` status when querying for the latest payout by account.

## Why

The latest payout query should return the most recent active payout, not a canceled one. This ensures that canceled payouts don't interfere with payout status tracking and related business logic that depends on retrieving the current active payout.

## How

Added a status filter to the WHERE clause in `get_latest_by_account()` to exclude payouts where `status == PayoutStatus.canceled`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01HqGGx6oFQfhMCau8WEZiYi