### PR TITLE
authz: consolidate product & custom_fields permissions (2/5)

### DIFF
--- a/server/polar/benefit/endpoints.py
+++ b/server/polar/benefit/endpoints.py
@@ -237,4 +237,4 @@ async def delete(
     if benefit is None:
         raise ResourceNotFound()
 
-    await benefit_service.delete(session, benefit)
+    await benefit_service.delete(session, benefit, auth_subject)

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.strategies import BenefitRetriableError
 from polar.customer.repository import CustomerRepository
@@ -161,7 +162,9 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         ],
     ) -> tuple[Sequence[BenefitGrant], int]:
         repository = BenefitGrantRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.customers_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .join(Customer, BenefitGrant.customer_id == Customer.id)

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -5,7 +5,12 @@ from pydantic import BaseModel
 from sqlalchemy import case, delete
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.exceptions import NotPermitted, PolarRequestValidationError
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
@@ -44,7 +49,9 @@ class BenefitService:
         query: str | None = None,
     ) -> tuple[Sequence[Benefit], int]:
         repository = BenefitRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if type is not None:
@@ -97,7 +104,9 @@ class BenefitService:
         id: uuid.UUID,
     ) -> Benefit | None:
         repository = BenefitRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Benefit.id == id)
@@ -114,6 +123,12 @@ class BenefitService:
     ) -> Benefit:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
         )
 
         try:
@@ -157,6 +172,10 @@ class BenefitService:
         benefit_update: BenefitUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> Benefit:
+        await assert_resource_permission(
+            session, auth_subject, benefit, OrganizationPermission.products_manage
+        )
+
         if benefit_update.type != benefit.type:
             raise PolarRequestValidationError(
                 [
@@ -199,7 +218,16 @@ class BenefitService:
 
         return benefit
 
-    async def delete(self, session: AsyncSession, benefit: Benefit) -> Benefit:
+    async def delete(
+        self,
+        session: AsyncSession,
+        benefit: Benefit,
+        auth_subject: AuthSubject[User | Organization],
+    ) -> Benefit:
+        await assert_resource_permission(
+            session, auth_subject, benefit, OrganizationPermission.products_manage
+        )
+
         if not benefit.deletable:
             raise NotPermitted()
 

--- a/server/polar/checkout_link/endpoints.py
+++ b/server/polar/checkout_link/endpoints.py
@@ -152,7 +152,7 @@ async def delete(
     if checkout_link is None:
         raise ResourceNotFound()
 
-    await checkout_link_service.delete(session, checkout_link)
+    await checkout_link_service.delete(session, checkout_link, auth_subject)
 
 
 @router.get("/{client_secret}/redirect", include_in_schema=False)

--- a/server/polar/checkout_link/service.py
+++ b/server/polar/checkout_link/service.py
@@ -6,7 +6,12 @@ from sqlalchemy import UnaryExpression, asc, desc
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.discount.service import discount as discount_service
 from polar.exceptions import PolarRequestValidationError, ValidationError
@@ -54,7 +59,9 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         ],
     ) -> tuple[Sequence[CheckoutLink], int]:
         repository = CheckoutLinkRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
         checkout_link_product_load = None
 
@@ -104,7 +111,9 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         id: uuid.UUID,
     ) -> CheckoutLink | None:
         repository = CheckoutLinkRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(CheckoutLink.id == id)
@@ -132,6 +141,13 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
             )
             products = [product]
         organization = products[0].organization
+
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+        )
 
         discount: Discount | None = None
         if checkout_link_create.discount_id is not None:
@@ -168,6 +184,10 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         checkout_link_update: CheckoutLinkUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> CheckoutLink:
+        await assert_resource_permission(
+            session, auth_subject, checkout_link, OrganizationPermission.products_manage
+        )
+
         if checkout_link_update.products is not None:
             products = await self._get_validated_products(
                 session, checkout_link_update.products, auth_subject
@@ -219,8 +239,14 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         )
 
     async def delete(
-        self, session: AsyncSession, checkout_link: CheckoutLink
+        self,
+        session: AsyncSession,
+        checkout_link: CheckoutLink,
+        auth_subject: AuthSubject[User | Organization],
     ) -> CheckoutLink:
+        await assert_resource_permission(
+            session, auth_subject, checkout_link, OrganizationPermission.products_manage
+        )
         repository = CheckoutLinkRepository.from_session(session)
         return await repository.soft_delete(checkout_link)
 
@@ -294,7 +320,9 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
         auth_subject: AuthSubject[User | Organization],
     ) -> tuple[Product, ProductPrice]:
         product_price_repository = ProductPriceRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         price = await product_price_repository.get_readable_by_id(price_id, org_ids)
 
         if price is None:

--- a/server/polar/custom_field/endpoints.py
+++ b/server/polar/custom_field/endpoints.py
@@ -124,7 +124,9 @@ async def update(
     if custom_field is None:
         raise ResourceNotFound()
 
-    return await custom_field_service.update(session, custom_field, custom_field_update)
+    return await custom_field_service.update(
+        session, custom_field, custom_field_update, auth_subject
+    )
 
 
 @router.delete(
@@ -147,4 +149,4 @@ async def delete(
     if custom_field is None:
         raise ResourceNotFound()
 
-    await custom_field_service.delete(session, custom_field)
+    await custom_field_service.delete(session, custom_field, auth_subject)

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -16,12 +16,18 @@ from sqlalchemy import (
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+)
 from polar.custom_field.sorting import CustomFieldSortProperty
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
-from polar.models import CustomField, Organization, User, UserOrganization
+from polar.models import CustomField, Organization, User
 from polar.models.custom_field import CustomFieldType
 from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncReadSession, AsyncSession
@@ -103,6 +109,12 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         organization = await get_payload_organization(
             session, auth_subject, custom_field_create
         )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.custom_fields_manage,
+        )
 
         existing_field = await self._get_by_organization_id_and_slug(
             session, organization.id, custom_field_create.slug
@@ -134,7 +146,15 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         session: AsyncSession,
         custom_field: CustomField,
         custom_field_update: CustomFieldUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> CustomField:
+        await assert_resource_permission(
+            session,
+            auth_subject,
+            custom_field,
+            OrganizationPermission.custom_fields_manage,
+        )
+
         if custom_field.type != custom_field_update.type:
             raise PolarRequestValidationError(
                 [
@@ -198,8 +218,17 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         return custom_field
 
     async def delete(
-        self, session: AsyncSession, custom_field: CustomField
+        self,
+        session: AsyncSession,
+        custom_field: CustomField,
+        auth_subject: AuthSubject[User | Organization],
     ) -> CustomField:
+        await assert_resource_permission(
+            session,
+            auth_subject,
+            custom_field,
+            OrganizationPermission.custom_fields_manage,
+        )
         custom_field.set_deleted_at()
         session.add(custom_field)
 
@@ -244,12 +273,11 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         )
 
         if is_user(auth_subject):
-            user = auth_subject.subject
             statement = statement.where(
                 CustomField.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        permission=OrganizationPermission.custom_fields_read,
                     )
                 )
             )

--- a/server/polar/discount/endpoints.py
+++ b/server/polar/discount/endpoints.py
@@ -121,7 +121,9 @@ async def update(
     if discount is None:
         raise ResourceNotFound()
 
-    return await discount_service.update(session, discount, discount_update)
+    return await discount_service.update(
+        session, discount, discount_update, auth_subject
+    )
 
 
 @router.delete(
@@ -144,4 +146,4 @@ async def delete(
     if discount is None:
         raise ResourceNotFound()
 
-    await discount_service.delete(session, discount)
+    await discount_service.delete(session, discount, auth_subject)

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -8,6 +8,12 @@ from sqlalchemy import Select, UnaryExpression, asc, delete, desc, func, or_, se
 from sqlalchemy.exc import DBAPIError
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+)
 from polar.discount.repository import DiscountRepository
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.db.locking import is_lock_not_available_error
@@ -21,7 +27,6 @@ from polar.models import (
     Organization,
     Product,
     User,
-    UserOrganization,
 )
 from polar.models.checkout import Checkout
 from polar.models.discount import DiscountFixed
@@ -108,6 +113,12 @@ class DiscountService(ResourceServiceReader[Discount]):
         organization = await get_payload_organization(
             session, auth_subject, discount_create
         )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
+        )
 
         repository = DiscountRepository.from_session(session)
 
@@ -179,7 +190,12 @@ class DiscountService(ResourceServiceReader[Discount]):
         session: AsyncSession,
         discount: Discount,
         discount_update: DiscountUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> Discount:
+        await assert_resource_permission(
+            session, auth_subject, discount, OrganizationPermission.products_manage
+        )
+
         if (
             "duration" in discount_update.model_fields_set
             and discount_update.duration != discount.duration
@@ -296,7 +312,15 @@ class DiscountService(ResourceServiceReader[Discount]):
 
         return discount
 
-    async def delete(self, session: AsyncSession, discount: Discount) -> Discount:
+    async def delete(
+        self,
+        session: AsyncSession,
+        discount: Discount,
+        auth_subject: AuthSubject[User | Organization],
+    ) -> Discount:
+        await assert_resource_permission(
+            session, auth_subject, discount, OrganizationPermission.products_manage
+        )
         discount.set_deleted_at()
         session.add(discount)
         return discount
@@ -447,12 +471,11 @@ class DiscountService(ResourceServiceReader[Discount]):
         statement = select(Discount).where(Discount.is_deleted.is_(False))
 
         if is_user(auth_subject):
-            user = auth_subject.subject
             statement = statement.where(
                 Discount.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        permission=OrganizationPermission.products_read,
                     )
                 )
             )

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -3,6 +3,11 @@ from typing import Annotated
 from fastapi import Depends, Path, Query
 from pydantic import UUID4
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+)
 from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
@@ -76,6 +81,12 @@ async def create(
 ) -> FileUpload:
     """Create a file."""
     organization = await get_payload_organization(session, auth_subject, file_create)
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        organization.id,
+        OrganizationPermission.products_manage,
+    )
 
     file_create.organization_id = organization.id
     return await file_service.generate_presigned_upload(
@@ -109,6 +120,9 @@ async def uploaded(
     if file is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, file, OrganizationPermission.products_manage
+    )
     return await file_service.complete_upload(
         session, file=file, completed_schema=completed_schema
     )
@@ -139,6 +153,9 @@ async def update(
     if file is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, file, OrganizationPermission.products_manage
+    )
     return await file_service.patch(session, file=file, patches=patches)
 
 
@@ -165,4 +182,7 @@ async def delete(
     if file is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, file, OrganizationPermission.products_manage
+    )
     await file_service.delete(session, file=file)

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import structlog
 
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.kit.pagination import PaginationParams
 from polar.models import Organization, ProductMedia, User
@@ -35,7 +36,9 @@ class FileService:
         pagination: PaginationParams,
     ) -> tuple[Sequence[File], int]:
         repository = FileRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
 
         statement = repository.get_statement_by_org_ids(org_ids).where(
             File.is_uploaded.is_(True)
@@ -58,7 +61,9 @@ class FileService:
         id: uuid.UUID,
     ) -> File | None:
         repository = FileRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(File.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/license_key/endpoints.py
+++ b/server/polar/license_key/endpoints.py
@@ -1,7 +1,11 @@
 from fastapi import Depends, Query
 from pydantic import UUID4
 
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.benefit.schemas import BenefitID
 from polar.exceptions import ResourceNotFound
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
@@ -118,6 +122,9 @@ async def update(
     if not lk:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, lk, OrganizationPermission.products_manage
+    )
     updated = await license_key_service.update(session, license_key=lk, updates=updates)
     return updated
 

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -7,6 +7,7 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Customer, Member
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.strategies.license_keys.properties import (
     BenefitLicenseKeysProperties,
@@ -48,7 +49,9 @@ class LicenseKeyService:
         status: Sequence[LicenseKeyStatus] | None = None,
     ) -> tuple[Sequence[LicenseKey], int]:
         repository = LicenseKeyRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .order_by(LicenseKey.created_at.asc())
@@ -75,7 +78,9 @@ class LicenseKeyService:
         id: UUID,
     ) -> LicenseKey | None:
         repository = LicenseKeyRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(LicenseKey.id == id)

--- a/server/polar/meter/endpoints.py
+++ b/server/polar/meter/endpoints.py
@@ -205,4 +205,4 @@ async def update(
     if meter is None:
         raise ResourceNotFound()
 
-    return await meter_service.update(session, meter, meter_update)
+    return await meter_service.update(session, meter, meter_update, auth_subject)

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -22,7 +22,12 @@ from sqlalchemy import (
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -73,7 +78,9 @@ class MeterService:
         ],
     ) -> tuple[Sequence[Meter], int]:
         repository = MeterRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -111,7 +118,9 @@ class MeterService:
         id: uuid.UUID,
     ) -> Meter | None:
         repository = MeterRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Meter.id == id)
@@ -128,6 +137,12 @@ class MeterService:
         repository = MeterRepository.from_session(session)
         organization = await get_payload_organization(
             session, auth_subject, meter_create
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
         )
 
         meter = await repository.create(
@@ -160,8 +175,15 @@ class MeterService:
         return meter
 
     async def update(
-        self, session: AsyncSession, meter: Meter, meter_update: MeterUpdate
+        self,
+        session: AsyncSession,
+        meter: Meter,
+        meter_update: MeterUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> Meter:
+        await assert_resource_permission(
+            session, auth_subject, meter, OrganizationPermission.products_manage
+        )
         repository = MeterRepository.from_session(session)
 
         errors: list[ValidationError] = []

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -8,7 +8,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import contains_eager, selectinload
 
 from polar.auth.models import AuthSubject, is_user
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.benefit.service import benefit as benefit_service
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.custom_field.service import custom_field as custom_field_service
@@ -79,7 +84,9 @@ class ProductService:
         ],
     ) -> tuple[Sequence[Product], int]:
         repository = ProductRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).join(
             ProductPrice,
             onclause=(
@@ -145,7 +152,9 @@ class ProductService:
         id: uuid.UUID,
     ) -> Product | None:
         repository = ProductRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Product.id == id)
@@ -162,6 +171,12 @@ class ProductService:
         repository = ProductRepository.from_session(session)
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.products_manage,
         )
 
         errors: list[ValidationError] = []
@@ -254,6 +269,10 @@ class ProductService:
         update_schema: ProductUpdate,
         auth_subject: AuthSubject[User | Organization],
     ) -> Product:
+        await assert_resource_permission(
+            session, auth_subject, product, OrganizationPermission.products_manage
+        )
+
         errors: list[ValidationError] = []
 
         # Validate prices
@@ -425,6 +444,10 @@ class ProductService:
         benefits: Sequence[uuid.UUID],
         auth_subject: AuthSubject[User | Organization],
     ) -> tuple[Product, set[Benefit], set[Benefit]]:
+        await assert_resource_permission(
+            session, auth_subject, product, OrganizationPermission.products_manage
+        )
+
         previous_benefits = set(product.benefits)
         new_benefits: set[Benefit] = set()
 
@@ -513,7 +536,9 @@ class ProductService:
         builtins.list[ValidationError],
     ]:
         meter_repository = MeterRepository.from_session(session)
-        meter_org_ids = await get_accessible_org_ids(session, auth_subject)
+        meter_org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.products_read
+        )
         prices: list[ProductPrice] = []
         prices_per_currency = defaultdict[str, list[tuple[ProductPrice, int]]](list)
         existing_prices: set[ProductPrice] = set()

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -405,6 +405,7 @@ class TestDelete:
     async def test_not_deletable_benefit(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
@@ -417,7 +418,7 @@ class TestDelete:
         )
 
         with pytest.raises(NotPermitted):
-            await benefit_service.delete(session, benefit)
+            await benefit_service.delete(session, benefit, auth_subject)
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),
@@ -427,10 +428,13 @@ class TestDelete:
         self,
         enqueue_job_mock: AsyncMock,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
         benefit_organization: Benefit,
         user_organization: UserOrganization,
     ) -> None:
-        updated_benefit = await benefit_service.delete(session, benefit_organization)
+        updated_benefit = await benefit_service.delete(
+            session, benefit_organization, auth_subject
+        )
 
         assert updated_benefit.deleted_at is not None
 

--- a/server/tests/checkout_link/test_service.py
+++ b/server/tests/checkout_link/test_service.py
@@ -210,6 +210,7 @@ class TestUpdate:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         checkout_link: CheckoutLink,
     ) -> None:
         updated_checkout_link = await checkout_link_service.update(
@@ -228,6 +229,7 @@ class TestUpdate:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         checkout_link: CheckoutLink,
     ) -> None:
         updated_checkout_link = await checkout_link_service.update(
@@ -246,6 +248,7 @@ class TestUpdate:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         checkout_link: CheckoutLink,
         discount_fixed_once: Discount,
     ) -> None:
@@ -344,11 +347,16 @@ class TestUpdate:
 
 @pytest.mark.asyncio
 class TestDelete:
+    @pytest.mark.auth
     async def test_valid(
-        self, session: AsyncSession, checkout_link: CheckoutLink
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        checkout_link: CheckoutLink,
+        user_organization: UserOrganization,
     ) -> None:
         deleted_checkout_link = await checkout_link_service.delete(
-            session, checkout_link
+            session, checkout_link, auth_subject
         )
 
         assert deleted_checkout_link.deleted_at is not None

--- a/server/tests/custom_field/test_service.py
+++ b/server/tests/custom_field/test_service.py
@@ -1,9 +1,10 @@
 import pytest
 import pytest_asyncio
 
+from polar.auth.models import AuthSubject
 from polar.custom_field.schemas import CustomFieldUpdateText
 from polar.custom_field.service import custom_field as custom_field_service
-from polar.models import Customer, Order, Organization, Product
+from polar.models import Customer, Order, Organization, Product, User, UserOrganization
 from polar.models.custom_field import CustomFieldText, CustomFieldType
 from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession
@@ -42,9 +43,12 @@ async def order_text_field_data(
 
 @pytest.mark.asyncio
 class TestUpdate:
+    @pytest.mark.auth
     async def test_slug_update(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         text_field: CustomFieldText,
         order_text_field_data: Order,
     ) -> None:
@@ -52,6 +56,7 @@ class TestUpdate:
             session,
             text_field,
             CustomFieldUpdateText(type=text_field.type, slug="updatedslug"),
+            auth_subject,
         )
 
         assert updated_field.slug == "updatedslug"

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -75,8 +75,11 @@ class TestCreate:
 
 @pytest.mark.asyncio
 class TestUpdate:
+    @pytest.mark.auth
     async def test_duration_change(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -95,10 +98,14 @@ class TestUpdate:
                 session,
                 discount,
                 discount_update=DiscountUpdate(duration=DiscountDuration.once),
+                auth_subject=auth_subject,
             )
 
+    @pytest.mark.auth
     async def test_type_change(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -117,6 +124,7 @@ class TestUpdate:
                 session,
                 discount,
                 discount_update=DiscountUpdate(type=DiscountType.fixed),
+                auth_subject=auth_subject,
             )
 
     @pytest.mark.parametrize(
@@ -127,8 +135,11 @@ class TestUpdate:
             ("basis_points", 1000),
         ],
     )
+    @pytest.mark.auth
     async def test_update_forbidden_field_with_redemptions(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         field: Literal["amount", "amounts", "basis_points"],
         value: Any,
         save_fixture: SaveFixture,
@@ -171,6 +182,7 @@ class TestUpdate:
                         "currency": "usd",
                     }
                 ),
+                auth_subject=auth_subject,
             )
 
     @pytest.mark.parametrize(
@@ -197,8 +209,11 @@ class TestUpdate:
             ),
         ],
     )
+    @pytest.mark.auth
     async def test_update_sensitive_fields(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         type: DiscountType,
         payload: DiscountUpdate,
         save_fixture: SaveFixture,
@@ -226,7 +241,10 @@ class TestUpdate:
         updated_ends_at = utc_now() + timedelta(days=2)
         payload.ends_at = updated_ends_at
         updated_discount = await discount_service.update(
-            session, discount, discount_update=payload
+            session,
+            discount,
+            discount_update=payload,
+            auth_subject=auth_subject,
         )
 
         if isinstance(updated_discount, DiscountPercentage):
@@ -236,8 +254,11 @@ class TestUpdate:
 
         assert updated_discount.ends_at == updated_ends_at
 
+    @pytest.mark.auth
     async def test_update_name(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -254,12 +275,16 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(name="Updated Name"),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.name == "Updated Name"
 
+    @pytest.mark.auth
     async def test_update_products(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -279,12 +304,16 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(products=[product_one_time.id]),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.products == [product_one_time]
 
+    @pytest.mark.auth
     async def test_update_products_reset(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -303,12 +332,16 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(products=[]),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.products == []
 
+    @pytest.mark.auth
     async def test_update_discount_past_dates(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -331,14 +364,18 @@ class TestUpdate:
                 starts_at=discount.starts_at,
                 ends_at=discount.ends_at,
             ),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.name == "Updated Name"
         assert updated_discount.starts_at == discount.starts_at
         assert updated_discount.ends_at == discount.ends_at
 
+    @pytest.mark.auth
     async def test_update_code_already_exists(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -365,13 +402,17 @@ class TestUpdate:
                 session,
                 discount_to_update,
                 discount_update=DiscountUpdate(code="EXISTING"),
+                auth_subject=auth_subject,
             )
 
         assert exc_info.value.errors()[0]["loc"] == ("body", "code")
         assert "already exists" in exc_info.value.errors()[0]["msg"]
 
+    @pytest.mark.auth
     async def test_update_code_same_discount(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -389,6 +430,7 @@ class TestUpdate:
             session,
             discount,
             discount_update=DiscountUpdate(code="mycode"),
+            auth_subject=auth_subject,
         )
 
         assert updated_discount.code == "mycode"

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -37,6 +37,8 @@ from polar.models import (
     Organization,
     Product,
     Subscription,
+    User,
+    UserOrganization,
 )
 from polar.models.billing_entry import BillingEntryDirection
 from polar.models.customer_seat import SeatStatus
@@ -217,8 +219,11 @@ class TestUpdate:
             ),
         ],
     )
+    @pytest.mark.auth
     async def test_sensitive_update_forbidden(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         meter_update: MeterUpdate,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -234,7 +239,7 @@ class TestUpdate:
         )
 
         with pytest.raises(PolarRequestValidationError):
-            await meter_service.update(session, meter, meter_update)
+            await meter_service.update(session, meter, meter_update, auth_subject)
 
     @pytest.mark.parametrize(
         "meter_update",
@@ -258,8 +263,11 @@ class TestUpdate:
             ),
         ],
     )
+    @pytest.mark.auth
     async def test_sensitive_update_allowed(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         meter_update: MeterUpdate,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -269,15 +277,20 @@ class TestUpdate:
             save_fixture, organization=organization, last_billed_event=None
         )
 
-        updated_meter = await meter_service.update(session, meter, meter_update)
+        updated_meter = await meter_service.update(
+            session, meter, meter_update, auth_subject
+        )
 
         if meter_update.filter:
             assert updated_meter.filter == meter_update.filter
         if meter_update.aggregation:
             assert updated_meter.aggregation == meter_update.aggregation
 
+    @pytest.mark.auth
     async def test_insensitive_update(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -295,6 +308,7 @@ class TestUpdate:
             session,
             meter,
             MeterUpdate(name="New Name"),  # pyright: ignore
+            auth_subject=auth_subject,
         )
         assert updated_meter.name == "New Name"
 
@@ -302,8 +316,11 @@ class TestUpdate:
         "unit",
         [MeterUnit.scalar, MeterUnit.tokens, MeterUnit.custom],
     )
+    @pytest.mark.auth
     async def test_update_unit(
         self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
         unit: MeterUnit,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -315,6 +332,7 @@ class TestUpdate:
             session,
             meter,
             MeterUpdate(unit=unit),  # pyright: ignore
+            auth_subject=auth_subject,
         )
 
         assert updated_meter.unit == unit


### PR DESCRIPTION
## Summary

**Related Issue**: #11402

Second in the stack. Enforces `products:read` / `products:manage` and `custom_fields:read` / `custom_fields:manage` across the catalog surface, using the foundation helpers from the previous PR.

**Stacked on top of #11609** — review/merge that one first; this PR's base auto-rebases onto `main` once it lands.

## What

### Endpoints / services switched onto the new permissions

- `product/`: reads filtered by `products:read`; `create` / `update` / `update_benefits` / `get_validated_prices` gated by `products:manage`.
- `checkout_link/`: reads filtered by `products:read`; `create` / `update` / `delete` gated by `products:manage`.
- `discount/`: same shape — reads by `products:read`, mutations by `products:manage`.
- `benefit/`: same. `benefit/grant/service.list` reads filtered by `customers:read` (member-visible).
- `meter/`: same shape as products.
- `file/`: reads filtered by `products:read`; mutations gated by `products:manage` (covers `POST /files/{id}/uploaded`, `PATCH /files/{id}`, `DELETE /files/{id}`).
- `license_key/`: same shape. `PATCH /license-keys/{id}` mutation gated by `products:manage`. The customer-portal-side `/validate` and `/activate` endpoints are intentionally unchanged — they're authenticated by the license key itself, not the org role.
- `custom_field/`: reads filtered by `custom_fields:read`; `create` / `update` / `delete` gated by `custom_fields:manage`.

### Tests

Section test suites updated for the role-permission gating; the default `user_organization` fixture (owner role) continues to pass since admin/owner carry every `*:manage` permission.

### TS client

Regenerated.

## Why

Members of an org with the right token scope could previously call admin endpoints on the catalog surface — create/update/delete products, discounts, benefits, custom fields, etc. This PR closes that gap by requiring the admin/owner role for those mutations. Member-level reads (list/get) continue to work for all roles.

The `products:manage` permission covers everything product-adjacent (checkout_links, discounts, benefits, meters, files, license keys) intentionally — these are all surfaces a "product admin" reaches for, so folding them into one permission keeps the role model section-shaped and avoids needing a new permission per related entity.

## How

Two call-site shapes (introduced in the foundation PR):

- **Collection reads** — services call `get_accessible_org_ids(session, auth_subject, permission=products_read)` and pass the result to repository statements (e.g. `get_statement_by_org_ids(org_ids)`).
- **Resource mutations** — services / endpoints call `assert_resource_permission(session, auth_subject, resource, permission)` after fetching the resource via the service's own auth-aware `get(...)`. Callers always gate the fetch first (404 on missing) so the assert's 403 doesn't leak existence.

For repositories that need a permission-aware subquery (e.g. `discount/service._get_readable_discount_statement`, `custom_field/service._get_readable_custom_field_statement`), `select_user_org_ids(... permission=...)` returns the right `Select` for `Resource.organization_id.in_(...)`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included