### PR TITLE
Show subscription amount instead of current price

### DIFF
--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
@@ -128,6 +128,8 @@ export default function Index() {
       <ProductRow
         product={subscription.product}
         currency={subscription.currency}
+        amount={subscription.amount}
+        interval={subscription.recurring_interval}
       />
 
       <Box>

--- a/clients/apps/app/components/Products/ProductRow.tsx
+++ b/clients/apps/app/components/Products/ProductRow.tsx
@@ -9,15 +9,24 @@ import { StyleProp, TextStyle } from 'react-native'
 import { Pill } from '../Shared/Pill'
 import { Text } from '../Shared/Text'
 import { Touchable } from '../Shared/Touchable'
+import AmountLabel from './AmountLabel'
 import { ProductPriceLabel } from './ProductPriceLabel'
 
 export interface ProductRowProps {
   product: schemas['Product']
   currency: string
+  amount?: number
+  interval?: schemas['SubscriptionRecurringInterval']
   style?: StyleProp<TextStyle>
 }
 
-export const ProductRow = ({ product, currency, style }: ProductRowProps) => {
+export const ProductRow = ({
+  product,
+  currency,
+  amount,
+  interval,
+  style,
+}: ProductRowProps) => {
   const theme = useTheme()
 
   return (
@@ -83,7 +92,15 @@ export const ProductRow = ({ product, currency, style }: ProductRowProps) => {
             </Text>
             {product.is_archived ? <Pill color="red">Archived</Pill> : null}
           </Box>
-          <ProductPriceLabel product={product} currency={currency} />
+          {amount !== undefined ? (
+            <AmountLabel
+              amount={amount}
+              currency={currency}
+              interval={interval}
+            />
+          ) : (
+            <ProductPriceLabel product={product} currency={currency} />
+          )}
         </Box>
       </Touchable>
     </Link>

--- a/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
+++ b/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
@@ -7,7 +7,7 @@ import { schemas } from '@polar-sh/client'
 import { Link } from 'expo-router'
 import React from 'react'
 import { StyleProp, TextStyle } from 'react-native'
-import { ProductPriceLabel } from '../Products/ProductPriceLabel'
+import AmountLabel from '../Products/AmountLabel'
 import { Pill } from '../Shared/Pill'
 import { Text } from '../Shared/Text'
 
@@ -109,10 +109,11 @@ export const SubscriptionRow = ({
             </Pill>
           </Box>
           <Box flex={1} flexDirection="row" alignItems="center" gap="spacing-8">
-            <ProductPriceLabel
+            <AmountLabel
               loading={loading}
-              product={subscription?.product}
+              amount={subscription?.amount ?? 0}
               currency={subscription?.currency || 'usd'}
+              interval={subscription?.recurring_interval}
             />
             {showCustomer ? (
               <>


### PR DESCRIPTION
Fix subscription price displays in the mobile app to show the customer's `subscription.amount` instead of the product's current price.

Fixes: https://github.com/polarsource/feedback/issues/149