### PR TITLE
fix: ensure `dev up` with tinybird works on orbstack

### DIFF
--- a/dev/cli/up_steps/04_start_infrastructure.py
+++ b/dev/cli/up_steps/04_start_infrastructure.py
@@ -40,11 +40,11 @@ def run(ctx: Context) -> bool:
         step_status(True, "Docker containers", "already running")
         return True
 
-    # Build compose command
-    compose_cmd = ["docker", "compose", "up", "-d"]
+    compose_cmd = ["docker", "compose"]
     # Include tinybird profile by default; exclude it when skip_tinybird is set
     if not ctx.skip_tinybird:
         compose_cmd.extend(["--profile", "tinybird"])
+    compose_cmd.extend(["up", "-d"])
 
     service_name = "PostgreSQL, Redis, Minio"
     if not ctx.skip_tinybird:


### PR DESCRIPTION
The `--profile` option only works on the top level of `docker compose` on orbstack.
So switch `docker compose up -d --profile tinybird` to `docker compose --profile up -d` and then everyone's happy