### PR TITLE
clients/checkout: make sure to reprompt customer if the payment still requires action

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -52,10 +52,14 @@ const StripeRequiresAction = ({
       setPendingHandling(true)
       if (intent_status === 'requires_action') {
         try {
-          await stripe.handleNextAction({
+          const { paymentIntent, setupIntent } = await stripe.handleNextAction({
             clientSecret: intent_client_secret,
           })
-          setSuccess(true)
+          const currentIntentStatus =
+            paymentIntent?.status || setupIntent?.status
+          if (currentIntentStatus === 'succeeded') {
+            setSuccess(true)
+          }
         } catch (err) {
           // Case where the intent is already confirmed, but we didn't receive the webhook update yet
           if (

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -231,15 +231,19 @@ export const CheckoutFormProvider = ({
       const { intent_status, intent_client_secret } =
         updatedCheckout.payment_processor_metadata
 
-      if (intent_status === 'requires_action') {
-        const { error } = await stripe.handleNextAction({
-          clientSecret: intent_client_secret,
-        })
+      let currentIntentStatus = intent_status
+      while (currentIntentStatus === 'requires_action') {
+        const { error, paymentIntent, setupIntent } =
+          await stripe.handleNextAction({
+            clientSecret: intent_client_secret,
+          })
         if (error) {
           setLoading(false)
           setError('root', { message: error.message })
           throw new Error(error.message)
         }
+        currentIntentStatus =
+          paymentIntent?.status || setupIntent?.status || intent_status
       }
 
       setLoading(false)


### PR DESCRIPTION

Some merchants report that a few customers aren't able to complete their Cash App payments. After careful investigation, it seems that everything is working properly.

My main theory is those customers inadvertently close the Cash App modal before they complete the payment, which causes the checkout page to be in a stuck state without possibilty for them to try again.

Those changes make sure that we re-trigger the requires action prompt while the payment is still in requires action state, which should give customers the chance to complete their payment if they accidentally close the Cash App modal.
