### PR TITLE
feat(billing): wire up organization order history

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
@@ -10,10 +10,10 @@ import { BillingAddressSection } from '@/components/Settings/Billing/BillingAddr
 import { BillingOrdersTable } from '@/components/Settings/Billing/BillingOrdersTable'
 import { BillingPaymentMethods } from '@/components/Settings/Billing/BillingPaymentMethods'
 import { BillingSubscriptionCard } from '@/components/Settings/Billing/BillingSubscriptionCard'
-import { MOCK_ORDERS } from '@/components/Settings/Billing/mockData'
 import { Section, SectionDescription } from '@/components/Settings/Section'
 import { LoadingBox } from '@/components/Shared/LoadingBox'
 import {
+  useOrganizationOrders,
   useOrganizationPlans,
   useOrganizationSubscription,
 } from '@/hooks/queries/billing'
@@ -35,6 +35,7 @@ export default function BillingPage({
 
   const subscriptionQuery = useOrganizationSubscription(organization.id)
   const plansQuery = useOrganizationPlans(organization.id)
+  const ordersQuery = useOrganizationOrders(organization.id)
 
   const {
     isShown: isAddPaymentMethodOpen,
@@ -98,7 +99,14 @@ export default function BillingPage({
             title="Order history"
             description="Past invoices for your Polar subscription"
           />
-          <BillingOrdersTable orders={MOCK_ORDERS} />
+          {ordersQuery.isLoading ? (
+            <LoadingBox height={240} borderRadius="l" />
+          ) : (
+            <BillingOrdersTable
+              organizationId={organization.id}
+              orders={ordersQuery.data?.items ?? []}
+            />
+          )}
         </Section>
       </Box>
 

--- a/clients/apps/web/src/components/Settings/Billing/BillingOrdersTable.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingOrdersTable.tsx
@@ -1,90 +1,135 @@
 'use client'
 
+import { useGetOrganizationOrderInvoice } from '@/hooks/queries/billing'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
-import { Text } from '@polar-sh/orbit'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import {
   DataTable,
   DataTableColumnDef,
 } from '@polar-sh/ui/components/atoms/DataTable'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
-import { Status } from '@polar-sh/ui/components/atoms/Status'
-import { formatCurrency } from '@polar-sh/currency'
-import { twMerge } from 'tailwind-merge'
-import { BillingOrder } from './mockData'
+import Pill from '@polar-sh/ui/components/atoms/Pill'
+import { useCallback } from 'react'
 
 const formatPrice = formatCurrency('standard', 'en-US')
 
-const STATUS_LABEL: Record<BillingOrder['status'], string> = {
-  paid: 'Paid',
-  pending: 'Pending',
-  refunded: 'Refunded',
-  void: 'Void',
+type PillColor = React.ComponentProps<typeof Pill>['color']
+
+const STATUS: Record<string, { label: string; color: PillColor }> = {
+  paid: { label: 'Paid', color: 'green' },
+  pending: { label: 'Pending', color: 'yellow' },
+  refunded: { label: 'Refunded', color: 'purple' },
+  partially_refunded: { label: 'Partially refunded', color: 'purple' },
 }
 
-const STATUS_COLOR: Record<BillingOrder['status'], string> = {
-  paid: 'bg-emerald-100 text-emerald-500 dark:bg-emerald-950 dark:text-emerald-500',
-  pending:
-    'bg-yellow-100 text-yellow-500 dark:bg-yellow-950 dark:text-yellow-500',
-  refunded:
-    'bg-violet-100 text-violet-500 dark:bg-violet-950 dark:text-violet-400',
-  void: 'bg-red-100 text-red-500 dark:bg-red-950 dark:text-red-400',
+const BILLING_REASON_LABEL: Record<string, string> = {
+  purchase: 'Purchase',
+  subscription_create: 'Subscription',
+  subscription_cycle: 'Subscription renewal',
+  subscription_update: 'Subscription change',
 }
 
-export const BillingOrdersTable = ({ orders }: { orders: BillingOrder[] }) => {
-  const columns: DataTableColumnDef<BillingOrder>[] = [
+const formatDescription = (order: schemas['OrganizationOrder']): string => {
+  const reason =
+    BILLING_REASON_LABEL[order.billing_reason] ?? order.billing_reason
+  return `${order.product_name} — ${reason}`
+}
+
+const DownloadInvoiceButton = ({
+  organizationId,
+  order,
+}: {
+  organizationId: string
+  order: schemas['OrganizationOrder']
+}) => {
+  const getInvoice = useGetOrganizationOrderInvoice(organizationId)
+
+  const onClick = useCallback(async () => {
+    const result = await getInvoice.mutateAsync(order.id)
+    const opened = window.open(result.url, '_blank', 'noopener,noreferrer')
+    if (!opened) {
+      window.location.href = result.url
+    }
+  }, [getInvoice, order.id])
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      loading={getInvoice.isPending}
+      disabled={getInvoice.isPending}
+      aria-label={`Download invoice ${order.invoice_number}`}
+    >
+      <FileDownloadOutlined fontSize="small" />
+    </Button>
+  )
+}
+
+export const BillingOrdersTable = ({
+  organizationId,
+  orders,
+}: {
+  organizationId: string
+  orders: schemas['OrganizationOrder'][]
+}) => {
+  const columns: DataTableColumnDef<schemas['OrganizationOrder']>[] = [
     {
-      accessorKey: 'date',
+      accessorKey: 'created_at',
       header: 'Date',
       size: 110,
       cell: ({ row: { original } }) => (
-        <FormattedDateTime datetime={original.date} />
+        <FormattedDateTime datetime={original.created_at} />
       ),
     },
     {
       accessorKey: 'description',
       header: 'Description',
-      size: 200,
+      size: 240,
       cell: ({ row: { original } }) => (
-        <Text as="span">{original.description}</Text>
+        <Text as="span">{formatDescription(original)}</Text>
       ),
     },
     {
-      accessorKey: 'amount',
+      accessorKey: 'total_amount',
       header: 'Amount',
-      size: 90,
+      size: 100,
       cell: ({ row: { original } }) => (
         <Text as="span" variant="label">
-          {formatPrice(original.amount, original.currency)}
+          {formatPrice(original.total_amount, original.currency)}
         </Text>
       ),
     },
     {
       accessorKey: 'status',
       header: 'Status',
-      size: 90,
-      cell: ({ row: { original } }) => (
-        <Status
-          className={twMerge(STATUS_COLOR[original.status], 'w-fit')}
-          status={STATUS_LABEL[original.status]}
-        />
-      ),
+      size: 130,
+      cell: ({ row: { original } }) => {
+        const entry = STATUS[original.status]
+        return (
+          <Pill color={entry?.color ?? 'gray'}>
+            {entry?.label ?? original.status}
+          </Pill>
+        )
+      },
     },
     {
       id: 'actions',
       header: () => null,
       size: 56,
-      cell: ({ row: { original } }) => (
-        <Box display="flex" justifyContent="end">
-          <a
-            href={original.invoiceUrl}
-            aria-label={`Download invoice ${original.number}`}
-            className="dark:text-polar-400 dark:hover:bg-polar-700 inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:hover:text-white"
-          >
-            <FileDownloadOutlined fontSize="small" />
-          </a>
-        </Box>
-      ),
+      cell: ({ row: { original } }) =>
+        original.is_invoice_generated ? (
+          <Box display="flex" justifyContent="end">
+            <DownloadInvoiceButton
+              organizationId={organizationId}
+              order={original}
+            />
+          </Box>
+        ) : null,
     },
   ]
 

--- a/clients/apps/web/src/components/Settings/Billing/mockData.ts
+++ b/clients/apps/web/src/components/Settings/Billing/mockData.ts
@@ -39,17 +39,6 @@ export type BillingSubscription = {
   }
 }
 
-export type BillingOrder = {
-  id: string
-  number: string
-  date: string
-  description: string
-  amount: number
-  currency: string
-  status: 'paid' | 'pending' | 'refunded' | 'void'
-  invoiceUrl: string
-}
-
 export const BILLING_PLANS: BillingPlan[] = [
   {
     id: 'starter',
@@ -127,69 +116,6 @@ export const MOCK_SUBSCRIPTION: BillingSubscription = {
     last4: '4242',
   },
 }
-
-export const MOCK_ORDERS: BillingOrder[] = [
-  {
-    id: 'ord_9k2j',
-    number: 'POL-2026-0009',
-    date: '2026-04-12T09:30:00Z',
-    description: 'Pro subscription',
-    amount: 2000,
-    currency: 'USD',
-    status: 'paid',
-    invoiceUrl: '#',
-  },
-  {
-    id: 'ord_8h1f',
-    number: 'POL-2026-0008',
-    date: '2026-03-12T09:30:00Z',
-    description: 'Pro subscription',
-    amount: 2000,
-    currency: 'USD',
-    status: 'paid',
-    invoiceUrl: '#',
-  },
-  {
-    id: 'ord_7g0e',
-    number: 'POL-2026-0007',
-    date: '2026-02-12T09:30:00Z',
-    description: 'Pro subscription',
-    amount: 2000,
-    currency: 'USD',
-    status: 'paid',
-    invoiceUrl: '#',
-  },
-  {
-    id: 'ord_6f9d',
-    number: 'POL-2026-0006',
-    date: '2026-01-12T09:30:00Z',
-    description: 'Pro subscription',
-    amount: 2000,
-    currency: 'USD',
-    status: 'paid',
-    invoiceUrl: '#',
-  },
-  {
-    id: 'ord_5e8c',
-    number: 'POL-2025-0012',
-    date: '2025-12-12T09:30:00Z',
-    description: 'Pro subscription',
-    amount: 2000,
-    currency: 'USD',
-    status: 'paid',
-    invoiceUrl: '#',
-  },
-  {
-    id: 'ord_4d7b',
-    number: 'POL-2025-0011',
-    date: '2025-11-12T09:30:00Z',
-    description: 'Pro subscription',
-    amount: 2000,
-    currency: 'USD',
-    status: 'refunded',
-    invoiceUrl: '#',
-  },
-]
 
 export const getPlanById = (id: BillingPlanId): BillingPlan =>
   BILLING_PLANS.find((p) => p.id === id) ?? BILLING_PLANS[0]

--- a/clients/apps/web/src/hooks/queries/billing.ts
+++ b/clients/apps/web/src/hooks/queries/billing.ts
@@ -42,6 +42,34 @@ export type OrganizationPaymentMethodAddResult = {
   client_secret: string
 }
 
+export const useOrganizationOrders = (organizationId: string) =>
+  useQuery({
+    queryKey: ['organization-billing', organizationId, 'orders'],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/organizations/{id}/orders', {
+          params: {
+            path: { id: organizationId },
+            query: { page: 1, limit: 50 },
+          },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!organizationId,
+  })
+
+export const useGetOrganizationOrderInvoice = (organizationId: string) =>
+  useMutation({
+    mutationFn: (orderId: string) =>
+      unwrap(
+        api.GET('/v1/organizations/{id}/orders/{order_id}/invoice', {
+          params: {
+            path: { id: organizationId, order_id: orderId },
+          },
+        }),
+      ),
+  })
+
 export const useOrganizationPlans = (organizationId: string) =>
   useQuery({
     queryKey: ['organization-billing', organizationId, 'plans'],

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1014,6 +1014,46 @@ export interface paths {
     patch: operations['organizations:change_subscription_plan']
     trace?: never
   }
+  '/v1/organizations/{id}/orders': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Organization Orders
+     * @description List Polar orders billed to this organization.
+     */
+    get: operations['organizations:list_orders']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/organizations/{id}/orders/{order_id}/invoice': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Organization Order Invoice
+     * @description Get the invoice URL for a Polar order belonging to this organization.
+     */
+    get: operations['organizations:get_order_invoice']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/subscriptions/': {
     parameters: {
       query?: never
@@ -19713,6 +19753,12 @@ export interface components {
       items: components['schemas']['OrganizationMember'][]
       pagination: components['schemas']['Pagination']
     }
+    /** ListResource[OrganizationOrder] */
+    ListResource_OrganizationOrder_: {
+      /** Items */
+      items: components['schemas']['OrganizationOrder'][]
+      pagination: components['schemas']['Pagination']
+    }
     /** ListResource[Organization] */
     ListResource_Organization_: {
       /** Items */
@@ -23692,6 +23738,45 @@ export interface components {
       new_order: boolean
       /** New Subscription */
       new_subscription: boolean
+    }
+    /** OrganizationOrder */
+    OrganizationOrder: {
+      /** Id */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string
+      /** Invoice Number */
+      invoice_number: string
+      /** Status */
+      status: string
+      /** Paid */
+      paid: boolean
+      /**
+       * Total Amount
+       * @description Total amount in cents, after discount and tax.
+       */
+      total_amount: number
+      /**
+       * Refunded Amount
+       * @description Refunded amount in cents.
+       */
+      refunded_amount: number
+      /** Currency */
+      currency: string
+      /** Billing Reason */
+      billing_reason: string
+      /** Product Name */
+      product_name: string
+      /** Is Invoice Generated */
+      is_invoice_generated: boolean
+    }
+    /** OrganizationOrderInvoice */
+    OrganizationOrderInvoice: {
+      /** Url */
+      url: string
     }
     /** OrganizationPaymentStatus */
     OrganizationPaymentStatus: {
@@ -33162,6 +33247,92 @@ export interface operations {
         }
       }
       /** @description Organization or subscription not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:list_orders': {
+    parameters: {
+      query?: {
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_OrganizationOrder_']
+        }
+      }
+      /** @description Organization not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:get_order_invoice': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        order_id: string
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Order invoice URL returned. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrganizationOrderInvoice']
+        }
+      }
+      /** @description Order or invoice not found. */
       404: {
         headers: {
           [name: string]: unknown

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         Checkout,
         Customer,
         Member,
+        Order,
         Product,
         Subscription,
         SubscriptionProrationBehavior,
@@ -136,6 +137,83 @@ class PolarSelfClient:
 
     async def get_customer_by_external_id(self, external_id: str) -> Customer:
         return await self._sdk.customers.get_external_async(external_id=external_id)
+
+    async def get_customer_by_external_id_or_none(
+        self, external_id: str
+    ) -> Customer | None:
+        from polar_sdk.models.polarerror import PolarError
+
+        try:
+            return await self.get_customer_by_external_id(external_id)
+        except PolarError as e:
+            if e.status_code == 404:
+                return None
+            raise
+
+    async def list_customer_orders(
+        self,
+        *,
+        customer_id: str,
+        page: int = 1,
+        limit: int = 50,
+    ) -> tuple[list[Order], int]:
+        from polar_sdk.models import OrderSortProperty
+        from polar_sdk.models.polarerror import PolarError
+
+        with logfire.span(
+            "polar.list_customer_orders",
+            customer_id=customer_id,
+            page=page,
+            limit=limit,
+        ) as span:
+            try:
+                response = await self._sdk.orders.list_async(
+                    customer_id=customer_id,
+                    page=page,
+                    limit=limit,
+                    sorting=[OrderSortProperty.MINUS_CREATED_AT],
+                )
+            except PolarError as e:
+                _raise_error(span, e, "list_customer_orders")
+            except httpx.RequestError as e:
+                _raise_network_error(span, e, "list_customer_orders")
+
+            if response is None:
+                return [], 0
+            items = list(response.result.items)
+            total = response.result.pagination.total_count
+            span.set_attribute("order_count", len(items))
+            span.set_attribute("total_count", total)
+            return items, total
+
+    async def get_order(self, *, order_id: str) -> Order | None:
+        from polar_sdk.models.polarerror import PolarError
+
+        with logfire.span("polar.get_order", order_id=order_id) as span:
+            try:
+                return await self._sdk.orders.get_async(id=order_id)
+            except PolarError as e:
+                if e.status_code == 404:
+                    span.set_attribute("not_found", True)
+                    return None
+                _raise_error(span, e, "get_order")
+            except httpx.RequestError as e:
+                _raise_network_error(span, e, "get_order")
+
+    async def get_order_invoice(self, *, order_id: str) -> str | None:
+        from polar_sdk.models.polarerror import PolarError
+
+        with logfire.span("polar.get_order_invoice", order_id=order_id) as span:
+            try:
+                invoice = await self._sdk.orders.invoice_async(id=order_id)
+            except PolarError as e:
+                if e.status_code == 404:
+                    span.set_attribute("not_found", True)
+                    return None
+                _raise_error(span, e, "get_order_invoice")
+            except httpx.RequestError as e:
+                _raise_network_error(span, e, "get_order_invoice")
+            return invoice.url
 
     async def list_recurring_products(self, *, organization_id: str) -> list[Product]:
         from polar_sdk.models import ProductVisibility

--- a/server/polar/integrations/polar/schemas.py
+++ b/server/polar/integrations/polar/schemas.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from polar.kit.schemas import Schema
 
 if TYPE_CHECKING:
-    from polar_sdk.models import Checkout, Product, Subscription
+    from polar_sdk.models import Checkout, Order, Product, Subscription
 
 
 class OrganizationPlanPrice(Schema):
@@ -153,3 +153,40 @@ class OrganizationCheckoutResponse(Schema):
 
 class OrganizationSubscriptionUpdate(Schema):
     product_id: str = Field(description="Polar product ID to switch the plan to.")
+
+
+class OrganizationOrder(Schema):
+    id: str
+    created_at: datetime
+    invoice_number: str
+    status: str
+    paid: bool
+    total_amount: int = Field(
+        description="Total amount in cents, after discount and tax."
+    )
+    refunded_amount: int = Field(description="Refunded amount in cents.")
+    currency: str
+    billing_reason: str
+    product_name: str
+    is_invoice_generated: bool
+
+    @classmethod
+    def from_sdk(cls, order: "Order") -> "OrganizationOrder":
+        product = order.product
+        return cls(
+            id=order.id,
+            created_at=order.created_at,
+            invoice_number=order.invoice_number,
+            status=order.status.value,
+            paid=order.paid,
+            total_amount=order.total_amount,
+            refunded_amount=order.refunded_amount,
+            currency=order.currency,
+            billing_reason=order.billing_reason.value,
+            product_name=product.name if product is not None else order.description,
+            is_invoice_generated=order.is_invoice_generated,
+        )
+
+
+class OrganizationOrderInvoice(Schema):
+    url: str

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -18,7 +18,14 @@ from polar.worker import enqueue_job
 from .client import get_client
 
 if TYPE_CHECKING:
-    from polar_sdk.models import BenefitGrant, Checkout, Customer, Product, Subscription
+    from polar_sdk.models import (
+        BenefitGrant,
+        Checkout,
+        Customer,
+        Order,
+        Product,
+        Subscription,
+    )
 
 
 BenefitGrantWebhookPayload = (
@@ -55,6 +62,12 @@ class PolarSelfNoActiveSubscription(PolarError):
             status_code=404,
         )
         self.organization_id = organization_id
+
+
+class PolarSelfOrderNotFound(PolarError):
+    def __init__(self, order_id: str) -> None:
+        super().__init__(f"Order {order_id!r} not found.", status_code=404)
+        self.order_id = order_id
 
 
 class PolarSelfService:
@@ -220,6 +233,51 @@ class PolarSelfService:
             subscription_id=subscription.id,
             product_id=product_id,
         )
+
+    async def list_orders(
+        self,
+        organization_id: uuid.UUID,
+        *,
+        page: int = 1,
+        limit: int = 50,
+    ) -> tuple[list["Order"], int]:
+        if not self.is_configured:
+            raise PolarSelfNotConfigured()
+
+        client = get_client()
+        customer = await client.get_customer_by_external_id_or_none(
+            str(organization_id)
+        )
+        if customer is None:
+            return [], 0
+
+        return await client.list_customer_orders(
+            customer_id=customer.id,
+            page=page,
+            limit=limit,
+        )
+
+    async def get_order_invoice_url(
+        self, organization_id: uuid.UUID, order_id: str
+    ) -> str:
+        if not self.is_configured:
+            raise PolarSelfNotConfigured()
+
+        client = get_client()
+        customer = await client.get_customer_by_external_id_or_none(
+            str(organization_id)
+        )
+        if customer is None:
+            raise PolarSelfOrderNotFound(order_id)
+
+        order = await client.get_order(order_id=order_id)
+        if order is None or order.customer_id != customer.id:
+            raise PolarSelfOrderNotFound(order_id)
+
+        url = await client.get_order_invoice(order_id=order_id)
+        if url is None:
+            raise PolarSelfOrderNotFound(order_id)
+        return url
 
     async def handle_benefit_grant_event(
         self, session: AsyncSession, payload: BenefitGrantWebhookPayload

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -28,6 +28,8 @@ from polar.exceptions import (
 from polar.integrations.polar.schemas import (
     OrganizationCheckoutRequest,
     OrganizationCheckoutResponse,
+    OrganizationOrder,
+    OrganizationOrderInvoice,
     OrganizationPlan,
     OrganizationSubscription,
     OrganizationSubscriptionUpdate,
@@ -837,3 +839,51 @@ async def change_subscription_plan(
         product_id=body.product_id,
     )
     return OrganizationSubscription.from_sdk(subscription)
+
+
+@router.get(
+    "/{id}/orders",
+    response_model=ListResource[OrganizationOrder],
+    summary="List Organization Orders",
+    responses={404: OrganizationNotFound},
+    tags=[APITag.private],
+)
+async def list_orders(
+    authz: AuthorizeOrgAccess,
+    pagination: PaginationParamsQuery,
+) -> ListResource[OrganizationOrder]:
+    """List Polar orders billed to this organization."""
+    items, total = await polar_self_service.list_orders(
+        authz.organization.id,
+        page=pagination.page,
+        limit=pagination.limit,
+    )
+    return ListResource.from_paginated_results(
+        [OrganizationOrder.from_sdk(order) for order in items],
+        total,
+        pagination,
+    )
+
+
+@router.get(
+    "/{id}/orders/{order_id}/invoice",
+    response_model=OrganizationOrderInvoice,
+    summary="Get Organization Order Invoice",
+    responses={
+        200: {"description": "Order invoice URL returned."},
+        404: {
+            "description": "Order or invoice not found.",
+            "model": ResourceNotFound.schema(),
+        },
+    },
+    tags=[APITag.private],
+)
+async def get_order_invoice(
+    authz: AuthorizeOrgAccess,
+    order_id: str,
+) -> OrganizationOrderInvoice:
+    """Get the invoice URL for a Polar order belonging to this organization."""
+    url = await polar_self_service.get_order_invoice_url(
+        authz.organization.id, order_id
+    )
+    return OrganizationOrderInvoice(url=url)

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -7,6 +7,7 @@ import pytest
 from polar_sdk.models import (
     BenefitGrant,
     CustomerIndividual,
+    Order,
     Product,
     Subscription,
     WebhookBenefitGrantCreatedPayload,
@@ -17,6 +18,7 @@ from pytest_mock import MockerFixture
 from polar.integrations.polar.service import (
     PolarSelfNoActiveSubscription,
     PolarSelfNotConfigured,
+    PolarSelfOrderNotFound,
     PolarSelfPlanNotFound,
     PolarSelfWebhookError,
     SupportBenefitError,
@@ -828,3 +830,164 @@ class TestChangePlan:
             subscription_id="sub_existing",
             product_id="prod_2",
         )
+
+
+def _make_order(
+    *,
+    id: str = "ord_1",
+    customer_id: str = _CUSTOMER_ID,
+    product_id: str = "prod_1",
+    status: str = "paid",
+) -> Order:
+    return Order.model_validate(
+        {
+            "id": id,
+            "created_at": "2026-01-01T00:00:00Z",
+            "modified_at": None,
+            "status": status,
+            "paid": status == "paid",
+            "subtotal_amount": 2000,
+            "discount_amount": 0,
+            "net_amount": 2000,
+            "tax_amount": 0,
+            "total_amount": 2000,
+            "applied_balance_amount": 0,
+            "due_amount": 2000,
+            "refunded_amount": 0,
+            "refunded_tax_amount": 0,
+            "currency": "usd",
+            "billing_reason": "subscription_cycle",
+            "billing_name": None,
+            "billing_address": None,
+            "invoice_number": "POLAR-0001",
+            "is_invoice_generated": True,
+            "customer_id": customer_id,
+            "product_id": product_id,
+            "discount_id": None,
+            "subscription_id": "00000000-0000-0000-0000-000000000001",
+            "checkout_id": None,
+            "metadata": {},
+            "platform_fee_amount": 0,
+            "platform_fee_currency": None,
+            "customer": _CUSTOMER_DICT,
+            "product": _make_product(id=product_id).model_dump(mode="json"),
+            "discount": None,
+            "subscription": None,
+            "items": [],
+            "description": "Pro subscription",
+        }
+    )
+
+
+@pytest.fixture
+def orders_client_mock(mocker: MockerFixture) -> MagicMock:
+    client = MagicMock()
+    client.get_customer_by_external_id_or_none = AsyncMock(
+        return_value=_make_customer(external_id=str(ORG_A))
+    )
+    client.list_customer_orders = AsyncMock(return_value=([], 0))
+    client.get_order = AsyncMock(return_value=None)
+    client.get_order_invoice = AsyncMock(return_value=None)
+    mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+    return client
+
+
+@pytest.mark.asyncio
+class TestListOrders:
+    async def test_not_configured_raises(self, mocker: MockerFixture) -> None:
+        settings = mocker.patch("polar.integrations.polar.service.settings")
+        settings.POLAR_SELF_ENABLED = False
+
+        with pytest.raises(PolarSelfNotConfigured):
+            await polar_self.list_orders(ORG_A)
+
+    async def test_returns_empty_when_customer_not_found(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        orders_client_mock.get_customer_by_external_id_or_none.return_value = None
+
+        items, total = await polar_self.list_orders(ORG_A)
+
+        assert items == []
+        assert total == 0
+        orders_client_mock.list_customer_orders.assert_not_awaited()
+
+    async def test_lists_orders_for_resolved_customer(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        order = _make_order(id="ord_1")
+        orders_client_mock.list_customer_orders.return_value = ([order], 1)
+
+        items, total = await polar_self.list_orders(ORG_A, page=2, limit=20)
+
+        assert items == [order]
+        assert total == 1
+        orders_client_mock.list_customer_orders.assert_awaited_once_with(
+            customer_id=_CUSTOMER_ID,
+            page=2,
+            limit=20,
+        )
+
+
+@pytest.mark.asyncio
+class TestGetOrderInvoiceUrl:
+    async def test_not_configured_raises(self, mocker: MockerFixture) -> None:
+        settings = mocker.patch("polar.integrations.polar.service.settings")
+        settings.POLAR_SELF_ENABLED = False
+
+        with pytest.raises(PolarSelfNotConfigured):
+            await polar_self.get_order_invoice_url(ORG_A, "ord_1")
+
+    async def test_customer_not_found_raises_order_not_found(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        orders_client_mock.get_customer_by_external_id_or_none.return_value = None
+
+        with pytest.raises(PolarSelfOrderNotFound):
+            await polar_self.get_order_invoice_url(ORG_A, "ord_1")
+
+        orders_client_mock.get_order.assert_not_awaited()
+
+    async def test_order_not_found(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        orders_client_mock.get_order.return_value = None
+
+        with pytest.raises(PolarSelfOrderNotFound):
+            await polar_self.get_order_invoice_url(ORG_A, "ord_1")
+
+        orders_client_mock.get_order_invoice.assert_not_awaited()
+
+    async def test_order_belongs_to_other_customer(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        orders_client_mock.get_order.return_value = _make_order(
+            customer_id="some-other-customer"
+        )
+
+        with pytest.raises(PolarSelfOrderNotFound):
+            await polar_self.get_order_invoice_url(ORG_A, "ord_1")
+
+        orders_client_mock.get_order_invoice.assert_not_awaited()
+
+    async def test_invoice_not_available_raises(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        orders_client_mock.get_order.return_value = _make_order()
+        orders_client_mock.get_order_invoice.return_value = None
+
+        with pytest.raises(PolarSelfOrderNotFound):
+            await polar_self.get_order_invoice_url(ORG_A, "ord_1")
+
+    async def test_returns_invoice_url(
+        self, configured: None, orders_client_mock: MagicMock
+    ) -> None:
+        orders_client_mock.get_order.return_value = _make_order()
+        orders_client_mock.get_order_invoice.return_value = (
+            "https://example.com/inv.pdf"
+        )
+
+        url = await polar_self.get_order_invoice_url(ORG_A, "ord_1")
+
+        assert url == "https://example.com/inv.pdf"
+        orders_client_mock.get_order_invoice.assert_awaited_once_with(order_id="ord_1")


### PR DESCRIPTION
## Summary

- Replaces the mocked order history on the org billing page with the live list of orders billed to the organization via the upstream Polar SaaS.
- Adds two private endpoints — `GET /v1/organizations/{id}/orders` and `GET /v1/organizations/{id}/orders/{order_id}/invoice` — that proxy through to Polar via the SDK. The invoice endpoint resolves the upstream customer by `external_id = org.id` and verifies `order.customer_id` matches before returning the presigned invoice URL, so an org cannot read another org's invoice.
- Frontend rebuilds the orders table against the new `OrganizationOrder` schema: Orbit `Button` (ghost/icon) for downloads, Orbit `Pill` with semantic colors for status, paginated query (page 1, limit 50) for now.

## Test plan

- [ ] `cd server && uv run pytest tests/integrations/polar/test_service.py` (covers list/invoice happy paths, cross-customer IDOR, missing customer, missing order, missing invoice).
- [ ] `cd server && uv run task lint_types`.
- [ ] `cd clients/apps/web && pnpm typecheck && pnpm lint`.
- [ ] Manually: open an org's Billing settings, confirm orders load, status pills render, "Download invoice" opens the presigned URL in a new tab, empty state renders when an org has no orders yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)