### PR TITLE
feat: allow offboarding to denied transition in backoffice

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -576,7 +576,10 @@ class OrganizationDetailView:
                             ):
                                 text("Deny")
 
-                    elif self.org.status == OrganizationStatus.CREATED:
+                    elif self.org.status in (
+                        OrganizationStatus.CREATED,
+                        OrganizationStatus.OFFBOARDING,
+                    ):
                         with tag.div(classes="w-full"):
                             with button(
                                 variant="secondary",

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -403,6 +403,7 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
     ),
     OrganizationStatus.OFFBOARDING: frozenset(
         {
+            OrganizationStatus.DENIED,
             OrganizationStatus.BLOCKED,
         }
     ),

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3528,6 +3528,14 @@ class TestStatusTransitions:
         organization.set_status(OrganizationStatus.OFFBOARDING)
         assert organization.status == OrganizationStatus.OFFBOARDING
 
+    async def test_offboarding_can_go_to_denied(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.set_status(OrganizationStatus.DENIED)
+        assert organization.status == OrganizationStatus.DENIED
+
     @pytest.mark.parametrize(
         "current",
         [


### PR DESCRIPTION
## Summary

A teammate hit a case where an org under offboarding needed to be denied, but the transition wasn't allowed. This PR adds the `OFFBOARDING → DENIED` transition and exposes a Deny button in the backoffice for offboarding orgs, reusing the existing deny-dialog flow (reason required, audited).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included