### PR TITLE
billing: Show current plan if hidden, and only show custom plan if custom

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -136,8 +136,15 @@ export default function ChangePlanPage({
   } = useModal()
 
   const billingHref = `/dashboard/${organization.slug}/settings/billing`
-  const plans = useMemo(() => plansQuery.data ?? [], [plansQuery.data])
   const subscription = subscriptionQuery.data
+  const plans = useMemo(() => {
+    const data = plansQuery.data ?? []
+    if (!subscription) return data
+    const currentInList = data.some(
+      (p) => p.product_id === subscription.product_id,
+    )
+    return currentInList ? data : [...data, subscription.plan]
+  }, [plansQuery.data, subscription])
   const isCurrentPlanFree = subscription?.amount === 0
 
   const selectedPlan = useMemo(

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -137,14 +137,16 @@ export default function ChangePlanPage({
 
   const billingHref = `/dashboard/${organization.slug}/settings/billing`
   const subscription = subscriptionQuery.data
+  const isCurrentPlanCustom = subscription?.plan.custom === true
   const plans = useMemo(() => {
     const data = plansQuery.data ?? []
     if (!subscription) return data
+    if (isCurrentPlanCustom) return [subscription.plan]
     const currentInList = data.some(
       (p) => p.product_id === subscription.product_id,
     )
     return currentInList ? data : [...data, subscription.plan]
-  }, [plansQuery.data, subscription])
+  }, [plansQuery.data, subscription, isCurrentPlanCustom])
   const isCurrentPlanFree = subscription?.amount === 0
 
   const selectedPlan = useMemo(
@@ -237,8 +239,9 @@ export default function ChangePlanPage({
               Change plan
             </Text>
             <Text color="muted">
-              Pick a new plan for your Polar subscription. You can change again
-              at any time.
+              {isCurrentPlanCustom
+                ? 'You are on a custom plan. Send an email to support to change plan or discuss terms.'
+                : 'Pick a new plan for your Polar subscription. You can change again at any time.'}
             </Text>
           </Box>
         </Box>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23729,6 +23729,11 @@ export interface components {
        * @default false
        */
       highlight: boolean
+      /**
+       * Custom
+       * @default false
+       */
+      custom: boolean
       /** Features */
       features?: string[]
     }

--- a/server/polar/integrations/polar/schemas.py
+++ b/server/polar/integrations/polar/schemas.py
@@ -28,6 +28,7 @@ class OrganizationPlan(Schema):
     price: OrganizationPlanPrice | None = None
     transaction_fee: OrganizationPlanFee | None = None
     highlight: bool = False
+    custom: bool = False
     features: list[str] = Field(default_factory=list)
 
     @classmethod
@@ -76,6 +77,7 @@ class OrganizationPlan(Schema):
                 else None
             ),
             highlight=bool(metadata.get("highlight", False)),
+            custom=bool(metadata.get("custom", False)),
             features=[f.strip() for f in str(features_raw).split(",") if f.strip()],
         )
 


### PR DESCRIPTION
On a custom plan we only show the custom plan. If you are on a grandfathered (but hidden) plan it gets shown but allows you to switch