### PR TITLE
Add missing events for account review funnel

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequiredV2.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequiredV2.tsx
@@ -77,6 +77,11 @@ export const AccountPageDetailsRequiredV2 = ({ organization }: Props) => {
       return
     }
 
+    posthog.capture('dashboard:organizations:account_review:done', {
+      organization_id: organization.id,
+      section: 'cta',
+    })
+
     router.refresh()
   }
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageInReview.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageInReview.tsx
@@ -3,13 +3,23 @@
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import AIValidationResult from '@/components/Organization/AIValidationResult'
 import { Section, SectionDescription } from '@/components/Settings/Section'
+import { usePostHog } from '@/hooks/posthog'
 import { schemas } from '@polar-sh/client'
+import { useEffect } from 'react'
 
 interface Props {
   organization: schemas['Organization']
 }
 
 export const AccountPageInReview = ({ organization }: Props) => {
+  const posthog = usePostHog()
+
+  useEffect(() => {
+    posthog.capture('dashboard:organizations:account_review:view', {
+      organization_id: organization.id,
+    })
+  }, [organization.id, posthog])
+
   return (
     <DashboardBody wrapperClassName="max-w-(--breakpoint-sm)!">
       <div className="flex flex-col gap-y-12">


### PR DESCRIPTION
This will add some missing events to make sure we can track the following funnel

* Account review landing
* Submit
* Done
* Account "in review" view