### PR TITLE
fix(customer-portal): send magic code to the login email

### DIFF
--- a/server/polar/customer_portal/service/customer_session.py
+++ b/server/polar/customer_portal/service/customer_session.py
@@ -195,7 +195,6 @@ class CustomerSessionService:
         customer_session_code: CustomerSessionCode,
         code: str,
     ) -> None:
-        customer = customer_session_code.customer
         organization_repository = OrganizationRepository.from_session(session)
         organization = await organization_repository.get_by_id(
             customer_session_code.customer.organization_id
@@ -206,14 +205,14 @@ class CustomerSessionService:
         code_lifetime_minutes = int(ceil(delta.seconds / 60))
 
         domain = settings.frontend_hostname
-        if customer.email is None:
-            raise CustomerSessionCodeInvalidOrExpired()
 
+        # Recipient is the login email (member.email in the member flow); the
+        # customer record may have no email (team customer) or a billing one.
         enqueue_email_template(
             CustomerSessionCodeEmail(
                 props=CustomerSessionCodeProps.model_validate(
                     {
-                        "email": customer.email,
+                        "email": customer_session_code.email,
                         "organization": organization,
                         "code": code,
                         "code_lifetime_minutes": code_lifetime_minutes,
@@ -225,7 +224,7 @@ class CustomerSessionService:
                 )
             ),
             **organization.email_from_reply,
-            to_email_addr=customer.email,
+            to_email_addr=customer_session_code.email,
             subject=f"Access your {organization.name} purchases",
         )
 

--- a/server/tests/customer_portal/service/test_customer_session.py
+++ b/server/tests/customer_portal/service/test_customer_session.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import timedelta
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy import select
 
 from polar.customer.schemas.customer import CustomerUpdate
@@ -33,6 +34,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_account,
     create_customer,
+    create_member,
     create_organization,
 )
 
@@ -535,6 +537,55 @@ class TestRequestMemberEnabledOrgGracefulFallback:
             await customer_session_service.request(
                 session, "nobody@example.com", organization.id
             )
+
+
+@pytest.mark.asyncio
+class TestSend:
+    @pytest.mark.parametrize(
+        "customer_email",
+        [
+            pytest.param(None, id="team_customer_no_email"),
+            pytest.param("billing@example.com", id="customer_email_differs"),
+        ],
+    )
+    async def test_sends_to_member_email(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer_email: str | None,
+    ) -> None:
+        # Regression: code must reach the address typed at login (member.email),
+        # not customer.email — which is absent for team customers and may hold
+        # an unrelated billing address otherwise.
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        customer = await create_customer(save_fixture, organization=organization)
+        customer.email = customer_email
+        await save_fixture(customer)
+        await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="member@example.com",
+        )
+
+        enqueue_mock = mocker.patch(
+            "polar.customer_portal.service.customer_session.enqueue_email_template"
+        )
+
+        customer_session_code, code = await customer_session_service.request(
+            session, "member@example.com", organization.id
+        )
+        await session.flush()
+        await customer_session_service.send(session, customer_session_code, code)
+
+        enqueue_mock.assert_called_once()
+        _, kwargs = enqueue_mock.call_args
+        assert kwargs["to_email_addr"] == "member@example.com"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

During the dogfooding of Polar for Pola, we noticed members of team customers without email couldn't enter the Customer Portal, the magic-code request returned 401.

## What

Send the verification code to `customer_session_code.email` (the login email) instead of `customer.email`, and drop the now-unreachable `customer.email is None` guard. Adds a parametrized regression test covering both failure modes.

## Why

`customer.email` is nullable for team customers

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
