### PR TITLE
Get plan description from metafield

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -223,7 +223,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
               name={customer.email ?? customer.name ?? '—'}
             />
             <div className="fw-medium overflow-hidden text-ellipsis">
-              {customer.email ?? '—'}
+              {customer.name || customer.email || '—'}
             </div>
           </div>
         )

--- a/server/polar/integrations/polar/schemas.py
+++ b/server/polar/integrations/polar/schemas.py
@@ -107,7 +107,11 @@ class OrganizationPlan(Schema):
         return cls(
             product_id=product.id,
             name=product.name,
-            description=product.description,
+            description=(
+                str(metadata["description"])
+                if "description" in metadata
+                else product.description
+            ),
             recurring_interval=(
                 product.recurring_interval.value
                 if product.recurring_interval is not None

--- a/server/scripts/seed_polar_for_polar.py
+++ b/server/scripts/seed_polar_for_polar.py
@@ -117,6 +117,7 @@ PRODUCTS: list[dict[str, object]] = [
         "metadata": {
             "custom": False,
             "order": 2,
+            "description": "For entrepreneurs & early teams.",
             "features": "All features on Free, Prioritized Support",
         },
         "benefits": ["Transaction Fee (Tier 2)", "Support (Tier 2)"],
@@ -129,6 +130,7 @@ PRODUCTS: list[dict[str, object]] = [
             "custom": False,
             "order": 3,
             "highlight": True,
+            "description": "For scaling startups.",
             "features": "All features on Pro, Prioritized Support",
         },
         "benefits": ["Transaction Fee (Tier 3)", "Support (Tier 3)"],
@@ -140,6 +142,7 @@ PRODUCTS: list[dict[str, object]] = [
         "metadata": {
             "custom": False,
             "order": 4,
+            "description": "For fast growing businesses.",
             "features": "All features on Growth, Slack Channel, P1 Support",
         },
         "benefits": ["Transaction Fee (Tier 4)", "Support (Tier 4)"],


### PR DESCRIPTION
* Get plan description from metafield (with temporary product description fallback) to get rid of the checkout description
* Show customer name primarily on subscription page

<img width="1155" height="445" alt="Monosnap Polar | Scale 2026-05-20 16-56-36" src="https://github.com/user-attachments/assets/db5a7732-f79d-4bad-a37b-fe95497d4c7c" />
