### PR TITLE
Add drag-and-drop reordering for custom field select options

### DIFF
--- a/clients/apps/web/src/components/CustomFields/CustomFieldForm.tsx
+++ b/clients/apps/web/src/components/CustomFields/CustomFieldForm.tsx
@@ -1,4 +1,13 @@
-import ClearOutlined from '@mui/icons-material/ClearOutlined'
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { enums, schemas } from '@polar-sh/client'
 import {
   Accordion,
@@ -27,6 +36,7 @@ import {
 import React from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import CustomFieldTypeLabel from './CustomFieldTypeLabel'
+import SortableOptionRow from './SortableOptionRow'
 
 const CustomFieldTextProperties = () => {
   const { control } = useFormContext<
@@ -191,64 +201,56 @@ const CustomFieldSelectProperties = () => {
       type: 'select'
     }
   >()
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, move } = useFieldArray({
     control,
     name: 'properties.options',
     rules: {
       minLength: 1,
     },
   })
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 150, tolerance: 5 },
+    }),
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) {
+      return
+    }
+    const oldIndex = fields.findIndex((f) => f.id === active.id)
+    const newIndex = fields.findIndex((f) => f.id === over.id)
+    if (oldIndex !== -1 && newIndex !== -1) {
+      move(oldIndex, newIndex)
+    }
+  }
+
   return (
     <FormItem>
       <FormLabel>Select options</FormLabel>
       <div className="flex flex-col gap-2">
-        {fields.map((field, index) => (
-          <div key={field.id} className="flex flex-row items-center gap-2">
-            <FormField
-              control={control}
-              name={`properties.options.${index}.value`}
-              render={({ field }) => (
-                <div className="flex flex-col">
-                  <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value || ''}
-                      placeholder="Value"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </div>
-              )}
-            />
-            <FormField
-              control={control}
-              name={`properties.options.${index}.label`}
-              render={({ field }) => (
-                <div className="flex flex-col">
-                  <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value || ''}
-                      placeholder="Label"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </div>
-              )}
-            />
-            <Button
-              className={
-                'border-none bg-transparent text-[16px] opacity-50 transition-opacity hover:opacity-100 dark:bg-transparent'
-              }
-              size="icon"
-              variant="secondary"
-              type="button"
-              onClick={() => remove(index)}
-            >
-              <ClearOutlined fontSize="inherit" />
-            </Button>
-          </div>
-        ))}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={fields.map((f) => f.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {fields.map((field, index) => (
+              <SortableOptionRow
+                key={field.id}
+                id={field.id}
+                index={index}
+                onRemove={() => remove(index)}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
         <Button
           size="sm"
           variant="secondary"

--- a/clients/apps/web/src/components/CustomFields/SortableOptionRow.tsx
+++ b/clients/apps/web/src/components/CustomFields/SortableOptionRow.tsx
@@ -1,0 +1,106 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import ClearOutlined from '@mui/icons-material/ClearOutlined'
+import DragIndicatorOutlined from '@mui/icons-material/DragIndicatorOutlined'
+import { schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import Input from '@polar-sh/ui/components/atoms/Input'
+import {
+  FormControl,
+  FormField,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { twMerge } from 'tailwind-merge'
+
+interface SortableOptionRowProps {
+  id: string
+  index: number
+  onRemove: () => void
+}
+
+const SortableOptionRow: React.FC<SortableOptionRowProps> = ({
+  id,
+  index,
+  onRemove,
+}) => {
+  const { control } = useFormContext<
+    (schemas['CustomFieldCreate'] | schemas['CustomFieldUpdate']) & {
+      type: 'select'
+    }
+  >()
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={twMerge(
+        'flex flex-row items-center gap-2',
+        isDragging && 'z-10 opacity-50',
+      )}
+    >
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        aria-label="Reorder option"
+        className="dark:text-polar-500 dark:hover:text-polar-300 flex shrink-0 cursor-grab touch-none items-center justify-center text-gray-400 transition-colors hover:text-gray-600 active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <DragIndicatorOutlined fontSize="small" />
+      </button>
+      <FormField
+        control={control}
+        name={`properties.options.${index}.value`}
+        render={({ field }) => (
+          <div className="flex flex-col">
+            <FormControl>
+              <Input {...field} value={field.value || ''} placeholder="Value" />
+            </FormControl>
+            <FormMessage />
+          </div>
+        )}
+      />
+      <FormField
+        control={control}
+        name={`properties.options.${index}.label`}
+        render={({ field }) => (
+          <div className="flex flex-col">
+            <FormControl>
+              <Input {...field} value={field.value || ''} placeholder="Label" />
+            </FormControl>
+            <FormMessage />
+          </div>
+        )}
+      />
+      <Button
+        className={
+          'border-none bg-transparent text-[16px] opacity-50 transition-opacity hover:opacity-100 dark:bg-transparent'
+        }
+        size="icon"
+        variant="secondary"
+        type="button"
+        onClick={onRemove}
+      >
+        <ClearOutlined fontSize="inherit" />
+      </Button>
+    </div>
+  )
+}
+
+export default SortableOptionRow

--- a/clients/apps/web/src/components/CustomFields/SortableOptionRow.tsx
+++ b/clients/apps/web/src/components/CustomFields/SortableOptionRow.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
-import DragIndicatorOutlined from '@mui/icons-material/DragIndicatorOutlined'
+import DragHandleOutlined from '@mui/icons-material/DragHandleOutlined'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import Input from '@polar-sh/ui/components/atoms/Input'
@@ -62,7 +62,7 @@ const SortableOptionRow: React.FC<SortableOptionRowProps> = ({
         {...attributes}
         {...listeners}
       >
-        <DragIndicatorOutlined fontSize="small" />
+        <DragHandleOutlined fontSize="small" />
       </button>
       <FormField
         control={control}


### PR DESCRIPTION
## Summary

Completely vibe-coded but tested manually and it works.

Adds drag-and-drop functionality to reorder select options in the custom field form, improving the UX for managing option ordering.

## What

- Created new `SortableOptionRow` component that wraps individual select option rows with drag-and-drop capabilities using `@dnd-kit`
- Integrated `DndContext` and `SortableContext` into `CustomFieldSelectProperties` to enable drag-and-drop reordering
- Extracted option row rendering logic from `CustomFieldSelectProperties` into the new `SortableOptionRow` component
- Added drag handle icon and visual feedback (opacity change during drag)
- Configured mouse and touch sensors with appropriate activation constraints for better UX

## Why

Previously, users had no way to reorder select options after creating them. This change enables intuitive drag-and-drop reordering, which is a common pattern for managing ordered lists in modern UIs.

## How

- Used `@dnd-kit/sortable` library for drag-and-drop functionality
- Extracted the option row UI into a separate component that integrates with the sortable context
- Implemented `handleDragEnd` callback to update field array order using the `move` function from `useFieldArray`
- Added visual indicators (drag handle, opacity feedback) to make the interaction discoverable

## Checklist

- [x] This PR addresses a single concern (add drag-and-drop for select options)
- [x] The diff is reasonably sized and easy to review
- [x] No new tests needed (existing form tests cover the functionality)
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_012mxNu8z2aRzajN2R4s7V5f