### PR TITLE
docs: clarify payout delay scope and rationale

### DIFF
--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -8,9 +8,9 @@ You can issue a withdrawal — also called a payout — once your balance meets 
 
 ## Payout Delay
 
-Transactions are subject to a **7-day settlement delay** from the date they occur before the corresponding funds become available for payout. This applies to all new accounts by default — existing accounts that were created before this policy was introduced have no delay.
+Transactions are subject to a **7-day settlement delay** from the date they occur before the corresponding funds become available for payout. This delay applies by default to organizations created on or after May 12, 2026. Organizations created before this date continue to receive instant payouts.
 
-Polar reserves the right to increase this delay or place specific transactions on hold if deemed necessary for risk management or compliance purposes.
+We may also extend this delay or hold specific transactions when it makes sense — most commonly to align your settlement window with your refund policy, and occasionally for risk or compliance reasons.
 
 ## Minimum Payout Thresholds
 


### PR DESCRIPTION
Switch from "accounts" to "organizations", anchor the cutoff to May 12, 2026, and rephrase the discretionary delay sentence to lead with the refund-policy alignment use case instead of legal phrasing.