### PR TITLE
plain: Set name as email

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -1391,7 +1391,6 @@ class PlainService:
         *,
         external_id: str,
         email: str,
-        name: str,
         email_verified: bool = False,
     ) -> None:
         if not self.enabled:
@@ -1403,7 +1402,7 @@ class PlainService:
                     identifier=UpsertCustomerIdentifierInput(external_id=external_id),
                     on_create=UpsertCustomerOnCreateInput(
                         external_id=external_id,
-                        full_name=name,
+                        full_name=email,
                         email=EmailAddressInput(
                             email=email, is_verified=email_verified
                         ),
@@ -1417,6 +1416,10 @@ class PlainService:
             )
             if result.error is not None:
                 raise PlainCustomerError(uuid.UUID(external_id), result.error.message)
+            if result.customer is None:
+                raise PlainCustomerError(
+                    uuid.UUID(external_id), "No customer returned by upsert"
+                )
 
     async def upsert_tenant(self, *, external_id: str, name: str) -> None:
         if not self.enabled:

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -53,7 +53,6 @@ async def create_customer(
     await plain_service.upsert_customer(
         external_id=owner_external_id,
         email=owner_email,
-        name=owner_name,
     )
     await plain_service.add_customer_to_tenant(
         customer_external_id=owner_external_id,
@@ -92,7 +91,6 @@ async def add_member(
     await plain_service.upsert_customer(
         external_id=external_id,
         email=email,
-        name=name,
     )
     await plain_service.add_customer_to_tenant(
         customer_external_id=external_id,

--- a/server/scripts/backfill_plain_tenants.py
+++ b/server/scripts/backfill_plain_tenants.py
@@ -120,7 +120,6 @@ async def run_backfill(
                     await plain_service.upsert_customer(
                         external_id=str(user.id),
                         email=user.email,
-                        name=user.public_name,
                         email_verified=user.email_verified,
                     )
                     await plain_service.add_customer_to_tenant(


### PR DESCRIPTION
Similar to how we've done it in the past, we can set the name as the email. Otherwise we get a single letter name.
