### PR TITLE
plain: set explicit httpx timeout for the GraphQL client

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -1542,6 +1542,7 @@ class PlainService:
     async def _get_plain_client(self) -> AsyncIterator[Plain]:
         async with httpx.AsyncClient(
             headers={"Authorization": f"Bearer {settings.PLAIN_TOKEN}"},
+            timeout=httpx.Timeout(10.0, connect=5.0),
             # Set a MockTransport if not enabled
             # Basically, we disable Plain requests.
             transport=(


### PR DESCRIPTION
Plain GraphQL writes were hitting httpx's 5s default and surfacing ReadTimeout in background tasks. Use a 10s read / 5s connect timeout matching the typical Plain mutation latency.

Fixes SERVER-4K9
