### PR TITLE
fix(order): prevent dunning retry for void orders

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -149,6 +149,7 @@ class OrderRepository(
             .where(
                 Order.next_payment_attempt_at.is_not(None),
                 Order.next_payment_attempt_at <= utc_now(),
+                Order.is_void.is_(False),
                 Organization.is_deleted.is_(False),
                 Organization.can_renew_subscriptions.is_(True),
             )

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2167,6 +2167,17 @@ class OrderService:
         """Handle the first dunning attempt for an order, setting the next payment
         attempt date and marking the subscription as past due.
         """
+        # Don't schedule retries for void orders
+        if order.is_void:
+            log.info(
+                "Ignoring first dunning attempt for void order",
+                order_id=order.id,
+            )
+            repository = OrderRepository.from_session(session)
+            return await repository.update(
+                order, update_dict={"next_payment_attempt_at": None}
+            )
+
         assert order.subscription is not None
         subscription = order.subscription
 
@@ -2379,6 +2390,16 @@ class OrderService:
                 organization_id=order.organization_id,
             )
             return order
+
+        if order.is_void:
+            log.info(
+                "Order is void, skipping dunning",
+                order_id=order.id,
+            )
+            repository = OrderRepository.from_session(session)
+            return await repository.update(
+                order, update_dict={"next_payment_attempt_at": None}
+            )
 
         if order.subscription is None:
             log.warning(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2990,6 +2990,44 @@ class TestHandlePaymentFailure:
         mock_revoke.assert_called_once()
 
     @freeze_time("2024-01-01 12:00:00")
+    async def test_void_order_with_null_next_payment_attempt(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that handle_payment_failure does not set next_payment_attempt_at
+        for void orders when next_payment_attempt_at is None.
+
+        This prevents the inconsistent state where status=void but
+        next_payment_attempt_at is not None.
+        """
+        # Given
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.void,
+            next_payment_attempt_at=None,
+        )
+        await save_fixture(order)
+
+        # When
+        result_order = await order_service.handle_payment_failure(session, order)
+
+        # Then - next_payment_attempt_at should remain None for void orders
+        assert result_order.next_payment_attempt_at is None
+        assert result_order.status == OrderStatus.void
+
+    @freeze_time("2024-01-01 12:00:00")
     async def test_non_recoverable_decline_code_skips_dunning(
         self,
         session: AsyncSession,
@@ -3321,6 +3359,36 @@ class TestProcessDunningOrder:
             payment_method_id=payment_method.id,
             payment_trigger="retry_dunning",
         )
+
+    async def test_process_dunning_order_void_order(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+        subscription: Subscription,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that process_dunning_order skips void orders."""
+        # Given
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        subscription.payment_method = payment_method
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.void,
+        )
+        order.next_payment_attempt_at = utc_now() + timedelta(days=1)
+        await save_fixture(order)
+
+        # When
+        result_order = await order_service.process_dunning_order(session, order)
+
+        # Then - void orders should not be processed for dunning
+        assert result_order.status == OrderStatus.void
+        assert result_order.next_payment_attempt_at is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This fixes an inconsistent state where an Order could have `status=void` but also a non-null `next_payment_attempt_at` field.

## The Problem

When an order was voided, it correctly set `status: void` and `next_payment_attempt_at: None`. However, if a dunning task was already queued for this order, the following sequence would occur:

1. `process_dunning_order` task runs for the order
2. It loads the order with `status: void` and `next_payment_attempt_at: None`
3. Since `next_payment_attempt_at is None`, `handle_payment_failure` calls `_handle_first_dunning_attempt`
4. `_handle_first_dunning_attempt` **did not check if the order was void** and would set a new `next_payment_attempt_at` value

Result: Order has `status: void` and `next_payment_attempt_at: <some date>` — an inconsistent state.

## The Fix

- **`_handle_first_dunning_attempt`**: Added `is_void` check to return early with `next_payment_attempt_at` cleared
- **`process_dunning_order`**: Added `is_void` check to skip processing void orders and clear `next_payment_attempt_at`
- **`get_due_dunning_orders`**: Added `Order.is_void.is_(False)` filter to prevent void orders from being fetched for dunning

## Related Issues

This fix also helps address [SERVER-33A](https://polar-sh.sentry.io/issues/SERVER-33A) where `trigger_payment` was being called for non-pending (void) orders, resulting in `OrderNotPending` errors.

## Testing

Added two new test cases:
- `TestHandlePaymentFailure.test_void_order_with_null_next_payment_attempt`
- `TestProcessDunningOrder.test_process_dunning_order_void_order`

All existing tests continue to pass.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>