### PR TITLE
customer-portal: Add default billing method API

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15322,6 +15322,8 @@ export interface components {
       billing_address?: components['schemas']['AddressInput'] | null
       /** Tax Id */
       tax_id?: string | null
+      /** Default Payment Method Id */
+      default_payment_method_id?: string | null
     }
     /**
      * CustomerPortalMember

--- a/server/polar/customer_portal/schemas/customer.py
+++ b/server/polar/customer_portal/schemas/customer.py
@@ -39,6 +39,7 @@ class CustomerPortalCustomerUpdate(Schema):
     billing_name: Annotated[str | None, EmptyStrToNoneValidator] = None
     billing_address: AddressInput | None = None
     tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
+    default_payment_method_id: UUID4 | None = None
 
 
 CustomerPaymentMethod = Annotated[

--- a/server/polar/customer_portal/service/customer.py
+++ b/server/polar/customer_portal/service/customer.py
@@ -13,6 +13,7 @@ from polar.kit.pagination import PaginationParams
 from polar.models import Customer as CustomerModel
 from polar.models import PaymentMethod
 from polar.order.service import order as order_service
+from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.postgres import AsyncSession
 from polar.tax.tax_id import InvalidTaxID, to_stripe_tax_id, validate_tax_id
@@ -66,6 +67,37 @@ class CustomerService:
             else:
                 customer.billing_address = customer_update.billing_address
 
+        new_default_payment_method: PaymentMethod | None = None
+        if "default_payment_method_id" in customer_update.model_fields_set:
+            if customer_update.default_payment_method_id is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "missing",
+                            "loc": ("body", "default_payment_method_id"),
+                            "msg": "Default payment method cannot be reset to null.",
+                            "input": customer_update.default_payment_method_id,
+                        }
+                    ]
+                )
+            payment_method_repository = PaymentMethodRepository.from_session(session)
+            new_default_payment_method = (
+                await payment_method_repository.get_by_id_and_customer(
+                    customer_update.default_payment_method_id, customer.id
+                )
+            )
+            if new_default_payment_method is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "invalid",
+                            "loc": ("body", "default_payment_method_id"),
+                            "msg": "Payment method not found.",
+                            "input": str(customer_update.default_payment_method_id),
+                        }
+                    ]
+                )
+
         tax_id = customer_update.tax_id or (
             customer.tax_id[0] if customer.tax_id else None
         )
@@ -102,9 +134,20 @@ class CustomerService:
             customer,
             update_dict=customer_update.model_dump(
                 exclude_unset=True,
-                exclude={"billing_name", "billing_address", "tax_id"},
+                exclude={
+                    "billing_name",
+                    "billing_address",
+                    "tax_id",
+                    "default_payment_method_id",
+                },
             ),
         )
+
+        if new_default_payment_method is not None:
+            customer = await repository.update(
+                customer,
+                update_dict={"default_payment_method": new_default_payment_method},
+            )
 
         if customer.stripe_customer_id is not None:
             params: ModifyCustomerParams = {"email": customer.email}
@@ -112,12 +155,21 @@ class CustomerService:
                 params["name"] = customer.billing_name
             if customer.billing_address is not None:
                 params["address"] = customer.billing_address.to_dict()
+            if new_default_payment_method is not None:
+                params["invoice_settings"] = {
+                    "default_payment_method": new_default_payment_method.processor_id,
+                }
             await stripe_service.update_customer(
                 customer.stripe_customer_id,
                 tax_id=to_stripe_tax_id(customer.tax_id)
                 if customer.tax_id is not None
                 else None,
                 **params,
+            )
+
+        if new_default_payment_method is not None:
+            await order_service.schedule_retry_for_past_due_orders(
+                session, customer, new_default_payment_method
             )
 
         return customer

--- a/server/tests/customer_portal/endpoints/test_customer.py
+++ b/server/tests/customer_portal/endpoints/test_customer.py
@@ -28,6 +28,7 @@ def stripe_service_mock(mocker: MockerFixture) -> MagicMock:
     mock = MagicMock(spec=StripeService)
     mocker.patch("polar.payment_method.service.stripe_service", new=mock)
     mocker.patch("polar.customer_email_update.service.stripe_service", new=mock)
+    mocker.patch("polar.customer_portal.service.customer.stripe_service", new=mock)
     return mock
 
 
@@ -198,6 +199,100 @@ class TestDeletePaymentMethod:
         # Verify payment method is soft deleted
         await session.refresh(payment_method)
         assert payment_method.deleted_at is not None
+
+
+@pytest.mark.asyncio
+class TestUpdateDefaultPaymentMethod:
+    async def test_anonymous(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        customer: Customer,
+    ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer)
+        response = await client.patch(
+            "/v1/customer-portal/customers/me",
+            json={"default_payment_method_id": str(payment_method.id)},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_payment_method_not_found(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        import uuid
+
+        response = await client.patch(
+            "/v1/customer-portal/customers/me",
+            json={"default_payment_method_id": str(uuid.uuid4())},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_payment_method_not_owned_by_customer(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        other_customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="other@example.com",
+            stripe_customer_id="STRIPE_OTHER_CUSTOMER_ID",
+        )
+        other_payment_method = await create_payment_method(save_fixture, other_customer)
+
+        response = await client.patch(
+            "/v1/customer-portal/customers/me",
+            json={"default_payment_method_id": str(other_payment_method.id)},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_null_default_payment_method_id_rejected(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        response = await client.patch(
+            "/v1/customer-portal/customers/me",
+            json={"default_payment_method_id": None},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_success(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        stripe_service_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer)
+
+        response = await client.patch(
+            "/v1/customer-portal/customers/me",
+            json={"default_payment_method_id": str(payment_method.id)},
+        )
+        assert response.status_code == 200
+
+        body = response.json()
+        assert body["default_payment_method_id"] == str(payment_method.id)
+
+        await session.refresh(customer)
+        assert customer.default_payment_method_id == payment_method.id
+
+        stripe_service_mock.update_customer.assert_awaited_once()
+        call_kwargs = stripe_service_mock.update_customer.await_args.kwargs
+        assert call_kwargs["invoice_settings"] == {
+            "default_payment_method": payment_method.processor_id,
+        }
 
 
 async def _create_verification(


### PR DESCRIPTION
Allows us to build a "switch default payment method" button when there are multiple payment methods added.
