### PR TITLE
Make duplicate product media more robust

### DIFF
--- a/clients/apps/web/src/components/Products/CreateProductPage.tsx
+++ b/clients/apps/web/src/components/Products/CreateProductPage.tsx
@@ -1,4 +1,3 @@
-import { Upload } from '@/components/FileUpload/Upload'
 import { useToast } from '@/components/Toast/use-toast'
 import {
   useBenefits,
@@ -21,32 +20,9 @@ import { useForm } from 'react-hook-form'
 import { DashboardBody } from '../Layout/DashboardLayout'
 import { getStatusRedirect } from '../Toast/utils'
 import { Benefits } from './Benefits/Benefits'
+import { duplicateProductMedia } from './duplicateMedia'
 import ProductForm from './ProductForm/ProductForm'
 import { Wand2Icon } from 'lucide-react'
-
-const reuploadMedia = async (
-  media: schemas['ProductMediaFileRead'],
-  organization: schemas['Organization'],
-): Promise<schemas['ProductMediaFileRead']> => {
-  const response = await fetch(media.public_url)
-  const blob = await response.blob()
-  const file = new File([blob], media.name, { type: media.mime_type })
-
-  return new Promise((resolve, reject) => {
-    const upload = new Upload({
-      organization,
-      service: 'product_media',
-      file,
-      onFileProcessing: () => {},
-      onFileCreate: () => {},
-      onFileUploadProgress: () => {},
-      onFileUploaded: (response) =>
-        resolve(response as schemas['ProductMediaFileRead']),
-      onFileUploadError: (_fileId, error) => reject(error),
-    })
-    upload.run().catch(reject)
-  })
-}
 
 export interface CreateProductPageProps {
   organization: schemas['Organization']
@@ -126,13 +102,22 @@ export const CreateProductPage = ({
       try {
         const { full_medias, metadata, ...productCreateRest } = productCreate
 
-        // When duplicating, re-upload medias to create new files
         let mediaIds = full_medias.map((media) => media.id)
         if (sourceProduct && full_medias.length > 0) {
-          const reuploadedMedias = await Promise.all(
-            full_medias.map((media) => reuploadMedia(media, organization)),
+          const results = await Promise.allSettled(
+            full_medias.map((media) =>
+              duplicateProductMedia(media, organization),
+            ),
           )
-          mediaIds = reuploadedMedias.map((media) => media.id)
+          mediaIds = results.flatMap((r) =>
+            r.status === 'fulfilled' ? [r.value.id] : [],
+          )
+          if (mediaIds.length < full_medias.length) {
+            toast({
+              title: 'Error',
+              description: 'Some images could not be copied',
+            })
+          }
         }
 
         const { data: product, error } = await createProduct.mutateAsync({

--- a/clients/apps/web/src/components/Products/duplicateMedia.ts
+++ b/clients/apps/web/src/components/Products/duplicateMedia.ts
@@ -1,0 +1,49 @@
+import { Upload } from '@/components/FileUpload/Upload'
+import { retryWithBackoff } from '@/utils/retry'
+import { schemas } from '@polar-sh/client'
+import * as Sentry from '@sentry/nextjs'
+
+const uploadProductMedia = (
+  file: File,
+  organization: schemas['Organization'],
+): Promise<schemas['ProductMediaFileRead']> =>
+  new Promise((resolve, reject) => {
+    const upload = new Upload({
+      organization,
+      service: 'product_media',
+      file,
+      onFileProcessing: () => {},
+      onFileCreate: () => {},
+      onFileUploadProgress: () => {},
+      onFileUploaded: (uploaded) =>
+        resolve(uploaded as schemas['ProductMediaFileRead']),
+      onFileUploadError: (_fileId, error) => reject(error),
+    })
+    upload.run().catch(reject)
+  })
+
+export const duplicateProductMedia = async (
+  media: schemas['ProductMediaFileRead'],
+  organization: schemas['Organization'],
+): Promise<schemas['ProductMediaFileRead']> => {
+  try {
+    const response = await retryWithBackoff(() => fetch(media.public_url), {
+      initialDelayMs: 500,
+      maxDelayMs: 3000,
+    })
+    const blob = await response.blob()
+    const file = new File([blob], media.name, { type: media.mime_type })
+    return await uploadProductMedia(file, organization)
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'product-duplicate-media-copy' },
+      extra: {
+        mediaId: media.id,
+        mediaName: media.name,
+        mimeType: media.mime_type,
+        size: media.size,
+      },
+    })
+    throw error
+  }
+}

--- a/clients/apps/web/src/utils/retry.ts
+++ b/clients/apps/web/src/utils/retry.ts
@@ -1,0 +1,25 @@
+export interface RetryOptions {
+  maxRetries?: number
+  initialDelayMs?: number
+  maxDelayMs?: number
+}
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  {
+    maxRetries = 3,
+    initialDelayMs = 100,
+    maxDelayMs = 1000,
+  }: RetryOptions = {},
+): Promise<T> {
+  const attempt = async (remaining: number, delay: number): Promise<T> => {
+    try {
+      return await fn()
+    } catch (error) {
+      if (remaining <= 0) throw error
+      await new Promise((resolve) => setTimeout(resolve, delay))
+      return attempt(remaining - 1, Math.min(delay * 2, maxDelayMs))
+    }
+  }
+  return attempt(maxRetries, initialDelayMs)
+}


### PR DESCRIPTION
We have gotten a few reports that duplicating a product that has images sometimes causes errors, making the duplication fail. This PR aims to make that a bit more robust by:

* Adding 3x retries for uploads
* Don't error out if a subset of the images fail to upload
* Add Sentry captions for errors