### PR TITLE
chore(claude): tighten /yeet PR creation flow

### DIFF
--- a/.claude/commands/yeet.md
+++ b/.claude/commands/yeet.md
@@ -24,7 +24,7 @@ Lint, type-check, and create a PR.
 
 4. **If lint auto-fixed files** (e.g. ruff formatted), stage and commit those changes with a message like "lint: auto-fix formatting".
 
-5. **Create the PR** using the standard PR creation instructions from the system prompt. Use the full commit history from `main` to draft the PR title and description.
+5. **Create the PR as a draft** using the standard PR creation instructions from the system prompt. Use the full commit history from `main` to draft the PR title and description. Pass `--draft` to `gh pr create`.
 
    **PR title must use a conventional commit prefix** — one of: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `perf:`, `ci:`, `build:`, `style:`. Choose the prefix that best describes the overall change. Examples:
    - `feat: add webhook retry with exponential backoff`
@@ -32,6 +32,13 @@ Lint, type-check, and create a PR.
    - `refactor: extract payment validation into service layer`
 
    This is important because we use **merge queues with squash**, so the PR title becomes the final commit message on `main`.
+
+   **Build the description from the repo PR template.** Before writing the body, read `.github/pull_request_template.md` and use it as the structural guide. Keep the section headers you use (e.g. `## Summary`, `## What`, `## Why`, `## How`, `## Checklist`) consistent with the template.
+
+   - Include only the sections that add real information for this PR. Skip any section that would otherwise be empty or trivial. A small fix may only need `## Summary`; a feature may need `## Summary` + `## What` + `## Why`.
+   - Always keep the `## Checklist` section from the template. Tick the boxes for items you actually verified in this run (e.g. lint and type checks passed → tick the lint/type-check box; the PR is genuinely focused and small → tick those boxes). Leave unchecked anything you did not verify (e.g. you did not add tests).
+   - Omit `Related Issue: #<n>` unless an issue is actually referenced in the branch or commits.
+   - Each kept section is at most a couple of short sentences or a few short bullets. A reviewer should scan the whole PR body in under a minute. Do not pad, do not restate the diff line-by-line.
 
    **Important — this is a public repo.** When writing the PR title and description:
    - **No PII**: Do not include any personally identifiable information such as names, emails, user IDs, API keys, tokens, internal URLs, or customer data — even if they appear in commit messages or diffs.


### PR DESCRIPTION
## Summary

Update the `/yeet` slash command so the PR it generates is a draft, follows the repo PR template, and reflects what was actually verified.

## What

- Pass `--draft` to `gh pr create`.
- Read `.github/pull_request_template.md` and use it as the structural guide for the body; skip subsections that don't add information.
- Tick checklist boxes for items verified in the run; leave the rest unchecked.

## Why

PRs created by `/yeet` were being opened ready-for-review with an empty/unstructured body and a fully unchecked checklist. Drafting by default plus a template-aligned, evidence-based checklist makes the resulting PRs easier to review and more honest about what was checked.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included