### PR TITLE
chore: add backfill script for failed checkouts

### DIFF
--- a/server/scripts/checkout_failed_to_expired_backfill.py
+++ b/server/scripts/checkout_failed_to_expired_backfill.py
@@ -1,0 +1,53 @@
+import typer
+from sqlalchemy import select, update
+
+from polar.models import Checkout
+from polar.models.checkout import CheckoutStatus
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+@cli.command()
+@typer_async
+async def checkout_failed_to_expired_backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """
+    Migrate deprecated `failed` checkouts to `expired`.
+
+    The `failed` status is no longer assigned: when a payment fails the
+    checkout is reset to `open` so the customer can retry. This backfill
+    rewrites any remaining `failed` rows so the enum value can be removed.
+    """
+    subquery = (
+        select(Checkout.id)
+        .where(Checkout.status == CheckoutStatus.failed)
+        .order_by(Checkout.id)
+        .limit(limit_bindparam())
+        .scalar_subquery()
+    )
+
+    update_statement = (
+        update(Checkout)
+        .values(status=CheckoutStatus.expired)
+        .where(Checkout.id.in_(subquery))
+    )
+
+    await run_batched_update(
+        update_statement,
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary

The `failed` checkout status is deprecated and no longer assigned. Checkouts that hit a payment failure are now reset to `open` so the customer can retry. This PR adds a one-shot backfill script that rewrites any remaining `failed` rows to `expired`, so a follow-up PR can remove the enum value cleanly.

## What

- New script `server/scripts/checkout_failed_to_expired_backfill.py` that uses `run_batched_update` (batch size 5000, 0.1s sleep) to migrate `Checkout` rows from `status='failed'` to `status='expired'`.

## Why

`failed` is a dead enum value (the dashboard filter for it is unassigned), and the only thing keeping the value alive is a handful of legacy rows. Backfilling them lets us drop the enum entry and clean up the dashboard filter in a follow-up.

`checkouts` is one of the largest tables, so a single `UPDATE` in a migration would lock for too long. The batched helper avoids that.

## How

Mirrors the existing `checkout_require_3ds_backfill.py` pattern. Run via a Render One-Off Job on the worker service:

```
uv run python -m scripts.checkout_failed_to_expired_backfill
```

Once this has been deployed and the backfill has run to zero `failed` rows, the follow-up PR will:
- Remove `failed` from the `CheckoutStatus` enum
- Drop the dead branch in `checkout_service.handle_failure`
- Remove `failed` entries from the frontend status display maps (the dashboard filter is regenerated from the enum, so it disappears automatically)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)