### PR TITLE
server/auth: add EmailOTP and TOTP factors

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1451,6 +1451,142 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/auth/start': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Start */
+    post: operations['auth:start']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Status */
+    get: operations['auth:status']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/complete': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Complete */
+    get: operations['auth:complete']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/email-otp/request': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Email Otp Request */
+    post: operations['auth:email_otp_request']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/email-otp/verify': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Email Otp Verify */
+    post: operations['auth:email_otp_verify']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/totp/enroll': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Totp Enroll */
+    post: operations['auth:totp_enroll']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/totp/enable': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Totp Enable */
+    post: operations['auth:totp_enable']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/auth/totp/verify': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Totp Verify */
+    post: operations['auth:totp_verify']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/oauth2/': {
     parameters: {
       query?: never
@@ -6532,6 +6668,18 @@ export interface components {
        * @description Whether the value is required for this custom field.
        */
       required: boolean
+    }
+    /** AuthenticationSession */
+    AuthenticationSession: {
+      /** Identity Id */
+      identity_id: string | null
+      /** Available Factors */
+      available_factors: components['schemas']['Factor'][]
+    }
+    /** AuthenticationSessionStart */
+    AuthenticationSessionStart: {
+      /** Return To */
+      return_to?: string | null
     }
     /** AuthorizeOrganization */
     AuthorizeOrganization: {
@@ -18399,6 +18547,16 @@ export interface components {
       benefit_id: string
       file: components['schemas']['FileDownload']
     }
+    /** EmailOTPRequest */
+    EmailOTPRequest: {
+      /** Email */
+      email: string
+    }
+    /** EmailOTPVerify */
+    EmailOTPVerify: {
+      /** Code */
+      code: string
+    }
     /** EmailUpdateRequest */
     EmailUpdateRequest: {
       /**
@@ -18843,6 +19001,8 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** @enum {string} */
+    Factor: 'email_otp' | 'totp'
     /** Feedback */
     Feedback: {
       /**
@@ -19207,6 +19367,17 @@ export interface components {
       exp: number
       /** Iat */
       iat: number
+    }
+    /** InvalidAuthenticationSession */
+    InvalidAuthenticationSession: {
+      /**
+       * Error
+       * @example InvalidAuthenticationSession
+       * @constant
+       */
+      error: 'InvalidAuthenticationSession'
+      /** Detail */
+      detail: string
     }
     /** LLMMetadata */
     LLMMetadata: {
@@ -29791,6 +29962,24 @@ export interface components {
       | components['schemas']['BalanceRefundReversalEvent']
       | components['schemas']['BalanceDisputeEvent']
       | components['schemas']['BalanceDisputeReversalEvent']
+    /** TOTPEnable */
+    TOTPEnable: {
+      /** Code */
+      code: string
+    }
+    /** TOTPEnrollment */
+    TOTPEnrollment: {
+      /** Secret */
+      secret: string
+      /** Algorithm */
+      algorithm: string
+      /** Digits */
+      digits: number
+      /** Period */
+      period: number
+      /** Provisioning Uri */
+      provisioning_uri: string
+    }
     /**
      * TaxBehavior
      * @enum {string}
@@ -35022,6 +35211,249 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+    }
+  }
+  'auth:start': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AuthenticationSessionStart']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AuthenticationSession']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'auth:status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AuthenticationSession']
+        }
+      }
+      /** @description No active authentication session */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['InvalidAuthenticationSession']
+        }
+      }
+    }
+  }
+  'auth:complete': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
+  'auth:email_otp_request': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EmailOTPRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'auth:email_otp_verify': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EmailOTPVerify']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AuthenticationSession']
+        }
+      }
+      /** @description Invalid or expired OTP */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'auth:totp_enroll': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TOTPEnrollment']
+        }
+      }
+    }
+  }
+  'auth:totp_enable': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TOTPEnable']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'auth:totp_verify': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TOTPEnable']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AuthenticationSession']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
         }
       }
     }
@@ -54926,6 +55358,9 @@ export const eventTypesSortPropertyValues: ReadonlyArray<
   'last_seen',
   '-last_seen',
 ]
+export const factorValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['Factor']
+> = ['email_otp', 'totp']
 export const feedbackStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['FeedbackStatus']
 > = ['new', 'triaged']

--- a/server/polar/auth/authentication_session.py
+++ b/server/polar/auth/authentication_session.py
@@ -1,0 +1,155 @@
+import typing
+import uuid
+
+from fastapi import Depends, Request, Response
+from reauth.authentication_session import (
+    AuthenticationSession as AuthenticationSessionDataclass,
+)
+from reauth.authentication_session import (
+    AuthenticationSessionService as AuthenticationSessionServiceBase,
+)
+from reauth.authentication_session import (
+    ExpiredSessionException,
+    InvalidSessionTokenException,
+)
+from reauth.factors import FactorBase
+from sqlalchemy import delete, select, update
+
+from polar.config import settings
+from polar.exceptions import PolarError
+from polar.kit.http import is_localhost
+from polar.models import AuthenticationSession
+from polar.postgres import AsyncSession, get_db_session
+
+from .factors import get_factors
+from .schemas import AuthenticationSession as AuthenticationSessionSchema
+
+TOKEN_PREFIX = "polar_auth_session_"
+
+
+class AuthenticationSessionException(PolarError): ...
+
+
+class InvalidAuthenticationSession(AuthenticationSessionException):
+    def __init__(self) -> None:
+        super().__init__("Invalid or missing authentication session token.", 401)
+
+
+class AuthenticationSessionService(AuthenticationSessionServiceBase):
+    def __init__(
+        self, session: AsyncSession, factors: set[FactorBase[typing.Any]]
+    ) -> None:
+        self.session = session
+        super().__init__(
+            hash_secret=settings.SECRET,
+            factors=factors,
+            token_prefix=TOKEN_PREFIX,
+            lifetime=settings.AUTHENTICATION_SESSION_TTL,
+        )
+
+    async def insert(
+        self, authentication_session: AuthenticationSessionDataclass
+    ) -> uuid.UUID:
+        authentication_session_orm = AuthenticationSession(
+            token_hash=authentication_session.token_hash,
+            expires_at=authentication_session.expires_at,
+            step=authentication_session.step,
+            authentication_method_references=authentication_session.amr,
+            used_factors=authentication_session.used_factors,
+            context=authentication_session.context,
+            identity_id=authentication_session.identity_id,
+        )
+        self.session.add(authentication_session_orm)
+        await self.session.flush()
+        return authentication_session_orm.id
+
+    async def get_by_token_hash(
+        self, token_hash: str
+    ) -> AuthenticationSessionDataclass | None:
+        statement = select(AuthenticationSession).where(
+            AuthenticationSession.token_hash == token_hash
+        )
+        result = await self.session.execute(statement)
+        authentication_session = result.scalar_one_or_none()
+        if authentication_session is None:
+            return None
+        return authentication_session.to_dataclass()
+
+    async def update(
+        self, authentication_session: AuthenticationSessionDataclass
+    ) -> None:
+        statement = (
+            update(AuthenticationSession)
+            .where(AuthenticationSession.id == authentication_session.id)
+            .values(
+                token_hash=authentication_session.token_hash,
+                expires_at=authentication_session.expires_at,
+                step=authentication_session.step,
+                authentication_method_references=authentication_session.amr,
+                used_factors=authentication_session.used_factors,
+                identity_id=authentication_session.identity_id,
+            )
+        )
+        await self.session.execute(statement)
+        await self.session.flush()
+
+    async def delete(
+        self, authentication_session: AuthenticationSessionDataclass
+    ) -> None:
+        statement = delete(AuthenticationSession).where(
+            AuthenticationSession.id == authentication_session.id
+        )
+        await self.session.execute(statement)
+        await self.session.flush()
+
+    async def set_cookie(
+        self, request: Request, response: Response, value: str, expires_at: int
+    ) -> None:
+        response.set_cookie(
+            key=settings.AUTHENTICATION_SESSION_COOKIE_KEY,
+            value=value,
+            domain=settings.AUTHENTICATION_SESSION_COOKIE_DOMAIN,
+            path="/",
+            httponly=True,
+            secure=not is_localhost(request),
+            samesite="lax",
+            expires=expires_at,
+        )
+
+    async def to_schema(
+        self, authentication_session: AuthenticationSessionDataclass
+    ) -> AuthenticationSessionSchema:
+        factors = await self.get_available_factors(authentication_session)
+        return AuthenticationSessionSchema.from_session_and_factors(
+            authentication_session, factors
+        )
+
+    async def get_from_request(
+        self, request: Request
+    ) -> AuthenticationSessionDataclass:
+        token = request.cookies.get(settings.AUTHENTICATION_SESSION_COOKIE_KEY)
+        if token is None:
+            raise InvalidSessionTokenException()
+        return await self.get_by_token(token)
+
+
+async def get_authentication_session_service(
+    session: AsyncSession = Depends(get_db_session),
+    factors: set[FactorBase[typing.Any]] = Depends(get_factors),
+) -> AuthenticationSessionService:
+    return AuthenticationSessionService(session, factors)
+
+
+async def get_authentication_session(
+    request: Request,
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+) -> AuthenticationSessionDataclass:
+    token = request.cookies.get(settings.AUTHENTICATION_SESSION_COOKIE_KEY)
+    if token is None:
+        raise InvalidAuthenticationSession()
+    try:
+        return await authentication_session_service.get_by_token(token)
+    except (InvalidSessionTokenException, ExpiredSessionException) as e:
+        raise InvalidAuthenticationSession() from e

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -1,25 +1,254 @@
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
+from reauth.authentication_session import (
+    AuthenticationSession,
+    FactorsRemainingException,
+    IdentityNotAttachedException,
+)
+from reauth.factors.email_otp import ExpiredOTPException, InvalidOTPException
+from reauth.factors.totp import (
+    AlreadyEnabledTOTPException,
+    AlreadyEnrolledTOTPException,
+    InvalidTOTPCodeException,
+    NotEnrolledTOTPException,
+)
 
+from polar.authz.dependencies import AuthorizeWebUserWrite
+from polar.exceptions import NotPermitted
 from polar.models import UserSession as UserSession
 from polar.openapi import APITag
 from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
+from polar.user.repository import UserRepository
+from polar.user.service import user as user_service
 
+from .authentication_session import (
+    AuthenticationSessionService,
+    InvalidAuthenticationSession,
+    get_authentication_session,
+    get_authentication_session_service,
+)
+from .factors import (
+    EmailOTPFactor,
+    TOTPFactor,
+    get_email_otp_factor,
+    get_totp_factor,
+)
+from .schemas import AuthenticationSession as AuthenticationSessionSchema
+from .schemas import (
+    AuthenticationSessionStart,
+    EmailOTPRequest,
+    EmailOTPVerify,
+    TOTPEnable,
+    TOTPEnrollment,
+)
 from .service import auth as auth_service
 
-router = APIRouter(tags=["auth", APITag.private])
+router = APIRouter(prefix="/auth", tags=["auth", APITag.private])
 
 
-class ImpersonateResponse(BaseModel):
-    success: bool
-    message: str
-
-
-@router.get("/auth/logout")
+@router.get("/logout")
 async def logout(
     request: Request, session: AsyncSession = Depends(get_db_session)
 ) -> RedirectResponse:
     user_session = await auth_service.authenticate(session, request)
     return await auth_service.get_logout_response(session, request, user_session)
+
+
+@router.post("/start", status_code=201)
+async def start(
+    authentication_session_start: AuthenticationSessionStart,
+    request: Request,
+    response: Response,
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+) -> AuthenticationSessionSchema:
+    token, authentication_session = await authentication_session_service.start(
+        return_to=authentication_session_start.return_to
+    )
+    await authentication_session_service.set_cookie(
+        request, response, token, authentication_session.expires_at
+    )
+    return await authentication_session_service.to_schema(authentication_session)
+
+
+@router.get(
+    "/status",
+    responses={
+        401: {
+            "description": "No active authentication session",
+            "model": InvalidAuthenticationSession.schema(),
+        }
+    },
+)
+async def status(
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+) -> AuthenticationSessionSchema:
+    return await authentication_session_service.to_schema(authentication_session)
+
+
+@router.get("/complete")
+async def complete(
+    request: Request,
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> RedirectResponse:
+    try:
+        identity_id, _ = await authentication_session_service.complete(
+            authentication_session
+        )
+    except (IdentityNotAttachedException, FactorsRemainingException) as e:
+        raise NotPermitted("Authentication session cannot be completed") from e
+
+    user_repository = UserRepository.from_session(session)
+    user = await user_repository.get_by_id(identity_id)
+    if user is None:
+        raise NotPermitted("User not found for authenticated identity")
+
+    return_to = (
+        authentication_session.context.get("return_to")
+        if authentication_session.context
+        else None
+    )
+
+    response = await auth_service.get_login_response(
+        session,
+        request,
+        user,
+        return_to=return_to,
+    )
+    await authentication_session_service.set_cookie(request, response, "", 0)
+    return response
+
+
+@router.post("/email-otp/request", status_code=202)
+async def email_otp_request(
+    email_otp_request: EmailOTPRequest,
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+    email_otp_factor: EmailOTPFactor = Depends(get_email_otp_factor),
+) -> None:
+    factors = await authentication_session_service.get_available_factors(
+        authentication_session
+    )
+    if email_otp_factor not in factors:
+        raise NotPermitted("Email OTP factor not available for this session")
+
+    await email_otp_factor.request(email_otp_request, authentication_session)
+
+
+@router.post(
+    "/email-otp/verify",
+    responses={
+        403: {"description": "Invalid or expired OTP", "model": NotPermitted.schema()}
+    },
+)
+async def email_otp_verify(
+    email_otp_verify: EmailOTPVerify,
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+    email_otp_factor: EmailOTPFactor = Depends(get_email_otp_factor),
+    session: AsyncSession = Depends(get_db_session),
+) -> AuthenticationSessionSchema:
+    factors = await authentication_session_service.get_available_factors(
+        authentication_session
+    )
+    if email_otp_factor not in factors:
+        raise NotPermitted("Email OTP factor not available for this session")
+
+    try:
+        identity_id, email = await email_otp_factor.consume(
+            email_otp_verify.code, authentication_session.id
+        )
+    except (InvalidOTPException, ExpiredOTPException) as e:
+        raise NotPermitted("Invalid or expired OTP") from e
+
+    # New user
+    if identity_id is None:
+        user, _ = await user_service.get_by_email_or_create(session, email)
+        user.email_verified = True
+        session.add(user)
+        identity_id = user.id
+
+    authentication_session = await authentication_session_service.advance(
+        authentication_session, identity_id, email_otp_factor
+    )
+    return await authentication_session_service.to_schema(authentication_session)
+
+
+@router.post("/totp/enroll", status_code=201)
+async def totp_enroll(
+    auth_subject: AuthorizeWebUserWrite,
+    totp_factor: TOTPFactor = Depends(get_totp_factor),
+) -> TOTPEnrollment:
+    user = auth_subject.subject
+
+    try:
+        enrollment = await totp_factor.enroll(user.id)
+    except AlreadyEnrolledTOTPException as e:
+        raise HTTPException(409, "TOTP factor already enrolled") from e
+
+    return TOTPEnrollment(
+        secret=enrollment.secret,
+        algorithm=enrollment.algorithm,
+        digits=enrollment.code_length,
+        period=enrollment.time_step,
+        provisioning_uri=enrollment.get_provisioning_uri(user.email, "Polar"),
+    )
+
+
+@router.post("/totp/enable", status_code=202)
+async def totp_enable(
+    enable: TOTPEnable,
+    auth_subject: AuthorizeWebUserWrite,
+    totp_factor: TOTPFactor = Depends(get_totp_factor),
+) -> None:
+    user = auth_subject.subject
+    try:
+        await totp_factor.enable(user.id, enable.code)
+    except NotEnrolledTOTPException as e:
+        raise NotPermitted("TOTP factor not enrolled") from e
+    except AlreadyEnabledTOTPException as e:
+        raise NotPermitted("TOTP factor already enabled") from e
+    except InvalidTOTPCodeException as e:
+        raise NotPermitted("Invalid TOTP code") from e
+    return None
+
+
+@router.post("/totp/verify")
+async def totp_verify(
+    enable: TOTPEnable,
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_authentication_session_service
+    ),
+    totp_factor: TOTPFactor = Depends(get_totp_factor),
+) -> AuthenticationSessionSchema:
+    factors = await authentication_session_service.get_available_factors(
+        authentication_session
+    )
+    if totp_factor not in factors:
+        raise NotPermitted("TOTP factor not available for this session")
+
+    try:
+        await totp_factor.verify(authentication_session.identity_id, enable.code)
+    except NotEnrolledTOTPException as e:
+        raise NotPermitted("TOTP factor not enrolled") from e
+    except InvalidTOTPCodeException as e:
+        raise NotPermitted("Invalid TOTP code") from e
+
+    authentication_session = await authentication_session_service.advance(
+        authentication_session, authentication_session.identity_id, totp_factor
+    )
+    return await authentication_session_service.to_schema(authentication_session)

--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -1,0 +1,192 @@
+import typing
+import uuid
+from math import ceil
+
+import structlog
+from fastapi import Depends
+from reauth.authentication_session import AuthenticationSession
+from reauth.factors import FactorBase
+from reauth.factors.email_otp import EmailOTP as EmailOTPDataclass
+from reauth.factors.email_otp import EmailOTPEnrollment
+from reauth.factors.email_otp import EmailOTPFactor as EmailOTPFactorBase
+from reauth.factors.totp import TOTPEnrollment as TOTPEnrollmentDataclass
+from reauth.factors.totp import TOTPFactor as TOTPFactorBase
+from sqlalchemy import delete, select, update
+
+from polar.config import settings
+from polar.email.schemas import LoginCodeEmail, LoginCodeProps
+from polar.email.sender import enqueue_email_template
+from polar.kit.utils import utc_now
+from polar.logging import Logger
+from polar.models import EmailOTP, TOTPEnrollment
+from polar.postgres import AsyncSession, get_db_session
+from polar.user.repository import UserRepository
+
+if typing.TYPE_CHECKING:
+    from .schemas import EmailOTPRequest
+
+log: Logger = structlog.get_logger()
+
+
+class EmailOTPFactor(EmailOTPFactorBase):
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        super().__init__(
+            hash_secret=settings.SECRET,
+            code_length=settings.LOGIN_CODE_LENGTH,
+            lifetime=settings.LOGIN_CODE_TTL,
+        )
+
+    async def get_enrollment(self, identity_id: uuid.UUID) -> EmailOTPEnrollment | None:
+        user_repository = UserRepository.from_session(self.session)
+        user = await user_repository.get_by_id(identity_id)
+        if user is None:
+            return None
+        return EmailOTPEnrollment(id=user.id, email=user.email, identity_id=identity_id)
+
+    async def insert(self, email_otp: EmailOTPDataclass) -> uuid.UUID:
+        email_otp_orm = EmailOTP(
+            code_hash=email_otp.code_hash,
+            expires_at=email_otp.expires_at,
+            email=email_otp.email,
+            identity_id=email_otp.identity_id,
+            authentication_session_id=email_otp.authentication_session_id,
+        )
+        self.session.add(email_otp_orm)
+        await self.session.flush()
+        return email_otp_orm.id
+
+    async def get_by_code_hash_and_authentication_session_id(
+        self, code_hash: str, authentication_session_id: uuid.UUID
+    ) -> EmailOTPDataclass | None:
+        statement = select(EmailOTP).where(
+            EmailOTP.code_hash == code_hash,
+            EmailOTP.authentication_session_id == authentication_session_id,
+        )
+        result = await self.session.execute(statement)
+        login_code_orm = result.scalar_one_or_none()
+        if login_code_orm is None:
+            return None
+        return login_code_orm.to_dataclass()
+
+    async def delete(self, email_otp: EmailOTPDataclass) -> None:
+        statement = delete(EmailOTP).where(EmailOTP.id == email_otp.id)
+        await self.session.execute(statement)
+        await self.session.flush()
+
+    async def delete_by_authentication_session_id(
+        self, authentication_session_id: uuid.UUID
+    ) -> None:
+        statement = delete(EmailOTP).where(
+            EmailOTP.authentication_session_id == authentication_session_id
+        )
+        await self.session.execute(statement)
+        await self.session.flush()
+
+    async def request(
+        self, request: "EmailOTPRequest", authentication_session: AuthenticationSession
+    ) -> None:
+        user_repository = UserRepository.from_session(self.session)
+        user = await user_repository.get_by_email(request.email)
+        if user is None:
+            return
+
+        code, email_otp = await self.create(
+            identity_id=user.id,
+            email=request.email,
+            authentication_session_id=authentication_session.id,
+        )
+
+        delta = email_otp.expires_at - int(utc_now().timestamp())
+        code_lifetime_minutes = int(ceil(delta / 60))
+
+        domain = settings.frontend_hostname
+        subject = "Sign in to Polar"
+        enqueue_email_template(
+            LoginCodeEmail(
+                props=LoginCodeProps(
+                    email=email_otp.email,
+                    code=code,
+                    code_lifetime_minutes=code_lifetime_minutes,
+                    domain=domain,
+                )
+            ),
+            to_email_addr=email_otp.email,
+            subject=subject,
+        )
+
+        if settings.is_development():
+            log.info(
+                "\n"
+                "╔══════════════════════════════════════════════════════════╗\n"
+                "║                                                          ║\n"
+                f"║                   🔑 LOGIN CODE: {code}                  ║\n"
+                "║                                                          ║\n"
+                "╚══════════════════════════════════════════════════════════╝"
+            )
+
+
+class TOTPFactor(TOTPFactorBase):
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        super().__init__()
+
+    async def get_enrollment(
+        self, identity_id: uuid.UUID
+    ) -> TOTPEnrollmentDataclass | None:
+        statement = select(TOTPEnrollment).where(
+            TOTPEnrollment.identity_id == identity_id
+        )
+        result = await self.session.execute(statement)
+        totp_orm = result.scalar_one_or_none()
+        if totp_orm is None:
+            return None
+        return totp_orm.to_dataclass()
+
+    async def insert(self, totp: TOTPEnrollmentDataclass) -> uuid.UUID:
+        totp_orm = TOTPEnrollment(
+            enabled=totp.enabled,
+            secret=totp.secret,
+            algorithm=totp.algorithm,
+            code_length=totp.code_length,
+            time_step=totp.time_step,
+            last_verified_time_step=totp.last_verified_time_step,
+            identity_id=totp.identity_id,
+        )
+        self.session.add(totp_orm)
+        await self.session.flush()
+        return totp_orm.id
+
+    async def update(self, totp: TOTPEnrollmentDataclass) -> None:
+        statement = (
+            update(TOTPEnrollment)
+            .where(TOTPEnrollment.id == totp.id)
+            .values(
+                enabled=totp.enabled,
+                algorithm=totp.algorithm,
+                code_length=totp.code_length,
+                time_step=totp.time_step,
+                last_verified_time_step=totp.last_verified_time_step,
+            )
+        )
+        await self.session.execute(statement)
+        await self.session.flush()
+
+
+async def get_email_otp_factor(
+    session: AsyncSession = Depends(get_db_session),
+) -> EmailOTPFactor:
+    return EmailOTPFactor(session)
+
+
+async def get_totp_factor(
+    session: AsyncSession = Depends(get_db_session),
+) -> TOTPFactor:
+    return TOTPFactor(session)
+
+
+async def get_factors(
+    email_otp_factor: EmailOTPFactor = Depends(get_email_otp_factor),
+    totp_factor: TOTPFactor = Depends(get_totp_factor),
+) -> set[FactorBase[typing.Any]]:
+    return {email_otp_factor, totp_factor}

--- a/server/polar/auth/schemas.py
+++ b/server/polar/auth/schemas.py
@@ -1,0 +1,59 @@
+import typing
+from collections.abc import Iterable
+
+from pydantic import UUID4
+from reauth.authentication_session import (
+    AuthenticationSession as AuthenticationSessionDataclass,
+)
+from reauth.factors import FactorBase
+
+from polar.kit.http import ReturnTo
+from polar.kit.schemas import Schema
+
+type Factor = typing.Literal["email_otp", "totp"]
+
+
+class AuthenticationSessionStart(Schema):
+    return_to: ReturnTo | None = None
+
+
+class AuthenticationSession(Schema):
+    identity_id: UUID4 | None
+    available_factors: list[Factor]
+
+    @classmethod
+    def from_session_and_factors(
+        cls,
+        authentication_session: AuthenticationSessionDataclass,
+        factors: Iterable[FactorBase[typing.Any]],
+    ) -> typing.Self:
+        return cls(
+            identity_id=authentication_session.identity_id,
+            available_factors=[
+                typing.cast(Factor, factor.identifier) for factor in factors
+            ],
+        )
+
+
+class EmailOTPRequest(Schema):
+    email: str
+
+
+class EmailOTPVerify(Schema):
+    code: str
+
+
+class TOTPEnrollment(Schema):
+    secret: str
+    algorithm: str
+    digits: int
+    period: int
+    provisioning_uri: str
+
+
+class TOTPEnable(Schema):
+    code: str
+
+
+class TOTPVerify(Schema):
+    code: str

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -121,6 +121,11 @@ class Settings(BaseSettings):
         "http://127.0.0.1:8000/v1/checkout-links/{client_secret}/redirect"
     )
 
+    # Authentication session
+    AUTHENTICATION_SESSION_TTL: timedelta = timedelta(minutes=15)
+    AUTHENTICATION_SESSION_COOKIE_KEY: str = "polar_auth_session"
+    AUTHENTICATION_SESSION_COOKIE_DOMAIN: str = "127.0.0.1"
+
     # User session
     USER_SESSION_TTL: timedelta = timedelta(days=31)
     USER_SESSION_COOKIE_KEY: str = "polar_session"

--- a/server/polar/kit/http.py
+++ b/server/polar/kit/http.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import anyio
 import httpx
-from fastapi import Depends, Query
+from fastapi import Depends, Query, Request
 from pydantic import AfterValidator, HttpUrl, PlainSerializer, ValidationError
 from safe_redirect_url import url_has_allowed_host_and_scheme
 
@@ -171,3 +171,7 @@ def add_query_parameters(url: str, **kwargs: str | list[str]) -> str:
             fragment,
         )
     )
+
+
+def is_localhost(request: Request) -> bool:
+    return request.url.hostname in {"127.0.0.1", "localhost"}


### PR DESCRIPTION

Add new routes for email OTP and TOTP factors.

Deliberately not reusing the existing login routes to not break existing flows, until we're not completely done here.
