### PR TITLE
feat(authz): RBAC Phase 3 — role-permission authorization cutover

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -804,8 +804,7 @@ export interface paths {
      * Leave Organization
      * @description Leave an organization.
      *
-     *     Users can only leave an organization if they are not the admin
-     *     and there is at least one other member.
+     *     The organization owner cannot leave; ownership must be transferred first.
      */
     delete: operations['organizations:leave_organization']
     options?: never
@@ -833,7 +832,15 @@ export interface paths {
     delete: operations['organizations:remove_member']
     options?: never
     head?: never
-    patch?: never
+    /**
+     * Set Member Role
+     * @description Change a member's role on an organization.
+     *
+     *     Only `admin` and `member` are accepted; ownership transfers go through
+     *     a separate flow (`Account.admin_id` mutation, today the backoffice
+     *     `change_admin` endpoint).
+     */
+    patch: operations['organizations:set_member_role']
     trace?: never
   }
   '/v1/organizations/{id}/ai-validation': {
@@ -23647,12 +23654,13 @@ export interface components {
       email: string
       /** Avatar Url */
       avatar_url: string | null
+      /** @description The user's role on the organization. */
+      role: components['schemas']['OrganizationRole']
       /**
        * Is Admin
-       * @description Whether the user is an admin of the organization.
-       * @default false
+       * @description Whether the user has admin capability on the organization. Derived from `role`: true for `owner` or `admin`. Kept as a transitional alias; prefer reading `role` directly.
        */
-      is_admin: boolean
+      readonly is_admin: boolean
     }
     /** OrganizationMemberInvite */
     OrganizationMemberInvite: {
@@ -23662,6 +23670,15 @@ export interface components {
        * @description Email address of the user to invite
        */
       email: string
+    }
+    /** OrganizationMemberRoleUpdate */
+    OrganizationMemberRoleUpdate: {
+      /**
+       * Role
+       * @description The role to assign. `owner` is rejected — ownership transfers go through a separate flow.
+       * @enum {string}
+       */
+      role: 'admin' | 'member'
     }
     /** OrganizationNotificationSettings */
     OrganizationNotificationSettings: {
@@ -23839,6 +23856,11 @@ export interface components {
        */
       appeal_reviewed_at?: string | null
     }
+    /**
+     * OrganizationRole
+     * @enum {string}
+     */
+    OrganizationRole: 'owner' | 'admin' | 'member'
     /** OrganizationSlugAvailability */
     OrganizationSlugAvailability: {
       /**
@@ -32647,6 +32669,60 @@ export interface operations {
         content?: never
       }
       /** @description Not authorized to remove members. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Organization not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:set_member_role': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        user_id: string
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['OrganizationMemberRoleUpdate']
+      }
+    }
+    responses: {
+      /** @description Role updated. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrganizationMember']
+        }
+      }
+      /** @description Not authorized to change member roles, or the role transition is not allowed. */
       403: {
         headers: {
           [name: string]: unknown
@@ -54365,6 +54441,9 @@ export const organizationKYCCountryAnyOf0Values: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const organizationMemberRoleUpdateRoleValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationMemberRoleUpdate']['role']
+> = ['admin', 'member']
 export const organizationReviewCheckKeyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewCheckKey']
 > = [
@@ -54397,6 +54476,9 @@ export const organizationReviewStateVerdictAnyOf0Values: ReadonlyArray<
 export const organizationReviewStatusVerdictAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewStatus']['verdict']
 > = ['PASS', 'FAIL', 'UNCERTAIN']
+export const organizationRoleValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationRole']
+> = ['owner', 'admin', 'member']
 export const organizationSocialPlatformsValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationSocialPlatforms']
 > = [

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -152,6 +152,16 @@ AuthorizeMembersManage = Annotated[
         )
     ),
 ]
+AuthorizeMembersSetRole = Annotated[
+    AuthzContext[User],
+    Depends(
+        OrgPolicyGuard(
+            members.can_set_role,
+            allowed_subjects={User},
+            required_scopes={Scope.members_write},
+        )
+    ),
+]
 AuthorizeOrgDelete = Annotated[
     AuthzContext[User],
     Depends(

--- a/server/polar/authz/policies/__init__.py
+++ b/server/polar/authz/policies/__init__.py
@@ -1,0 +1,36 @@
+from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
+from polar.auth.permission import OrganizationPermission, role_has_permission
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+from polar.user_organization.service import (
+    user_organization as user_organization_service,
+)
+
+
+async def _require_permission(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+    *,
+    permission: OrganizationPermission,
+    denied_msg: str,
+) -> PolicyResult:
+    """Check that the subject's role on the organization grants ``permission``.
+
+    Organization-token subjects are always permitted (the token *is* the org).
+    User subjects are permitted iff their ``UserOrganization.role`` grants the
+    permission per ``ROLE_PERMISSIONS``.
+    """
+    if is_organization(auth_subject):
+        return True
+    if is_user(auth_subject):
+        user_org = await user_organization_service.get_by_user_and_org(
+            session, auth_subject.subject.id, organization.id
+        )
+        if user_org is None:
+            return denied_msg
+        if role_has_permission(user_org.role, permission):
+            return True
+        return denied_msg
+    return "Not permitted"

--- a/server/polar/authz/policies/finance.py
+++ b/server/polar/authz/policies/finance.py
@@ -1,8 +1,10 @@
-from polar.account.service import account as account_service
-from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.types import PolicyResult
 from polar.models import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
+
+from . import _require_permission
 
 
 async def can_read(
@@ -11,17 +13,13 @@ async def can_read(
     organization: OrganizationModel,
 ) -> PolicyResult:
     """Can the subject view accounts, transactions, payouts for this org?"""
-    if is_organization(auth_subject):
-        return True
-    if is_user(auth_subject):
-        if organization.account_id is None:
-            return "Organization has no account"
-        if await account_service.is_user_admin(
-            session, organization.account_id, auth_subject.subject
-        ):
-            return True
-        return "Only the account admin can access financial information"
-    return "Not permitted"
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.transactions_read,
+        denied_msg="Only an organization admin can access financial information",
+    )
 
 
 async def can_write(
@@ -30,4 +28,10 @@ async def can_write(
     organization: OrganizationModel,
 ) -> PolicyResult:
     """Can the subject manage payouts, update billing info for this org?"""
-    return await can_read(session, auth_subject, organization)
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.transactions_write,
+        denied_msg="Only an organization admin can manage financial information",
+    )

--- a/server/polar/authz/policies/members.py
+++ b/server/polar/authz/policies/members.py
@@ -1,9 +1,10 @@
 from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.types import PolicyResult
 from polar.models import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
 
-from .organization import _require_account_admin
+from . import _require_permission
 
 
 async def can_manage(
@@ -11,10 +12,17 @@ async def can_manage(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject invite/remove/change members?"""
-    return await _require_account_admin(
+    """Can the subject invite/remove/change members?
+
+    `members:invite` is used as a representative permission — admin and
+    owner share the full member-management set, so checking any one of
+    `members:invite`, `members:remove`, `members:set_role` gives the
+    same answer in this iteration.
+    """
+    return await _require_permission(
         session,
         auth_subject,
         organization,
-        "Only the account admin can manage members",
+        permission=OrganizationPermission.members_invite,
+        denied_msg="Only an organization admin can manage members",
     )

--- a/server/polar/authz/policies/members.py
+++ b/server/polar/authz/policies/members.py
@@ -26,3 +26,18 @@ async def can_manage(
         permission=OrganizationPermission.members_invite,
         denied_msg="Only an organization admin can manage members",
     )
+
+
+async def can_set_role(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject change another member's role?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.members_set_role,
+        denied_msg="Only an organization admin can change member roles",
+    )

--- a/server/polar/authz/policies/organization.py
+++ b/server/polar/authz/policies/organization.py
@@ -1,37 +1,10 @@
-from polar.account.service import account as account_service
-from polar.auth.models import (
-    AuthSubject,
-    Organization,
-    User,
-    is_organization,
-    is_user,
-)
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.types import PolicyResult
 from polar.models import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
 
-
-async def _require_account_admin(
-    session: AsyncReadSession,
-    auth_subject: AuthSubject[User | Organization],
-    organization: OrganizationModel,
-    denied_msg: str,
-) -> PolicyResult:
-    """Check that the subject is the account admin of the organization.
-
-    Organizations always have a billing account. Only the account admin
-    (the user whose ``admin_id`` matches the account) is allowed.
-    Organization-token subjects are always permitted.
-    """
-    if is_organization(auth_subject):
-        return True
-    if is_user(auth_subject):
-        if await account_service.is_user_admin(
-            session, organization.account_id, auth_subject.subject
-        ):
-            return True
-        return denied_msg
-    return "Not permitted"
+from . import _require_permission
 
 
 async def can_delete(
@@ -40,11 +13,12 @@ async def can_delete(
     organization: OrganizationModel,
 ) -> PolicyResult:
     """Can the subject delete this organization?"""
-    return await _require_account_admin(
+    return await _require_permission(
         session,
         auth_subject,
         organization,
-        "Only the account admin can delete the organization",
+        permission=OrganizationPermission.organizations_delete,
+        denied_msg="Only an organization admin can delete the organization",
     )
 
 
@@ -54,9 +28,10 @@ async def can_manage_payout_account(
     organization: OrganizationModel,
 ) -> PolicyResult:
     """Can the subject set or change the payout account for this organization?"""
-    return await _require_account_admin(
+    return await _require_permission(
         session,
         auth_subject,
         organization,
-        "Only the account admin can manage the payout account",
+        permission=OrganizationPermission.organizations_manage_payout_account,
+        denied_msg="Only an organization admin can manage the payout account",
     )

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -49,7 +49,7 @@ from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.user.repository import UserRepository
 from polar.user_organization.service import (
-    CannotRemoveOrganizationAdmin,
+    CannotRemoveOrganizationOwner,
     UserNotMemberOfOrganization,
 )
 from polar.user_organization.service import (
@@ -857,10 +857,10 @@ async def remove_member(
             status_code=400, detail="User is not a member of this organization"
         )
 
-    except CannotRemoveOrganizationAdmin:
+    except CannotRemoveOrganizationOwner:
         raise HTTPException(
             status_code=403,
-            detail=f"Cannot remove {user_email} - they are the organization admin",
+            detail=f"Cannot remove {user_email} - they are the organization owner",
         )
 
     except Exception:

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -9,6 +9,7 @@ from polar.account.service import account as account_service
 from polar.authz.dependencies import (
     AuthorizeFinanceRead,
     AuthorizeMembersManage,
+    AuthorizeMembersSetRole,
     AuthorizeOrgAccess,
     AuthorizeOrgAccessUser,
     AuthorizeOrgAccessWrite,
@@ -37,7 +38,7 @@ from polar.integrations.polar.service import (
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.http import check_url_reachable
 from polar.kit.pagination import ListResource, Pagination, PaginationParamsQuery
-from polar.models import Account, Organization
+from polar.models import Account, Organization, UserOrganization
 from polar.models.user_organization import OrganizationRole
 from polar.openapi import APITag
 from polar.organization.repository import (
@@ -55,9 +56,12 @@ from polar.user.service import user as user_service
 from polar.user_organization.schemas import (
     OrganizationMember,
     OrganizationMemberInvite,
+    OrganizationMemberRoleUpdate,
 )
 from polar.user_organization.service import (
     CannotRemoveOrganizationOwner,
+    InvalidOwnerRoleAssignment,
+    OwnerRoleCannotBeRemoved,
     UserNotMemberOfOrganization,
 )
 from polar.user_organization.service import (
@@ -529,6 +533,53 @@ async def remove_member(
         raise ResourceNotFound()
     except CannotRemoveOrganizationOwner:
         raise NotPermitted("Cannot remove the organization owner.")
+
+
+@router.patch(
+    "/{id}/members/{user_id}",
+    response_model=OrganizationMember,
+    summary="Set Member Role",
+    tags=[APITag.private],
+    responses={
+        200: {"description": "Role updated."},
+        403: {
+            "description": "Not authorized to change member roles, or the role "
+            "transition is not allowed.",
+            "model": NotPermitted.schema(),
+        },
+        404: OrganizationNotFound,
+    },
+)
+async def set_member_role(
+    authz: AuthorizeMembersSetRole,
+    user_id: UUID,
+    body: OrganizationMemberRoleUpdate,
+    session: AsyncSession = Depends(get_db_session),
+) -> UserOrganization:
+    """Change a member's role on an organization.
+
+    Only `admin` and `member` are accepted; ownership transfers go through
+    a separate flow (`Account.admin_id` mutation, today the backoffice
+    `change_admin` endpoint).
+    """
+    try:
+        return await user_organization_service.set_role(
+            session,
+            user_id=user_id,
+            organization_id=authz.organization.id,
+            role=body.role,
+        )
+    except UserNotMemberOfOrganization:
+        raise ResourceNotFound()
+    except OwnerRoleCannotBeRemoved:
+        raise NotPermitted(
+            "The organization owner cannot be moved to another role; "
+            "transfer ownership first."
+        )
+    except InvalidOwnerRoleAssignment:
+        # Should be unreachable given the schema rejects `owner`, but kept
+        # as defence-in-depth in case the schema constraint is ever relaxed.
+        raise NotPermitted("Cannot assign the owner role via this endpoint.")
 
 
 @router.post(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -38,9 +38,9 @@ from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.http import check_url_reachable
 from polar.kit.pagination import ListResource, Pagination, PaginationParamsQuery
 from polar.models import Account, Organization
+from polar.models.user_organization import OrganizationRole
 from polar.openapi import APITag
 from polar.organization.repository import (
-    OrganizationRepository,
     OrganizationReviewRepository,
 )
 from polar.payout_account.repository import PayoutAccountRepository
@@ -52,9 +52,12 @@ from polar.postgres import (
 )
 from polar.routing import APIRouter
 from polar.user.service import user as user_service
-from polar.user_organization.schemas import OrganizationMember, OrganizationMemberInvite
+from polar.user_organization.schemas import (
+    OrganizationMember,
+    OrganizationMemberInvite,
+)
 from polar.user_organization.service import (
-    CannotRemoveOrganizationAdmin,
+    CannotRemoveOrganizationOwner,
     UserNotMemberOfOrganization,
 )
 from polar.user_organization.service import (
@@ -374,21 +377,8 @@ async def members(
     organization = authz.organization
     members = await user_organization_service.list_by_org(session, organization.id)
 
-    # Get admin user to set is_admin flag
-    org_repo = OrganizationRepository.from_session(session)
-    admin_user = await org_repo.get_admin_user(organization)
-    admin_user_id = admin_user.id if admin_user else None
-
-    # Build response with is_admin flag
-    member_items = []
-    for m in members:
-        member_data = OrganizationMember.model_validate(m)
-        if admin_user_id and m.user_id == admin_user_id:
-            member_data.is_admin = True
-        member_items.append(member_data)
-
     return ListResource(
-        items=member_items,
+        items=[OrganizationMember.model_validate(m) for m in members],
         pagination=Pagination(total_count=len(members), max_page=1),
     )
 
@@ -471,17 +461,21 @@ async def leave_organization(
 ) -> None:
     """Leave an organization.
 
-    Users can only leave an organization if they are not the admin
-    and there is at least one other member.
+    The organization owner cannot leave; ownership must be transferred first.
     """
     organization = authz.organization
     user = authz.auth_subject.subject
 
-    org_repo = OrganizationRepository.from_session(session)
-    admin_user = await org_repo.get_admin_user(organization)
+    user_org = await user_organization_service.get_by_user_and_org(
+        session, user.id, organization.id
+    )
+    if user_org is None:
+        raise ResourceNotFound()
 
-    if admin_user and admin_user.id == user.id:
-        raise NotPermitted("Organization admins cannot leave the organization.")
+    if user_org.role == OrganizationRole.owner:
+        raise NotPermitted(
+            "The organization owner cannot leave; transfer ownership first."
+        )
 
     # Check if user is the only member
     member_count = await user_organization_service.get_member_count(
@@ -490,7 +484,6 @@ async def leave_organization(
     if member_count <= 1:
         raise NotPermitted("Cannot leave organization as the only member.")
 
-    # Remove the user from the organization
     await user_organization_service.remove_member(
         session,
         user_id=user.id,
@@ -534,8 +527,8 @@ async def remove_member(
         )
     except UserNotMemberOfOrganization:
         raise ResourceNotFound()
-    except CannotRemoveOrganizationAdmin:
-        raise NotPermitted("Cannot remove the organization admin.")
+    except CannotRemoveOrganizationOwner:
+        raise NotPermitted("Cannot remove the organization owner.")
 
 
 @router.post(

--- a/server/polar/user_organization/schemas.py
+++ b/server/polar/user_organization/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import AliasPath, Field, computed_field
@@ -36,3 +37,12 @@ class OrganizationMember(Schema):
 
 class OrganizationMemberInvite(Schema):
     email: EmailStrDNS = Field(description="Email address of the user to invite")
+
+
+class OrganizationMemberRoleUpdate(Schema):
+    role: Literal[OrganizationRole.admin, OrganizationRole.member] = Field(
+        description=(
+            "The role to assign. `owner` is rejected — ownership transfers "
+            "go through a separate flow."
+        ),
+    )

--- a/server/polar/user_organization/schemas.py
+++ b/server/polar/user_organization/schemas.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import AliasPath, Field
+from pydantic import AliasPath, Field, computed_field
 
 from polar.kit.email import EmailStrDNS
 from polar.kit.schemas import Schema
+from polar.models.user_organization import OrganizationRole
 
 
 class OrganizationMember(Schema):
@@ -17,10 +18,20 @@ class OrganizationMember(Schema):
     )
     email: str = Field(validation_alias=AliasPath("user", "email"))
     avatar_url: str | None = Field(validation_alias=AliasPath("user", "avatar_url"))
-    is_admin: bool = Field(
-        default=False,
-        description="Whether the user is an admin of the organization.",
+    role: OrganizationRole = Field(
+        description="The user's role on the organization.",
     )
+
+    @computed_field(  # type: ignore[prop-decorator]
+        description=(
+            "Whether the user has admin capability on the organization. "
+            "Derived from `role`: true for `owner` or `admin`. "
+            "Kept as a transitional alias; prefer reading `role` directly."
+        ),
+    )
+    @property
+    def is_admin(self) -> bool:
+        return self.role in {OrganizationRole.owner, OrganizationRole.admin}
 
 
 class OrganizationMemberInvite(Schema):

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -114,7 +114,7 @@ class UserOrganizationService:
 
     async def get_by_user_and_org(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         user_id: UUID,
         organization_id: UUID,
     ) -> UserOrganization | None:

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -33,11 +33,21 @@ class UserNotMemberOfOrganization(UserOrganizationError):
         super().__init__(message, 404)
 
 
-class CannotRemoveOrganizationAdmin(UserOrganizationError):
+class CannotRemoveOrganizationOwner(UserOrganizationError):
     def __init__(self, user_id: UUID, organization_id: UUID) -> None:
         self.user_id = user_id
         self.organization_id = organization_id
-        message = f"Cannot remove user {user_id} - they are the admin of organization {organization_id}."
+        message = f"Cannot remove user {user_id} - they are the owner of organization {organization_id}."
+        super().__init__(message, 403)
+
+
+class OrganizationWouldHaveNoAdmins(UserOrganizationError):
+    def __init__(self, organization_id: UUID) -> None:
+        self.organization_id = organization_id
+        message = (
+            f"Operation rejected: organization {organization_id} would be left "
+            f"with no users holding admin or owner role."
+        )
         super().__init__(message, 403)
 
 
@@ -191,6 +201,10 @@ class UserOrganizationService:
         user_id: UUID,
         organization_id: UUID,
     ) -> None:
+        await self._assert_admin_capability_after_removal(
+            session, user_id=user_id, organization_id=organization_id
+        )
+
         stmt = (
             sql.update(UserOrganization)
             .where(
@@ -209,6 +223,48 @@ class UserOrganizationService:
                 external_id=str(user_id),
             )
 
+    async def _assert_admin_capability_after_removal(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: UUID,
+        organization_id: UUID,
+    ) -> None:
+        """
+        Defense-in-depth guard for the admin-capability invariant: an
+        organization always has at least one user in `role ∈ {owner, admin}`.
+
+        The owner-non-removable invariant in `remove_member_safe` already
+        covers the common case (every org has an owner who counts as
+        admin-capable), but raw `remove_member` callers bypass that check
+        — so we re-assert here. Rejects only when the removal would
+        actually reduce admin-capable count to zero; non-admin-capable
+        removals from a degraded organization are still allowed (they
+        don't make the state worse).
+        """
+        target_role = await session.scalar(
+            sql.select(UserOrganization.role).where(
+                UserOrganization.organization_id == organization_id,
+                UserOrganization.user_id == user_id,
+                UserOrganization.is_deleted.is_(False),
+            )
+        )
+        if target_role not in {OrganizationRole.owner, OrganizationRole.admin}:
+            return
+
+        other_admin_capable = await session.scalar(
+            sql.select(func.count(UserOrganization.user_id)).where(
+                UserOrganization.organization_id == organization_id,
+                UserOrganization.user_id != user_id,
+                UserOrganization.role.in_(
+                    [OrganizationRole.owner, OrganizationRole.admin]
+                ),
+                UserOrganization.is_deleted.is_(False),
+            )
+        )
+        if (other_admin_capable or 0) == 0:
+            raise OrganizationWouldHaveNoAdmins(organization_id)
+
     async def remove_member_safe(
         self,
         session: AsyncSession,
@@ -222,7 +278,7 @@ class UserOrganizationService:
         Raises:
             OrganizationNotFound: If the organization doesn't exist
             UserNotMemberOfOrganization: If the user is not a member of the organization
-            CannotRemoveOrganizationAdmin: If the user is the organization admin
+            CannotRemoveOrganizationOwner: If the user holds the `owner` role
         """
         from polar.organization.repository import OrganizationRepository
 
@@ -232,16 +288,13 @@ class UserOrganizationService:
         if not organization:
             raise OrganizationNotFound(organization_id)
 
-        # Check if user is actually a member
         user_org = await self.get_by_user_and_org(session, user_id, organization_id)
         if not user_org:
             raise UserNotMemberOfOrganization(user_id, organization_id)
 
-        admin_user = await org_repo.get_admin_user(organization)
-        if admin_user and admin_user.id == user_id:
-            raise CannotRemoveOrganizationAdmin(user_id, organization_id)
+        if user_org.role == OrganizationRole.owner:
+            raise CannotRemoveOrganizationOwner(user_id, organization_id)
 
-        # Remove the member
         await self.remove_member(
             session,
             user_id=user_id,

--- a/server/tests/authz/test_endpoints.py
+++ b/server/tests/authz/test_endpoints.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 
 from polar.models import Organization, User
 from polar.models.organization import OrganizationStatus
-from polar.models.user_organization import UserOrganization
+from polar.models.user_organization import OrganizationRole, UserOrganization
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_account
 
@@ -43,10 +43,8 @@ class TestPolicyGuardGetAccount:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        other_user = User(email="admin@example.com")
-        await save_fixture(other_user)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
 
         response = await client.get(f"/v1/organizations/{organization.id}/account")
         assert response.status_code == 403
@@ -109,16 +107,14 @@ class TestPolicyGuardDeleteOrganization:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        other_user = User(email="admin@example.com")
-        await save_fixture(other_user)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
 
         response = await client.delete(f"/v1/organizations/{organization.id}")
         assert response.status_code == 403
         assert (
             response.json()["detail"]
-            == "Only the account admin can delete the organization"
+            == "Only an organization admin can delete the organization"
         )
 
 
@@ -153,17 +149,17 @@ class TestPolicyGuardInviteMember:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        other_user = User(email="admin@example.com")
-        await save_fixture(other_user)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
 
         response = await client.post(
             f"/v1/organizations/{organization.id}/members/invite",
             json={"email": "newmember@example.com"},
         )
         assert response.status_code == 403
-        assert response.json()["detail"] == "Only the account admin can manage members"
+        assert (
+            response.json()["detail"] == "Only an organization admin can manage members"
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -5,15 +5,23 @@ from polar.authz.policies import finance, members
 from polar.authz.policies import organization as org_policy
 from polar.authz.policies import payout_account as pa_policy
 from polar.models import Organization, User
-from polar.models.user_organization import UserOrganization
+from polar.models.user_organization import OrganizationRole, UserOrganization
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
-    create_account,
     create_payout_account,
     create_user,
 )
+
+
+async def _set_role(
+    save_fixture: SaveFixture,
+    user_organization: UserOrganization,
+    role: OrganizationRole,
+) -> None:
+    user_organization.role = role
+    await save_fixture(user_organization)
 
 
 @pytest.mark.asyncio
@@ -24,18 +32,16 @@ class TestFinanceCanRead:
         session: AsyncSession,
         auth_subject: AuthSubject[User],
         save_fixture: SaveFixture,
-        user: User,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        organization.account = await create_account(save_fixture, user=user)
-        await save_fixture(organization)
+        await _set_role(save_fixture, user_organization, OrganizationRole.admin)
 
         result = await finance.can_read(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
-    async def test_non_admin_denied_with_message(
+    async def test_owner_allowed(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
@@ -43,27 +49,25 @@ class TestFinanceCanRead:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        other_user = User(email="admin@example.com")
-        await save_fixture(other_user)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        await _set_role(save_fixture, user_organization, OrganizationRole.owner)
+
+        result = await finance.can_read(session, auth_subject, organization)
+        assert result is True
+
+    @pytest.mark.auth
+    async def test_member_denied(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.member)
 
         result = await finance.can_read(session, auth_subject, organization)
         assert isinstance(result, str)
         assert "admin" in result.lower()
-
-    @pytest.mark.auth
-    async def test_no_account_denied(
-        self,
-        session: AsyncSession,
-        auth_subject: AuthSubject[User],
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        object.__setattr__(organization, "account_id", None)
-
-        result = await finance.can_read(session, auth_subject, organization)
-        assert isinstance(result, str)
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_organization_subject_allowed(
@@ -85,18 +89,16 @@ class TestOrgCanDelete:
         session: AsyncSession,
         auth_subject: AuthSubject[User],
         save_fixture: SaveFixture,
-        user: User,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        organization.account = await create_account(save_fixture, user=user)
-        await save_fixture(organization)
+        await _set_role(save_fixture, user_organization, OrganizationRole.admin)
 
         result = await org_policy.can_delete(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
-    async def test_non_admin_denied_with_specific_message(
+    async def test_member_denied_with_specific_message(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
@@ -104,14 +106,10 @@ class TestOrgCanDelete:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        other_user = User(email="admin@example.com")
-        await save_fixture(other_user)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        await _set_role(save_fixture, user_organization, OrganizationRole.member)
 
         result = await org_policy.can_delete(session, auth_subject, organization)
-        assert isinstance(result, str)
-        assert result == "Only the account admin can delete the organization"
+        assert result == "Only an organization admin can delete the organization"
 
 
 @pytest.mark.asyncio
@@ -122,18 +120,16 @@ class TestMembersCanManage:
         session: AsyncSession,
         auth_subject: AuthSubject[User],
         save_fixture: SaveFixture,
-        user: User,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        organization.account = await create_account(save_fixture, user=user)
-        await save_fixture(organization)
+        await _set_role(save_fixture, user_organization, OrganizationRole.admin)
 
         result = await members.can_manage(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
-    async def test_non_admin_denied_with_specific_message(
+    async def test_member_denied_with_specific_message(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
@@ -141,14 +137,10 @@ class TestMembersCanManage:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        other_user = User(email="admin@example.com")
-        await save_fixture(other_user)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        await _set_role(save_fixture, user_organization, OrganizationRole.member)
 
         result = await members.can_manage(session, auth_subject, organization)
-        assert isinstance(result, str)
-        assert result == "Only the account admin can manage members"
+        assert result == "Only an organization admin can manage members"
 
 
 @pytest.mark.asyncio

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -122,6 +122,7 @@ from polar.models.product_price import (
 from polar.models.subscription import SubscriptionStatus
 from polar.models.transaction import Processor, TransactionType
 from polar.models.user import OAuthAccount, OAuthPlatform
+from polar.models.user_organization import OrganizationRole
 from polar.models.wallet import WalletType
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.notification_recipient.schemas import NotificationRecipientPlatform
@@ -320,7 +321,14 @@ async def user_organization(
     organization: Organization,
     user: User,
 ) -> UserOrganization:
-    user_organization = UserOrganization(user=user, organization=organization)
+    # `user` is `account.admin_id` by virtue of the fixture chain (the
+    # `account` fixture creates an Account with `user` as admin), so the
+    # owner-validity invariant says they carry `owner` on the membership.
+    # Tests that need a non-admin user should either downgrade the role
+    # explicitly or use `user_second` / `user_organization_second`.
+    user_organization = UserOrganization(
+        user=user, organization=organization, role=OrganizationRole.owner
+    )
     await save_fixture(user_organization)
     return user_organization
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -9,7 +9,7 @@ from polar.models import Product, User
 from polar.models.account import Account
 from polar.models.organization import Organization, OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
-from polar.models.user_organization import UserOrganization
+from polar.models.user_organization import OrganizationRole, UserOrganization
 from polar.payout_account.service import PayoutAccountServiceError
 from polar.postgres import AsyncSession
 from polar.user_organization.service import (
@@ -644,9 +644,8 @@ class TestSetPayoutAccount:
         user: User,
     ) -> None:
         """A regular org member (not admin) cannot set the payout account."""
-        other_user = await create_user(save_fixture)
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
 
         payout_account = await create_payout_account(save_fixture, organization, user)
         organization.payout_account = None
@@ -916,20 +915,17 @@ class TestDeleteOrganization:
         user: User,
         mocker: MockerFixture,
     ) -> None:
-        # Create an account with a different admin (not the current user)
-        other_user = User(
-            email="other@example.com",
-        )
-        await save_fixture(other_user)
-
-        organization.account = await create_account(save_fixture, user=other_user)
-        await save_fixture(organization)
+        # User is a regular member, not an admin.
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
 
         response = await client.delete(f"/v1/organizations/{organization.id}")
 
         assert response.status_code == 403
         json = response.json()
-        assert json["detail"] == "Only the account admin can delete the organization"
+        assert (
+            json["detail"] == "Only an organization admin can delete the organization"
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -546,6 +546,122 @@ class TestInviteOrganization:
 
 
 @pytest.mark.asyncio
+class TestSetMemberRole:
+    @pytest.mark.auth
+    @pytest.mark.keep_session_state
+    async def test_promote_member_to_admin(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_second: User,
+        user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{user_second.id}",
+            json={"role": "admin"},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["user_id"] == str(user_second.id)
+        assert json["role"] == "admin"
+        assert json["is_admin"] is True
+
+    @pytest.mark.auth
+    @pytest.mark.keep_session_state
+    async def test_demote_admin_to_member(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_second: User,
+        user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        user_organization_second.role = OrganizationRole.admin
+        await save_fixture(user_organization_second)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{user_second.id}",
+            json={"role": "member"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["role"] == "member"
+        assert response.json()["is_admin"] is False
+
+    @pytest.mark.auth
+    async def test_owner_role_in_body_rejected(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_second: User,
+        user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{user_second.id}",
+            json={"role": "owner"},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_cannot_demote_owner(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        # `user_organization` defaults to role=owner; the endpoint must
+        # refuse moving the owner to admin/member.
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{user.id}",
+            json={"role": "admin"},
+        )
+
+        assert response.status_code == 403
+        assert "owner" in response.json()["detail"].lower()
+
+    @pytest.mark.auth
+    async def test_target_user_not_member_returns_404(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{uuid.uuid4()}",
+            json={"role": "admin"},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_caller_not_admin_returns_403(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_second: User,
+        user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        # Caller is a regular member, not an admin/owner.
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{user_second.id}",
+            json={"role": "admin"},
+        )
+
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 @pytest.mark.auth
 async def test_list_members(
     session: AsyncSession,

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -7,9 +7,10 @@ from pytest_mock import MockerFixture
 from polar.models import Account, Organization, User, UserOrganization
 from polar.models.user_organization import OrganizationRole
 from polar.user_organization.service import (
-    CannotRemoveOrganizationAdmin,
+    CannotRemoveOrganizationOwner,
     InvalidOwnerRoleAssignment,
     OrganizationNotFound,
+    OrganizationWouldHaveNoAdmins,
     OwnerRoleCannotBeRemoved,
     UserNotMemberOfOrganization,
 )
@@ -82,7 +83,7 @@ class TestRemoveMemberSafe:
         assert exc_info.value.user_id == user.id
         assert exc_info.value.organization_id == organization.id
 
-    async def test_remove_member_cannot_remove_admin(
+    async def test_remove_member_cannot_remove_owner(
         self,
         session: Any,
         account: Account,
@@ -90,20 +91,18 @@ class TestRemoveMemberSafe:
         user: User,
         save_fixture: Any,
     ) -> None:
-        # Create user organization relationship for admin
         from polar.kit.utils import utc_now
         from polar.models import UserOrganization
 
-        # The user fixture becomes the admin through organization_account fixture
-        admin_user_org = UserOrganization(
+        owner_user_org = UserOrganization(
             user_id=user.id,
             organization_id=organization.id,
+            role=OrganizationRole.owner,
             created_at=utc_now(),
         )
-        await save_fixture(admin_user_org)
+        await save_fixture(owner_user_org)
 
-        # Test trying to remove organization admin
-        with pytest.raises(CannotRemoveOrganizationAdmin) as exc_info:
+        with pytest.raises(CannotRemoveOrganizationOwner) as exc_info:
             await user_organization_service.remove_member_safe(
                 session,
                 user_id=user.id,
@@ -154,28 +153,29 @@ class TestRemoveMember:
         self,
         session: Any,
         organization: Organization,
-        user: User,
+        user_second: User,
         user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
     ) -> None:
-        # Test that remove_member performs soft delete
+        # Use a regular member (user_second / user_organization_second
+        # default to role=member). The owner from `user_organization`
+        # remains, satisfying the admin-capability invariant.
         await user_organization_service.remove_member(
             session,
-            user_id=user.id,
+            user_id=user_second.id,
             organization_id=organization.id,
         )
 
-        # Verify the member was soft deleted (not returned by get_by_user_and_org)
         user_org = await user_organization_service.get_by_user_and_org(
-            session, user.id, organization.id
+            session, user_second.id, organization.id
         )
         assert user_org is None
 
-        # But the record still exists in DB with deleted_at set
         from polar.postgres import sql
 
         result = await session.execute(
             sql.select(UserOrganization).where(
-                UserOrganization.user_id == user.id,
+                UserOrganization.user_id == user_second.id,
                 UserOrganization.organization_id == organization.id,
             )
         )
@@ -188,8 +188,9 @@ class TestRemoveMember:
         mocker: MockerFixture,
         session: Any,
         organization: Organization,
-        user: User,
+        user_second: User,
         user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
     ) -> None:
         enqueue_remove_member_mock = mocker.patch(
             "polar.user_organization.service.polar_self_service.enqueue_remove_member"
@@ -197,13 +198,13 @@ class TestRemoveMember:
 
         await user_organization_service.remove_member(
             session,
-            user_id=user.id,
+            user_id=user_second.id,
             organization_id=organization.id,
         )
 
         enqueue_remove_member_mock.assert_called_once_with(
             external_customer_id=str(organization.id),
-            external_id=str(user.id),
+            external_id=str(user_second.id),
         )
 
     async def test_does_not_enqueue_when_member_not_found(
@@ -225,6 +226,48 @@ class TestRemoveMember:
 
         enqueue_remove_member_mock.assert_not_called()
 
+    async def test_admin_capability_invariant_rejects_last_admin_removal(
+        self,
+        session: Any,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        # The fixture's `user_organization` is the only admin-capable user
+        # in the org (role=owner). Raw `remove_member` bypasses the
+        # owner-non-removable guard in `remove_member_safe`, so the
+        # admin-capability invariant must catch it directly.
+        with pytest.raises(OrganizationWouldHaveNoAdmins) as exc_info:
+            await user_organization_service.remove_member(
+                session,
+                user_id=user.id,
+                organization_id=organization.id,
+            )
+
+        assert exc_info.value.organization_id == organization.id
+
+    async def test_admin_capability_invariant_allows_member_removal(
+        self,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+        user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        # Removing a non-admin-capable user (member) doesn't reduce the
+        # admin-capable count — should be allowed even via raw
+        # `remove_member`.
+        await user_organization_service.remove_member(
+            session,
+            user_id=user_second.id,
+            organization_id=organization.id,
+        )
+
+        user_org = await user_organization_service.get_by_user_and_org(
+            session, user_second.id, organization.id
+        )
+        assert user_org is None
+
 
 @pytest.mark.asyncio
 class TestListByOrg:
@@ -233,22 +276,25 @@ class TestListByOrg:
         session: Any,
         organization: Organization,
         user: User,
+        user_second: User,
         user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
     ) -> None:
-        # Initially should return the member
+        # Initially should return both members (owner + member).
         members = await user_organization_service.list_by_org(session, organization.id)
-        assert len(members) == 1
-        assert members[0].user_id == user.id
+        assert len(members) == 2
 
-        # After soft delete, should not return the member
+        # Soft-delete the regular member; the owner stays so the
+        # admin-capability invariant is satisfied.
         await user_organization_service.remove_member(
             session,
-            user_id=user.id,
+            user_id=user_second.id,
             organization_id=organization.id,
         )
 
         members = await user_organization_service.list_by_org(session, organization.id)
-        assert len(members) == 0
+        assert len(members) == 1
+        assert members[0].user_id == user.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #11400.

## Summary

Phase 3 of the RBAC rollout: switches policy-time authorization from `Account.admin_id` checks to a role-permission check against `UserOrganization.role`, ships the role-change endpoint, and adds the data-integrity invariants. The route-level token-scope check is unchanged and remains an independent first gate.

- **Policy cutover** (`d69c8063`): new `_require_permission` helper in `authz/policies/__init__.py`. `members.can_manage`, `organization.can_delete`, `organization.can_manage_payout_account`, `finance.can_read`, `finance.can_write` now consult `ROLE_PERMISSIONS[caller_role_in_org]`. Org-token subjects always pass; the old `_require_account_admin` helper is gone.
- **Member role exposure + removal invariants** (`d3d600ac`): `OrganizationMember.role` added; `is_admin` becomes a `@computed_field` derived from `role ∈ {owner, admin}`. `CannotRemoveOrganizationAdmin` renamed to `CannotRemoveOrganizationOwner` and now rejects when `user_org.role == owner`. New `OrganizationWouldHaveNoAdmins` invariant rejects removals that would drop admin-capable count to zero.
- **Role-change endpoint** (`99d099b8`): `PATCH /v1/organizations/{id}/members/{user_id}` route-gated by `members:write` scope, policy-gated by `members:set_role`. Body accepts `admin` / `member`; `owner` rejected at the schema layer (422). Ownership transfers continue to flow through `Account.admin_id` mutation (backoffice `change_admin`).

## Pre-merge verification (manual, gating the deploy)

- [ ] Every `Account.admin_id` user has the `owner` role on their org
- [ ] Exactly one owner per organization
- [ ] Every organization has admin capability (≥1 user in `role ∈ {owner, admin}`)

## Test plan

- [x] `uv run task test` — authz policies, organization endpoints, user_organization service
- [ ] Manual: promote a member to admin via `PATCH /members/{user_id}`, confirm new permission set takes effect
- [ ] Manual: attempt to demote the owner, confirm 403
- [ ] Manual: attempt to remove the last admin-capable user, confirm `OrganizationWouldHaveNoAdmins`