### PR TITLE
Expose metadata types in product create

### DIFF
--- a/clients/apps/web/src/components/Products/ProductMetadataForm.tsx
+++ b/clients/apps/web/src/components/Products/ProductMetadataForm.tsx
@@ -1,8 +1,16 @@
-import { FormField, FormLabel } from '@polar-sh/ui/components/ui/form'
+import { FormField } from '@polar-sh/ui/components/ui/form'
 
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
+import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import Input from '@polar-sh/ui/components/atoms/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@polar-sh/ui/components/atoms/Select'
 import {
   FormControl,
   FormItem,
@@ -11,6 +19,81 @@ import {
 import { useCallback } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import { ProductFormType } from './ProductForm/ProductForm'
+
+type MetadataValue = NonNullable<schemas['ProductCreate']['metadata']>[string]
+type MetadataValueType = 'string' | 'number' | 'boolean'
+
+const getValueType = (value: MetadataValue): MetadataValueType => {
+  if (typeof value === 'number') return 'number'
+  if (typeof value === 'boolean') return 'boolean'
+  return 'string'
+}
+
+const defaultValueForType = (type: MetadataValueType): MetadataValue => {
+  switch (type) {
+    case 'number':
+      return 0
+    case 'boolean':
+      return false
+    default:
+      return ''
+  }
+}
+
+const MetadataValueInput = ({
+  type,
+  value,
+  onChange,
+}: {
+  type: MetadataValueType
+  value: MetadataValue
+  onChange: (value: MetadataValue) => void
+}) => {
+  if (type === 'boolean') {
+    return (
+      <Select
+        value={value === true ? 'true' : 'false'}
+        onValueChange={(v) => onChange(v === 'true')}
+      >
+        <SelectTrigger className="flex-1 font-mono">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem className="font-mono" value="true">
+            true
+          </SelectItem>
+          <SelectItem className="font-mono" value="false">
+            false
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  if (type === 'number') {
+    return (
+      <Input
+        type="number"
+        value={value.toString()}
+        placeholder="value"
+        className="font-mono"
+        onChange={(e) => {
+          const parsed = e.target.valueAsNumber
+          onChange(Number.isNaN(parsed) ? 0 : parsed)
+        }}
+      />
+    )
+  }
+
+  return (
+    <Input
+      value={value.toString()}
+      placeholder="value"
+      className="font-mono"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}
 
 export const ProductMetadataForm = () => {
   const { control, trigger, getValues } = useFormContext<ProductFormType>()
@@ -44,25 +127,16 @@ export const ProductMetadataForm = () => {
 
   return (
     <FormItem className="flex flex-col gap-2">
-      <div className="flex flex-row items-center justify-between">
-        <FormLabel>Metadata</FormLabel>
-        <p className="dark:text-polar-500 text-sm text-gray-500">
-          <Button
-            size="sm"
-            variant="secondary"
-            className="self-start"
-            type="button"
-            onClick={() => {
-              append({ key: '', value: '' })
-            }}
-          >
-            Add Metadata
-          </Button>
-        </p>
-      </div>
-
       {fields.length > 0 && (
         <div className="flex flex-col gap-2">
+          <div className="dark:text-polar-500 flex flex-row items-center gap-2 text-sm text-gray-500">
+            <div className="w-48">Key</div>
+            <div className="flex flex-1 flex-row gap-2">
+              <div className="w-32 shrink-0">Type</div>
+              <div className="flex-1">Value</div>
+            </div>
+            <div className="w-8 shrink-0" />
+          </div>
           {fields.map((field, index) => (
             <div key={field.id} className="flex flex-row items-start gap-2">
               <FormField
@@ -72,12 +146,13 @@ export const ProductMetadataForm = () => {
                   validate: (value: string) => validateUniqueKey(value, index),
                 }}
                 render={({ field }) => (
-                  <div className="flex flex-col gap-2">
+                  <div className="flex w-48 flex-col gap-2">
                     <FormControl>
                       <Input
                         {...field}
+                        className="font-mono"
                         value={field.value || ''}
-                        placeholder="Key"
+                        placeholder="key"
                         onChange={(e) => {
                           field.onChange(e)
                           revalidateAllKeys()
@@ -91,18 +166,40 @@ export const ProductMetadataForm = () => {
               <FormField
                 control={control}
                 name={`metadata.${index}.value`}
-                render={({ field }) => (
-                  <>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        value={field.value.toString() || ''}
-                        placeholder="Value"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </>
-                )}
+                render={({ field }) => {
+                  const type = getValueType(field.value)
+                  return (
+                    <div className="flex flex-1 flex-col gap-2">
+                      <div className="flex flex-row items-center gap-2">
+                        <Select
+                          value={type}
+                          onValueChange={(nextType) =>
+                            field.onChange(
+                              defaultValueForType(
+                                nextType as MetadataValueType,
+                              ),
+                            )
+                          }
+                        >
+                          <SelectTrigger className="w-32 shrink-0">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="string">String</SelectItem>
+                            <SelectItem value="number">Number</SelectItem>
+                            <SelectItem value="boolean">Boolean</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <MetadataValueInput
+                          type={type}
+                          value={field.value}
+                          onChange={field.onChange}
+                        />
+                      </div>
+                      <FormMessage />
+                    </div>
+                  )
+                }}
               />
               <div className="flex h-10">
                 <Button
@@ -127,6 +224,22 @@ export const ProductMetadataForm = () => {
           No metadata added
         </p>
       )}
+
+      <div className="flex flex-row items-center justify-end">
+        <p className="dark:text-polar-500 text-sm text-gray-500">
+          <Button
+            size="sm"
+            variant="secondary"
+            className="self-start"
+            type="button"
+            onClick={() => {
+              append({ key: '', value: '' })
+            }}
+          >
+            Add Metadata
+          </Button>
+        </p>
+      </div>
     </FormItem>
   )
 }


### PR DESCRIPTION
Expose the metadata type in product creation/editing. The backend supports `string | bool | number` but we only expose strings in the UI. This can make it tricky to know exactly what a value is.

* String: Text input
* Number: Number input
* Boolean: True/False dropdown

Also sprinkled some of that sweet sweet monospace font in there to better convey what does what.

### Before
<img width="763" height="416" alt="Screenshot 2026-05-20 at 20 57 38" src="https://github.com/user-attachments/assets/561b83b4-39f2-4a90-978c-7715355552c4" />


### After
<img width="762" height="442" alt="Screenshot 2026-05-20 at 21 10 59" src="https://github.com/user-attachments/assets/371ecb01-1629-4282-8e1d-91e68fa01d41" />



