### PR TITLE
fix: allow editing organization details after initial status

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -494,7 +494,7 @@ class OrganizationService:
             },
         )
 
-        if update_schema.details and organization.status == OrganizationStatus.CREATED:
+        if update_schema.details:
             organization.details = cast(
                 OrganizationDetails, update_schema.details.model_dump()
             )

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -445,7 +445,7 @@ class TestUpdateReviewSubmission:
         assert ("body", "details", "product_description") in error_locations
 
     @pytest.mark.auth
-    async def test_update_details_ignored_after_initial_status(
+    async def test_update_details_allowed_after_initial_status(
         self,
         session: AsyncSession,
         organization: Organization,
@@ -466,7 +466,7 @@ class TestUpdateReviewSubmission:
             organization,
             OrganizationUpdate(
                 details=OrganizationDetails(
-                    product_description="Attempted tampering after approval.",
+                    product_description="Updated description after approval.",
                     selling_categories=["Other"],
                     pricing_models=["One-time"],
                     switching=True,
@@ -474,7 +474,13 @@ class TestUpdateReviewSubmission:
             ),
         )
 
-        assert result.details == original_details
+        assert result.details is not None
+        assert result.details["product_description"] == (
+            "Updated description after approval."
+        )
+        assert result.details["selling_categories"] == ["Other"]
+        assert result.details["pricing_models"] == ["One-time"]
+        assert result.details["switching"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Remove the status gate so `organization.details` can be updated via the org update endpoint regardless of the org's current status. We should be able to allow modifications of the details going forward, like asking orgs to complete all the details in here.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)