### PR TITLE
Fix: Organization management read-only access

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -696,7 +696,7 @@ export interface paths {
      * Get Organization KYC Details
      * @description Get an organization's KYC/compliance details.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:get_kyc']
     put?: never
@@ -950,7 +950,7 @@ export interface paths {
      * Get Organization Review Status
      * @description Get the current review status and appeal information for an organization.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:get_review_status']
     put?: never
@@ -975,7 +975,7 @@ export interface paths {
      *     Powers the account review UI: pre-submission gating checks plus,
      *     after submission, the AI verdict and appeal state.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:get_review']
     put?: never
@@ -1019,7 +1019,7 @@ export interface paths {
      * List Available Plans
      * @description List the plans this organization can subscribe to.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:list_plans']
     put?: never
@@ -1041,7 +1041,7 @@ export interface paths {
      * Get Organization Subscription
      * @description Get the current Polar subscription for this organization.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:get_subscription']
     put?: never

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -158,6 +158,22 @@ AuthorizeOrgManage = Annotated[
         )
     ),
 ]
+# Read-only counterpart to `AuthorizeOrgManage`: same `can_manage` policy
+# (so the endpoint is still gated to org admins) but accepts either the
+# read or write scope, so read-only sessions (e.g. backoffice impersonation)
+# can hit GET endpoints that expose admin-only data.
+AuthorizeOrgManageRead = Annotated[
+    AuthzContext[User | Organization],
+    Depends(
+        OrgPolicyGuard(
+            org_policy.can_manage,
+            required_scopes={
+                Scope.organizations_read,
+                Scope.organizations_write,
+            },
+        )
+    ),
+]
 AuthorizeOrgManageUser = Annotated[
     AuthzContext[User],
     Depends(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -14,6 +14,7 @@ from polar.authz.dependencies import (
     AuthorizeOrgAccess,
     AuthorizeOrgAccessUser,
     AuthorizeOrgManage,
+    AuthorizeOrgManageRead,
     AuthorizeOrgManageUser,
 )
 from polar.config import settings
@@ -219,7 +220,7 @@ async def set_payout_account(
     tags=[APITag.private],
 )
 async def get_kyc(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageRead,
 ) -> Organization:
     """Get an organization's KYC/compliance details."""
     return authz.organization
@@ -682,7 +683,7 @@ async def mark_ai_onboarding_complete(
     tags=[APITag.private],
 )
 async def get_review_status(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageRead,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewStatus:
     """Get the current review status and appeal information for an organization."""
@@ -713,7 +714,7 @@ async def get_review_status(
     tags=[APITag.private],
 )
 async def get_review(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageRead,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationReviewState:
     """Get the merchant self-review checklist state.
@@ -755,7 +756,7 @@ async def validate_website(
     tags=[APITag.private],
 )
 async def list_plans(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageRead,
 ) -> Sequence[OrganizationPlan]:
     """List the plans this organization can subscribe to."""
     products = await polar_self_service.list_plans()
@@ -775,7 +776,7 @@ async def list_plans(
     tags=[APITag.private],
 )
 async def get_subscription(
-    authz: AuthorizeOrgManage,
+    authz: AuthorizeOrgManageRead,
 ) -> OrganizationSubscription:
     """Get the current Polar subscription for this organization."""
     subscription = await polar_self_service.get_subscription(authz.organization.id)


### PR DESCRIPTION
# What

Fix so tokens with the proper permissions but having only `organizations:read` scope can still fetch organization management related information.

# Why

Impersonation sessions can't access org review-related information

# How
Allow tokens with scope `organizations:read` can fetch org management related information instead of requiring `organizations:write`