### PR TITLE
tailscale: Set render node to be ephemeral

### DIFF
--- a/infra/tailscale/run-tailscale.sh
+++ b/infra/tailscale/run-tailscale.sh
@@ -4,7 +4,7 @@
 PID=$!
 
 ADVERTISE_ROUTES=${ADVERTISE_ROUTES:-10.208.0.0/16}
-until /render/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES" --advertise-tags="tag:render"; do
+until /render/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES" --advertise-tags="tag:render" --ephemeral; do
   sleep 0.1
 done
 export ALL_PROXY=socks5://localhost:1055/


### PR DESCRIPTION
Since it's running in Render, it might be recreated, so the node should be ephemeral rather than static