### PR TITLE
feat: sync Polar org subscription tier to Plain tenant

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -9,6 +9,7 @@ import pycountry
 import pycountry.db
 import structlog
 from plain_client import (
+    AddCustomerToTenantsInput,
     ComponentContainerContentInput,
     ComponentContainerInput,
     ComponentCopyButtonInput,
@@ -28,13 +29,18 @@ from plain_client import (
     CustomerIdentifierInput,
     EmailAddressInput,
     Plain,
+    RemoveCustomerFromTenantsInput,
+    TenantIdentifierInput,
     ThreadsFilter,
     ThreadStatus,
+    TierIdentifierInput,
+    UpdateTenantTierInput,
     UpsertCustomerIdentifierInput,
     UpsertCustomerInput,
     UpsertCustomerOnCreateInput,
     UpsertCustomerOnUpdateInput,
     UpsertCustomerUpsertCustomer,
+    UpsertTenantInput,
 )
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
@@ -91,6 +97,16 @@ class PlainCustomerError(PlainServiceError):
         self.user_id = user_id
         self.message = message
         super().__init__(f"Error with Plain customer for user ID {user_id}: {message}")
+
+
+class TenantOperationError(PlainServiceError):
+    def __init__(self, tenant_external_id: str, operation: str, message: str) -> None:
+        self.tenant_external_id = tenant_external_id
+        self.operation = operation
+        self.message = message
+        super().__init__(
+            f"Plain tenant {operation} failed for {tenant_external_id!r}: {message}"
+        )
 
 
 class FeedbackThreadCreationError(PlainServiceError):
@@ -1369,6 +1385,87 @@ class PlainService:
                     nr_threads += 1
             log.info(f"There are {nr_threads} threads for user {customer_email}")
             return nr_threads > 0
+
+    async def upsert_tenant(self, *, external_id: str, name: str) -> None:
+        if not self.enabled:
+            return
+
+        async with self._get_plain_client() as plain:
+            result = await plain.upsert_tenant(
+                UpsertTenantInput(
+                    identifier=TenantIdentifierInput(external_id=external_id),
+                    name=name,
+                    external_id=external_id,
+                )
+            )
+            if result.error is not None:
+                raise TenantOperationError(external_id, "upsert", result.error.message)
+
+    async def add_customer_to_tenant(
+        self, *, customer_external_id: str, tenant_external_id: str
+    ) -> None:
+        if not self.enabled:
+            return
+
+        async with self._get_plain_client() as plain:
+            result = await plain.add_customer_to_tenants(
+                AddCustomerToTenantsInput(
+                    customer_identifier=CustomerIdentifierInput(
+                        external_id=customer_external_id
+                    ),
+                    tenant_identifiers=[
+                        TenantIdentifierInput(external_id=tenant_external_id)
+                    ],
+                )
+            )
+            if result.error is not None:
+                raise TenantOperationError(
+                    tenant_external_id, "add_customer", result.error.message
+                )
+
+    async def remove_customer_from_tenant(
+        self, *, customer_external_id: str, tenant_external_id: str
+    ) -> None:
+        if not self.enabled:
+            return
+
+        async with self._get_plain_client() as plain:
+            result = await plain.remove_customer_from_tenants(
+                RemoveCustomerFromTenantsInput(
+                    customer_identifier=CustomerIdentifierInput(
+                        external_id=customer_external_id
+                    ),
+                    tenant_identifiers=[
+                        TenantIdentifierInput(external_id=tenant_external_id)
+                    ],
+                )
+            )
+            if result.error is not None:
+                raise TenantOperationError(
+                    tenant_external_id, "remove_customer", result.error.message
+                )
+
+    async def update_tenant_tier(
+        self, *, tenant_external_id: str, tier_external_id: str | None
+    ) -> None:
+        if not self.enabled:
+            return
+
+        async with self._get_plain_client() as plain:
+            result = await plain.update_tenant_tier(
+                UpdateTenantTierInput(
+                    tenant_identifier=TenantIdentifierInput(
+                        external_id=tenant_external_id
+                    ),
+                    tier_identifier=TierIdentifierInput(external_id=tier_external_id)
+                    if tier_external_id is not None
+                    else None,
+                )
+            )
+            if result.error is not None:
+                raise TenantOperationError(
+                    tenant_external_id, "update_tier", result.error.message
+                )
 
     @contextlib.asynccontextmanager
     async def _get_plain_client(self) -> AsyncIterator[Plain]:

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -12,6 +12,7 @@ from polar_sdk.models import (
 from polar.account.repository import AccountRepository
 from polar.config import settings
 from polar.exceptions import PolarError
+from polar.integrations.plain.service import plain as plain_service
 from polar.postgres import AsyncSession
 from polar.worker import enqueue_job
 
@@ -338,11 +339,19 @@ class PolarSelfService:
 
     def _extract_support(
         self, metadata: dict[str, Any], benefit_id: str
-    ) -> tuple[int, bool, bool]:
+    ) -> tuple[int, bool, bool, str | None]:
         level = self._parse_support_level(metadata, benefit_id)
         slack = self._parse_bool_metadata(metadata, "slack", benefit_id)
         prioritized = self._parse_bool_metadata(metadata, "prioritized", benefit_id)
-        return level, slack, prioritized
+        plain_tier_external_id = metadata.get("plain_tier_external_id")
+        if plain_tier_external_id is not None and not (
+            isinstance(plain_tier_external_id, str) and plain_tier_external_id
+        ):
+            raise SupportBenefitError(
+                f"Benefit {benefit_id} has invalid plain_tier_external_id: "
+                f"{plain_tier_external_id!r}"
+            )
+        return level, slack, prioritized, plain_tier_external_id
 
     def _parse_support_level(self, metadata: dict[str, Any], benefit_id: str) -> int:
         value = metadata.get("level")
@@ -387,19 +396,24 @@ class PolarSelfService:
             level: int | None = None
             slack: bool | None = None
             prioritized: bool | None = None
+            plain_tier_external_id: str | None = None
         else:
-            level, slack, prioritized = self._extract_support(
+            level, slack, prioritized, plain_tier_external_id = self._extract_support(
                 grant.benefit.metadata or {}, grant.benefit_id
             )
 
-        # TODO: persist once support tier fields exist on the org/account.
-        logfire.info(
+        with logfire.span(
             "polar_self.webhook.support.applied",
             organization_id=str(organization_id),
             level=level,
             slack=slack,
             prioritized=prioritized,
-        )
+            plain_tier_external_id=plain_tier_external_id,
+        ):
+            await plain_service.update_tenant_tier(
+                tenant_external_id=str(organization_id),
+                tier_external_id=plain_tier_external_id,
+            )
 
     async def _fetch_active_grant(
         self, customer_id: str, benefit_type: str

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -12,6 +12,7 @@ from polar_sdk.models import (
 from polar.config import settings
 from polar.event.repository import EventRepository
 from polar.external_event.service import external_event as external_event_service
+from polar.integrations.plain.service import plain as plain_service
 from polar.kit.utils import utc_now
 from polar.models.external_event import ExternalEventSource
 from polar.worker import (
@@ -48,6 +49,7 @@ async def create_customer(
         external_customer_id=external_id,
         product_id=product_id,
     )
+    await plain_service.upsert_tenant(external_id=external_id, name=name)
 
 
 @actor(actor_name="polar_self.create_free_subscription", priority=TaskPriority.LOW)
@@ -78,6 +80,10 @@ async def add_member(
         name=name,
         external_id=external_id,
     )
+    await plain_service.add_customer_to_tenant(
+        customer_external_id=external_id,
+        tenant_external_id=external_customer_id,
+    )
 
 
 @actor(actor_name="polar_self.remove_member", priority=TaskPriority.LOW)
@@ -100,6 +106,10 @@ async def remove_member(external_customer_id: str, external_id: str) -> None:
     await client.remove_member(
         external_customer_id=external_customer_id,
         external_id=external_id,
+    )
+    await plain_service.remove_customer_from_tenant(
+        customer_external_id=external_id,
+        tenant_external_id=external_customer_id,
     )
 
 

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -201,6 +201,16 @@ def set_platform_fee_mock(mocker: MockerFixture) -> AsyncMock:
 
 
 @pytest.fixture
+def plain_update_tenant_tier_mock(mocker: MockerFixture) -> AsyncMock:
+    mock = AsyncMock()
+    mocker.patch(
+        "polar.integrations.polar.service.plain_service.update_tenant_tier",
+        mock,
+    )
+    return mock
+
+
+@pytest.fixture
 def list_grants_mock(mocker: MockerFixture) -> AsyncMock:
     client = MagicMock()
     client.list_customer_benefit_grants = AsyncMock(return_value=[])
@@ -353,17 +363,28 @@ class TestExtractSupport:
     def test_valid(self) -> None:
         assert polar_self._extract_support(
             {"level": "2", "slack": "true", "prioritized": "false"}, _BENEFIT_ID
-        ) == (2, True, False)
+        ) == (2, True, False, None)
 
     def test_native_typed_values(self) -> None:
         assert polar_self._extract_support(
             {"level": 2, "slack": True, "prioritized": False}, _BENEFIT_ID
-        ) == (2, True, False)
+        ) == (2, True, False, None)
 
     def test_whole_float_level(self) -> None:
         assert polar_self._extract_support(
             {"level": 2.0, "slack": True, "prioritized": False}, _BENEFIT_ID
-        ) == (2, True, False)
+        ) == (2, True, False, None)
+
+    def test_plain_tier_external_id(self) -> None:
+        assert polar_self._extract_support(
+            {
+                "level": "2",
+                "slack": "true",
+                "prioritized": "false",
+                "plain_tier_external_id": "pro",
+            },
+            _BENEFIT_ID,
+        ) == (2, True, False, "pro")
 
     @pytest.mark.parametrize(
         ("metadata", "match"),
@@ -378,6 +399,42 @@ class TestExtractSupport:
             ({"level": "1", "slack": "true"}, "prioritized"),
             ({"level": "1", "slack": "true", "prioritized": "yes"}, "prioritized"),
             ({"level": "1", "slack": "true", "prioritized": 0}, "prioritized"),
+            (
+                {
+                    "level": "1",
+                    "slack": "true",
+                    "prioritized": "true",
+                    "plain_tier_external_id": 123,
+                },
+                "plain_tier_external_id",
+            ),
+            (
+                {
+                    "level": "1",
+                    "slack": "true",
+                    "prioritized": "true",
+                    "plain_tier_external_id": 0,
+                },
+                "plain_tier_external_id",
+            ),
+            (
+                {
+                    "level": "1",
+                    "slack": "true",
+                    "prioritized": "true",
+                    "plain_tier_external_id": False,
+                },
+                "plain_tier_external_id",
+            ),
+            (
+                {
+                    "level": "1",
+                    "slack": "true",
+                    "prioritized": "true",
+                    "plain_tier_external_id": "",
+                },
+                "plain_tier_external_id",
+            ),
         ],
     )
     def test_invalid_field_raises(self, metadata: dict[str, Any], match: str) -> None:
@@ -436,13 +493,50 @@ class TestApplyTransactionFee:
 
 @pytest.mark.asyncio
 class TestApplySupport:
-    async def test_active_grant(self, session_mock: AsyncSession) -> None:
+    async def test_active_grant(
+        self,
+        session_mock: AsyncSession,
+        plain_update_tenant_tier_mock: AsyncMock,
+    ) -> None:
         grant = _make_support_grant()
 
         await polar_self._apply_support(session_mock, ORG_A, grant)
 
-    async def test_no_grant(self, session_mock: AsyncSession) -> None:
+        plain_update_tenant_tier_mock.assert_awaited_once_with(
+            tenant_external_id=str(ORG_A), tier_external_id=None
+        )
+
+    async def test_active_grant_with_plain_tier(
+        self,
+        session_mock: AsyncSession,
+        plain_update_tenant_tier_mock: AsyncMock,
+    ) -> None:
+        grant = _make_grant(
+            metadata={
+                "type": "support",
+                "level": "2",
+                "slack": "true",
+                "prioritized": "true",
+                "plain_tier_external_id": "pro",
+            }
+        )
+
+        await polar_self._apply_support(session_mock, ORG_A, grant)
+
+        plain_update_tenant_tier_mock.assert_awaited_once_with(
+            tenant_external_id=str(ORG_A), tier_external_id="pro"
+        )
+
+    async def test_no_grant_unsets_tier(
+        self,
+        session_mock: AsyncSession,
+        plain_update_tenant_tier_mock: AsyncMock,
+    ) -> None:
         await polar_self._apply_support(session_mock, ORG_A, None)
+
+        plain_update_tenant_tier_mock.assert_awaited_once_with(
+            tenant_external_id=str(ORG_A), tier_external_id=None
+        )
 
     async def test_invalid_metadata_raises(self, session_mock: AsyncSession) -> None:
         grant = _make_support_grant(level="two")

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -11,6 +11,7 @@ from pytest_mock import MockerFixture
 from polar.integrations.polar.client import PolarSelfClient
 from polar.integrations.polar.tasks import (
     add_member,
+    create_customer,
     delete_customer,
     remove_member,
     track_event_ingestion,
@@ -18,11 +19,58 @@ from polar.integrations.polar.tasks import (
 )
 
 
+@pytest.fixture
+def plain_service_mock(mocker: MockerFixture) -> MagicMock:
+    mock = MagicMock()
+    mock.upsert_tenant = AsyncMock()
+    mock.add_customer_to_tenant = AsyncMock()
+    mock.remove_customer_from_tenant = AsyncMock()
+    mocker.patch("polar.integrations.polar.tasks.plain_service", mock)
+    return mock
+
+
+@pytest.mark.asyncio
+class TestCreateCustomer:
+    async def test_creates_customer_subscription_and_plain_tenant(
+        self,
+        mocker: MockerFixture,
+        plain_service_mock: MagicMock,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await create_customer(
+            external_id="org-123",
+            name="Acme Inc",
+            organization_id="self-org",
+            product_id="prod-free",
+            owner_external_id="user-123",
+            owner_email="owner@example.com",
+            owner_name="Owner",
+        )
+
+        client.create_customer.assert_called_once_with(
+            external_id="org-123",
+            name="Acme Inc",
+            owner_external_id="user-123",
+            owner_email="owner@example.com",
+            owner_name="Owner",
+        )
+        client.create_free_subscription.assert_called_once_with(
+            external_customer_id="org-123",
+            product_id="prod-free",
+        )
+        plain_service_mock.upsert_tenant.assert_awaited_once_with(
+            external_id="org-123", name="Acme Inc"
+        )
+
+
 @pytest.mark.asyncio
 class TestAddMember:
     async def test_adds_member_to_existing_customer(
         self,
         mocker: MockerFixture,
+        plain_service_mock: MagicMock,
     ) -> None:
         fake_customer = MagicMock(id="polar-customer-123")
         client = AsyncMock(spec=PolarSelfClient)
@@ -42,6 +90,10 @@ class TestAddMember:
             email="user@example.com",
             name="User Example",
             external_id="user-123",
+        )
+        plain_service_mock.add_customer_to_tenant.assert_awaited_once_with(
+            customer_external_id="user-123",
+            tenant_external_id="org-123",
         )
 
     async def test_retries_when_customer_is_not_ready(
@@ -103,6 +155,7 @@ class TestRemoveMember:
     async def test_removes_existing_member(
         self,
         mocker: MockerFixture,
+        plain_service_mock: MagicMock,
     ) -> None:
         client = AsyncMock(spec=PolarSelfClient)
         client.get_member_by_external_id.return_value = MagicMock(id="member-123")
@@ -120,6 +173,10 @@ class TestRemoveMember:
         client.remove_member.assert_called_once_with(
             external_customer_id="org-123",
             external_id="user-123",
+        )
+        plain_service_mock.remove_customer_from_tenant.assert_awaited_once_with(
+            customer_external_id="user-123",
+            tenant_external_id="org-123",
         )
 
     async def test_retries_when_member_is_not_ready(


### PR DESCRIPTION
## Summary

Wires the polar-for-polar self-billing flow into Plain Tenants so each Polar organization corresponds to a Plain Tenant (`externalId = org.id`), members sync as tenant customers, and the support benefit grant drives the tenant's tier.

- `polar_self.create_customer` now also upserts a Plain Tenant for the organization.
- `polar_self.add_member` / `remove_member` add and remove the user as a tenant customer (keyed by user external_id).
- The support `benefit_grant.*` webhook handler reads `plain_tier_external_id` from benefit metadata and calls `plain.update_tenant_tier` with the matching tier external id; an absent key clears the tier.
- Metadata is strictly validated: non-string or empty values raise `SupportBenefitError` instead of silently clearing the tier.

Plain operations are idempotent (`upsert_tenant`; membership add/remove are no-ops if already in the desired state), and the existing Polar SDK calls already handle 409 conflicts as success, so task retries after a Plain failure are safe end-to-end.

## Test plan

- [x] `uv run task lint` passes
- [x] `uv run task lint_types` passes
- [x] `tests/integrations/polar/` passes (89 tests, including new coverage for tenant upsert, add/remove customer, tier update, and metadata validation)
- [ ] Set `plain_tier_external_id` on each of the four support benefits in Polar product config before enabling in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)