### PR TITLE
authz: consolidate customers & seats permissions (3/5)

### DIFF
--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -5,7 +5,11 @@ from fastapi import Depends, Query, Response
 from fastapi.responses import StreamingResponse
 from pydantic import TypeAdapter
 
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
@@ -134,7 +138,9 @@ async def export(
         )
 
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.customers_read
+        )
         stream = repository.stream_by_organization(org_ids, organization_id)
 
         async for customer in stream:
@@ -303,6 +309,9 @@ async def update(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, customer, OrganizationPermission.customers_manage
+    )
     return await customer_service.update(session, customer, customer_update)
 
 
@@ -327,6 +336,9 @@ async def update_external(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, customer, OrganizationPermission.customers_manage
+    )
     return await customer_service.update(session, customer, customer_update)
 
 
@@ -375,6 +387,9 @@ async def delete(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, customer, OrganizationPermission.customers_manage
+    )
     await customer_service.delete(session, customer, anonymize=anonymize)
 
 
@@ -410,4 +425,7 @@ async def delete_external(
     if customer is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, customer, OrganizationPermission.customers_manage
+    )
     await customer_service.delete(session, customer, anonymize=anonymize)

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -10,7 +10,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    get_accessible_org_ids,
+)
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.config import settings
 from polar.customer_meter.repository import CustomerMeterRepository
@@ -79,7 +83,9 @@ class CustomerService:
         ],
     ) -> tuple[Sequence[Customer], int]:
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.customers_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -122,7 +128,9 @@ class CustomerService:
         id: uuid.UUID,
     ) -> Customer | None:
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.customers_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             Customer.id == id
         )
@@ -135,7 +143,9 @@ class CustomerService:
         external_id: str,
     ) -> Customer | None:
         repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.customers_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             Customer.external_id == external_id
         )
@@ -151,6 +161,12 @@ class CustomerService:
     ) -> Customer:
         organization = await get_payload_organization(
             session, auth_subject, customer_create
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.customers_manage,
         )
         repository = CustomerRepository.from_session(session)
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -11,7 +11,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_resource_permission
+from polar.authz.types import AccessibleOrganizationID
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.billing_entry.service import MeteredLineItem
 from polar.billing_entry.service import billing_entry as billing_entry_service
@@ -403,39 +405,47 @@ class SubscriptionService:
                 }
             )
 
-        customer: Customer | None = None
+        if len(errors) > 0:
+            raise PolarRequestValidationError(errors)
+
+        assert product is not None
+
+        await assert_resource_permission(
+            session, auth_subject, product, OrganizationPermission.customers_manage
+        )
+
+        # Scope the customer lookup to the product's own org so a caller with
+        # `customers:manage` on the product's org can't pair it with a customer
+        # belonging to another org they happen to also be a member of.
         customer_repository = CustomerRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        product_org_ids = {AccessibleOrganizationID(product.organization_id)}
         error_loc: str
         input_value: uuid.UUID | str
+        customer: Customer | None
         if isinstance(subscription_create, SubscriptionCreateCustomer):
             error_loc = "customer_id"
             input_value = subscription_create.customer_id
             customer = await customer_repository.get_readable_by_id(
-                org_ids, input_value
+                product_org_ids, input_value
             )
         else:
             error_loc = "external_customer_id"
             input_value = subscription_create.external_customer_id
             customer = await customer_repository.get_readable_by_external_id(
-                org_ids, input_value
+                product_org_ids, input_value
             )
 
         if customer is None:
-            errors.append(
-                {
-                    "type": "value_error",
-                    "loc": ("body", error_loc),
-                    "msg": "Customer does not exist.",
-                    "input": input_value,
-                }
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", error_loc),
+                        "msg": "Customer does not exist.",
+                        "input": input_value,
+                    }
+                ]
             )
-
-        if len(errors) > 0:
-            raise PolarRequestValidationError(errors)
-
-        assert product is not None
-        assert customer is not None
 
         assert is_recurring_product(product)
         recurring_interval = product.recurring_interval

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -206,11 +206,9 @@ class TestCreate:
             )
 
         errors = exc_info.value.errors()
-        assert len(errors) == 2
+        assert len(errors) == 1
         assert errors[0]["loc"] == ("body", "product_id")
         assert errors[0]["msg"] == "Product does not exist."
-        assert errors[1]["loc"] == ("body", "customer_id")
-        assert errors[1]["msg"] == "Customer does not exist."
 
     @pytest.mark.auth
     async def test_product_not_recurring(


### PR DESCRIPTION
## Summary

**Related Issue**: #11402

Third in the stack. Two changes for the customer surface:

1. Named `customers:read` / `customers:manage` gates on the admin customer endpoints and `subscription.create`. Per #11665 `customers:manage` is now a member-level permission, so the gates don't restrict members today — they're named hooks reserved for future custom roles. Behaviour for member-role callers is unchanged.
2. A real **cross-org IDOR fix** in `subscription.create`: previously the customer lookup ran with the caller's full set of accessible orgs, so an admin of OrgA who was also a member of OrgB could pair an OrgA product with an OrgB customer (creating a subscription owned by OrgA but referencing a customer in another org). The fix scopes the customer lookup to the product's org only and runs the permission assert before the lookup.

> Heads-up: the customer-seat work originally planned for this PR is gone — #11648 refactored seats independently on `main`, so I dropped those changes during the rebase and took main's version.

## What

### Customer admin endpoints

`POST /v1/customers/`, `PATCH /v1/customers/{id}`, `PATCH /v1/customers/external/{external_id}`, `DELETE /v1/customers/{id}`, `DELETE /v1/customers/external/{external_id}` now go through the `customers:manage` named gate. List endpoints filter by `customers:read`. Member-role callers continue to pass the gate (per #11665); the gate documents intent and is the seam future custom roles will use.

### `subscription.create` cross-org pairing

Before: a multi-org caller (admin in OrgA, member in OrgB) could create a free subscription pairing an OrgA product with an OrgB customer. The flow looked up the customer with the caller's *full* set of accessible orgs, and asserted `customers:manage` only afterwards (on the product's org).

After: the permission assert runs first against the product's org. Then the customer lookup is restricted to that same org, so the customer must belong to the product's organization. Cross-org pairing now fails with "Customer does not exist."

### Test impact

`test_product_does_not_exist` no longer expects an accumulated "customer missing" error alongside the product-missing one — product validation now short-circuits before the customer lookup is attempted.

## Why

Two reasons:

1. **Named gates for future custom roles.** Even though `customers:manage` is currently member-level, the gate makes intent explicit and lets a future custom role drop the permission without changing every call site.
2. **Cross-org IDOR.** The `subscription.create` flow previously trusted the caller's whole-membership set for the customer lookup; the fix tightens that to the resource's own org.

## How

Same patterns as previous PRs in the stack:

- **Endpoint-layer asserts** (`assert_resource_permission`) for the customer admin-API mutations, because `customer_service.update`/`delete` are shared with customer-portal and backoffice flows that legitimately should NOT do an org-role check. Pushing the asserts into the service would block those callers.
- **Service-layer assert** for `customer_service.create` (only called from the admin endpoint).
- **Service-layer assert + scoped lookup** for `subscription.create` — assert first, then look up the customer using `{product.organization_id}` as the org-id filter.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included