### PR TITLE
server/login_code: use a pure timedelta for TTL config

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     IMPERSONATION_INDICATOR_COOKIE_KEY: str = "polar_is_impersonating"
 
     # Login code
-    LOGIN_CODE_TTL_SECONDS: int = 60 * 30  # 30 minutes
+    LOGIN_CODE_TTL: timedelta = timedelta(minutes=30)
     LOGIN_CODE_LENGTH: int = 6
 
     # OAuth state

--- a/server/polar/login_code/service.py
+++ b/server/polar/login_code/service.py
@@ -1,4 +1,3 @@
-import datetime
 import secrets
 import string
 from math import ceil
@@ -49,8 +48,7 @@ class LoginCodeService:
             code_hash=code_hash,
             email=email,
             user_id=user.id if user is not None else None,
-            expires_at=utc_now()
-            + datetime.timedelta(seconds=settings.LOGIN_CODE_TTL_SECONDS),
+            expires_at=utc_now() + settings.LOGIN_CODE_TTL,
         )
         session.add(login_code)
         await session.flush()


### PR DESCRIPTION
- server/login_code: use a pure timedelta for TTL config