### PR TITLE
tailscale: Use oauth client and set preauth+ephemeral as query args

### DIFF
--- a/infra/tailscale/run-tailscale.sh
+++ b/infra/tailscale/run-tailscale.sh
@@ -4,7 +4,7 @@
 PID=$!
 
 ADVERTISE_ROUTES=${ADVERTISE_ROUTES:-10.208.0.0/16}
-until /render/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES" --advertise-tags="tag:render"; do
+until /render/tailscale up --authkey="${TAILSCALE_AUTHKEY}?ephemeral=true&preauthorized=true" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES" --advertise-tags="tag:render"; do
   sleep 0.1
 done
 export ALL_PROXY=socks5://localhost:1055/

--- a/terraform/modules/tailscale_router/main.tf
+++ b/terraform/modules/tailscale_router/main.tf
@@ -19,6 +19,4 @@ resource "render_background_worker" "tailscale_router" {
     TAILSCALE_VERSION   = { value = var.tailscale_version }
     RENDER_SERVICE_NAME = { value = "tailscale-router-${var.environment}" }
   }
-
-  # TODO: add a persistent disk for Tailscale state to avoid re-auth on deploys
 }


### PR DESCRIPTION
Switch over to use an oauth client as an auth key for Tailscale. Sets preauthorized and ephemeral as query params, as that's how you're supposed to do it 😄 