### PR TITLE
feat: surface setup_readiness sub-check reasons and FAILED checkout state

### DIFF
--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -119,6 +119,20 @@ class CheckoutLinkRepository(
         result = await self.session.execute(statement)
         return result.scalar_one_or_none() is not None
 
+    async def has_by_organization_id(self, organization_id: UUID) -> bool:
+        """Whether the organization has any live checkout link, regardless
+        of fulfillment configuration."""
+        statement = (
+            select(CheckoutLink.id)
+            .where(
+                CheckoutLink.organization_id == organization_id,
+                CheckoutLink.deleted_at.is_(None),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none() is not None
+
     async def archive_product(self, product_id: UUID) -> None:
         statement = (
             self.get_base_statement()

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -608,6 +608,9 @@ class OrganizationReviewCheckReason(StrEnum):
 
     # Setup readiness
     SETUP_READINESS_WEBHOOK_MISSING = "setup_readiness.webhook_missing"
+    SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT = (
+        "setup_readiness.checkout_link_no_fulfillment"
+    )
 
 
 class OrganizationReviewSubCheckKey(StrEnum):

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1562,14 +1562,20 @@ class OrganizationService:
         endpoint.
 
         A checkout link with neither benefits nor a success_url has no
-        automatic fulfillment path, which is a broken integration.
+        automatic fulfillment path, which is a broken integration: the
+        checkout link sub-check is FAILED in that case (vs PENDING when no
+        checkout link exists at all). FAILED blocks submission because the
+        AI review penalizes orgs with broken checkout links.
 
         An access token without a webhook is a non-blocking warning rather
         than a failure: the merchant can still fulfill via success_url +
         API calls, we just can't observe state changes (refunds,
         cancellations) without webhooks during review. Aggregate checks
         expose per-component state via `sub_checks`; the parent `status`
-        remains the source of truth for gating.
+        remains the source of truth for gating. Sub-check reasons that
+        match the parent's terminal status are also surfaced on the parent
+        so the FE can render a single explanatory line without re-deriving
+        which sub-item drove the rollup.
         """
         key = OrganizationReviewCheckKey.SETUP_READINESS
 
@@ -1596,7 +1602,7 @@ class OrganizationService:
         )
         has_webhook = await webhook_repository.has_by_organization_id(organization.id)
 
-        def _sub(
+        def _passed_or_pending(
             sub_key: OrganizationReviewSubCheckKey, ok: bool
         ) -> OrganizationReviewSubCheck:
             return OrganizationReviewSubCheck(
@@ -1607,13 +1613,28 @@ class OrganizationService:
                 reasons=[] if ok else [OrganizationReviewCheckReason.NOT_STARTED],
             )
 
-        checkout_link_sub = _sub(
-            OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK,
-            has_fulfillable_checkout_link,
-        )
-        access_token_sub = _sub(
-            OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN,
-            has_access_token,
+        if has_fulfillable_checkout_link:
+            checkout_link_sub = OrganizationReviewSubCheck(
+                key=OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK,
+                status=OrganizationReviewCheckStatus.PASSED,
+            )
+        elif await checkout_link_repository.has_by_organization_id(organization.id):
+            checkout_link_sub = OrganizationReviewSubCheck(
+                key=OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK,
+                status=OrganizationReviewCheckStatus.FAILED,
+                reasons=[
+                    OrganizationReviewCheckReason.SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT
+                ],
+            )
+        else:
+            checkout_link_sub = OrganizationReviewSubCheck(
+                key=OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK,
+                status=OrganizationReviewCheckStatus.PENDING,
+                reasons=[OrganizationReviewCheckReason.NOT_STARTED],
+            )
+
+        access_token_sub = _passed_or_pending(
+            OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN, has_access_token
         )
 
         # Webhook escalates to WARNING (not just PENDING) when the merchant
@@ -1627,22 +1648,40 @@ class OrganizationService:
                 reasons=[OrganizationReviewCheckReason.SETUP_READINESS_WEBHOOK_MISSING],
             )
         else:
-            webhook_sub = _sub(
+            webhook_sub = _passed_or_pending(
                 OrganizationReviewSubCheckKey.SETUP_READINESS_WEBHOOK, has_webhook
             )
 
-        if checkout_link_sub.status == OrganizationReviewCheckStatus.PASSED:
+        sub_checks = [checkout_link_sub, access_token_sub, webhook_sub]
+
+        # A broken checkout link is a blocking signal regardless of whether
+        # the API path is also configured: the AI review will flag it.
+        if checkout_link_sub.status == OrganizationReviewCheckStatus.FAILED:
+            parent_status = OrganizationReviewCheckStatus.FAILED
+        elif checkout_link_sub.status == OrganizationReviewCheckStatus.PASSED:
             parent_status = OrganizationReviewCheckStatus.PASSED
         elif access_token_sub.status == OrganizationReviewCheckStatus.PASSED:
-            # PASSED when webhook is set up, WARNING otherwise.
             parent_status = webhook_sub.status
         else:
             parent_status = OrganizationReviewCheckStatus.PENDING
 
+        # Surface terminal sub-check reasons on the parent so the FE can
+        # render a single explanatory line. PENDING is self-explanatory and
+        # multiple sub-checks may be in that state, so skip it.
+        parent_reasons: list[OrganizationReviewCheckReason] = []
+        if parent_status in (
+            OrganizationReviewCheckStatus.WARNING,
+            OrganizationReviewCheckStatus.FAILED,
+        ):
+            for sub in sub_checks:
+                if sub.status == parent_status:
+                    parent_reasons.extend(sub.reasons)
+
         return OrganizationReviewCheck(
             key=key,
             status=parent_status,
-            sub_checks=[checkout_link_sub, access_token_sub, webhook_sub],
+            reasons=parent_reasons,
+            sub_checks=sub_checks,
         )
 
     async def submit_appeal(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1837,12 +1837,21 @@ class TestGetReviewState:
         state = await organization_service.get_review_state(session, organization)
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
-        assert step.status == OrganizationReviewCheckStatus.PENDING
+        # A checkout link exists but has no fulfillable benefit and no
+        # success_url, so the integration is broken: FAILED, not pending.
+        assert step.status == OrganizationReviewCheckStatus.FAILED
         checkout_link_sub = _sub(
             step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
         )
-        assert checkout_link_sub.status == OrganizationReviewCheckStatus.PENDING
-        assert OrganizationReviewCheckReason.NOT_STARTED in checkout_link_sub.reasons
+        assert checkout_link_sub.status == OrganizationReviewCheckStatus.FAILED
+        assert (
+            OrganizationReviewCheckReason.SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT
+            in checkout_link_sub.reasons
+        )
+        assert (
+            OrganizationReviewCheckReason.SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT
+            in step.reasons
+        )
 
     async def test_setup_readiness_checkout_link_with_success_url_passes(
         self,
@@ -1870,7 +1879,7 @@ class TestGetReviewState:
             == OrganizationReviewCheckStatus.PASSED
         )
 
-    async def test_setup_readiness_checkout_link_without_benefits_or_success_url_is_not_started(
+    async def test_setup_readiness_checkout_link_without_benefits_or_success_url_fails(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -1884,12 +1893,50 @@ class TestGetReviewState:
         state = await organization_service.get_review_state(session, organization)
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
-        assert step.status == OrganizationReviewCheckStatus.PENDING
+        assert step.status == OrganizationReviewCheckStatus.FAILED
         checkout_link_sub = _sub(
             step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
         )
-        assert checkout_link_sub.status == OrganizationReviewCheckStatus.PENDING
-        assert OrganizationReviewCheckReason.NOT_STARTED in checkout_link_sub.reasons
+        assert checkout_link_sub.status == OrganizationReviewCheckStatus.FAILED
+        assert (
+            OrganizationReviewCheckReason.SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT
+            in checkout_link_sub.reasons
+        )
+        assert (
+            OrganizationReviewCheckReason.SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT
+            in step.reasons
+        )
+
+    async def test_setup_readiness_broken_checkout_link_fails_even_with_api_path(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Even with the API path configured (access token + webhook), a
+        # broken checkout link is a blocking signal the AI review will flag.
+        product = await create_product(
+            save_fixture, organization=organization, recurring_interval=None
+        )
+        await create_checkout_link(save_fixture, products=[product])
+        await save_fixture(
+            OrganizationAccessToken(
+                comment="test",
+                token="hash",
+                organization=organization,
+                scope="openid",
+            )
+        )
+        await create_webhook_endpoint(save_fixture, organization=organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
+
+        assert step.status == OrganizationReviewCheckStatus.FAILED
+        assert (
+            OrganizationReviewCheckReason.SETUP_READINESS_CHECKOUT_LINK_NO_FULFILLMENT
+            in step.reasons
+        )
 
     async def test_setup_readiness_access_token_and_webhook_passes(
         self,
@@ -1947,7 +1994,12 @@ class TestGetReviewState:
         step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
 
         assert step.status == OrganizationReviewCheckStatus.WARNING
-        assert step.reasons == []
+        # Webhook-missing reason is propagated to the parent so the FE can
+        # render an explanatory line at the rolled-up level.
+        assert (
+            OrganizationReviewCheckReason.SETUP_READINESS_WEBHOOK_MISSING
+            in step.reasons
+        )
         access_token_sub = _sub(
             step, OrganizationReviewSubCheckKey.SETUP_READINESS_ACCESS_TOKEN
         )


### PR DESCRIPTION
## Summary

- Propagate WARNING/FAILED sub-check reasons up to the parent `setup_readiness` check so the dashboard can render a single explanatory line (e.g. "Adding a webhook is recommended").
- A checkout link that exists but has neither a fulfillable benefit nor a success URL now resolves to `FAILED` (previously `PENDING`), blocking submission to match the AI review's expectations.

## Test plan

- [x] Backend lint (`uv run task lint`)
- [x] Backend type check (`uv run task lint_types`)
- [x] Setup-readiness unit tests pass (`uv run pytest tests/organization/test_service.py`)
- [ ] Verify in the dashboard that the parent `setup_readiness` check displays the propagated reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)