### PR TITLE
events: Add exchange_rate to balance.credit_order events

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6663,6 +6663,8 @@ export interface components {
       tax_country?: string | null
       /** Fee */
       fee: number
+      /** Exchange Rate */
+      exchange_rate?: number
     }
     /**
      * BalanceDisputeEvent

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -69,6 +69,36 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             Event.organization_id == organization_id
         )
         return await self.get_all(statement)
+
+    async def get_recent_balance_order_exchange_rate(
+        self,
+        organization_id: UUID,
+        presentment_currency: str,
+        *,
+        before: datetime,
+    ) -> float | None:
+        # Cap how far back we'll reach. A months-old FX rate doesn't represent
+        # the current value of credit, so prefer "no rate" (which the readers
+        # know how to fall back from) over a stale one.
+        since = before - timedelta(days=30)
+        statement = (
+            select(Event.user_metadata["exchange_rate"].as_string())
+            .where(
+                Event.organization_id == organization_id,
+                Event.source == EventSource.system,
+                Event.name == SystemEvent.balance_order.value,
+                Event.user_metadata["presentment_currency"].as_string()
+                == presentment_currency,
+                Event.user_metadata["exchange_rate"].is_not(None),
+                Event.timestamp < before,
+                Event.timestamp >= since,
+            )
+            .order_by(Event.timestamp.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        value = result.scalar_one_or_none()
+        return float(value) if value is not None else None
 
     async def insert_batch(
         self, events: Sequence[dict[str, Any]]

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -501,6 +501,7 @@ class BalanceCreditOrderMetadata(TypedDict):
     tax_state: NotRequired[str | None]
     tax_country: NotRequired[str | None]
     fee: int
+    exchange_rate: NotRequired[float]
 
 
 class BalanceCreditOrderEvent(Event):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -32,6 +32,7 @@ from polar.enums import (
     TaxBehaviorOption,
     TaxProcessor,
 )
+from polar.event.repository import EventRepository
 from polar.event.service import event as event_service
 from polar.event.system import (
     BalanceCreditOrderMetadata,
@@ -2078,6 +2079,17 @@ class OrderService:
                 credit_metadata["subscription_id"] = str(order.subscription_id)
             if order.product_id is not None:
                 credit_metadata["product_id"] = str(order.product_id)
+
+            event_repository = EventRepository.from_session(session)
+            exchange_rate = (
+                await event_repository.get_recent_balance_order_exchange_rate(
+                    organization.id,
+                    order.currency,
+                    before=order.created_at,
+                )
+            )
+            if exchange_rate is not None:
+                credit_metadata["exchange_rate"] = exchange_rate
 
             credit_event = build_system_event(
                 SystemEvent.balance_credit_order,

--- a/server/tests/event/test_repository.py
+++ b/server/tests/event/test_repository.py
@@ -19,6 +19,7 @@ async def _create_event(
     timestamp: datetime | None = None,
     source: EventSource = EventSource.user,
     name: str = "test_event",
+    user_metadata: dict[str, object] | None = None,
 ) -> Event:
     event_id = uuid.uuid4()
     event = Event(
@@ -29,7 +30,7 @@ async def _create_event(
         name=name,
         organization=organization,
         root_id=event_id,
-        user_metadata={},
+        user_metadata=user_metadata or {},
     )
     await save_fixture(event)
     return event
@@ -258,6 +259,181 @@ class TestGetLatestPolarSelfIngestionTimestamp:
         repository = EventRepository.from_session(session)
         result = await repository.get_latest_polar_self_ingestion_timestamp(
             organization.id
+        )
+
+        assert result is None
+
+
+async def _create_balance_order(
+    save_fixture: SaveFixture,
+    *,
+    organization: Organization,
+    timestamp: datetime,
+    exchange_rate: float,
+    presentment_currency: str = "eur",
+) -> Event:
+    return await _create_event(
+        save_fixture,
+        organization=organization,
+        ingested_at=timestamp,
+        timestamp=timestamp,
+        source=EventSource.system,
+        name="balance.order",
+        user_metadata={
+            "presentment_currency": presentment_currency,
+            "exchange_rate": exchange_rate,
+        },
+    )
+
+
+@pytest.mark.asyncio
+class TestGetRecentBalanceOrderExchangeRate:
+    async def test_returns_most_recent_prior_match(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_balance_order(
+            save_fixture,
+            organization=organization,
+            timestamp=now - timedelta(hours=2),
+            exchange_rate=0.30,
+        )
+        await _create_balance_order(
+            save_fixture,
+            organization=organization,
+            timestamp=now - timedelta(hours=1),
+            exchange_rate=0.35,
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=now
+        )
+
+        assert result == 0.35
+
+    async def test_returns_none_without_prior_balance_order(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=utc_now()
+        )
+
+        assert result is None
+
+    async def test_filters_by_presentment_currency(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_balance_order(
+            save_fixture,
+            organization=organization,
+            timestamp=now - timedelta(hours=1),
+            exchange_rate=0.30,
+            presentment_currency="gbp",
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=now
+        )
+
+        assert result is None
+
+    async def test_filters_by_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_balance_order(
+            save_fixture,
+            organization=organization_second,
+            timestamp=now - timedelta(hours=1),
+            exchange_rate=0.30,
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=now
+        )
+
+        assert result is None
+
+    async def test_ignores_events_after_before_cutoff(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_balance_order(
+            save_fixture,
+            organization=organization,
+            timestamp=now + timedelta(hours=1),
+            exchange_rate=0.30,
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=now
+        )
+
+        assert result is None
+
+    async def test_ignores_events_older_than_30_day_lookback(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_balance_order(
+            save_fixture,
+            organization=organization,
+            timestamp=now - timedelta(days=31),
+            exchange_rate=0.30,
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=now
+        )
+
+        assert result is None
+
+    async def test_skips_balance_order_without_exchange_rate(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        now = utc_now()
+        await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=now - timedelta(hours=1),
+            timestamp=now - timedelta(hours=1),
+            source=EventSource.system,
+            name="balance.order",
+            user_metadata={"presentment_currency": "eur"},
+        )
+
+        repository = EventRepository.from_session(session)
+        result = await repository.get_recent_balance_order_exchange_rate(
+            organization.id, "eur", before=now
         )
 
         assert result is None


### PR DESCRIPTION
We look it up to the closest event with an existing exchange rate when emitting the credit_order event. If there is no such event, we dont write it and let the fallback in Tinybird handle it.

This is an alternative path for #11614, so that we don't need to follow the slow path every time. We will need to do both however.