### PR TITLE
fix(currency): treat UGX as two-decimal to match Stripe

### DIFF
--- a/clients/packages/currency/src/index.ts
+++ b/clients/packages/currency/src/index.ts
@@ -9,7 +9,6 @@ const ZERO_DECIMAL_CURRENCIES = new Set<string>([
   'mga',
   'pyg',
   'rwf',
-  'ugx',
   'vnd',
   'vuv',
   'xaf',

--- a/clients/packages/orbit/src/components/Input.tsx
+++ b/clients/packages/orbit/src/components/Input.tsx
@@ -22,7 +22,6 @@ const ZERO_DECIMAL_CURRENCIES = new Set([
   'MGA',
   'PYG',
   'RWF',
-  'UGX',
   'VND',
   'VUV',
   'XAF',

--- a/server/polar/kit/currency.py
+++ b/server/polar/kit/currency.py
@@ -166,7 +166,6 @@ _ZERO_DECIMAL_CURRENCIES: set[str] = {
     "mga",
     "pyg",
     "rwf",
-    "ugx",
     "vnd",
     "vuv",
     "xaf",
@@ -333,7 +332,7 @@ MINIMUM_PRICE_PER_CURRENCY: dict[str, int] = {
     "twd": 2000,  # 20.00 TWD > 0.50 USD
     "tzs": 200000,  # 2000.00 TZS > 0.50 USD
     "uah": 3000,  # 30.00 UAH > 0.50 USD
-    "ugx": 2000,  # 2000 UGX > 0.50 USD
+    "ugx": 200000,  # 2000.00 UGX > 0.50 USD (Stripe requires UGX in two-decimal format)
     "uyu": 2000,  # 20.00 UYU > 0.50 USD
     "uzs": 700000,  # 7000.00 UZS > 0.50 USD
     "vnd": 20000,  # 20000 VND > 0.50 USD


### PR DESCRIPTION
## Summary
- Remove `ugx` from `_ZERO_DECIMAL_CURRENCIES` in `server/polar/kit/currency.py`. Stripe requires UGX in two-decimal format (major units × 100, trailing `00`), the same as ISK/HUF/TWD — none of which are in the zero-decimal set. UGX was the lone inconsistency, which also matches the payout-side handling in `server/polar/payout/service.py:58` where UGX is grouped with `isk`, `huf`, `twd`.
- Bump `MINIMUM_PRICE_PER_CURRENCY["ugx"]` from `2000` → `200000` so the validated minimum represents 2000.00 UGX in Stripe's expected representation, matching the developer's original intent of "min 2000 UGX".

## Behavior change
| | before | after |
|---|---|---|
| `_get_currency_decimal_factor("ugx")` | `1` | `100` |
| `get_minimum_currency_amount("ugx")` | `2000` (Stripe would charge 20 UGX) | `200000` (Stripe charges 2000 UGX) |
| `format_currency(200000, "ugx")` | `UGX200,000` | `UGX2,000` |

## Data migration note
Any existing UGX prices stored in the database are currently in the wrong representation (100× too small relative to what Stripe would charge). If there are live UGX prices, they'd need a one-off ×100 backfill. Worth a quick check on production before merging.

Bug: https://app.detail.dev/org_ecfbc7cf-6d21-4ce1-8c61-cda1d650ccf7/bugs/bug_4ec3381d-d444-4904-ba54-65feb21acdb9

## Test plan
- [ ] `uv run pytest tests/kit/test_currency.py tests/payout/test_service.py`
- [ ] Manual: confirm UGX product creation rejects amounts below 200000 (= 2000.00 UGX) and that the error message displays `UGX2,000`
- [ ] Audit existing UGX prices (if any) before merging — they may need a 100× backfill

https://claude.ai/code/session_014myLKxUnoQKTzWeTkqzG4m

---
_Generated by [Claude Code](https://claude.ai/code/session_014myLKxUnoQKTzWeTkqzG4m)_