### PR TITLE
feat: add environment banner to backoffice

### DIFF
--- a/server/polar/backoffice/components/_base.py
+++ b/server/polar/backoffice/components/_base.py
@@ -4,7 +4,24 @@ from collections.abc import Generator, Sequence
 from fastapi import Request
 from tagflow import tag, text
 
+from polar.config import settings
+
 from ..static_urls import static_url
+
+
+def _environment_banner() -> None:
+    if settings.is_production():
+        return
+    label = "LOCAL" if settings.is_development() else settings.ENV.value.upper()
+    color_classes = (
+        "bg-warning text-warning-content"
+        if settings.is_sandbox()
+        else "bg-info text-info-content"
+    )
+    with tag.div(
+        classes=f"w-full text-center text-xs font-semibold uppercase tracking-widest py-1 {color_classes}"
+    ):
+        text(label)
 
 
 @contextlib.contextmanager
@@ -56,6 +73,7 @@ def base(request: Request, title_parts: Sequence[str]) -> Generator[None]:
                 """)
 
         with tag.body():
+            _environment_banner()
             yield
 
             with tag.div(id="modal"):


### PR DESCRIPTION
## Summary

Adds a top banner to every backoffice page indicating the current environment when it isn't production.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)