### PR TITLE
docs: add Members API reference pages

### DIFF
--- a/docs/api-reference/members/create.mdx
+++ b/docs/api-reference/members/create.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/members/
+---

--- a/docs/api-reference/members/delete-external.mdx
+++ b/docs/api-reference/members/delete-external.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/members/external/{external_id}
+---

--- a/docs/api-reference/members/delete.mdx
+++ b/docs/api-reference/members/delete.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/members/{id}
+---

--- a/docs/api-reference/members/get-external.mdx
+++ b/docs/api-reference/members/get-external.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/members/external/{external_id}
+---

--- a/docs/api-reference/members/get.mdx
+++ b/docs/api-reference/members/get.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/members/{id}
+---

--- a/docs/api-reference/members/list.mdx
+++ b/docs/api-reference/members/list.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/members/
+---

--- a/docs/api-reference/members/update-external.mdx
+++ b/docs/api-reference/members/update-external.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/members/external/{external_id}
+---

--- a/docs/api-reference/members/update.mdx
+++ b/docs/api-reference/members/update.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/members/{id}
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -362,6 +362,19 @@
                 ]
               },
               {
+                "group": "Members",
+                "pages": [
+                  "api-reference/members/list",
+                  "api-reference/members/create",
+                  "api-reference/members/get",
+                  "api-reference/members/update",
+                  "api-reference/members/delete",
+                  "api-reference/members/get-external",
+                  "api-reference/members/update-external",
+                  "api-reference/members/delete-external"
+                ]
+              },
+              {
                 "group": "Customer Seats",
                 "pages": [
                   "api-reference/customer-seats/assign",


### PR DESCRIPTION
## Summary

The `/v1/members` endpoints exist in the OpenAPI spec but were missing from the Mintlify sidebar :(
