### PR TITLE
Fix Transactions API: account_amount ignores platform fees during payout-delay window

### DIFF
--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -195,12 +195,12 @@ class TransactionService(BaseTransactionService):
                         func.sum(Transaction.account_amount).filter(
                             or_(
                                 Transaction.type == TransactionType.payout,
-                                and_(
-                                    Transaction.type != TransactionType.payout,
-                                    Transaction.created_at
-                                    + Account.payout_transaction_delay
-                                    <= func.now(),
+                                Transaction.platform_fee_type.in_(
+                                    PlatformFeeType.payout_fee_types()
                                 ),
+                                Transaction.created_at
+                                + Account.payout_transaction_delay
+                                <= func.now(),
                             )
                         ),
                         0,

--- a/server/tests/transaction/conftest.py
+++ b/server/tests/transaction/conftest.py
@@ -18,7 +18,7 @@ from polar.models import (
     User,
 )
 from polar.models.pledge import PledgeType
-from polar.models.transaction import Processor, TransactionType
+from polar.models.transaction import PlatformFeeType, Processor, TransactionType
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_order,
@@ -54,6 +54,7 @@ async def create_transaction(
     charge_id: str | None = None,
     dispute_id: str | None = None,
     created_at: datetime | None = None,
+    platform_fee_type: PlatformFeeType | None = None,
 ) -> Transaction:
     transaction = Transaction(
         created_at=created_at,
@@ -82,6 +83,7 @@ async def create_transaction(
         charge_id=charge_id,
         dispute_id=dispute_id,
         incurred_transactions=[],
+        platform_fee_type=platform_fee_type,
     )
     await save_fixture(transaction)
     return transaction

--- a/server/tests/transaction/service/test_transaction.py
+++ b/server/tests/transaction/service/test_transaction.py
@@ -7,7 +7,7 @@ from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams
 from polar.kit.utils import utc_now
 from polar.models import Account, Organization, Transaction, User, UserOrganization
-from polar.models.transaction import TransactionType
+from polar.models.transaction import PlatformFeeType, TransactionType
 from polar.postgres import AsyncSession
 from polar.transaction.service.transaction import transaction as transaction_service
 from tests.fixtures.database import SaveFixture
@@ -217,17 +217,29 @@ class TestGetSummary:
             created_at=now - timedelta(days=2),
         )
 
+        # Create a payout fee (2 days ago - should ALWAYS be available)
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=-100,
+            currency="usd",
+            account_currency="usd",
+            created_at=now - timedelta(days=2),
+            platform_fee_type=PlatformFeeType.payout,
+        )
+
         summary = await transaction_service.get_summary(session, account)
 
         # Total balance should include all transactions
-        assert summary.balance.amount == 1000 + 500 - 2000
-        assert summary.balance.account_amount == 1000 + 500 - 2000
+        assert summary.balance.amount == 1000 + 500 - 2000 - 100
+        assert summary.balance.account_amount == 1000 + 500 - 2000 - 100
 
         # Available balance should exclude recent non-payout transactions
         # old_balance (1000) + payout (-2000) = -1000
         # recent_balance (500) is excluded because it's only 2 days old (< 7 days)
-        assert summary.available_balance.amount == 1000 - 2000
-        assert summary.available_balance.account_amount == 1000 - 2000
+        assert summary.available_balance.amount == 1000 - 2000 - 100
+        assert summary.available_balance.account_amount == 1000 - 2000 - 100
 
         # Payout balance should include all payouts
         assert summary.payout.amount == -2000


### PR DESCRIPTION

Fix for #11705
