### PR TITLE
fix: Gate order/subscription/checkout mutations on sales_manage

### DIFF
--- a/server/polar/checkout/endpoints.py
+++ b/server/polar/checkout/endpoints.py
@@ -4,6 +4,8 @@ from fastapi import Depends, Path, Query, Request
 from pydantic import UUID4
 from sse_starlette.sse import EventSourceResponse
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_resource_permission
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
 from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
@@ -189,6 +191,10 @@ async def update(
 
     if checkout is None:
         raise ResourceNotFound()
+
+    await assert_resource_permission(
+        session, auth_subject, checkout, OrganizationPermission.sales_manage
+    )
 
     return await checkout_service.update(
         session, checkout, checkout_update, ip_geolocation_client

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from polar.auth.models import Anonymous, AuthSubject
 from polar.auth.permission import OrganizationPermission
-from polar.authz.service import get_accessible_org_ids
+from polar.authz.service import assert_resource_permission, get_accessible_org_ids
 from polar.checkout.guard import has_product_checkout
 from polar.checkout.schemas import (
     CheckoutConfirm,
@@ -380,6 +380,10 @@ class CheckoutService:
 
         if not product.organization.can_authenticate:
             raise NotPermitted()
+
+        await assert_resource_permission(
+            session, auth_subject, product, OrganizationPermission.sales_manage
+        )
 
         if checkout_create.amount is not None and is_custom_price(price):
             self._validate_custom_price_amount(price, checkout_create.amount, currency)

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -4,6 +4,8 @@ from fastapi import Depends, Query, Response
 from fastapi.responses import StreamingResponse
 from pydantic import UUID4
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_resource_permission
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
 from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
@@ -206,6 +208,10 @@ async def update(
     if order is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session, auth_subject, order, OrganizationPermission.sales_manage
+    )
+
     return await order_service.update(session, order, order_update)
 
 
@@ -230,6 +236,10 @@ async def generate_invoice(
 
     if order is None:
         raise ResourceNotFound()
+
+    await assert_resource_permission(
+        session, auth_subject, order, OrganizationPermission.sales_manage
+    )
 
     await order_service.trigger_invoice_generation(session, order)
 

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -5,6 +5,8 @@ import structlog
 from fastapi import Depends, Query, Response
 from fastapi.responses import StreamingResponse
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import assert_resource_permission
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
 from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
@@ -308,6 +310,13 @@ async def update(
     if subscription is None:
         raise ResourceNotFound()
 
+    await assert_resource_permission(
+        session,
+        auth_subject,
+        subscription.product,
+        OrganizationPermission.sales_manage,
+    )
+
     log.info(
         "subscription.update",
         id=id,
@@ -347,6 +356,13 @@ async def revoke(
     subscription = await subscription_service.get(session, auth_subject, id)
     if subscription is None:
         raise ResourceNotFound()
+
+    await assert_resource_permission(
+        session,
+        auth_subject,
+        subscription.product,
+        OrganizationPermission.sales_manage,
+    )
 
     log.info(
         "subscription.revoke", id=id, admin_id=auth_subject.subject.id, immediate=True


### PR DESCRIPTION
## Summary

Mutating endpoints on orders, subscriptions, and checkouts previously relied solely on the scope check plus a `sales_read` readability filter during the resource fetch. This adds an explicit `sales_manage` role-permission assertion between the fetch and the mutation, matching the refund pattern from #11733 and the conventional read/manage split used by other domains (customers, products, analytics, finance).

## What

Added `assert_resource_permission(..., sales_manage)` to:

- `PATCH /v1/orders/{id}`
- `POST /v1/orders/{id}/invoice`
- `PATCH /v1/subscriptions/{id}`
- `DELETE /v1/subscriptions/{id}`
- `POST /v1/checkouts/`
- `PATCH /v1/checkouts/{id}`

Customer-portal endpoints, internal callers (`dispute_service` cancellations, order task flows), and the customer-facing `/v1/checkouts/client/{client_secret}` route are untouched.

## Why

Refund creation (#11733) introduced `sales_manage` (member-accessible) and is currently the only sales mutation enforcing it. The other sales-adjacent writes were going through scope alone, which leaves the permission table inconsistent — a `member` could mutate orders/subscriptions/checkouts but not refunds without `sales_manage`, and now the inverse asymmetry exists post-#11733. This PR closes that loop.

`sales_read` would have functionally fit too, but allowing a read-tier permission to authorize PATCH/POST/DELETE breaks the read-XOR-write invariant the rest of the permission table observes (see `auth/permission.py`).

## How

Endpoint-level `assert_resource_permission` (matching the payouts pattern), rather than service-level. Service methods like `order_service.update`, `subscription_service.update`, `subscription_service.revoke`, and `checkout_service.update` have non-endpoint callers (customer portal, dispute handling, internal order flows) that should not run the role-permission check.

`checkout_service.create` puts the check inside the service, after product resolution — same pattern as `subscription_service.create`'s existing `customers_manage` check, since the endpoint has no pre-fetched org-scoped resource.

**Behavior:** no-op today. `sales_manage` is granted to all org roles, and `assert_resource_permission` short-circuits for organization-token subjects (see `authz/service.py:31`). The value is defense-in-depth (if a sub-member role is ever introduced) and consistency.

## Follow-ups (not in this PR)

- `POST /v1/orders/{id}/invoice` is declared on `orders:read` scope despite being a mutation. Breaking change for read-only-token consumers; tracked separately.
- `POST /v1/subscriptions/` currently uses `customers_manage` — defensible since it touches customer state, but worth aligning to `sales_manage` for consistency in a future pass.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — no new behavior to test (behavior no-op); existing 762 order/subscription/checkout tests pass unchanged
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included