### PR TITLE
Skip name prefill for team customers in checkout

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -567,6 +567,9 @@ class CheckoutService:
                 "tax_id",
             )
             for attribute in prefill_attributes:
+                # A team customer's name refers to the team, not the purchaser.
+                if attribute == "name" and checkout.customer.type == CustomerType.team:
+                    continue
                 checkout_attribute = f"customer_{attribute}"
                 if getattr(checkout, checkout_attribute) is None:
                     setattr(

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -559,7 +559,7 @@ class CheckoutService:
         )
 
         if checkout.customer is not None:
-            prefill_attributes = (
+            prefill_attributes: tuple[str, ...] = (
                 "email",
                 "billing_name",
                 "billing_address",

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -561,15 +561,14 @@ class CheckoutService:
         if checkout.customer is not None:
             prefill_attributes = (
                 "email",
-                "name",
                 "billing_name",
                 "billing_address",
                 "tax_id",
             )
+            # A team customer's name refers to the team, not the purchaser.
+            if checkout.customer.type != CustomerType.team:
+                prefill_attributes += ("name",)
             for attribute in prefill_attributes:
-                # A team customer's name refers to the team, not the purchaser.
-                if attribute == "name" and checkout.customer.type == CustomerType.team:
-                    continue
                 checkout_attribute = f"customer_{attribute}"
                 if getattr(checkout, checkout_attribute) is None:
                     setattr(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -67,6 +67,7 @@ from polar.models import (
 )
 from polar.models.checkout import CheckoutStatus
 from polar.models.custom_field import CustomFieldType
+from polar.models.customer import CustomerType
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.order import OrderBillingReasonInternal
 from polar.models.organization import OrganizationStatus
@@ -1575,6 +1576,45 @@ class TestCreate:
             checkout.payment_processor_metadata["customer_session_client_secret"]
             == "STRIPE_CUSTOMER_SESSION_SECRET"
         )
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_valid_team_customer_skips_name_prefill(
+        self,
+        stripe_service_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        stripe_service_mock.create_customer_session.return_value = SimpleNamespace(
+            client_secret="STRIPE_CUSTOMER_SESSION_SECRET",
+        )
+
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        price = product_one_time.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+
+        checkout = await checkout_service.create(
+            session,
+            CheckoutPriceCreate(
+                product_price_id=price.id,
+                customer_id=customer.id,
+            ),
+            auth_subject,
+        )
+
+        assert checkout.customer == customer
+        assert checkout.customer_email == customer.email
+        assert checkout.customer_name is None
+        assert checkout.customer_billing_address == customer.billing_address
+        assert checkout.customer_tax_id == customer.tax_id
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),


### PR DESCRIPTION
## Summary

[Context in Slack](https://polar-olw4768.slack.com/archives/C0APUNCDYL8/p1779288266024009)

Prevent team customer names from being prefilled in checkout, since a team customer's name refers to the team organization rather than the individual purchaser.

## What

- Added logic to skip the `name` attribute when prefilling checkout customer data for team-type customers
- Added test case `test_valid_team_customer_skips_name_prefill` to verify team customers don't have their name prefilled
- Imported `CustomerType` model to support the type check

## Why

Team customers represent organizations/teams rather than individuals. Prefilling the team name as the customer name in checkout is incorrect—the purchaser's name should either be collected separately or left blank. This change ensures team customers are handled appropriately during the checkout creation flow.

## How

Modified `checkout_service.create()` to check if a customer is of type `team` before prefilling the `name` attribute. If the customer is a team, the name prefill is skipped while other attributes (email, billing address, tax ID) are still prefilled normally.

## Checklist

- [x] This PR addresses a single concern (skip name prefill for team customers)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (added `test_valid_team_customer_skips_name_prefill`)
- [ ] Linting and type checking pass (to be verified by CI)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01Gcd9WZ9WfA1od3tkThV8ve