### PR TITLE
Add "Payment method" SDK

### DIFF
--- a/clients/.changeset/fresh-planes-decide.md
+++ b/clients/.changeset/fresh-planes-decide.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/checkout": minor
+---
+
+Adds an embedded payment method to @polar-sh/checkout. With a modal SDK (PolarEmbedPaymentMethod.create()) and React component (<PolarPaymentMethod />) for attaching a card to a customer/member. The CDN embed.global.js now bundles both checkout and payment-method auto-init in a single script.

--- a/clients/.changeset/pre.json
+++ b/clients/.changeset/pre.json
@@ -1,0 +1,20 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@polar-sh/app": "1.2.0",
+    "web": "0.1.0",
+    "@examples/checkout-embed": "1.0.0",
+    "@polar-sh/checkout": "0.2.1",
+    "@polar-sh/client": "0.0.0",
+    "@polar-sh/currency": "0.1.0",
+    "@polar-sh/eslint-config": "0.0.0",
+    "@polar-sh/i18n": "0.1.0",
+    "@polar-sh/mdx": "0.0.0",
+    "@polar-sh/orbit": "0.1.0",
+    "@polar-sh/typescript-config": "0.0.0",
+    "@polar-sh/ui": "0.1.2",
+    "@polar-sh/box-codemod": "0.0.0"
+  },
+  "changesets": []
+}

--- a/clients/.oxfmtrc.json
+++ b/clients/.oxfmtrc.json
@@ -7,5 +7,5 @@
   "useTabs": false,
   "sortTailwindcss": {},
   "sortPackageJson": false,
-  "ignorePatterns": ["node_modules", "dist", "coverage"]
+  "ignorePatterns": ["node_modules", "dist", "coverage", ".changeset"]
 }

--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -433,7 +433,7 @@ const nextConfig = {
 
     return [
       {
-        source: '/((?!checkout|oauth2|docs).*)',
+        source: '/((?!checkout|embed|oauth2|docs).*)',
         headers: baseHeaders,
       },
       {
@@ -465,6 +465,28 @@ const nextConfig = {
       },
       {
         source: '/checkout/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: embeddedCSP.replace(/\n/g, ''),
+          },
+          {
+            key: 'Permissions-Policy',
+            value: `payment=*, publickey-credentials-get=*, camera=(), microphone=(), geolocation=()`,
+          },
+          ...(ENVIRONMENT === 'sandbox'
+            ? [
+                {
+                  key: 'X-Robots-Tag',
+                  value:
+                    'noindex, nofollow, noarchive, nosnippet, noimageindex',
+                },
+              ]
+            : []),
+        ],
+      },
+      {
+        source: '/embed/:path*',
         headers: [
           {
             key: 'Content-Security-Policy',

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/EmbedError.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/EmbedError.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
+import { useEffect } from 'react'
+
+type Code = 'invalid_request' | 'unauthorized' | 'unknown'
+
+const MESSAGES: Record<Code, string> = {
+  invalid_request: 'Missing required parameters.',
+  unauthorized: 'Session expired.',
+  unknown: 'Something went wrong.',
+}
+
+interface Props {
+  code: Code
+  embedOrigin?: string
+}
+
+export const EmbedError = ({ code, embedOrigin }: Props) => {
+  useEffect(() => {
+    if (!embedOrigin) return
+    PolarEmbedPaymentMethod.postMessage({ event: 'error', code }, embedOrigin)
+    PolarEmbedPaymentMethod.postMessage({ event: 'loaded' }, embedOrigin)
+  }, [code, embedOrigin])
+
+  return (
+    <p role="alert" className="p-4 text-center text-sm text-red-500">
+      {MESSAGES[code]}
+    </p>
+  )
+}

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodEmbed.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodEmbed.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
+import { createClient, schemas } from '@polar-sh/client'
+import { getThemePreset } from '@polar-sh/ui/hooks/theming'
+import { X } from 'lucide-react'
+import { useCallback, useEffect, useMemo } from 'react'
+import { PaymentMethodForm } from './PaymentMethodForm'
+
+interface Props {
+  sessionToken: string
+  embedOrigin: string
+  theme?: 'light' | 'dark'
+  mode: 'modal' | 'inline'
+  serverURL: string
+  setupIntentParams?: {
+    setup_intent_client_secret: string
+    setup_intent: string
+  }
+}
+
+export const PaymentMethodEmbed = ({
+  sessionToken,
+  embedOrigin,
+  theme = 'light',
+  mode,
+  serverURL,
+  setupIntentParams,
+}: Props) => {
+  const themePreset = useMemo(() => getThemePreset(theme), [theme])
+  const api = useMemo(
+    () => createClient(serverURL, sessionToken),
+    [serverURL, sessionToken],
+  )
+
+  useEffect(() => {
+    PolarEmbedPaymentMethod.postMessage({ event: 'loaded' }, embedOrigin)
+  }, [embedOrigin])
+
+  useEffect(() => {
+    if (mode !== 'inline') return
+
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height ?? 0
+      PolarEmbedPaymentMethod.postMessage(
+        { event: 'resize', height },
+        embedOrigin,
+      )
+    })
+    observer.observe(document.body)
+    return () => observer.disconnect()
+  }, [mode, embedOrigin])
+
+  const handleClose = useCallback(() => {
+    PolarEmbedPaymentMethod.postMessage({ event: 'close' }, embedOrigin)
+  }, [embedOrigin])
+
+  const handleProcessingStart = useCallback(() => {
+    PolarEmbedPaymentMethod.postMessage({ event: 'confirmed' }, embedOrigin)
+  }, [embedOrigin])
+
+  const handleSuccess = useCallback(
+    (paymentMethod: schemas['CustomerPaymentMethod']) => {
+      PolarEmbedPaymentMethod.postMessage(
+        { event: 'success', paymentMethodId: paymentMethod.id },
+        embedOrigin,
+      )
+    },
+    [embedOrigin],
+  )
+
+  useEffect(() => {
+    if (mode !== 'modal') return
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      const content = document.getElementById('polar-embed-content')
+      if (content && !content.contains(event.target as Node)) {
+        handleClose()
+      }
+    }
+    const layout = document.getElementById('polar-embed-layout')
+    layout?.addEventListener('click', handleOutsideClick)
+    return () => layout?.removeEventListener('click', handleOutsideClick)
+  }, [mode, handleClose])
+
+  const form = (
+    <PaymentMethodForm
+      api={api}
+      themePreset={themePreset}
+      onProcessingStart={handleProcessingStart}
+      onPaymentMethodAdded={handleSuccess}
+      setupIntentParams={setupIntentParams}
+    />
+  )
+
+  if (mode === 'inline') {
+    return <div className={theme === 'dark' ? 'dark' : 'light'}>{form}</div>
+  }
+
+  return (
+    <div
+      className={theme === 'dark' ? 'dark' : 'light'}
+      id="polar-embed-layout"
+    >
+      <div className="flex h-full w-full items-center justify-center p-0 md:p-12 dark:text-white">
+        <div
+          className="dark:bg-polar-900 h-full w-full max-w-lg overflow-y-auto rounded-none bg-white p-8 md:h-auto md:rounded-2xl"
+          id="polar-embed-content"
+        >
+          <div className="mb-6 flex items-center justify-between">
+            <h2 className="text-lg font-medium">Add payment method</h2>
+          </div>
+          {form}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="dark:bg-polar-950 fixed top-2 right-2 cursor-pointer rounded-full bg-white p-2 shadow-xl md:top-4 md:right-4 dark:text-white"
+        onClick={handleClose}
+        aria-label="Close"
+      >
+        <X className="h-4 w-4 md:h-6 md:w-6" />
+      </button>
+    </div>
+  )
+}

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodEmbed.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodEmbed.tsx
@@ -5,18 +5,21 @@ import { createClient, schemas } from '@polar-sh/client'
 import { getThemePreset } from '@polar-sh/ui/hooks/theming'
 import { X } from 'lucide-react'
 import { useCallback, useEffect, useMemo } from 'react'
-import { PaymentMethodForm } from './PaymentMethodForm'
+import {
+  PaymentMethodForm,
+  type CustomerBillingDetails,
+  type SetupIntent,
+} from './PaymentMethodForm'
 
 interface Props {
   sessionToken: string
   embedOrigin: string
   theme?: 'light' | 'dark'
   mode: 'modal' | 'inline'
+  setAsDefault: boolean
   serverURL: string
-  setupIntentParams?: {
-    setup_intent_client_secret: string
-    setup_intent: string
-  }
+  customerBillingDetails: CustomerBillingDetails
+  setupIntent?: SetupIntent
 }
 
 export const PaymentMethodEmbed = ({
@@ -24,8 +27,10 @@ export const PaymentMethodEmbed = ({
   embedOrigin,
   theme = 'light',
   mode,
+  setAsDefault,
   serverURL,
-  setupIntentParams,
+  customerBillingDetails,
+  setupIntent,
 }: Props) => {
   const themePreset = useMemo(() => getThemePreset(theme), [theme])
   const api = useMemo(
@@ -87,9 +92,11 @@ export const PaymentMethodEmbed = ({
     <PaymentMethodForm
       api={api}
       themePreset={themePreset}
+      setAsDefault={setAsDefault}
+      customerBillingDetails={customerBillingDetails}
       onProcessingStart={handleProcessingStart}
       onPaymentMethodAdded={handleSuccess}
-      setupIntentParams={setupIntentParams}
+      setupIntent={setupIntent}
     />
   )
 

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import { type Client, schemas, unwrap } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import { ThemingPresetProps } from '@polar-sh/ui/hooks/theming'
+import {
+  Elements,
+  ElementsConsumer,
+  PaymentElement,
+} from '@stripe/react-stripe-js'
+import { loadStripe, type Stripe, type StripeElements } from '@stripe/stripe-js'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+interface Props {
+  api: Client
+  themePreset: ThemingPresetProps
+  onProcessingStart: () => void
+  onPaymentMethodAdded: (
+    paymentMethod: schemas['CustomerPaymentMethod'],
+  ) => void
+  /**
+   * When the embed re-enters after Stripe's 3DS full-page redirect,
+   * these are the params Stripe appends to the return URL. Presence
+   * means: confirm the setup intent and clean the URL.
+   */
+  setupIntentParams?: {
+    setup_intent_client_secret: string
+    setup_intent: string
+  }
+}
+
+const FALLBACK_ERROR = 'Something went wrong. Please try again.'
+
+export const PaymentMethodForm = ({
+  api,
+  themePreset,
+  onProcessingStart,
+  onPaymentMethodAdded,
+  setupIntentParams,
+}: Props) => {
+  const stripePromise = useMemo(
+    () => loadStripe(process.env.NEXT_PUBLIC_STRIPE_KEY || ''),
+    [],
+  )
+  const [error, setError] = useState<string | null>(null)
+  // Start loading if we're re-entering from a 3DS redirect — the confirm
+  // call below will flip it back to false. Avoids a flash of the
+  // submittable form before the in-flight confirm resolves.
+  const [loading, setLoading] = useState(!!setupIntentParams)
+
+  const confirmSetupIntent = useCallback(
+    async (setupIntentId: string) => {
+      let confirmed
+      try {
+        confirmed = await unwrap(
+          api.POST('/v1/customer-portal/customers/me/payment-methods/confirm', {
+            body: { setup_intent_id: setupIntentId, set_default: true },
+          }),
+        )
+      } catch {
+        setError(FALLBACK_ERROR)
+        setLoading(false)
+        return
+      }
+
+      setLoading(false)
+      if (confirmed.status === 'succeeded') {
+        onPaymentMethodAdded(confirmed.payment_method)
+      } else {
+        setError(FALLBACK_ERROR)
+      }
+    },
+    [api, onPaymentMethodAdded],
+  )
+
+  // 3DS re-entry: if Stripe redirected the customer back with setup intent
+  // params, confirm the intent server-side and strip the params from the
+  // URL so a refresh doesn't re-confirm.
+  const reentryConfirmedRef = useRef(false)
+  const router = useRouter()
+  useEffect(() => {
+    if (!setupIntentParams || reentryConfirmedRef.current) return
+    reentryConfirmedRef.current = true
+    ;(async () => {
+      await confirmSetupIntent(setupIntentParams.setup_intent)
+      const search = new URLSearchParams(window.location.search)
+      search.delete('setup_intent_client_secret')
+      search.delete('setup_intent')
+      router.replace(`${window.location.pathname}?${search.toString()}`)
+    })()
+  }, [setupIntentParams, confirmSetupIntent, router])
+
+  const handleSubmit = useCallback(
+    async (
+      event: React.FormEvent<HTMLFormElement>,
+      stripe: Stripe | null,
+      elements: StripeElements | null,
+    ) => {
+      event.preventDefault()
+      if (!stripe || !elements) return
+
+      setError(null)
+      setLoading(true)
+
+      const { error: submitError } = await elements.submit()
+      if (submitError) {
+        setError(submitError.message ?? FALLBACK_ERROR)
+        setLoading(false)
+        return
+      }
+
+      const { confirmationToken, error: tokenError } =
+        await stripe.createConfirmationToken({
+          elements,
+          params: {
+            payment_method_data: {
+              billing_details: {
+                name: null,
+                email: null,
+                phone: null,
+                address: {
+                  line1: null,
+                  line2: null,
+                  postal_code: null,
+                  city: null,
+                  state: null,
+                  country: null,
+                },
+              },
+            },
+          },
+        })
+
+      if (tokenError || !confirmationToken) {
+        setError(tokenError?.message ?? FALLBACK_ERROR)
+        setLoading(false)
+        return
+      }
+
+      onProcessingStart()
+
+      let created
+      try {
+        created = await unwrap(
+          api.POST('/v1/customer-portal/customers/me/payment-methods', {
+            body: {
+              confirmation_token_id: confirmationToken.id,
+              set_default: true,
+              return_url: window.location.href,
+            },
+          }),
+        )
+      } catch {
+        setError(FALLBACK_ERROR)
+        setLoading(false)
+        return
+      }
+
+      if (created.status === 'succeeded') {
+        setLoading(false)
+        onPaymentMethodAdded(created.payment_method)
+        return
+      }
+
+      const { error: actionError, setupIntent } = await stripe.handleNextAction(
+        { clientSecret: created.client_secret },
+      )
+
+      if (actionError || !setupIntent) {
+        setError(actionError?.message ?? FALLBACK_ERROR)
+        setLoading(false)
+        return
+      }
+
+      await confirmSetupIntent(setupIntent.id)
+    },
+    [api, confirmSetupIntent, onPaymentMethodAdded, onProcessingStart],
+  )
+
+  return (
+    <Elements
+      stripe={stripePromise}
+      options={{
+        locale: 'en',
+        mode: 'setup',
+        paymentMethodCreation: 'manual',
+        setupFutureUsage: 'off_session',
+        currency: 'usd',
+        appearance: themePreset.stripe,
+      }}
+    >
+      <ElementsConsumer>
+        {({ stripe, elements }) => (
+          <form
+            onSubmit={(e) => handleSubmit(e, stripe, elements)}
+            className="flex flex-col gap-6"
+          >
+            <PaymentElement
+              options={{
+                layout: 'tabs',
+                fields: {
+                  billingDetails: {
+                    name: 'never',
+                    email: 'never',
+                    phone: 'never',
+                    address: 'never',
+                  },
+                },
+              }}
+            />
+            {error && (
+              <p role="alert" className="text-sm text-red-500">
+                {error}
+              </p>
+            )}
+            <Button
+              type="submit"
+              className="self-start"
+              disabled={!stripe || loading}
+              loading={loading}
+            >
+              Add payment method
+            </Button>
+          </form>
+        )}
+      </ElementsConsumer>
+    </Elements>
+  )
+}

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
@@ -12,32 +12,53 @@ import { loadStripe, type Stripe, type StripeElements } from '@stripe/stripe-js'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+export interface CustomerBillingDetails {
+  name: string | null
+  email: string | null
+  address: schemas['Address'] | null
+}
+
+export interface SetupIntent {
+  clientSecret: string
+  id: string
+}
+
 interface Props {
   api: Client
   themePreset: ThemingPresetProps
-  onProcessingStart: () => void
-  onPaymentMethodAdded: (
+  setAsDefault: boolean
+  customerBillingDetails: CustomerBillingDetails
+  onProcessingStart?: () => void
+  onPaymentMethodAdded?: (
     paymentMethod: schemas['CustomerPaymentMethod'],
   ) => void
-  /**
-   * When the embed re-enters after Stripe's 3DS full-page redirect,
-   * these are the params Stripe appends to the return URL. Presence
-   * means: confirm the setup intent and clean the URL.
-   */
-  setupIntentParams?: {
-    setup_intent_client_secret: string
-    setup_intent: string
-  }
+  setupIntent?: SetupIntent
 }
 
 const FALLBACK_ERROR = 'Something went wrong. Please try again.'
 
+const toStripeBillingDetails = (customer: CustomerBillingDetails) => ({
+  name: customer.name,
+  email: customer.email,
+  phone: null,
+  address: {
+    line1: customer.address?.line1 ?? null,
+    line2: customer.address?.line2 ?? null,
+    postal_code: customer.address?.postal_code ?? null,
+    city: customer.address?.city ?? null,
+    state: customer.address?.state ?? null,
+    country: customer.address?.country ?? null,
+  },
+})
+
 export const PaymentMethodForm = ({
   api,
   themePreset,
+  setAsDefault,
+  customerBillingDetails,
   onProcessingStart,
   onPaymentMethodAdded,
-  setupIntentParams,
+  setupIntent,
 }: Props) => {
   const stripePromise = useMemo(
     () => loadStripe(process.env.NEXT_PUBLIC_STRIPE_KEY || ''),
@@ -47,7 +68,7 @@ export const PaymentMethodForm = ({
   // Start loading if we're re-entering from a 3DS redirect — the confirm
   // call below will flip it back to false. Avoids a flash of the
   // submittable form before the in-flight confirm resolves.
-  const [loading, setLoading] = useState(!!setupIntentParams)
+  const [loading, setLoading] = useState(!!setupIntent)
 
   const confirmSetupIntent = useCallback(
     async (setupIntentId: string) => {
@@ -55,7 +76,7 @@ export const PaymentMethodForm = ({
       try {
         confirmed = await unwrap(
           api.POST('/v1/customer-portal/customers/me/payment-methods/confirm', {
-            body: { setup_intent_id: setupIntentId, set_default: true },
+            body: { setup_intent_id: setupIntentId, set_default: setAsDefault },
           }),
         )
       } catch {
@@ -66,12 +87,12 @@ export const PaymentMethodForm = ({
 
       setLoading(false)
       if (confirmed.status === 'succeeded') {
-        onPaymentMethodAdded(confirmed.payment_method)
+        onPaymentMethodAdded?.(confirmed.payment_method)
       } else {
         setError(FALLBACK_ERROR)
       }
     },
-    [api, onPaymentMethodAdded],
+    [api, onPaymentMethodAdded, setAsDefault],
   )
 
   // 3DS re-entry: if Stripe redirected the customer back with setup intent
@@ -80,16 +101,16 @@ export const PaymentMethodForm = ({
   const reentryConfirmedRef = useRef(false)
   const router = useRouter()
   useEffect(() => {
-    if (!setupIntentParams || reentryConfirmedRef.current) return
+    if (!setupIntent || reentryConfirmedRef.current) return
     reentryConfirmedRef.current = true
     ;(async () => {
-      await confirmSetupIntent(setupIntentParams.setup_intent)
+      await confirmSetupIntent(setupIntent.id)
       const search = new URLSearchParams(window.location.search)
       search.delete('setup_intent_client_secret')
       search.delete('setup_intent')
       router.replace(`${window.location.pathname}?${search.toString()}`)
     })()
-  }, [setupIntentParams, confirmSetupIntent, router])
+  }, [setupIntent, confirmSetupIntent, router])
 
   const handleSubmit = useCallback(
     async (
@@ -115,19 +136,7 @@ export const PaymentMethodForm = ({
           elements,
           params: {
             payment_method_data: {
-              billing_details: {
-                name: null,
-                email: null,
-                phone: null,
-                address: {
-                  line1: null,
-                  line2: null,
-                  postal_code: null,
-                  city: null,
-                  state: null,
-                  country: null,
-                },
-              },
+              billing_details: toStripeBillingDetails(customerBillingDetails),
             },
           },
         })
@@ -138,7 +147,7 @@ export const PaymentMethodForm = ({
         return
       }
 
-      onProcessingStart()
+      onProcessingStart?.()
 
       let created
       try {
@@ -146,7 +155,7 @@ export const PaymentMethodForm = ({
           api.POST('/v1/customer-portal/customers/me/payment-methods', {
             body: {
               confirmation_token_id: confirmationToken.id,
-              set_default: true,
+              set_default: setAsDefault,
               return_url: window.location.href,
             },
           }),
@@ -159,23 +168,29 @@ export const PaymentMethodForm = ({
 
       if (created.status === 'succeeded') {
         setLoading(false)
-        onPaymentMethodAdded(created.payment_method)
+        onPaymentMethodAdded?.(created.payment_method)
         return
       }
 
-      const { error: actionError, setupIntent } = await stripe.handleNextAction(
-        { clientSecret: created.client_secret },
-      )
+      const { error: actionError, setupIntent: nextActionIntent } =
+        await stripe.handleNextAction({ clientSecret: created.client_secret })
 
-      if (actionError || !setupIntent) {
+      if (actionError || !nextActionIntent) {
         setError(actionError?.message ?? FALLBACK_ERROR)
         setLoading(false)
         return
       }
 
-      await confirmSetupIntent(setupIntent.id)
+      await confirmSetupIntent(nextActionIntent.id)
     },
-    [api, confirmSetupIntent, onPaymentMethodAdded, onProcessingStart],
+    [
+      api,
+      confirmSetupIntent,
+      customerBillingDetails,
+      onPaymentMethodAdded,
+      onProcessingStart,
+      setAsDefault,
+    ],
   )
 
   return (

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
@@ -222,6 +222,7 @@ export const PaymentMethodForm = ({
                     address: 'never',
                   },
                 },
+                wallets: { link: 'never' },
               }}
             />
             {error && (

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
@@ -1,0 +1,88 @@
+import { getPublicServerURL } from '@/utils/api'
+import { getServerSideAPI } from '@/utils/client/serverside'
+import type { Metadata } from 'next'
+import { EmbedError } from './EmbedError'
+import { PaymentMethodEmbed } from './PaymentMethodEmbed'
+
+export const metadata: Metadata = {
+  title: 'Add payment method | Polar',
+  robots: { index: false, follow: false },
+}
+
+interface SearchParams {
+  customer_session_token?: string
+  member_session_token?: string
+  embed_origin?: string
+  theme?: 'light' | 'dark'
+  mode?: 'modal' | 'inline'
+  setup_intent_client_secret?: string
+  setup_intent?: string
+}
+
+const isValidEmbedOrigin = (origin: string): boolean => {
+  try {
+    const url = new URL(origin)
+    if (origin !== url.origin) return false
+    if (url.protocol === 'https:') return true
+    if (url.protocol === 'http:') {
+      return ['localhost', '127.0.0.1'].includes(url.hostname)
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+export default async function Page(props: {
+  searchParams: Promise<SearchParams>
+}) {
+  const {
+    customer_session_token,
+    member_session_token,
+    embed_origin,
+    theme,
+    mode,
+    setup_intent_client_secret,
+    setup_intent,
+  } = await props.searchParams
+
+  const embedOrigin =
+    embed_origin && isValidEmbedOrigin(embed_origin) ? embed_origin : undefined
+
+  const sessionToken =
+    customer_session_token && member_session_token
+      ? null
+      : (customer_session_token ?? member_session_token)
+
+  if (!sessionToken || !embedOrigin) {
+    return <EmbedError code="invalid_request" embedOrigin={embedOrigin} />
+  }
+
+  const api = await getServerSideAPI(sessionToken)
+  const { response } = await api.GET('/v1/customer-portal/customers/me', {
+    cache: 'no-store',
+  })
+
+  if (response.status === 401) {
+    return <EmbedError code="unauthorized" embedOrigin={embedOrigin} />
+  }
+
+  if (!response.ok) {
+    return <EmbedError code="unknown" embedOrigin={embedOrigin} />
+  }
+
+  return (
+    <PaymentMethodEmbed
+      sessionToken={sessionToken}
+      embedOrigin={embedOrigin}
+      theme={theme}
+      mode={mode === 'modal' ? 'modal' : 'inline'}
+      serverURL={getPublicServerURL()}
+      setupIntentParams={
+        setup_intent_client_secret && setup_intent
+          ? { setup_intent_client_secret, setup_intent }
+          : undefined
+      }
+    />
+  )
+}

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
@@ -1,5 +1,6 @@
 import { getPublicServerURL } from '@/utils/api'
 import { getServerSideAPI } from '@/utils/client/serverside'
+import { unwrap, UnauthorizedResponseError } from '@polar-sh/client'
 import type { Metadata } from 'next'
 import { EmbedError } from './EmbedError'
 import { PaymentMethodEmbed } from './PaymentMethodEmbed'
@@ -15,6 +16,7 @@ interface SearchParams {
   embed_origin?: string
   theme?: 'light' | 'dark'
   mode?: 'modal' | 'inline'
+  set_default?: string
   setup_intent_client_secret?: string
   setup_intent?: string
 }
@@ -42,6 +44,7 @@ export default async function Page(props: {
     embed_origin,
     theme,
     mode,
+    set_default,
     setup_intent_client_secret,
     setup_intent,
   } = await props.searchParams
@@ -59,16 +62,22 @@ export default async function Page(props: {
   }
 
   const api = await getServerSideAPI(sessionToken)
-  const { response } = await api.GET('/v1/customer-portal/customers/me', {
-    cache: 'no-store',
-  })
-
-  if (response.status === 401) {
-    return <EmbedError code="unauthorized" embedOrigin={embedOrigin} />
-  }
-
-  if (!response.ok) {
-    return <EmbedError code="unknown" embedOrigin={embedOrigin} />
+  let customer
+  try {
+    customer = await unwrap(
+      api.GET('/v1/customer-portal/customers/me', { cache: 'no-store' }),
+    )
+  } catch (error) {
+    return (
+      <EmbedError
+        code={
+          error instanceof UnauthorizedResponseError
+            ? 'unauthorized'
+            : 'unknown'
+        }
+        embedOrigin={embedOrigin}
+      />
+    )
   }
 
   return (
@@ -77,10 +86,16 @@ export default async function Page(props: {
       embedOrigin={embedOrigin}
       theme={theme}
       mode={mode === 'modal' ? 'modal' : 'inline'}
+      setAsDefault={set_default !== 'false'}
       serverURL={getPublicServerURL()}
-      setupIntentParams={
+      customerBillingDetails={{
+        name: customer.name ?? null,
+        email: customer.email ?? null,
+        address: customer.billing_address ?? null,
+      }}
+      setupIntent={
         setup_intent_client_secret && setup_intent
-          ? { setup_intent_client_secret, setup_intent }
+          ? { clientSecret: setup_intent_client_secret, id: setup_intent }
           : undefined
       }
     />

--- a/clients/apps/web/src/app/(embed)/layout.tsx
+++ b/clients/apps/web/src/app/(embed)/layout.tsx
@@ -1,0 +1,36 @@
+import { Metadata } from 'next/types'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default function EmbedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div translate="no">
+      <link
+        rel="preload"
+        href="https://js.stripe.com/clover/stripe.js"
+        as="script"
+      />
+      <link
+        rel="preload"
+        href="/fonts/Inter-Regular.woff2"
+        as="font"
+        type="font/woff2"
+        crossOrigin=""
+      />
+      <link
+        rel="preload"
+        href="/fonts/Inter-Medium.woff2"
+        as="font"
+        type="font/woff2"
+        crossOrigin=""
+      />
+      {children}
+    </div>
+  )
+}

--- a/clients/packages/checkout/README.md
+++ b/clients/packages/checkout/README.md
@@ -1,3 +1,51 @@
 # `@polar-sh/checkout`
 
-This package contains JavaScript utilities to easily integrate Polar Checkout into your website or application.
+JavaScript utilities for embedding Polar into your website. Drop in the single CDN script (auto-init) or import per-feature from npm for tree-shaking.
+
+## Payment Method
+
+### Modal — vanilla JS
+
+```ts
+import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
+
+const embed = await PolarEmbedPaymentMethod.create({
+  customerSessionToken, // or memberSessionToken — see below
+  theme: 'light',
+})
+
+embed.addEventListener('success', (event) => {
+  console.log('Attached:', event.detail.paymentMethodId)
+})
+```
+
+### Inline — React
+
+```tsx
+import { PolarPaymentMethod } from '@polar-sh/checkout/react/payment-method'
+;<PolarPaymentMethod
+  customerSessionToken={token} // or memberSessionToken
+  onSuccess={(id) => console.log('Attached:', id)}
+/>
+```
+
+### Auto-init via data attribute
+
+```html
+<script
+  defer
+  data-auto-init
+  src="https://cdn.jsdelivr.net/npm/@polar-sh/checkout@latest/dist/embed.global.js"
+></script>
+
+<button data-polar-payment-method="polar_cst_xxx">Add payment method</button>
+```
+
+### Tokens
+
+`POST /v1/customer-sessions` returns one of two prefixes depending on whether the organisation uses the member model. Pass exactly one option:
+
+- `polar_cst_*` → `customerSessionToken`
+- `polar_mst_*` → `memberSessionToken`
+
+The auto-init data attribute accepts either prefix — the SDK detects it.

--- a/clients/packages/checkout/package.json
+++ b/clients/packages/checkout/package.json
@@ -25,6 +25,14 @@
       "types": "./dist/embed.d.ts",
       "default": "./dist/embed.js"
     },
+    "./payment-method": {
+      "types": "./dist/payment-method.d.ts",
+      "default": "./dist/payment-method.js"
+    },
+    "./react/payment-method": {
+      "types": "./dist/react/payment-method.d.ts",
+      "default": "./dist/react/payment-method.js"
+    },
     "./components": {
       "types": "./dist/components/index.d.ts",
       "default": "./src/components/index.ts"
@@ -48,6 +56,14 @@
       "./embed": {
         "types": "./dist/embed.d.ts",
         "default": "./dist/embed.js"
+      },
+      "./payment-method": {
+        "types": "./dist/payment-method.d.ts",
+        "default": "./dist/payment-method.js"
+      },
+      "./react/payment-method": {
+        "types": "./dist/react/payment-method.d.ts",
+        "default": "./dist/react/payment-method.js"
       },
       "./components": {
         "types": "./dist/components/index.d.ts",

--- a/clients/packages/checkout/src/checkout.test.ts
+++ b/clients/packages/checkout/src/checkout.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
-import { PolarEmbedCheckout } from './embed'
+import { PolarEmbedCheckout } from './checkout'
 
 const ALLOWED_ORIGIN = 'http://127.0.0.1:3000'
 

--- a/clients/packages/checkout/src/checkout.ts
+++ b/clients/packages/checkout/src/checkout.ts
@@ -399,15 +399,17 @@ class EmbedCheckout {
 }
 
 declare global {
+  interface PolarWindow {
+    EmbedCheckout: typeof EmbedCheckout
+  }
   interface Window {
-    Polar: {
-      EmbedCheckout: typeof EmbedCheckout
-    }
+    Polar: Partial<PolarWindow>
   }
 }
 
 if (typeof window !== 'undefined') {
   window.Polar = {
+    ...(window.Polar ?? {}),
     EmbedCheckout,
   }
 }

--- a/clients/packages/checkout/src/embed-global.ts
+++ b/clients/packages/checkout/src/embed-global.ts
@@ -1,0 +1,2 @@
+import './checkout'
+import './payment-method'

--- a/clients/packages/checkout/src/payment-method.test.ts
+++ b/clients/packages/checkout/src/payment-method.test.ts
@@ -1,0 +1,533 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { PolarEmbedPaymentMethod } from './payment-method'
+
+const ALLOWED_ORIGIN = 'http://127.0.0.1:3000'
+const CUSTOMER_SESSION_TOKEN = 'polar_cst_test_token'
+
+beforeAll(() => {
+  // @ts-expect-error - Global defined at build time by tsup
+  globalThis.__POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__ = ALLOWED_ORIGIN
+})
+
+const cleanupDom = () => {
+  document.querySelectorAll('iframe').forEach((el) => el.remove())
+  document.querySelectorAll('style').forEach((el) => el.remove())
+  document.querySelectorAll('div').forEach((el) => el.remove())
+  document.body.classList.remove('polar-no-scroll')
+}
+
+const dispatchLoaded = () => {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      origin: ALLOWED_ORIGIN,
+      data: { type: 'POLAR_PAYMENT_METHOD', event: 'loaded' },
+    }),
+  )
+}
+
+describe('PolarEmbedPaymentMethod', () => {
+  describe('postMessage', () => {
+    it('posts a message to the parent window with the correct type', () => {
+      const postMessageSpy = vi.spyOn(window.parent, 'postMessage')
+
+      PolarEmbedPaymentMethod.postMessage({ event: 'loaded' }, ALLOWED_ORIGIN)
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { event: 'loaded', type: 'POLAR_PAYMENT_METHOD' },
+        ALLOWED_ORIGIN,
+      )
+
+      postMessageSpy.mockRestore()
+    })
+
+    it('includes event data for success messages', () => {
+      const postMessageSpy = vi.spyOn(window.parent, 'postMessage')
+
+      PolarEmbedPaymentMethod.postMessage(
+        { event: 'success', paymentMethodId: 'pm_123' },
+        ALLOWED_ORIGIN,
+      )
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        {
+          event: 'success',
+          paymentMethodId: 'pm_123',
+          type: 'POLAR_PAYMENT_METHOD',
+        },
+        ALLOWED_ORIGIN,
+      )
+
+      postMessageSpy.mockRestore()
+    })
+  })
+
+  describe('create', () => {
+    afterEach(cleanupDom)
+
+    it('creates an iframe with the correct src and modal mode', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      const iframe = document.querySelector('iframe')
+      expect(iframe).not.toBeNull()
+
+      const src = new URL(iframe!.src)
+      expect(src.pathname).toBe('/embed/payment-method')
+      expect(src.origin).toBe(ALLOWED_ORIGIN)
+      expect(src.searchParams.get('customer_session_token')).toBe(
+        CUSTOMER_SESSION_TOKEN,
+      )
+      expect(src.searchParams.get('embed')).toBe('true')
+      expect(src.searchParams.get('embed_origin')).toBe(window.location.origin)
+      expect(src.searchParams.get('mode')).toBe('modal')
+
+      embed.close()
+    })
+
+    it('sets theme query parameter when provided', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        theme: 'dark',
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      const iframe = document.querySelector('iframe')
+      const src = new URL(iframe!.src)
+      expect(src.searchParams.get('theme')).toBe('dark')
+
+      embed.close()
+    })
+
+    it('uses member_session_token URL param when given a member token', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        memberSessionToken: 'polar_mst_test_member',
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      const iframe = document.querySelector('iframe')!
+      const src = new URL(iframe.src)
+      expect(src.searchParams.get('member_session_token')).toBe(
+        'polar_mst_test_member',
+      )
+      expect(src.searchParams.get('customer_session_token')).toBeNull()
+
+      embed.close()
+    })
+
+    it('throws when neither token is provided', () => {
+      expect(() =>
+        PolarEmbedPaymentMethod.create(
+          {} as unknown as Parameters<typeof PolarEmbedPaymentMethod.create>[0],
+        ),
+      ).toThrow(/one of `customerSessionToken` or `memberSessionToken`/)
+    })
+
+    it('throws when both tokens are provided', () => {
+      expect(() =>
+        PolarEmbedPaymentMethod.create({
+          customerSessionToken: CUSTOMER_SESSION_TOKEN,
+          memberSessionToken: 'polar_mst_test_member',
+        } as unknown as Parameters<typeof PolarEmbedPaymentMethod.create>[0]),
+      ).toThrow(/only one of/)
+    })
+
+    it('adds polar-no-scroll class to body', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      expect(document.body.classList.contains('polar-no-scroll')).toBe(true)
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.close()
+    })
+
+    it('calls onLoaded callback when the embed loads', async () => {
+      const onLoaded = vi.fn()
+
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        onLoaded,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      expect(onLoaded).toHaveBeenCalledTimes(1)
+      embed.close()
+    })
+  })
+
+  describe('close', () => {
+    afterEach(cleanupDom)
+
+    it('removes the iframe from the DOM', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      expect(document.querySelector('iframe')).not.toBeNull()
+      embed.close()
+      expect(document.querySelector('iframe')).toBeNull()
+    })
+
+    it('removes polar-no-scroll class from body', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.close()
+
+      expect(document.body.classList.contains('polar-no-scroll')).toBe(false)
+    })
+  })
+
+  describe('event handling', () => {
+    afterEach(cleanupDom)
+
+    it('dispatches close event and removes iframe', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).toBeNull()
+      embed.close()
+    })
+
+    it('prevents close after confirmed event', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'confirmed' },
+        }),
+      )
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).not.toBeNull()
+      embed.close()
+    })
+
+    it('re-enables closing after success event', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'confirmed' },
+        }),
+      )
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_PAYMENT_METHOD',
+            event: 'success',
+            paymentMethodId: 'pm_123',
+          },
+        }),
+      )
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).toBeNull()
+      embed.close()
+    })
+
+    it('forwards success event detail to listeners', async () => {
+      const successListener = vi.fn()
+
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('success', successListener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_PAYMENT_METHOD',
+            event: 'success',
+            paymentMethodId: 'pm_abc',
+          },
+        }),
+      )
+
+      expect(successListener).toHaveBeenCalledTimes(1)
+      const event = successListener.mock.calls[0][0] as CustomEvent
+      expect(event.detail.paymentMethodId).toBe('pm_abc')
+
+      embed.close()
+    })
+
+    it('forwards error event detail to listeners', async () => {
+      const errorListener = vi.fn()
+
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('error', errorListener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_PAYMENT_METHOD',
+            event: 'error',
+            code: 'unauthorized',
+          },
+        }),
+      )
+
+      expect(errorListener).toHaveBeenCalledTimes(1)
+      expect((errorListener.mock.calls[0][0] as CustomEvent).detail.code).toBe(
+        'unauthorized',
+      )
+
+      embed.close()
+    })
+
+    it('silently drops resize messages in modal mode', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      const iframe = document.querySelector('iframe')!
+      const heightBefore = iframe.style.height
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            type: 'POLAR_PAYMENT_METHOD',
+            event: 'resize',
+            height: 480,
+          },
+        }),
+      )
+
+      expect(iframe.style.height).toBe(heightBefore)
+      embed.close()
+    })
+
+    it('ignores messages from disallowed origins', async () => {
+      const closeListener = vi.fn()
+
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('close', closeListener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://evil.com',
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'close' },
+        }),
+      )
+
+      expect(closeListener).not.toHaveBeenCalled()
+      expect(document.querySelector('iframe')).not.toBeNull()
+
+      embed.close()
+    })
+
+    it('ignores messages with the wrong type', async () => {
+      const closeListener = vi.fn()
+
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('close', closeListener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_CHECKOUT', event: 'close' },
+        }),
+      )
+
+      expect(closeListener).not.toHaveBeenCalled()
+      embed.close()
+    })
+
+    it('skips the default close action when preventDefault is called', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('close', (event) => event.preventDefault())
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'close' },
+        }),
+      )
+
+      expect(document.querySelector('iframe')).not.toBeNull()
+      embed.close()
+    })
+  })
+
+  describe('addEventListener / removeEventListener', () => {
+    afterEach(cleanupDom)
+
+    it('removes event listeners', async () => {
+      const listener = vi.fn()
+
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('confirmed', listener)
+      embed.removeEventListener('confirmed', listener)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ALLOWED_ORIGIN,
+          data: { type: 'POLAR_PAYMENT_METHOD', event: 'confirmed' },
+        }),
+      )
+
+      expect(listener).not.toHaveBeenCalled()
+      embed.close()
+    })
+  })
+
+  describe('init', () => {
+    afterEach(() => {
+      document
+        .querySelectorAll('[data-polar-payment-method]')
+        .forEach((el) => el.remove())
+      cleanupDom()
+    })
+
+    it('attaches click handlers that open the embed with the token', () => {
+      const button = document.createElement('button')
+      button.setAttribute('data-polar-payment-method', CUSTOMER_SESSION_TOKEN)
+      document.body.appendChild(button)
+
+      PolarEmbedPaymentMethod.init()
+
+      button.click()
+
+      const iframe = document.querySelector('iframe')
+      expect(iframe).not.toBeNull()
+      const src = new URL(iframe!.src)
+      expect(src.searchParams.get('customer_session_token')).toBe(
+        CUSTOMER_SESSION_TOKEN,
+      )
+    })
+
+    it('detects member tokens and uses member_session_token URL param', () => {
+      const button = document.createElement('button')
+      button.setAttribute('data-polar-payment-method', 'polar_mst_auto_init')
+      document.body.appendChild(button)
+
+      PolarEmbedPaymentMethod.init()
+      button.click()
+
+      const iframe = document.querySelector('iframe')!
+      const src = new URL(iframe.src)
+      expect(src.searchParams.get('member_session_token')).toBe(
+        'polar_mst_auto_init',
+      )
+      expect(src.searchParams.get('customer_session_token')).toBeNull()
+    })
+
+    it('reads theme from data-polar-payment-method-theme', () => {
+      const button = document.createElement('button')
+      button.setAttribute('data-polar-payment-method', CUSTOMER_SESSION_TOKEN)
+      button.setAttribute('data-polar-payment-method-theme', 'dark')
+      document.body.appendChild(button)
+
+      PolarEmbedPaymentMethod.init()
+      button.click()
+
+      const iframe = document.querySelector('iframe')
+      const src = new URL(iframe!.src)
+      expect(src.searchParams.get('theme')).toBe('dark')
+    })
+
+    it('does nothing when the data attribute is empty', () => {
+      const button = document.createElement('button')
+      button.setAttribute('data-polar-payment-method', '')
+      document.body.appendChild(button)
+
+      PolarEmbedPaymentMethod.init()
+      button.click()
+
+      expect(document.querySelector('iframe')).toBeNull()
+    })
+  })
+
+  describe('window.Polar', () => {
+    it('exposes EmbedPaymentMethod on window.Polar', () => {
+      expect(window.Polar).toBeDefined()
+      expect(window.Polar.EmbedPaymentMethod).toBe(PolarEmbedPaymentMethod)
+    })
+  })
+})

--- a/clients/packages/checkout/src/payment-method.test.ts
+++ b/clients/packages/checkout/src/payment-method.test.ts
@@ -104,6 +104,35 @@ describe('PolarEmbedPaymentMethod', () => {
       embed.close()
     })
 
+    it('sets set_default=false when setAsDefault is explicitly false', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        setAsDefault: false,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      const iframe = document.querySelector('iframe')!
+      expect(new URL(iframe.src).searchParams.get('set_default')).toBe('false')
+
+      embed.close()
+    })
+
+    it('omits set_default URL param by default', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+
+      const iframe = document.querySelector('iframe')!
+      expect(new URL(iframe.src).searchParams.get('set_default')).toBeNull()
+
+      embed.close()
+    })
+
     it('uses member_session_token URL param when given a member token', async () => {
       const promise = PolarEmbedPaymentMethod.create({
         memberSessionToken: 'polar_mst_test_member',

--- a/clients/packages/checkout/src/payment-method.test.ts
+++ b/clients/packages/checkout/src/payment-method.test.ts
@@ -272,7 +272,7 @@ describe('PolarEmbedPaymentMethod', () => {
       embed.close()
     })
 
-    it('re-enables closing after success event', async () => {
+    it('auto-closes the modal on success', async () => {
       const promise = PolarEmbedPaymentMethod.create({
         customerSessionToken: CUSTOMER_SESSION_TOKEN,
       })
@@ -296,14 +296,32 @@ describe('PolarEmbedPaymentMethod', () => {
           },
         }),
       )
+
+      expect(document.querySelector('iframe')).toBeNull()
+      embed.close()
+    })
+
+    it('skips the default auto-close when success listener calls preventDefault', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.addEventListener('success', (event) => event.preventDefault())
+
       window.dispatchEvent(
         new MessageEvent('message', {
           origin: ALLOWED_ORIGIN,
-          data: { type: 'POLAR_PAYMENT_METHOD', event: 'close' },
+          data: {
+            type: 'POLAR_PAYMENT_METHOD',
+            event: 'success',
+            paymentMethodId: 'pm_123',
+          },
         }),
       )
 
-      expect(document.querySelector('iframe')).toBeNull()
+      expect(document.querySelector('iframe')).not.toBeNull()
       embed.close()
     })
 

--- a/clients/packages/checkout/src/payment-method.ts
+++ b/clients/packages/checkout/src/payment-method.ts
@@ -438,6 +438,7 @@ class EmbedPaymentMethod {
 
   private handleSuccess(): void {
     this.closable = true
+    this.close()
   }
 
   /**

--- a/clients/packages/checkout/src/payment-method.ts
+++ b/clients/packages/checkout/src/payment-method.ts
@@ -102,6 +102,11 @@ interface EmbedPaymentMethodBaseOptions {
    */
   theme?: 'light' | 'dark'
   /**
+   * Whether the new card should be marked as the customer's default
+   * payment method. Defaults to `true`.
+   */
+  setAsDefault?: boolean
+  /**
    * Convenience callback fired once when the embed has loaded.
    */
   onLoaded?: (event: CustomEvent<EmbedPaymentMethodMessageLoaded>) => void
@@ -201,7 +206,7 @@ class EmbedPaymentMethod {
     options: EmbedPaymentMethodCreateOptions,
   ): Promise<EmbedPaymentMethod> {
     const session = resolveSessionParam(options)
-    const { theme, onLoaded } = options
+    const { theme, setAsDefault, onLoaded } = options
 
     const styleSheet = document.createElement('style')
     styleSheet.innerText = `
@@ -244,6 +249,9 @@ class EmbedPaymentMethod {
     embedURL.searchParams.set('mode', 'modal')
     if (theme) {
       embedURL.searchParams.set('theme', theme)
+    }
+    if (setAsDefault === false) {
+      embedURL.searchParams.set('set_default', 'false')
     }
 
     const iframe = document.createElement('iframe')
@@ -393,6 +401,9 @@ class EmbedPaymentMethod {
       | 'light'
       | 'dark'
       | null
+    const setAsDefaultAttr = element.getAttribute(
+      'data-polar-payment-method-set-as-default',
+    )
     // Sniff the token prefix to forward as the right option. Customer
     // tokens use `polar_cst_`, member tokens use `polar_mst_`. Anything
     // else falls back to customer for backward compat.
@@ -402,6 +413,8 @@ class EmbedPaymentMethod {
     EmbedPaymentMethod.create({
       ...sessionOption,
       theme: theme ?? undefined,
+      setAsDefault:
+        setAsDefaultAttr === null ? undefined : setAsDefaultAttr !== 'false',
     })
   }
 

--- a/clients/packages/checkout/src/payment-method.ts
+++ b/clients/packages/checkout/src/payment-method.ts
@@ -1,0 +1,505 @@
+const POLAR_PAYMENT_METHOD_EVENT = 'POLAR_PAYMENT_METHOD'
+const EMBED_PATH = '/embed/payment-method'
+
+/**
+ * Message sent to the parent window when the embedded payment method
+ * iframe is fully loaded and ready for input.
+ */
+interface EmbedPaymentMethodMessageLoaded {
+  event: 'loaded'
+}
+
+/**
+ * Message sent to the parent window when the embed should be closed
+ * (X button, outside click, or programmatically).
+ */
+interface EmbedPaymentMethodMessageClose {
+  event: 'close'
+}
+
+/**
+ * Message sent to the parent window when the customer's card has been
+ * submitted and Stripe processing has started.
+ *
+ * Once received, the parent shouldn't allow the embed to be closed
+ * until `success` or `error` follows.
+ */
+interface EmbedPaymentMethodMessageConfirmed {
+  event: 'confirmed'
+}
+
+/**
+ * Message sent to the parent window when the payment method has been
+ * successfully attached to the customer.
+ */
+interface EmbedPaymentMethodMessageSuccess {
+  event: 'success'
+  paymentMethodId: string
+}
+
+/**
+ * Message sent to the parent window when the iframe can't render the
+ * form (e.g. token missing, expired, or rejected by the server).
+ */
+interface EmbedPaymentMethodMessageError {
+  event: 'error'
+  code: 'invalid_request' | 'unauthorized' | 'unknown'
+}
+
+/**
+ * Internal: iframe announces its current content height. Consumed by
+ * inline-mode embeds (the React component) to keep the iframe sized to
+ * its content. Not exposed to consumers.
+ */
+interface EmbedPaymentMethodMessageResize {
+  event: 'resize'
+  height: number
+}
+
+type EmbedPaymentMethodMessage =
+  | EmbedPaymentMethodMessageLoaded
+  | EmbedPaymentMethodMessageClose
+  | EmbedPaymentMethodMessageConfirmed
+  | EmbedPaymentMethodMessageSuccess
+  | EmbedPaymentMethodMessageError
+  | EmbedPaymentMethodMessageResize
+
+const isEmbedPaymentMethodMessage = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  message: any,
+): message is EmbedPaymentMethodMessage => {
+  return message.type === POLAR_PAYMENT_METHOD_EVENT
+}
+
+/**
+ * Discriminated union enforcing that callers pass exactly one of
+ * `customerSessionToken` or `memberSessionToken`. Passing both, or
+ * neither, is a compile-time error.
+ */
+type EmbedPaymentMethodTokenOptions =
+  | {
+      /**
+       * A short-lived customer session token (prefix `polar_cst_`),
+       * minted server-side via `POST /v1/customer-sessions` using a
+       * Polar API key.
+       */
+      customerSessionToken: string
+      memberSessionToken?: never
+    }
+  | {
+      customerSessionToken?: never
+      /**
+       * A short-lived member session token (prefix `polar_mst_`),
+       * minted server-side via `POST /v1/customer-sessions` when the
+       * organisation has `member_model_enabled`.
+       */
+      memberSessionToken: string
+    }
+
+interface EmbedPaymentMethodBaseOptions {
+  /**
+   * Color scheme for the embed. Defaults to `light`.
+   */
+  theme?: 'light' | 'dark'
+  /**
+   * Convenience callback fired once when the embed has loaded.
+   */
+  onLoaded?: (event: CustomEvent<EmbedPaymentMethodMessageLoaded>) => void
+}
+
+type EmbedPaymentMethodCreateOptions = EmbedPaymentMethodTokenOptions &
+  EmbedPaymentMethodBaseOptions
+
+const resolveSessionParam = (options: {
+  customerSessionToken?: string
+  memberSessionToken?: string
+}): {
+  name: 'customer_session_token' | 'member_session_token'
+  value: string
+} => {
+  const { customerSessionToken, memberSessionToken } = options
+  if (customerSessionToken && memberSessionToken) {
+    throw new Error(
+      'PolarEmbedPaymentMethod: pass only one of `customerSessionToken` or `memberSessionToken`, not both.',
+    )
+  }
+  if (customerSessionToken) {
+    return { name: 'customer_session_token', value: customerSessionToken }
+  }
+  if (memberSessionToken) {
+    return { name: 'member_session_token', value: memberSessionToken }
+  }
+  throw new Error(
+    'PolarEmbedPaymentMethod: one of `customerSessionToken` or `memberSessionToken` is required.',
+  )
+}
+
+const resolveEmbedBaseURL = (): string => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - Defined at build time by tsup
+  const origins = __POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__ as string
+  return origins.split(',')[0]
+}
+
+/**
+ * Represents an embedded payment method instance rendered as a
+ * full-screen modal overlay on the merchant's page.
+ *
+ * For an inline, chrome-less embed that can be composed into a custom
+ * UI, use the React component at `@polar-sh/checkout/react/payment-method`.
+ */
+class EmbedPaymentMethod {
+  private iframe: HTMLIFrameElement
+  private loader: HTMLDivElement
+  private loaded: boolean
+  private closable: boolean
+  private eventTarget: EventTarget
+  private windowMessageListener: (event: MessageEvent) => void
+
+  public constructor(iframe: HTMLIFrameElement, loader: HTMLDivElement) {
+    this.iframe = iframe
+    this.loader = loader
+    this.loaded = false
+    this.closable = true
+    this.eventTarget = new EventTarget()
+    this.windowMessageListener = this.handleWindowMessage.bind(this)
+    window.addEventListener('message', this.windowMessageListener)
+  }
+
+  /**
+   * Send a message from the iframe to the parent window.
+   *
+   * Used internally by the Polar-hosted iframe page; not normally called
+   * by SDK consumers.
+   */
+  public static postMessage(
+    message: EmbedPaymentMethodMessage,
+    targetOrigin: string,
+  ): void {
+    window.parent.postMessage(
+      { ...message, type: POLAR_PAYMENT_METHOD_EVENT },
+      targetOrigin,
+    )
+  }
+
+  /**
+   * Create a new full-screen modal embed.
+   *
+   * @example
+   * ```ts
+   * const embed = await PolarEmbedPaymentMethod.create({
+   *   customerSessionToken: 'polar_cst_xxx',
+   *   theme: 'dark',
+   * })
+   *
+   * embed.addEventListener('success', (event) => {
+   *   console.log('Attached:', event.detail.paymentMethodId)
+   * })
+   * ```
+   */
+  public static create(
+    options: EmbedPaymentMethodCreateOptions,
+  ): Promise<EmbedPaymentMethod> {
+    const session = resolveSessionParam(options)
+    const { theme, onLoaded } = options
+
+    const styleSheet = document.createElement('style')
+    styleSheet.innerText = `
+      .polar-loader-spinner {
+        width: 20px;
+        aspect-ratio: 1;
+        border-radius: 50%;
+        background: ${theme === 'dark' ? '#000' : '#fff'};
+        box-shadow: 0 0 0 0 ${theme === 'dark' ? '#fff' : '#000'};
+        animation: polar-loader-spinner-animation 1s infinite;
+      }
+      @keyframes polar-loader-spinner-animation {
+        100% {box-shadow: 0 0 0 30px #0000}
+      }
+      body.polar-no-scroll {
+        overflow: hidden;
+      }
+    `
+    document.head.appendChild(styleSheet)
+
+    const loader = document.createElement('div')
+    loader.style.position = 'absolute'
+    loader.style.top = '50%'
+    loader.style.left = '50%'
+    loader.style.transform = 'translate(-50%, -50%)'
+    loader.style.zIndex = '2147483647'
+    loader.style.colorScheme = 'auto'
+
+    const spinner = document.createElement('div')
+    spinner.className = 'polar-loader-spinner'
+    loader.appendChild(spinner)
+
+    document.body.classList.add('polar-no-scroll')
+    document.body.appendChild(loader)
+
+    const embedURL = new URL(EMBED_PATH, resolveEmbedBaseURL())
+    embedURL.searchParams.set(session.name, session.value)
+    embedURL.searchParams.set('embed', 'true')
+    embedURL.searchParams.set('embed_origin', window.location.origin)
+    embedURL.searchParams.set('mode', 'modal')
+    if (theme) {
+      embedURL.searchParams.set('theme', theme)
+    }
+
+    const iframe = document.createElement('iframe')
+    iframe.src = embedURL.toString()
+    iframe.style.position = 'fixed'
+    iframe.style.top = '0'
+    iframe.style.left = '0'
+    iframe.style.width = '100%'
+    iframe.style.height = '100%'
+    iframe.style.border = 'none'
+    iframe.style.zIndex = '2147483647'
+    iframe.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
+    iframe.style.colorScheme = 'auto'
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - Defined at build time by tsup
+    const origins = __POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__
+      .split(',')
+      .join(' ')
+    iframe.allow = `payment 'self' ${origins}; publickey-credentials-get 'self' ${origins};`
+
+    document.body.appendChild(iframe)
+
+    const embed = new EmbedPaymentMethod(iframe, loader)
+
+    if (onLoaded) {
+      embed.addEventListener('loaded', onLoaded, { once: true })
+    }
+
+    return new Promise((resolve) => {
+      embed.addEventListener('loaded', () => resolve(embed), { once: true })
+    })
+  }
+
+  /**
+   * Initialize click triggers on elements marked with the
+   * `data-polar-payment-method` attribute. The attribute value is the
+   * customer session token. Theme can be set via
+   * `data-polar-payment-method-theme="dark"`.
+   *
+   * @example
+   * ```html
+   * <button
+   *   data-polar-payment-method="polar_cst_xxx"
+   *   data-polar-payment-method-theme="dark"
+   * >
+   *   Add payment method
+   * </button>
+   * ```
+   */
+  public static init(): void {
+    const elements = document.querySelectorAll('[data-polar-payment-method]')
+    elements.forEach((element) => {
+      element.removeEventListener(
+        'click',
+        EmbedPaymentMethod.elementClickHandler,
+      )
+      element.addEventListener('click', EmbedPaymentMethod.elementClickHandler)
+    })
+  }
+
+  /**
+   * Close the embed and remove it from the DOM.
+   */
+  public close(): void {
+    window.removeEventListener('message', this.windowMessageListener)
+    if (document.body.contains(this.iframe))
+      document.body.removeChild(this.iframe)
+    document.body.classList.remove('polar-no-scroll')
+  }
+
+  public addEventListener(
+    type: 'loaded',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageLoaded>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  public addEventListener(
+    type: 'close',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageClose>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  public addEventListener(
+    type: 'confirmed',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageConfirmed>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  public addEventListener(
+    type: 'success',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageSuccess>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  public addEventListener(
+    type: 'error',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageError>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  public addEventListener(
+    type: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listener: any,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    this.eventTarget.addEventListener(type, listener, options)
+  }
+
+  public removeEventListener(
+    type: 'loaded',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageLoaded>) => void,
+  ): void
+  public removeEventListener(
+    type: 'close',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageClose>) => void,
+  ): void
+  public removeEventListener(
+    type: 'confirmed',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageConfirmed>) => void,
+  ): void
+  public removeEventListener(
+    type: 'success',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageSuccess>) => void,
+  ): void
+  public removeEventListener(
+    type: 'error',
+    listener: (event: CustomEvent<EmbedPaymentMethodMessageError>) => void,
+  ): void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public removeEventListener(type: string, listener: any): void {
+    this.eventTarget.removeEventListener(type, listener)
+  }
+
+  private static async elementClickHandler(e: Event) {
+    e.preventDefault()
+    let element = e.target as HTMLElement
+
+    while (!element.hasAttribute('data-polar-payment-method')) {
+      if (!element.parentElement) {
+        return
+      }
+      element = element.parentElement
+    }
+
+    const token = element.getAttribute('data-polar-payment-method')
+    if (!token) {
+      return
+    }
+    const theme = element.getAttribute('data-polar-payment-method-theme') as
+      | 'light'
+      | 'dark'
+      | null
+    // Sniff the token prefix to forward as the right option. Customer
+    // tokens use `polar_cst_`, member tokens use `polar_mst_`. Anything
+    // else falls back to customer for backward compat.
+    const sessionOption = token.startsWith('polar_mst_')
+      ? { memberSessionToken: token }
+      : { customerSessionToken: token }
+    EmbedPaymentMethod.create({
+      ...sessionOption,
+      theme: theme ?? undefined,
+    })
+  }
+
+  private handleLoaded(): void {
+    if (this.loaded) {
+      return
+    }
+    document.body.removeChild(this.loader)
+    this.loaded = true
+  }
+
+  private handleClose(): void {
+    if (this.closable) {
+      this.close()
+    }
+  }
+
+  private handleConfirmed(): void {
+    this.closable = false
+  }
+
+  private handleSuccess(): void {
+    this.closable = true
+  }
+
+  /**
+   * Validate origin, parse the message, dispatch a cancelable
+   * `CustomEvent` to consumer listeners, then run the default action
+   * unless a listener called `event.preventDefault()`.
+   */
+  private handleWindowMessage({ data, origin }: MessageEvent): void {
+    if (
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - Defined at build time by tsup
+      !__POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__
+        .split(',')
+        .includes(origin)
+    ) {
+      return
+    }
+    if (!isEmbedPaymentMethodMessage(data)) {
+      return
+    }
+
+    // `resize` is an internal protocol message used by inline embeds —
+    // never relevant for modal mode, so silently drop it.
+    if (data.event === 'resize') {
+      return
+    }
+
+    const event = new CustomEvent(data.event, {
+      detail: data,
+      cancelable: true,
+    })
+    this.eventTarget.dispatchEvent(event)
+    if (event.defaultPrevented) {
+      return
+    }
+    switch (data.event) {
+      case 'loaded':
+        this.handleLoaded()
+        break
+      case 'close':
+        this.handleClose()
+        break
+      case 'confirmed':
+        this.handleConfirmed()
+        break
+      case 'success':
+        this.handleSuccess()
+        break
+    }
+  }
+}
+
+declare global {
+  interface PolarWindow {
+    EmbedPaymentMethod: typeof EmbedPaymentMethod
+  }
+  interface Window {
+    Polar: Partial<PolarWindow>
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.Polar = {
+    ...(window.Polar ?? {}),
+    EmbedPaymentMethod,
+  }
+}
+
+if (typeof document !== 'undefined') {
+  const currentScript = document.currentScript as HTMLScriptElement | null
+  if (currentScript && currentScript.hasAttribute('data-auto-init')) {
+    document.addEventListener('DOMContentLoaded', () => {
+      EmbedPaymentMethod.init()
+    })
+  }
+}
+
+export { EmbedPaymentMethod as PolarEmbedPaymentMethod }

--- a/clients/packages/checkout/src/react/payment-method.test.tsx
+++ b/clients/packages/checkout/src/react/payment-method.test.tsx
@@ -1,0 +1,201 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { PolarPaymentMethod } from './payment-method'
+
+const ALLOWED_ORIGIN = 'http://127.0.0.1:3000'
+const CUSTOMER_SESSION_TOKEN = 'polar_cst_test_token'
+
+beforeAll(() => {
+  // @ts-expect-error - Global defined at build time by tsup
+  globalThis.__POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__ = ALLOWED_ORIGIN
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const post = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any,
+  origin: string = ALLOWED_ORIGIN,
+) => {
+  window.dispatchEvent(new MessageEvent('message', { origin, data }))
+}
+
+describe('PolarPaymentMethod', () => {
+  it('renders an iframe pointing at the bare embed route', () => {
+    const { container } = render(
+      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+    )
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+
+    const src = new URL(iframe!.src)
+    expect(src.pathname).toBe('/embed/payment-method')
+    expect(src.origin).toBe(ALLOWED_ORIGIN)
+    expect(src.searchParams.get('customer_session_token')).toBe(
+      CUSTOMER_SESSION_TOKEN,
+    )
+    expect(src.searchParams.get('embed')).toBe('true')
+    expect(src.searchParams.get('embed_origin')).toBe(window.location.origin)
+    expect(src.searchParams.get('mode')).toBeNull()
+  })
+
+  it('uses member_session_token URL param when given a member token', () => {
+    const { container } = render(
+      <PolarPaymentMethod memberSessionToken="polar_mst_xyz" />,
+    )
+
+    const iframe = container.querySelector('iframe')!
+    const src = new URL(iframe.src)
+    expect(src.searchParams.get('member_session_token')).toBe('polar_mst_xyz')
+    expect(src.searchParams.get('customer_session_token')).toBeNull()
+  })
+
+  it('sets the theme query parameter when provided', () => {
+    const { container } = render(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        theme="dark"
+      />,
+    )
+
+    const iframe = container.querySelector('iframe')!
+    expect(new URL(iframe.src).searchParams.get('theme')).toBe('dark')
+  })
+
+  it('forwards lifecycle events to props', () => {
+    const onLoaded = vi.fn()
+    const onConfirmed = vi.fn()
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    render(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        onLoaded={onLoaded}
+        onConfirmed={onConfirmed}
+        onSuccess={onSuccess}
+        onError={onError}
+      />,
+    )
+
+    post({ type: 'POLAR_PAYMENT_METHOD', event: 'loaded' })
+    expect(onLoaded).toHaveBeenCalledTimes(1)
+
+    post({ type: 'POLAR_PAYMENT_METHOD', event: 'confirmed' })
+    expect(onConfirmed).toHaveBeenCalledTimes(1)
+
+    post({
+      type: 'POLAR_PAYMENT_METHOD',
+      event: 'success',
+      paymentMethodId: 'pm_abc',
+    })
+    expect(onSuccess).toHaveBeenCalledWith('pm_abc')
+
+    post({
+      type: 'POLAR_PAYMENT_METHOD',
+      event: 'error',
+      code: 'unauthorized',
+    })
+    expect(onError).toHaveBeenCalledWith('unauthorized')
+  })
+
+  it('updates iframe height in response to resize messages', () => {
+    const { container } = render(
+      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+    )
+
+    post({
+      type: 'POLAR_PAYMENT_METHOD',
+      event: 'resize',
+      height: 480.4,
+    })
+
+    const iframe = container.querySelector('iframe')!
+    expect(iframe.style.height).toBe('481px')
+  })
+
+  it('ignores messages from disallowed origins', () => {
+    const onSuccess = vi.fn()
+
+    render(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        onSuccess={onSuccess}
+      />,
+    )
+
+    post(
+      {
+        type: 'POLAR_PAYMENT_METHOD',
+        event: 'success',
+        paymentMethodId: 'pm_evil',
+      },
+      'https://evil.com',
+    )
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('ignores messages with the wrong protocol type', () => {
+    const onSuccess = vi.fn()
+
+    render(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        onSuccess={onSuccess}
+      />,
+    )
+
+    post({
+      type: 'POLAR_CHECKOUT',
+      event: 'success',
+      paymentMethodId: 'pm_other',
+    })
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('removes the iframe on unmount', () => {
+    const { container, unmount } = render(
+      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+    )
+    expect(container.querySelector('iframe')).not.toBeNull()
+
+    unmount()
+
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+
+  it('uses the latest callback props without re-mounting the iframe', () => {
+    const firstSuccess = vi.fn()
+    const secondSuccess = vi.fn()
+
+    const { rerender, container } = render(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        onSuccess={firstSuccess}
+      />,
+    )
+    const iframe = container.querySelector('iframe')
+
+    rerender(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        onSuccess={secondSuccess}
+      />,
+    )
+    expect(container.querySelector('iframe')).toBe(iframe)
+
+    post({
+      type: 'POLAR_PAYMENT_METHOD',
+      event: 'success',
+      paymentMethodId: 'pm_latest',
+    })
+
+    expect(firstSuccess).not.toHaveBeenCalled()
+    expect(secondSuccess).toHaveBeenCalledWith('pm_latest')
+  })
+})

--- a/clients/packages/checkout/src/react/payment-method.test.tsx
+++ b/clients/packages/checkout/src/react/payment-method.test.tsx
@@ -42,6 +42,27 @@ describe('PolarPaymentMethod', () => {
     expect(src.searchParams.get('mode')).toBeNull()
   })
 
+  it('sets set_default=false when setAsDefault is explicitly false', () => {
+    const { container } = render(
+      <PolarPaymentMethod
+        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        setAsDefault={false}
+      />,
+    )
+
+    const iframe = container.querySelector('iframe')!
+    expect(new URL(iframe.src).searchParams.get('set_default')).toBe('false')
+  })
+
+  it('omits set_default URL param by default', () => {
+    const { container } = render(
+      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+    )
+
+    const iframe = container.querySelector('iframe')!
+    expect(new URL(iframe.src).searchParams.get('set_default')).toBeNull()
+  })
+
   it('uses member_session_token URL param when given a member token', () => {
     const { container } = render(
       <PolarPaymentMethod memberSessionToken="polar_mst_xyz" />,

--- a/clients/packages/checkout/src/react/payment-method.tsx
+++ b/clients/packages/checkout/src/react/payment-method.tsx
@@ -1,0 +1,226 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+const POLAR_PAYMENT_METHOD_EVENT = 'POLAR_PAYMENT_METHOD'
+const EMBED_PATH = '/embed/payment-method'
+
+type ErrorCode = 'invalid_request' | 'unauthorized' | 'unknown'
+
+type IncomingMessage =
+  | { event: 'loaded' }
+  | { event: 'confirmed' }
+  | { event: 'success'; paymentMethodId: string }
+  | { event: 'error'; code: ErrorCode }
+  | { event: 'resize'; height: number }
+
+const isPolarMessage = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  message: any,
+): message is IncomingMessage & { type: typeof POLAR_PAYMENT_METHOD_EVENT } => {
+  return (
+    !!message &&
+    typeof message === 'object' &&
+    message.type === POLAR_PAYMENT_METHOD_EVENT
+  )
+}
+
+const resolveEmbedBaseURL = (): string => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - Defined at build time by tsup
+  const origins = __POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__ as string
+  return origins.split(',')[0]
+}
+
+const isAllowedOrigin = (origin: string): boolean => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - Defined at build time by tsup
+  return (__POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__ as string)
+    .split(',')
+    .includes(origin)
+}
+
+const buildIframeAllow = (): string => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - Defined at build time by tsup
+  const origins = (__POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__ as string)
+    .split(',')
+    .join(' ')
+  return `payment 'self' ${origins}; publickey-credentials-get 'self' ${origins};`
+}
+
+/**
+ * Discriminated union enforcing that callers pass exactly one of
+ * `customerSessionToken` or `memberSessionToken`. Passing both, or
+ * neither, is a compile-time error.
+ */
+type TokenProps =
+  | {
+      /**
+       * A short-lived customer session token (prefix `polar_cst_`),
+       * minted server-side via `POST /v1/customer-sessions` using a
+       * Polar API key.
+       */
+      customerSessionToken: string
+      memberSessionToken?: never
+    }
+  | {
+      customerSessionToken?: never
+      /**
+       * A short-lived member session token (prefix `polar_mst_`), minted
+       * server-side via `POST /v1/customer-sessions` when the
+       * organisation has `member_model_enabled`.
+       */
+      memberSessionToken: string
+    }
+
+interface PolarPaymentMethodBaseProps {
+  /**
+   * Color scheme for the embed. Defaults to `light`.
+   */
+  theme?: 'light' | 'dark'
+  /**
+   * Fires once when the iframe has loaded and the form is interactive.
+   */
+  onLoaded?: () => void
+  /**
+   * Fires when the customer submits the card and Stripe processing
+   * begins. Use this to disable any "close" / "cancel" actions you
+   * render around the embed until `onSuccess` or `onError` fires.
+   */
+  onConfirmed?: () => void
+  /**
+   * Fires when the payment method has been attached to the customer.
+   */
+  onSuccess?: (paymentMethodId: string) => void
+  /**
+   * Fires when the iframe could not render the form (token missing,
+   * expired, or rejected).
+   */
+  onError?: (code: ErrorCode) => void
+  /**
+   * Optional class name applied to the wrapping `div`. Use this to size
+   * or position the embed.
+   */
+  className?: string
+  /**
+   * Optional inline style applied to the wrapping `div`.
+   */
+  style?: React.CSSProperties
+}
+
+export type PolarPaymentMethodProps = TokenProps & PolarPaymentMethodBaseProps
+
+/**
+ * Embeds the Polar "add payment method" form as a bare, chrome-less
+ * iframe inside the parent React tree.
+ *
+ * The merchant is responsible for any surrounding UI (modal, sheet,
+ * inline card, etc). For a one-line modal experience, use
+ * `PolarEmbedPaymentMethod.create()` from `@polar-sh/checkout/payment-method`
+ * instead.
+ *
+ * The iframe auto-resizes to its content height; you don't need to set
+ * one. To constrain its width, style the wrapping `div` via `className`
+ * or `style`.
+ *
+ * @example
+ * ```tsx
+ * <PolarPaymentMethod
+ *   customerSessionToken={token}
+ *   onSuccess={(id) => console.log('Attached:', id)}
+ *   onError={(code) => console.error(code)}
+ * />
+ * ```
+ */
+export const PolarPaymentMethod = ({
+  customerSessionToken,
+  memberSessionToken,
+  theme,
+  onLoaded,
+  onConfirmed,
+  onSuccess,
+  onError,
+  className,
+  style,
+}: PolarPaymentMethodProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Keep handlers in a ref so the effect doesn't re-mount the iframe
+  // every time the parent re-renders with new callback identities.
+  const handlersRef = useRef({ onLoaded, onConfirmed, onSuccess, onError })
+  useEffect(() => {
+    handlersRef.current = { onLoaded, onConfirmed, onSuccess, onError }
+  })
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    if (customerSessionToken && memberSessionToken) {
+      throw new Error(
+        'PolarPaymentMethod: pass only one of `customerSessionToken` or `memberSessionToken`, not both.',
+      )
+    }
+    const sessionParamName = memberSessionToken
+      ? 'member_session_token'
+      : 'customer_session_token'
+    const sessionParamValue = memberSessionToken ?? customerSessionToken
+    if (!sessionParamValue) {
+      throw new Error(
+        'PolarPaymentMethod: one of `customerSessionToken` or `memberSessionToken` is required.',
+      )
+    }
+
+    const embedURL = new URL(EMBED_PATH, resolveEmbedBaseURL())
+    embedURL.searchParams.set(sessionParamName, sessionParamValue)
+    embedURL.searchParams.set('embed', 'true')
+    embedURL.searchParams.set('embed_origin', window.location.origin)
+    if (theme) {
+      embedURL.searchParams.set('theme', theme)
+    }
+
+    const iframe = document.createElement('iframe')
+    iframe.src = embedURL.toString()
+    iframe.style.display = 'block'
+    iframe.style.width = '100%'
+    iframe.style.height = '0'
+    iframe.style.border = 'none'
+    iframe.style.colorScheme = 'auto'
+    iframe.allow = buildIframeAllow()
+
+    container.replaceChildren(iframe)
+
+    const messageListener = ({ data, origin }: MessageEvent) => {
+      if (!isAllowedOrigin(origin)) return
+      if (!isPolarMessage(data)) return
+
+      switch (data.event) {
+        case 'loaded':
+          handlersRef.current.onLoaded?.()
+          break
+        case 'confirmed':
+          handlersRef.current.onConfirmed?.()
+          break
+        case 'success':
+          handlersRef.current.onSuccess?.(data.paymentMethodId)
+          break
+        case 'error':
+          handlersRef.current.onError?.(data.code)
+          break
+        case 'resize':
+          iframe.style.height = `${Math.max(0, Math.ceil(data.height))}px`
+          break
+      }
+    }
+
+    window.addEventListener('message', messageListener)
+
+    return () => {
+      window.removeEventListener('message', messageListener)
+      iframe.remove()
+    }
+  }, [customerSessionToken, memberSessionToken, theme])
+
+  return <div ref={containerRef} className={className} style={style} />
+}

--- a/clients/packages/checkout/src/react/payment-method.tsx
+++ b/clients/packages/checkout/src/react/payment-method.tsx
@@ -80,6 +80,11 @@ interface PolarPaymentMethodBaseProps {
    */
   theme?: 'light' | 'dark'
   /**
+   * Whether the new card should be marked as the customer's default
+   * payment method. Defaults to `true`.
+   */
+  setAsDefault?: boolean
+  /**
    * Fires once when the iframe has loaded and the form is interactive.
    */
   onLoaded?: () => void
@@ -137,6 +142,7 @@ export const PolarPaymentMethod = ({
   customerSessionToken,
   memberSessionToken,
   theme,
+  setAsDefault,
   onLoaded,
   onConfirmed,
   onSuccess,
@@ -179,6 +185,9 @@ export const PolarPaymentMethod = ({
     if (theme) {
       embedURL.searchParams.set('theme', theme)
     }
+    if (setAsDefault === false) {
+      embedURL.searchParams.set('set_default', 'false')
+    }
 
     const iframe = document.createElement('iframe')
     iframe.src = embedURL.toString()
@@ -220,7 +229,7 @@ export const PolarPaymentMethod = ({
       window.removeEventListener('message', messageListener)
       iframe.remove()
     }
-  }, [customerSessionToken, memberSessionToken, theme])
+  }, [customerSessionToken, memberSessionToken, theme, setAsDefault])
 
   return <div ref={containerRef} className={className} style={style} />
 }

--- a/clients/packages/checkout/tsup.config.ts
+++ b/clients/packages/checkout/tsup.config.ts
@@ -1,15 +1,27 @@
 import { defineConfig, Options } from 'tsup'
 
+const allowedOriginsDefine = {
+  __POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__: `'${process.env.POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS ? process.env.POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS : 'http://127.0.0.1:3000'}'`,
+}
+
 export const options: Options[] = [
   {
-    entry: ['src/embed.ts'],
-    format: ['cjs', 'esm', 'iife'],
+    entry: {
+      embed: 'src/checkout.ts',
+      'payment-method': 'src/payment-method.ts',
+      'react/payment-method': 'src/react/payment-method.tsx',
+    },
+    format: ['cjs', 'esm'],
     dts: true,
     minify: 'terser',
-    define: {
-      // @ts-expect-error - Global defined at build time by tsup
-      __POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__: `'${process.env.POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS ? process.env.POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS : 'http://127.0.0.1:3000'}'`,
-    },
+    define: allowedOriginsDefine,
+    external: ['react'],
+  },
+  {
+    entry: { embed: 'src/embed-global.ts' },
+    format: ['iife'],
+    minify: 'terser',
+    define: allowedOriginsDefine,
   },
   {
     entry: [


### PR DESCRIPTION
This PR will add a new embedded payment method feature.

The new embedded component borrows _a lot_ of code from our already existing [AddPaymentMethodModal.tsx](https://github.com/polarsource/polar/blob/ccfe617b46524e6e0ddc759b80b45ca6fd31bffe/clients/apps/web/src/components/CustomerPortal/AddPaymentMethodModal.tsx) component in our Customer Portal. The plan is to deprecate that component in favor of this new SDK.

It also mimics the `embed.ts` API with the same methods.

Three notable changes:

* `embed.ts` is now renamed to `checkout.ts` to better convey what it does
* `embed.ts` now exports the renamed `checkout.ts`  (old `embed.ts`)
* `embed.ts` now exports the new `payment-method.ts` (adds ~3KB to bundle size)

The other changes should not have any effect on the already existing embed checkout feature.

## Example usages

```ts
// Node
import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'

const embed = await PolarEmbedPaymentMethod.create({
  customerSessionToken, // or memberSessionToken
})

embed.addEventListener('success', (event) => {
  console.log({event})
})
```

```tsx
// React
import { PolarPaymentMethod } from '@polar-sh/checkout/react/payment-method'
return (
  <PolarPaymentMethod
    customerSessionToken={token} // or memberSessionToken
    onSuccess={(event) => console.log({event})}
  />
)
```

```html
// Code snippet, using the same embed.global.js path
<script
  defer
  data-auto-init
  src="https://cdn.jsdelivr.net/npm/@polar-sh/checkout@latest/dist/embed.global.js">
</script>
<button data-polar-payment-method="polar_cst_xxx">Add payment method</button>
```

## Screenshot

<img width="1840" height="1133" alt="Screenshot 2026-05-18 at 16 36 05" src="https://github.com/user-attachments/assets/4c9ad0cf-760a-4101-882c-c3b6a0974cb6" />

