### PR TITLE
server/order: use account currency to determine platform_fee_currency

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1848,7 +1848,8 @@ class OrderService:
         order.platform_fee_amount = sum(
             incoming.amount for _, incoming in platform_fee_transactions
         )
-        order.platform_fee_currency = platform_fee_transactions[0][0].currency
+        # Settlement currency in which we compute the balances
+        order.platform_fee_currency = account.currency
         session.add(order)
         await self._on_order_updated(session, order=order, previous_status=order.status)
 


### PR DESCRIPTION
Fix #11778

- server/order: use account currency to determine platform_fee_currency
