### PR TITLE
feat: accept checkout link success_url as setup readiness path

### DIFF
--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -103,6 +103,22 @@ class CheckoutLinkRepository(
         result = await self.session.execute(statement)
         return result.scalar_one_or_none() is not None
 
+    async def has_with_success_url(self, organization_id: UUID) -> bool:
+        """Whether the organization has any live checkout link with a
+        success_url set, meaning the merchant handles fulfillment by
+        redirecting customers to their own site after checkout."""
+        statement = (
+            select(CheckoutLink.id)
+            .where(
+                CheckoutLink.organization_id == organization_id,
+                CheckoutLink.deleted_at.is_(None),
+                CheckoutLink._success_url.isnot(None),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none() is not None
+
     async def archive_product(self, product_id: UUID) -> None:
         statement = (
             self.get_base_statement()

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1553,9 +1553,14 @@ class OrganizationService:
     async def _build_setup_readiness_check(
         self, session: AsyncReadSession, organization: Organization
     ) -> OrganizationReviewCheck:
-        """Setup readiness passes when the merchant either has a checkout
-        link selling a Polar-fulfilled benefit, or has both an organization
-        access token and a webhook endpoint.
+        """Setup readiness passes when the merchant has at least one
+        auto-fulfillable checkout link (selling a Polar-fulfilled benefit,
+        or with a success_url so the merchant handles fulfillment via
+        redirect), or has both an organization access token and a webhook
+        endpoint.
+
+        A checkout link with neither benefits nor a success_url has no
+        automatic fulfillment path, which is a broken integration.
 
         An access token without a webhook is a non-blocking warning rather
         than a failure: the merchant can still fulfill via success_url +
@@ -1567,7 +1572,7 @@ class OrganizationService:
         checkout_link_repository = CheckoutLinkRepository.from_session(session)
         if await checkout_link_repository.has_with_benefit_types(
             organization.id, _CHECKOUT_FULFILLABLE_BENEFITS
-        ):
+        ) or await checkout_link_repository.has_with_success_url(organization.id):
             return self._passed_check(key)
 
         access_token_repository = OrganizationAccessTokenRepository.from_session(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1802,6 +1802,43 @@ class TestGetReviewState:
         assert step.status == OrganizationReviewCheckStatus.PENDING
         assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
 
+    async def test_setup_readiness_checkout_link_with_success_url_passes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        product = await create_product(
+            save_fixture, organization=organization, recurring_interval=None
+        )
+        await create_checkout_link(
+            save_fixture,
+            products=[product],
+            success_url="https://example.com/thank-you",
+        )
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+
+    async def test_setup_readiness_checkout_link_without_benefits_or_success_url_is_not_started(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        product = await create_product(
+            save_fixture, organization=organization, recurring_interval=None
+        )
+        await create_checkout_link(save_fixture, products=[product])
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
+
+        assert step.status == OrganizationReviewCheckStatus.PENDING
+        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+
     async def test_setup_readiness_access_token_and_webhook_passes(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

We consider that the organization passed the setup review when they also have a success_url on their checkout links. Aside of the existing considtions

## Test plan

- [x] New unit test: checkout link with `success_url` passes setup readiness.
- [x] New unit test: checkout link without benefits or `success_url` keeps the check in `PENDING` / `not_started`.
- [x] Existing setup readiness tests still pass.
- [x] `uv run task lint` passes.
- [x] `uv run task lint_types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)