### PR TITLE
fix(backoffice): replace broken Create Plain Thread button with working ticket action

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2002,7 +2002,7 @@ async def create_review_ticket(
             )
             return
 
-        with modal("Review Ticket Created", open=True):
+        with modal("Plain Ticket Created", open=True):
             with tag.div(classes="flex flex-col gap-4"):
                 with tag.p():
                     text(f'Plain ticket "{title}" created successfully.')

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -122,7 +122,7 @@ class OrganizationDetailView:
                 ),
                 hx_target="#modal",
             ):
-                text("Create Review Ticket")
+                text("Create Plain Ticket")
 
     @contextlib.contextmanager
     def right_sidebar(self, request: Request) -> Generator[None]:
@@ -501,8 +501,6 @@ class OrganizationDetailView:
                             ):
                                 text("Set Offboarding")
 
-                        self._render_create_review_ticket_button(request)
-
                     elif self.org.status == OrganizationStatus.SNOOZED:
                         deadline = self.org.snoozed_until
                         snooze_type = self.org.snooze_type or SnoozeType.NEXT_SALE
@@ -578,8 +576,6 @@ class OrganizationDetailView:
                             ):
                                 text("Deny")
 
-                        self._render_create_review_ticket_button(request)
-
                     elif self.org.status == OrganizationStatus.CREATED:
                         with tag.div(classes="w-full"):
                             with button(
@@ -600,21 +596,7 @@ class OrganizationDetailView:
                     with tag.div(classes="divider my-2"):
                         pass
 
-                    with tag.div(classes="w-full"):
-                        with button(
-                            variant="secondary",
-                            size="sm",
-                            outline=True,
-                            hx_get=str(
-                                request.url_for(
-                                    "organizations:detail",
-                                    organization_id=self.org.id,
-                                )
-                            )
-                            + "/plain-thread",
-                            hx_target="#modal",
-                        ):
-                            text("Create Plain Thread")
+                    self._render_create_review_ticket_button(request)
 
                     with tag.div(classes="w-full"):
                         with button(


### PR DESCRIPTION
## Summary

The org detail page sidebar had two ticket-creation buttons. "Create Plain Thread" pointed at a non-existent v2 route and silently failed; "Create Review Ticket" worked but was only shown on UNDER_REVIEW / SNOOZED orgs. Consolidated to a single working "Create Plain Ticket" action in the always-available section.

## How

- Removed the broken `Create Plain Thread` button (`hx_get` to `/plain-thread`, no matching route).
- The working button is now visible in all org status

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)