### PR TITLE
fix(loops): Handle 'Multiple contacts found' error by consolidating contacts

### DIFF
--- a/server/polar/integrations/loops/client.py
+++ b/server/polar/integrations/loops/client.py
@@ -62,6 +62,12 @@ class LoopsClientLogicalError(LoopsClientError):
         super().__init__(message)
 
 
+class LoopsClientMultipleContactsError(LoopsClientLogicalError):
+    """Raised when Loops API returns 'Multiple contacts found' error."""
+
+    pass
+
+
 class LoopsClient:
     def __init__(self, api_key: str | None) -> None:
         self.client = httpx.AsyncClient(
@@ -126,6 +132,9 @@ class LoopsClient:
         if response.is_server_error or response.status_code == 429:
             raise LoopsClientOperationalError(response.text)
         elif response.is_client_error:
+            # Check for specific "Multiple contacts found" error
+            if "Multiple contacts found" in response.text:
+                raise LoopsClientMultipleContactsError(response)
             raise LoopsClientLogicalError(response)
 
         return response
@@ -133,4 +142,4 @@ class LoopsClient:
 
 client = LoopsClient(settings.LOOPS_API_KEY)
 
-__all__ = ["Properties", "client"]
+__all__ = ["LoopsClientMultipleContactsError", "Properties", "client"]

--- a/server/polar/integrations/loops/tasks.py
+++ b/server/polar/integrations/loops/tasks.py
@@ -2,8 +2,13 @@ from typing import Unpack
 
 from polar.worker import TaskPriority, actor
 
-from .client import Properties
-from .client import client as loops_client
+from .client import (
+    LoopsClientMultipleContactsError,
+    Properties,
+)
+from .client import (
+    client as loops_client,
+)
 
 
 @actor(actor_name="loops.update_contact", priority=TaskPriority.LOW)
@@ -17,7 +22,18 @@ async def loops_update_contact(
 async def loops_send_event(
     email: str, event_name: str, **properties: Unpack[Properties]
 ) -> None:
-    await loops_client.send_event(email, event_name, **properties)
+    try:
+        await loops_client.send_event(email, event_name, **properties)
+    except LoopsClientMultipleContactsError:
+        # If we get "Multiple contacts found" error, try to update the contact
+        # with the userId to consolidate duplicates, then retry sending the event
+        user_id = properties.get("userId")
+        if user_id:
+            await loops_client.update_contact(email, user_id, **properties)
+            await loops_client.send_event(email, event_name, **properties)
+        else:
+            # If no userId, we can't consolidate contacts, so re-raise
+            raise
 
 
 def _loops_update_last_order_at_debounce_key(


### PR DESCRIPTION
## Fix for SENTRY-47Q

**Issue**: The Loops integration was failing with `LoopsClientLogicalError: Loops API returned status code 400 with body: {"success":false,"message":"Multiple contacts found for the given criteria"}`

### Root Cause
When sending events to Loops via the `loops.send_event` background task, if Loops had duplicate contacts for an email address, it would return a 400 client error. The current code treated all client errors generically with `LoopsClientLogicalError`, causing the dramatiq task to fail and retry up to 20+ times without resolving the issue (as evidenced by `retries: 21` in Sentry events).

### Solution
1. **New Exception Class**: Added `LoopsClientMultipleContactsError` to specifically handle this error condition
2. **Error Detection**: Modified `_make_request` in `client.py` to detect "Multiple contacts found" in the response and raise the specific exception
3. **Automatic Recovery**: Modified `loops_send_event` task to catch this exception and:
   - Extract the `userId` from properties
   - Call `update_contact` with email and userId to consolidate duplicate contacts in Loops
   - Retry sending the event

### Impact
- Prevents wasted worker retries (20+ retries per failed task)
- Ensures events are properly delivered to Loops by first resolving contact duplicates
- Maintains backward compatibility with existing error handling

### Files Changed
- `server/polar/integrations/loops/client.py`: +9 lines
- `server/polar/integrations/loops/tasks.py`: +11 lines

### Verification
- ✅ Lint passes
- ✅ Type checking passes
- ✅ Syntax valid

### Links
- Sentry Issue: [SERVER-47Q](https://polar-sh.sentry.io/issues/SERVER-47Q)
- Occurrences: 495 events over the last ~2 months