### PR TITLE
Enable new account review feature for all new sign ups

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -305,6 +305,7 @@ class OrganizationService:
         feature_settings = create_data.get("feature_settings", {})
         feature_settings["member_model_enabled"] = True
         feature_settings["seat_based_pricing_enabled"] = True
+        feature_settings["account_review_v2_enabled"] = True
         create_data["feature_settings"] = feature_settings
 
         if settings.is_sandbox():

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -155,6 +155,7 @@ class TestCreate:
         assert organization.feature_settings == {
             "member_model_enabled": True,
             "seat_based_pricing_enabled": True,
+            "account_review_v2_enabled": True,
         }
 
         user_organization = await user_organization_service.get_by_user_and_org(
@@ -218,6 +219,7 @@ class TestCreate:
             "issue_funding_enabled": False,
             "member_model_enabled": True,
             "seat_based_pricing_enabled": True,
+            "account_review_v2_enabled": True,
         }
 
     @pytest.mark.auth


### PR DESCRIPTION
⚠️ **Do not merge** until the feature is complete.

------------------------

This PR enables the `account_review_v2_enabled` for all new sign ups, meaning we don't have to grandfather old ones.