### PR TITLE
metrics: Fix FX-incorrect credit_order contribution in fast-path revenue

### DIFF
--- a/server/tests/metrics/test_tinybird_metrics.py
+++ b/server/tests/metrics/test_tinybird_metrics.py
@@ -118,6 +118,7 @@ class OrderScenario:
     include_balance_net_amount: bool = True
     balance_exchange_rate: float | None = None
     balance_presentment_currency: str = "usd"
+    balance_credit_order_currency: str = "usd"
     include_order_created_at_metadata: bool = True
     include_order_paid: bool = True
     include_balance: bool = True
@@ -631,6 +632,29 @@ def _build_gamma_customers() -> tuple[CustomerScenario, ...]:
                 ),
             ),
         ),
+        CustomerScenario(
+            key="gamma_credit_order_fast_path",
+            one_time_orders=(
+                OrderScenario(
+                    product_key="one_time",
+                    ordered_at=_dt(date(2025, 6, 1), 10, 0),
+                    amount=2_000,
+                    balance_amount=2_000,
+                    balance_net_amount=2_000,
+                    balance_exchange_rate=0.5,
+                    balance_presentment_currency="eur",
+                ),
+                OrderScenario(
+                    product_key="one_time",
+                    ordered_at=_dt(date(2025, 6, 15), 10, 0),
+                    amount=2_000,
+                    emit_balance_credit_order=True,
+                    balance_credit_order_currency="eur",
+                    balance_amount=2_000,
+                    include_balance_net_amount=False,
+                ),
+            ),
+        ),
     )
 
 
@@ -912,6 +936,14 @@ QUERY_CASES: tuple[QueryCase, ...] = (
         end_date=date(2024, 1, 31),
         interval=TimeInterval.month,
     ),
+    QueryCase(
+        label="gamma_daily_credit_order_fast_path",
+        organization_key="gamma",
+        start_date=date(2025, 6, 15),
+        end_date=date(2025, 6, 15),
+        interval=TimeInterval.day,
+        metrics=("revenue", "net_revenue"),
+    ),
 )
 
 
@@ -1074,6 +1106,7 @@ async def _create_paid_order_events(
     include_balance_net_amount: bool = True,
     balance_exchange_rate: float | None = None,
     balance_presentment_currency: str = "usd",
+    balance_credit_order_currency: str = "usd",
     include_order_created_at_metadata: bool = True,
     include_order_paid: bool = True,
     include_balance: bool = True,
@@ -1144,6 +1177,8 @@ async def _create_paid_order_events(
         balance_metadata["transaction_id"] = str(transaction.id)
         balance_metadata["presentment_amount"] = balance_amount_value
         balance_metadata["presentment_currency"] = balance_presentment_currency
+    else:
+        balance_metadata["currency"] = balance_credit_order_currency
     if balance_exchange_rate is not None:
         balance_metadata["exchange_rate"] = balance_exchange_rate
 
@@ -1345,6 +1380,9 @@ async def _seed_customer_scenario(
                     ),
                     balance_exchange_rate=subscription_order.balance_exchange_rate,
                     balance_presentment_currency=subscription_order.balance_presentment_currency,
+                    balance_credit_order_currency=(
+                        subscription_order.balance_credit_order_currency
+                    ),
                     include_order_created_at_metadata=(
                         subscription_order.include_order_created_at_metadata
                     ),
@@ -1438,6 +1476,9 @@ async def _seed_customer_scenario(
                 include_balance_net_amount=one_time_order.include_balance_net_amount,
                 balance_exchange_rate=one_time_order.balance_exchange_rate,
                 balance_presentment_currency=one_time_order.balance_presentment_currency,
+                balance_credit_order_currency=(
+                    one_time_order.balance_credit_order_currency
+                ),
                 include_order_created_at_metadata=(
                     one_time_order.include_order_created_at_metadata
                 ),
@@ -1622,8 +1663,25 @@ async def metrics_harness(
                     events=events,
                 )
 
+            # Ingest in two batches so balance.credit_order events land in a
+            # separate ClickHouse block from prior balance.order events. This
+            # mirrors the production timing gap (the order's Stripe-backed
+            # balance.order is emitted after the synchronous credit_order on the
+            # next order) and forces any FX lookup that depends on a self-join
+            # to events_by_ingested_at inside an MV trigger to fail — which is
+            # the bug class this suite needs to defend against.
             tinybird_events = [_event_to_tinybird(event) for event in events]
-            await tinybird_client.ingest(DATASOURCE_EVENTS, tinybird_events, wait=True)
+            credit_order_events = [
+                e for e in tinybird_events if e.get("name") == "balance.credit_order"
+            ]
+            other_events = [
+                e for e in tinybird_events if e.get("name") != "balance.credit_order"
+            ]
+            await tinybird_client.ingest(DATASOURCE_EVENTS, other_events, wait=True)
+            if credit_order_events:
+                await tinybird_client.ingest(
+                    DATASOURCE_EVENTS, credit_order_events, wait=True
+                )
 
             await session.commit()
 
@@ -1848,6 +1906,20 @@ class TestTinybirdMetrics:
         assert period.orders == 1
         assert period.net_revenue == 4_800
         assert period.one_time_products_net_revenue == 4_800
+
+    def test_credit_order_fast_path_uses_lookup_fx(
+        self, metrics_harness: MetricsHarness
+    ) -> None:
+        snapshot = metrics_harness.snapshots["gamma_daily_credit_order_fast_path"]
+        period = snapshot.periods[0]
+
+        # credit_order event has currency=eur, amount=2000. The prior balance.order
+        # for the same customer used presentment_currency=eur and exchange_rate=0.5,
+        # so the lookup_fx must resolve to 0.5 → settlement contribution = 2000 * 0.5
+        # = 1000. If the fast path falls back to FX=1.0 (the MV-trigger bug), this
+        # would be 2000 instead.
+        assert period.revenue == 1_000
+        assert period.net_revenue == 1_000
 
     def test_renewed_credit_order_with_negative_applied_balance(
         self, metrics_harness: MetricsHarness

--- a/server/tinybird/endpoints/metrics_revenue.pipe
+++ b/server/tinybird/endpoints/metrics_revenue.pipe
@@ -28,8 +28,7 @@ SQL >
         {% else %} toStartOfDay(toDateTime(m.quarter_hour, {{ String(tz, 'UTC') }})) AS day,
         {% end %}
         COALESCE(sumMerge(m.settlement_revenue), 0) AS settlement_revenue,
-        COALESCE(sumMerge(m.settlement_fee), 0) AS settlement_fee,
-        COALESCE(sumMerge(m.applied_balance_settlement), 0) AS applied_balance_settlement
+        COALESCE(sumMerge(m.settlement_fee), 0) AS settlement_fee
     FROM orders_base_state_by_quarter_hour AS m
     WHERE
         m.organization_id IN (
@@ -135,13 +134,115 @@ SQL >
         {% end %}
     GROUP BY day
 
+NODE credit_resolve_fx
+SQL >
+    %
+    SELECT
+        e.organization_id,
+        e.order_id,
+        COALESCE(e.order_created_at, e.timestamp) AS event_ts,
+        e.product_id,
+        e.amount,
+        multiIf(
+            e.exchange_rate IS NOT NULL AND e.exchange_rate != 0,
+            toFloat64(e.exchange_rate),
+            e.presentment_amount IS NOT NULL AND e.presentment_amount != 0,
+            toFloat64(e.amount) / toFloat64(e.presentment_amount),
+            NULL
+        ) AS own_fx,
+        argMax(
+            multiIf(
+                s.exchange_rate IS NOT NULL AND s.exchange_rate != 0,
+                toFloat64(s.exchange_rate),
+                s.presentment_amount IS NOT NULL AND s.presentment_amount != 0,
+                toFloat64(s.amount) / toFloat64(s.presentment_amount),
+                NULL
+            ),
+            tuple(
+                toUInt8(
+                    if(e.subscription_id IS NOT NULL AND s.subscription_id = e.subscription_id, 1, 0)
+                ),
+                s.timestamp
+            )
+        ) AS lookup_fx
+    FROM system_events_by_org AS e
+    LEFT JOIN
+        system_events_by_org AS s
+        ON s.organization_id = e.organization_id
+        AND s.name = 'balance.order'
+        AND s.order_id IS NOT NULL
+        AND s.customer_id = e.customer_id
+        AND COALESCE(s.presentment_currency, s.currency) = e.currency
+        AND s.timestamp < e.timestamp
+        AND s.order_id != e.order_id
+    WHERE
+        e.order_id IS NOT NULL
+        AND e.name = 'balance.credit_order'
+        AND e.organization_id IN (
+            SELECT
+                toUUID(
+                    arrayJoin(
+                        splitByChar(',', {{ String(org_ids, '00000000-0000-0000-0000-000000000000') }})
+                    )
+                )
+        )
+        AND COALESCE(e.order_created_at, e.timestamp)
+        <= toDateTime({{ String(bounds_end, '2024-01-02 00:00:00') }}, {{ String(tz, 'UTC') }})
+    GROUP BY e.organization_id, e.order_id, event_ts, e.product_id, e.subscription_id, e.amount, own_fx
+
+NODE credit_by_bucket
+SQL >
+    %
+    SELECT
+        {% if not defined(interval) or interval == 'day' %}
+            toStartOfDay(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
+        {% elif interval == 'hour' %}
+            toStartOfHour(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
+        {% elif interval == 'week' %}
+            toStartOfWeek(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }}), 1) AS day,
+        {% elif interval == 'month' %}
+            toStartOfMonth(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
+        {% elif interval == 'year' %}
+            toStartOfYear(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
+        {% else %} toStartOfDay(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
+        {% end %}
+        COALESCE(
+            SUM(toInt64(round(COALESCE(cfx.amount, 0) * COALESCE(cfx.own_fx, cfx.lookup_fx, 1.0)))), 0
+        ) AS credit_revenue
+    FROM credit_resolve_fx AS cfx
+    WHERE
+        cfx.event_ts
+        >= toDateTime({{ String(bounds_start, '2024-01-01 00:00:00') }}, {{ String(tz, 'UTC') }})
+        AND cfx.event_ts
+        <= toDateTime({{ String(bounds_end, '2024-01-02 00:00:00') }}, {{ String(tz, 'UTC') }})
+        {% if defined(product_ids) and product_ids != '' %}
+            AND COALESCE(cfx.product_id, toUUID('00000000-0000-0000-0000-000000000000'))
+            IN (SELECT toUUIDOrNull(arrayJoin(splitByChar(',', {{ String(product_ids) }}))))
+        {% end %}
+    GROUP BY day
+
+NODE credit_baseline
+SQL >
+    %
+    SELECT
+        COALESCE(
+            SUM(toInt64(round(COALESCE(cfx.amount, 0) * COALESCE(cfx.own_fx, cfx.lookup_fx, 1.0)))), 0
+        ) AS hist_credit_revenue
+    FROM credit_resolve_fx AS cfx
+    WHERE
+        cfx.event_ts
+        < toDateTime({{ String(bounds_start, '2024-01-01 00:00:00') }}, {{ String(tz, 'UTC') }})
+        {% if defined(product_ids) and product_ids != '' %}
+            AND COALESCE(cfx.product_id, toUUID('00000000-0000-0000-0000-000000000000'))
+            IN (SELECT toUUIDOrNull(arrayJoin(splitByChar(',', {{ String(product_ids) }}))))
+        {% end %}
+
 NODE mv_baseline
 SQL >
     %
     SELECT
         COALESCE(sumMerge(m.settlement_revenue), 0) AS hist_settlement_revenue,
-        COALESCE(sumMerge(m.settlement_fee), 0) AS hist_settlement_fee,
-        COALESCE(sumMerge(m.applied_balance_settlement), 0) AS hist_applied_balance_settlement
+        COALESCE(sumMerge(m.settlement_fee), 0) AS hist_settlement_fee
     FROM orders_base_state_by_quarter_hour AS m
     WHERE
         m.organization_id IN (
@@ -199,35 +300,37 @@ SQL >
     %
     SELECT
         w.interval AS timestamp,
-        COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0) AS revenue,
-        (COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0))
+        COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0) AS revenue,
+        (COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0))
         - COALESCE(r.settlement_fee, 0)
         + COALESCE(a.adjustment_net_amount, 0) AS net_revenue,
         COALESCE(
-            sum(COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0)) OVER (
+            sum(COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0)) OVER (
                 ORDER BY w.interval
             ),
             0
         )
-        + (mb.hist_settlement_revenue - mb.hist_applied_balance_settlement) AS cumulative_revenue,
+        + (mb.hist_settlement_revenue + cb.hist_credit_revenue) AS cumulative_revenue,
         COALESCE(
             sum(
-                (COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0))
+                (COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0))
                 - COALESCE(r.settlement_fee, 0)
                 + COALESCE(a.adjustment_net_amount, 0)
             ) OVER (ORDER BY w.interval),
             0
         ) + (
             mb.hist_settlement_revenue
-            - mb.hist_applied_balance_settlement
+            + cb.hist_credit_revenue
             - mb.hist_settlement_fee
             + ab.hist_adjustment_net_amount
         ) AS net_cumulative_revenue
     FROM intervals w
     LEFT JOIN revenue_from_mv r ON r.day = w.interval
     LEFT JOIN adjustments_by_bucket a ON a.day = w.interval
+    LEFT JOIN credit_by_bucket c ON c.day = w.interval
     CROSS JOIN mv_baseline mb
     CROSS JOIN adj_baseline ab
+    CROSS JOIN credit_baseline cb
     ORDER BY w.interval
 
 NODE direct_resolve_fx

--- a/server/tinybird/pipes/orders_base_state_by_quarter_hour_mv.pipe
+++ b/server/tinybird/pipes/orders_base_state_by_quarter_hour_mv.pipe
@@ -46,10 +46,7 @@ SQL >
         AND COALESCE(s.presentment_currency, s.currency) = e.currency
         AND s.timestamp < e.timestamp
         AND s.order_id != e.order_id
-    WHERE
-        e.source = 'system'
-        AND e.order_id IS NOT NULL
-        AND e.name IN ('order.paid', 'balance.order', 'balance.credit_order')
+    WHERE e.source = 'system' AND e.order_id IS NOT NULL AND e.name IN ('order.paid', 'balance.order')
     GROUP BY
         e.organization_id,
         e.order_id,
@@ -80,63 +77,34 @@ SQL >
         sumState(
             toInt64(
                 if(
-                    name IN ('balance.order', 'balance.credit_order'),
+                    name = 'balance.order',
                     toInt64(round(COALESCE(net_amount, amount, 0) * COALESCE(own_fx, lookup_fx, 1.0))),
                     0
                 )
             )
         ) AS settlement_revenue,
-        sumState(
-            toInt64(if(name IN ('balance.order', 'balance.credit_order'), COALESCE(fee, 0), 0))
-        ) AS settlement_fee,
+        sumState(toInt64(if(name = 'balance.order', COALESCE(fee, 0), 0))) AS settlement_fee,
         sumState(
             toInt64(
                 if(
-                    name IN ('balance.order', 'balance.credit_order') AND subscription_id IS NULL,
+                    name = 'balance.order' AND subscription_id IS NULL,
                     toInt64(round(COALESCE(net_amount, amount, 0) * COALESCE(own_fx, lookup_fx, 1.0))),
                     0
                 )
             )
         ) AS one_time_settlement_revenue,
         sumState(
-            toInt64(
-                if(
-                    name IN ('balance.order', 'balance.credit_order') AND subscription_id IS NULL,
-                    COALESCE(fee, 0),
-                    0
-                )
-            )
+            toInt64(if(name = 'balance.order' AND subscription_id IS NULL, COALESCE(fee, 0), 0))
         ) AS one_time_settlement_fee,
-        sumState(
-            toInt64(
-                if(
-                    name IN ('balance.order', 'balance.credit_order') AND net_amount IS NULL,
-                    toInt64(
-                        round(
-                            greatest(COALESCE(applied_balance_amount, 0), 0)
-                            * COALESCE(own_fx, lookup_fx, 1.0)
-                        )
-                    ),
-                    0
-                )
-            )
-        ) AS applied_balance_settlement,
-        sumState(
-            toInt64(
-                if(
-                    name IN ('balance.order', 'balance.credit_order')
-                    AND subscription_id IS NULL
-                    AND net_amount IS NULL,
-                    toInt64(
-                        round(
-                            greatest(COALESCE(applied_balance_amount, 0), 0)
-                            * COALESCE(own_fx, lookup_fx, 1.0)
-                        )
-                    ),
-                    0
-                )
-            )
-        ) AS one_time_applied_balance_settlement
+        -- TODO: drop these columns from orders_base_state_by_quarter_hour.
+        -- They were meant to net customer-balance payments out of revenue at
+        -- the MV layer, but credit_order events never carry
+        -- applied_balance_amount, so the column has always emitted 0 in
+        -- practice. metrics_revenue.pipe's fast path no longer references
+        -- them. Pending a Tinybird schema migration to remove the columns
+        -- from the datasource.
+        sumState(toInt64(0)) AS applied_balance_settlement,
+        sumState(toInt64(0)) AS one_time_applied_balance_settlement
     FROM resolve_fx
     GROUP BY organization_id, quarter_hour, product_id, billing_type, settlement_currency
 


### PR DESCRIPTION
credit_order events don't carry their own exchange_rate, so the MV looked one up via a self-join to the customer's most recent balance.order. That join doesn't see prior insert batches when it runs inside an MV trigger, and balance.order has ingestion lag while credit_order is synchronous, so the two events basically never land in the same batch. FX silently fell back to 1.0 and non-USD amounts got stored as if they were USD.

Drop credit_order from the MV. Resolve it at query time in revenue_fast instead, with the same join revenue_direct already uses (it works fine outside an MV trigger).

Tests now ingest credit_order in a second batch so this class of bug actually reproduces. MV needs a repopulate after deploy.