### PR TITLE
authz: consolidate finance permissions (5/5)

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import Anonymous, AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.checkout.guard import has_product_checkout
 from polar.checkout.schemas import (
@@ -256,7 +257,9 @@ class CheckoutService:
         ],
     ) -> tuple[Sequence[Checkout], int]:
         repository = CheckoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).options(
             *repository.get_eager_options()
         )
@@ -294,7 +297,9 @@ class CheckoutService:
         id: uuid.UUID,
     ) -> Checkout | None:
         repository = CheckoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Checkout.id == id)

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -5,6 +5,7 @@ import stripe as stripe_lib
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.customer.repository import CustomerRepository
@@ -62,7 +63,9 @@ class DisputeService:
         ],
     ) -> tuple[Sequence[Dispute], int]:
         repository = DisputeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -87,7 +90,9 @@ class DisputeService:
         id: uuid.UUID,
     ) -> Dispute | None:
         repository = DisputeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(Dispute.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.customer.repository import CustomerRepository
@@ -1171,16 +1172,9 @@ class EventService:
 
             return _validate_organization_id_by_organization
 
-        statement = select(Organization.id).where(
-            Organization.id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.is_deleted.is_(False),
-                )
-            ),
+        allowed_organizations = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.events_ingest
         )
-        result = await session.execute(statement)
-        allowed_organizations = set(result.scalars().all())
 
         def _validate_organization_id_by_user(
             index: int, organization_id: uuid.UUID | None
@@ -1311,7 +1305,9 @@ class EventService:
         organization_id: Sequence[uuid.UUID] | None,
     ) -> set[AccessibleOrganizationID]:
         """Get accessible org IDs, optionally filtered to a subset."""
-        organization_ids = await get_accessible_org_ids(session, auth_subject)
+        organization_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         if organization_id is not None:
             return {
                 AccessibleOrganizationID(oid)

--- a/server/polar/event_type/endpoints.py
+++ b/server/polar/event_type/endpoints.py
@@ -95,6 +95,10 @@ async def update(
         raise ResourceNotFound()
 
     updated_event_type = await event_type_service.update(
-        session, event_type, body.label, body.label_property_selector
+        session,
+        event_type,
+        body.label,
+        auth_subject,
+        label_property_selector=body.label_property_selector,
     )
     return schemas.EventType.model_validate(updated_event_type)

--- a/server/polar/event_type/service.py
+++ b/server/polar/event_type/service.py
@@ -2,7 +2,11 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.customer.repository import CustomerRepository
 from polar.event.system import SYSTEM_EVENT_LABELS
 from polar.event.tinybird_repository import TinybirdEventRepository
@@ -27,7 +31,9 @@ class EventTypeService:
         id: UUID,
     ) -> EventType | None:
         repository = EventTypeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             EventType.id == id
         )
@@ -51,7 +57,9 @@ class EventTypeService:
         ],
     ) -> tuple[Sequence[EventTypeWithStats], int]:
         event_type_repository = EventTypeRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         if organization_id is not None:
             org_ids = org_ids & set(organization_id)
         organization_ids = list(org_ids)
@@ -190,8 +198,13 @@ class EventTypeService:
         session: AsyncSession,
         event_type: EventType,
         label: str,
+        auth_subject: AuthSubject[User | Organization],
+        *,
         label_property_selector: str | None = None,
     ) -> EventType:
+        await assert_resource_permission(
+            session, auth_subject, event_type, OrganizationPermission.analytics_manage
+        )
         event_type.label = label
         event_type.label_property_selector = label_property_selector
         session.add(event_type)

--- a/server/polar/metrics/endpoints.py
+++ b/server/polar/metrics/endpoints.py
@@ -356,7 +356,9 @@ async def update_dashboard(
     dashboard = await metrics_service.get_dashboard(session, auth_subject, id)
     if dashboard is None:
         raise ResourceNotFound()
-    updated = await metrics_service.update_dashboard(session, dashboard, body)
+    updated = await metrics_service.update_dashboard(
+        session, dashboard, body, auth_subject
+    )
     return MetricDashboardSchema.model_validate(updated)
 
 
@@ -374,4 +376,4 @@ async def delete_dashboard(
     dashboard = await metrics_service.get_dashboard(session, auth_subject, id)
     if dashboard is None:
         raise ResourceNotFound()
-    await metrics_service.delete_dashboard(session, dashboard)
+    await metrics_service.delete_dashboard(session, dashboard, auth_subject)

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -9,7 +9,12 @@ import logfire
 from sqlalchemy import ColumnElement, FromClause, select, text
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+    get_accessible_org_ids,
+)
 from polar.authz.types import AccessibleOrganizationID
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
@@ -111,7 +116,9 @@ class MetricsService:
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> Sequence[MetricDashboard]:
         repository = MetricDashboardRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
         if organization_id is not None:
             statement = statement.where(
@@ -126,7 +133,9 @@ class MetricsService:
         id: uuid.UUID,
     ) -> MetricDashboard | None:
         repository = MetricDashboardRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             MetricDashboard.id == id
         )
@@ -140,6 +149,12 @@ class MetricsService:
     ) -> MetricDashboard:
         organization = await get_payload_organization(
             session, auth_subject, create_schema
+        )
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization.id,
+            OrganizationPermission.analytics_manage,
         )
 
         repository = MetricDashboardRepository.from_session(session)
@@ -155,7 +170,11 @@ class MetricsService:
         session: AsyncSession,
         dashboard: MetricDashboard,
         update_schema: MetricDashboardUpdate,
+        auth_subject: AuthSubject[User | Organization],
     ) -> MetricDashboard:
+        await assert_resource_permission(
+            session, auth_subject, dashboard, OrganizationPermission.analytics_manage
+        )
         repository = MetricDashboardRepository.from_session(session)
         update_dict = update_schema.model_dump(exclude_unset=True)
         return await repository.update(dashboard, update_dict=update_dict)
@@ -164,7 +183,11 @@ class MetricsService:
         self,
         session: AsyncSession,
         dashboard: MetricDashboard,
+        auth_subject: AuthSubject[User | Organization],
     ) -> None:
+        await assert_resource_permission(
+            session, auth_subject, dashboard, OrganizationPermission.analytics_manage
+        )
         await session.delete(dashboard)
         await session.flush()
 
@@ -443,7 +466,9 @@ class MetricsService:
         organization_id: Sequence[uuid.UUID] | None = None,
     ) -> list[AccessibleOrganizationID]:
         """Get accessible org IDs, optionally filtered to a subset."""
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.analytics_read
+        )
         if organization_id is not None and len(organization_id) > 0:
             return [
                 AccessibleOrganizationID(oid)

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -14,6 +14,8 @@ from polar.auth.models import (
     is_organization,
     is_user,
 )
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
     Options,
@@ -33,7 +35,6 @@ from polar.models import (
     Product,
     ProductPrice,
     Subscription,
-    UserOrganization,
 )
 from polar.models.order import OrderStatus
 from polar.models.subscription import SubscriptionStatus
@@ -245,12 +246,11 @@ class OrderRepository(
         statement = self.get_base_statement()
 
         if is_user(auth_subject):
-            user = auth_subject.subject
             statement = statement.where(
                 Order.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        permission=OrganizationPermission.sales_read,
                     )
                 )
             )

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.account.repository import AccountRepository
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
@@ -321,7 +322,9 @@ class OrderService:
         ],
     ) -> tuple[Sequence[Order], int]:
         repository = OrderRepository.from_session(session)
-        accessible_org_ids = await get_accessible_org_ids(session, auth_subject)
+        accessible_org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(accessible_org_ids)
 
         statement = (

--- a/server/polar/payment/service.py
+++ b/server/polar/payment/service.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import stripe as stripe_lib
 
 from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.enums import PaymentProcessor
 from polar.exceptions import PolarError
@@ -59,7 +60,9 @@ class PaymentService:
         ],
     ) -> tuple[Sequence[Payment], int]:
         repository = PaymentRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if organization_id is not None:
@@ -93,7 +96,9 @@ class PaymentService:
         id: uuid.UUID,
     ) -> Payment | None:
         repository = PaymentRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).where(Payment.id == id)
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/payout/endpoints.py
+++ b/server/polar/payout/endpoints.py
@@ -3,6 +3,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import UUID4
 from sqlalchemy.orm import joinedload
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_organization_permission
 from polar.exceptions import ResourceNotFound
 from polar.kit.db.postgres import AsyncSessionMaker
 from polar.kit.pagination import ListResource, PaginationParamsQuery
@@ -84,6 +86,12 @@ async def get_estimate(
     if organization is None:
         raise ResourceNotFound()
 
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        organization.id,
+        OrganizationPermission.finance_read,
+    )
     return await payout_service.estimate(session, organization)
 
 
@@ -106,6 +114,13 @@ async def create(
     )
     if organization is None:
         raise ResourceNotFound()
+
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        organization.id,
+        OrganizationPermission.finance_manage,
+    )
     return await payout_service.create(session, locker, organization)
 
 
@@ -143,7 +158,9 @@ async def generate_invoice(
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     """Trigger generation of an order's invoice."""
-    payout = await payout_service.get(session, auth_subject, id)
+    payout = await payout_service.get(
+        session, auth_subject, id, permission=OrganizationPermission.finance_manage
+    )
 
     if payout is None:
         raise ResourceNotFound()

--- a/server/polar/payout/endpoints.py
+++ b/server/polar/payout/endpoints.py
@@ -90,7 +90,7 @@ async def get_estimate(
         session,
         auth_subject,
         organization.id,
-        OrganizationPermission.finance_read,
+        OrganizationPermission.finance_manage,
     )
     return await payout_service.estimate(session, organization)
 

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -8,6 +8,7 @@ import stripe as stripe_lib
 import structlog
 
 from polar.auth.models import AuthSubject, User
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.config import settings
 from polar.enums import PayoutAccountType
@@ -228,7 +229,9 @@ class PayoutService:
         ],
     ) -> tuple[Sequence[Payout], int]:
         repository = PayoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.finance_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids).options(
             *repository.get_eager_options()
         )
@@ -250,9 +253,13 @@ class PayoutService:
         session: AsyncSession,
         auth_subject: AuthSubject[User],
         id: uuid.UUID,
+        *,
+        permission: OrganizationPermission = OrganizationPermission.finance_read,
     ) -> Payout | None:
         repository = PayoutRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=permission
+        )
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .where(Payout.id == id)

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -8,7 +8,8 @@ import structlog
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_resource_permission, get_accessible_org_ids
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.dispute.repository import DisputeRepository
 from polar.enums import PaymentProcessor
@@ -129,7 +130,9 @@ class RefundService:
         ],
     ) -> tuple[Sequence[Refund], int]:
         repository = RefundRepository.from_session(session)
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=OrganizationPermission.sales_read
+        )
         statement = repository.get_statement_by_org_ids(org_ids)
 
         if id is not None:
@@ -189,6 +192,10 @@ class RefundService:
                     }
                 ]
             )
+
+        await assert_resource_permission(
+            session, auth_subject, order, OrganizationPermission.finance_manage
+        )
 
         try:
             return await self.create(session, order, create_schema=create_schema)

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -22,6 +22,8 @@ from polar.auth.models import (
 from polar.auth.models import (
     Customer as AuthCustomer,
 )
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.repository import (
     Options,
@@ -42,7 +44,6 @@ from polar.models import (
     SubscriptionMeter,
     SubscriptionProductPrice,
     SubscriptionUpdate,
-    UserOrganization,
 )
 from polar.models.customer_seat import SeatStatus
 from polar.models.email_log import EmailLog, EmailLogStatus
@@ -188,12 +189,11 @@ class SubscriptionRepository(
         statement = self.get_base_statement().join(Product)
 
         if is_user(auth_subject):
-            user = auth_subject.subject
             statement = statement.where(
                 Product.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        permission=OrganizationPermission.sales_read,
                     )
                 )
             )

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -7,6 +7,7 @@ from sqlalchemy import Select, UnaryExpression, and_, asc, desc, func, or_, sele
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import aliased, joinedload, subqueryload
 
+from polar.auth.permission import OrganizationPermission, roles_with_permission
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.sorting import Sorting
@@ -296,9 +297,21 @@ class TransactionService(BaseTransactionService):
             .where(
                 or_(
                     User.id == user.id,
-                    UserOrganization.user_id == user.id,
+                    and_(
+                        UserOrganization.user_id == user.id,
+                        UserOrganization.is_deleted.is_(False),
+                        UserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.finance_read)
+                        ),
+                    ),
                     Transaction.payment_user_id == user.id,
-                    PaymentUserOrganization.user_id == user.id,
+                    and_(
+                        PaymentUserOrganization.user_id == user.id,
+                        PaymentUserOrganization.is_deleted.is_(False),
+                        PaymentUserOrganization.role.in_(
+                            roles_with_permission(OrganizationPermission.finance_read)
+                        ),
+                    ),
                 )
             )
         )


### PR DESCRIPTION
## Summary

**Related Issue**: #11402

Final PR in the stack. Enforces `finance:read` and `finance:manage` across the payout and transaction surfaces. Unlike the previous two PRs in the stack, finance permissions *did* stay admin-only after #11665 — so this is a real behaviour tightening for member-role callers, not just a named hook.

## What

### Payouts

`GET /v1/payouts/`, `GET /v1/payouts/estimate`, `GET /v1/payouts/{id}/csv`, `GET /v1/payouts/{id}/invoice` now require `finance:read` (admin/owner). `POST /v1/payouts/` and `POST /v1/payouts/{id}/invoice` require `finance:manage`. Member-role callers with `payouts:read` / `payouts:write` scopes no longer see payouts or trigger invoice generation.

### Transactions

`GET /v1/transactions/` now requires `finance:read`. Member-role callers with `transactions:read` no longer see transaction history.

### Removed members

A user removed from an org (`UserOrganization.is_deleted = true`) no longer sees that org's transactions — the soft-delete state wasn't being checked alongside the role, so removed admins kept visibility.

## Why

Payouts move real money out of the org's account and transaction lists expose revenue and fee detail. Pre-PR these were gated by token scope only — any org member with `payouts:read` / `transactions:read` could see financial data, and any with `payouts:write` could trigger invoice generation. After this PR the role check joins the scope check, locking these to admin/owner.

The removed-member bug was latent and surfaced naturally during the cutover: the existing transaction read path filtered by `UserOrganization.user_id` but never by `is_deleted`, so a removed admin's stale row still counted as access.

## How

Same patterns as previous PRs:

- **Lookup-time filter**: `get_accessible_org_ids(... permission=finance_read)` filters payout reads to orgs where the caller has the permission.
- **Endpoint-level assert**: `assert_organization_permission(... finance_manage)` for `payout.create` and `payout.generate_invoice` — both resolve their organization from a payload field rather than a `{id}` path.
- **Repository-level role filter**: `roles_with_permission(finance_read)` plus `is_deleted.is_(False)` inside the `or_(...)` clauses of `_get_readable_transactions_statement` — keeps the existing user / payment-user / org-admin tri-way readability shape and tightens which org-admin roles count.

`Payout` is keyed by `account_id` (one account can back multiple orgs), so the `assert_resource_permission(payout, ...)` pattern used elsewhere in the cutover doesn't apply — there's no single `payout.organization_id` to assert against. `payout_service.get` instead takes a `permission` keyword (defaulting to `finance:read`) and `generate_invoice` passes `finance_manage` to upgrade the lookup-time filter.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included