### PR TITLE
fix: redirect stale approve-denied dialog instead of 500

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1222,6 +1222,18 @@ async def approve_denied_dialog(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    if organization.status not in (
+        OrganizationStatus.DENIED,
+        OrganizationStatus.BLOCKED,
+    ):
+        return HXRedirectResponse(
+            request,
+            str(
+                request.url_for("organizations:detail", organization_id=organization_id)
+            ),
+            303,
+        )
+
     # Fetch AI review for context (needed for both POST validation and GET rendering)
     review_repo = OrganizationReviewRepository.from_session(session)
     agent_review = await review_repo.get_latest_agent_review(organization_id)


### PR DESCRIPTION
## Summary

Fixes [SERVER-4JC](https://polar-sh.sentry.io/issues/SERVER-4JC). I think this happened when there were 2 tabs opened with the same org.

## How

Guard at the top of the handler so both GET (don't render stale dialog) and POST (don't submit) short-circuit to the org detail page when the org status is not DENIED/BLOCKED.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included