### PR TITLE
Clarify pricing and subscription payment messaging

### DIFF
--- a/clients/apps/web/src/components/Landing/features/FinancePage.tsx
+++ b/clients/apps/web/src/components/Landing/features/FinancePage.tsx
@@ -130,7 +130,7 @@ export const FinancePage = () => {
           {
             title: 'Subscription payments',
             description:
-              '+0.5% on recurring charges for Early Member accounts. No subscription surcharge on Starter, Pro, Growth, or Scale.',
+              'No surcharge on recurring charges. Subscription payments are billed at the same rate as one-off payments.',
           },
           {
             title: 'Refunds',

--- a/clients/apps/web/src/components/Landing/resources/WhyPolarPage.tsx
+++ b/clients/apps/web/src/components/Landing/resources/WhyPolarPage.tsx
@@ -201,11 +201,11 @@ export const WhyPolarPage = () => {
       <ResourceSection id="pricing" title="Pricing">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-2">
-            <h3>Transparent, published pricing</h3>
+            <h3>Transparent pricing</h3>
             <p className="dark:text-polar-300 text-gray-500">
-              Polar posts every rate publicly. Start free on Starter (5% + 50¢),
-              or upgrade to Pro, Growth, or Scale for lower fees and prioritized
-              support. No sales process required.
+              Start free on Starter (5% + 50¢), or upgrade to Pro, Growth, or
+              Scale for lower fees and prioritized support. No sales process
+              required.
             </p>
           </div>
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

Updates pricing and subscription payment messaging on the landing page and finance page to be clearer and more accurate.

## What

- **WhyPolarPage.tsx**: Simplified "Transparent, published pricing" heading to "Transparent pricing" and removed redundant mention of "Polar posts every rate publicly" from the description
- **FinancePage.tsx**: Updated subscription payment description to clarify that there is no surcharge on recurring charges and that subscription payments are billed at the same rate as one-off payments

## Why

The previous messaging was either redundant (the heading and description both mentioned publishing rates) or potentially confusing (the subscription payment description mentioned "Early Member accounts" which may not be current terminology). These changes make the value proposition clearer and more directly communicate the pricing structure to users.

## How

Updated the text content in two landing page components to be more concise and accurate.

## Checklist

- [x] This PR addresses a single concern (messaging clarification)
- [x] The diff is reasonably sized and easy to review
- [x] No testing needed (content-only changes)

https://claude.ai/code/session_018SN71buTUsu3kgNQTsmJ5u