### PR TITLE
fix: Allow org members to manage refunds

### DIFF
--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -42,6 +42,7 @@ class OrganizationPermission(StrEnum):
 
     # Sales — granted to all roles.
     sales_read = "sales:read"
+    sales_manage = "sales:manage"
 
     # Analytics.
     analytics_read = "analytics:read"
@@ -73,6 +74,7 @@ _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.customers_read,
     OrganizationPermission.customers_manage,
     OrganizationPermission.sales_read,
+    OrganizationPermission.sales_manage,
     OrganizationPermission.analytics_read,
     OrganizationPermission.analytics_manage,
     OrganizationPermission.events_ingest,
@@ -96,6 +98,7 @@ PERMISSION_DENIED_MESSAGE: dict[OrganizationPermission, str] = {
     OrganizationPermission.customers_read: "You don't have permission to view customers",
     OrganizationPermission.customers_manage: "You don't have permission to manage customers",
     OrganizationPermission.sales_read: "You don't have permission to view sales data",
+    OrganizationPermission.sales_manage: "You don't have permission to manage sales",
     OrganizationPermission.analytics_read: "You don't have permission to view analytics",
     OrganizationPermission.analytics_manage: "You don't have permission to manage analytics",
     OrganizationPermission.events_ingest: "You don't have permission to ingest events",

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -194,7 +194,7 @@ class RefundService:
             )
 
         await assert_resource_permission(
-            session, auth_subject, order, OrganizationPermission.finance_manage
+            session, auth_subject, order, OrganizationPermission.sales_manage
         )
 
         try:

--- a/server/tests/refund/test_endpoints.py
+++ b/server/tests/refund/test_endpoints.py
@@ -22,6 +22,7 @@ from polar.models.dispute import DisputeStatus
 from polar.models.order import OrderStatus
 from polar.models.refund import RefundReason, RefundStatus
 from polar.models.subscription import SubscriptionStatus
+from polar.models.user_organization import OrganizationRole
 from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession
 from polar.refund.schemas import RefundCreate
@@ -489,6 +490,42 @@ class TestCreateRefunds(StripeRefund):
         assert order.refunded_amount == order_amount
         assert order.refunded_tax_amount == order_tax_amount
         assert order.refunded
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.refunds_write}),
+    )
+    async def test_member_role_can_create_refund(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        stripe_service_mock: MagicMock,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
+
+        order, payment, transaction = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            amount=2000,
+            tax_amount=500,
+        )
+
+        order, _ = await self.create_order_refund(
+            session,
+            client,
+            stripe_service_mock,
+            order,
+            transaction,
+            amount=2000,
+            tax=500,
+        )
+        assert order.status == OrderStatus.refunded
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Org members couldn't issue refunds — refund creation was gated on the admin-only `finance_manage` permission. This PR introduces a `sales_manage` permission granted to all org roles and moves refund creation onto it. Payouts continue to gate on `finance_manage`.

## What

- Add `OrganizationPermission.sales_manage` (granted to `member`, `admin`, `owner`)
- Switch `refund_service.user_create` from `finance_manage` to `sales_manage`
- Add endpoint test that exercises refund creation as a `member`-role user

## Why

Refund listing already used the member-accessible `sales_read`, so members could see refunds but not create them. Refunds are operational customer-facing work, not finance-admin work like payouts.

## How

`finance_manage` stays admin-only and continues to gate payouts (money flowing out to the org's bank). Refunds get their own member-accessible permission under the `sales` namespace, mirroring the `*_read` / `*_manage` pattern used by customers, products, and analytics.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included