### PR TITLE
polar_self: Retry until invoice is ready

### DIFF
--- a/server/polar/external_event/service.py
+++ b/server/polar/external_event/service.py
@@ -38,6 +38,8 @@ class ExternalEventService:
         task_name: str,
         external_id: str,
         data: dict[str, Any],
+        *,
+        delay: int | None = None,
     ) -> ExternalEvent:
         repository = ExternalEventRepository.from_session(session)
 
@@ -51,7 +53,7 @@ class ExternalEventService:
             ),
             flush=True,
         )
-        enqueue_job(task_name, event.id)
+        enqueue_job(task_name, event.id, delay=delay)
         return event
 
     async def resend(self, event: ExternalEvent) -> None:

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -49,7 +49,11 @@ from polar_sdk.models.polarerror import PolarError
 from polar.config import settings
 from polar.exceptions import PolarError as InternalPolarError
 
-from .exceptions import PolarSelfPaymentMethodInUse, PolarSelfPaymentMethodNotFound
+from .exceptions import (
+    PolarSelfNotPaidOrder,
+    PolarSelfPaymentMethodInUse,
+    PolarSelfPaymentMethodNotFound,
+)
 
 
 class PolarSelfClientError(InternalPolarError):
@@ -235,20 +239,22 @@ class PolarSelfClient:
                 _raise_network_error(span, e, "get_order_invoice")
             return invoice.url
 
-    async def trigger_order_invoice_generation(self, *, order_id: str) -> bool:
-        """Trigger PDF generation for an order. Returns True if accepted,
-        False if the order isn't billable (e.g. not paid yet, missing billing
-        details) — in which case no invoice will ever be produced."""
+    async def trigger_order_invoice_generation(self, *, order_id: str) -> None:
+        """Trigger PDF generation for an order.
+
+        Raises ``PolarSelfNotPaidOrder`` if the API returns 422 — the order's
+        payment hasn't settled yet, and the caller should retry later.
+        """
         with logfire.span(
             "polar.trigger_order_invoice_generation", order_id=order_id
         ) as span:
             try:
                 await self._sdk.orders.generate_invoice_async(id=order_id)
-                return True
             except PolarError as e:
                 if e.status_code == 422:
-                    span.set_attribute("not_billable", True)
-                    return False
+                    span.set_attribute("not_paid", True)
+                    span.set_attribute("error.body", str(e.body))
+                    raise PolarSelfNotPaidOrder(order_id) from e
                 _raise_error(span, e, "trigger_order_invoice_generation")
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "trigger_order_invoice_generation")

--- a/server/polar/integrations/polar/endpoints.py
+++ b/server/polar/integrations/polar/endpoints.py
@@ -26,6 +26,10 @@ IMPLEMENTED_WEBHOOKS = {
     "order.created",
 }
 
+# Defer order.created handling so payment settlement and invoice generation
+# have a chance to complete before we try to attach the invoice PDF.
+ORDER_CREATED_DELAY_MS = 60_000
+
 
 @router.post("/webhook", status_code=202, name="integrations.polar.webhook")
 async def webhook(
@@ -57,6 +61,12 @@ async def webhook(
         raise HTTPException(status_code=400)
 
     task_name = f"polar_self.webhook.{event_type}"
+    delay = ORDER_CREATED_DELAY_MS if event_type == "order.created" else None
     await external_event_service.enqueue(
-        session, ExternalEventSource.polar, task_name, delivery_id, payload
+        session,
+        ExternalEventSource.polar,
+        task_name,
+        delivery_id,
+        payload,
+        delay=delay,
     )

--- a/server/polar/integrations/polar/exceptions.py
+++ b/server/polar/integrations/polar/exceptions.py
@@ -81,3 +81,9 @@ class PolarSelfInvoiceNotReady(PolarSelfWebhookError):
     def __init__(self, order_id: str) -> None:
         super().__init__(f"Invoice for order {order_id!r} not yet generated.")
         self.order_id = order_id
+
+
+class PolarSelfNotPaidOrder(PolarSelfWebhookError):
+    def __init__(self, order_id: str) -> None:
+        super().__init__(f"Order {order_id!r} is not paid yet.")
+        self.order_id = order_id

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -26,7 +26,7 @@ from polar.email.sender import Attachment, enqueue_email_template
 from polar.integrations.plain.service import plain as plain_service
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession, AsyncSession
-from polar.worker import enqueue_job, get_retries
+from polar.worker import enqueue_job
 
 from .client import get_client
 from .exceptions import (
@@ -35,6 +35,7 @@ from .exceptions import (
     PolarSelfNoActiveSubscription,
     PolarSelfNotApproved,
     PolarSelfNotConfigured,
+    PolarSelfNotPaidOrder,
     PolarSelfOrderNotFound,
     PolarSelfPlanNotFound,
     PolarSelfWebhookError,
@@ -496,7 +497,12 @@ class PolarSelfService:
     async def handle_order_created_event(
         self, payload: WebhookOrderCreatedPayload
     ) -> None:
-        order = payload.data
+        # The webhook payload reflects the order at creation time; fields like
+        # ``is_invoice_generated`` flip to True later, so refetch over the API.
+        client = get_client()
+        order = await client.get_order(order_id=payload.data.id)
+        if order is None:
+            return
 
         if order.billing_reason not in (
             OrderBillingReason.SUBSCRIPTION_CREATE,
@@ -505,7 +511,10 @@ class PolarSelfService:
         ):
             return
 
-        client = get_client()
+        # Free orders (100% discount, $0 plans) shouldn't trigger an email.
+        if order.net_amount == 0:
+            return
+
         contacts = await client.list_billing_contacts(customer_id=order.customer.id)
         recipients = sorted({contact.email for contact in contacts if contact.email})
         if not recipients:
@@ -520,17 +529,18 @@ class PolarSelfService:
             template_name = "polar_self_subscription_confirmation"
             subject = f"You're now on {product_name}"
 
-        # Trigger invoice generation, then GET on each retry until the PDF
-        # is written. If POST is rejected (order not billable) or billing
-        # details are missing, no invoice will ever exist, then we can send without it.
         attachments: list[Attachment] | None = None
         invoice_expected = bool(order.billing_name and order.billing_address)
-        if invoice_expected and get_retries() == 0:
-            invoice_expected = await client.trigger_order_invoice_generation(
-                order_id=order.id
-            )
-
         if invoice_expected:
+            if not order.is_invoice_generated:
+                # Kick off PDF generation if the API hasn't done so yet, then
+                # retry — generation runs asynchronously on Polar's side.
+                try:
+                    await client.trigger_order_invoice_generation(order_id=order.id)
+                except PolarSelfNotPaidOrder as e:
+                    raise PolarSelfInvoiceNotReady(order.id) from e
+                raise PolarSelfInvoiceNotReady(order.id)
+
             invoice_url = await client.get_order_invoice(order_id=order.id)
             if invoice_url is None:
                 raise PolarSelfInvoiceNotReady(order.id)

--- a/server/tests/external_event/test_service.py
+++ b/server/tests/external_event/test_service.py
@@ -28,7 +28,7 @@ class TestEnqueue:
         assert event.task_name == "task_name"
         assert event.external_id == "EXTERNAL_EVENT_ID"
 
-        enqueue_job_mock.assert_called_once_with("task_name", event.id)
+        enqueue_job_mock.assert_called_once_with("task_name", event.id, delay=None)
 
     async def test_already_existing(
         self,

--- a/server/tests/integrations/polar/test_endpoints.py
+++ b/server/tests/integrations/polar/test_endpoints.py
@@ -139,6 +139,55 @@ def _subscription_event(event_type: str) -> dict[str, Any]:
     }
 
 
+_ORDER: dict[str, Any] = {
+    "id": "00000000-0000-0000-0000-000000000020",
+    "created_at": "2026-01-01T00:00:00Z",
+    "modified_at": None,
+    "status": "paid",
+    "paid": True,
+    "subtotal_amount": 2000,
+    "discount_amount": 0,
+    "net_amount": 2000,
+    "tax_amount": 0,
+    "total_amount": 2000,
+    "applied_balance_amount": 0,
+    "due_amount": 2000,
+    "refunded_amount": 0,
+    "refunded_tax_amount": 0,
+    "refundable_amount": 2000,
+    "refundable_tax_amount": 0,
+    "receipt_number": None,
+    "currency": "usd",
+    "billing_reason": "subscription_cycle",
+    "billing_name": None,
+    "billing_address": None,
+    "invoice_number": "POLAR-0001",
+    "is_invoice_generated": True,
+    "customer_id": "00000000-0000-0000-0000-000000000002",
+    "product_id": "00000000-0000-0000-0000-0000000000c1",
+    "discount_id": None,
+    "subscription_id": "00000000-0000-0000-0000-000000000001",
+    "checkout_id": None,
+    "metadata": {},
+    "platform_fee_amount": 0,
+    "platform_fee_currency": None,
+    "customer": _SUBSCRIPTION["customer"],
+    "product": _SUBSCRIPTION["product"],
+    "discount": None,
+    "subscription": None,
+    "items": [],
+    "description": "Pro subscription",
+}
+
+
+def _order_event(event_type: str) -> dict[str, Any]:
+    return {
+        "type": event_type,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "data": _ORDER,
+    }
+
+
 def _sign(
     payload: dict[str, Any], *, msg_id: str = "msg_test"
 ) -> tuple[bytes, dict[str, str]]:
@@ -258,6 +307,26 @@ class TestWebhook:
         assert call.args[2] == f"polar_self.webhook.{event_type}"
         assert call.args[3] == f"msg_{event_type}"
         assert call.args[4] == payload
+        assert call.kwargs["delay"] is None
+
+    async def test_order_created_is_enqueued_with_delay(
+        self,
+        client: AsyncClient,
+        enqueue_mock: AsyncMock,
+    ) -> None:
+        # Defer order.created processing so payment settlement and invoice
+        # generation have time to complete on Polar's side.
+        payload = _order_event("order.created")
+        body, headers = _sign(payload, msg_id="msg_order.created")
+
+        response = await client.post(WEBHOOK_URL, content=body, headers=headers)
+
+        assert response.status_code == 202
+        enqueue_mock.assert_awaited_once()
+        call = enqueue_mock.await_args
+        assert call is not None
+        assert call.args[2] == "polar_self.webhook.order.created"
+        assert call.kwargs["delay"] == 60_000
 
     async def test_subscription_revoked_is_ignored(
         self,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -13,14 +13,17 @@ from polar_sdk.models import (
     SubscriptionProrationBehavior,
     WebhookBenefitGrantCreatedPayload,
     WebhookBenefitGrantRevokedPayload,
+    WebhookOrderCreatedPayload,
 )
 from pytest_mock import MockerFixture
 
 from polar.config import settings
 from polar.integrations.polar.exceptions import (
+    PolarSelfInvoiceNotReady,
     PolarSelfNoActiveSubscription,
     PolarSelfNotApproved,
     PolarSelfNotConfigured,
+    PolarSelfNotPaidOrder,
     PolarSelfOrderNotFound,
     PolarSelfPlanNotFound,
     PolarSelfWebhookError,
@@ -1153,52 +1156,69 @@ class TestChangePlan:
         client_mock.update_subscription_product.assert_not_awaited()
 
 
-def _make_order(
+def _order_dict(
     *,
     id: str = "ord_1",
     customer_id: str = _CUSTOMER_ID,
     product_id: str = "prod_1",
     status: str = "paid",
-) -> Order:
-    return Order.model_validate(
+    net_amount: int = 2000,
+    billing_reason: str = "subscription_cycle",
+    billing_name: str | None = None,
+    billing_address: dict[str, Any] | None = None,
+    is_invoice_generated: bool = True,
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "created_at": "2026-01-01T00:00:00Z",
+        "modified_at": None,
+        "status": status,
+        "paid": status == "paid",
+        "subtotal_amount": net_amount,
+        "discount_amount": 0,
+        "net_amount": net_amount,
+        "tax_amount": 0,
+        "total_amount": net_amount,
+        "applied_balance_amount": 0,
+        "due_amount": net_amount,
+        "refunded_amount": 0,
+        "refunded_tax_amount": 0,
+        "refundable_amount": net_amount,
+        "refundable_tax_amount": 0,
+        "receipt_number": None,
+        "currency": "usd",
+        "billing_reason": billing_reason,
+        "billing_name": billing_name,
+        "billing_address": billing_address,
+        "invoice_number": "POLAR-0001",
+        "is_invoice_generated": is_invoice_generated,
+        "customer_id": customer_id,
+        "product_id": product_id,
+        "discount_id": None,
+        "subscription_id": "00000000-0000-0000-0000-000000000001",
+        "checkout_id": None,
+        "metadata": {},
+        "platform_fee_amount": 0,
+        "platform_fee_currency": None,
+        "customer": _CUSTOMER_DICT,
+        "product": _make_product(id=product_id).model_dump(mode="json"),
+        "discount": None,
+        "subscription": None,
+        "items": [],
+        "description": "Pro subscription",
+    }
+
+
+def _make_order(**kwargs: Any) -> Order:
+    return Order.model_validate(_order_dict(**kwargs))
+
+
+def _make_order_created_payload(**kwargs: Any) -> WebhookOrderCreatedPayload:
+    return WebhookOrderCreatedPayload.model_validate(
         {
-            "id": id,
-            "created_at": "2026-01-01T00:00:00Z",
-            "modified_at": None,
-            "status": status,
-            "paid": status == "paid",
-            "subtotal_amount": 2000,
-            "discount_amount": 0,
-            "net_amount": 2000,
-            "tax_amount": 0,
-            "total_amount": 2000,
-            "applied_balance_amount": 0,
-            "due_amount": 2000,
-            "refunded_amount": 0,
-            "refunded_tax_amount": 0,
-            "refundable_amount": 2000,
-            "refundable_tax_amount": 0,
-            "receipt_number": None,
-            "currency": "usd",
-            "billing_reason": "subscription_cycle",
-            "billing_name": None,
-            "billing_address": None,
-            "invoice_number": "POLAR-0001",
-            "is_invoice_generated": True,
-            "customer_id": customer_id,
-            "product_id": product_id,
-            "discount_id": None,
-            "subscription_id": "00000000-0000-0000-0000-000000000001",
-            "checkout_id": None,
-            "metadata": {},
-            "platform_fee_amount": 0,
-            "platform_fee_currency": None,
-            "customer": _CUSTOMER_DICT,
-            "product": _make_product(id=product_id).model_dump(mode="json"),
-            "discount": None,
-            "subscription": None,
-            "items": [],
-            "description": "Pro subscription",
+            "type": "order.created",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "data": _order_dict(**kwargs),
         }
     )
 
@@ -1315,3 +1335,216 @@ class TestGetOrderInvoiceUrl:
 
         assert url == "https://example.com/inv.pdf"
         orders_client_mock.get_order_invoice.assert_awaited_once_with(order_id="ord_1")
+
+
+_BILLING_ADDRESS = {
+    "country": "US",
+    "line1": "1 Market St",
+    "line2": None,
+    "postal_code": "94105",
+    "city": "San Francisco",
+    "state": "CA",
+}
+
+
+def _make_contact(email: str) -> MagicMock:
+    contact = MagicMock()
+    contact.email = email
+    return contact
+
+
+@pytest.fixture
+def order_webhook_client_mock(mocker: MockerFixture) -> MagicMock:
+    client = MagicMock()
+    client.get_order = AsyncMock()
+    client.list_billing_contacts = AsyncMock(
+        return_value=[_make_contact("billing@example.com")]
+    )
+    client.trigger_order_invoice_generation = AsyncMock()
+    client.get_order_invoice = AsyncMock(return_value="https://example.com/inv.pdf")
+    mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+    return client
+
+
+@pytest.fixture
+def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("polar.integrations.polar.service.enqueue_email_template")
+
+
+@pytest.mark.asyncio
+class TestHandleOrderCreatedEvent:
+    async def test_ignores_non_subscription_billing_reasons(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = _make_order(
+            billing_reason="purchase"
+        )
+        payload = _make_order_created_payload(billing_reason="purchase")
+
+        await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.list_billing_contacts.assert_not_awaited()
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_when_order_not_found(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = None
+        payload = _make_order_created_payload()
+
+        await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.list_billing_contacts.assert_not_awaited()
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_when_net_amount_is_zero(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        # Free orders ($0 plans or 100%-discounted) shouldn't notify or attach
+        # an invoice — we'd email customers about an order they never paid for.
+        order_webhook_client_mock.get_order.return_value = _make_order(net_amount=0)
+        payload = _make_order_created_payload(net_amount=0)
+
+        await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.list_billing_contacts.assert_not_awaited()
+        order_webhook_client_mock.trigger_order_invoice_generation.assert_not_awaited()
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_when_no_billing_contacts(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = _make_order()
+        order_webhook_client_mock.list_billing_contacts.return_value = []
+        payload = _make_order_created_payload()
+
+        await polar_self.handle_order_created_event(payload)
+
+        enqueue_email_mock.assert_not_called()
+
+    async def test_sends_email_without_invoice_when_billing_details_missing(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = _make_order(
+            billing_name=None, billing_address=None
+        )
+        payload = _make_order_created_payload()
+
+        await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.trigger_order_invoice_generation.assert_not_awaited()
+        order_webhook_client_mock.get_order_invoice.assert_not_awaited()
+        enqueue_email_mock.assert_called_once()
+        assert enqueue_email_mock.call_args.kwargs["attachments"] is None
+
+    async def test_attaches_invoice_when_already_generated(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = _make_order(
+            billing_name="Acme Inc",
+            billing_address=_BILLING_ADDRESS,
+            is_invoice_generated=True,
+        )
+        payload = _make_order_created_payload()
+
+        await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.trigger_order_invoice_generation.assert_not_awaited()
+        order_webhook_client_mock.get_order_invoice.assert_awaited_once_with(
+            order_id="ord_1"
+        )
+        enqueue_email_mock.assert_called_once()
+        attachments = enqueue_email_mock.call_args.kwargs["attachments"]
+        assert attachments == [
+            {
+                "remote_url": "https://example.com/inv.pdf",
+                "filename": "POLAR-0001.pdf",
+            }
+        ]
+
+    async def test_triggers_generation_and_retries_when_not_yet_generated(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = _make_order(
+            billing_name="Acme Inc",
+            billing_address=_BILLING_ADDRESS,
+            is_invoice_generated=False,
+        )
+        payload = _make_order_created_payload()
+
+        with pytest.raises(PolarSelfInvoiceNotReady):
+            await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.trigger_order_invoice_generation.assert_awaited_once_with(
+            order_id="ord_1"
+        )
+        enqueue_email_mock.assert_not_called()
+
+    async def test_retries_when_invoice_generation_returns_not_paid(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        # NotPaidOrder (422) means payment hasn't settled yet — retry rather
+        # than silently sending the email without an invoice attached.
+        order_webhook_client_mock.get_order.return_value = _make_order(
+            billing_name="Acme Inc",
+            billing_address=_BILLING_ADDRESS,
+            is_invoice_generated=False,
+        )
+        order_webhook_client_mock.trigger_order_invoice_generation.side_effect = (
+            PolarSelfNotPaidOrder("ord_1")
+        )
+        payload = _make_order_created_payload()
+
+        with pytest.raises(PolarSelfInvoiceNotReady):
+            await polar_self.handle_order_created_event(payload)
+
+        enqueue_email_mock.assert_not_called()
+
+    async def test_retries_when_invoice_url_is_none(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        order_webhook_client_mock.get_order.return_value = _make_order(
+            billing_name="Acme Inc",
+            billing_address=_BILLING_ADDRESS,
+            is_invoice_generated=True,
+        )
+        order_webhook_client_mock.get_order_invoice.return_value = None
+        payload = _make_order_created_payload()
+
+        with pytest.raises(PolarSelfInvoiceNotReady):
+            await polar_self.handle_order_created_event(payload)
+
+        enqueue_email_mock.assert_not_called()
+
+    async def test_uses_fresh_order_payload_from_api(
+        self,
+        order_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        # The webhook payload's net_amount could be stale; the fresh fetch is
+        # the source of truth — here, the fresh order is free, so we skip.
+        order_webhook_client_mock.get_order.return_value = _make_order(net_amount=0)
+        payload = _make_order_created_payload(net_amount=2000)
+
+        await polar_self.handle_order_created_event(payload)
+
+        order_webhook_client_mock.get_order.assert_awaited_once_with(order_id="ord_1")
+        enqueue_email_mock.assert_not_called()


### PR DESCRIPTION
Defer ``polar_self.webhook.order.created`` processing by one minute via Dramatiq's built-in delay so payment settlement has time to complete.

 - Refactor the handler to refetch the order over the API (the webhook payload's ``is_invoice_generated`` will be stale upon retries)
 - Skip the email entirely for free orders (``net_amount == 0``)
 - Retry rather than silently sending the email without an invoice attached when the order isn't paid yet (422 ``NotPaidOrder``) or the PDF hasn't been written.