### PR TITLE
authz: enforce role-permission across admin org-context endpoints

### DIFF
--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -28,8 +28,7 @@ class OrganizationPermission(StrEnum):
 
     # Member management.
     members_read = "members:read"
-    members_invite = "members:invite"
-    members_remove = "members:remove"
+    members_manage = "members:manage"
     members_set_role = "members:set_role"
 
     # Finance — admin-only.
@@ -44,8 +43,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organizations_edit_settings,
     OrganizationPermission.organizations_delete,
     OrganizationPermission.organizations_manage_payout_account,
-    OrganizationPermission.members_invite,
-    OrganizationPermission.members_remove,
+    OrganizationPermission.members_manage,
     OrganizationPermission.members_set_role,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -29,7 +29,6 @@ class OrganizationPermission(StrEnum):
     # Member management.
     members_read = "members:read"
     members_manage = "members:manage"
-    members_set_role = "members:set_role"
 
     # Finance — admin-only.
     account_read = "account:read"
@@ -44,7 +43,6 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organizations_delete,
     OrganizationPermission.organizations_manage_payout_account,
     OrganizationPermission.members_manage,
-    OrganizationPermission.members_set_role,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,
     OrganizationPermission.payouts_read,

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -39,6 +39,10 @@ class OrganizationPermission(StrEnum):
     # Sales — granted to all roles.
     sales_read = "sales:read"
 
+    # Analytics.
+    analytics_read = "analytics:read"
+    analytics_manage = "analytics:manage"
+
     # Finance — admin-only.
     account_read = "account:read"
     account_write = "account:write"
@@ -49,6 +53,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.members_manage,
     OrganizationPermission.products_manage,
     OrganizationPermission.customers_manage,
+    OrganizationPermission.analytics_manage,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,
 }
@@ -58,6 +63,7 @@ _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.products_read,
     OrganizationPermission.customers_read,
     OrganizationPermission.sales_read,
+    OrganizationPermission.analytics_read,
 }
 
 ROLE_PERMISSIONS: dict[OrganizationRole, set[OrganizationPermission]] = {

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -28,6 +28,10 @@ class OrganizationPermission(StrEnum):
     members_read = "members:read"
     members_manage = "members:manage"
 
+    # Products.
+    products_read = "products:read"
+    products_manage = "products:manage"
+
     # Sales — granted to all roles.
     sales_read = "sales:read"
 
@@ -39,12 +43,14 @@ class OrganizationPermission(StrEnum):
 _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organization_manage,
     OrganizationPermission.members_manage,
+    OrganizationPermission.products_manage,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,
 }
 
 _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.members_read,
+    OrganizationPermission.products_read,
     OrganizationPermission.sales_read,
 }
 

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -32,6 +32,10 @@ class OrganizationPermission(StrEnum):
     products_read = "products:read"
     products_manage = "products:manage"
 
+    # Custom fields.
+    custom_fields_read = "custom_fields:read"
+    custom_fields_manage = "custom_fields:manage"
+
     # Customers.
     customers_read = "customers:read"
     customers_manage = "customers:manage"
@@ -52,6 +56,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organization_manage,
     OrganizationPermission.members_manage,
     OrganizationPermission.products_manage,
+    OrganizationPermission.custom_fields_manage,
     OrganizationPermission.customers_manage,
     OrganizationPermission.analytics_manage,
     OrganizationPermission.account_read,
@@ -61,6 +66,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
 _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.members_read,
     OrganizationPermission.products_read,
+    OrganizationPermission.custom_fields_read,
     OrganizationPermission.customers_read,
     OrganizationPermission.sales_read,
     OrganizationPermission.analytics_read,

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -48,8 +48,8 @@ class OrganizationPermission(StrEnum):
     analytics_manage = "analytics:manage"
 
     # Finance — admin-only.
-    account_read = "account:read"
-    account_write = "account:write"
+    finance_read = "finance:read"
+    finance_manage = "finance:manage"
 
 
 _ADMIN_ONLY: set[OrganizationPermission] = {
@@ -59,8 +59,8 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.custom_fields_manage,
     OrganizationPermission.customers_manage,
     OrganizationPermission.analytics_manage,
-    OrganizationPermission.account_read,
-    OrganizationPermission.account_write,
+    OrganizationPermission.finance_read,
+    OrganizationPermission.finance_manage,
 }
 
 _MEMBER_PERMISSIONS: set[OrganizationPermission] = {

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -22,9 +22,8 @@ from polar.models.user_organization import OrganizationRole
 
 class OrganizationPermission(StrEnum):
     # Org management.
-    organizations_edit_settings = "organizations:edit_settings"
-    organizations_delete = "organizations:delete"
-    organizations_manage_payout_account = "organizations:manage_payout_account"
+    organization_manage = "organization:manage"
+    organization_manage_payout_account = "organization:manage_payout_account"
 
     # Member management.
     members_read = "members:read"
@@ -39,9 +38,8 @@ class OrganizationPermission(StrEnum):
 
 
 _ADMIN_ONLY: set[OrganizationPermission] = {
-    OrganizationPermission.organizations_edit_settings,
-    OrganizationPermission.organizations_delete,
-    OrganizationPermission.organizations_manage_payout_account,
+    OrganizationPermission.organization_manage,
+    OrganizationPermission.organization_manage_payout_account,
     OrganizationPermission.members_manage,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -37,8 +37,6 @@ class OrganizationPermission(StrEnum):
     transactions_write = "transactions:write"
     payouts_read = "payouts:read"
     payouts_write = "payouts:write"
-    wallets_read = "wallets:read"
-    wallets_write = "wallets:write"
     disputes_read = "disputes:read"
 
 
@@ -53,8 +51,6 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.transactions_write,
     OrganizationPermission.payouts_read,
     OrganizationPermission.payouts_write,
-    OrganizationPermission.wallets_read,
-    OrganizationPermission.wallets_write,
     OrganizationPermission.disputes_read,
 }
 

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -33,8 +33,8 @@ class OrganizationPermission(StrEnum):
     members_set_role = "members:set_role"
 
     # Finance — admin-only.
-    transactions_read = "transactions:read"
-    transactions_write = "transactions:write"
+    account_read = "account:read"
+    account_write = "account:write"
     payouts_read = "payouts:read"
     payouts_write = "payouts:write"
     disputes_read = "disputes:read"
@@ -47,8 +47,8 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.members_invite,
     OrganizationPermission.members_remove,
     OrganizationPermission.members_set_role,
-    OrganizationPermission.transactions_read,
-    OrganizationPermission.transactions_write,
+    OrganizationPermission.account_read,
+    OrganizationPermission.account_write,
     OrganizationPermission.payouts_read,
     OrganizationPermission.payouts_write,
     OrganizationPermission.disputes_read,

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -30,12 +30,12 @@ class OrganizationPermission(StrEnum):
     members_read = "members:read"
     members_manage = "members:manage"
 
+    # Sales — granted to all roles.
+    sales_read = "sales:read"
+
     # Finance — admin-only.
     account_read = "account:read"
     account_write = "account:write"
-    payouts_read = "payouts:read"
-    payouts_write = "payouts:write"
-    disputes_read = "disputes:read"
 
 
 _ADMIN_ONLY: set[OrganizationPermission] = {
@@ -45,13 +45,11 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.members_manage,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,
-    OrganizationPermission.payouts_read,
-    OrganizationPermission.payouts_write,
-    OrganizationPermission.disputes_read,
 }
 
 _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.members_read,
+    OrganizationPermission.sales_read,
 }
 
 ROLE_PERMISSIONS: dict[OrganizationRole, set[OrganizationPermission]] = {
@@ -65,3 +63,10 @@ def role_has_permission(
     role: OrganizationRole, permission: OrganizationPermission
 ) -> bool:
     return permission in ROLE_PERMISSIONS[role]
+
+
+def roles_with_permission(
+    permission: OrganizationPermission,
+) -> set[OrganizationRole]:
+    """Return the set of roles that grant the given permission."""
+    return {role for role, perms in ROLE_PERMISSIONS.items() if permission in perms}

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -23,7 +23,6 @@ from polar.models.user_organization import OrganizationRole
 class OrganizationPermission(StrEnum):
     # Org management.
     organization_manage = "organization:manage"
-    organization_manage_payout_account = "organization:manage_payout_account"
 
     # Member management.
     members_read = "members:read"
@@ -39,7 +38,6 @@ class OrganizationPermission(StrEnum):
 
 _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organization_manage,
-    OrganizationPermission.organization_manage_payout_account,
     OrganizationPermission.members_manage,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -32,6 +32,10 @@ class OrganizationPermission(StrEnum):
     products_read = "products:read"
     products_manage = "products:manage"
 
+    # Customers.
+    customers_read = "customers:read"
+    customers_manage = "customers:manage"
+
     # Sales — granted to all roles.
     sales_read = "sales:read"
 
@@ -44,6 +48,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organization_manage,
     OrganizationPermission.members_manage,
     OrganizationPermission.products_manage,
+    OrganizationPermission.customers_manage,
     OrganizationPermission.account_read,
     OrganizationPermission.account_write,
 }
@@ -51,6 +56,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
 _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.members_read,
     OrganizationPermission.products_read,
+    OrganizationPermission.customers_read,
     OrganizationPermission.sales_read,
 }
 

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -19,7 +19,8 @@ from polar.organization.schemas import OrganizationID
 from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import AsyncSession, get_db_session
 
-from .policies import finance, members
+from .policies import account as account_policy
+from .policies import members
 from .policies import organization as org_policy
 from .policies import payout_account as pa_policy
 from .service import get_accessible_org_ids, get_accessible_organization
@@ -120,7 +121,7 @@ AuthorizeFinanceRead = Annotated[
     AuthzContext[User | Organization],
     Depends(
         OrgPolicyGuard(
-            finance.can_read,
+            account_policy.can_read,
             required_scopes={
                 Scope.transactions_read,
                 Scope.transactions_write,
@@ -134,7 +135,7 @@ AuthorizeFinanceWrite = Annotated[
     AuthzContext[User | Organization],
     Depends(
         OrgPolicyGuard(
-            finance.can_write,
+            account_policy.can_write,
             required_scopes={
                 Scope.transactions_write,
                 Scope.payouts_write,
@@ -405,11 +406,11 @@ def PayoutAccountPolicyGuard(
 
 
 AuthorizeAccountRead = Annotated[
-    AuthorizedAccount, Depends(AccountPolicyGuard(finance.can_read))
+    AuthorizedAccount, Depends(AccountPolicyGuard(account_policy.can_read))
 ]
 AuthorizeAccountWrite = Annotated[
     AuthorizedAccount,
-    Depends(AccountPolicyGuard(finance.can_write)),
+    Depends(AccountPolicyGuard(account_policy.can_write)),
 ]
 AuthorizePayoutAccountRead = Annotated[
     AuthorizedPayoutAccount, Depends(PayoutAccountPolicyGuard(pa_policy.can_read))

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -143,6 +143,18 @@ AuthorizeFinanceWrite = Annotated[
         )
     ),
 ]
+AuthorizeMembersRead = Annotated[
+    AuthzContext[User | Organization],
+    Depends(
+        OrgPolicyGuard(
+            members.can_read,
+            required_scopes={
+                Scope.organizations_read,
+                Scope.organizations_write,
+            },
+        )
+    ),
+]
 AuthorizeMembersManage = Annotated[
     AuthzContext[User],
     Depends(

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -19,7 +19,7 @@ from polar.organization.schemas import OrganizationID
 from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import AsyncSession, get_db_session
 
-from .policies import account as account_policy
+from .policies import finance as finance_policy
 from .policies import members
 from .policies import organization as org_policy
 from .policies import payout_account as pa_policy
@@ -121,7 +121,7 @@ AuthorizeFinanceRead = Annotated[
     AuthzContext[User | Organization],
     Depends(
         OrgPolicyGuard(
-            account_policy.can_read,
+            finance_policy.can_read,
             required_scopes={
                 Scope.transactions_read,
                 Scope.transactions_write,
@@ -135,7 +135,7 @@ AuthorizeFinanceWrite = Annotated[
     AuthzContext[User | Organization],
     Depends(
         OrgPolicyGuard(
-            account_policy.can_write,
+            finance_policy.can_manage,
             required_scopes={
                 Scope.transactions_write,
                 Scope.payouts_write,
@@ -417,11 +417,11 @@ def PayoutAccountPolicyGuard(
 
 
 AuthorizeAccountRead = Annotated[
-    AuthorizedAccount, Depends(AccountPolicyGuard(account_policy.can_read))
+    AuthorizedAccount, Depends(AccountPolicyGuard(finance_policy.can_read))
 ]
 AuthorizeAccountWrite = Annotated[
     AuthorizedAccount,
-    Depends(AccountPolicyGuard(account_policy.can_write)),
+    Depends(AccountPolicyGuard(finance_policy.can_manage)),
 ]
 AuthorizePayoutAccountRead = Annotated[
     AuthorizedPayoutAccount, Depends(PayoutAccountPolicyGuard(pa_policy.can_read))

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -173,16 +173,6 @@ AuthorizeOrgManage = Annotated[
         )
     ),
 ]
-AuthorizeOrgManagePayoutAccount = Annotated[
-    AuthzContext[User],
-    Depends(
-        OrgPolicyGuard(
-            org_policy.can_manage_payout_account,
-            allowed_subjects={User},
-            required_scopes={Scope.organizations_write},
-        )
-    ),
-]
 AuthorizeOrgAccess = Annotated[
     AuthzContext[User | Organization], Depends(OrgPolicyGuard(_always_allow))
 ]

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -163,11 +163,11 @@ AuthorizeMembersSetRole = Annotated[
         )
     ),
 ]
-AuthorizeOrgDelete = Annotated[
+AuthorizeOrgManage = Annotated[
     AuthzContext[User],
     Depends(
         OrgPolicyGuard(
-            org_policy.can_delete,
+            org_policy.can_manage,
             allowed_subjects={User},
             required_scopes={Scope.organizations_write},
         )

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -176,6 +176,15 @@ AuthorizeMembersSetRole = Annotated[
     ),
 ]
 AuthorizeOrgManage = Annotated[
+    AuthzContext[User | Organization],
+    Depends(
+        OrgPolicyGuard(
+            org_policy.can_manage,
+            required_scopes={Scope.organizations_write},
+        )
+    ),
+]
+AuthorizeOrgManageUser = Annotated[
     AuthzContext[User],
     Depends(
         OrgPolicyGuard(

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -157,7 +157,7 @@ AuthorizeMembersSetRole = Annotated[
     AuthzContext[User],
     Depends(
         OrgPolicyGuard(
-            members.can_set_role,
+            members.can_manage,
             allowed_subjects={User},
             required_scopes={Scope.members_write},
         )

--- a/server/polar/authz/policies/account.py
+++ b/server/polar/authz/policies/account.py
@@ -12,13 +12,13 @@ async def can_read(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject view accounts, transactions, payouts for this org?"""
+    """Can the subject view the org's financial account?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.transactions_read,
-        denied_msg="Only an organization admin can access financial information",
+        permission=OrganizationPermission.account_read,
+        denied_msg="Only an organization admin can access the account",
     )
 
 
@@ -27,11 +27,11 @@ async def can_write(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject manage payouts, update billing info for this org?"""
+    """Can the subject update the org's financial account?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.transactions_write,
-        denied_msg="Only an organization admin can manage financial information",
+        permission=OrganizationPermission.account_write,
+        denied_msg="Only an organization admin can update the account",
     )

--- a/server/polar/authz/policies/analytics.py
+++ b/server/polar/authz/policies/analytics.py
@@ -1,0 +1,38 @@
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+
+from . import _require_permission
+
+
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject view analytics (metrics, events, event types) for this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.analytics_read,
+        denied_msg="You don't have permission to view analytics",
+    )
+
+
+async def can_manage(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject create, update, or delete analytics resources
+    (e.g. metric dashboards) for this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.analytics_manage,
+        denied_msg="Only an organization admin can manage analytics",
+    )

--- a/server/polar/authz/policies/custom_fields.py
+++ b/server/polar/authz/policies/custom_fields.py
@@ -1,0 +1,37 @@
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+
+from . import _require_permission
+
+
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject view custom fields in this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.custom_fields_read,
+        denied_msg="You don't have permission to view custom fields",
+    )
+
+
+async def can_manage(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject create, update, or delete custom fields in this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.custom_fields_manage,
+        denied_msg="Only an organization admin can manage custom fields",
+    )

--- a/server/polar/authz/policies/customers.py
+++ b/server/polar/authz/policies/customers.py
@@ -1,0 +1,37 @@
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+
+from . import _require_permission
+
+
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject view customers in this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.customers_read,
+        denied_msg="You don't have permission to view customers",
+    )
+
+
+async def can_manage(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject create, update, or delete customers in this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.customers_manage,
+        denied_msg="Only an organization admin can manage customers",
+    )

--- a/server/polar/authz/policies/finance.py
+++ b/server/polar/authz/policies/finance.py
@@ -12,26 +12,26 @@ async def can_read(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject view the org's financial account?"""
+    """Can the subject view the org's financial data (account, transactions, payouts)?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.account_read,
-        denied_msg="Only an organization admin can access the account",
+        permission=OrganizationPermission.finance_read,
+        denied_msg="Only an organization admin can access financial data",
     )
 
 
-async def can_write(
+async def can_manage(
     session: AsyncReadSession,
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject update the org's financial account?"""
+    """Can the subject update the org's financial data (account, payouts)?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.account_write,
-        denied_msg="Only an organization admin can update the account",
+        permission=OrganizationPermission.finance_manage,
+        denied_msg="Only an organization admin can manage financial data",
     )

--- a/server/polar/authz/policies/members.py
+++ b/server/polar/authz/policies/members.py
@@ -7,6 +7,21 @@ from polar.postgres import AsyncReadSession
 from . import _require_permission
 
 
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject view the members of this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.members_read,
+        denied_msg="You don't have permission to view members",
+    )
+
+
 async def can_manage(
     session: AsyncReadSession,
     auth_subject: AuthSubject[User | Organization],

--- a/server/polar/authz/policies/members.py
+++ b/server/polar/authz/policies/members.py
@@ -12,18 +12,12 @@ async def can_manage(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject invite/remove/change members?
-
-    `members:invite` is used as a representative permission — admin and
-    owner share the full member-management set, so checking any one of
-    `members:invite`, `members:remove`, `members:set_role` gives the
-    same answer in this iteration.
-    """
+    """Can the subject invite or remove members?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.members_invite,
+        permission=OrganizationPermission.members_manage,
         denied_msg="Only an organization admin can manage members",
     )
 

--- a/server/polar/authz/policies/members.py
+++ b/server/polar/authz/policies/members.py
@@ -12,26 +12,11 @@ async def can_manage(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject invite or remove members?"""
+    """Can the subject invite, remove, or change the role of members?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
         permission=OrganizationPermission.members_manage,
         denied_msg="Only an organization admin can manage members",
-    )
-
-
-async def can_set_role(
-    session: AsyncReadSession,
-    auth_subject: AuthSubject[User | Organization],
-    organization: OrganizationModel,
-) -> PolicyResult:
-    """Can the subject change another member's role?"""
-    return await _require_permission(
-        session,
-        auth_subject,
-        organization,
-        permission=OrganizationPermission.members_set_role,
-        denied_msg="Only an organization admin can change member roles",
     )

--- a/server/polar/authz/policies/organization.py
+++ b/server/polar/authz/policies/organization.py
@@ -12,26 +12,11 @@ async def can_manage(
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject edit or delete this organization?"""
+    """Can the subject edit, delete, or set the payout account for this organization?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
         permission=OrganizationPermission.organization_manage,
         denied_msg="Only an organization admin can manage the organization",
-    )
-
-
-async def can_manage_payout_account(
-    session: AsyncReadSession,
-    auth_subject: AuthSubject[User | Organization],
-    organization: OrganizationModel,
-) -> PolicyResult:
-    """Can the subject set or change the payout account for this organization?"""
-    return await _require_permission(
-        session,
-        auth_subject,
-        organization,
-        permission=OrganizationPermission.organization_manage_payout_account,
-        denied_msg="Only an organization admin can manage the payout account",
     )

--- a/server/polar/authz/policies/organization.py
+++ b/server/polar/authz/policies/organization.py
@@ -7,18 +7,18 @@ from polar.postgres import AsyncReadSession
 from . import _require_permission
 
 
-async def can_delete(
+async def can_manage(
     session: AsyncReadSession,
     auth_subject: AuthSubject[User | Organization],
     organization: OrganizationModel,
 ) -> PolicyResult:
-    """Can the subject delete this organization?"""
+    """Can the subject edit or delete this organization?"""
     return await _require_permission(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.organizations_delete,
-        denied_msg="Only an organization admin can delete the organization",
+        permission=OrganizationPermission.organization_manage,
+        denied_msg="Only an organization admin can manage the organization",
     )
 
 
@@ -32,6 +32,6 @@ async def can_manage_payout_account(
         session,
         auth_subject,
         organization,
-        permission=OrganizationPermission.organizations_manage_payout_account,
+        permission=OrganizationPermission.organization_manage_payout_account,
         denied_msg="Only an organization admin can manage the payout account",
     )

--- a/server/polar/authz/policies/products.py
+++ b/server/polar/authz/policies/products.py
@@ -1,0 +1,37 @@
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+
+from . import _require_permission
+
+
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject view products in this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.products_read,
+        denied_msg="You don't have permission to view products",
+    )
+
+
+async def can_manage(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject create, update, or archive products in this organization?"""
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.products_manage,
+        denied_msg="Only an organization admin can manage products",
+    )

--- a/server/polar/authz/policies/sales.py
+++ b/server/polar/authz/policies/sales.py
@@ -1,0 +1,29 @@
+from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
+from polar.authz.types import PolicyResult
+from polar.models import Organization as OrganizationModel
+from polar.postgres import AsyncReadSession
+
+from . import _require_permission
+
+
+async def can_read(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization: OrganizationModel,
+) -> PolicyResult:
+    """Can the subject read sales data (orders, subscriptions, checkouts,
+    disputes, refunds, payments) for this organization?
+
+    Enforced at the data-fetch layer for list endpoints (filtering
+    `UserOrganization` by roles with `sales:read`). This policy is the
+    canonical site to plug into `OrgPolicyGuard` if/when a sales-section
+    endpoint exposes a single-org `{id}` path.
+    """
+    return await _require_permission(
+        session,
+        auth_subject,
+        organization,
+        permission=OrganizationPermission.sales_read,
+        denied_msg="You don't have permission to view sales data",
+    )

--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from sqlalchemy import select
 
 from polar.auth.models import AuthSubject, User, is_organization, is_user
+from polar.auth.permission import OrganizationPermission, roles_with_permission
 from polar.models import Organization, UserOrganization
 from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncReadSession
@@ -20,6 +21,27 @@ class AuthzRepository:
             .where(
                 UserOrganization.user_id == user_id,
                 UserOrganization.is_deleted.is_(False),
+                Organization.is_deleted.is_(False),
+                Organization.can_authenticate,
+            )
+        )
+        result = await self.session.scalars(stmt)
+        return set(result.all())
+
+    async def get_user_org_ids_with_permission(
+        self, user_id: UUID, permission: OrganizationPermission
+    ) -> set[UUID]:
+        """Get organization IDs where the user's role grants ``permission``."""
+        roles = roles_with_permission(permission)
+        if not roles:
+            return set()
+        stmt = (
+            select(UserOrganization.organization_id)
+            .join(Organization, UserOrganization.organization_id == Organization.id)
+            .where(
+                UserOrganization.user_id == user_id,
+                UserOrganization.is_deleted.is_(False),
+                UserOrganization.role.in_(roles),
                 Organization.is_deleted.is_(False),
                 Organization.can_authenticate,
             )

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
+from polar.exceptions import NotPermitted
 from polar.models.organization import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
 
@@ -52,3 +53,24 @@ async def get_accessible_organization(
     """Fetch an organization by ID, returning it only if the subject can access it."""
     repository = AuthzRepository(session)
     return await repository.get_accessible_organization(auth_subject, organization_id)
+
+
+async def assert_organization_permission(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    organization_id: UUID,
+    permission: OrganizationPermission,
+    denied_msg: str,
+) -> None:
+    """Raise ``NotPermitted`` if the subject does not hold ``permission`` for
+    the given organization.
+
+    Use at service-layer mutation entry points where the resource has already
+    been fetched (so policy-by-OrgPolicyGuard doesn't apply). For payload-driven
+    creates, prefer combining with ``get_payload_organization``.
+    """
+    org_ids = await get_accessible_org_ids_with_permission(
+        session, auth_subject, permission
+    )
+    if organization_id not in org_ids:
+        raise NotPermitted(denied_msg)

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
+from polar.auth.permission import OrganizationPermission
 from polar.models.organization import Organization as OrganizationModel
 from polar.postgres import AsyncReadSession
 
@@ -18,6 +19,27 @@ async def get_accessible_org_ids(
     if is_user(auth_subject):
         repository = AuthzRepository(session)
         raw_ids = await repository.get_user_org_ids(auth_subject.subject.id)
+        return {AccessibleOrganizationID(uid) for uid in raw_ids}
+    return set()
+
+
+async def get_accessible_org_ids_with_permission(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User | Organization],
+    permission: OrganizationPermission,
+) -> set[AccessibleOrganizationID]:
+    """Resolve organization IDs the subject can access AND has ``permission`` for.
+
+    Organization-token subjects always pass (the token represents the org
+    itself). User subjects are filtered by their `UserOrganization.role`.
+    """
+    if is_organization(auth_subject):
+        return {AccessibleOrganizationID(auth_subject.subject.id)}
+    if is_user(auth_subject):
+        repository = AuthzRepository(session)
+        raw_ids = await repository.get_user_org_ids_with_permission(
+            auth_subject.subject.id, permission
+        )
         return {AccessibleOrganizationID(uid) for uid in raw_ids}
     return set()
 

--- a/server/polar/backoffice/webhooks/endpoints.py
+++ b/server/polar/backoffice/webhooks/endpoints.py
@@ -10,7 +10,6 @@ from polar.kit.pagination import PaginationParamsQuery
 from polar.models import Organization, WebhookEndpoint
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.webhook.repository import WebhookEndpointRepository
-from polar.webhook.schemas import WebhookEndpointUpdate
 from polar.webhook.service import webhook as webhook_service
 from polar.webhook.sorting import WebhookSortProperty
 
@@ -266,9 +265,8 @@ async def toggle_enabled(
     if webhook is None:
         raise HTTPException(status_code=404)
 
-    update_schema = WebhookEndpointUpdate(enabled=not webhook.enabled)
-    webhook = await webhook_service.update_endpoint(
-        session, endpoint=webhook, update_schema=update_schema
+    webhook = await repository.update(
+        webhook, update_dict={"enabled": not webhook.enabled}
     )
     await session.flush()
 

--- a/server/polar/benefit/endpoints.py
+++ b/server/polar/benefit/endpoints.py
@@ -237,4 +237,4 @@ async def delete(
     if benefit is None:
         raise ResourceNotFound()
 
-    await benefit_service.delete(session, benefit)
+    await benefit_service.delete(session, benefit, auth_subject)

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -10,7 +10,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    get_accessible_org_ids,
+    get_accessible_org_ids_with_permission,
+)
 from polar.benefit.strategies import BenefitRetriableError
 from polar.customer.repository import CustomerRepository
 from polar.event.service import event as event_service
@@ -161,7 +165,9 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         ],
     ) -> tuple[Sequence[BenefitGrant], int]:
         repository = BenefitGrantRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.customers_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .join(Customer, BenefitGrant.customer_id == Customer.id)

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -5,7 +5,11 @@ from pydantic import BaseModel
 from sqlalchemy import case, delete
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.exceptions import NotPermitted, PolarRequestValidationError
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
@@ -44,7 +48,9 @@ class BenefitService:
         query: str | None = None,
     ) -> tuple[Sequence[Benefit], int]:
         repository = BenefitRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if type is not None:
@@ -97,7 +103,9 @@ class BenefitService:
         id: uuid.UUID,
     ) -> Benefit | None:
         repository = BenefitRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Benefit.id == id)
@@ -114,6 +122,13 @@ class BenefitService:
     ) -> Benefit:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
         )
 
         try:
@@ -157,6 +172,14 @@ class BenefitService:
         benefit_update: BenefitUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> Benefit:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            benefit.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
+
         if benefit_update.type != benefit.type:
             raise PolarRequestValidationError(
                 [
@@ -199,7 +222,20 @@ class BenefitService:
 
         return benefit
 
-    async def delete(self, session: AsyncSession, benefit: Benefit) -> Benefit:
+    async def delete(
+        self,
+        session: AsyncSession,
+        benefit: Benefit,
+        auth_subject: AuthSubject[User | Organization],
+    ) -> Benefit:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            benefit.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
+
         if not benefit.deletable:
             raise NotPermitted()
 

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -12,7 +12,11 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import Anonymous, AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    get_accessible_org_ids,
+    get_accessible_org_ids_with_permission,
+)
 from polar.checkout.guard import has_product_checkout
 from polar.checkout.schemas import (
     CheckoutConfirm,
@@ -256,7 +260,9 @@ class CheckoutService:
         ],
     ) -> tuple[Sequence[Checkout], int]:
         repository = CheckoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).options(
             *repository.get_eager_options()
         )
@@ -294,7 +300,9 @@ class CheckoutService:
         id: uuid.UUID,
     ) -> Checkout | None:
         repository = CheckoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Checkout.id == id)

--- a/server/polar/checkout_link/endpoints.py
+++ b/server/polar/checkout_link/endpoints.py
@@ -152,7 +152,7 @@ async def delete(
     if checkout_link is None:
         raise ResourceNotFound()
 
-    await checkout_link_service.delete(session, checkout_link)
+    await checkout_link_service.delete(session, checkout_link, auth_subject)
 
 
 @router.get("/{client_secret}/redirect", include_in_schema=False)

--- a/server/polar/checkout_link/service.py
+++ b/server/polar/checkout_link/service.py
@@ -6,7 +6,12 @@ from sqlalchemy import UnaryExpression, asc, desc
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids,
+    get_accessible_org_ids_with_permission,
+)
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.discount.service import discount as discount_service
 from polar.exceptions import PolarRequestValidationError, ValidationError
@@ -54,7 +59,9 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         ],
     ) -> tuple[Sequence[CheckoutLink], int]:
         repository = CheckoutLinkRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
         checkout_link_product_load = None
 
@@ -104,7 +111,9 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         id: uuid.UUID,
     ) -> CheckoutLink | None:
         repository = CheckoutLinkRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(CheckoutLink.id == id)
@@ -132,6 +141,14 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
             )
             products = [product]
         organization = products[0].organization
+
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
 
         discount: Discount | None = None
         if checkout_link_create.discount_id is not None:
@@ -168,6 +185,14 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         checkout_link_update: CheckoutLinkUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> CheckoutLink:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            checkout_link.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
+
         if checkout_link_update.products is not None:
             products = await self._get_validated_products(
                 session, checkout_link_update.products, auth_subject
@@ -219,8 +244,18 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         )
 
     async def delete(
-        self, session: AsyncSession, checkout_link: CheckoutLink
+        self,
+        session: AsyncSession,
+        checkout_link: CheckoutLink,
+        auth_subject: AuthSubject[User | Organization],
     ) -> CheckoutLink:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            checkout_link.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
         repository = CheckoutLinkRepository.from_session(session)
         return await repository.soft_delete(checkout_link)
 

--- a/server/polar/custom_field/endpoints.py
+++ b/server/polar/custom_field/endpoints.py
@@ -124,7 +124,9 @@ async def update(
     if custom_field is None:
         raise ResourceNotFound()
 
-    return await custom_field_service.update(session, custom_field, custom_field_update)
+    return await custom_field_service.update(
+        session, custom_field, custom_field_update, auth_subject
+    )
 
 
 @router.delete(
@@ -147,4 +149,4 @@ async def delete(
     if custom_field is None:
         raise ResourceNotFound()
 
-    await custom_field_service.delete(session, custom_field)
+    await custom_field_service.delete(session, custom_field, auth_subject)

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -16,6 +16,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission, roles_with_permission
+from polar.authz.service import assert_organization_permission
 from polar.custom_field.sorting import CustomFieldSortProperty
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams, paginate
@@ -103,6 +105,13 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         organization = await get_payload_organization(
             session, auth_subject, custom_field_create
         )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.custom_fields_manage,
+            "Only an organization admin can manage custom fields",
+        )
 
         existing_field = await self._get_by_organization_id_and_slug(
             session, organization.id, custom_field_create.slug
@@ -134,7 +143,16 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         session: AsyncSession,
         custom_field: CustomField,
         custom_field_update: CustomFieldUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> CustomField:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            custom_field.organization_id,
+            OrganizationPermission.custom_fields_manage,
+            "Only an organization admin can manage custom fields",
+        )
+
         if custom_field.type != custom_field_update.type:
             raise PolarRequestValidationError(
                 [
@@ -198,8 +216,18 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         return custom_field
 
     async def delete(
-        self, session: AsyncSession, custom_field: CustomField
+        self,
+        session: AsyncSession,
+        custom_field: CustomField,
+        auth_subject: AuthSubject[User | Organization],
     ) -> CustomField:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            custom_field.organization_id,
+            OrganizationPermission.custom_fields_manage,
+            "Only an organization admin can manage custom fields",
+        )
         custom_field.set_deleted_at()
         session.add(custom_field)
 
@@ -250,6 +278,11 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
                     select(UserOrganization.organization_id).where(
                         UserOrganization.user_id == user.id,
                         UserOrganization.is_deleted.is_(False),
+                        UserOrganization.role.in_(
+                            roles_with_permission(
+                                OrganizationPermission.custom_fields_read
+                            )
+                        ),
                     )
                 )
             )

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -5,7 +5,11 @@ from fastapi import Depends, Query, Response
 from fastapi.responses import StreamingResponse
 from pydantic import TypeAdapter
 
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids,
+)
 from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
@@ -303,6 +307,13 @@ async def update(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        customer.organization_id,
+        OrganizationPermission.customers_manage,
+        "Only an organization admin can manage customers",
+    )
     return await customer_service.update(session, customer, customer_update)
 
 
@@ -327,6 +338,13 @@ async def update_external(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        customer.organization_id,
+        OrganizationPermission.customers_manage,
+        "Only an organization admin can manage customers",
+    )
     return await customer_service.update(session, customer, customer_update)
 
 
@@ -375,6 +393,13 @@ async def delete(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        customer.organization_id,
+        OrganizationPermission.customers_manage,
+        "Only an organization admin can manage customers",
+    )
     await customer_service.delete(session, customer, anonymize=anonymize)
 
 
@@ -410,4 +435,11 @@ async def delete_external(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        customer.organization_id,
+        OrganizationPermission.customers_manage,
+        "Only an organization admin can manage customers",
+    )
     await customer_service.delete(session, customer, anonymize=anonymize)

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -8,7 +8,7 @@ from pydantic import TypeAdapter
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import (
     assert_organization_permission,
-    get_accessible_org_ids,
+    get_accessible_org_ids_with_permission,
 )
 from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
@@ -138,7 +138,9 @@ async def export(
         )
 
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.customers_read
+        )
         stream = repository.stream_by_organization(org_ids, organization_id)
 
         async for customer in stream:

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -10,7 +10,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.config import settings
 from polar.customer_meter.repository import CustomerMeterRepository
@@ -79,7 +83,9 @@ class CustomerService:
         ],
     ) -> tuple[Sequence[Customer], int]:
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.customers_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -122,7 +128,9 @@ class CustomerService:
         id: uuid.UUID,
     ) -> Customer | None:
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.customers_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             Customer.id == id
         )
@@ -135,7 +143,9 @@ class CustomerService:
         external_id: str,
     ) -> Customer | None:
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.customers_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             Customer.external_id == external_id
         )
@@ -151,6 +161,13 @@ class CustomerService:
     ) -> Customer:
         organization = await get_payload_organization(
             session, auth_subject, customer_create
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.customers_manage,
+            "Only an organization admin can manage customers",
         )
         repository = CustomerRepository.from_session(session)
 

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -8,7 +8,8 @@ from sse_starlette import EventSourceResponse
 
 from polar.auth.models import Anonymous, Organization, User
 from polar.auth.models import AuthSubject as AuthSubjectType
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.checkout.repository import CheckoutRepository
 from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
@@ -270,7 +271,9 @@ async def revoke_seat(
 
     typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
     seat_repository = CustomerSeatRepository.from_session(session)
-    org_ids = await get_accessible_org_ids(session, typed_auth_subject)
+    org_ids = await get_accessible_org_ids_with_permission(
+        session, typed_auth_subject, OrganizationPermission.customers_manage
+    )
 
     seat = await seat_repository.get_by_id_and_org_ids(
         org_ids,
@@ -314,7 +317,9 @@ async def resend_invitation(
 
     typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
     seat_repository = CustomerSeatRepository.from_session(session)
-    org_ids = await get_accessible_org_ids(session, typed_auth_subject)
+    org_ids = await get_accessible_org_ids_with_permission(
+        session, typed_auth_subject, OrganizationPermission.customers_manage
+    )
 
     seat = await seat_repository.get_by_id_and_org_ids(
         org_ids,

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -9,7 +9,10 @@ from sse_starlette import EventSourceResponse
 from polar.auth.models import Anonymous, Organization, User
 from polar.auth.models import AuthSubject as AuthSubjectType
 from polar.auth.permission import OrganizationPermission
-from polar.authz.service import get_accessible_org_ids_with_permission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.checkout.repository import CheckoutRepository
 from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
@@ -164,6 +167,21 @@ async def assign_seat(
 
     container = subscription or order
     assert container is not None  # Already validated above
+
+    if not isinstance(auth_subject.subject, Anonymous):
+        typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
+        organization_id = (
+            container.product.organization_id
+            if isinstance(container, Subscription)
+            else container.organization_id
+        )
+        await assert_organization_permission(
+            session,
+            typed_auth_subject,
+            organization_id,
+            OrganizationPermission.customers_manage,
+            "Only an organization admin can manage customers",
+        )
 
     seat = await seat_service.assign_seat(
         session,

--- a/server/polar/discount/endpoints.py
+++ b/server/polar/discount/endpoints.py
@@ -121,7 +121,9 @@ async def update(
     if discount is None:
         raise ResourceNotFound()
 
-    return await discount_service.update(session, discount, discount_update)
+    return await discount_service.update(
+        session, discount, discount_update, auth_subject
+    )
 
 
 @router.delete(
@@ -144,4 +146,4 @@ async def delete(
     if discount is None:
         raise ResourceNotFound()
 
-    await discount_service.delete(session, discount)
+    await discount_service.delete(session, discount, auth_subject)

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -8,6 +8,8 @@ from sqlalchemy import Select, UnaryExpression, asc, delete, desc, func, or_, se
 from sqlalchemy.exc import DBAPIError
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission, roles_with_permission
+from polar.authz.service import assert_organization_permission
 from polar.discount.repository import DiscountRepository
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.db.locking import is_lock_not_available_error
@@ -108,6 +110,13 @@ class DiscountService(ResourceServiceReader[Discount]):
         organization = await get_payload_organization(
             session, auth_subject, discount_create
         )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
 
         repository = DiscountRepository.from_session(session)
 
@@ -179,7 +188,16 @@ class DiscountService(ResourceServiceReader[Discount]):
         session: AsyncSession,
         discount: Discount,
         discount_update: DiscountUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> Discount:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            discount.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
+
         if (
             "duration" in discount_update.model_fields_set
             and discount_update.duration != discount.duration
@@ -296,7 +314,19 @@ class DiscountService(ResourceServiceReader[Discount]):
 
         return discount
 
-    async def delete(self, session: AsyncSession, discount: Discount) -> Discount:
+    async def delete(
+        self,
+        session: AsyncSession,
+        discount: Discount,
+        auth_subject: AuthSubject[User | Organization],
+    ) -> Discount:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            discount.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
         discount.set_deleted_at()
         session.add(discount)
         return discount
@@ -453,6 +483,9 @@ class DiscountService(ResourceServiceReader[Discount]):
                     select(UserOrganization.organization_id).where(
                         UserOrganization.user_id == user.id,
                         UserOrganization.is_deleted.is_(False),
+                        UserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.products_read)
+                        ),
                     )
                 )
             )

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -5,7 +5,8 @@ import stripe as stripe_lib
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.customer.repository import CustomerRepository
 from polar.enums import PaymentProcessor
@@ -62,7 +63,9 @@ class DisputeService:
         ],
     ) -> tuple[Sequence[Dispute], int]:
         repository = DisputeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -87,7 +90,9 @@ class DisputeService:
         id: uuid.UUID,
     ) -> Dispute | None:
         repository = DisputeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(Dispute.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -13,7 +13,10 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    get_accessible_org_ids_with_permission,
+)
 from polar.authz.types import AccessibleOrganizationID
 from polar.customer.repository import CustomerRepository
 from polar.customer_meter.repository import CustomerMeterRepository
@@ -1311,7 +1314,9 @@ class EventService:
         organization_id: Sequence[uuid.UUID] | None,
     ) -> set[AccessibleOrganizationID]:
         """Get accessible org IDs, optionally filtered to a subset."""
-        organization_ids = await get_accessible_org_ids(session, auth_subject)
+        organization_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.analytics_read
+        )
         if organization_id is not None:
             return {
                 AccessibleOrganizationID(oid)

--- a/server/polar/event_type/endpoints.py
+++ b/server/polar/event_type/endpoints.py
@@ -95,6 +95,6 @@ async def update(
         raise ResourceNotFound()
 
     updated_event_type = await event_type_service.update(
-        session, event_type, body.label, body.label_property_selector
+        session, event_type, body.label, auth_subject, body.label_property_selector
     )
     return schemas.EventType.model_validate(updated_event_type)

--- a/server/polar/event_type/service.py
+++ b/server/polar/event_type/service.py
@@ -2,7 +2,11 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.customer.repository import CustomerRepository
 from polar.event.system import SYSTEM_EVENT_LABELS
 from polar.event.tinybird_repository import TinybirdEventRepository
@@ -27,7 +31,9 @@ class EventTypeService:
         id: UUID,
     ) -> EventType | None:
         repository = EventTypeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             EventType.id == id
         )
@@ -51,7 +57,9 @@ class EventTypeService:
         ],
     ) -> tuple[Sequence[EventTypeWithStats], int]:
         event_type_repository = EventTypeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.analytics_read
+        )
         if organization_id is not None:
             org_ids = org_ids & set(organization_id)
         organization_ids = list(org_ids)
@@ -190,8 +198,16 @@ class EventTypeService:
         session: AsyncSession,
         event_type: EventType,
         label: str,
+        auth_subject: AuthSubject[User | Organization],
         label_property_selector: str | None = None,
     ) -> EventType:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            event_type.organization_id,
+            OrganizationPermission.analytics_manage,
+            "Only an organization admin can manage analytics",
+        )
         event_type.label = label
         event_type.label_property_selector = label_property_selector
         session.add(event_type)

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -3,6 +3,8 @@ from typing import Annotated
 from fastapi import Depends, Path, Query
 from pydantic import UUID4
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_organization_permission
 from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
@@ -76,6 +78,13 @@ async def create(
 ) -> FileUpload:
     """Create a file."""
     organization = await get_payload_organization(session, auth_subject, file_create)
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        organization.id,
+        OrganizationPermission.products_manage,
+        "Only an organization admin can manage products",
+    )
 
     file_create.organization_id = organization.id
     return await file_service.generate_presigned_upload(

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -5,7 +5,8 @@ from datetime import datetime
 import structlog
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.kit.pagination import PaginationParams
 from polar.models import Organization, ProductMedia, User
 from polar.models.file import File, ProductMediaFile
@@ -35,7 +36,9 @@ class FileService:
         pagination: PaginationParams,
     ) -> tuple[Sequence[File], int]:
         repository = FileRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_manage
+        )
 
         statement = repository.get_statement_by_org_ids(org_ids).where(
             File.is_uploaded.is_(True)
@@ -58,7 +61,9 @@ class FileService:
         id: uuid.UUID,
     ) -> File | None:
         repository = FileRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_manage
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(File.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -7,7 +7,8 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Customer, Member
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.benefit.strategies.license_keys.properties import (
     BenefitLicenseKeysProperties,
 )
@@ -48,7 +49,9 @@ class LicenseKeyService:
         status: Sequence[LicenseKeyStatus] | None = None,
     ) -> tuple[Sequence[LicenseKey], int]:
         repository = LicenseKeyRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_manage
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .order_by(LicenseKey.created_at.asc())
@@ -75,7 +78,9 @@ class LicenseKeyService:
         id: UUID,
     ) -> LicenseKey | None:
         repository = LicenseKeyRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_manage
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(LicenseKey.id == id)

--- a/server/polar/meter/endpoints.py
+++ b/server/polar/meter/endpoints.py
@@ -205,4 +205,4 @@ async def update(
     if meter is None:
         raise ResourceNotFound()
 
-    return await meter_service.update(session, meter, meter_update)
+    return await meter_service.update(session, meter, meter_update, auth_subject)

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -22,7 +22,11 @@ from sqlalchemy import (
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -73,7 +77,9 @@ class MeterService:
         ],
     ) -> tuple[Sequence[Meter], int]:
         repository = MeterRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -111,7 +117,9 @@ class MeterService:
         id: uuid.UUID,
     ) -> Meter | None:
         repository = MeterRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Meter.id == id)
@@ -128,6 +136,13 @@ class MeterService:
         repository = MeterRepository.from_session(session)
         organization = await get_payload_organization(
             session, auth_subject, meter_create
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
         )
 
         meter = await repository.create(
@@ -160,8 +175,19 @@ class MeterService:
         return meter
 
     async def update(
-        self, session: AsyncSession, meter: Meter, meter_update: MeterUpdate
+        self,
+        session: AsyncSession,
+        meter: Meter,
+        meter_update: MeterUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> Meter:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            meter.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
         repository = MeterRepository.from_session(session)
 
         errors: list[ValidationError] = []

--- a/server/polar/metrics/endpoints.py
+++ b/server/polar/metrics/endpoints.py
@@ -356,7 +356,9 @@ async def update_dashboard(
     dashboard = await metrics_service.get_dashboard(session, auth_subject, id)
     if dashboard is None:
         raise ResourceNotFound()
-    updated = await metrics_service.update_dashboard(session, dashboard, body)
+    updated = await metrics_service.update_dashboard(
+        session, dashboard, body, auth_subject
+    )
     return MetricDashboardSchema.model_validate(updated)
 
 
@@ -374,4 +376,4 @@ async def delete_dashboard(
     dashboard = await metrics_service.get_dashboard(session, auth_subject, id)
     if dashboard is None:
         raise ResourceNotFound()
-    await metrics_service.delete_dashboard(session, dashboard)
+    await metrics_service.delete_dashboard(session, dashboard, auth_subject)

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -9,7 +9,11 @@ import logfire
 from sqlalchemy import ColumnElement, FromClause, select, text
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.authz.types import AccessibleOrganizationID
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -111,7 +115,9 @@ class MetricsService:
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> Sequence[MetricDashboard]:
         repository = MetricDashboardRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
         if organization_id is not None:
             statement = statement.where(
@@ -126,7 +132,9 @@ class MetricsService:
         id: uuid.UUID,
     ) -> MetricDashboard | None:
         repository = MetricDashboardRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             MetricDashboard.id == id
         )
@@ -140,6 +148,13 @@ class MetricsService:
     ) -> MetricDashboard:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.analytics_manage,
+            "Only an organization admin can manage analytics",
         )
 
         repository = MetricDashboardRepository.from_session(session)
@@ -155,7 +170,15 @@ class MetricsService:
         session: AsyncSession,
         dashboard: MetricDashboard,
         update_schema: MetricDashboardUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> MetricDashboard:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            dashboard.organization_id,
+            OrganizationPermission.analytics_manage,
+            "Only an organization admin can manage analytics",
+        )
         repository = MetricDashboardRepository.from_session(session)
         update_dict = update_schema.model_dump(exclude_unset=True)
         return await repository.update(dashboard, update_dict=update_dict)
@@ -164,7 +187,15 @@ class MetricsService:
         self,
         session: AsyncSession,
         dashboard: MetricDashboard,
+        auth_subject: AuthSubject[User | Organization],
     ) -> None:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            dashboard.organization_id,
+            OrganizationPermission.analytics_manage,
+            "Only an organization admin can manage analytics",
+        )
         await session.delete(dashboard)
         await session.flush()
 
@@ -443,7 +474,9 @@ class MetricsService:
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> list[AccessibleOrganizationID]:
         """Get accessible org IDs, optionally filtered to a subset."""
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.analytics_read
+        )
         if organization_id is not None and len(organization_id) > 0:
             return [
                 AccessibleOrganizationID(oid)

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -14,6 +14,7 @@ from polar.auth.models import (
     is_organization,
     is_user,
 )
+from polar.auth.permission import OrganizationPermission, roles_with_permission
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
     Options,
@@ -221,6 +222,9 @@ class OrderRepository(
                     select(UserOrganization.organization_id).where(
                         UserOrganization.user_id == user.id,
                         UserOrganization.is_deleted.is_(False),
+                        UserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.sales_read)
+                        ),
                     )
                 )
             )

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -12,7 +12,8 @@ from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.account.repository import AccountRepository
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
 from polar.checkout.guard import has_product_checkout
@@ -320,7 +321,9 @@ class OrderService:
         ],
     ) -> tuple[Sequence[Order], int]:
         repository = OrderRepository.from_session(session)
-        accessible_org_ids = await get_accessible_org_ids(session, auth_subject)
+        accessible_org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(accessible_org_ids)
 
         statement = (

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -13,7 +13,7 @@ from polar.authz.dependencies import (
     AuthorizeOrgAccess,
     AuthorizeOrgAccessUser,
     AuthorizeOrgAccessWrite,
-    AuthorizeOrgDelete,
+    AuthorizeOrgManage,
     AuthorizeOrgManagePayoutAccount,
 )
 from polar.authz.policies import payout_account as pa_policy
@@ -267,7 +267,7 @@ async def check_slug(
     tags=[APITag.public],
 )
 async def update(
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     organization_update: OrganizationUpdate,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
@@ -316,7 +316,7 @@ async def submit_review(
     tags=[APITag.private],
 )
 async def delete(
-    authz: AuthorizeOrgDelete,
+    authz: AuthorizeOrgManage,
     session: AsyncSession = Depends(get_db_session),
 ) -> OrganizationDeletionResponse:
     """Request deletion of an organization.

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -9,6 +9,7 @@ from polar.account.service import account as account_service
 from polar.authz.dependencies import (
     AuthorizeFinanceRead,
     AuthorizeMembersManage,
+    AuthorizeMembersRead,
     AuthorizeMembersSetRole,
     AuthorizeOrgAccess,
     AuthorizeOrgAccessUser,
@@ -373,7 +374,7 @@ async def get_payment_status(
     tags=[APITag.private],
 )
 async def members(
-    authz: AuthorizeOrgAccess,
+    authz: AuthorizeMembersRead,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[OrganizationMember]:
     """List members in an organization."""

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -14,7 +14,6 @@ from polar.authz.dependencies import (
     AuthorizeOrgAccessUser,
     AuthorizeOrgAccessWrite,
     AuthorizeOrgManage,
-    AuthorizeOrgManagePayoutAccount,
 )
 from polar.authz.policies import payout_account as pa_policy
 from polar.config import settings
@@ -178,7 +177,7 @@ async def get_account(
     tags=[APITag.private],
 )
 async def set_payout_account(
-    authz: AuthorizeOrgManagePayoutAccount,
+    authz: AuthorizeOrgManage,
     body: OrganizationPayoutAccountSet,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import joinedload
 
 from polar.account.schemas import Account as AccountSchema
 from polar.account.service import account as account_service
+from polar.auth.models import is_user
+from polar.auth.permission import ROLE_PERMISSIONS
 from polar.authz.dependencies import (
     AuthorizeFinanceRead,
     AuthorizeMembersManage,
@@ -15,6 +17,7 @@ from polar.authz.dependencies import (
     AuthorizeOrgAccessUser,
     AuthorizeOrgAccessWrite,
     AuthorizeOrgManage,
+    AuthorizeOrgManageUser,
 )
 from polar.authz.policies import payout_account as pa_policy
 from polar.config import settings
@@ -53,10 +56,12 @@ from polar.postgres import (
 )
 from polar.routing import APIRouter
 from polar.user.service import user as user_service
+from polar.user_organization.repository import UserOrganizationRepository
 from polar.user_organization.schemas import (
     OrganizationMember,
     OrganizationMemberInvite,
     OrganizationMemberRoleUpdate,
+    OrganizationRoleDefinition,
 )
 from polar.user_organization.service import (
     CannotRemoveOrganizationOwner,
@@ -77,6 +82,7 @@ from .schemas import (
     OrganizationDeletionResponse,
     OrganizationID,
     OrganizationKYC,
+    OrganizationListItem,
     OrganizationPaymentStatus,
     OrganizationPayoutAccountSet,
     OrganizationReviewState,
@@ -100,16 +106,17 @@ OrganizationNotFound = {
 @router.get(
     "/",
     summary="List Organizations",
-    response_model=ListResource[OrganizationSchema],
+    response_model=ListResource[OrganizationListItem],
     tags=[APITag.public],
+    operation_id="organizations:list",
 )
-async def list(
+async def list_organizations(
     auth_subject: auth.OrganizationsRead,
     pagination: PaginationParamsQuery,
     sorting: sorting.ListSorting,
     slug: str | None = Query(None, description="Filter by slug."),
     session: AsyncReadSession = Depends(get_db_read_session),
-) -> ListResource[OrganizationSchema]:
+) -> ListResource[OrganizationListItem]:
     """List organizations."""
     results, count = await organization_service.list(
         session,
@@ -119,8 +126,22 @@ async def list(
         sorting=sorting,
     )
 
+    roles_by_org_id: dict[UUID, OrganizationRole] = {}
+    if is_user(auth_subject):
+        user_organization_repository = UserOrganizationRepository(session)
+        roles_by_org_id = (
+            await user_organization_repository.get_roles_by_organization_ids(
+                auth_subject.subject.id, [result.id for result in results]
+            )
+        )
+
     return ListResource.from_paginated_results(
-        [OrganizationSchema.model_validate(result) for result in results],
+        [
+            OrganizationListItem.model_validate(result).model_copy(
+                update={"role": roles_by_org_id.get(result.id)}
+            )
+            for result in results
+        ],
         count,
         pagination,
     )
@@ -178,7 +199,7 @@ async def get_account(
     tags=[APITag.private],
 )
 async def set_payout_account(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageUser,
     body: OrganizationPayoutAccountSet,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
@@ -214,7 +235,7 @@ async def set_payout_account(
     tags=[APITag.private],
 )
 async def get_kyc(
-    authz: AuthorizeOrgAccess,
+    authz: AuthorizeOrgManage,
 ) -> Organization:
     """Get an organization's KYC/compliance details."""
     return authz.organization
@@ -267,7 +288,7 @@ async def check_slug(
     tags=[APITag.public],
 )
 async def update(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageUser,
     organization_update: OrganizationUpdate,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
@@ -316,7 +337,7 @@ async def submit_review(
     tags=[APITag.private],
 )
 async def delete(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageUser,
     session: AsyncSession = Depends(get_db_session),
 ) -> OrganizationDeletionResponse:
     """Request deletion of an organization.
@@ -385,6 +406,25 @@ async def members(
         items=[OrganizationMember.model_validate(m) for m in members],
         pagination=Pagination(total_count=len(members), max_page=1),
     )
+
+
+@router.get(
+    "/{id}/roles",
+    response_model=list[OrganizationRoleDefinition],
+    tags=[APITag.private],
+)
+async def roles(authz: AuthorizeOrgAccess) -> list[OrganizationRoleDefinition]:
+    """List the roles available in an organization, with the permissions
+    each role grants.
+
+    The set is currently static (identical across organizations); the
+    per-organization route shape leaves room for org-level role
+    customization in the future.
+    """
+    return [
+        OrganizationRoleDefinition(id=role, permissions=sorted(permissions))
+        for role, permissions in ROLE_PERMISSIONS.items()
+    ]
 
 
 @router.post(
@@ -593,7 +633,7 @@ async def set_member_role(
     tags=[APITag.private],
 )
 async def validate_with_ai(
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     session: AsyncSession = Depends(get_db_session),
 ) -> OrganizationReviewStatus:
     """Get the AI validation status. Review runs asynchronously in the background."""
@@ -625,7 +665,7 @@ async def validate_with_ai(
     tags=[APITag.private],
 )
 async def submit_appeal(
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     appeal_request: OrganizationAppealRequest,
     session: AsyncSession = Depends(get_db_session),
 ) -> OrganizationAppealResponse:
@@ -664,7 +704,7 @@ async def submit_appeal(
     tags=[APITag.private],
 )
 async def mark_ai_onboarding_complete(
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Mark the AI onboarding as completed for this organization."""
@@ -684,7 +724,7 @@ async def mark_ai_onboarding_complete(
     tags=[APITag.private],
 )
 async def get_review_status(
-    authz: AuthorizeOrgAccess,
+    authz: AuthorizeOrgManage,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewStatus:
     """Get the current review status and appeal information for an organization."""
@@ -715,7 +755,7 @@ async def get_review_status(
     tags=[APITag.private],
 )
 async def get_review(
-    authz: AuthorizeOrgAccess,
+    authz: AuthorizeOrgManage,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewState:
     """Get the merchant self-review checklist state.
@@ -737,7 +777,7 @@ async def get_review(
     tags=[APITag.private],
 )
 async def validate_website(
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     body: OrganizationValidateWebsiteRequest,
 ) -> OrganizationValidateWebsiteResponse:
     """Validate that a website URL is reachable and not targeting a private network."""
@@ -757,7 +797,7 @@ async def validate_website(
     tags=[APITag.private],
 )
 async def list_plans(
-    authz: AuthorizeOrgAccess,
+    authz: AuthorizeOrgManage,
 ) -> Sequence[OrganizationPlan]:
     """List the plans this organization can subscribe to."""
     products = await polar_self_service.list_plans()
@@ -777,7 +817,7 @@ async def list_plans(
     tags=[APITag.private],
 )
 async def get_subscription(
-    authz: AuthorizeOrgAccess,
+    authz: AuthorizeOrgManage,
 ) -> OrganizationSubscription:
     """Get the current Polar subscription for this organization."""
     subscription = await polar_self_service.get_subscription(authz.organization.id)
@@ -799,7 +839,7 @@ async def get_subscription(
 )
 async def start_subscription_checkout(
     request: Request,
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     body: OrganizationCheckoutRequest,
 ) -> OrganizationCheckoutResponse:
     """Create a Polar checkout session for an initial paid subscription."""
@@ -828,7 +868,7 @@ async def start_subscription_checkout(
     tags=[APITag.private],
 )
 async def change_subscription_plan(
-    authz: AuthorizeOrgAccessWrite,
+    authz: AuthorizeOrgManage,
     body: OrganizationSubscriptionUpdate,
 ) -> OrganizationSubscription:
     """Change the plan for an organization's existing subscription."""

--- a/server/polar/organization_access_token/endpoints.py
+++ b/server/polar/organization_access_token/endpoints.py
@@ -104,4 +104,6 @@ async def delete(
     if organization_access_token is None:
         raise ResourceNotFound()
 
-    await organization_access_token_service.delete(session, organization_access_token)
+    await organization_access_token_service.delete(
+        session, auth_subject, organization_access_token
+    )

--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -8,7 +8,11 @@ from sqlalchemy import UnaryExpression, asc, desc
 
 from polar.auth.models import AuthSubject, Organization, is_user
 from polar.auth.scope import Scope
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.config import settings
 from polar.email.schemas import (
     OrganizationAccessTokenLeakedEmail,
@@ -52,7 +56,9 @@ class OrganizationAccessTokenService:
         ],
     ) -> tuple[Sequence[OrganizationAccessToken], int]:
         repository = OrganizationAccessTokenRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.organization_manage
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -92,7 +98,9 @@ class OrganizationAccessTokenService:
         id: UUID,
     ) -> OrganizationAccessToken | None:
         repository = OrganizationAccessTokenRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.organization_manage
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             OrganizationAccessToken.id == id,
             OrganizationAccessToken.is_deleted.is_(False),
@@ -114,6 +122,13 @@ class OrganizationAccessTokenService:
     ) -> tuple[OrganizationAccessToken, str]:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
         )
         self._validate_scopes_within_caller(auth_subject, create_schema.scopes)
         token, token_hash = generate_token_hash_pair(
@@ -149,6 +164,13 @@ class OrganizationAccessTokenService:
         organization_access_token: OrganizationAccessToken,
         update_schema: OrganizationAccessTokenUpdate,
     ) -> OrganizationAccessToken:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization_access_token.organization_id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
+        )
         repository = OrganizationAccessTokenRepository.from_session(session)
 
         update_dict = update_schema.model_dump(exclude={"scopes"}, exclude_unset=True)
@@ -181,8 +203,18 @@ class OrganizationAccessTokenService:
             )
 
     async def delete(
-        self, session: AsyncSession, organization_access_token: OrganizationAccessToken
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        organization_access_token: OrganizationAccessToken,
     ) -> None:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization_access_token.organization_id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
+        )
         repository = OrganizationAccessTokenRepository.from_session(session)
         await repository.soft_delete(organization_access_token)
 

--- a/server/polar/payment/service.py
+++ b/server/polar/payment/service.py
@@ -4,7 +4,8 @@ from collections.abc import Sequence
 import stripe as stripe_lib
 
 from polar.auth.models import AuthSubject, Organization, User
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.enums import PaymentProcessor
 from polar.exceptions import PolarError
 from polar.kit.pagination import PaginationParams
@@ -59,7 +60,9 @@ class PaymentService:
         ],
     ) -> tuple[Sequence[Payment], int]:
         repository = PaymentRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -93,7 +96,9 @@ class PaymentService:
         id: uuid.UUID,
     ) -> Payment | None:
         repository = PaymentRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(Payment.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/payout/endpoints.py
+++ b/server/polar/payout/endpoints.py
@@ -3,6 +3,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import UUID4
 from sqlalchemy.orm import joinedload
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_organization_permission
 from polar.exceptions import ResourceNotFound
 from polar.kit.db.postgres import AsyncSessionMaker
 from polar.kit.pagination import ListResource, PaginationParamsQuery
@@ -84,6 +86,13 @@ async def get_estimate(
     if organization is None:
         raise ResourceNotFound()
 
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        organization.id,
+        OrganizationPermission.finance_read,
+        "Only an organization admin can access financial data",
+    )
     return await payout_service.estimate(session, organization)
 
 
@@ -106,6 +115,14 @@ async def create(
     )
     if organization is None:
         raise ResourceNotFound()
+
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        organization.id,
+        OrganizationPermission.finance_manage,
+        "Only an organization admin can manage financial data",
+    )
     return await payout_service.create(session, locker, organization)
 
 

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -8,7 +8,10 @@ import stripe as stripe_lib
 import structlog
 
 from polar.auth.models import AuthSubject, User
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    get_accessible_org_ids_with_permission,
+)
 from polar.config import settings
 from polar.enums import PayoutAccountType
 from polar.eventstream.service import publish as eventstream_publish
@@ -228,7 +231,9 @@ class PayoutService:
         ],
     ) -> tuple[Sequence[Payout], int]:
         repository = PayoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.finance_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).options(
             *repository.get_eager_options()
         )
@@ -252,7 +257,9 @@ class PayoutService:
         id: uuid.UUID,
     ) -> Payout | None:
         repository = PayoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.finance_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Payout.id == id)

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import contains_eager, selectinload
 from polar.auth.models import AuthSubject, is_user
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import (
+    assert_organization_permission,
     get_accessible_org_ids,
     get_accessible_org_ids_with_permission,
 )
@@ -18,7 +19,6 @@ from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.custom_field.service import custom_field as custom_field_service
 from polar.enums import SubscriptionRecurringInterval
 from polar.exceptions import (
-    NotPermitted,
     PolarRequestValidationError,
     ValidationError,
 )
@@ -172,7 +172,13 @@ class ProductService:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
         )
-        await self._require_manage(session, auth_subject, organization.id)
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
 
         errors: list[ValidationError] = []
         prices, _, _, prices_errors = await self.get_validated_prices(
@@ -264,7 +270,13 @@ class ProductService:
         update_schema: ProductUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> Product:
-        await self._require_manage(session, auth_subject, product.organization_id)
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            product.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
 
         errors: list[ValidationError] = []
 
@@ -437,7 +449,13 @@ class ProductService:
         benefits: Sequence[uuid.UUID],
         auth_subject: AuthSubject[User | Organization],
     ) -> tuple[Product, set[Benefit], set[Benefit]]:
-        await self._require_manage(session, auth_subject, product.organization_id)
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            product.organization_id,
+            OrganizationPermission.products_manage,
+            "Only an organization admin can manage products",
+        )
 
         previous_benefits = set(product.benefits)
         new_benefits: set[Benefit] = set()
@@ -690,18 +708,6 @@ class ProductService:
             )
 
         return prices, existing_prices, added_prices, errors
-
-    async def _require_manage(
-        self,
-        session: AsyncReadSession,
-        auth_subject: AuthSubject[User | Organization],
-        organization_id: uuid.UUID,
-    ) -> None:
-        manage_org_ids = await get_accessible_org_ids_with_permission(
-            session, auth_subject, OrganizationPermission.products_manage
-        )
-        if organization_id not in manage_org_ids:
-            raise NotPermitted("Only an organization admin can manage products")
 
     async def _archive(self, session: AsyncSession, product: Product) -> Product:
         product.is_archived = True

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -8,12 +8,17 @@ from sqlalchemy import select
 from sqlalchemy.orm import contains_eager, selectinload
 
 from polar.auth.models import AuthSubject, is_user
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    get_accessible_org_ids,
+    get_accessible_org_ids_with_permission,
+)
 from polar.benefit.service import benefit as benefit_service
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.custom_field.service import custom_field as custom_field_service
 from polar.enums import SubscriptionRecurringInterval
 from polar.exceptions import (
+    NotPermitted,
     PolarRequestValidationError,
     ValidationError,
 )
@@ -79,7 +84,9 @@ class ProductService:
         ],
     ) -> tuple[Sequence[Product], int]:
         repository = ProductRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).join(
             ProductPrice,
             onclause=(
@@ -145,7 +152,9 @@ class ProductService:
         id: uuid.UUID,
     ) -> Product | None:
         repository = ProductRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Product.id == id)
@@ -163,6 +172,7 @@ class ProductService:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
         )
+        await self._require_manage(session, auth_subject, organization.id)
 
         errors: list[ValidationError] = []
         prices, _, _, prices_errors = await self.get_validated_prices(
@@ -254,6 +264,8 @@ class ProductService:
         update_schema: ProductUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> Product:
+        await self._require_manage(session, auth_subject, product.organization_id)
+
         errors: list[ValidationError] = []
 
         # Validate prices
@@ -425,6 +437,8 @@ class ProductService:
         benefits: Sequence[uuid.UUID],
         auth_subject: AuthSubject[User | Organization],
     ) -> tuple[Product, set[Benefit], set[Benefit]]:
+        await self._require_manage(session, auth_subject, product.organization_id)
+
         previous_benefits = set(product.benefits)
         new_benefits: set[Benefit] = set()
 
@@ -676,6 +690,18 @@ class ProductService:
             )
 
         return prices, existing_prices, added_prices, errors
+
+    async def _require_manage(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        organization_id: uuid.UUID,
+    ) -> None:
+        manage_org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_manage
+        )
+        if organization_id not in manage_org_ids:
+            raise NotPermitted("Only an organization admin can manage products")
 
     async def _archive(self, session: AsyncSession, product: Product) -> Product:
         product.is_archived = True

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -11,7 +11,6 @@ from polar.auth.models import AuthSubject, is_user
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import (
     assert_organization_permission,
-    get_accessible_org_ids,
     get_accessible_org_ids_with_permission,
 )
 from polar.benefit.service import benefit as benefit_service
@@ -545,7 +544,9 @@ class ProductService:
         builtins.list[ValidationError],
     ]:
         meter_repository = MeterRepository.from_session(session)
-        meter_org_ids = await get_accessible_org_ids(session, auth_subject)
+        meter_org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.products_read
+        )
         prices: list[ProductPrice] = []
         prices_per_currency = defaultdict[str, list[tuple[ProductPrice, int]]](list)
         existing_prices: set[ProductPrice] = set()

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -8,7 +8,8 @@ import structlog
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids_with_permission
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.dispute.repository import DisputeRepository
 from polar.enums import PaymentProcessor
@@ -129,7 +130,9 @@ class RefundService:
         ],
     ) -> tuple[Sequence[Refund], int]:
         repository = RefundRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if id is not None:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -22,6 +22,7 @@ from polar.auth.models import (
 from polar.auth.models import (
     Customer as AuthCustomer,
 )
+from polar.auth.permission import OrganizationPermission, roles_with_permission
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.repository import (
     Options,
@@ -158,6 +159,9 @@ class SubscriptionRepository(
                     select(UserOrganization.organization_id).where(
                         UserOrganization.user_id == user.id,
                         UserOrganization.is_deleted.is_(False),
+                        UserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.sales_read)
+                        ),
                     )
                 )
             )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -11,7 +11,11 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids,
+)
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.billing_entry.service import MeteredLineItem
 from polar.billing_entry.service import billing_entry as billing_entry_service
@@ -436,6 +440,14 @@ class SubscriptionService:
 
         assert product is not None
         assert customer is not None
+
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            product.organization_id,
+            OrganizationPermission.customers_manage,
+            "Only an organization admin can manage customers",
+        )
 
         assert is_recurring_product(product)
         recurring_interval = product.recurring_interval

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -3,10 +3,11 @@ from collections.abc import Sequence
 from enum import StrEnum
 from typing import Any, cast
 
-from sqlalchemy import Select, UnaryExpression, asc, desc, func, or_, select
+from sqlalchemy import Select, UnaryExpression, and_, asc, desc, func, or_, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import aliased, joinedload, subqueryload
 
+from polar.auth.permission import OrganizationPermission, roles_with_permission
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.sorting import Sorting
@@ -245,9 +246,19 @@ class TransactionService(BaseTransactionService):
             .where(
                 or_(
                     User.id == user.id,
-                    UserOrganization.user_id == user.id,
+                    and_(
+                        UserOrganization.user_id == user.id,
+                        UserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.finance_read)
+                        ),
+                    ),
                     Transaction.payment_user_id == user.id,
-                    PaymentUserOrganization.user_id == user.id,
+                    and_(
+                        PaymentUserOrganization.user_id == user.id,
+                        PaymentUserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.finance_read)
+                        ),
+                    ),
                 )
             )
         )

--- a/server/polar/webhook/endpoints.py
+++ b/server/polar/webhook/endpoints.py
@@ -108,7 +108,7 @@ async def update_webhook_endpoint(
         raise ResourceNotFound()
 
     return await webhook_service.update_endpoint(
-        session, endpoint=endpoint, update_schema=update
+        session, auth_subject, endpoint=endpoint, update_schema=update
     )
 
 
@@ -132,7 +132,9 @@ async def reset_webhook_endpoint_secret(
     if not endpoint:
         raise ResourceNotFound()
 
-    return await webhook_service.reset_endpoint_secret(session, endpoint=endpoint)
+    return await webhook_service.reset_endpoint_secret(
+        session, auth_subject, endpoint=endpoint
+    )
 
 
 @router.delete(
@@ -155,7 +157,7 @@ async def delete_webhook_endpoint(
     if not endpoint:
         raise ResourceNotFound()
 
-    await webhook_service.delete_endpoint(session, endpoint)
+    await webhook_service.delete_endpoint(session, auth_subject, endpoint)
 
 
 @router.get(

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -11,7 +11,11 @@ from sqlalchemy import cast as sql_cast
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids_with_permission,
+)
 from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
 from polar.checkout.repository import CheckoutRepository
 from polar.config import settings
@@ -96,7 +100,9 @@ class WebhookService:
         pagination: PaginationParams,
     ) -> tuple[Sequence[WebhookEndpoint], int]:
         repository = WebhookEndpointRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.organization_manage
+        )
         statement = repository.get_statement_by_org_ids(org_ids).order_by(
             WebhookEndpoint.created_at.desc()
         )
@@ -117,7 +123,9 @@ class WebhookService:
         id: UUID,
     ) -> WebhookEndpoint | None:
         repository = WebhookEndpointRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.organization_manage
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             WebhookEndpoint.id == id
         )
@@ -132,6 +140,13 @@ class WebhookService:
         repository = WebhookEndpointRepository.from_session(session)
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
         )
         if create_schema.secret is not None:
             secret = create_schema.secret
@@ -160,10 +175,18 @@ class WebhookService:
     async def update_endpoint(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         *,
         endpoint: WebhookEndpoint,
         update_schema: WebhookEndpointUpdate,
     ) -> WebhookEndpoint:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            endpoint.organization_id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
+        )
         repository = WebhookEndpointRepository.from_session(session)
 
         is_enabling = update_schema.enabled is True and not endpoint.enabled
@@ -185,8 +208,19 @@ class WebhookService:
         )
 
     async def reset_endpoint_secret(
-        self, session: AsyncSession, *, endpoint: WebhookEndpoint
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        endpoint: WebhookEndpoint,
     ) -> WebhookEndpoint:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            endpoint.organization_id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
+        )
         repository = WebhookEndpointRepository.from_session(session)
         return await repository.update(
             endpoint,
@@ -198,8 +232,16 @@ class WebhookService:
     async def delete_endpoint(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         endpoint: WebhookEndpoint,
     ) -> WebhookEndpoint:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            endpoint.organization_id,
+            OrganizationPermission.organization_manage,
+            "Only an organization admin can manage the organization",
+        )
         repository = WebhookEndpointRepository.from_session(session)
         return await repository.soft_delete(endpoint)
 
@@ -218,7 +260,9 @@ class WebhookService:
         pagination: PaginationParams,
     ) -> tuple[Sequence[WebhookDelivery], int]:
         repository = WebhookDeliveryRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.organization_manage
+        )
 
         if endpoint_id is not None:
             endpoint_repository = WebhookEndpointRepository.from_session(session)
@@ -295,7 +339,9 @@ class WebhookService:
         id: UUID,
     ) -> None:
         repository = WebhookEventRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids_with_permission(
+            session, auth_subject, OrganizationPermission.organization_manage
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             WebhookEvent.id == id
         )

--- a/server/tests/authz/test_endpoints.py
+++ b/server/tests/authz/test_endpoints.py
@@ -83,6 +83,35 @@ class TestPolicyGuardGetAccount:
 
 
 @pytest.mark.asyncio
+class TestPolicyGuardUpdateOrganization:
+    """Test PolicyGuard behavior on PATCH /organizations/{id}."""
+
+    async def test_anonymous_returns_401(self, client: AsyncClient) -> None:
+        response = await client.patch(f"/v1/organizations/{uuid.uuid4()}", json={})
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_non_admin_returns_403_with_message(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}", json={"name": "Updated"}
+        )
+        assert response.status_code == 403
+        assert (
+            response.json()["detail"]
+            == "Only an organization admin can manage the organization"
+        )
+
+
+@pytest.mark.asyncio
 class TestPolicyGuardDeleteOrganization:
     """Test PolicyGuard behavior on DELETE /organizations/{id}."""
 
@@ -114,7 +143,7 @@ class TestPolicyGuardDeleteOrganization:
         assert response.status_code == 403
         assert (
             response.json()["detail"]
-            == "Only an organization admin can delete the organization"
+            == "Only an organization admin can manage the organization"
         )
 
 

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -83,7 +83,7 @@ class TestAccountCanRead:
 
 
 @pytest.mark.asyncio
-class TestOrgCanDelete:
+class TestOrgCanManage:
     @pytest.mark.auth
     async def test_admin_allowed(
         self,
@@ -95,7 +95,7 @@ class TestOrgCanDelete:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.admin)
 
-        result = await org_policy.can_delete(session, auth_subject, organization)
+        result = await org_policy.can_manage(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
@@ -109,8 +109,8 @@ class TestOrgCanDelete:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.member)
 
-        result = await org_policy.can_delete(session, auth_subject, organization)
-        assert result == "Only an organization admin can delete the organization"
+        result = await org_policy.can_manage(session, auth_subject, organization)
+        assert result == "Only an organization admin can manage the organization"
 
 
 @pytest.mark.asyncio

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -1,7 +1,7 @@
 import pytest
 
 from polar.auth.models import AuthSubject
-from polar.authz.policies import account as account_policy
+from polar.authz.policies import finance as finance_policy
 from polar.authz.policies import members
 from polar.authz.policies import organization as org_policy
 from polar.authz.policies import payout_account as pa_policy
@@ -26,7 +26,7 @@ async def _set_role(
 
 
 @pytest.mark.asyncio
-class TestAccountCanRead:
+class TestFinanceCanRead:
     @pytest.mark.auth
     async def test_admin_allowed(
         self,
@@ -38,7 +38,7 @@ class TestAccountCanRead:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.admin)
 
-        result = await account_policy.can_read(session, auth_subject, organization)
+        result = await finance_policy.can_read(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
@@ -52,7 +52,7 @@ class TestAccountCanRead:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.owner)
 
-        result = await account_policy.can_read(session, auth_subject, organization)
+        result = await finance_policy.can_read(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
@@ -66,7 +66,7 @@ class TestAccountCanRead:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.member)
 
-        result = await account_policy.can_read(session, auth_subject, organization)
+        result = await finance_policy.can_read(session, auth_subject, organization)
         assert isinstance(result, str)
         assert "admin" in result.lower()
 
@@ -78,7 +78,7 @@ class TestAccountCanRead:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        result = await account_policy.can_read(session, auth_subject, organization)
+        result = await finance_policy.can_read(session, auth_subject, organization)
         assert result is True
 
 

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -1,7 +1,8 @@
 import pytest
 
 from polar.auth.models import AuthSubject
-from polar.authz.policies import finance, members
+from polar.authz.policies import account as account_policy
+from polar.authz.policies import members
 from polar.authz.policies import organization as org_policy
 from polar.authz.policies import payout_account as pa_policy
 from polar.models import Organization, User
@@ -25,7 +26,7 @@ async def _set_role(
 
 
 @pytest.mark.asyncio
-class TestFinanceCanRead:
+class TestAccountCanRead:
     @pytest.mark.auth
     async def test_admin_allowed(
         self,
@@ -37,7 +38,7 @@ class TestFinanceCanRead:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.admin)
 
-        result = await finance.can_read(session, auth_subject, organization)
+        result = await account_policy.can_read(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
@@ -51,7 +52,7 @@ class TestFinanceCanRead:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.owner)
 
-        result = await finance.can_read(session, auth_subject, organization)
+        result = await account_policy.can_read(session, auth_subject, organization)
         assert result is True
 
     @pytest.mark.auth
@@ -65,7 +66,7 @@ class TestFinanceCanRead:
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.member)
 
-        result = await finance.can_read(session, auth_subject, organization)
+        result = await account_policy.can_read(session, auth_subject, organization)
         assert isinstance(result, str)
         assert "admin" in result.lower()
 
@@ -77,7 +78,7 @@ class TestFinanceCanRead:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        result = await finance.can_read(session, auth_subject, organization)
+        result = await account_policy.can_read(session, auth_subject, organization)
         assert result is True
 
 

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -405,6 +405,7 @@ class TestDelete:
     async def test_not_deletable_benefit(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
@@ -417,7 +418,7 @@ class TestDelete:
         )
 
         with pytest.raises(NotPermitted):
-            await benefit_service.delete(session, benefit)
+            await benefit_service.delete(session, benefit, auth_subject)
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),
@@ -427,10 +428,13 @@ class TestDelete:
         self,
         enqueue_job_mock: AsyncMock,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         benefit_organization: Benefit,
         user_organization: UserOrganization,
     ) -> None:
-        updated_benefit = await benefit_service.delete(session, benefit_organization)
+        updated_benefit = await benefit_service.delete(
+            session, benefit_organization, auth_subject
+        )
 
         assert updated_benefit.deleted_at is not None
 

--- a/server/tests/checkout_link/test_service.py
+++ b/server/tests/checkout_link/test_service.py
@@ -210,6 +210,7 @@ class TestUpdate:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         checkout_link: CheckoutLink,
     ) -> None:
         updated_checkout_link = await checkout_link_service.update(
@@ -228,6 +229,7 @@ class TestUpdate:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         checkout_link: CheckoutLink,
     ) -> None:
         updated_checkout_link = await checkout_link_service.update(
@@ -246,6 +248,7 @@ class TestUpdate:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         checkout_link: CheckoutLink,
         discount_fixed_once: Discount,
     ) -> None:
@@ -344,11 +347,16 @@ class TestUpdate:
 
 @pytest.mark.asyncio
 class TestDelete:
+    @pytest.mark.auth
     async def test_valid(
-        self, session: AsyncSession, checkout_link: CheckoutLink
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        checkout_link: CheckoutLink,
+        user_organization: UserOrganization,
     ) -> None:
         deleted_checkout_link = await checkout_link_service.delete(
-            session, checkout_link
+            session, checkout_link, auth_subject
         )
 
         assert deleted_checkout_link.deleted_at is not None

--- a/server/tests/custom_field/test_service.py
+++ b/server/tests/custom_field/test_service.py
@@ -1,9 +1,10 @@
 import pytest
 import pytest_asyncio
 
+from polar.auth.models import AuthSubject
 from polar.custom_field.schemas import CustomFieldUpdateText
 from polar.custom_field.service import custom_field as custom_field_service
-from polar.models import Customer, Order, Organization, Product
+from polar.models import Customer, Order, Organization, Product, User, UserOrganization
 from polar.models.custom_field import CustomFieldText, CustomFieldType
 from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession
@@ -42,9 +43,12 @@ async def order_text_field_data(
 
 @pytest.mark.asyncio
 class TestUpdate:
+    @pytest.mark.auth
     async def test_slug_update(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         text_field: CustomFieldText,
         order_text_field_data: Order,
     ) -> None:
@@ -52,6 +56,7 @@ class TestUpdate:
             session,
             text_field,
             CustomFieldUpdateText(type=text_field.type, slug="updatedslug"),
+            auth_subject,
         )
 
         assert updated_field.slug == "updatedslug"

--- a/server/tests/customer_seat/conftest.py
+++ b/server/tests/customer_seat/conftest.py
@@ -12,6 +12,7 @@ from polar.models import (
     User,
     UserOrganization,
 )
+from polar.models.user_organization import OrganizationRole
 from polar.models.checkout import CheckoutStatus
 from polar.models.customer_seat import CustomerSeat, SeatStatus
 from polar.models.order import OrderStatus
@@ -70,6 +71,7 @@ async def user_organization_seat_enabled(
     user_organization = UserOrganization(
         user_id=user.id,
         organization_id=seat_enabled_organization.id,
+        role=OrganizationRole.owner,
     )
     await save_fixture(user_organization)
     return user_organization

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -75,8 +75,11 @@ class TestCreate:
 
 @pytest.mark.asyncio
 class TestUpdate:
+    @pytest.mark.auth
     async def test_duration_change(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -95,10 +98,14 @@ class TestUpdate:
                 session,
                 discount,
                 discount_update=DiscountUpdate(duration=DiscountDuration.once),
+                auth_subject=auth_subject,
             )
 
+    @pytest.mark.auth
     async def test_type_change(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -117,6 +124,7 @@ class TestUpdate:
                 session,
                 discount,
                 discount_update=DiscountUpdate(type=DiscountType.fixed),
+                auth_subject=auth_subject,
             )
 
     @pytest.mark.parametrize(
@@ -127,8 +135,11 @@ class TestUpdate:
             ("basis_points", 1000),
         ],
     )
+    @pytest.mark.auth
     async def test_update_forbidden_field_with_redemptions(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         field: Literal["amount", "amounts", "basis_points"],
         value: Any,
         save_fixture: SaveFixture,
@@ -171,6 +182,7 @@ class TestUpdate:
                         "currency": "usd",
                     }
                 ),
+                auth_subject=auth_subject,
             )
 
     @pytest.mark.parametrize(
@@ -197,8 +209,11 @@ class TestUpdate:
             ),
         ],
     )
+    @pytest.mark.auth
     async def test_update_sensitive_fields(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         type: DiscountType,
         payload: DiscountUpdate,
         save_fixture: SaveFixture,
@@ -226,7 +241,10 @@ class TestUpdate:
         updated_ends_at = utc_now() + timedelta(days=2)
         payload.ends_at = updated_ends_at
         updated_discount = await discount_service.update(
-            session, discount, discount_update=payload
+            session,
+            discount,
+            discount_update=payload,
+            auth_subject=auth_subject,
         )
 
         if isinstance(updated_discount, DiscountPercentage):
@@ -236,8 +254,11 @@ class TestUpdate:
 
         assert updated_discount.ends_at == updated_ends_at
 
+    @pytest.mark.auth
     async def test_update_name(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -254,12 +275,16 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(name="Updated Name"),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.name == "Updated Name"
 
+    @pytest.mark.auth
     async def test_update_products(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -279,12 +304,16 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(products=[product_one_time.id]),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.products == [product_one_time]
 
+    @pytest.mark.auth
     async def test_update_products_reset(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -303,12 +332,16 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(products=[]),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.products == []
 
+    @pytest.mark.auth
     async def test_update_discount_past_dates(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -331,14 +364,18 @@ class TestUpdate:
                 starts_at=discount.starts_at,
                 ends_at=discount.ends_at,
             ),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.name == "Updated Name"
         assert updated_discount.starts_at == discount.starts_at
         assert updated_discount.ends_at == discount.ends_at
 
+    @pytest.mark.auth
     async def test_update_code_already_exists(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -365,13 +402,17 @@ class TestUpdate:
                 session,
                 discount_to_update,
                 discount_update=DiscountUpdate(code="EXISTING"),
+                auth_subject=auth_subject,
             )
 
         assert exc_info.value.errors()[0]["loc"] == ("body", "code")
         assert "already exists" in exc_info.value.errors()[0]["msg"]
 
+    @pytest.mark.auth
     async def test_update_code_same_discount(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -389,6 +430,7 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(code="mycode"),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.code == "mycode"

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -37,6 +37,8 @@ from polar.models import (
     Organization,
     Product,
     Subscription,
+    User,
+    UserOrganization,
 )
 from polar.models.billing_entry import BillingEntryDirection
 from polar.models.customer_seat import SeatStatus
@@ -217,8 +219,11 @@ class TestUpdate:
             ),
         ],
     )
+    @pytest.mark.auth
     async def test_sensitive_update_forbidden(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         meter_update: MeterUpdate,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -234,7 +239,7 @@ class TestUpdate:
         )
 
         with pytest.raises(PolarRequestValidationError):
-            await meter_service.update(session, meter, meter_update)
+            await meter_service.update(session, meter, meter_update, auth_subject)
 
     @pytest.mark.parametrize(
         "meter_update",
@@ -258,8 +263,11 @@ class TestUpdate:
             ),
         ],
     )
+    @pytest.mark.auth
     async def test_sensitive_update_allowed(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         meter_update: MeterUpdate,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -269,15 +277,20 @@ class TestUpdate:
             save_fixture, organization=organization, last_billed_event=None
         )
 
-        updated_meter = await meter_service.update(session, meter, meter_update)
+        updated_meter = await meter_service.update(
+            session, meter, meter_update, auth_subject
+        )
 
         if meter_update.filter:
             assert updated_meter.filter == meter_update.filter
         if meter_update.aggregation:
             assert updated_meter.aggregation == meter_update.aggregation
 
+    @pytest.mark.auth
     async def test_insensitive_update(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -294,7 +307,8 @@ class TestUpdate:
         updated_meter = await meter_service.update(
             session,
             meter,
-            MeterUpdate(name="New Name"),  # pyright: ignore
+            MeterUpdate(name="New Name"),  # pyright: ignore,
+            auth_subject=auth_subject,
         )
         assert updated_meter.name == "New Name"
 
@@ -302,8 +316,11 @@ class TestUpdate:
         "unit",
         [MeterUnit.scalar, MeterUnit.tokens, MeterUnit.custom],
     )
+    @pytest.mark.auth
     async def test_update_unit(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         unit: MeterUnit,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -314,7 +331,8 @@ class TestUpdate:
         updated_meter = await meter_service.update(
             session,
             meter,
-            MeterUpdate(unit=unit),  # pyright: ignore
+            MeterUpdate(unit=unit),  # pyright: ignore,
+            auth_subject=auth_subject,
         )
 
         assert updated_meter.unit == unit

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1040,7 +1040,7 @@ class TestDeleteOrganization:
         assert response.status_code == 403
         json = response.json()
         assert (
-            json["detail"] == "Only an organization admin can delete the organization"
+            json["detail"] == "Only an organization admin can manage the organization"
         )
 
 

--- a/server/tests/webhooks/test_service.py
+++ b/server/tests/webhooks/test_service.py
@@ -82,14 +82,20 @@ class TestUpdateEndpoint:
         AuthSubjectFixture(subject="organization", scopes={Scope.webhooks_write})
     )
     async def test_organization_endpoint_valid(
-        self, session: AsyncSession, webhook_endpoint_organization: WebhookEndpoint
+        self,
+        auth_subject: AuthSubject[Organization],
+        session: AsyncSession,
+        webhook_endpoint_organization: WebhookEndpoint,
     ) -> None:
         update_schema = WebhookEndpointUpdate(
             url=cast(HttpsUrl, "https://example.com/hook-updated")
         )
 
         updated_endpoint = await webhook_service.update_endpoint(
-            session, endpoint=webhook_endpoint_organization, update_schema=update_schema
+            session,
+            auth_subject,
+            endpoint=webhook_endpoint_organization,
+            update_schema=update_schema,
         )
         assert updated_endpoint.url == "https://example.com/hook-updated"
 
@@ -100,11 +106,14 @@ class TestResetEndpointSecret:
         AuthSubjectFixture(subject="organization", scopes={Scope.webhooks_write})
     )
     async def test_organization_endpoint_valid(
-        self, session: AsyncSession, webhook_endpoint_organization: WebhookEndpoint
+        self,
+        auth_subject: AuthSubject[Organization],
+        session: AsyncSession,
+        webhook_endpoint_organization: WebhookEndpoint,
     ) -> None:
         old_secret = webhook_endpoint_organization.secret
         updated_endpoint = await webhook_service.reset_endpoint_secret(
-            session, endpoint=webhook_endpoint_organization
+            session, auth_subject, endpoint=webhook_endpoint_organization
         )
         assert updated_endpoint.secret != old_secret
 
@@ -115,10 +124,13 @@ class TestDeleteEndpoint:
         AuthSubjectFixture(subject="organization", scopes={Scope.webhooks_write})
     )
     async def test_organization_endpoint_valid(
-        self, session: AsyncSession, webhook_endpoint_organization: WebhookEndpoint
+        self,
+        auth_subject: AuthSubject[Organization],
+        session: AsyncSession,
+        webhook_endpoint_organization: WebhookEndpoint,
     ) -> None:
         deleted_endpoint = await webhook_service.delete_endpoint(
-            session, webhook_endpoint_organization
+            session, auth_subject, webhook_endpoint_organization
         )
         assert deleted_endpoint.deleted_at is not None
 


### PR DESCRIPTION
Backend-only preparation work that uniformly enforces role-permission checks across every admin org-context API endpoint. Splits out from #11402 — the frontend work for that issue will be a separate follow-up PR.

## Summary

- **Vocabulary cleanup**: removed unwired permissions (`wallets:*`, `disputes:read`, `payouts:*`, `transactions:*`, `members:invite`, `members:remove`, `members:set_role`, `members:read` baseline, `organizations:edit_settings`, `organizations:delete`, `organizations:manage_payout_account`, `organizations:*`/`account:*` renames).
- **Section-shaped permissions** mirroring dashboard sections:
  - All-roles reads: `members:read`, `products:read`, `custom_fields:read`, `customers:read`, `sales:read`, `analytics:read`
  - Admin/owner writes: `organization:manage`, `members:manage`, `products:manage`, `custom_fields:manage`, `customers:manage`, `analytics:manage`, `finance:read`, `finance:manage`
  - Singular `organization:*` / `finance:*` for unique-per-org permissions; plural `members:*` / `sales:*` / etc. for collections. No more string collisions with OAuth scope names.
- **Wired across every section**: members, products (+ checkout_link, discount, benefit, meter, file, license_key admin), customers (+ customer_seat assign/revoke/resend), sales (orders, subscriptions, checkouts, disputes, refunds, payments), analytics (metrics, events, event_types), finance (account, transactions, payouts), organization (settings, KYC/review, OATs, webhooks).
- New `polar/authz/service.assert_organization_permission` helper for service-layer mutation gating.
- New `polar/authz/service.get_accessible_org_ids_with_permission` for permission-aware data filtering in `get_readable_statement` patterns.

## Behavior changes

Regular org members lose access to admin-only operations they previously could call with the right token scope. None of these break the dashboard for admin/owner users:

- Organization: edit settings, delete, payout-account swap, KYC/review, Polar plan management, OATs, webhooks → admin-only
- Members: invite, remove, role-change → admin-only (unchanged from Phase 3)
- Products + checkout_links + discounts + benefits + meters + files + license_key admin ops → admin-only writes
- Custom fields: CRUD → admin-only writes
- Customers: admin-API create/update/delete, subscription create, seat assign/revoke/resend → admin-only writes
- Analytics: metric dashboards CRUD, event_type label edits → admin-only writes
- Finance: transactions read, payout reads + create + invoice generation → admin-only

Org-token (organization access token) callers continue to pass on permissions that previously accepted them.

## Test plan

- [x] mypy clean (`uv run task lint_types`)
- [x] ruff/format clean (`uv run task lint`)
- [x] All backend test suites pass under each touched module
- [ ] Manual: verify admin/owner can still perform all admin operations in the dashboard
- [ ] Manual: verify members get a 4xx (403/404) on each tightened endpoint
- [ ] Manual: verify customer-portal flows are unaffected (wallets, customer seats claim, license validate/activate)

## Out of scope

- Per-user organizations endpoint exposing `role` and the new `GET /v1/organizations/{id}/roles` endpoint — held back for the #11402 frontend PR
- TS client regeneration — same, will land alongside the frontend work
- Backoffice/staff flows
- Customer-portal endpoints (intentionally not org-role-shaped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)