### PR TITLE
authz: consolidate sales, analytics & events permissions (4/5)

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import Anonymous, AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.checkout.guard import has_product_checkout
 from polar.checkout.schemas import (
@@ -256,7 +257,9 @@ class CheckoutService:
         ],
     ) -> tuple[Sequence[Checkout], int]:
         repository = CheckoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).options(
             *repository.get_eager_options()
         )
@@ -294,7 +297,9 @@ class CheckoutService:
         id: uuid.UUID,
     ) -> Checkout | None:
         repository = CheckoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Checkout.id == id)

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -5,6 +5,7 @@ import stripe as stripe_lib
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.customer.repository import CustomerRepository
@@ -62,7 +63,9 @@ class DisputeService:
         ],
     ) -> tuple[Sequence[Dispute], int]:
         repository = DisputeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -87,7 +90,9 @@ class DisputeService:
         id: uuid.UUID,
     ) -> Dispute | None:
         repository = DisputeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(Dispute.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.customer.repository import CustomerRepository
@@ -1171,16 +1172,9 @@ class EventService:
 
             return _validate_organization_id_by_organization
 
-        statement = select(Organization.id).where(
-            Organization.id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.is_deleted.is_(False),
-                )
-            ),
+        allowed_organizations = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.events_ingest
         )
-        result = await session.execute(statement)
-        allowed_organizations = set(result.scalars().all())
 
         def _validate_organization_id_by_user(
             index: int, organization_id: uuid.UUID | None
@@ -1311,7 +1305,9 @@ class EventService:
         organization_id: Sequence[uuid.UUID] | None,
     ) -> set[AccessibleOrganizationID]:
         """Get accessible org IDs, optionally filtered to a subset."""
-        organization_ids = await get_accessible_org_ids(session, auth_subject)
+        organization_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         if organization_id is not None:
             return {
                 AccessibleOrganizationID(oid)

--- a/server/polar/event_type/endpoints.py
+++ b/server/polar/event_type/endpoints.py
@@ -95,6 +95,10 @@ async def update(
         raise ResourceNotFound()
 
     updated_event_type = await event_type_service.update(
-        session, event_type, body.label, body.label_property_selector
+        session,
+        event_type,
+        body.label,
+        auth_subject,
+        label_property_selector=body.label_property_selector,
     )
     return schemas.EventType.model_validate(updated_event_type)

--- a/server/polar/event_type/service.py
+++ b/server/polar/event_type/service.py
@@ -2,7 +2,11 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.customer.repository import CustomerRepository
 from polar.event.system import SYSTEM_EVENT_LABELS
 from polar.event.tinybird_repository import TinybirdEventRepository
@@ -27,7 +31,9 @@ class EventTypeService:
         id: UUID,
     ) -> EventType | None:
         repository = EventTypeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             EventType.id == id
         )
@@ -51,7 +57,9 @@ class EventTypeService:
         ],
     ) -> tuple[Sequence[EventTypeWithStats], int]:
         event_type_repository = EventTypeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         if organization_id is not None:
             org_ids = org_ids & set(organization_id)
         organization_ids = list(org_ids)
@@ -190,8 +198,13 @@ class EventTypeService:
         session: AsyncSession,
         event_type: EventType,
         label: str,
+        auth_subject: AuthSubject[User | Organization],
+        *,
         label_property_selector: str | None = None,
     ) -> EventType:
+        await assert_resource_permission(
+            session, auth_subject, event_type, OrganizationPermission.analytics_manage
+        )
         event_type.label = label
         event_type.label_property_selector = label_property_selector
         session.add(event_type)

--- a/server/polar/metrics/endpoints.py
+++ b/server/polar/metrics/endpoints.py
@@ -356,7 +356,9 @@ async def update_dashboard(
     dashboard = await metrics_service.get_dashboard(session, auth_subject, id)
     if dashboard is None:
         raise ResourceNotFound()
-    updated = await metrics_service.update_dashboard(session, dashboard, body)
+    updated = await metrics_service.update_dashboard(
+        session, dashboard, body, auth_subject
+    )
     return MetricDashboardSchema.model_validate(updated)
 
 
@@ -374,4 +376,4 @@ async def delete_dashboard(
     dashboard = await metrics_service.get_dashboard(session, auth_subject, id)
     if dashboard is None:
         raise ResourceNotFound()
-    await metrics_service.delete_dashboard(session, dashboard)
+    await metrics_service.delete_dashboard(session, dashboard, auth_subject)

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -9,7 +9,12 @@ import logfire
 from sqlalchemy import ColumnElement, FromClause, select, text
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.authz.types import AccessibleOrganizationID
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -111,7 +116,9 @@ class MetricsService:
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> Sequence[MetricDashboard]:
         repository = MetricDashboardRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
         if organization_id is not None:
             statement = statement.where(
@@ -126,7 +133,9 @@ class MetricsService:
         id: uuid.UUID,
     ) -> MetricDashboard | None:
         repository = MetricDashboardRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             MetricDashboard.id == id
         )
@@ -140,6 +149,12 @@ class MetricsService:
     ) -> MetricDashboard:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.analytics_manage,
         )
 
         repository = MetricDashboardRepository.from_session(session)
@@ -155,7 +170,11 @@ class MetricsService:
         session: AsyncSession,
         dashboard: MetricDashboard,
         update_schema: MetricDashboardUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> MetricDashboard:
+        await assert_resource_permission(
+            session, auth_subject, dashboard, OrganizationPermission.analytics_manage
+        )
         repository = MetricDashboardRepository.from_session(session)
         update_dict = update_schema.model_dump(exclude_unset=True)
         return await repository.update(dashboard, update_dict=update_dict)
@@ -164,7 +183,11 @@ class MetricsService:
         self,
         session: AsyncSession,
         dashboard: MetricDashboard,
+        auth_subject: AuthSubject[User | Organization],
     ) -> None:
+        await assert_resource_permission(
+            session, auth_subject, dashboard, OrganizationPermission.analytics_manage
+        )
         await session.delete(dashboard)
         await session.flush()
 
@@ -443,7 +466,9 @@ class MetricsService:
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> list[AccessibleOrganizationID]:
         """Get accessible org IDs, optionally filtered to a subset."""
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         if organization_id is not None and len(organization_id) > 0:
             return [
                 AccessibleOrganizationID(oid)

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -14,6 +14,8 @@ from polar.auth.models import (
     is_organization,
     is_user,
 )
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
     Options,
@@ -33,7 +35,6 @@ from polar.models import (
     Product,
     ProductPrice,
     Subscription,
-    UserOrganization,
 )
 from polar.models.order import OrderStatus
 from polar.models.subscription import SubscriptionStatus
@@ -245,12 +246,11 @@ class OrderRepository(
         statement = self.get_base_statement()
 
         if is_user(auth_subject):
-            user = auth_subject.subject
             statement = statement.where(
                 Order.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        permission=OrganizationPermission.sales_read,
                     )
                 )
             )

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.account.repository import AccountRepository
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
@@ -321,7 +322,9 @@ class OrderService:
         ],
     ) -> tuple[Sequence[Order], int]:
         repository = OrderRepository.from_session(session)
-        accessible_org_ids = await get_accessible_org_ids(session, auth_subject)
+        accessible_org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(accessible_org_ids)
 
         statement = (

--- a/server/polar/payment/service.py
+++ b/server/polar/payment/service.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import stripe as stripe_lib
 
 from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.enums import PaymentProcessor
 from polar.exceptions import PolarError
@@ -59,7 +60,9 @@ class PaymentService:
         ],
     ) -> tuple[Sequence[Payment], int]:
         repository = PaymentRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -93,7 +96,9 @@ class PaymentService:
         id: uuid.UUID,
     ) -> Payment | None:
         repository = PaymentRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(Payment.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -8,7 +8,8 @@ import structlog
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_resource_permission, get_accessible_org_ids
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.dispute.repository import DisputeRepository
 from polar.enums import PaymentProcessor
@@ -129,7 +130,9 @@ class RefundService:
         ],
     ) -> tuple[Sequence[Refund], int]:
         repository = RefundRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if id is not None:
@@ -189,6 +192,10 @@ class RefundService:
                     }
                 ]
             )
+
+        await assert_resource_permission(
+            session, auth_subject, order, OrganizationPermission.finance_manage
+        )
 
         try:
             return await self.create(session, order, create_schema=create_schema)

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -22,6 +22,8 @@ from polar.auth.models import (
 from polar.auth.models import (
     Customer as AuthCustomer,
 )
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.repository import (
     Options,
@@ -42,7 +44,6 @@ from polar.models import (
     SubscriptionMeter,
     SubscriptionProductPrice,
     SubscriptionUpdate,
-    UserOrganization,
 )
 from polar.models.customer_seat import SeatStatus
 from polar.models.email_log import EmailLog, EmailLogStatus
@@ -188,12 +189,11 @@ class SubscriptionRepository(
         statement = self.get_base_statement().join(Product)
 
         if is_user(auth_subject):
-            user = auth_subject.subject
             statement = statement.where(
                 Product.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        permission=OrganizationPermission.sales_read,
                     )
                 )
             )


### PR DESCRIPTION
## Summary

**Related Issue**: #11402

Fourth in the stack. Three changes for the sales / analytics / events surface:

1. `sales:read` filter on order, subscription, dispute, payment, refund, and checkout reads — named hook for the sales pipeline.
2. `analytics:read` filter and `analytics:manage` gate on metric and event-type endpoints. Per #11665 `analytics:manage` is now member-level, so the gate documents intent and reserves the seam for future custom roles; member-role behaviour is unchanged.
3. A new `events:ingest` permission closing a real gap: analytics reads were already gated by `analytics:read` after the foundation PR landed, but `event/service.ingest` — a *write* path that drives metering and billing — was still scope-only. It now goes through the named permission.

## What

### Sales reads

`GET /v1/orders`, `GET /v1/subscriptions`, `GET /v1/disputes`, `GET /v1/payments`, `GET /v1/refunds`, `GET /v1/checkouts` and their `{id}` siblings now filter the user-subject branch by `sales:read`. Granted to every role today; the hook is in place for a future role that drops it.

### Analytics reads & writes

`GET /v1/metrics`, `GET /v1/metrics/limits`, metric dashboard list / get, event-type list / get — filtered by `analytics:read`. Metric dashboard create / update / delete and event-type label edits — go through the `analytics:manage` named gate.

### `event/service.ingest`

Membership validation switches from an inline UserOrganization query (no role filter) to `get_accessible_org_ids(... events_ingest)`. `events:ingest` is granted to every role by default so apps and integrations running as member-role users keep working; the gate exists so a future custom role can withhold ingest.

## Why

Sales / analytics / events was the broadest unfinished surface from the earlier cutover. Naming the gates aligns intent with the rest of the role model. The `events:ingest` change closes a concrete asymmetry: the *read* side was role-aware, the *write* side wasn't.

## How

Same patterns as previous PRs in the stack:

- **Collection reads** — `get_accessible_org_ids(session, auth_subject, permission=...)` at the service layer.
- **Repository-level subquery** — `select_user_org_ids(... permission=sales_read)` inside `Resource.organization_id.in_(...)` for `get_readable_statement` shapes.
- **Resource mutations** — `assert_resource_permission(session, auth_subject, resource, permission)` after the auth-aware fetch.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included