### PR TITLE
Fix SERVER-2N8: Add operational error handling for Resend email sender network errors

### DIFF
--- a/server/polar/email/sender.py
+++ b/server/polar/email/sender.py
@@ -36,6 +36,12 @@ def to_ascii_email(email: str) -> str:
 class EmailSenderError(PolarError): ...
 
 
+class EmailSenderOperationalError(EmailSenderError):
+    """Operational error for email sender (e.g., timeout, network issues)."""
+
+    pass
+
+
 class SendEmailError(EmailSenderError):
     def __init__(self, message: str) -> None:
         super().__init__(message)
@@ -134,6 +140,14 @@ class ResendEmailSender(EmailSender):
             response = await self.client.post("/emails", json=payload)
             response.raise_for_status()
             email = response.json()
+        except httpx.RequestError as e:
+            log.warning(
+                "resend.send_network_error",
+                to_email_addr=to_email_addr_ascii,
+                subject=subject,
+                error=e,
+            )
+            raise EmailSenderOperationalError(str(e)) from e
         except httpx.HTTPError as e:
             log.warning(
                 "resend.send_error",

--- a/server/polar/operational_errors.py
+++ b/server/polar/operational_errors.py
@@ -91,6 +91,13 @@ def _polar_self_client_operational_error_matcher(exc: BaseException) -> bool:
     return isinstance(exc, PolarSelfClientOperationalError)
 
 
+def _email_sender_operational_error_matcher(exc: BaseException) -> bool:
+    # Import deferred to avoid circular dependency
+    from polar.email.sender import EmailSenderOperationalError
+
+    return isinstance(exc, EmailSenderOperationalError)
+
+
 _operation_error_matchers: dict[str, OperationalErrorMatcher] = {
     "sql_timeout_error": _sql_timeout_error_matcher,
     "sql_lock_not_available_error": _sql_lock_not_available_error_matcher,
@@ -100,6 +107,7 @@ _operation_error_matchers: dict[str, OperationalErrorMatcher] = {
     "loops_client_operational_error": _loops_client_operational_error_matcher,
     "tinybird_operational_error": _tinybird_operational_error_matcher,
     "polar_self_client_operational_error": _polar_self_client_operational_error_matcher,
+    "email_sender_operational_error": _email_sender_operational_error_matcher,
 }
 
 


### PR DESCRIPTION
## Summary

Fixes [SERVER-2N8](https://polar-sh.sentry.io/issues/SERVER-2N8) - SendEmailError caused by ReadTimeout when calling the Resend API.

## Changes

- Add `EmailSenderOperationalError` class for network-level errors in the email sender
- Catch `httpx.RequestError` explicitly in `ResendEmailSender.send()` and raise `EmailSenderOperationalError`
- Add `email_sender_operational_error` matcher in `operational_errors.py`

## Impact

Network errors (timeouts, connection errors, etc.) when sending emails via Resend are now marked as operational errors. This means:
- Sentry issues will be tagged with `is_operational_error=true`
- The error level is set to warning instead of error
- Operational error counters are incremented for monitoring

This allows the system to properly classify and handle transient network issues separately from application errors.

## Related

- Sentry Issue: SERVER-2N8
- Logfire correlation_id: b60d3997-62ec-46a7-9bb5-8f88da66aae9