### PR TITLE
fix gnarly stripe iframe color scheme bug

### DIFF
--- a/clients/apps/web/src/styles/globals.css
+++ b/clients/apps/web/src/styles/globals.css
@@ -391,6 +391,10 @@ pre.shiki {
     font-weight: var(--shiki-dark-font-weight) !important;
     text-decoration: var(--shiki-dark-text-decoration) !important;
   }
+
+  iframe[src*='stripe.com'] {
+    color-scheme: normal;
+  }
 }
 
 @keyframes marquee {


### PR DESCRIPTION
Implements a fix for the ugly dark mode flash on checkout which happens when Stripe injects its pre-auth iframe.

Learn more about the fix here — https://sergeyski.com/css-color-scheme-and-iframes-lessons-learned-from-disqus-background-bug/