### PR TITLE
Add back payout account and verification sections for non-active orgs

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { InfoCard } from '@/components/Finance/Account/InfoCard'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import OrganizationProfileSettings from '@/components/Settings/OrganizationProfileSettings'
 import { Section, SectionDescription } from '@/components/Settings/Section'
@@ -10,6 +11,8 @@ interface Props {
 }
 
 export const AccountPageDetailsRequired = ({ organization }: Props) => {
+  const isDenied = organization.status === 'denied'
+
   return (
     <DashboardBody wrapperClassName="max-w-(--breakpoint-sm)!">
       <div className="flex flex-col gap-y-12">
@@ -20,6 +23,26 @@ export const AccountPageDetailsRequired = ({ organization }: Props) => {
           />
           <OrganizationProfileSettings organization={organization} kyc={true} />
         </Section>
+
+        {!isDenied && (
+          <>
+            <Section>
+              <SectionDescription
+                title="Payout Account"
+                description="Set up your payout account to receive payouts."
+              />
+              <InfoCard>Please go through account review first</InfoCard>
+            </Section>
+
+            <Section>
+              <SectionDescription
+                title="Identity Verification"
+                description="Verify your identity to comply with financial regulations."
+              />
+              <InfoCard>Please go through account review first</InfoCard>
+            </Section>
+          </>
+        )}
       </div>
     </DashboardBody>
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageInReview.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageInReview.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { InfoCard } from '@/components/Finance/Account/InfoCard'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import AIValidationResult from '@/components/Organization/AIValidationResult'
 import { Section, SectionDescription } from '@/components/Settings/Section'
@@ -13,6 +14,7 @@ interface Props {
 
 export const AccountPageInReview = ({ organization }: Props) => {
   const posthog = usePostHog()
+  const isDenied = organization.status === 'denied'
 
   useEffect(() => {
     posthog.capture('dashboard:organizations:account_review:view', {
@@ -30,6 +32,26 @@ export const AccountPageInReview = ({ organization }: Props) => {
           />
           <AIValidationResult organization={organization} />
         </Section>
+
+        {!isDenied && (
+          <>
+            <Section>
+              <SectionDescription
+                title="Payout Account"
+                description="Set up your payout account to receive payouts."
+              />
+              <InfoCard>Please go through account review first</InfoCard>
+            </Section>
+
+            <Section>
+              <SectionDescription
+                title="Identity Verification"
+                description="Verify your identity to comply with financial regulations."
+              />
+              <InfoCard>Please go through account review first</InfoCard>
+            </Section>
+          </>
+        )}
       </div>
     </DashboardBody>
   )

--- a/clients/apps/web/src/components/Finance/Account/InfoCard.tsx
+++ b/clients/apps/web/src/components/Finance/Account/InfoCard.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import React from 'react'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export const InfoCard = ({ children }: Props) => {
+  return (
+    <Box
+      borderRadius="l"
+      backgroundColor="background-card"
+      padding="l"
+      textAlign="center"
+    >
+      <Text variant="caption" color="muted">
+        {children}
+      </Text>
+    </Box>
+  )
+}


### PR DESCRIPTION
Fix a regression from https://github.com/polarsource/polar/pull/11253 where we drop the `Payout account` and `Account verification` sections.

| Before | After  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-05-18 at 11 02 31" src="https://github.com/user-attachments/assets/b3ddb412-4c86-4da2-902b-486ccb506f6b" /> | <img width="1840" height="1133" alt="Screenshot 2026-05-18 at 11 01 57" src="https://github.com/user-attachments/assets/53eeb14a-af8a-44a2-b33c-01a256260634" /> |
