### PR TITLE
refactor: drop anonymous branch from merchant seat-assignment API

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -228,7 +228,10 @@ export const CheckoutConfirmation = ({
           )}
           {status === 'succeeded' && (
             <>
-              <CheckoutSeatInvitations checkout={checkout} />
+              <CheckoutSeatInvitations
+                checkout={checkout}
+                customerSessionToken={customerSessionToken}
+              />
               {hasProductCheckout(checkout) &&
                 checkout.product_price.amount_type !== 'seat_based' && (
                   <CheckoutBenefits

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -12,6 +12,7 @@ import { Well, WellContent, WellHeader } from '../Shared/Well'
 
 export interface CheckoutSeatInvitationsProps {
   checkout: schemas['CheckoutPublic']
+  customerSessionToken?: string
 }
 
 interface EmailInput {
@@ -23,22 +24,43 @@ interface EmailInput {
 
 const CheckoutSeatInvitations = ({
   checkout,
+  customerSessionToken,
 }: CheckoutSeatInvitationsProps) => {
-  const {
-    seats,
-    id: checkoutId,
-    client_secret: checkoutClientSecret,
-  } = checkout
-
-  // Check if this is a seat-based product
   const isSeatBased =
     hasProductCheckout(checkout) &&
     checkout.product_price.amount_type === 'seat_based'
 
+  if (!isSeatBased || !checkout.seats || !customerSessionToken) {
+    return null
+  }
+
+  return (
+    <SeatInvitationsPanel
+      checkoutId={checkout.id}
+      customerEmail={checkout.customer_email}
+      seats={checkout.seats}
+      customerSessionToken={customerSessionToken}
+    />
+  )
+}
+
+interface SeatInvitationsPanelProps {
+  checkoutId: string
+  customerEmail: string | null
+  seats: number
+  customerSessionToken: string
+}
+
+const SeatInvitationsPanel = ({
+  checkoutId,
+  customerEmail,
+  seats,
+  customerSessionToken,
+}: SeatInvitationsPanelProps) => {
   const [emailInputs, setEmailInputs] = useState<EmailInput[]>(
-    checkout.customer_email
+    customerEmail
       ? [
-          { id: '1', value: checkout.customer_email },
+          { id: '1', value: customerEmail },
           { id: '2', value: '' },
         ]
       : [{ id: '1', value: '' }],
@@ -46,9 +68,9 @@ const CheckoutSeatInvitations = ({
   const [isSending, setIsSending] = useState(false)
   const [sentCount, setSentCount] = useState(0)
 
-  const assignSeat = useAssignSeatFromCheckout(checkoutId, checkoutClientSecret)
+  const assignSeat = useAssignSeatFromCheckout(checkoutId, customerSessionToken)
 
-  const availableSeats = (seats || 1) - sentCount
+  const availableSeats = seats - sentCount
   const canAddMore = emailInputs.length < availableSeats
 
   const addEmailInput = () => {
@@ -70,7 +92,6 @@ const CheckoutSeatInvitations = ({
   }
 
   const sendInvitations = async () => {
-    // Validate all emails
     const validatedInputs = emailInputs.map((input) => {
       if (!input.value.trim()) {
         return { ...input, error: 'Email is required' }
@@ -89,7 +110,6 @@ const CheckoutSeatInvitations = ({
 
     setIsSending(true)
 
-    // Send invitations sequentially
     for (const input of emailInputs) {
       if (input.sent) continue
 
@@ -117,11 +137,7 @@ const CheckoutSeatInvitations = ({
   const validEmails = emailInputs.filter(
     (input) => input.value.trim() && !input.error && !input.sent,
   ).length
-  const canSend = validEmails > 0 && !isSending
-
-  if (!isSeatBased || !seats) {
-    return null
-  }
+  const canSend = validEmails > 0 && !isSending && assignSeat.isReady
 
   return (
     <Well className="dark:border-polar-700 dark:bg-polar-800 w-full border border-gray-200 bg-white">

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -137,7 +137,7 @@ const SeatInvitationsPanel = ({
   const validEmails = emailInputs.filter(
     (input) => input.value.trim() && !input.error && !input.sent,
   ).length
-  const canSend = validEmails > 0 && !isSending && assignSeat.isReady
+  const canSend = validEmails > 0 && !isSending
 
   return (
     <Well className="dark:border-polar-700 dark:bg-polar-800 w-full border border-gray-200 bg-white">

--- a/clients/apps/web/src/hooks/queries/customerPortal.ts
+++ b/clients/apps/web/src/hooks/queries/customerPortal.ts
@@ -343,6 +343,21 @@ export const useCustomerOrders = (
     retry: defaultRetry,
   })
 
+export const useCustomerSubscriptions = (
+  api: Client,
+  parameters?: operations['customer_portal:subscriptions:list']['parameters']['query'],
+) =>
+  useQuery({
+    queryKey: ['customer_subscriptions', { ...(parameters || {}) }],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/customer-portal/subscriptions/', {
+          params: { query: parameters },
+        }),
+      ),
+    retry: defaultRetry,
+  })
+
 export const useCustomerSubscriptionChargePreview = (api: Client, id: string) =>
   useQuery({
     queryKey: ['customer_subscription_charge_preview', { id }],

--- a/clients/apps/web/src/hooks/queries/customerPortal.ts
+++ b/clients/apps/web/src/hooks/queries/customerPortal.ts
@@ -343,21 +343,6 @@ export const useCustomerOrders = (
     retry: defaultRetry,
   })
 
-export const useCustomerSubscriptions = (
-  api: Client,
-  parameters?: operations['customer_portal:subscriptions:list']['parameters']['query'],
-) =>
-  useQuery({
-    queryKey: ['customer_subscriptions', { ...(parameters || {}) }],
-    queryFn: () =>
-      unwrap(
-        api.GET('/v1/customer-portal/subscriptions/', {
-          params: { query: parameters },
-        }),
-      ),
-    retry: defaultRetry,
-  })
-
 export const useCustomerSubscriptionChargePreview = (api: Client, id: string) =>
   useQuery({
     queryKey: ['customer_subscription_charge_preview', { id }],

--- a/clients/apps/web/src/hooks/queries/seats.ts
+++ b/clients/apps/web/src/hooks/queries/seats.ts
@@ -1,51 +1,68 @@
-import { getServerURL } from '@/utils/api'
-import { api } from '@/utils/client'
+import { api, createClientSideAPI } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { useCustomerOrders, useCustomerSubscriptions } from './customerPortal'
 import { defaultRetry } from './retry'
 
+type SeatAssignVariables = Omit<
+  schemas['SeatAssign'],
+  'subscription_id' | 'order_id' | 'immediate_claim'
+>
+
+/**
+ * Post-checkout seat assignment via the customer portal endpoint. Looks up
+ * the subscription or order produced by the checkout, then POSTs the seat
+ * with the customer session token issued on confirm.
+ *
+ * Mount only after confirming the checkout is seat-based and the customer
+ * session token is set — the queries fetch unconditionally on mount.
+ */
 export const useAssignSeatFromCheckout = (
   checkoutId: string,
-  checkoutClientSecret: string,
+  customerSessionToken: string,
 ) => {
   const queryClient = useQueryClient()
+  const portalApi = useMemo(
+    () => createClientSideAPI(customerSessionToken),
+    [customerSessionToken],
+  )
 
-  return useMutation({
-    mutationFn: async (
-      variables: Omit<
-        schemas['SeatAssign'],
-        'checkout_id' | 'checkout_client_secret' | 'immediate_claim'
-      > & {
-        immediate_claim?: boolean
-      },
-    ) => {
-      const response = await fetch(`${getServerURL()}/v1/customer-seats`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...variables,
-          checkout_id: checkoutId,
-          checkout_client_secret: checkoutClientSecret,
-          immediate_claim: variables.immediate_claim ?? false,
-        }),
-      })
+  const subscriptions = useCustomerSubscriptions(portalApi)
+  const orders = useCustomerOrders(portalApi)
 
-      if (!response.ok) {
-        const error = await response.json().catch(() => ({}))
-        throw new Error(error.detail || 'Failed to assign seat')
+  const containerRef = useMemo(() => {
+    const subscription = subscriptions.data?.items.find(
+      (s) => s.checkout_id === checkoutId,
+    )
+    if (subscription) return { subscription_id: subscription.id } as const
+    const order = orders.data?.items.find((o) => o.checkout_id === checkoutId)
+    if (order) return { order_id: order.id } as const
+    return null
+  }, [checkoutId, subscriptions.data, orders.data])
+
+  const mutation = useMutation({
+    mutationFn: async (variables: SeatAssignVariables) => {
+      if (!containerRef) {
+        throw new Error('No subscription or order found for this checkout')
       }
-
-      return response.json()
+      const result = await portalApi.POST('/v1/customer-portal/seats', {
+        body: { ...variables, ...containerRef, immediate_claim: false },
+      })
+      if (result.error) {
+        const detail = (result.error as { detail?: unknown }).detail
+        throw new Error(
+          typeof detail === 'string' ? detail : 'Failed to assign seat',
+        )
+      }
+      return result.data
     },
     onSuccess: () => {
-      // Invalidate relevant queries if needed
-      queryClient.invalidateQueries({
-        queryKey: ['checkouts', checkoutId],
-      })
+      queryClient.invalidateQueries({ queryKey: ['customer_seats'] })
     },
   })
+
+  return { ...mutation, isReady: !!containerRef }
 }
 
 /**

--- a/clients/apps/web/src/hooks/queries/seats.ts
+++ b/clients/apps/web/src/hooks/queries/seats.ts
@@ -2,21 +2,17 @@ import { api, createClientSideAPI } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { useCustomerOrders, useCustomerSubscriptions } from './customerPortal'
 import { defaultRetry } from './retry'
 
 type SeatAssignVariables = Omit<
   schemas['SeatAssign'],
-  'subscription_id' | 'order_id' | 'immediate_claim'
+  'subscription_id' | 'order_id' | 'checkout_id' | 'immediate_claim'
 >
 
 /**
- * Post-checkout seat assignment via the customer portal endpoint. Looks up
- * the subscription or order produced by the checkout, then POSTs the seat
- * with the customer session token issued on confirm.
- *
- * Mount only after confirming the checkout is seat-based and the customer
- * session token is set — the queries fetch unconditionally on mount.
+ * Post-checkout seat assignment via the customer portal endpoint. Sends the
+ * checkout_id; the backend resolves the subscription or order produced by
+ * the checkout (scoped to the authenticated customer).
  */
 export const useAssignSeatFromCheckout = (
   checkoutId: string,
@@ -28,26 +24,14 @@ export const useAssignSeatFromCheckout = (
     [customerSessionToken],
   )
 
-  const subscriptions = useCustomerSubscriptions(portalApi)
-  const orders = useCustomerOrders(portalApi)
-
-  const containerRef = useMemo(() => {
-    const subscription = subscriptions.data?.items.find(
-      (s) => s.checkout_id === checkoutId,
-    )
-    if (subscription) return { subscription_id: subscription.id } as const
-    const order = orders.data?.items.find((o) => o.checkout_id === checkoutId)
-    if (order) return { order_id: order.id } as const
-    return null
-  }, [checkoutId, subscriptions.data, orders.data])
-
-  const mutation = useMutation({
+  return useMutation({
     mutationFn: async (variables: SeatAssignVariables) => {
-      if (!containerRef) {
-        throw new Error('No subscription or order found for this checkout')
-      }
       const result = await portalApi.POST('/v1/customer-portal/seats', {
-        body: { ...variables, ...containerRef, immediate_claim: false },
+        body: {
+          ...variables,
+          checkout_id: checkoutId,
+          immediate_claim: false,
+        },
       })
       if (result.error) {
         const detail = (result.error as { detail?: unknown }).detail
@@ -61,8 +45,6 @@ export const useAssignSeatFromCheckout = (
       queryClient.invalidateQueries({ queryKey: ['customer_seats'] })
     },
   })
-
-  return { ...mutation, isReady: !!containerRef }
 }
 
 /**

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15574,6 +15574,62 @@ export interface components {
         [key: string]: unknown
       } | null
     }
+    /** CustomerSeatAssign */
+    CustomerSeatAssign: {
+      /**
+       * Subscription Id
+       * @description Subscription ID. Required if neither order_id nor checkout_id is provided.
+       */
+      subscription_id?: string | null
+      /**
+       * Order Id
+       * @description Order ID for one-time purchases. Required if subscription_id is not provided.
+       */
+      order_id?: string | null
+      /**
+       * Email
+       * @description Email of the customer to assign the seat to
+       */
+      email?: string | null
+      /**
+       * External Customer Id
+       * @description External customer ID for the seat assignment
+       */
+      external_customer_id?: string | null
+      /**
+       * Customer Id
+       * @description Customer ID for the seat assignment
+       */
+      customer_id?: string | null
+      /**
+       * External Member Id
+       * @description External member ID for the seat assignment. Can be used alone (lookup existing member) or with email (create/validate member).
+       */
+      external_member_id?: string | null
+      /**
+       * Member Id
+       * @description Member ID for the seat assignment.
+       */
+      member_id?: string | null
+      /**
+       * Metadata
+       * @description Additional metadata for the seat (max 10 keys, 1KB total)
+       */
+      metadata?: {
+        [key: string]: unknown
+      } | null
+      /**
+       * Immediate Claim
+       * @description If true, the seat will be immediately claimed without sending an invitation email. API-only feature.
+       * @default false
+       */
+      immediate_claim: boolean
+      /**
+       * Checkout Id
+       * @description Checkout ID. Resolves to the subscription or order produced by the checkout.
+       */
+      checkout_id?: string | null
+    }
     /**
      * CustomerSeatClaimResponse
      * @description Response after successfully claiming a seat.
@@ -27014,14 +27070,9 @@ export interface components {
       subscription_id?: string | null
       /**
        * Order Id
-       * @description Order ID for one-time purchases. Required if neither subscription_id nor checkout_id is provided.
+       * @description Order ID for one-time purchases. Required if subscription_id is not provided.
        */
       order_id?: string | null
-      /**
-       * Checkout Id
-       * @description Checkout ID. The endpoint resolves the subscription or order produced by the checkout. Only supported by the customer portal endpoint (`POST /v1/customer-portal/seats`).
-       */
-      checkout_id?: string | null
       /**
        * Email
        * @description Email of the customer to assign the seat to
@@ -40185,7 +40236,7 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['SeatAssign']
+        'application/json': components['schemas']['CustomerSeatAssign']
       }
     }
     responses: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15578,25 +15578,39 @@ export interface components {
     CustomerSeatAssign: {
       /**
        * Subscription Id
-       * @description Subscription ID. Exactly one of subscription_id, order_id, or checkout_id must be provided.
+       * @description Subscription ID. Required if neither order_id nor checkout_id is provided.
        */
       subscription_id?: string | null
       /**
        * Order Id
-       * @description Order ID for one-time purchases. Exactly one of subscription_id, order_id, or checkout_id must be provided.
+       * @description Order ID for one-time purchases. Required if subscription_id is not provided.
        */
       order_id?: string | null
       /**
-       * Checkout Id
-       * @description Checkout ID. Resolves to the subscription or order produced by the checkout.
-       */
-      checkout_id?: string | null
-      /**
        * Email
-       * Format: email
        * @description Email of the customer to assign the seat to
        */
-      email: string
+      email?: string | null
+      /**
+       * External Customer Id
+       * @description External customer ID for the seat assignment
+       */
+      external_customer_id?: string | null
+      /**
+       * Customer Id
+       * @description Customer ID for the seat assignment
+       */
+      customer_id?: string | null
+      /**
+       * External Member Id
+       * @description External member ID for the seat assignment. Can be used alone (lookup existing member) or with email (create/validate member).
+       */
+      external_member_id?: string | null
+      /**
+       * Member Id
+       * @description Member ID for the seat assignment.
+       */
+      member_id?: string | null
       /**
        * Metadata
        * @description Additional metadata for the seat (max 10 keys, 1KB total)
@@ -15604,6 +15618,17 @@ export interface components {
       metadata?: {
         [key: string]: unknown
       } | null
+      /**
+       * Immediate Claim
+       * @description If true, the seat will be immediately claimed without sending an invitation email. API-only feature.
+       * @default false
+       */
+      immediate_claim: boolean
+      /**
+       * Checkout Id
+       * @description Checkout ID. Resolves to the subscription or order produced by the checkout.
+       */
+      checkout_id?: string | null
     }
     /**
      * CustomerSeatClaimResponse

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27009,22 +27009,12 @@ export interface components {
     SeatAssign: {
       /**
        * Subscription Id
-       * @description Subscription ID. Required if checkout_id and order_id are not provided.
+       * @description Subscription ID. Required if order_id is not provided.
        */
       subscription_id?: string | null
       /**
-       * Checkout Id
-       * @description Checkout ID. Used to look up subscription or order from the checkout page.
-       */
-      checkout_id?: string | null
-      /**
-       * Checkout Client Secret
-       * @description Client secret of the checkout. Required when assigning seats via checkout_id as an anonymous caller (e.g. the checkout confirmation page).
-       */
-      checkout_client_secret?: string | null
-      /**
        * Order Id
-       * @description Order ID for one-time purchases. Required if subscription_id and checkout_id are not provided.
+       * @description Order ID for one-time purchases. Required if subscription_id is not provided.
        */
       order_id?: string | null
       /**
@@ -41926,7 +41916,7 @@ export interface operations {
         }
         content?: never
       }
-      /** @description Authentication required for direct subscription or order assignment */
+      /** @description Authentication required */
       401: {
         headers: {
           [name: string]: unknown
@@ -41940,7 +41930,7 @@ export interface operations {
         }
         content?: never
       }
-      /** @description Subscription, order, checkout, or customer not found */
+      /** @description Subscription, order, or customer not found */
       404: {
         headers: {
           [name: string]: unknown

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27009,14 +27009,19 @@ export interface components {
     SeatAssign: {
       /**
        * Subscription Id
-       * @description Subscription ID. Required if order_id is not provided.
+       * @description Subscription ID. Required if neither order_id nor checkout_id is provided.
        */
       subscription_id?: string | null
       /**
        * Order Id
-       * @description Order ID for one-time purchases. Required if subscription_id is not provided.
+       * @description Order ID for one-time purchases. Required if neither subscription_id nor checkout_id is provided.
        */
       order_id?: string | null
+      /**
+       * Checkout Id
+       * @description Checkout ID. The endpoint resolves the subscription or order produced by the checkout. Only supported by the customer portal endpoint (`POST /v1/customer-portal/seats`).
+       */
+      checkout_id?: string | null
       /**
        * Email
        * @description Email of the customer to assign the seat to

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15578,39 +15578,25 @@ export interface components {
     CustomerSeatAssign: {
       /**
        * Subscription Id
-       * @description Subscription ID. Required if neither order_id nor checkout_id is provided.
+       * @description Subscription ID. Exactly one of subscription_id, order_id, or checkout_id must be provided.
        */
       subscription_id?: string | null
       /**
        * Order Id
-       * @description Order ID for one-time purchases. Required if subscription_id is not provided.
+       * @description Order ID for one-time purchases. Exactly one of subscription_id, order_id, or checkout_id must be provided.
        */
       order_id?: string | null
       /**
+       * Checkout Id
+       * @description Checkout ID. Resolves to the subscription or order produced by the checkout.
+       */
+      checkout_id?: string | null
+      /**
        * Email
+       * Format: email
        * @description Email of the customer to assign the seat to
        */
-      email?: string | null
-      /**
-       * External Customer Id
-       * @description External customer ID for the seat assignment
-       */
-      external_customer_id?: string | null
-      /**
-       * Customer Id
-       * @description Customer ID for the seat assignment
-       */
-      customer_id?: string | null
-      /**
-       * External Member Id
-       * @description External member ID for the seat assignment. Can be used alone (lookup existing member) or with email (create/validate member).
-       */
-      external_member_id?: string | null
-      /**
-       * Member Id
-       * @description Member ID for the seat assignment.
-       */
-      member_id?: string | null
+      email: string
       /**
        * Metadata
        * @description Additional metadata for the seat (max 10 keys, 1KB total)
@@ -15618,17 +15604,6 @@ export interface components {
       metadata?: {
         [key: string]: unknown
       } | null
-      /**
-       * Immediate Claim
-       * @description If true, the seat will be immediately claimed without sending an invitation email. API-only feature.
-       * @default false
-       */
-      immediate_claim: boolean
-      /**
-       * Checkout Id
-       * @description Checkout ID. Resolves to the subscription or order produced by the checkout.
-       */
-      checkout_id?: string | null
     }
     /**
      * CustomerSeatClaimResponse

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -5,7 +5,6 @@ from fastapi import Depends, Query
 from pydantic import UUID4
 from sqlalchemy.orm import joinedload, selectinload
 
-from polar.customer_seat.repository import CustomerSeatRepository
 from polar.customer_seat.schemas import CustomerSeat as CustomerSeatSchema
 from polar.customer_seat.schemas import SeatAssign, SeatsList
 from polar.customer_seat.service import seat_service
@@ -21,6 +20,7 @@ from polar.subscription.repository import SubscriptionRepository
 
 from .. import auth
 from ..schemas.subscription import CustomerSubscription
+from ..service.customer_seat import customer_seat as customer_seat_service
 from ..utils import get_customer
 
 log = structlog.get_logger()
@@ -119,81 +119,11 @@ async def assign_seat(
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeat:
     customer = get_customer(auth_subject)
+    container = await customer_seat_service.resolve_assign_container(
+        session, customer, seat_assign
+    )
 
-    subscription: Subscription | None = None
-    order: Order | None = None
-
-    if seat_assign.subscription_id:
-        subscription_repository = SubscriptionRepository.from_session(session)
-
-        statement = (
-            subscription_repository.get_base_statement()
-            .options(*subscription_repository.get_eager_options())
-            .where(
-                Subscription.id == seat_assign.subscription_id,
-                Subscription.customer_id == customer.id,
-            )
-        )
-        subscription = await subscription_repository.get_one_or_none(statement)
-
-        if not subscription:
-            raise ResourceNotFound("Subscription not found")
-
-    elif seat_assign.order_id:
-        order_repository = OrderRepository.from_session(session)
-
-        order_statement = (
-            order_repository.get_base_statement()
-            .options(*order_repository.get_eager_options())
-            .where(
-                Order.id == seat_assign.order_id,
-                Order.customer_id == customer.id,
-            )
-        )
-        order = await order_repository.get_one_or_none(order_statement)
-
-        if not order:
-            raise ResourceNotFound("Order not found")
-
-    elif seat_assign.checkout_id:
-        subscription_repository = SubscriptionRepository.from_session(session)
-        order_repository = OrderRepository.from_session(session)
-
-        subscription_statement = (
-            subscription_repository.get_base_statement()
-            .options(*subscription_repository.get_eager_options())
-            .where(
-                Subscription.checkout_id == seat_assign.checkout_id,
-                Subscription.customer_id == customer.id,
-            )
-        )
-        subscription = await subscription_repository.get_one_or_none(
-            subscription_statement
-        )
-
-        if not subscription:
-            order_statement = (
-                order_repository.get_base_statement()
-                .options(*order_repository.get_eager_options())
-                .where(
-                    Order.checkout_id == seat_assign.checkout_id,
-                    Order.customer_id == customer.id,
-                )
-            )
-            order = await order_repository.get_one_or_none(order_statement)
-
-            if not order:
-                raise ResourceNotFound(
-                    "No subscription or order found for this checkout"
-                )
-
-    else:
-        raise BadRequest("Either subscription_id, order_id, or checkout_id is required")
-
-    container = subscription or order
-    assert container is not None  # Already validated above
-
-    seat = await seat_service.assign_seat(
+    return await seat_service.assign_seat(
         session,
         container,
         email=seat_assign.email,
@@ -201,20 +131,6 @@ async def assign_seat(
         customer_id=seat_assign.customer_id,
         metadata=seat_assign.metadata,
     )
-
-    # Reload seat with customer and member relationships
-    seat_repository = CustomerSeatRepository.from_session(session)
-    seat_statement = (
-        seat_repository.get_base_statement()
-        .where(CustomerSeat.id == seat.id)
-        .options(joinedload(CustomerSeat.customer), joinedload(CustomerSeat.member))
-    )
-    reloaded_seat = await seat_repository.get_one_or_none(seat_statement)
-
-    if not reloaded_seat:
-        raise ResourceNotFound("Seat not found after creation")
-
-    return reloaded_seat
 
 
 @router.delete(

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -155,8 +155,40 @@ async def assign_seat(
         if not order:
             raise ResourceNotFound("Order not found")
 
+    elif seat_assign.checkout_id:
+        subscription_repository = SubscriptionRepository.from_session(session)
+        order_repository = OrderRepository.from_session(session)
+
+        subscription_statement = (
+            subscription_repository.get_base_statement()
+            .options(*subscription_repository.get_eager_options())
+            .where(
+                Subscription.checkout_id == seat_assign.checkout_id,
+                Subscription.customer_id == customer.id,
+            )
+        )
+        subscription = await subscription_repository.get_one_or_none(
+            subscription_statement
+        )
+
+        if not subscription:
+            order_statement = (
+                order_repository.get_base_statement()
+                .options(*order_repository.get_eager_options())
+                .where(
+                    Order.checkout_id == seat_assign.checkout_id,
+                    Order.customer_id == customer.id,
+                )
+            )
+            order = await order_repository.get_one_or_none(order_statement)
+
+            if not order:
+                raise ResourceNotFound(
+                    "No subscription or order found for this checkout"
+                )
+
     else:
-        raise BadRequest("Either subscription_id or order_id is required")
+        raise BadRequest("Either subscription_id, order_id, or checkout_id is required")
 
     container = subscription or order
     assert container is not None  # Already validated above

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -127,7 +127,12 @@ async def assign_seat(
         session,
         container,
         email=seat_assign.email,
+        external_customer_id=seat_assign.external_customer_id,
+        customer_id=seat_assign.customer_id,
+        external_member_id=seat_assign.external_member_id,
+        member_id=seat_assign.member_id,
         metadata=seat_assign.metadata,
+        immediate_claim=seat_assign.immediate_claim,
     )
 
 

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -6,7 +6,7 @@ from pydantic import UUID4
 from sqlalchemy.orm import joinedload, selectinload
 
 from polar.customer_seat.schemas import CustomerSeat as CustomerSeatSchema
-from polar.customer_seat.schemas import SeatAssign, SeatsList
+from polar.customer_seat.schemas import SeatsList
 from polar.customer_seat.service import seat_service
 from polar.exceptions import BadRequest, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
@@ -19,6 +19,7 @@ from polar.routing import APIRouter
 from polar.subscription.repository import SubscriptionRepository
 
 from .. import auth
+from ..schemas.seat import CustomerSeatAssign
 from ..schemas.subscription import CustomerSubscription
 from ..service.customer_seat import customer_seat as customer_seat_service
 from ..utils import get_customer
@@ -114,7 +115,7 @@ async def list_seats(
     },
 )
 async def assign_seat(
-    seat_assign: SeatAssign,
+    seat_assign: CustomerSeatAssign,
     auth_subject: auth.CustomerPortalUnionBillingWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeat:

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -127,8 +127,6 @@ async def assign_seat(
         session,
         container,
         email=seat_assign.email,
-        external_customer_id=seat_assign.external_customer_id,
-        customer_id=seat_assign.customer_id,
         metadata=seat_assign.metadata,
     )
 

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -118,9 +118,8 @@ async def assign_seat(
     auth_subject: auth.CustomerPortalUnionBillingWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeat:
-    customer = get_customer(auth_subject)
     container = await customer_seat_service.resolve_assign_container(
-        session, customer, seat_assign
+        session, auth_subject, seat_assign
     )
 
     return await seat_service.assign_seat(

--- a/server/polar/customer_portal/schemas/seat.py
+++ b/server/polar/customer_portal/schemas/seat.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from pydantic import Field
+
+from polar.customer_seat.schemas import SeatAssign
+
+
+class CustomerSeatAssign(SeatAssign):
+    checkout_id: UUID | None = Field(
+        None,
+        description=(
+            "Checkout ID. Resolves to the subscription or order produced by "
+            "the checkout."
+        ),
+    )
+
+    def _seat_source_ids(self) -> list[UUID | None]:
+        return [self.subscription_id, self.order_id, self.checkout_id]
+
+    def _seat_source_error_message(self) -> str:
+        return (
+            "Exactly one of subscription_id, order_id, or checkout_id must be provided"
+        )

--- a/server/polar/customer_portal/schemas/seat.py
+++ b/server/polar/customer_portal/schemas/seat.py
@@ -1,53 +1,23 @@
-import json
-from typing import Any
 from uuid import UUID
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field
 
-from polar.kit.email import EmailStrDNS
-from polar.kit.schemas import Schema
+from polar.customer_seat.schemas import SeatAssign
 
 
-class CustomerSeatAssign(Schema):
-    subscription_id: UUID | None = Field(
-        None,
-        description="Subscription ID. Exactly one of subscription_id, order_id, or checkout_id must be provided.",
-    )
-    order_id: UUID | None = Field(
-        None,
-        description="Order ID for one-time purchases. Exactly one of subscription_id, order_id, or checkout_id must be provided.",
-    )
+class CustomerSeatAssign(SeatAssign):
     checkout_id: UUID | None = Field(
         None,
-        description="Checkout ID. Resolves to the subscription or order produced by the checkout.",
-    )
-    email: EmailStrDNS = Field(
-        ..., description="Email of the customer to assign the seat to"
-    )
-    metadata: dict[str, Any] | None = Field(
-        None, description="Additional metadata for the seat (max 10 keys, 1KB total)"
+        description=(
+            "Checkout ID. Resolves to the subscription or order produced by "
+            "the checkout."
+        ),
     )
 
-    @field_validator("metadata")
-    @classmethod
-    def validate_metadata(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
-        if v is None:
-            return v
-        if len(v) > 10:
-            raise ValueError("Metadata cannot have more than 10 keys")
-        if len(json.dumps(v)) > 1024:
-            raise ValueError("Metadata size cannot exceed 1KB")
-        return v
+    def _seat_source_ids(self) -> list[UUID | None]:
+        return [self.subscription_id, self.order_id, self.checkout_id]
 
-    @model_validator(mode="after")
-    def validate_seat_source(self) -> "CustomerSeatAssign":
-        source_count = sum(
-            1
-            for x in [self.subscription_id, self.order_id, self.checkout_id]
-            if x is not None
+    def _seat_source_error_message(self) -> str:
+        return (
+            "Exactly one of subscription_id, order_id, or checkout_id must be provided"
         )
-        if source_count != 1:
-            raise ValueError(
-                "Exactly one of subscription_id, order_id, or checkout_id must be provided"
-            )
-        return self

--- a/server/polar/customer_portal/schemas/seat.py
+++ b/server/polar/customer_portal/schemas/seat.py
@@ -1,23 +1,53 @@
+import json
+from typing import Any
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
-from polar.customer_seat.schemas import SeatAssign
+from polar.kit.email import EmailStrDNS
+from polar.kit.schemas import Schema
 
 
-class CustomerSeatAssign(SeatAssign):
+class CustomerSeatAssign(Schema):
+    subscription_id: UUID | None = Field(
+        None,
+        description="Subscription ID. Exactly one of subscription_id, order_id, or checkout_id must be provided.",
+    )
+    order_id: UUID | None = Field(
+        None,
+        description="Order ID for one-time purchases. Exactly one of subscription_id, order_id, or checkout_id must be provided.",
+    )
     checkout_id: UUID | None = Field(
         None,
-        description=(
-            "Checkout ID. Resolves to the subscription or order produced by "
-            "the checkout."
-        ),
+        description="Checkout ID. Resolves to the subscription or order produced by the checkout.",
+    )
+    email: EmailStrDNS = Field(
+        ..., description="Email of the customer to assign the seat to"
+    )
+    metadata: dict[str, Any] | None = Field(
+        None, description="Additional metadata for the seat (max 10 keys, 1KB total)"
     )
 
-    def _seat_source_ids(self) -> list[UUID | None]:
-        return [self.subscription_id, self.order_id, self.checkout_id]
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        if v is None:
+            return v
+        if len(v) > 10:
+            raise ValueError("Metadata cannot have more than 10 keys")
+        if len(json.dumps(v)) > 1024:
+            raise ValueError("Metadata size cannot exceed 1KB")
+        return v
 
-    def _seat_source_error_message(self) -> str:
-        return (
-            "Exactly one of subscription_id, order_id, or checkout_id must be provided"
+    @model_validator(mode="after")
+    def validate_seat_source(self) -> "CustomerSeatAssign":
+        source_count = sum(
+            1
+            for x in [self.subscription_id, self.order_id, self.checkout_id]
+            if x is not None
         )
+        if source_count != 1:
+            raise ValueError(
+                "Exactly one of subscription_id, order_id, or checkout_id must be provided"
+            )
+        return self

--- a/server/polar/customer_portal/service/customer_seat.py
+++ b/server/polar/customer_portal/service/customer_seat.py
@@ -1,0 +1,61 @@
+from polar.customer_seat.schemas import SeatAssign
+from polar.exceptions import BadRequest, ResourceNotFound
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Customer, Order, Subscription
+from polar.order.repository import OrderRepository
+from polar.subscription.repository import SubscriptionRepository
+
+
+class CustomerSeatService:
+    async def resolve_assign_container(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        seat_assign: SeatAssign,
+    ) -> Subscription | Order:
+        subscription_repository = SubscriptionRepository.from_session(session)
+        order_repository = OrderRepository.from_session(session)
+
+        if seat_assign.subscription_id:
+            subscription = await subscription_repository.get_by_id_and_customer(
+                seat_assign.subscription_id,
+                customer.id,
+                options=subscription_repository.get_eager_options(),
+            )
+            if not subscription:
+                raise ResourceNotFound("Subscription not found")
+            return subscription
+
+        if seat_assign.order_id:
+            order = await order_repository.get_by_id_and_customer(
+                seat_assign.order_id,
+                customer.id,
+                options=order_repository.get_eager_options(),
+            )
+            if not order:
+                raise ResourceNotFound("Order not found")
+            return order
+
+        if seat_assign.checkout_id:
+            subscription = (
+                await subscription_repository.get_by_checkout_id_and_customer(
+                    seat_assign.checkout_id,
+                    customer.id,
+                    options=subscription_repository.get_eager_options(),
+                )
+            )
+            if subscription:
+                return subscription
+            order = await order_repository.get_earliest_by_checkout_id_and_customer(
+                seat_assign.checkout_id,
+                customer.id,
+                options=order_repository.get_eager_options(),
+            )
+            if order:
+                return order
+            raise ResourceNotFound("No subscription or order found for this checkout")
+
+        raise BadRequest("Either subscription_id, order_id, or checkout_id is required")
+
+
+customer_seat = CustomerSeatService()

--- a/server/polar/customer_portal/service/customer_seat.py
+++ b/server/polar/customer_portal/service/customer_seat.py
@@ -1,7 +1,8 @@
+from polar.auth.models import AuthSubject, Customer, Member
 from polar.customer_seat.schemas import SeatAssign
 from polar.exceptions import BadRequest, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
-from polar.models import Customer, Order, Subscription
+from polar.models import Order, Subscription
 from polar.order.repository import OrderRepository
 from polar.subscription.repository import SubscriptionRepository
 
@@ -10,47 +11,56 @@ class CustomerSeatService:
     async def resolve_assign_container(
         self,
         session: AsyncSession,
-        customer: Customer,
+        auth_subject: AuthSubject[Customer | Member],
         seat_assign: SeatAssign,
     ) -> Subscription | Order:
         subscription_repository = SubscriptionRepository.from_session(session)
         order_repository = OrderRepository.from_session(session)
 
         if seat_assign.subscription_id:
-            subscription = await subscription_repository.get_by_id_and_customer(
-                seat_assign.subscription_id,
-                customer.id,
-                options=subscription_repository.get_eager_options(),
+            subscription_statement = (
+                subscription_repository.get_readable_statement(auth_subject)
+                .where(Subscription.id == seat_assign.subscription_id)
+                .options(*subscription_repository.get_eager_options())
+            )
+            subscription = await subscription_repository.get_one_or_none(
+                subscription_statement
             )
             if not subscription:
                 raise ResourceNotFound("Subscription not found")
             return subscription
 
         if seat_assign.order_id:
-            order = await order_repository.get_by_id_and_customer(
-                seat_assign.order_id,
-                customer.id,
-                options=order_repository.get_eager_options(),
+            order_statement = (
+                order_repository.get_readable_statement(auth_subject)
+                .where(Order.id == seat_assign.order_id)
+                .options(*order_repository.get_eager_options())
             )
+            order = await order_repository.get_one_or_none(order_statement)
             if not order:
                 raise ResourceNotFound("Order not found")
             return order
 
         if seat_assign.checkout_id:
-            subscription = (
-                await subscription_repository.get_by_checkout_id_and_customer(
-                    seat_assign.checkout_id,
-                    customer.id,
-                    options=subscription_repository.get_eager_options(),
-                )
+            subscription_statement = (
+                subscription_repository.get_readable_statement(auth_subject)
+                .where(Subscription.checkout_id == seat_assign.checkout_id)
+                .options(*subscription_repository.get_eager_options())
+            )
+            subscription = await subscription_repository.get_one_or_none(
+                subscription_statement
             )
             if subscription:
                 return subscription
-            order = await order_repository.get_earliest_by_checkout_id_and_customer(
-                seat_assign.checkout_id,
-                customer.id,
-                options=order_repository.get_eager_options(),
+
+            order_statement = (
+                order_repository.get_readable_statement(auth_subject)
+                .where(Order.checkout_id == seat_assign.checkout_id)
+                .order_by(Order.created_at.asc())
+                .limit(1)
+                .options(*order_repository.get_eager_options())
             )
+            order = await order_repository.get_one_or_none(order_statement)
             if order:
                 return order
             raise ResourceNotFound("No subscription or order found for this checkout")

--- a/server/polar/customer_portal/service/customer_seat.py
+++ b/server/polar/customer_portal/service/customer_seat.py
@@ -18,49 +18,39 @@ class CustomerSeatService:
         order_repository = OrderRepository.from_session(session)
 
         if seat_assign.subscription_id:
-            subscription_statement = (
-                subscription_repository.get_readable_statement(auth_subject)
-                .where(Subscription.id == seat_assign.subscription_id)
-                .options(*subscription_repository.get_eager_options())
-            )
-            subscription = await subscription_repository.get_one_or_none(
-                subscription_statement
+            subscription = await subscription_repository.get_readable_by_id(
+                auth_subject,
+                seat_assign.subscription_id,
+                options=subscription_repository.get_eager_options(),
             )
             if not subscription:
                 raise ResourceNotFound("Subscription not found")
             return subscription
 
         if seat_assign.order_id:
-            order_statement = (
-                order_repository.get_readable_statement(auth_subject)
-                .where(Order.id == seat_assign.order_id)
-                .options(*order_repository.get_eager_options())
+            order = await order_repository.get_readable_by_id(
+                auth_subject,
+                seat_assign.order_id,
+                options=order_repository.get_eager_options(),
             )
-            order = await order_repository.get_one_or_none(order_statement)
             if not order:
                 raise ResourceNotFound("Order not found")
             return order
 
         if seat_assign.checkout_id:
-            subscription_statement = (
-                subscription_repository.get_readable_statement(auth_subject)
-                .where(Subscription.checkout_id == seat_assign.checkout_id)
-                .options(*subscription_repository.get_eager_options())
-            )
-            subscription = await subscription_repository.get_one_or_none(
-                subscription_statement
+            subscription = await subscription_repository.get_readable_by_checkout_id(
+                auth_subject,
+                seat_assign.checkout_id,
+                options=subscription_repository.get_eager_options(),
             )
             if subscription:
                 return subscription
 
-            order_statement = (
-                order_repository.get_readable_statement(auth_subject)
-                .where(Order.checkout_id == seat_assign.checkout_id)
-                .order_by(Order.created_at.asc())
-                .limit(1)
-                .options(*order_repository.get_eager_options())
+            order = await order_repository.get_earliest_readable_by_checkout_id(
+                auth_subject,
+                seat_assign.checkout_id,
+                options=order_repository.get_eager_options(),
             )
-            order = await order_repository.get_one_or_none(order_statement)
             if order:
                 return order
             raise ResourceNotFound("No subscription or order found for this checkout")

--- a/server/polar/customer_portal/service/customer_seat.py
+++ b/server/polar/customer_portal/service/customer_seat.py
@@ -1,10 +1,11 @@
 from polar.auth.models import AuthSubject, Customer, Member
-from polar.customer_seat.schemas import SeatAssign
 from polar.exceptions import BadRequest, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Order, Subscription
 from polar.order.repository import OrderRepository
 from polar.subscription.repository import SubscriptionRepository
+
+from ..schemas.seat import CustomerSeatAssign
 
 
 class CustomerSeatService:
@@ -12,7 +13,7 @@ class CustomerSeatService:
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[Customer | Member],
-        seat_assign: SeatAssign,
+        seat_assign: CustomerSeatAssign,
     ) -> Subscription | Order:
         subscription_repository = SubscriptionRepository.from_session(session)
         order_repository = OrderRepository.from_session(session)

--- a/server/polar/customer_seat/auth.py
+++ b/server/polar/customer_seat/auth.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 
 from polar.auth.dependencies import Authenticator
-from polar.auth.models import Anonymous, AuthSubject, Organization, User
+from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
 
 _SeatRead = Authenticator(
@@ -21,13 +21,3 @@ _SeatWrite = Authenticator(
     allowed_subjects={User, Organization},
 )
 SeatWrite = Annotated[AuthSubject[User | Organization], Depends(_SeatWrite)]
-
-_SeatWriteOrAnonymous = Authenticator(
-    required_scopes={
-        Scope.customer_seats_write,
-    },
-    allowed_subjects={User, Organization, Anonymous},
-)
-SeatWriteOrAnonymous = Annotated[
-    AuthSubject[User | Organization | Anonymous], Depends(_SeatWriteOrAnonymous)
-]

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -1,20 +1,14 @@
-import secrets
-from typing import Annotated, cast
+from typing import Annotated
 
 from fastapi import Depends, Query, Request
 from pydantic import UUID4
-from sqlalchemy.orm import joinedload
 from sse_starlette import EventSourceResponse
 
-from polar.auth.models import Anonymous, Organization, User
-from polar.auth.models import AuthSubject as AuthSubjectType
 from polar.authz.service import get_accessible_org_ids
-from polar.checkout.repository import CheckoutRepository
 from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
-from polar.exceptions import BadRequest, NotPermitted, ResourceNotFound
-from polar.models import CustomerSeat, Order, Product, Subscription
-from polar.models.checkout import CheckoutStatus
+from polar.exceptions import BadRequest, ResourceNotFound
+from polar.models import CustomerSeat, Order, Subscription
 from polar.models.customer_seat import SeatStatus
 from polar.openapi import APITag
 from polar.order.repository import OrderRepository
@@ -24,7 +18,7 @@ from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 from polar.subscription.repository import SubscriptionRepository
 
-from .auth import SeatWriteOrAnonymous
+from .auth import SeatWrite
 from .repository import CustomerSeatRepository
 from .schemas import CustomerSeat as CustomerSeatSchema
 from .schemas import (
@@ -48,38 +42,24 @@ router = APIRouter(
     response_model=CustomerSeatSchema,
     responses={
         400: {"description": "No available seats or customer already has a seat"},
-        401: {
-            "description": "Authentication required for direct subscription or order assignment"
-        },
+        401: {"description": "Authentication required"},
         403: {"description": "Not permitted or seat-based pricing not enabled"},
-        404: {"description": "Subscription, order, checkout, or customer not found"},
+        404: {"description": "Subscription, order, or customer not found"},
     },
 )
 async def assign_seat(
     seat_assign: SeatAssign,
-    auth_subject: SeatWriteOrAnonymous,
+    auth_subject: SeatWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeatSchema:
-    # Prevent anonymous users from using immediate_claim
-    if isinstance(auth_subject.subject, Anonymous) and seat_assign.immediate_claim:
-        raise NotPermitted(
-            "Anonymous users cannot use immediate_claim. This feature is only available for authenticated API access."
-        )
-
     subscription: Subscription | None = None
     order: Order | None = None
 
     if seat_assign.subscription_id:
-        if isinstance(auth_subject.subject, Anonymous):
-            raise NotPermitted(
-                "Authentication required for subscription-based assignment"
-            )
-
-        typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
         subscription_repository = SubscriptionRepository.from_session(session)
 
         statement = (
-            subscription_repository.get_readable_statement(typed_auth_subject)
+            subscription_repository.get_readable_statement(auth_subject)
             .options(*subscription_repository.get_eager_options())
             .where(Subscription.id == seat_assign.subscription_id)
         )
@@ -88,66 +68,11 @@ async def assign_seat(
         if not subscription:
             raise ResourceNotFound("Subscription not found")
 
-    elif seat_assign.checkout_id:
-        subscription_repository = SubscriptionRepository.from_session(session)
-        order_repository = OrderRepository.from_session(session)
-        checkout_repository = CheckoutRepository.from_session(session)
-        checkout = await checkout_repository.get_by_id(seat_assign.checkout_id)
-
-        if not checkout:
-            raise ResourceNotFound("Checkout not found")
-
-        if isinstance(auth_subject.subject, Anonymous):
-            if seat_assign.checkout_client_secret is None or not secrets.compare_digest(
-                seat_assign.checkout_client_secret, checkout.client_secret
-            ):
-                raise NotPermitted(
-                    "checkout_client_secret is required and must match the "
-                    "checkout when assigning seats as an anonymous caller."
-                )
-        elif seat_assign.checkout_client_secret is not None:
-            if not secrets.compare_digest(
-                seat_assign.checkout_client_secret, checkout.client_secret
-            ):
-                raise NotPermitted("checkout_client_secret does not match.")
-
-        if checkout.status != CheckoutStatus.succeeded:
-            raise NotPermitted("Seats can only be assigned from a successful checkout.")
-
-        if checkout.is_expired:
-            raise NotPermitted(
-                "Seats can no longer be assigned from this checkout because it has expired."
-            )
-
-        # Try to find subscription first (for recurring purchases)
-        subscription = await subscription_repository.get_by_checkout_id(
-            seat_assign.checkout_id,
-            options=(
-                joinedload(Subscription.product).joinedload(Product.organization),
-                joinedload(Subscription.customer),
-            ),
-        )
-
-        # If no subscription, try to find order (for one-time purchases)
-        if not subscription:
-            order = await order_repository.get_earliest_by_checkout_id(
-                seat_assign.checkout_id,
-                options=order_repository.get_eager_options(),
-            )
-            if not order:
-                raise ResourceNotFound(
-                    "No subscription or order found for this checkout"
-                )
-
     elif seat_assign.order_id:
-        if isinstance(auth_subject.subject, Anonymous):
-            raise NotPermitted("Authentication required for order-based assignment")
-
-        typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
         order_repository = OrderRepository.from_session(session)
 
         order_statement = (
-            order_repository.get_readable_statement(typed_auth_subject)
+            order_repository.get_readable_statement(auth_subject)
             .options(*order_repository.get_eager_options())
             .where(Order.id == seat_assign.order_id)
         )
@@ -156,10 +81,8 @@ async def assign_seat(
         if not order:
             raise ResourceNotFound("Order not found")
 
-    if not subscription and not order:
-        raise BadRequest(
-            "Either subscription_id, checkout_id, or order_id must be provided"
-        )
+    else:
+        raise BadRequest("Either subscription_id or order_id must be provided")
 
     container = subscription or order
     assert container is not None  # Already validated above
@@ -190,16 +113,11 @@ async def assign_seat(
     },
 )
 async def list_seats(
-    auth_subject: SeatWriteOrAnonymous,
+    auth_subject: SeatWrite,
     session: AsyncSession = Depends(get_db_session),
     subscription_id: Annotated[UUID4 | None, Query()] = None,
     order_id: Annotated[UUID4 | None, Query()] = None,
 ) -> SeatsList:
-    if isinstance(auth_subject.subject, Anonymous):
-        raise NotPermitted("Authentication required")
-
-    typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
-
     subscription: Subscription | None = None
     order: Order | None = None
     total_seats = 0
@@ -208,7 +126,7 @@ async def list_seats(
         subscription_repository = SubscriptionRepository.from_session(session)
 
         statement = (
-            subscription_repository.get_readable_statement(typed_auth_subject)
+            subscription_repository.get_readable_statement(auth_subject)
             .options(*subscription_repository.get_eager_options())
             .where(Subscription.id == subscription_id)
         )
@@ -223,7 +141,7 @@ async def list_seats(
         order_repository = OrderRepository.from_session(session)
 
         order_statement = (
-            order_repository.get_readable_statement(typed_auth_subject)
+            order_repository.get_readable_statement(auth_subject)
             .options(*order_repository.get_eager_options())
             .where(Order.id == order_id)
         )
@@ -262,15 +180,11 @@ async def list_seats(
 )
 async def revoke_seat(
     seat_id: UUID4,
-    auth_subject: SeatWriteOrAnonymous,
+    auth_subject: SeatWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeat:
-    if isinstance(auth_subject.subject, Anonymous):
-        raise NotPermitted("Authentication required")
-
-    typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
     seat_repository = CustomerSeatRepository.from_session(session)
-    org_ids = await get_accessible_org_ids(session, typed_auth_subject)
+    org_ids = await get_accessible_org_ids(session, auth_subject)
 
     seat = await seat_repository.get_by_id_and_org_ids(
         org_ids,
@@ -306,15 +220,11 @@ async def revoke_seat(
 )
 async def resend_invitation(
     seat_id: UUID4,
-    auth_subject: SeatWriteOrAnonymous,
+    auth_subject: SeatWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeat:
-    if isinstance(auth_subject.subject, Anonymous):
-        raise NotPermitted("Authentication required")
-
-    typed_auth_subject = cast(AuthSubjectType[User | Organization], auth_subject)
     seat_repository = CustomerSeatRepository.from_session(session)
-    org_ids = await get_accessible_org_ids(session, typed_auth_subject)
+    org_ids = await get_accessible_org_ids(session, auth_subject)
 
     seat = await seat_repository.get_by_id_and_org_ids(
         org_ids,

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -52,12 +52,6 @@ async def assign_seat(
     auth_subject: SeatWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeatSchema:
-    if seat_assign.checkout_id is not None:
-        raise BadRequest(
-            "checkout_id is not supported on the merchant API; "
-            "use POST /v1/customer-portal/seats with a customer session token."
-        )
-
     subscription: Subscription | None = None
     order: Order | None = None
 

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -52,6 +52,12 @@ async def assign_seat(
     auth_subject: SeatWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> CustomerSeatSchema:
+    if seat_assign.checkout_id is not None:
+        raise BadRequest(
+            "checkout_id is not supported on the merchant API; "
+            "use POST /v1/customer-portal/seats with a customer session token."
+        )
+
     subscription: Subscription | None = None
     order: Order | None = None
 

--- a/server/polar/customer_seat/schemas.py
+++ b/server/polar/customer_seat/schemas.py
@@ -18,15 +18,7 @@ class SeatAssign(Schema):
     )
     order_id: UUID | None = Field(
         None,
-        description="Order ID for one-time purchases. Required if neither subscription_id nor checkout_id is provided.",
-    )
-    checkout_id: UUID | None = Field(
-        None,
-        description=(
-            "Checkout ID. The endpoint resolves the subscription or order "
-            "produced by the checkout. Only supported by the customer portal "
-            "endpoint (`POST /v1/customer-portal/seats`)."
-        ),
+        description="Order ID for one-time purchases. Required if subscription_id is not provided.",
     )
     email: EmailStrDNS | None = Field(
         None, description="Email of the customer to assign the seat to"
@@ -70,17 +62,19 @@ class SeatAssign(Schema):
         return v
 
     @model_validator(mode="after")
-    def validate_identifiers(self) -> "SeatAssign":
-        seat_source_count = sum(
-            1
-            for x in [self.subscription_id, self.order_id, self.checkout_id]
-            if x is not None
-        )
-        if seat_source_count != 1:
-            raise ValueError(
-                "Exactly one of subscription_id, order_id, or checkout_id must be provided"
-            )
+    def validate_seat_source(self) -> "SeatAssign":
+        if sum(1 for x in self._seat_source_ids() if x is not None) != 1:
+            raise ValueError(self._seat_source_error_message())
+        return self
 
+    def _seat_source_ids(self) -> list[UUID | None]:
+        return [self.subscription_id, self.order_id]
+
+    def _seat_source_error_message(self) -> str:
+        return "Exactly one of subscription_id or order_id must be provided"
+
+    @model_validator(mode="after")
+    def validate_recipient(self) -> "SeatAssign":
         # Count identifier groups
         legacy_count = sum(
             1 for x in [self.external_customer_id, self.customer_id] if x is not None

--- a/server/polar/customer_seat/schemas.py
+++ b/server/polar/customer_seat/schemas.py
@@ -14,11 +14,19 @@ from polar.models.customer_seat import SeatStatus
 class SeatAssign(Schema):
     subscription_id: UUID | None = Field(
         None,
-        description="Subscription ID. Required if order_id is not provided.",
+        description="Subscription ID. Required if neither order_id nor checkout_id is provided.",
     )
     order_id: UUID | None = Field(
         None,
-        description="Order ID for one-time purchases. Required if subscription_id is not provided.",
+        description="Order ID for one-time purchases. Required if neither subscription_id nor checkout_id is provided.",
+    )
+    checkout_id: UUID | None = Field(
+        None,
+        description=(
+            "Checkout ID. The endpoint resolves the subscription or order "
+            "produced by the checkout. Only supported by the customer portal "
+            "endpoint (`POST /v1/customer-portal/seats`)."
+        ),
     )
     email: EmailStrDNS | None = Field(
         None, description="Email of the customer to assign the seat to"
@@ -63,13 +71,14 @@ class SeatAssign(Schema):
 
     @model_validator(mode="after")
     def validate_identifiers(self) -> "SeatAssign":
-        # Validate exactly one seat source
         seat_source_count = sum(
-            1 for x in [self.subscription_id, self.order_id] if x is not None
+            1
+            for x in [self.subscription_id, self.order_id, self.checkout_id]
+            if x is not None
         )
         if seat_source_count != 1:
             raise ValueError(
-                "Exactly one of subscription_id or order_id must be provided"
+                "Exactly one of subscription_id, order_id, or checkout_id must be provided"
             )
 
         # Count identifier groups

--- a/server/polar/customer_seat/schemas.py
+++ b/server/polar/customer_seat/schemas.py
@@ -14,23 +14,11 @@ from polar.models.customer_seat import SeatStatus
 class SeatAssign(Schema):
     subscription_id: UUID | None = Field(
         None,
-        description="Subscription ID. Required if checkout_id and order_id are not provided.",
-    )
-    checkout_id: UUID | None = Field(
-        None,
-        description="Checkout ID. Used to look up subscription or order from the checkout page.",
-    )
-    checkout_client_secret: str | None = Field(
-        None,
-        description=(
-            "Client secret of the checkout. Required when assigning seats "
-            "via checkout_id as an anonymous caller (e.g. the checkout "
-            "confirmation page)."
-        ),
+        description="Subscription ID. Required if order_id is not provided.",
     )
     order_id: UUID | None = Field(
         None,
-        description="Order ID for one-time purchases. Required if subscription_id and checkout_id are not provided.",
+        description="Order ID for one-time purchases. Required if subscription_id is not provided.",
     )
     email: EmailStrDNS | None = Field(
         None, description="Email of the customer to assign the seat to"
@@ -77,13 +65,11 @@ class SeatAssign(Schema):
     def validate_identifiers(self) -> "SeatAssign":
         # Validate exactly one seat source
         seat_source_count = sum(
-            1
-            for x in [self.subscription_id, self.checkout_id, self.order_id]
-            if x is not None
+            1 for x in [self.subscription_id, self.order_id] if x is not None
         )
         if seat_source_count != 1:
             raise ValueError(
-                "Exactly one of subscription_id, checkout_id, or order_id must be provided"
+                "Exactly one of subscription_id or order_id must be provided"
             )
 
         # Count identifier groups

--- a/server/polar/customer_seat/schemas.py
+++ b/server/polar/customer_seat/schemas.py
@@ -62,15 +62,19 @@ class SeatAssign(Schema):
         return v
 
     @model_validator(mode="after")
-    def validate_identifiers(self) -> "SeatAssign":
-        seat_source_count = sum(
-            1 for x in [self.subscription_id, self.order_id] if x is not None
-        )
-        if seat_source_count != 1:
-            raise ValueError(
-                "Exactly one of subscription_id or order_id must be provided"
-            )
+    def validate_seat_source(self) -> "SeatAssign":
+        if sum(1 for x in self._seat_source_ids() if x is not None) != 1:
+            raise ValueError(self._seat_source_error_message())
+        return self
 
+    def _seat_source_ids(self) -> list[UUID | None]:
+        return [self.subscription_id, self.order_id]
+
+    def _seat_source_error_message(self) -> str:
+        return "Exactly one of subscription_id or order_id must be provided"
+
+    @model_validator(mode="after")
+    def validate_recipient(self) -> "SeatAssign":
         # Count identifier groups
         legacy_count = sum(
             1 for x in [self.external_customer_id, self.customer_id] if x is not None

--- a/server/polar/customer_seat/schemas.py
+++ b/server/polar/customer_seat/schemas.py
@@ -62,19 +62,15 @@ class SeatAssign(Schema):
         return v
 
     @model_validator(mode="after")
-    def validate_seat_source(self) -> "SeatAssign":
-        if sum(1 for x in self._seat_source_ids() if x is not None) != 1:
-            raise ValueError(self._seat_source_error_message())
-        return self
+    def validate_identifiers(self) -> "SeatAssign":
+        seat_source_count = sum(
+            1 for x in [self.subscription_id, self.order_id] if x is not None
+        )
+        if seat_source_count != 1:
+            raise ValueError(
+                "Exactly one of subscription_id or order_id must be provided"
+            )
 
-    def _seat_source_ids(self) -> list[UUID | None]:
-        return [self.subscription_id, self.order_id]
-
-    def _seat_source_error_message(self) -> str:
-        return "Exactly one of subscription_id or order_id must be provided"
-
-    @model_validator(mode="after")
-    def validate_recipient(self) -> "SeatAssign":
         # Count identifier groups
         legacy_count = sum(
             1 for x in [self.external_customer_id, self.customer_id] if x is not None

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -90,6 +90,36 @@ class OrderRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_readable_by_id(
+        self,
+        auth_subject: AuthSubject[User | Organization | Customer | Member],
+        id: UUID,
+        *,
+        options: Options = (),
+    ) -> Order | None:
+        statement = (
+            self.get_readable_statement(auth_subject)
+            .where(Order.id == id)
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def get_earliest_readable_by_checkout_id(
+        self,
+        auth_subject: AuthSubject[User | Organization | Customer | Member],
+        checkout_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Order | None:
+        statement = (
+            self.get_readable_statement(auth_subject)
+            .where(Order.checkout_id == checkout_id)
+            .order_by(Order.created_at.asc())
+            .limit(1)
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
     async def lock_for_receipt_allocation(self, order_id: UUID) -> str | None:
         """Lock the Order row and return its current ``receipt_number``.
 

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -90,42 +90,6 @@ class OrderRepository(
         )
         return await self.get_one_or_none(statement)
 
-    async def get_by_id_and_customer(
-        self,
-        id: UUID,
-        customer_id: UUID,
-        *,
-        options: Options = (),
-    ) -> Order | None:
-        statement = (
-            self.get_base_statement()
-            .where(
-                Order.id == id,
-                Order.customer_id == customer_id,
-            )
-            .options(*options)
-        )
-        return await self.get_one_or_none(statement)
-
-    async def get_earliest_by_checkout_id_and_customer(
-        self,
-        checkout_id: UUID,
-        customer_id: UUID,
-        *,
-        options: Options = (),
-    ) -> Order | None:
-        statement = (
-            self.get_base_statement()
-            .where(
-                Order.checkout_id == checkout_id,
-                Order.customer_id == customer_id,
-            )
-            .order_by(Order.created_at.asc())
-            .limit(1)
-            .options(*options)
-        )
-        return await self.get_one_or_none(statement)
-
     async def lock_for_receipt_allocation(self, order_id: UUID) -> str | None:
         """Lock the Order row and return its current ``receipt_number``.
 

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -90,6 +90,42 @@ class OrderRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_by_id_and_customer(
+        self,
+        id: UUID,
+        customer_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Order | None:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Order.id == id,
+                Order.customer_id == customer_id,
+            )
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def get_earliest_by_checkout_id_and_customer(
+        self,
+        checkout_id: UUID,
+        customer_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Order | None:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Order.checkout_id == checkout_id,
+                Order.customer_id == customer_id,
+            )
+            .order_by(Order.created_at.asc())
+            .limit(1)
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
     async def lock_for_receipt_allocation(self, order_id: UUID) -> str | None:
         """Lock the Order row and return its current ``receipt_number``.
 

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -138,6 +138,34 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
+    async def get_readable_by_id(
+        self,
+        auth_subject: AuthSubject[User | Organization | Customer | Member],
+        id: UUID,
+        *,
+        options: Options = (),
+    ) -> Subscription | None:
+        statement = (
+            self.get_readable_statement(auth_subject)
+            .where(Subscription.id == id)
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def get_readable_by_checkout_id(
+        self,
+        auth_subject: AuthSubject[User | Organization | Customer | Member],
+        checkout_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Subscription | None:
+        statement = (
+            self.get_readable_statement(auth_subject)
+            .where(Subscription.checkout_id == checkout_id)
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
     def get_eager_options(
         self, *, product_load: "_AbstractLoad | None" = None
     ) -> Options:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -138,40 +138,6 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
-    async def get_by_id_and_customer(
-        self,
-        id: UUID,
-        customer_id: UUID,
-        *,
-        options: Options = (),
-    ) -> Subscription | None:
-        statement = (
-            self.get_base_statement()
-            .where(
-                Subscription.id == id,
-                Subscription.customer_id == customer_id,
-            )
-            .options(*options)
-        )
-        return await self.get_one_or_none(statement)
-
-    async def get_by_checkout_id_and_customer(
-        self,
-        checkout_id: UUID,
-        customer_id: UUID,
-        *,
-        options: Options = (),
-    ) -> Subscription | None:
-        statement = (
-            self.get_base_statement()
-            .where(
-                Subscription.checkout_id == checkout_id,
-                Subscription.customer_id == customer_id,
-            )
-            .options(*options)
-        )
-        return await self.get_one_or_none(statement)
-
     def get_eager_options(
         self, *, product_load: "_AbstractLoad | None" = None
     ) -> Options:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -138,6 +138,40 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
+    async def get_by_id_and_customer(
+        self,
+        id: UUID,
+        customer_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Subscription | None:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.id == id,
+                Subscription.customer_id == customer_id,
+            )
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def get_by_checkout_id_and_customer(
+        self,
+        checkout_id: UUID,
+        customer_id: UUID,
+        *,
+        options: Options = (),
+    ) -> Subscription | None:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.checkout_id == checkout_id,
+                Subscription.customer_id == customer_id,
+            )
+            .options(*options)
+        )
+        return await self.get_one_or_none(statement)
+
     def get_eager_options(
         self, *, product_load: "_AbstractLoad | None" = None
     ) -> Options:

--- a/server/tests/customer_portal/endpoints/test_customer_seat.py
+++ b/server/tests/customer_portal/endpoints/test_customer_seat.py
@@ -266,6 +266,51 @@ class TestAssignSeat:
         assert data["subscription_id"] == str(subscription.id)
 
     @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_valid_with_member_model_enabled(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        organization.feature_settings["seat_based_pricing_enabled"] = True
+        organization.feature_settings["member_model_enabled"] = True
+        attributes.flag_modified(organization, "feature_settings")
+        await save_fixture(organization)
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=5,
+        )
+
+        response = await client.post(
+            "/v1/customer-portal/seats",
+            json={
+                "subscription_id": str(subscription.id),
+                "email": "teammate@example.com",
+                "external_member_id": "ext-member-1",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["email"] == "teammate@example.com"
+        assert data["member_id"] is not None
+        assert data["member"] is not None
+        assert data["member"]["email"] == "teammate@example.com"
+        assert data["member"]["external_id"] == "ext-member-1"
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
     async def test_checkout_id_not_customer(
         self,
         client: AsyncClient,

--- a/server/tests/customer_portal/endpoints/test_customer_seat.py
+++ b/server/tests/customer_portal/endpoints/test_customer_seat.py
@@ -210,6 +210,111 @@ class TestAssignSeat:
         assert data["status"] == "pending"
         assert data["subscription_id"] == str(subscription.id)
 
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_valid_with_checkout_id(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        from tests.fixtures.random_objects import create_checkout
+
+        organization.feature_settings["seat_based_pricing_enabled"] = True
+        attributes.flag_modified(organization, "feature_settings")
+        await save_fixture(organization)
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=5,
+        )
+
+        await session.refresh(product, ["prices"])
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            price=product.prices[0],
+            subscription=subscription,
+            seats=5,
+        )
+
+        subscription.checkout_id = checkout.id
+        await save_fixture(subscription)
+
+        response = await client.post(
+            "/v1/customer-portal/seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "email": "teammate@example.com",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["customer_email"] == "teammate@example.com"
+        assert data["status"] == "pending"
+        assert data["subscription_id"] == str(subscription.id)
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_checkout_id_not_customer(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer_second: Customer,
+        session: AsyncSession,
+    ) -> None:
+        from tests.fixtures.random_objects import create_checkout
+
+        organization.feature_settings["seat_based_pricing_enabled"] = True
+        attributes.flag_modified(organization, "feature_settings")
+        await save_fixture(organization)
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer_second,
+            seats=5,
+        )
+
+        await session.refresh(product, ["prices"])
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            price=product.prices[0],
+            subscription=subscription,
+            seats=5,
+        )
+
+        subscription.checkout_id = checkout.id
+        await save_fixture(subscription)
+
+        response = await client.post(
+            "/v1/customer-portal/seats",
+            json={
+                "checkout_id": str(checkout.id),
+                "email": "teammate@example.com",
+            },
+        )
+        assert response.status_code == 404
+
 
 @pytest.mark.asyncio
 class TestRevokeSeat:

--- a/server/tests/customer_seat/conftest.py
+++ b/server/tests/customer_seat/conftest.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.utils import utc_now
 from polar.models import (
-    Checkout,
     Customer,
     Order,
     Organization,
@@ -12,13 +11,11 @@ from polar.models import (
     User,
     UserOrganization,
 )
-from polar.models.checkout import CheckoutStatus
 from polar.models.customer_seat import CustomerSeat, SeatStatus
 from polar.models.order import OrderStatus
 from polar.models.subscription import SubscriptionStatus
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
-    create_checkout,
     create_customer_seat,
     create_order_with_seats,
     create_product,
@@ -135,28 +132,6 @@ async def order_with_seats(
         status=OrderStatus.paid,
     )
     return order
-
-
-@pytest_asyncio.fixture
-async def checkout_with_order(
-    save_fixture: SaveFixture,
-    order_with_seats: Order,
-    session: AsyncSession,
-) -> Checkout:
-    # Refresh product to load prices
-    await session.refresh(order_with_seats.product, ["prices"])
-
-    assert order_with_seats.product is not None
-    checkout = await create_checkout(
-        save_fixture,
-        products=[order_with_seats.product],
-        customer=order_with_seats.customer,
-        status=CheckoutStatus.succeeded,
-    )
-    # Link order to checkout
-    order_with_seats.checkout_id = checkout.id
-    await save_fixture(order_with_seats)
-    return checkout
 
 
 @pytest_asyncio.fixture

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -7,19 +7,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from polar.auth.scope import Scope
 from polar.models import (
-    Checkout,
     Customer,
     CustomerSeat,
     Order,
     Subscription,
     UserOrganization,
 )
-from polar.models.checkout import CheckoutStatus
 from polar.models.customer_seat import SeatStatus
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
-    create_checkout,
     create_customer,
     create_customer_seat,
     create_member,
@@ -103,7 +100,7 @@ class TestListSeats:
             params={"subscription_id": str(subscription_with_seats.id)},
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -355,251 +352,7 @@ class TestAssignSeat:
             },
         )
 
-        assert response.status_code == 403
-
-    async def test_assign_seat_from_checkout_anonymous(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        from tests.fixtures.random_objects import create_checkout, create_customer
-
-        await create_customer(
-            save_fixture,
-            organization=subscription_with_seats.product.organization,
-            email="checkout-user@example.com",
-        )
-
-        await session.refresh(subscription_with_seats.product, ["prices"])
-
-        checkout = await create_checkout(
-            save_fixture,
-            products=[subscription_with_seats.product],
-            price=subscription_with_seats.product.prices[0],
-            subscription=subscription_with_seats,
-            seats=5,
-            status=CheckoutStatus.succeeded,
-        )
-
-        subscription_with_seats.checkout_id = checkout.id
-        await save_fixture(subscription_with_seats)
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "checkout_client_secret": checkout.client_secret,
-                "email": "checkout-user@example.com",
-            },
-        )
-
-        assert response.status_code == 200, f"Error: {response.json()}"
-        data = response.json()
-        assert data["status"] == "pending"
-        assert data["subscription_id"] == str(subscription_with_seats.id)
-
-    async def test_assign_seat_from_checkout_anonymous_missing_client_secret(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        from tests.fixtures.random_objects import create_checkout, create_customer
-
-        await create_customer(
-            save_fixture,
-            organization=subscription_with_seats.product.organization,
-            email="checkout-user@example.com",
-        )
-
-        await session.refresh(subscription_with_seats.product, ["prices"])
-
-        checkout = await create_checkout(
-            save_fixture,
-            products=[subscription_with_seats.product],
-            price=subscription_with_seats.product.prices[0],
-            subscription=subscription_with_seats,
-            seats=5,
-        )
-
-        subscription_with_seats.checkout_id = checkout.id
-        await save_fixture(subscription_with_seats)
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "email": "attacker@example.com",
-            },
-        )
-
-        assert response.status_code == 403, f"Error: {response.json()}"
-
-    async def test_assign_seat_from_checkout_anonymous_wrong_client_secret(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        from tests.fixtures.random_objects import create_checkout, create_customer
-
-        await create_customer(
-            save_fixture,
-            organization=subscription_with_seats.product.organization,
-            email="checkout-user@example.com",
-        )
-
-        await session.refresh(subscription_with_seats.product, ["prices"])
-
-        checkout = await create_checkout(
-            save_fixture,
-            products=[subscription_with_seats.product],
-            price=subscription_with_seats.product.prices[0],
-            subscription=subscription_with_seats,
-            seats=5,
-        )
-
-        subscription_with_seats.checkout_id = checkout.id
-        await save_fixture(subscription_with_seats)
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "checkout_client_secret": "not-the-real-secret",
-                "email": "attacker@example.com",
-            },
-        )
-
-        assert response.status_code == 403, f"Error: {response.json()}"
-
-    async def _create_checkout_for_subscription(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        status: CheckoutStatus,
-    ) -> Checkout:
-        await create_customer(
-            save_fixture,
-            organization=subscription_with_seats.product.organization,
-            email="checkout-user@example.com",
-        )
-        await session.refresh(subscription_with_seats.product, ["prices"])
-        checkout = await create_checkout(
-            save_fixture,
-            products=[subscription_with_seats.product],
-            price=subscription_with_seats.product.prices[0],
-            subscription=subscription_with_seats,
-            seats=5,
-            status=status,
-        )
-        subscription_with_seats.checkout_id = checkout.id
-        await save_fixture(subscription_with_seats)
-        return checkout
-
-    @pytest.mark.parametrize(
-        "checkout_status",
-        [
-            CheckoutStatus.open,
-            CheckoutStatus.expired,
-            CheckoutStatus.confirmed,
-            CheckoutStatus.failed,
-        ],
-    )
-    async def test_assign_seat_from_checkout_anonymous_rejected_when_not_succeeded(
-        self,
-        checkout_status: CheckoutStatus,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        checkout = await self._create_checkout_for_subscription(
-            save_fixture, session, subscription_with_seats, checkout_status
-        )
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "checkout_client_secret": checkout.client_secret,
-                "email": "checkout-user@example.com",
-            },
-        )
-
-        assert response.status_code == 403, f"Error: {response.json()}"
-        assert "successful checkout" in response.json()["detail"].lower()
-
-    async def test_assign_seat_from_checkout_anonymous_rejected_when_expired(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        await create_customer(
-            save_fixture,
-            organization=subscription_with_seats.product.organization,
-            email="checkout-user@example.com",
-        )
-        await session.refresh(subscription_with_seats.product, ["prices"])
-        checkout = await create_checkout(
-            save_fixture,
-            products=[subscription_with_seats.product],
-            price=subscription_with_seats.product.prices[0],
-            subscription=subscription_with_seats,
-            seats=5,
-            status=CheckoutStatus.succeeded,
-            expires_at=datetime.now(UTC) - timedelta(hours=1),
-        )
-        subscription_with_seats.checkout_id = checkout.id
-        await save_fixture(subscription_with_seats)
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "checkout_client_secret": checkout.client_secret,
-                "email": "checkout-user@example.com",
-            },
-        )
-
-        assert response.status_code == 403, f"Error: {response.json()}"
-        assert "expired" in response.json()["detail"].lower()
-
-    @pytest.mark.auth(SEAT_AUTH)
-    async def test_assign_seat_from_checkout_rejected_when_not_succeeded_authenticated(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        checkout = await self._create_checkout_for_subscription(
-            save_fixture, session, subscription_with_seats, CheckoutStatus.expired
-        )
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "email": "checkout-user@example.com",
-            },
-        )
-
-        assert response.status_code == 403, f"Error: {response.json()}"
-        assert "successful checkout" in response.json()["detail"].lower()
+        assert response.status_code == 401
 
     @pytest.mark.auth(SEAT_AUTH)
     async def test_assign_seat_immediate_claim_success(
@@ -630,45 +383,6 @@ class TestAssignSeat:
         assert data["subscription_id"] == str(subscription_with_seats.id)
         assert data["claimed_at"] is not None
         assert data["invitation_token_expires_at"] is None
-
-    async def test_assign_seat_immediate_claim_anonymous_forbidden(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        subscription_with_seats: Subscription,
-    ) -> None:
-        await create_customer(
-            save_fixture,
-            organization=subscription_with_seats.product.organization,
-            email="test@example.com",
-        )
-
-        await session.refresh(subscription_with_seats.product, ["prices"])
-
-        checkout = await create_checkout(
-            save_fixture,
-            products=[subscription_with_seats.product],
-            price=subscription_with_seats.product.prices[0],
-            subscription=subscription_with_seats,
-            seats=5,
-        )
-
-        subscription_with_seats.checkout_id = checkout.id
-        await save_fixture(subscription_with_seats)
-
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout.id),
-                "email": "test@example.com",
-                "immediate_claim": True,
-            },
-        )
-
-        assert response.status_code == 403
-        data = response.json()
-        assert "immediate_claim" in data["detail"].lower()
 
 
 @pytest.mark.asyncio
@@ -1009,7 +723,7 @@ class TestRevokeSeat:
     ) -> None:
         response = await client.delete(f"/v1/customer-seats/{customer_seat_claimed.id}")
 
-        assert response.status_code == 403
+        assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -1050,28 +764,6 @@ class TestOrderBasedSeats:
             json={
                 "order_id": str(order_with_seats.id),
                 "email": "newuser@example.com",
-            },
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["order_id"] == str(order_with_seats.id)
-        assert data["subscription_id"] is None
-        assert data["status"] == "pending"
-
-    async def test_assign_seat_from_checkout_with_order(
-        self,
-        client: AsyncClient,
-        checkout_with_order: Checkout,
-        order_with_seats: Order,
-    ) -> None:
-        """Test anonymous seat assignment via checkout_id for orders."""
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(checkout_with_order.id),
-                "checkout_client_secret": checkout_with_order.client_secret,
-                "email": "holder@example.com",
             },
         )
 
@@ -1172,10 +864,9 @@ class TestOrderBasedSeats:
         assert data["can_claim"] is True
 
 
-# Seat endpoints use `SeatWriteOrAnonymous`, a hybrid dependency that returns
-# 403 (not 401) for anonymous callers, since assign/claim flows accept
-# checkout_client_secret or invitation_token. Claim endpoints are
-# intentionally public (token-gated).
+# Merchant-API seat endpoints reject anonymous callers with 401. Claim
+# endpoints (`/claim/{token}`, `POST /claim`) are intentionally public
+# (token-gated) and unaffected.
 
 
 @pytest.mark.asyncio
@@ -1190,7 +881,22 @@ class TestCustomerSeatsAuthentication:
             params={"subscription_id": str(subscription_with_seats.id)},
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 401
+
+    async def test_assign_seat_anonymous_rejected(
+        self,
+        client: AsyncClient,
+        subscription_with_seats: Subscription,
+    ) -> None:
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "subscription_id": str(subscription_with_seats.id),
+                "email": "test@example.com",
+            },
+        )
+
+        assert response.status_code == 401
 
     async def test_revoke_seat_anonymous_rejected(
         self,
@@ -1201,7 +907,7 @@ class TestCustomerSeatsAuthentication:
             f"/v1/customer-seats/{customer_seat_claimed.id}",
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     async def test_resend_invitation_anonymous_rejected(
         self,
@@ -1212,7 +918,7 @@ class TestCustomerSeatsAuthentication:
             f"/v1/customer-seats/{customer_seat_pending.id}/resend",
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -898,24 +898,6 @@ class TestCustomerSeatsAuthentication:
 
         assert response.status_code == 401
 
-    @pytest.mark.auth(SEAT_AUTH)
-    async def test_assign_seat_rejects_checkout_id(
-        self,
-        client: AsyncClient,
-        subscription_with_seats: Subscription,
-        user_organization_seat_enabled: UserOrganization,
-    ) -> None:
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "checkout_id": str(uuid.uuid4()),
-                "email": "test@example.com",
-            },
-        )
-
-        assert response.status_code == 400
-        assert "checkout_id" in response.json()["detail"].lower()
-
     async def test_revoke_seat_anonymous_rejected(
         self,
         client: AsyncClient,

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -898,6 +898,24 @@ class TestCustomerSeatsAuthentication:
 
         assert response.status_code == 401
 
+    @pytest.mark.auth(SEAT_AUTH)
+    async def test_assign_seat_rejects_checkout_id(
+        self,
+        client: AsyncClient,
+        subscription_with_seats: Subscription,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/customer-seats",
+            json={
+                "checkout_id": str(uuid.uuid4()),
+                "email": "test@example.com",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "checkout_id" in response.json()["detail"].lower()
+
     async def test_revoke_seat_anonymous_rejected(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## Summary

The post-checkout success page was the only caller of the anonymous branch of `POST /v1/customer-seats`, gated only by `checkout_client_secret`. The checkout confirm response already includes a fresh `customer_session_token`, so the frontend can authenticate against the customer portal seat endpoint instead. 

## What

- Backend: the merchant `assign_seat` now requires `SeatWrite`. Checked on logfire, we are the only ones using the merchant endpoint in the last 30 days.
- Frontend: `useAssignSeatFromCheckout` is a `useMutation` that POSTs to `/v1/customer-portal/seats` with the customer session token and `checkout_id`; backend resolves the container. `CheckoutSeatInvitations` is split into a guard and a panel so the panel only renders once the required props are present.

## Why

The anonymous merchant-API branch was an oversight, not a workaround for a missing capability: the customer session token has been issued at checkout confirm since long before the seats module existed. Removing it makes the merchant API uniformly authenticated and lets the frontend use the customer-portal path that the rest of the post-purchase surface already uses.

## How

- Switched the merchant endpoint dependency to `SeatWrite`, removed dead schema fields, and dropped the cast/null-narrowing boilerplate.
- Split `SeatAssign.validate_identifiers` into `validate_seat_source` and `validate_recipient`, with overridable `_seat_source_ids` / `_seat_source_error_message` helpers so the portal subclass adds `checkout_id` without touching the recipient identifier rules.
- Added `get_readable_by_id` / `get_readable_by_checkout_id` to `SubscriptionRepository` and `get_readable_by_id` / `get_earliest_readable_by_checkout_id` to `OrderRepository`, following the `get_readable_by_id` precedent in customer / meter / product / license_key repos. The portal service is pure orchestration — no inline `.where(...).options(...)` composition.
- Updated unauthorized tests from 403 → 401 (the dependency is now pure `SeatWrite`) and added explicit IDOR coverage for the `checkout_id` path on the customer-portal endpoint.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)