### PR TITLE
Avoid overriding customer name with cardholder

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2566,15 +2566,24 @@ class CheckoutService:
                 # Could be a malicious user trying to take over an existing customer's account by using their email
                 generate_customer_session = False
 
+        # Preserve any existing customer.name (e.g. a person's name) so it isn't
+        # overridden by the cardholder name on a wallet/payment method when an
+        # employee or third party checks out on the customer's behalf.
+        # customer.billing_name (the company name) is intentionally updatable.
+        stripe_name = (
+            checkout.customer_billing_name
+            or customer.billing_name
+            or customer.name
+            or checkout.customer_name
+        )
+
         stripe_customer_id = customer.stripe_customer_id
         if stripe_customer_id is None:
             create_params: CustomerCreateParams = {}
             if customer.email is not None:
                 create_params["email"] = customer.email
-            if checkout.customer_billing_name is not None:
-                create_params["name"] = checkout.customer_billing_name
-            elif checkout.customer_name is not None:
-                create_params["name"] = checkout.customer_name
+            if stripe_name is not None:
+                create_params["name"] = stripe_name
             if checkout.customer_billing_address is not None:
                 create_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             if checkout.customer_tax_id is not None:
@@ -2589,7 +2598,7 @@ class CheckoutService:
                 update_params["email"] = customer.email
             if checkout.customer_billing_name is not None:
                 update_params["name"] = checkout.customer_billing_name
-            elif checkout.customer_name is not None:
+            elif customer.name is None and checkout.customer_name is not None:
                 update_params["name"] = checkout.customer_name
             if checkout.customer_billing_address is not None:
                 update_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
@@ -2603,7 +2612,7 @@ class CheckoutService:
                 **update_params,
             )
 
-        if checkout.customer_name is not None:
+        if customer.name is None and checkout.customer_name is not None:
             customer.name = checkout.customer_name
         if checkout.customer_billing_name is not None:
             customer.billing_name = checkout.customer_billing_name

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2567,13 +2567,15 @@ class CheckoutService:
                 generate_customer_session = False
 
         stripe_customer_id = customer.stripe_customer_id
-        name = checkout.customer_billing_name or checkout.customer_name
+        stripe_customer_name = (
+            checkout.customer_billing_name or checkout.customer_name
+        )
         if stripe_customer_id is None:
             create_params: CustomerCreateParams = {}
             if customer.email is not None:
                 create_params["email"] = customer.email
-            if name is not None:
-                create_params["name"] = name
+            if stripe_customer_name is not None:
+                create_params["name"] = stripe_customer_name
             if checkout.customer_billing_address is not None:
                 create_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             if checkout.customer_tax_id is not None:
@@ -2586,8 +2588,8 @@ class CheckoutService:
             update_params: CustomerModifyParams = {}
             if customer.email is not None:
                 update_params["email"] = customer.email
-            if name is not None:
-                update_params["name"] = name
+            if stripe_customer_name is not None:
+                update_params["name"] = stripe_customer_name
             if checkout.customer_billing_address is not None:
                 update_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             await stripe_service.update_customer(
@@ -2600,11 +2602,13 @@ class CheckoutService:
                 **update_params,
             )
 
-        # For existing customers (linked via customer_id or matched by email),
-        # preserve customer.name — checkout.customer_name may be the cardholder
-        # name from a wallet/payment method, not the customer's actual name.
-        if created and name is not None:
-            customer.name = name
+        # Only populate customer.name when creating a new customer. For existing
+        # customers (linked via customer_id or matched by email),
+        # checkout.customer_name may be the cardholder name on a wallet/payment
+        # method — e.g. a CFO or office manager paying on behalf of a company
+        # customer — and must not overwrite the company's name.
+        if created and stripe_customer_name is not None:
+            customer.name = stripe_customer_name
         if checkout.customer_billing_name is not None:
             customer.billing_name = checkout.customer_billing_name
         if checkout.customer_billing_address is not None:

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2566,24 +2566,17 @@ class CheckoutService:
                 # Could be a malicious user trying to take over an existing customer's account by using their email
                 generate_customer_session = False
 
-        # Preserve any existing customer.name (e.g. a person's name) so it isn't
-        # overridden by the cardholder name on a wallet/payment method when an
-        # employee or third party checks out on the customer's behalf.
-        # customer.billing_name (the company name) is intentionally updatable.
-        stripe_name = (
-            checkout.customer_billing_name
-            or customer.billing_name
-            or customer.name
-            or checkout.customer_name
-        )
-
         stripe_customer_id = customer.stripe_customer_id
         if stripe_customer_id is None:
             create_params: CustomerCreateParams = {}
             if customer.email is not None:
                 create_params["email"] = customer.email
-            if stripe_name is not None:
-                create_params["name"] = stripe_name
+            # Preserve any existing customer.name (e.g. a company name) so it
+            # isn't overridden by the cardholder name on a wallet/payment method
+            # when an employee or third party checks out on the customer's behalf.
+            name = customer.name or checkout.customer_name
+            if name is not None:
+                create_params["name"] = name
             if checkout.customer_billing_address is not None:
                 create_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             if checkout.customer_tax_id is not None:
@@ -2596,9 +2589,7 @@ class CheckoutService:
             update_params: CustomerModifyParams = {}
             if customer.email is not None:
                 update_params["email"] = customer.email
-            if checkout.customer_billing_name is not None:
-                update_params["name"] = checkout.customer_billing_name
-            elif customer.name is None and checkout.customer_name is not None:
+            if customer.name is None and checkout.customer_name is not None:
                 update_params["name"] = checkout.customer_name
             if checkout.customer_billing_address is not None:
                 update_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2567,14 +2567,11 @@ class CheckoutService:
                 generate_customer_session = False
 
         stripe_customer_id = customer.stripe_customer_id
+        name = checkout.customer_billing_name or checkout.customer_name
         if stripe_customer_id is None:
             create_params: CustomerCreateParams = {}
             if customer.email is not None:
                 create_params["email"] = customer.email
-            # Preserve any existing customer.name (e.g. a company name) so it
-            # isn't overridden by the cardholder name on a wallet/payment method
-            # when an employee or third party checks out on the customer's behalf.
-            name = customer.name or checkout.customer_name
             if name is not None:
                 create_params["name"] = name
             if checkout.customer_billing_address is not None:
@@ -2589,8 +2586,8 @@ class CheckoutService:
             update_params: CustomerModifyParams = {}
             if customer.email is not None:
                 update_params["email"] = customer.email
-            if customer.name is None and checkout.customer_name is not None:
-                update_params["name"] = checkout.customer_name
+            if name is not None:
+                update_params["name"] = name
             if checkout.customer_billing_address is not None:
                 update_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             await stripe_service.update_customer(
@@ -2603,8 +2600,11 @@ class CheckoutService:
                 **update_params,
             )
 
-        if customer.name is None and checkout.customer_name is not None:
-            customer.name = checkout.customer_name
+        # For existing customers (linked via customer_id or matched by email),
+        # preserve customer.name — checkout.customer_name may be the cardholder
+        # name from a wallet/payment method, not the customer's actual name.
+        if created and name is not None:
+            customer.name = name
         if checkout.customer_billing_name is not None:
             customer.billing_name = checkout.customer_billing_name
         if checkout.customer_billing_address is not None:

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2567,15 +2567,13 @@ class CheckoutService:
                 generate_customer_session = False
 
         stripe_customer_id = customer.stripe_customer_id
-        stripe_customer_name = (
-            checkout.customer_billing_name or checkout.customer_name
-        )
+        customer_name = checkout.customer_billing_name or checkout.customer_name
         if stripe_customer_id is None:
             create_params: CustomerCreateParams = {}
             if customer.email is not None:
                 create_params["email"] = customer.email
-            if stripe_customer_name is not None:
-                create_params["name"] = stripe_customer_name
+            if customer_name is not None:
+                create_params["name"] = customer_name
             if checkout.customer_billing_address is not None:
                 create_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             if checkout.customer_tax_id is not None:
@@ -2588,8 +2586,8 @@ class CheckoutService:
             update_params: CustomerModifyParams = {}
             if customer.email is not None:
                 update_params["email"] = customer.email
-            if stripe_customer_name is not None:
-                update_params["name"] = stripe_customer_name
+            if customer_name is not None:
+                update_params["name"] = customer_name
             if checkout.customer_billing_address is not None:
                 update_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             await stripe_service.update_customer(
@@ -2607,8 +2605,8 @@ class CheckoutService:
         # checkout.customer_name may be the cardholder name on a wallet/payment
         # method — e.g. a CFO or office manager paying on behalf of a company
         # customer — and must not overwrite the company's name.
-        if created and stripe_customer_name is not None:
-            customer.name = stripe_customer_name
+        if created and customer_name is not None:
+            customer.name = customer_name
         if checkout.customer_billing_name is not None:
             customer.billing_name = checkout.customer_billing_name
         if checkout.customer_billing_address is not None:

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4707,8 +4707,10 @@ class TestConfirm:
         assert checkout.customer.name == "Existing Person"
         assert checkout.customer.billing_name == "ACME Corp Inc."
 
+        # Stripe's customer.name must stay in sync with Polar's customer.name —
+        # billing_name is a Polar-only concept and shouldn't reach Stripe.
         update_call = stripe_service_mock.update_customer.call_args
-        assert update_call.kwargs.get("name") == "ACME Corp Inc."
+        assert "name" not in update_call.kwargs
 
     async def test_valid_stripe_existing_customer_email(
         self,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4655,8 +4655,10 @@ class TestConfirm:
         assert checkout.customer is not None
         assert checkout.customer.name == "ACME Corp Inc."
 
+        # Stripe still receives the checkout-provided name (which may be the
+        # cardholder name); only Polar's customer.name is protected.
         update_call = stripe_service_mock.update_customer.call_args
-        assert "name" not in update_call.kwargs
+        assert update_call.kwargs.get("name") == "John Smith"
 
     async def test_existing_customer_billing_name_updated(
         self,
@@ -4707,10 +4709,8 @@ class TestConfirm:
         assert checkout.customer.name == "Existing Person"
         assert checkout.customer.billing_name == "ACME Corp Inc."
 
-        # Stripe's customer.name must stay in sync with Polar's customer.name —
-        # billing_name is a Polar-only concept and shouldn't reach Stripe.
         update_call = stripe_service_mock.update_customer.call_args
-        assert "name" not in update_call.kwargs
+        assert update_call.kwargs.get("name") == "ACME Corp Inc."
 
     async def test_valid_stripe_existing_customer_email(
         self,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4615,6 +4615,101 @@ class TestConfirm:
         assert checkout.customer is not None
         assert checkout.customer.user_metadata == {"key": "updated", "key2": "value2"}
 
+    async def test_existing_customer_name_not_overridden(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            name="ACME Corp Inc.",
+            stripe_customer_id="CHECKOUT_CUSTOMER_ID",
+        )
+        checkout_one_time_fixed.customer = customer
+        checkout_one_time_fixed.customer_email = customer.email
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                    "customer_name": "John Smith",
+                    "customer_billing_address": {"country": "FR"},
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.customer is not None
+        assert checkout.customer.name == "ACME Corp Inc."
+
+        update_call = stripe_service_mock.update_customer.call_args
+        assert "name" not in update_call.kwargs
+
+    async def test_existing_customer_billing_name_updated(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            name="Existing Person",
+            stripe_customer_id="CHECKOUT_CUSTOMER_ID",
+        )
+        checkout_one_time_fixed.customer = customer
+        checkout_one_time_fixed.customer_email = customer.email
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                    "customer_name": "Cardholder Name",
+                    "is_business_customer": True,
+                    "customer_billing_name": "ACME Corp Inc.",
+                    "customer_billing_address": {
+                        "line1": "123 Main St",
+                        "postal_code": "12345",
+                        "city": "New York",
+                        "state": "US-NY",
+                        "country": "US",
+                    },
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.customer is not None
+        assert checkout.customer.name == "Existing Person"
+        assert checkout.customer.billing_name == "ACME Corp Inc."
+
+        update_call = stripe_service_mock.update_customer.call_args
+        assert update_call.kwargs.get("name") == "ACME Corp Inc."
+
     async def test_valid_stripe_existing_customer_email(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
I went back and forth quite a bit and I'm not even sure if this is the correct approach.

Basically, I noticed that when you have a company customer "ACME" that you create a checkout for, and you check out with _Cardholder name_ "John Doe", we'll update the customer's name to be "John Doe" after checkout.

That's very annoying in a B2B context.