### PR TITLE
chore: Dedicated queue for PDF generation jobs step 10

### DIFF
--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -234,17 +234,6 @@ async def order_invoice(order_id: uuid.UUID) -> None:
     await _run_order_invoice(order_id)
 
 
-# Kept temporarily to drain in-flight `order.invoice.v2` messages still in the
-# `invoices_and_receipts` queue from before the rename. Remove once drained.
-@actor(
-    actor_name="order.invoice.v2",
-    priority=TaskPriority.LOW,
-    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
-)
-async def order_invoice_v2(order_id: uuid.UUID) -> None:
-    await _run_order_invoice(order_id)
-
-
 @actor(
     actor_name="order.process_dunning",
     cron_trigger=CronTrigger.from_crontab("0 * * * *"),

--- a/server/polar/receipt/tasks.py
+++ b/server/polar/receipt/tasks.py
@@ -62,15 +62,3 @@ async def _run_receipt_render(order_id: uuid.UUID) -> None:
 )
 async def receipt_render(order_id: uuid.UUID) -> None:
     await _run_receipt_render(order_id)
-
-
-# Kept temporarily to drain in-flight `receipt.render.v2` messages still in the
-# `invoices_and_receipts` queue from before the rename. Remove once drained.
-@actor(
-    actor_name="receipt.render.v2",
-    priority=TaskPriority.LOW,
-    queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
-    time_limit=180_000,  # 3 min: 120s lock TTL + 60s render budget + headroom
-)
-async def receipt_render_v2(order_id: uuid.UUID) -> None:
-    await _run_receipt_render(order_id)

--- a/server/tests/e2e/infra/task_drain.py
+++ b/server/tests/e2e/infra/task_drain.py
@@ -39,7 +39,6 @@ DEFAULT_IGNORED_ACTORS: frozenset[str] = frozenset(
         "order.balance",
         # Uploads invoice PDF to S3/MinIO
         "order.invoice",
-        "order.invoice.v2",
         # Loops.so CRM integration
         "loops.update_last_order_at",
         "loops.update_contact",


### PR DESCRIPTION
# Dedicated queue for PDF generation jobs

## Why

Currently, if enough pdf generation jobs (such as for instance `order.invoice`) is processed concurrently the worker machine runs out of memory.

## What

Move `order.invoice` and `receipt.render` jobs to a dedicated queue `invoices_and_receipts`, consumed by dedicated workers dimensioned for high(er) memory usage but still to not OOM.

## How

Multi-step release plan
1. ~Update existing workers to start consuming a new queue~ **Done**
2. ~Duplicate `order.invoice` => `order.invoice.v2` and `receipt.render` => `receipt.render.v2` and enqueue the new variants to the new queue~ **Done**
3. ~Create a new worker in sandbox that consumes only `invoices_and_receipts`~ **Done**
  3.1 ~terraform wiring~ **Done**
4. ~Update the regular worker in sandbox so it stops consuming the new queue~ **Done**
5. ~Verify this solves OOM issues in sandbox~ **Done**
6. ~Create a new worker in production that consumes only `invoices_and_receipts`~ **Done**
  6.1 ~terraform wiring - ensure the new worker has correct image and is deployed properly~ **Done**
7. ~Update the low priority worker in production so it stops consuming the new queue~ **Done**
8. ~Verify this solves OOM issues in production~ **Done**
9. ~Rename jobs back to `order.invoice` and `receipt.render` (keeping `.v2` around a while to drain in queue/flight jobs)~ **Done**
10. Remove `.v2` entirely (**this step**)