### PR TITLE
feat: expose setup_readiness breakdown via nested sub_checks

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23780,6 +23780,11 @@ export interface components {
        * @description Optional contextual value associated with the check, e.g. the product URL for the `product_url` check.
        */
       value?: string | null
+      /**
+       * Sub Checks
+       * @description Per-component breakdown, populated only for aggregate checks (currently `setup_readiness`). The parent `status` is the source of truth for gating.
+       */
+      sub_checks?: components['schemas']['OrganizationReviewSubCheck'][]
     }
     /**
      * OrganizationReviewCheckKey
@@ -23865,6 +23870,38 @@ export interface components {
        */
       appeal_reviewed_at?: string | null
     }
+    /**
+     * OrganizationReviewSubCheck
+     * @description A nested sub-item that contributes to a parent check's rolled-up status.
+     *
+     *     Sub-checks expose the per-component breakdown for aggregate checks (e.g.
+     *     `setup_readiness`) so the frontend doesn't have to re-derive which path
+     *     is configured. The parent's `status` is the source of truth for gating;
+     *     reasons explaining a sub-item live on the sub-check itself.
+     */
+    OrganizationReviewSubCheck: {
+      key: components['schemas']['OrganizationReviewSubCheckKey']
+      status: components['schemas']['OrganizationReviewCheckStatus']
+      /**
+       * Reasons
+       * @description Reasons for the sub-check's current status. Empty when `passed`.
+       */
+      reasons?: components['schemas']['OrganizationReviewCheckReason'][]
+      /**
+       * Value
+       * @description Optional contextual value associated with the sub-check.
+       */
+      value?: string | null
+    }
+    /**
+     * OrganizationReviewSubCheckKey
+     * @description Stable identifiers for nested sub-checks inside a parent check.
+     * @enum {string}
+     */
+    OrganizationReviewSubCheckKey:
+      | 'setup_readiness.checkout_link'
+      | 'setup_readiness.access_token'
+      | 'setup_readiness.webhook'
     /**
      * OrganizationRole
      * @enum {string}
@@ -54489,6 +54526,13 @@ export const organizationReviewStateVerdictAnyOf0Values: ReadonlyArray<
 export const organizationReviewStatusVerdictAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewStatus']['verdict']
 > = ['PASS', 'FAIL', 'UNCERTAIN']
+export const organizationReviewSubCheckKeyValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationReviewSubCheckKey']
+> = [
+  'setup_readiness.checkout_link',
+  'setup_readiness.access_token',
+  'setup_readiness.webhook',
+]
 export const organizationRoleValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationRole']
 > = ['owner', 'admin', 'member']

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -610,6 +610,35 @@ class OrganizationReviewCheckReason(StrEnum):
     SETUP_READINESS_WEBHOOK_MISSING = "setup_readiness.webhook_missing"
 
 
+class OrganizationReviewSubCheckKey(StrEnum):
+    """Stable identifiers for nested sub-checks inside a parent check."""
+
+    SETUP_READINESS_CHECKOUT_LINK = "setup_readiness.checkout_link"
+    SETUP_READINESS_ACCESS_TOKEN = "setup_readiness.access_token"
+    SETUP_READINESS_WEBHOOK = "setup_readiness.webhook"
+
+
+class OrganizationReviewSubCheck(Schema):
+    """A nested sub-item that contributes to a parent check's rolled-up status.
+
+    Sub-checks expose the per-component breakdown for aggregate checks (e.g.
+    `setup_readiness`) so the frontend doesn't have to re-derive which path
+    is configured. The parent's `status` is the source of truth for gating;
+    reasons explaining a sub-item live on the sub-check itself.
+    """
+
+    key: OrganizationReviewSubCheckKey
+    status: OrganizationReviewCheckStatus
+    reasons: list[OrganizationReviewCheckReason] = Field(
+        default_factory=list,
+        description="Reasons for the sub-check's current status. Empty when `passed`.",
+    )
+    value: str | None = Field(
+        default=None,
+        description="Optional contextual value associated with the sub-check.",
+    )
+
+
 class OrganizationReviewCheck(Schema):
     """A single item in the self-review checklist."""
 
@@ -624,6 +653,14 @@ class OrganizationReviewCheck(Schema):
         description=(
             "Optional contextual value associated with the check, e.g. the "
             "product URL for the `product_url` check."
+        ),
+    )
+    sub_checks: list[OrganizationReviewSubCheck] = Field(
+        default_factory=list,
+        description=(
+            "Per-component breakdown, populated only for aggregate checks "
+            "(currently `setup_readiness`). The parent `status` is the "
+            "source of truth for gating."
         ),
     )
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -88,6 +88,8 @@ from .schemas import (
     OrganizationReviewCheckReason,
     OrganizationReviewCheckStatus,
     OrganizationReviewState,
+    OrganizationReviewSubCheck,
+    OrganizationReviewSubCheckKey,
     OrganizationReviewSubmissionBody,
     OrganizationReviewVerdict,
     OrganizationSlugAvailability,
@@ -1565,29 +1567,82 @@ class OrganizationService:
         An access token without a webhook is a non-blocking warning rather
         than a failure: the merchant can still fulfill via success_url +
         API calls, we just can't observe state changes (refunds,
-        cancellations) without webhooks during review.
+        cancellations) without webhooks during review. Aggregate checks
+        expose per-component state via `sub_checks`; the parent `status`
+        remains the source of truth for gating.
         """
         key = OrganizationReviewCheckKey.SETUP_READINESS
 
         checkout_link_repository = CheckoutLinkRepository.from_session(session)
-        if await checkout_link_repository.has_with_benefit_types(
-            organization.id, _CHECKOUT_FULFILLABLE_BENEFITS
-        ) or await checkout_link_repository.has_with_success_url(organization.id):
-            return self._passed_check(key)
-
         access_token_repository = OrganizationAccessTokenRepository.from_session(
             session
         )
-        if not await access_token_repository.has_by_organization_id(organization.id):
-            return self._not_started_check(key)
-
         webhook_repository = WebhookEndpointRepository.from_session(session)
-        if await webhook_repository.has_by_organization_id(organization.id):
-            return self._passed_check(key)
+
+        has_checkout_link_with_fulfillable_benefit = (
+            await checkout_link_repository.has_with_benefit_types(
+                organization.id, _CHECKOUT_FULFILLABLE_BENEFITS
+            )
+        )
+        has_checkout_link_with_success_url = (
+            await checkout_link_repository.has_with_success_url(organization.id)
+        )
+        has_fulfillable_checkout_link = (
+            has_checkout_link_with_fulfillable_benefit
+            or has_checkout_link_with_success_url
+        )
+        has_access_token = await access_token_repository.has_by_organization_id(
+            organization.id
+        )
+        has_webhook = await webhook_repository.has_by_organization_id(organization.id)
+
+        def _sub(
+            sub_key: OrganizationReviewSubCheckKey, ok: bool
+        ) -> OrganizationReviewSubCheck:
+            return OrganizationReviewSubCheck(
+                key=sub_key,
+                status=OrganizationReviewCheckStatus.PASSED
+                if ok
+                else OrganizationReviewCheckStatus.PENDING,
+                reasons=[] if ok else [OrganizationReviewCheckReason.NOT_STARTED],
+            )
+
+        checkout_link_sub = _sub(
+            OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK,
+            has_fulfillable_checkout_link,
+        )
+        access_token_sub = _sub(
+            OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN,
+            has_access_token,
+        )
+
+        # Webhook escalates to WARNING (not just PENDING) when the merchant
+        # has chosen the API path: at that point we expect a webhook for
+        # observability, and its absence is a non-blocking flag rather than
+        # a "not started yet" state.
+        if has_access_token and not has_webhook:
+            webhook_sub = OrganizationReviewSubCheck(
+                key=OrganizationReviewSubCheckKey.SETUP_READINESS_WEBHOOK,
+                status=OrganizationReviewCheckStatus.WARNING,
+                reasons=[OrganizationReviewCheckReason.SETUP_READINESS_WEBHOOK_MISSING],
+            )
+        else:
+            webhook_sub = _sub(
+                OrganizationReviewSubCheckKey.SETUP_READINESS_WEBHOOK, has_webhook
+            )
+
+        if checkout_link_sub.status == OrganizationReviewCheckStatus.PASSED:
+            parent_status = OrganizationReviewCheckStatus.PASSED
+        elif access_token_sub.status == OrganizationReviewCheckStatus.PASSED:
+            # PASSED when webhook is set up, WARNING otherwise.
+            parent_status = webhook_sub.status
+        else:
+            parent_status = OrganizationReviewCheckStatus.PENDING
+
         return OrganizationReviewCheck(
             key=key,
-            status=OrganizationReviewCheckStatus.WARNING,
-            reasons=[OrganizationReviewCheckReason.SETUP_READINESS_WEBHOOK_MISSING],
+            status=parent_status,
+            sub_checks=[checkout_link_sub, access_token_sub, webhook_sub],
         )
 
     async def submit_appeal(

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1105,9 +1105,10 @@ class TestGetReview:
         assert json["verdict"] is None
         assert json["appeal"] is None
         assert all(step["status"] == "pending" for step in json["preliminary_steps"])
-        assert all(
-            "not_started" in step["reasons"] for step in json["preliminary_steps"]
-        )
+        # Aggregate checks carry reasons on sub_checks, not the parent.
+        for step in json["preliminary_steps"]:
+            targets = step["sub_checks"] or [step]
+            assert all("not_started" in node["reasons"] for node in targets)
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -44,6 +44,8 @@ from polar.organization.schemas import (
     OrganizationReviewCheckReason,
     OrganizationReviewCheckStatus,
     OrganizationReviewState,
+    OrganizationReviewSubCheck,
+    OrganizationReviewSubCheckKey,
     OrganizationSocialLink,
     OrganizationSocialPlatforms,
     OrganizationUpdate,
@@ -1353,6 +1355,15 @@ def _step(
     raise AssertionError(f"step {key} missing from {state}")
 
 
+def _sub(
+    step: OrganizationReviewCheck, key: OrganizationReviewSubCheckKey
+) -> OrganizationReviewSubCheck:
+    for sub in step.sub_checks:
+        if sub.key == key:
+            return sub
+    raise AssertionError(f"sub_check {key} missing from {step}")
+
+
 @pytest.mark.asyncio
 class TestGetReviewState:
     """Test the merchant self-review checklist."""
@@ -1381,10 +1392,17 @@ class TestGetReviewState:
             step.status == OrganizationReviewCheckStatus.PENDING
             for step in state.preliminary_steps
         )
-        assert all(
-            OrganizationReviewCheckReason.NOT_STARTED in step.reasons
-            for step in state.preliminary_steps
-        )
+        # Aggregate checks carry reasons on sub_checks, not the parent.
+        for step in state.preliminary_steps:
+            reason_lists = (
+                [sub.reasons for sub in step.sub_checks]
+                if step.sub_checks
+                else [step.reasons]
+            )
+            assert all(
+                OrganizationReviewCheckReason.NOT_STARTED in reasons
+                for reasons in reason_lists
+            )
 
     async def test_email_set_passes(
         self,
@@ -1747,7 +1765,15 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.PENDING
-        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+        assert step.reasons == []
+        for sub_key in (
+            OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK,
+            OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN,
+            OrganizationReviewSubCheckKey.SETUP_READINESS_WEBHOOK,
+        ):
+            sub = _sub(step, sub_key)
+            assert sub.status == OrganizationReviewCheckStatus.PENDING
+            assert OrganizationReviewCheckReason.NOT_STARTED in sub.reasons
 
     async def test_setup_readiness_checkout_link_with_eligible_benefit_passes(
         self,
@@ -1770,6 +1796,18 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert (
+            _sub(
+                step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
+            ).status
+            == OrganizationReviewCheckStatus.PASSED
+        )
+        assert (
+            _sub(
+                step, OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN
+            ).status
+            == OrganizationReviewCheckStatus.PENDING
+        )
 
     @pytest.mark.parametrize(
         "benefit_type",
@@ -1800,7 +1838,11 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.PENDING
-        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+        checkout_link_sub = _sub(
+            step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
+        )
+        assert checkout_link_sub.status == OrganizationReviewCheckStatus.PENDING
+        assert OrganizationReviewCheckReason.NOT_STARTED in checkout_link_sub.reasons
 
     async def test_setup_readiness_checkout_link_with_success_url_passes(
         self,
@@ -1821,6 +1863,12 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert (
+            _sub(
+                step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
+            ).status
+            == OrganizationReviewCheckStatus.PASSED
+        )
 
     async def test_setup_readiness_checkout_link_without_benefits_or_success_url_is_not_started(
         self,
@@ -1837,7 +1885,11 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.PENDING
-        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+        checkout_link_sub = _sub(
+            step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
+        )
+        assert checkout_link_sub.status == OrganizationReviewCheckStatus.PENDING
+        assert OrganizationReviewCheckReason.NOT_STARTED in checkout_link_sub.reasons
 
     async def test_setup_readiness_access_token_and_webhook_passes(
         self,
@@ -1859,6 +1911,22 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert (
+            _sub(
+                step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
+            ).status
+            == OrganizationReviewCheckStatus.PENDING
+        )
+        assert (
+            _sub(
+                step, OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN
+            ).status
+            == OrganizationReviewCheckStatus.PASSED
+        )
+        assert (
+            _sub(step, OrganizationReviewSubCheckKey.SETUP_READINESS_WEBHOOK).status
+            == OrganizationReviewCheckStatus.PASSED
+        )
 
     async def test_setup_readiness_access_token_without_webhook_warns(
         self,
@@ -1879,9 +1947,16 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.WARNING
+        assert step.reasons == []
+        access_token_sub = _sub(
+            step, OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN
+        )
+        assert access_token_sub.status == OrganizationReviewCheckStatus.PASSED
+        webhook_sub = _sub(step, OrganizationReviewSubCheckKey.SETUP_READINESS_WEBHOOK)
+        assert webhook_sub.status == OrganizationReviewCheckStatus.WARNING
         assert (
             OrganizationReviewCheckReason.SETUP_READINESS_WEBHOOK_MISSING
-            in step.reasons
+            in webhook_sub.reasons
         )
         # Warnings do not block submission, even when this check is in WARNING.
         non_setup_failing = [


### PR DESCRIPTION
## Summary

Splits the aggregate `setup_readiness` check on `GET /v1/organizations/{id}/review` into a parent rollup plus a per-component breakdown (`checkout_link`, `access_token`, `webhook`) under a new `sub_checks` field, so the merchant review UI can render each sub-item's state without re-deriving the OR logic.

The parent `status` remains the source of truth for gating; sub-checks carry their own `status` + `reasons`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included