### PR TITLE
fix(organization): activate orgs with UNCERTAIN verdict + approved appeal

### DIFF
--- a/server/polar/models/organization_review.py
+++ b/server/polar/models/organization_review.py
@@ -73,15 +73,12 @@ class OrganizationReview(RecordModel):
     def is_approved(self) -> bool:
         """Whether the review clears the merchant to operate.
 
-        True when the verdict is PASS, or when the verdict was FAIL but the
-        appeal has been APPROVED by a human reviewer.
+        True when the verdict is PASS, or when a non-PASS verdict has been
+        APPROVED on appeal by a human reviewer.
         """
         if self.verdict == self.Verdict.PASS:
             return True
-        return (
-            self.verdict == self.Verdict.FAIL
-            and self.appeal_decision == self.AppealDecision.APPROVED
-        )
+        return self.appeal_decision == self.AppealDecision.APPROVED
 
     def __repr__(self) -> str:
         return f"OrganizationReview(id={self.id}, organization_id={self.organization_id}, verdict={self.verdict})"

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1173,6 +1173,38 @@ class TestMaybeActivate:
         assert result is False
         assert organization.status == OrganizationStatus.DENIED
 
+    async def test_activates_uncertain_verdict_with_approved_appeal(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.UNCERTAIN,
+            risk_score=50.0,
+            violated_sections=[],
+            reason="Borderline",
+            model_used="test",
+            appeal_submitted_at=datetime(2025, 2, 1, tzinfo=UTC),
+            appeal_reason="Please reconsider",
+            appeal_decision=OrganizationReview.AppealDecision.APPROVED,
+            appeal_reviewed_at=datetime(2025, 2, 2, tzinfo=UTC),
+        )
+        session.add(review)
+        await session.flush()
+
+        result = await organization_service.maybe_activate(session, organization)
+
+        assert result is True
+        assert organization.status == OrganizationStatus.ACTIVE
+
 
 @pytest.mark.asyncio
 class TestBackofficeApprove:


### PR DESCRIPTION
## Summary

`OrganizationReview.is_approved` only cleared verdict `PASS` or `FAIL` + `APPROVED` appeal. Legacy `UNCERTAIN` verdicts with an approved appeal never cleared the gate, so `OrganizationService.maybe_activate` could not promote those orgs out of `CREATED` even after identity verification (or any other onboarding webhook) fired.

## What

Loosen `is_approved` to return `True` for any non-`PASS` verdict whose appeal is `APPROVED`. Added a `TestMaybeActivate` case covering `UNCERTAIN` + `APPROVED` against a CREATED org with passing onboarding gates.

## Why

A merchant whose review verdict was `UNCERTAIN` (legacy AI output) and whose appeal had been approved by a human reviewer could complete Stripe identity verification and still see their org stuck in `CREATED`. The verdict-side gate was too narrow — `submit_appeal` already allows appeals for any non-`PASS` verdict, so the `is_approved` check should mirror that.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)