### PR TITLE
Unify member and customer token in payment method SDK

### DIFF
--- a/clients/.changeset/hot-rooms-cheat.md
+++ b/clients/.changeset/hot-rooms-cheat.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/checkout": patch
+---
+
+Simplify the payment method embed API with a single sessionToken prop/parameter

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
@@ -11,8 +11,7 @@ export const metadata: Metadata = {
 }
 
 interface SearchParams {
-  customer_session_token?: string
-  member_session_token?: string
+  session_token?: string
   embed_origin?: string
   theme?: 'light' | 'dark'
   mode?: 'modal' | 'inline'
@@ -39,8 +38,7 @@ export default async function Page(props: {
   searchParams: Promise<SearchParams>
 }) {
   const {
-    customer_session_token,
-    member_session_token,
+    session_token: sessionToken,
     embed_origin,
     theme,
     mode,
@@ -51,11 +49,6 @@ export default async function Page(props: {
 
   const embedOrigin =
     embed_origin && isValidEmbedOrigin(embed_origin) ? embed_origin : undefined
-
-  const sessionToken =
-    customer_session_token && member_session_token
-      ? null
-      : (customer_session_token ?? member_session_token)
 
   if (!sessionToken || !embedOrigin) {
     return <EmbedError code="invalid_request" embedOrigin={embedOrigin} />

--- a/clients/packages/checkout/README.md
+++ b/clients/packages/checkout/README.md
@@ -4,13 +4,15 @@ JavaScript utilities for embedding Polar into your website. Drop in the single C
 
 ## Payment Method
 
+Pass the `token` returned by `POST /v1/customer-sessions` — the SDK accepts either `polar_cst_*` or `polar_mst_*` prefix and routes internally.
+
 ### Modal — vanilla JS
 
 ```ts
 import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
 
 const embed = await PolarEmbedPaymentMethod.create({
-  customerSessionToken, // or memberSessionToken — see below
+  sessionToken,
   theme: 'light',
 })
 
@@ -19,15 +21,61 @@ embed.addEventListener('success', (event) => {
 })
 ```
 
+#### `create()` options
+
+| Option         | Type                           | Default | Description                                                                                       |
+| -------------- | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------- |
+| `sessionToken` | `string`                       | —       | **Required.** Session token from `POST /v1/customer-sessions` (`polar_cst_*` or `polar_mst_*`).   |
+| `theme`        | `'light' \| 'dark'`            | `light` | Colour scheme for the embed.                                                                      |
+| `setAsDefault` | `boolean`                      | `true`  | Whether the new card should become the customer's default payment method.                         |
+| `onLoaded`     | `(event: CustomEvent) => void` | —       | Convenience callback for the `loaded` event. Equivalent to `embed.addEventListener('loaded', …)`. |
+
+#### Events
+
+All events are dispatched as cancelable `CustomEvent`s on the `embed` instance. Call `event.preventDefault()` to opt out of the SDK's default action.
+
+| Event       | Detail                        | Default action                                                        |
+| ----------- | ----------------------------- | --------------------------------------------------------------------- |
+| `loaded`    | —                             | Removes the loader spinner once the iframe is ready.                  |
+| `close`     | —                             | Tears down the iframe (unless locked by a pending `confirmed`).       |
+| `confirmed` | —                             | Marks the modal as non-closable while Stripe is processing.           |
+| `success`   | `{ paymentMethodId: string }` | **Auto-closes the modal.** Call `preventDefault()` to keep it open.   |
+| `error`     | `{ code: ErrorCode }`         | None. `ErrorCode = 'invalid_request' \| 'unauthorized' \| 'unknown'`. |
+
+#### Instance methods
+
+| Method                                      | Description                                             |
+| ------------------------------------------- | ------------------------------------------------------- |
+| `embed.close()`                             | Programmatically close the modal and remove the iframe. |
+| `embed.addEventListener(type, listener)`    | Subscribe to an event. Returns `void`.                  |
+| `embed.removeEventListener(type, listener)` | Unsubscribe.                                            |
+
 ### Inline — React
 
 ```tsx
 import { PolarPaymentMethod } from '@polar-sh/checkout/react/payment-method'
-;<PolarPaymentMethod
-  customerSessionToken={token} // or memberSessionToken
-  onSuccess={(id) => console.log('Attached:', id)}
-/>
+
+return (
+  <PolarPaymentMethod
+    sessionToken={token}
+    onSuccess={(id) => console.log('Attached:', id)}
+  />
+)
 ```
+
+#### Props
+
+| Prop           | Type                                | Default | Description                                                                       |
+| -------------- | ----------------------------------- | ------- | --------------------------------------------------------------------------------- |
+| `sessionToken` | `string`                            | —       | **Required.** Session token from `POST /v1/customer-sessions`.                    |
+| `theme`        | `'light' \| 'dark'`                 | `light` | Colour scheme.                                                                    |
+| `setAsDefault` | `boolean`                           | `true`  | Whether the new card should become the customer's default payment method.         |
+| `onLoaded`     | `() => void`                        | —       | Fires once when the iframe finishes loading and the form becomes interactive.     |
+| `onConfirmed`  | `() => void`                        | —       | Fires when the customer submits and Stripe processing starts.                     |
+| `onSuccess`    | `(paymentMethodId: string) => void` | —       | Fires after the card has been attached to the customer.                           |
+| `onError`      | `(code: ErrorCode) => void`         | —       | Fires when the iframe can't render (token missing/expired). `ErrorCode` as above. |
+| `className`    | `string`                            | —       | Applied to the wrapping `<div>`. Use it to size or position the embed.            |
+| `style`        | `React.CSSProperties`               | —       | Inline style on the wrapping `<div>`.                                             |
 
 ### Auto-init via data attribute
 
@@ -41,11 +89,12 @@ import { PolarPaymentMethod } from '@polar-sh/checkout/react/payment-method'
 <button data-polar-payment-method="polar_cst_xxx">Add payment method</button>
 ```
 
-### Tokens
+The same script also powers `PolarEmbedCheckout` triggers — one tag covers every Polar embed.
 
-`POST /v1/customer-sessions` returns one of two prefixes depending on whether the organisation uses the member model. Pass exactly one option:
+#### Attributes
 
-- `polar_cst_*` → `customerSessionToken`
-- `polar_mst_*` → `memberSessionToken`
-
-The auto-init data attribute accepts either prefix — the SDK detects it.
+| Attribute                                  | Value           | Description                                                                                        |
+| ------------------------------------------ | --------------- | -------------------------------------------------------------------------------------------------- |
+| `data-polar-payment-method`                | `string`        | **Required.** The session token. Clicking the element opens the modal.                             |
+| `data-polar-payment-method-theme`          | `light \| dark` | Optional theme override.                                                                           |
+| `data-polar-payment-method-set-as-default` | `true \| false` | Optional. Default `true`. Passing `"false"` adds the card without overriding the existing default. |

--- a/clients/packages/checkout/src/payment-method.test.ts
+++ b/clients/packages/checkout/src/payment-method.test.ts
@@ -66,7 +66,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('creates an iframe with the correct src and modal mode', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -78,9 +78,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const src = new URL(iframe!.src)
       expect(src.pathname).toBe('/embed/payment-method')
       expect(src.origin).toBe(ALLOWED_ORIGIN)
-      expect(src.searchParams.get('customer_session_token')).toBe(
-        CUSTOMER_SESSION_TOKEN,
-      )
+      expect(src.searchParams.get('session_token')).toBe(CUSTOMER_SESSION_TOKEN)
       expect(src.searchParams.get('embed')).toBe('true')
       expect(src.searchParams.get('embed_origin')).toBe(window.location.origin)
       expect(src.searchParams.get('mode')).toBe('modal')
@@ -90,7 +88,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('sets theme query parameter when provided', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
         theme: 'dark',
       })
 
@@ -106,7 +104,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('sets set_default=false when setAsDefault is explicitly false', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
         setAsDefault: false,
       })
 
@@ -121,7 +119,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('omits set_default URL param by default', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -133,9 +131,9 @@ describe('PolarEmbedPaymentMethod', () => {
       embed.close()
     })
 
-    it('uses member_session_token URL param when given a member token', async () => {
+    it('forwards a member token verbatim — no client-side type sniffing', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        memberSessionToken: 'polar_mst_test_member',
+        sessionToken: 'polar_mst_test_member',
       })
 
       dispatchLoaded()
@@ -143,34 +141,16 @@ describe('PolarEmbedPaymentMethod', () => {
 
       const iframe = document.querySelector('iframe')!
       const src = new URL(iframe.src)
-      expect(src.searchParams.get('member_session_token')).toBe(
+      expect(src.searchParams.get('session_token')).toBe(
         'polar_mst_test_member',
       )
-      expect(src.searchParams.get('customer_session_token')).toBeNull()
 
       embed.close()
     })
 
-    it('throws when neither token is provided', () => {
-      expect(() =>
-        PolarEmbedPaymentMethod.create(
-          {} as unknown as Parameters<typeof PolarEmbedPaymentMethod.create>[0],
-        ),
-      ).toThrow(/one of `customerSessionToken` or `memberSessionToken`/)
-    })
-
-    it('throws when both tokens are provided', () => {
-      expect(() =>
-        PolarEmbedPaymentMethod.create({
-          customerSessionToken: CUSTOMER_SESSION_TOKEN,
-          memberSessionToken: 'polar_mst_test_member',
-        } as unknown as Parameters<typeof PolarEmbedPaymentMethod.create>[0]),
-      ).toThrow(/only one of/)
-    })
-
     it('adds polar-no-scroll class to body', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       expect(document.body.classList.contains('polar-no-scroll')).toBe(true)
@@ -184,7 +164,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const onLoaded = vi.fn()
 
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
         onLoaded,
       })
 
@@ -201,7 +181,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('removes the iframe from the DOM', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -214,7 +194,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('removes polar-no-scroll class from body', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -230,7 +210,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('dispatches close event and removes iframe', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -249,7 +229,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('prevents close after confirmed event', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -274,7 +254,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('auto-closes the modal on success', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -303,7 +283,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('skips the default auto-close when success listener calls preventDefault', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -329,7 +309,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const successListener = vi.fn()
 
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -358,7 +338,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const errorListener = vi.fn()
 
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -386,7 +366,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('silently drops resize messages in modal mode', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -414,7 +394,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const closeListener = vi.fn()
 
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -438,7 +418,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const closeListener = vi.fn()
 
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -458,7 +438,7 @@ describe('PolarEmbedPaymentMethod', () => {
 
     it('skips the default close action when preventDefault is called', async () => {
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -484,7 +464,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const listener = vi.fn()
 
       const promise = PolarEmbedPaymentMethod.create({
-        customerSessionToken: CUSTOMER_SESSION_TOKEN,
+        sessionToken: CUSTOMER_SESSION_TOKEN,
       })
 
       dispatchLoaded()
@@ -524,25 +504,7 @@ describe('PolarEmbedPaymentMethod', () => {
       const iframe = document.querySelector('iframe')
       expect(iframe).not.toBeNull()
       const src = new URL(iframe!.src)
-      expect(src.searchParams.get('customer_session_token')).toBe(
-        CUSTOMER_SESSION_TOKEN,
-      )
-    })
-
-    it('detects member tokens and uses member_session_token URL param', () => {
-      const button = document.createElement('button')
-      button.setAttribute('data-polar-payment-method', 'polar_mst_auto_init')
-      document.body.appendChild(button)
-
-      PolarEmbedPaymentMethod.init()
-      button.click()
-
-      const iframe = document.querySelector('iframe')!
-      const src = new URL(iframe.src)
-      expect(src.searchParams.get('member_session_token')).toBe(
-        'polar_mst_auto_init',
-      )
-      expect(src.searchParams.get('customer_session_token')).toBeNull()
+      expect(src.searchParams.get('session_token')).toBe(CUSTOMER_SESSION_TOKEN)
     })
 
     it('reads theme from data-polar-payment-method-theme', () => {

--- a/clients/packages/checkout/src/payment-method.ts
+++ b/clients/packages/checkout/src/payment-method.ts
@@ -71,32 +71,14 @@ const isEmbedPaymentMethodMessage = (
   return message.type === POLAR_PAYMENT_METHOD_EVENT
 }
 
-/**
- * Discriminated union enforcing that callers pass exactly one of
- * `customerSessionToken` or `memberSessionToken`. Passing both, or
- * neither, is a compile-time error.
- */
-type EmbedPaymentMethodTokenOptions =
-  | {
-      /**
-       * A short-lived customer session token (prefix `polar_cst_`),
-       * minted server-side via `POST /v1/customer-sessions` using a
-       * Polar API key.
-       */
-      customerSessionToken: string
-      memberSessionToken?: never
-    }
-  | {
-      customerSessionToken?: never
-      /**
-       * A short-lived member session token (prefix `polar_mst_`),
-       * minted server-side via `POST /v1/customer-sessions` when the
-       * organisation has `member_model_enabled`.
-       */
-      memberSessionToken: string
-    }
-
-interface EmbedPaymentMethodBaseOptions {
+interface EmbedPaymentMethodCreateOptions {
+  /**
+   * A short-lived session token returned by
+   * `POST /v1/customer-sessions`. Pass whatever the API returned —
+   * the SDK detects the prefix (`polar_cst_` vs `polar_mst_`) and
+   * routes the request to the right endpoint internally.
+   */
+  sessionToken: string
   /**
    * Color scheme for the embed. Defaults to `light`.
    */
@@ -110,33 +92,6 @@ interface EmbedPaymentMethodBaseOptions {
    * Convenience callback fired once when the embed has loaded.
    */
   onLoaded?: (event: CustomEvent<EmbedPaymentMethodMessageLoaded>) => void
-}
-
-type EmbedPaymentMethodCreateOptions = EmbedPaymentMethodTokenOptions &
-  EmbedPaymentMethodBaseOptions
-
-const resolveSessionParam = (options: {
-  customerSessionToken?: string
-  memberSessionToken?: string
-}): {
-  name: 'customer_session_token' | 'member_session_token'
-  value: string
-} => {
-  const { customerSessionToken, memberSessionToken } = options
-  if (customerSessionToken && memberSessionToken) {
-    throw new Error(
-      'PolarEmbedPaymentMethod: pass only one of `customerSessionToken` or `memberSessionToken`, not both.',
-    )
-  }
-  if (customerSessionToken) {
-    return { name: 'customer_session_token', value: customerSessionToken }
-  }
-  if (memberSessionToken) {
-    return { name: 'member_session_token', value: memberSessionToken }
-  }
-  throw new Error(
-    'PolarEmbedPaymentMethod: one of `customerSessionToken` or `memberSessionToken` is required.',
-  )
 }
 
 const resolveEmbedBaseURL = (): string => {
@@ -193,7 +148,7 @@ class EmbedPaymentMethod {
    * @example
    * ```ts
    * const embed = await PolarEmbedPaymentMethod.create({
-   *   customerSessionToken: 'polar_cst_xxx',
+   *   sessionToken: 'polar_cst_xxx',
    *   theme: 'dark',
    * })
    *
@@ -205,8 +160,7 @@ class EmbedPaymentMethod {
   public static create(
     options: EmbedPaymentMethodCreateOptions,
   ): Promise<EmbedPaymentMethod> {
-    const session = resolveSessionParam(options)
-    const { theme, setAsDefault, onLoaded } = options
+    const { sessionToken, theme, setAsDefault, onLoaded } = options
 
     const styleSheet = document.createElement('style')
     styleSheet.innerText = `
@@ -243,7 +197,7 @@ class EmbedPaymentMethod {
     document.body.appendChild(loader)
 
     const embedURL = new URL(EMBED_PATH, resolveEmbedBaseURL())
-    embedURL.searchParams.set(session.name, session.value)
+    embedURL.searchParams.set('session_token', sessionToken)
     embedURL.searchParams.set('embed', 'true')
     embedURL.searchParams.set('embed_origin', window.location.origin)
     embedURL.searchParams.set('mode', 'modal')
@@ -404,14 +358,8 @@ class EmbedPaymentMethod {
     const setAsDefaultAttr = element.getAttribute(
       'data-polar-payment-method-set-as-default',
     )
-    // Sniff the token prefix to forward as the right option. Customer
-    // tokens use `polar_cst_`, member tokens use `polar_mst_`. Anything
-    // else falls back to customer for backward compat.
-    const sessionOption = token.startsWith('polar_mst_')
-      ? { memberSessionToken: token }
-      : { customerSessionToken: token }
     EmbedPaymentMethod.create({
-      ...sessionOption,
+      sessionToken: token,
       theme: theme ?? undefined,
       setAsDefault:
         setAsDefaultAttr === null ? undefined : setAsDefaultAttr !== 'false',

--- a/clients/packages/checkout/src/react/payment-method.test.tsx
+++ b/clients/packages/checkout/src/react/payment-method.test.tsx
@@ -25,7 +25,7 @@ const post = (
 describe('PolarPaymentMethod', () => {
   it('renders an iframe pointing at the bare embed route', () => {
     const { container } = render(
-      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+      <PolarPaymentMethod sessionToken={CUSTOMER_SESSION_TOKEN} />,
     )
 
     const iframe = container.querySelector('iframe')
@@ -34,9 +34,7 @@ describe('PolarPaymentMethod', () => {
     const src = new URL(iframe!.src)
     expect(src.pathname).toBe('/embed/payment-method')
     expect(src.origin).toBe(ALLOWED_ORIGIN)
-    expect(src.searchParams.get('customer_session_token')).toBe(
-      CUSTOMER_SESSION_TOKEN,
-    )
+    expect(src.searchParams.get('session_token')).toBe(CUSTOMER_SESSION_TOKEN)
     expect(src.searchParams.get('embed')).toBe('true')
     expect(src.searchParams.get('embed_origin')).toBe(window.location.origin)
     expect(src.searchParams.get('mode')).toBeNull()
@@ -45,7 +43,7 @@ describe('PolarPaymentMethod', () => {
   it('sets set_default=false when setAsDefault is explicitly false', () => {
     const { container } = render(
       <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        sessionToken={CUSTOMER_SESSION_TOKEN}
         setAsDefault={false}
       />,
     )
@@ -56,30 +54,27 @@ describe('PolarPaymentMethod', () => {
 
   it('omits set_default URL param by default', () => {
     const { container } = render(
-      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+      <PolarPaymentMethod sessionToken={CUSTOMER_SESSION_TOKEN} />,
     )
 
     const iframe = container.querySelector('iframe')!
     expect(new URL(iframe.src).searchParams.get('set_default')).toBeNull()
   })
 
-  it('uses member_session_token URL param when given a member token', () => {
+  it('forwards a member token verbatim — no client-side type sniffing', () => {
     const { container } = render(
-      <PolarPaymentMethod memberSessionToken="polar_mst_xyz" />,
+      <PolarPaymentMethod sessionToken="polar_mst_xyz" />,
     )
 
     const iframe = container.querySelector('iframe')!
-    const src = new URL(iframe.src)
-    expect(src.searchParams.get('member_session_token')).toBe('polar_mst_xyz')
-    expect(src.searchParams.get('customer_session_token')).toBeNull()
+    expect(new URL(iframe.src).searchParams.get('session_token')).toBe(
+      'polar_mst_xyz',
+    )
   })
 
   it('sets the theme query parameter when provided', () => {
     const { container } = render(
-      <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
-        theme="dark"
-      />,
+      <PolarPaymentMethod sessionToken={CUSTOMER_SESSION_TOKEN} theme="dark" />,
     )
 
     const iframe = container.querySelector('iframe')!
@@ -94,7 +89,7 @@ describe('PolarPaymentMethod', () => {
 
     render(
       <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        sessionToken={CUSTOMER_SESSION_TOKEN}
         onLoaded={onLoaded}
         onConfirmed={onConfirmed}
         onSuccess={onSuccess}
@@ -125,7 +120,7 @@ describe('PolarPaymentMethod', () => {
 
   it('updates iframe height in response to resize messages', () => {
     const { container } = render(
-      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+      <PolarPaymentMethod sessionToken={CUSTOMER_SESSION_TOKEN} />,
     )
 
     post({
@@ -143,7 +138,7 @@ describe('PolarPaymentMethod', () => {
 
     render(
       <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        sessionToken={CUSTOMER_SESSION_TOKEN}
         onSuccess={onSuccess}
       />,
     )
@@ -165,7 +160,7 @@ describe('PolarPaymentMethod', () => {
 
     render(
       <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        sessionToken={CUSTOMER_SESSION_TOKEN}
         onSuccess={onSuccess}
       />,
     )
@@ -181,7 +176,7 @@ describe('PolarPaymentMethod', () => {
 
   it('removes the iframe on unmount', () => {
     const { container, unmount } = render(
-      <PolarPaymentMethod customerSessionToken={CUSTOMER_SESSION_TOKEN} />,
+      <PolarPaymentMethod sessionToken={CUSTOMER_SESSION_TOKEN} />,
     )
     expect(container.querySelector('iframe')).not.toBeNull()
 
@@ -196,7 +191,7 @@ describe('PolarPaymentMethod', () => {
 
     const { rerender, container } = render(
       <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        sessionToken={CUSTOMER_SESSION_TOKEN}
         onSuccess={firstSuccess}
       />,
     )
@@ -204,7 +199,7 @@ describe('PolarPaymentMethod', () => {
 
     rerender(
       <PolarPaymentMethod
-        customerSessionToken={CUSTOMER_SESSION_TOKEN}
+        sessionToken={CUSTOMER_SESSION_TOKEN}
         onSuccess={secondSuccess}
       />,
     )

--- a/clients/packages/checkout/src/react/payment-method.tsx
+++ b/clients/packages/checkout/src/react/payment-method.tsx
@@ -49,32 +49,14 @@ const buildIframeAllow = (): string => {
   return `payment 'self' ${origins}; publickey-credentials-get 'self' ${origins};`
 }
 
-/**
- * Discriminated union enforcing that callers pass exactly one of
- * `customerSessionToken` or `memberSessionToken`. Passing both, or
- * neither, is a compile-time error.
- */
-type TokenProps =
-  | {
-      /**
-       * A short-lived customer session token (prefix `polar_cst_`),
-       * minted server-side via `POST /v1/customer-sessions` using a
-       * Polar API key.
-       */
-      customerSessionToken: string
-      memberSessionToken?: never
-    }
-  | {
-      customerSessionToken?: never
-      /**
-       * A short-lived member session token (prefix `polar_mst_`), minted
-       * server-side via `POST /v1/customer-sessions` when the
-       * organisation has `member_model_enabled`.
-       */
-      memberSessionToken: string
-    }
-
 interface PolarPaymentMethodBaseProps {
+  /**
+   * A short-lived session token returned by
+   * `POST /v1/customer-sessions`. Pass whatever the API returned —
+   * the SDK detects the prefix (`polar_cst_` vs `polar_mst_`) and
+   * routes the request to the right endpoint internally.
+   */
+  sessionToken: string
   /**
    * Color scheme for the embed. Defaults to `light`.
    */
@@ -114,7 +96,7 @@ interface PolarPaymentMethodBaseProps {
   style?: React.CSSProperties
 }
 
-export type PolarPaymentMethodProps = TokenProps & PolarPaymentMethodBaseProps
+export type PolarPaymentMethodProps = PolarPaymentMethodBaseProps
 
 /**
  * Embeds the Polar "add payment method" form as a bare, chrome-less
@@ -132,15 +114,14 @@ export type PolarPaymentMethodProps = TokenProps & PolarPaymentMethodBaseProps
  * @example
  * ```tsx
  * <PolarPaymentMethod
- *   customerSessionToken={token}
+ *   sessionToken={token}
  *   onSuccess={(id) => console.log('Attached:', id)}
  *   onError={(code) => console.error(code)}
  * />
  * ```
  */
 export const PolarPaymentMethod = ({
-  customerSessionToken,
-  memberSessionToken,
+  sessionToken,
   theme,
   setAsDefault,
   onLoaded,
@@ -163,23 +144,8 @@ export const PolarPaymentMethod = ({
     const container = containerRef.current
     if (!container) return
 
-    if (customerSessionToken && memberSessionToken) {
-      throw new Error(
-        'PolarPaymentMethod: pass only one of `customerSessionToken` or `memberSessionToken`, not both.',
-      )
-    }
-    const sessionParamName = memberSessionToken
-      ? 'member_session_token'
-      : 'customer_session_token'
-    const sessionParamValue = memberSessionToken ?? customerSessionToken
-    if (!sessionParamValue) {
-      throw new Error(
-        'PolarPaymentMethod: one of `customerSessionToken` or `memberSessionToken` is required.',
-      )
-    }
-
     const embedURL = new URL(EMBED_PATH, resolveEmbedBaseURL())
-    embedURL.searchParams.set(sessionParamName, sessionParamValue)
+    embedURL.searchParams.set('session_token', sessionToken)
     embedURL.searchParams.set('embed', 'true')
     embedURL.searchParams.set('embed_origin', window.location.origin)
     if (theme) {
@@ -229,7 +195,7 @@ export const PolarPaymentMethod = ({
       window.removeEventListener('message', messageListener)
       iframe.remove()
     }
-  }, [customerSessionToken, memberSessionToken, theme, setAsDefault])
+  }, [sessionToken, theme, setAsDefault])
 
   return <div ref={containerRef} className={className} style={style} />
 }


### PR DESCRIPTION
* Unify the `customerSessionToken` and `memberSessionToken` into just `sessionToken`, the backend will figure out the type.
* Update README with docs on supported props/params