### PR TITLE
fix(metrics): handle empty periods and validate date ranges

### DIFF
--- a/server/polar/kit/time_queries.py
+++ b/server/polar/kit/time_queries.py
@@ -62,4 +62,6 @@ MIN_INTERVAL_DAYS: dict[TimeInterval, int] = {
 
 
 def is_under_limits(start_date: date, end_date: date, interval: TimeInterval) -> bool:
+    if start_date > end_date:
+        return False
     return end_date.toordinal() - start_date.toordinal() <= MAX_INTERVAL_DAYS[interval]

--- a/server/polar/metrics/metrics.py
+++ b/server/polar/metrics/metrics.py
@@ -69,7 +69,7 @@ def cumulative_sum(periods: Iterable["MetricsPeriod"], slug: str) -> int | float
 
 def cumulative_last(periods: Iterable["MetricsPeriod"], slug: str) -> int | float:
     dd = deque((getattr(p, slug) for p in periods), maxlen=1)
-    value = dd.pop()
+    value = dd.pop() if dd else None
     return value if value is not None else 0
 
 


### PR DESCRIPTION
Fixes SENTRY-3MC: IndexError: pop from an empty deque

## Problem
The `/v1/metrics/` endpoint crashed with `IndexError: pop from an empty deque` when provided with an invalid date range where `start_date > end_date` (e.g., `start_date=2026-05-17&end_date=2026-05-16`).

## Root Cause
1. The `is_under_limits()` validation function in `polar/kit/time_queries.py` only checked if the date difference was within limits
2. When `start_date > end_date`, the difference was negative, which always passed the `<= MAX_INTERVAL_DAYS` check
3. This caused queries to return empty periods
4. The `cumulative_last()` function in `polar/metrics/metrics.py` then tried to `.pop()` from an empty deque, raising an IndexError

## Solution
Two complementary fixes:

### 1. Input Validation Fix (Primary)
**File**: `server/polar/kit/time_queries.py:64-66`

Added explicit check to reject invalid date ranges:

```python
def is_under_limits(start_date: date, end_date: date, interval: TimeInterval) -> bool:
    if start_date > end_date:
        return False
    return end_date.toordinal() - start_date.toordinal() <= MAX_INTERVAL_DAYS[interval]
```

This affects all endpoints using `is_under_limits()`:
- `server/polar/metrics/endpoints.py` (2 places)
- `server/polar/meter/endpoints.py`
- `server/polar/event/endpoints.py`

Now invalid date ranges return a clear 422 validation error instead of a 500 internal server error.

### 2. Defensive Coding Fix (Secondary)
**File**: `server/polar/metrics/metrics.py:72`

Made `cumulative_last()` robust to empty periods:

```python
def cumulative_last(periods: Iterable["MetricsPeriod"], slug: str) -> int | float:
    dd = deque((getattr(p, slug) for p in periods), maxlen=1)
    value = dd.pop() if dd else None
    return value if value is not None else 0
```

This provides a safety net for any other edge case that might produce empty periods.

## Investigation
- **Sentry Issue**: SERVER-3MC (https://4505046560538624.sentry.io/issues/SERVER-3MC)
- **Correlation ID**: 963269cc-be5b-4795-b005-ae07a82481e4
- **Logfire Trace**: 019e32169c0bb2c8afce66fcb04861f7
- **First Seen**: 2025-12-07
- **Occurrences**: 120
- **Users Impacted**: 9

## Testing
Both fixes have been validated:
- Invalid date ranges now return 422 validation errors
- Empty periods return 0 instead of crashing
- Normal operation is unchanged

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>
