### PR TITLE
chore: drop OrganizationMember.is_admin from API responses

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24015,11 +24015,6 @@ export interface components {
       avatar_url: string | null
       /** @description The user's role on the organization. */
       role: components['schemas']['OrganizationRole']
-      /**
-       * Is Admin
-       * @description Whether the user has admin capability on the organization. Derived from `role`: true for `owner` or `admin`. Kept as a transitional alias; prefer reading `role` directly.
-       */
-      readonly is_admin: boolean
     }
     /** OrganizationMemberInvite */
     OrganizationMemberInvite: {

--- a/server/polar/user_organization/schemas.py
+++ b/server/polar/user_organization/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import AliasPath, Field, computed_field
+from pydantic import AliasPath, Field
 
 from polar.kit.email import EmailStrDNS
 from polar.kit.schemas import Schema
@@ -22,17 +22,6 @@ class OrganizationMember(Schema):
     role: OrganizationRole = Field(
         description="The user's role on the organization.",
     )
-
-    @computed_field(  # type: ignore[prop-decorator]
-        description=(
-            "Whether the user has admin capability on the organization. "
-            "Derived from `role`: true for `owner` or `admin`. "
-            "Kept as a transitional alias; prefer reading `role` directly."
-        ),
-    )
-    @property
-    def is_admin(self) -> bool:
-        return self.role in {OrganizationRole.owner, OrganizationRole.admin}
 
 
 class OrganizationMemberInvite(Schema):

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -607,7 +607,6 @@ class TestSetMemberRole:
         json = response.json()
         assert json["user_id"] == str(user_second.id)
         assert json["role"] == "admin"
-        assert json["is_admin"] is True
 
     @pytest.mark.auth
     @pytest.mark.keep_session_state
@@ -630,7 +629,6 @@ class TestSetMemberRole:
 
         assert response.status_code == 200
         assert response.json()["role"] == "member"
-        assert response.json()["is_admin"] is False
 
     @pytest.mark.auth
     async def test_owner_role_in_body_rejected(


### PR DESCRIPTION
## Summary

**Related Issue**: #11403

Phase 5 of the RBAC rollout — retires the transitional `is_admin` field on `OrganizationMember` from API responses.

## What

- Drop the `is_admin` computed field from `OrganizationMember` (`server/polar/user_organization/schemas.py`)
- Update the two `TestSetMemberRole` assertions that read `is_admin` from the role-update response
- Regenerate `clients/packages/client/src/v1.ts` so the SDK no longer types the field

`Account.admin_id` ↔ `owner` dual-write **stays in place** per the issue AC; that retires in Phase 6 (#11404).

## Why

Phase 4 (#11402, merged in 528932643) migrated the dashboard from the boolean `is_admin` to the typed `role` and the `hasPermission` hook. The field was kept on the API as a transitional alias while the frontend caught up. With Phase 4 shipped and no remaining frontend callsites referencing it, the alias is dead weight on the public schema — leaving it in place risks new code grabbing the legacy boolean instead of the role/permission system that's meant to replace it.

## How

**Stale-tab strategy: accept the brief break** (RFC default). Any tab still on the pre-Phase-4 bundle hitting `/v1/organizations/{id}/members` will see `is_admin === undefined` on each member. Practical impact is minimal — the surviving callsites would only fire inside a refresh-pending tab, and Phase 4 has been live in `main` for long enough that weekly-active sessions have largely rotated.

Removing the `computed_field` is sufficient — there's no Pydantic deprecation step needed because the alias has no database backing; it was always derived from `role` at serialization time.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included