### PR TITLE
Update documentation

### DIFF
--- a/docs/merchant-of-record/fees.mdx
+++ b/docs/merchant-of-record/fees.mdx
@@ -1,60 +1,93 @@
 ---
 title: "Fees"
-description: "Transparent fees at a 20% discount vs. other MoRs"
+description: "Transparent, public pricing — pick the plan that fits"
 ---
 
-Transaction Fees
------------------------
+## Plans
 
-All transactions on Polar come with a small fee of 4% + 40¢ - applied to the entire transaction amount.
+Polar offers a free Starter plan plus three optional paid plans — Pro, Growth, and Scale — that lower your variable rate and prioritize your support inquiries. You can switch between plans anytime, and your rate adjusts immediately.
 
-Polar is currently built on Stripe, and we cover their 2.9% + 30¢ fee from ours. However, they impose a few additional fees for certain transactions that we need to pass on.
+| Plan | Monthly fee | Per transaction | Support |
+| --- | --- | --- | --- |
+| **Starter** | Free | 5% + 50¢ | Standard Support |
+| **Pro** | $20 /mo | 3.8% + 40¢ | Prioritized Support |
+| **Growth** | $100 /mo | 3.6% + 35¢ | Prioritized Support |
+| **Scale** | $400 /mo | 3.4% + 30¢ | Slack + Prioritized Support |
 
-### **Additional Fees**
+The paid plans replace the per-transaction Merchant of Record premium with a fixed monthly fee and a lower variable rate.
 
-* +1.5% for international cards (non-US)
-* +0.5% for subscription payments
-* *We also reserve the right to pass on any other fees Stripe might impose in the future*
+### When does a paid plan pay off?
 
-**Example**
+Each paid plan crosses over to save you money at a predictable monthly sales threshold.
 
-Let's look at an example breakdown with all these additional fees applied. Below is a payment of a $30 subscription from Sweden (25% VAT).
+| Plan | Breakeven vs. Starter |
+| --- | --- |
+| **Pro** | ~$1,379 /mo in sales |
+| **Growth** | ~$5,634 /mo in sales |
+| **Scale** | ~$19,048 /mo in sales |
 
+Below your plan's threshold, a lower tier is the better deal. Above it, the paid plan saves money — and you get faster support on top.
+
+## Early Member
+
+Organizations created before **May 27, 2026** stay on the Early Member rate indefinitely. This was the rate we offered while Polar was catching up on feature parity with other Merchant of Record providers, and we've committed to honoring it for everyone who signed up under it.
+
+| Monthly fee | Per transaction | Subscription fee |
+| --- | --- | --- |
+| Free | 4% + 40¢ | +0.5% |
+
+**One trade-off worth understanding:** Early Member is yours forever as long as you stay on it. The moment you upgrade to a paid plan, Early Member is retired for that organization. You can still switch freely between the paid plans afterwards, but downgrading to Starter lands you on the new 5% + 50¢ rate, not your original Early Member rate.
+
+Organizations created on or after May 27, 2026 start on Starter (5% + 50¢). This applies to new organizations even if they're created by customers who signed up earlier.
+
+## Additional Fees
+
+These apply on top of your plan's per-transaction fee.
+
+* **+1.5%** for international cards (non-US)
+* **+0.5%** for subscription payments — **Early Member only**. Starter, Pro, Growth, and Scale have no separate subscription fee.
+* *We also reserve the right to pass on any other fees Stripe might impose in the future.*
+
+### Example
+
+Below is a $30 purchase from Sweden (25% VAT) paid with an international card.
 
 | Item | Amount |
 | --- | --- |
 | Product Price | $30 |
 | VAT (25%) | $7.5 |
 | **Total Transaction Value** | **$37.5** |
-| Transaction Fee (4% + 40¢) | $1.9 |
-| International Card (+1.5%) | $0.56 |
-| Subscription (+0.5%) | $0.19 |
-| **Total Fees (Before Payout)** | **$2.65** |
 
-### Refunds
+Here's how the fees on that $37.5 transaction compare across plans.
+
+| Plan | Transaction Fee | International (+1.5%) | Total Fees |
+| --- | --- | --- | --- |
+| **Starter** (5% + 50¢) | $2.38 | $0.56 | **$2.94** |
+| **Pro** (3.8% + 40¢) | $1.83 | $0.56 | **$2.39** |
+| **Growth** (3.6% + 35¢) | $1.70 | $0.56 | **$2.26** |
+| **Scale** (3.4% + 30¢) | $1.58 | $0.56 | **$2.14** |
+
+## Refunds
 
 You can issue both full or partial refunds on Polar to your customers. However, the initial transaction fees are not refunded to you since credit card networks and PSPs charge them regardless of a future refund.
 
-Please note: Polar reserves the right to issue refunds at our own discretion up to 60 days after the purchase as part of our efforts to continuously and proactively reduce disputes & chargebacks which costs you $15/dispute. We only leverage this right for this purpose and in the interest of reducing chargebacks and fees for you.
+Please note: Polar reserves the right to issue refunds at our own discretion up to 60 days after the purchase as part of our efforts to continuously and proactively reduce disputes & chargebacks which cost you $15/dispute. We only leverage this right for this purpose and in the interest of reducing chargebacks and fees for you.
 
-### Dispute/Chargeback Fees
+[Learn more about refunds →](/features/refunds)
+
+## Dispute/Chargeback Fees
 
 Sometimes, customers can open a **dispute/chargeback** via their bank for a purchase. **Disputes cost $15 per dispute** regardless of outcome and is deducted from your balance directly. This fee is charged by the underlying credit card networks & PSPs regardless of outcome and therefore something we cannot refund.
 
 However, we continuously work to proactively reduce the rate of chargebacks across Polar to be at or lower than industry standards.
 
-
-
 Credit card networks impose monitoring programs, penalties and higher chargeback costs for sellers with high chargeback rates (~0.7%+). Since Polar is the Merchant of Record, we therefore always monitor and proactively prevent our rate coming close to these thresholds.
 
 Therefore, we might need to intervene and even suspend your account unless swift and proactive measures are taken to reduce chargebacks to an acceptable industry standard.
 
+## Payout Fees
 
-
-Payout Fees
-------------------
-
-While payouts may incur fees charged by our payout provider (Stripe), Polar does not add any extra fees or markup. These are strictly Stripe’s fees, and Polar does not profit from them.
+While payouts may incur fees charged by our payout provider (Stripe), Polar does not add any extra fees or markup. These are strictly Stripe's fees, and Polar does not profit from them.
 
 In addition, Polar offers manual withdrawals for developers. Keeping you in control of when to issue payouts.
 
@@ -66,8 +99,6 @@ In addition, Polar offers manual withdrawals for developers. Keeping you in cont
 * 0.25% + $0.25 per payout
 * Cross border fees (currency conversion): 0.25% (EU) - 1% in other countries.
 
-Volume pricing
----------------------
+## Volume pricing
 
-Large or fast-growing business? We can offer custom pricing to better fit your needs. [Reach out to us](/support).
-
+Large or fast-growing business? The published Scale plan is our cheapest public rate. If you need something custom on top of that, [reach out to us](/support).


### PR DESCRIPTION
## Summary

Restructures the fees documentation to introduce a new tiered pricing model with four plans (Starter, Pro, Growth, Scale) while preserving the Early Member legacy rate for existing customers.

## What

- **New pricing structure**: Replaced flat 4% + 40¢ fee with tiered plans offering lower per-transaction rates in exchange for monthly fees
- **Plan details**: Added Starter (free, 5% + 50¢), Pro ($20/mo, 3.8% + 40¢), Growth ($100/mo, 3.6% + 35¢), and Scale ($400/mo, 3.4% + 30¢)
- **Breakeven calculator**: Added table showing at what monthly sales threshold each paid plan becomes cost-effective
- **Early Member legacy rate**: Documented the 4% + 40¢ rate for organizations created before May 27, 2026, with clear explanation of the one-way upgrade path
- **Improved examples**: Updated transaction fee examples to show comparisons across all plans using a real-world international transaction scenario
- **Clearer structure**: Reorganized content with better headings and removed subscription fee from non-Early Member plans
- **Support tiers**: Added support level differentiation across plans (Standard vs. Prioritized, with Slack access on Scale)

## Why

This change communicates Polar's new pricing model to customers and clarifies the transition from the legacy Early Member rate to the new tiered system. It helps customers understand:
- Which plan fits their business size
- When upgrading to a paid plan becomes financially beneficial
- That existing customers retain their favorable Early Member rate indefinitely (unless they upgrade)
- How fees compare across different transaction types and plans

## How

- Restructured the page with a Plans section leading with the pricing table
- Added a "When does a paid plan pay off?" section with breakeven thresholds
- Created a dedicated Early Member section explaining the legacy rate and upgrade implications
- Enhanced the example to show fee comparisons across all plans for the same transaction
- Clarified that subscription fees only apply to Early Member, not newer plans
- Updated volume pricing section to reference the Scale plan as the baseline for custom negotiations

## Checklist

- [x] This PR addresses a single concern (pricing documentation restructure)
- [x] The diff is reasonably sized and easy to review
- [x] No code changes required (documentation only)
- [x] No testing needed (documentation update)

https://claude.ai/code/session_017NTwm1ceq43Jeqc5rEvbfF