### PR TITLE
Add "Reply in Plain" shortcut to backoffice feedback management

### DIFF
--- a/server/polar/backoffice/feedbacks/endpoints.py
+++ b/server/polar/backoffice/feedbacks/endpoints.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import joinedload
 from tagflow import attr, document, tag, text
 
 from polar.feedback.repository import FeedbackRepository
+from polar.integrations.plain.service import PlainServiceError, plain
 from polar.kit.pagination import PaginationParamsQuery
 from polar.models import Feedback
 from polar.models.feedback import FeedbackStatus, FeedbackType
@@ -33,6 +34,17 @@ class UpdateFeedbackNoteForm(forms.BaseForm):
             ),
         ),
         Field(default="", title="Internal note"),
+    ]
+
+
+class UpdateSupportThreadURLForm(forms.BaseForm):
+    support_thread_url: Annotated[
+        str,
+        forms.InputField(
+            type="url",
+            placeholder="https://app.plain.com/workspace/.../thread/...",
+        ),
+        Field(default="", title="Support thread URL"),
     ]
 
 
@@ -309,45 +321,99 @@ async def get(
                             with tag.p(classes="text-gray-500"):
                                 text("No client context captured.")
 
-                # Internal note
-                with tag.div(classes="card card-border w-full shadow-sm"):
-                    with tag.div(classes="card-body"):
-                        with tag.div(classes="flex items-center justify-between gap-2"):
+                # Support thread + Internal note (stacked in the same column)
+                with tag.div(classes="flex flex-col gap-4"):
+                    # Support thread
+                    with tag.div(classes="card card-border w-full shadow-sm"):
+                        with tag.div(classes="card-body"):
                             with tag.h2(classes="card-title"):
-                                text("Internal note")
-                            if feedback.internal_note and feedback.modified_at:
-                                with tag.span(classes="text-xs text-gray-500"):
-                                    text(
-                                        "Updated "
-                                        + feedback.modified_at.strftime(
-                                            "%Y-%m-%d %H:%M UTC"
-                                        )
+                                text("Support thread")
+                            with UpdateSupportThreadURLForm.render(
+                                data={
+                                    "support_thread_url": feedback.support_thread_url
+                                    or ""
+                                },
+                                hx_post=str(
+                                    request.url_for(
+                                        "feedbacks:update_support_thread_url",
+                                        id=feedback.id,
                                     )
-                        with UpdateFeedbackNoteForm.render(
-                            data={"internal_note": feedback.internal_note or ""},
-                            hx_post=str(
-                                request.url_for("feedbacks:update_note", id=feedback.id)
-                            ),
-                            classes="flex flex-col gap-2",
-                        ):
-                            with tag.div(classes="flex justify-end gap-2"):
-                                with button(
-                                    type="submit",
-                                    name="action",
-                                    value="save",
-                                    size="sm",
-                                    ghost=True,
+                                ),
+                                classes="flex flex-col gap-2",
+                            ):
+                                with tag.div(
+                                    classes="flex flex-wrap justify-end gap-2"
                                 ):
-                                    text("Save note")
-                                if feedback.status == FeedbackStatus.new:
+                                    with button(
+                                        type="submit",
+                                        size="sm",
+                                        ghost=True,
+                                    ):
+                                        text("Save URL")
+                                    if feedback.support_thread_url:
+                                        with tag.a(
+                                            href=feedback.support_thread_url,
+                                            target="_blank",
+                                            rel="noopener noreferrer",
+                                            classes="btn btn-sm btn-primary",
+                                        ):
+                                            text("Open thread ↗")
+                                    else:
+                                        with button(
+                                            hx_post=str(
+                                                request.url_for(
+                                                    "feedbacks:reply_in_plain",
+                                                    id=feedback.id,
+                                                )
+                                            ),
+                                            variant="primary",
+                                            size="sm",
+                                        ):
+                                            text("Reply in Plain")
+
+                    # Internal note
+                    with tag.div(classes="card card-border w-full shadow-sm"):
+                        with tag.div(classes="card-body"):
+                            with tag.div(
+                                classes="flex items-center justify-between gap-2"
+                            ):
+                                with tag.h2(classes="card-title"):
+                                    text("Internal note")
+                                if feedback.internal_note and feedback.modified_at:
+                                    with tag.span(classes="text-xs text-gray-500"):
+                                        text(
+                                            "Updated "
+                                            + feedback.modified_at.strftime(
+                                                "%Y-%m-%d %H:%M UTC"
+                                            )
+                                        )
+                            with UpdateFeedbackNoteForm.render(
+                                data={"internal_note": feedback.internal_note or ""},
+                                hx_post=str(
+                                    request.url_for(
+                                        "feedbacks:update_note", id=feedback.id
+                                    )
+                                ),
+                                classes="flex flex-col gap-2",
+                            ):
+                                with tag.div(classes="flex justify-end gap-2"):
                                     with button(
                                         type="submit",
                                         name="action",
-                                        value="save_and_triage",
-                                        variant="primary",
+                                        value="save",
                                         size="sm",
+                                        ghost=True,
                                     ):
-                                        text("Save & Mark as triaged")
+                                        text("Save note")
+                                    if feedback.status == FeedbackStatus.new:
+                                        with button(
+                                            type="submit",
+                                            name="action",
+                                            value="save_and_triage",
+                                            variant="primary",
+                                            size="sm",
+                                        ):
+                                            text("Save & Mark as triaged")
 
 
 def _format_context_value(value: Any) -> str:
@@ -412,6 +478,72 @@ async def update_note(
         "Note saved and feedback marked as triaged." if triage else "Note saved.",
         "success",
     )
+    return HXRedirectResponse(
+        request, str(request.url_for("feedbacks:get", id=feedback.id))
+    )
+
+
+@router.post("/{id}/support-thread-url", name="feedbacks:update_support_thread_url")
+async def update_support_thread_url(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    repository = FeedbackRepository.from_session(session)
+    feedback = await repository.get_by_id(id)
+    if feedback is None:
+        raise HTTPException(status_code=404)
+
+    form_data = await request.form()
+    try:
+        form = UpdateSupportThreadURLForm.model_validate_form(form_data)
+    except ValidationError:
+        await add_toast(request, "Please enter a valid URL.", "error")
+        return HXRedirectResponse(
+            request, str(request.url_for("feedbacks:get", id=feedback.id))
+        )
+
+    url = form.support_thread_url.strip() or None
+    await repository.update(feedback, update_dict={"support_thread_url": url})
+    await add_toast(
+        request,
+        "Support thread URL updated." if url else "Support thread URL cleared.",
+        "success",
+    )
+    return HXRedirectResponse(
+        request, str(request.url_for("feedbacks:get", id=feedback.id))
+    )
+
+
+@router.post("/{id}/reply-in-plain", name="feedbacks:reply_in_plain")
+async def reply_in_plain(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    feedback = await _get_or_404(session, id)
+
+    if feedback.support_thread_url:
+        await add_toast(
+            request,
+            "A support thread is already linked. Clear the URL to create a new one.",
+            "warning",
+        )
+        return HXRedirectResponse(
+            request, str(request.url_for("feedbacks:get", id=feedback.id))
+        )
+
+    try:
+        thread_url = await plain.create_feedback_thread(feedback)
+    except PlainServiceError as e:
+        await add_toast(request, f"Plain error: {e}", "error")
+        return HXRedirectResponse(
+            request, str(request.url_for("feedbacks:get", id=feedback.id))
+        )
+
+    repository = FeedbackRepository.from_session(session)
+    await repository.update(feedback, update_dict={"support_thread_url": thread_url})
+    await add_toast(request, "Support thread created in Plain.", "success")
     return HXRedirectResponse(
         request, str(request.url_for("feedbacks:get", id=feedback.id))
     )

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -23,6 +23,7 @@ from plain_client import (
     ComponentTextColor,
     ComponentTextInput,
     ComponentTextSize,
+    CreateNoteInput,
     CreateThreadInput,
     CustomerIdentifierInput,
     EmailAddressInput,
@@ -45,6 +46,8 @@ from polar.kit.currency import format_currency
 from polar.kit.db.postgres import AsyncReadSessionMaker
 from polar.models import (
     Customer,
+    Feedback,
+    FeedbackType,
     OAuthAccount,
     Order,
     Organization,
@@ -88,6 +91,15 @@ class PlainCustomerError(PlainServiceError):
         self.user_id = user_id
         self.message = message
         super().__init__(f"Error with Plain customer for user ID {user_id}: {message}")
+
+
+class FeedbackThreadCreationError(PlainServiceError):
+    def __init__(self, feedback_id: uuid.UUID, message: str) -> None:
+        self.feedback_id = feedback_id
+        self.message = message
+        super().__init__(
+            f"Error creating Plain thread for feedback {feedback_id}: {message}"
+        )
 
 
 _card_getter_semaphore = asyncio.Semaphore(3)
@@ -1226,6 +1238,101 @@ class PlainService:
             raise PlainCustomerError(user.id, customer_result.error.message)
 
         return self._get_customer_identifier(customer_result, user.email)
+
+    async def _upsert_customer_id_for_user(self, plain: Plain, user: User) -> str:
+        """
+        Resolve the Plain customer ID for a Polar user, creating the customer
+        if it doesn't exist yet.
+
+        Mirrors `_get_or_create_customer` but returns the concrete Plain
+        `customer.id` string, which is required by APIs like `create_note`
+        that don't accept the polymorphic `CustomerIdentifierInput`.
+        """
+        existing = await plain.customer_by_email(email=user.email)
+        if existing is not None:
+            return existing.id
+
+        customer_result = await plain.upsert_customer(
+            UpsertCustomerInput(
+                identifier=UpsertCustomerIdentifierInput(external_id=str(user.id)),
+                on_create=UpsertCustomerOnCreateInput(
+                    external_id=str(user.id),
+                    full_name=user.email,
+                    email=EmailAddressInput(
+                        email=user.email, is_verified=user.email_verified
+                    ),
+                ),
+                on_update=UpsertCustomerOnUpdateInput(
+                    email=EmailAddressInput(
+                        email=user.email, is_verified=user.email_verified
+                    ),
+                ),
+            )
+        )
+        if customer_result.error is not None:
+            raise PlainCustomerError(user.id, customer_result.error.message)
+        if customer_result.customer is None:
+            raise PlainCustomerError(user.id, "No customer returned by upsert")
+        return customer_result.customer.id
+
+    async def create_feedback_thread(self, feedback: Feedback) -> str:
+        """
+        Open a Plain thread for a feedback record and attach the original
+        feedback message as an internal note. Returns the URL of the new
+        thread.
+
+        Requires `feedback.user` to be loaded (e.g. via `joinedload`).
+        """
+        if not self.enabled:
+            raise FeedbackThreadCreationError(
+                feedback.id, "Plain integration is disabled"
+            )
+
+        noun_by_type = {
+            FeedbackType.bug: "bug report",
+            FeedbackType.feedback: "feedback",
+            FeedbackType.question: "question",
+        }
+        title = f"Re: your recent {noun_by_type[feedback.type]}"
+
+        async with self._get_plain_client() as plain:
+            try:
+                customer_id = await self._upsert_customer_id_for_user(
+                    plain, feedback.user
+                )
+            except PlainCustomerError as e:
+                raise FeedbackThreadCreationError(feedback.id, e.message) from e
+
+            thread_result = await plain.create_thread(
+                CreateThreadInput(
+                    customer_identifier=CustomerIdentifierInput(
+                        customer_id=customer_id
+                    ),
+                    title=title,
+                )
+            )
+            if thread_result.error is not None:
+                raise FeedbackThreadCreationError(
+                    feedback.id, thread_result.error.message
+                )
+            if thread_result.thread is None:
+                raise FeedbackThreadCreationError(
+                    feedback.id, "No thread returned by create_thread"
+                )
+
+            note_result = await plain.create_note(
+                CreateNoteInput(
+                    customer_id=customer_id,
+                    thread_id=thread_result.thread.id,
+                    text=feedback.message,
+                )
+            )
+            if note_result.error is not None:
+                raise FeedbackThreadCreationError(
+                    feedback.id, note_result.error.message
+                )
+
+            return plain_thread_url(thread_result.thread.id)
 
     async def check_thread_exists(
         self, customer_email: str, thread_title: str, fuzzy: bool = False


### PR DESCRIPTION
Plain also has a way to post the initial message "impersonating" the customer, but I decided against it and use an internal note, in case we want to append the auto-created message with some more of our internal tooling.

Also, for in-app support, we'll append the full chat history, so that could be noisy if we add that all in the initial email.