### PR TITLE
Fix discount calculation for seat subscription updates

### DIFF
--- a/server/polar/subscription/update.py
+++ b/server/polar/subscription/update.py
@@ -207,13 +207,30 @@ def _generate_seats_subscription_update(
     old_base_amount = seat_price.calculate_amount(old_seats)
     new_base_amount = seat_price.calculate_amount(new_seats)
 
+    # Apply the discount to the old and new effective amounts, not to the delta.
+    # Computing the discount on the delta double-counts fixed discounts: a $10
+    # fixed discount applies once to the subscription total, not again to every
+    # seat change.
+    old_discount_amount = 0
+    new_discount_amount = 0
+    if subscription.discount and subscription.discount.is_applicable(
+        subscription.product, subscription.currency
+    ):
+        old_discount_amount = subscription.discount.get_discount_amount(
+            old_base_amount, subscription.currency
+        )
+        new_discount_amount = subscription.discount.get_discount_amount(
+            new_base_amount, subscription.currency
+        )
+
     start_timestamp = subscription_update.applies_at
     end_timestamp = subscription.current_period_end
 
     if subscription_update.proration_behavior == SubscriptionProrationBehavior.reset:
         # In reset mode, we don't prorate the amount, we just charge the full amount of the new seats immediately.
         proration_factor = Decimal(1)
-        base_amount_delta = new_base_amount
+        amount_delta = new_base_amount - new_discount_amount
+        entry_discount_amount = new_discount_amount
 
         # Resets the cycle
         new_cycle_start = subscription_update.applies_at
@@ -228,24 +245,12 @@ def _generate_seats_subscription_update(
             subscription.current_period_end,
             subscription_update.applies_at,
         )
-        base_amount_delta = new_base_amount - old_base_amount
-
-    # Calculate discount on the delta amount
-    discount_amount = 0
-    if subscription.discount and subscription.discount.is_applicable(
-        subscription.product, subscription.currency
-    ):
-        discount_amount = subscription.discount.get_discount_amount(
-            abs(base_amount_delta), subscription.currency
-        )
-
-    # Calculate the net amount delta after discount
-    if base_amount_delta > 0:
-        # Increase: reduce the charge by discount
-        amount_delta = base_amount_delta - discount_amount
-    else:
-        # Decrease: reduce the credit by discount
-        amount_delta = base_amount_delta + discount_amount
+        old_effective = old_base_amount - old_discount_amount
+        new_effective = new_base_amount - new_discount_amount
+        amount_delta = new_effective - old_effective
+        # The portion of the delta attributable to the discount is how much the
+        # discount itself changed between the old and new effective amounts.
+        entry_discount_amount = abs(new_discount_amount - old_discount_amount)
 
     prorated_amount = int(Decimal(amount_delta) * proration_factor)
 
@@ -262,8 +267,10 @@ def _generate_seats_subscription_update(
 
     # Calculate prorated discount amount
     prorated_discount_amount = 0
-    if discount_amount > 0:
-        prorated_discount_amount = int(Decimal(discount_amount) * proration_factor)
+    if entry_discount_amount > 0:
+        prorated_discount_amount = int(
+            Decimal(entry_discount_amount) * proration_factor
+        )
 
     billing_entry = BillingEntry(
         start_timestamp=start_timestamp,
@@ -275,7 +282,7 @@ def _generate_seats_subscription_update(
         discount_amount=prorated_discount_amount
         if prorated_discount_amount > 0
         else None,
-        discount=subscription.discount if discount_amount > 0 else None,
+        discount=subscription.discount if entry_discount_amount > 0 else None,
         currency=subscription.currency,
         direction=direction,
         type=entry_type,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4512,7 +4512,11 @@ class TestUpdateSeats:
         )
         await session.flush()
 
-        # Then: Discount applied to billing entry
+        # Then: Fixed discount does not change between old and new effective
+        # amounts, so it cancels out in the delta. The customer was already
+        # benefiting from the $10 off on the original $50, and continues to
+        # benefit from $10 off on the new $100 — the incremental charge is the
+        # full $50.
         billing_entry_repo = BillingEntryRepository.from_session(session)
         entries = await billing_entry_repo.get_pending_by_subscription(subscription.id)
         proration_entries = [
@@ -4521,15 +4525,10 @@ class TestUpdateSeats:
         assert len(proration_entries) == 1
         entry = proration_entries[0]
         assert entry.direction == BillingEntryDirection.debit
-        assert entry.discount_amount is not None
-        # Base delta is $50, fixed discount of $10 on the delta
-        # Since we're at the start of the period (100% time remaining),
-        # proration factor is 1.0, so full discount applies
-        assert entry.discount_amount == 1000  # $10 in cents
-        assert entry.discount == discount
-        # Net charge: $50 - $10 = $40
+        assert entry.discount_amount is None
+        assert entry.discount is None
         assert entry.amount is not None
-        assert entry.amount == 4000  # $40 in cents
+        assert entry.amount == 5000  # $50 in cents
 
     async def test_seat_increase_with_percentage_discount(
         self,
@@ -4643,7 +4642,9 @@ class TestUpdateSeats:
         )
         await session.flush()
 
-        # Then: Discount reduces the credit amount
+        # Then: Fixed discount applies equally to old ($100 → $90) and new
+        # ($50 → $40) effective amounts, so it cancels out in the delta. The
+        # credit reflects the full $50 difference in base amount.
         billing_entry_repo = BillingEntryRepository.from_session(session)
         entries = await billing_entry_repo.get_pending_by_subscription(subscription.id)
         credit_entries = [
@@ -4652,16 +4653,10 @@ class TestUpdateSeats:
         assert len(credit_entries) == 1
         entry = credit_entries[0]
         assert entry.direction == BillingEntryDirection.credit
-        assert entry.discount_amount is not None
-        # Base credit delta is -$50, discount of $10 on the delta
-        # reduces the credit to -$40 (customer gets less credit)
-        # Since we're at the start of the period (100% time remaining),
-        # proration factor is 1.0, so full discount applies
-        assert entry.discount_amount == 1000  # $10 in cents
-        assert entry.discount == discount
-        # Net credit: $50 - $10 = $40
+        assert entry.discount_amount is None
+        assert entry.discount is None
         assert entry.amount is not None
-        assert entry.amount == 4000  # $40 in cents
+        assert entry.amount == 5000  # $50 in cents
 
     async def test_seat_increase_without_discount(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Fix incorrect discount application in seat-based subscription updates. Previously, discounts were applied to the delta amount, which caused fixed discounts to be double-counted. Now discounts are applied to the effective amounts (base amount minus discount) before calculating the delta.

## What

Changed the discount calculation logic in `_generate_seats_subscription_update()` to:
1. Calculate discounts on the old and new effective amounts separately
2. Compute the delta from these effective amounts
3. Track only the change in discount amount (not the full discount) as the entry discount

Updated corresponding test expectations to reflect the corrected behavior.

## Why

The previous implementation applied discounts to the delta amount, which caused issues with fixed discounts:
- For a seat increase from 1 to 2 seats ($50 → $100) with a $10 fixed discount:
  - Old effective: $50 - $10 = $40
  - New effective: $100 - $10 = $90
  - Delta should be: $90 - $40 = $50 (full incremental charge)
  - Previous code incorrectly applied the $10 discount to the $50 delta, resulting in a $40 charge

Fixed discounts apply once to the subscription total, not to every seat change. The discount amount doesn't change in the delta calculation—only the base amount changes.

## How

1. Calculate `old_discount_amount` and `new_discount_amount` upfront based on the full base amounts
2. For reset mode: use the new effective amount (base - discount) as the charge
3. For proration mode: calculate delta from effective amounts and track only the discount change
4. Apply proration factor to the discount change, not the full discount amount

## Checklist

- [x] This PR addresses a single concern (discount calculation fix)
- [x] The diff is reasonably sized and easy to review
- [x] Tests updated to reflect corrected behavior
- [x] Linting and type checking pass
- [x] No unrelated changes included

https://claude.ai/code/session_01U4NTDNFmfREunQASW2igk6