### PR TITLE
fix: allow org members to manage products, customers, custom fields and analytics

### DIFF
--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -60,9 +60,6 @@ class OrganizationPermission(StrEnum):
 _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organization_manage,
     OrganizationPermission.members_manage,
-    OrganizationPermission.custom_fields_manage,
-    OrganizationPermission.customers_manage,
-    OrganizationPermission.analytics_manage,
     OrganizationPermission.finance_read,
     OrganizationPermission.finance_manage,
 }
@@ -72,9 +69,12 @@ _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.products_read,
     OrganizationPermission.products_manage,
     OrganizationPermission.custom_fields_read,
+    OrganizationPermission.custom_fields_manage,
     OrganizationPermission.customers_read,
+    OrganizationPermission.customers_manage,
     OrganizationPermission.sales_read,
     OrganizationPermission.analytics_read,
+    OrganizationPermission.analytics_manage,
     OrganizationPermission.events_ingest,
 }
 

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -60,7 +60,6 @@ class OrganizationPermission(StrEnum):
 _ADMIN_ONLY: set[OrganizationPermission] = {
     OrganizationPermission.organization_manage,
     OrganizationPermission.members_manage,
-    OrganizationPermission.products_manage,
     OrganizationPermission.custom_fields_manage,
     OrganizationPermission.customers_manage,
     OrganizationPermission.analytics_manage,
@@ -71,6 +70,7 @@ _ADMIN_ONLY: set[OrganizationPermission] = {
 _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.members_read,
     OrganizationPermission.products_read,
+    OrganizationPermission.products_manage,
     OrganizationPermission.custom_fields_read,
     OrganizationPermission.customers_read,
     OrganizationPermission.sales_read,


### PR DESCRIPTION
Bring back the possibility for org members (not only admins/owners) to manage:
- products
- customers
- custom fields
- analytics