### PR TITLE
chore: remove unused count_by_organization_id helpers

### DIFF
--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -76,13 +76,6 @@ class CheckoutLinkRepository(
             CheckoutLink.organization_id.in_(org_ids)
         )
 
-    async def count_by_organization_id(self, organization_id: UUID) -> int:
-        """Count checkout links for a specific organization."""
-        statement = self.get_base_statement().where(
-            CheckoutLink.organization_id == organization_id
-        )
-        return await self.count(statement)
-
     async def has_with_benefit_types(
         self, organization_id: UUID, benefit_types: Iterable[BenefitType]
     ) -> bool:

--- a/server/polar/organization_access_token/repository.py
+++ b/server/polar/organization_access_token/repository.py
@@ -58,19 +58,6 @@ class OrganizationAccessTokenRepository(
             OrganizationAccessToken.organization_id.in_(org_ids)
         )
 
-    async def count_by_organization_id(
-        self,
-        organization_id: UUID,
-    ) -> int:
-        """Count active organization access tokens for an organization."""
-        count = await self.session.scalar(
-            sql.select(sql.func.count(OrganizationAccessToken.id)).where(
-                OrganizationAccessToken.organization_id == organization_id,
-                OrganizationAccessToken.is_deleted.is_(False),
-            )
-        )
-        return count or 0
-
     async def has_by_organization_id(self, organization_id: UUID) -> bool:
         """Whether the organization has any active access token."""
         statement = (


### PR DESCRIPTION
## Summary

Delete unused code

## Test plan

- [x] `uv run task lint`
- [x] `uv run task lint_types`
- [x] `uv run pytest tests/checkout_link/ tests/organization_access_token/ tests/organization/` (397 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)