### PR TITLE
fix(backoffice): surface Plain API errors when creating a review ticket

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1980,6 +1980,19 @@ async def create_review_ticket(
             )
             await add_toast(request, f"Failed to create ticket: {e.message}", "error")
             return
+        except Exception as e:
+            error = repr(e)
+            logger.exception(
+                "Unexpected error creating Plain review ticket",
+                organization_id=str(organization_id),
+                error=error,
+            )
+            await add_toast(
+                request,
+                f"Failed to create ticket: {error[:200]}",
+                "error",
+            )
+            return
 
         if not thread_id:
             await add_toast(


### PR DESCRIPTION
## Summary

When Plain rate-limits the backoffice (HTTP 429), the create-review-ticket endpoint was returning a generic HTTP 500 and the modal sat there spinning with no feedback. Now any unexpected exception from the Plain call is caught, logged with `logger.exception`, and surfaced to the reviewer as an error toast that includes the exception class and a truncated message.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)