### PR TITLE
server/order: reduce customer balance when voiding an order

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -754,7 +754,7 @@ class OrderService:
             )
             total_amount = net_amount + tax_amount
             customer_balance = await wallet_service.get_billing_wallet_balance(
-                session, customer, subscription.currency
+                session, customer, subscription.currency, for_update=True
             )
 
             # Calculate balance change and applied amount
@@ -1945,7 +1945,7 @@ class OrderService:
 
         # Reduce positive customer balance
         customer_balance = await wallet_service.get_billing_wallet_balance(
-            session, order.customer, order.currency
+            session, order.customer, order.currency, for_update=True
         )
         if customer_balance > 0:
             reduction_amount = min(customer_balance, order.due_amount)

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1943,6 +1943,20 @@ class OrderService:
             update_dict={"status": OrderStatus.void, "next_payment_attempt_at": None},
         )
 
+        # Reduce positive customer balance
+        customer_balance = await wallet_service.get_billing_wallet_balance(
+            session, order.customer, order.currency
+        )
+        if customer_balance > 0:
+            reduction_amount = min(customer_balance, order.due_amount)
+            await wallet_service.create_balance_transaction(
+                session,
+                order.customer,
+                -reduction_amount,
+                order.currency,
+                order=order,
+            )
+
         await event_service.create_event(
             session,
             build_system_event(

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -502,7 +502,7 @@ class RefundService:
 
             # Reduce positive customer balance
             customer_balance = await wallet_service.get_billing_wallet_balance(
-                session, order.customer, order.currency
+                session, order.customer, order.currency, for_update=True
             )
             if customer_balance > 0:
                 reduction_amount = min(

--- a/server/polar/wallet/repository.py
+++ b/server/polar/wallet/repository.py
@@ -28,13 +28,20 @@ class WalletRepository(
     model = Wallet
 
     async def get_by_type_currency_customer(
-        self, type: WalletType, currency: str, customer_id: UUID
+        self,
+        type: WalletType,
+        currency: str,
+        customer_id: UUID,
+        *,
+        for_update: bool = False,
     ) -> Wallet | None:
         statement = self.get_base_statement().where(
             Wallet.type == type,
             Wallet.currency == currency,
             Wallet.customer_id == customer_id,
         )
+        if for_update:
+            statement = statement.with_for_update()
         return await self.get_one_or_none(statement)
 
     def get_statement_by_org_ids(

--- a/server/polar/wallet/service.py
+++ b/server/polar/wallet/service.py
@@ -205,11 +205,16 @@ class WalletService:
         )
 
     async def get_billing_wallet_balance(
-        self, session: AsyncSession, customer: Customer, currency: str
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        currency: str,
+        *,
+        for_update: bool = False,
     ) -> int:
         repository = WalletRepository.from_session(session)
         wallet = await repository.get_by_type_currency_customer(
-            WalletType.billing, currency, customer.id
+            WalletType.billing, currency, customer.id, for_update=for_update
         )
         # Small optimization to avoid creating wallet if not existing
         if wallet is None:

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -4736,6 +4736,42 @@ class TestVoidOrder:
         assert result_order.status == OrderStatus.void
         assert result_order.next_payment_attempt_at is None
 
+    @pytest.mark.asyncio
+    async def test_void_reduces_customer_balance(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Given
+        next_attempt_at = utc_now() + timedelta(hours=24)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subtotal_amount=800,
+        )
+
+        # Create customer balance
+        await create_wallet_billing(
+            save_fixture,
+            customer=customer,
+            initial_balance=1000,
+        )
+
+        # When
+        result_order = await order_service.void(session, order)
+
+        # Then
+        assert result_order.status == OrderStatus.void
+
+        new_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert new_balance == 200
+
 
 @pytest.mark.asyncio
 class TestVoidPendingOrdersForSubscription:


### PR DESCRIPTION

Consider the following scenario:

- A subscription is cycled with an order of 100$. The payment is failing, and the payment is dunning.
- The customer downgrades to a 10$ plan, they get a credit of 90$ on their account.
- Later, the order is voided (either by Polar support or subscription cancellation). The customer still has a credit of 90$, even if the payment never succeeded.

This PR takes care of reducing the customer balance by the amount of the order (floored at 0) when voiding an order, so that in the scenario above, the customer would have a balance of 0$ after voiding the order.

We already had the same mechanism in place for refunds.
