### PR TITLE
Fix SENTRY-48C: IntegrityError when updating product custom fields

### DIFF
--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import Literal
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import contains_eager, selectinload
 
 from polar.auth.models import AuthSubject, is_user
@@ -338,7 +338,10 @@ class ProductService:
         if update_schema.medias is not None:
             medias_errors: list[ValidationError] = []
             nested = await session.begin_nested()
-            product.medias = []
+            # Explicitly delete all existing medias to avoid unique constraint issues
+            await session.execute(
+                delete(ProductMedia).where(ProductMedia.product_id == product.id)
+            )
             await session.flush()
 
             for order, file_id in enumerate(update_schema.medias):
@@ -364,7 +367,13 @@ class ProductService:
         if update_schema.attached_custom_fields is not None:
             attached_custom_fields_errors: list[ValidationError] = []
             nested = await session.begin_nested()
-            product.attached_custom_fields = []
+            # Explicitly delete all existing custom fields to avoid unique constraint issues
+            # We can't rely on cascade delete because of the nested transaction
+            await session.execute(
+                delete(ProductCustomField).where(
+                    ProductCustomField.product_id == product.id
+                )
+            )
             await session.flush()
 
             for order, attached_custom_field in enumerate(
@@ -479,9 +488,10 @@ class ProductService:
             new_benefits.add(benefit)
             new_product_benefits.append(ProductBenefit(benefit=benefit, order=order))
 
-        # Remove all previous benefits: flush to actually remove them
-        product.product_benefits = []
-        session.add(product)
+        # Remove all previous benefits: explicitly delete to avoid unique constraint issues
+        await session.execute(
+            delete(ProductBenefit).where(ProductBenefit.product_id == product.id)
+        )
         await session.flush()
 
         # Set the new benefits


### PR DESCRIPTION
## Issue
Fixes SENTRY-48C: https://polar-sh.sentry.io/issues/SERVER-48C

The issue was an `IntegrityError: duplicate key value violates unique constraint "product_custom_fields_product_id_order_key"` when updating a product with attached custom fields.

## Root Cause
The code was relying on SQLAlchemy's cascade delete behavior when updating `attached_custom_fields`, `medias`, and `benefits`. It would clear the relationship list and flush, expecting all old records to be deleted via cascade.

However, due to:
1. Nested transaction savepoint issues
2. Not all records being properly loaded in the relationship
3. Potential race conditions in the transaction

The old records might not be deleted before trying to insert new ones.

Since `ProductCustomField`, `ProductMedia`, and `ProductBenefit` all have unique constraints on `(product_id, order)`, trying to insert new records with the same order values would fail if old records weren't deleted.

## Solution
Explicitly delete all existing records for the product using DELETE statements before inserting new ones, rather than relying on cascade delete from clearing the relationship.

## Changes
- Added explicit DELETE statements for `ProductCustomField`, `ProductMedia`, and `ProductBenefit` before inserting new records
- Added `delete` to the SQLAlchemy imports
- Updated comments to explain the fix

## Testing
- All 42 tests in `TestUpdate` passed
- All 16 tests in `TestUpdateBenefits` passed
- Linting and type checking passed