### PR TITLE
feat: Add identity verification section to user settings

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/account/preferences/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/account/preferences/page.tsx
@@ -1,5 +1,6 @@
 import AuthenticationSettings from '@/components/Settings/AuthenticationSettings'
 import GeneralSettings from '@/components/Settings/GeneralSettings'
+import IdentityVerificationSettings from '@/components/Settings/IdentityVerificationSettings'
 import { NotificationRecipientsSettings } from '@/components/Settings/NotificationRecipientsSettings'
 import PersonalInformationSettings from '@/components/Settings/PersonalInformationSettings'
 import { Section, SectionDescription } from '@/components/Settings/Section'
@@ -17,6 +18,13 @@ export default function Page() {
       <Section>
         <SectionDescription title="Personal Information" />
         <PersonalInformationSettings />
+      </Section>
+      <Section>
+        <SectionDescription
+          title="Identity Verification"
+          description="Confirm your identity with a government-issued ID."
+        />
+        <IdentityVerificationSettings />
       </Section>
       <Section>
         <SectionDescription title="General" />

--- a/clients/apps/web/src/components/Finance/Account/sections/IdentityVerificationSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/IdentityVerificationSection.tsx
@@ -1,20 +1,12 @@
 'use client'
 
+import { IdentityVerificationStatusContent } from '@/components/Identity/IdentityVerificationStatusContent'
 import { useStartIdentityVerification } from '@/hooks/identityVerification'
 import { getQueryClient } from '@/utils/api/query'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
-import Button from '@polar-sh/ui/components/atoms/Button'
-import {
-  ArrowRight,
-  CheckIcon,
-  ClockIcon,
-  ShieldIcon,
-  XIcon,
-} from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { PathCardBanner } from './PathCardBanner'
-import { StatusBlock } from './StatusBlock'
 
 interface Props {
   organization: schemas['Organization']
@@ -41,71 +33,25 @@ export const IdentityVerificationSection = ({
   }, [identityVerificationStatus, organization.id])
 
   const tone = step.status === 'failed' ? 'danger' : 'warning'
-  const banners = reasonItems.length > 0 && (
-    <Box display="flex" flexDirection="column" rowGap="m">
-      {reasonItems.map((reason) => (
-        <PathCardBanner key={reason} tone={tone} title={reason} />
-      ))}
-    </Box>
-  )
-
-  if (identityVerificationStatus === 'verified') {
-    return (
-      <StatusBlock
-        tone="success"
-        icon={CheckIcon}
-        title="Identity verified"
-        description="Your identity has been successfully verified."
-      />
-    )
-  }
-
-  if (identityVerificationStatus === 'pending') {
-    return (
-      <StatusBlock
-        tone="pending"
-        icon={ClockIcon}
-        title="Identity verification pending"
-        description="Your identity verification is being processed. This usually takes a few minutes but can take up to 24 hours. We'll notify you once verification is complete."
-      />
-    )
-  }
-
-  if (identityVerificationStatus === 'failed') {
-    return (
-      <>
-        <StatusBlock
-          tone="danger"
-          icon={XIcon}
-          title="Identity verification failed"
-          description="We were unable to verify your identity. This could be due to document quality or information mismatch."
-          action={
-            <Button onClick={start}>
-              Try again
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Button>
-          }
-        />
-        {banners}
-      </>
-    )
-  }
+  const showBanners =
+    reasonItems.length > 0 &&
+    (identityVerificationStatus === 'failed' ||
+      identityVerificationStatus === 'unverified' ||
+      !identityVerificationStatus)
 
   return (
     <>
-      <StatusBlock
-        tone="neutral"
-        icon={ShieldIcon}
-        title="Verify your identity"
-        description="To comply with financial regulations and secure your account, we need to verify your identity using a government-issued ID."
-        action={
-          <Button onClick={start}>
-            Start identity verification
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
-        }
+      <IdentityVerificationStatusContent
+        status={identityVerificationStatus}
+        onStart={start}
       />
-      {banners}
+      {showBanners && (
+        <Box display="flex" flexDirection="column" rowGap="m">
+          {reasonItems.map((reason) => (
+            <PathCardBanner key={reason} tone={tone} title={reason} />
+          ))}
+        </Box>
+      )}
     </>
   )
 }

--- a/clients/apps/web/src/components/Identity/IdentityVerificationStatusContent.tsx
+++ b/clients/apps/web/src/components/Identity/IdentityVerificationStatusContent.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { StatusBlock } from '@/components/Finance/Account/sections/StatusBlock'
+import { schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import {
+  ArrowRight,
+  CheckIcon,
+  ClockIcon,
+  ShieldIcon,
+  XIcon,
+} from 'lucide-react'
+
+interface Props {
+  status: schemas['IdentityVerificationStatus'] | undefined
+  onStart: () => void
+  unverifiedDescription?: string
+}
+
+const DEFAULT_UNVERIFIED_DESCRIPTION =
+  'To comply with financial regulations and secure your account, we need to verify your identity using a government-issued ID.'
+
+export const IdentityVerificationStatusContent = ({
+  status,
+  onStart,
+  unverifiedDescription = DEFAULT_UNVERIFIED_DESCRIPTION,
+}: Props) => {
+  if (status === 'verified') {
+    return (
+      <StatusBlock
+        tone="success"
+        icon={CheckIcon}
+        title="Identity verified"
+        description="Your identity has been successfully verified."
+      />
+    )
+  }
+
+  if (status === 'pending') {
+    return (
+      <StatusBlock
+        tone="pending"
+        icon={ClockIcon}
+        title="Identity verification pending"
+        description="Your identity verification is being processed. This usually takes a few minutes but can take up to 24 hours. We'll notify you once verification is complete."
+      />
+    )
+  }
+
+  if (status === 'failed') {
+    return (
+      <StatusBlock
+        tone="danger"
+        icon={XIcon}
+        title="Identity verification failed"
+        description="We were unable to verify your identity. This could be due to document quality or information mismatch."
+        action={
+          <Button onClick={onStart}>
+            Try again
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        }
+      />
+    )
+  }
+
+  return (
+    <StatusBlock
+      tone="neutral"
+      icon={ShieldIcon}
+      title="Verify your identity"
+      description={unverifiedDescription}
+      action={
+        <Button onClick={onStart}>
+          Start identity verification
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      }
+    />
+  )
+}

--- a/clients/apps/web/src/components/Settings/IdentityVerificationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/IdentityVerificationSettings.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { IdentityVerificationStatusContent } from '@/components/Identity/IdentityVerificationStatusContent'
+import { useStartIdentityVerification } from '@/hooks/identityVerification'
+import { Box } from '@polar-sh/orbit/Box'
+
+const IdentityVerificationSettings = () => {
+  const { start, identityVerificationStatus } = useStartIdentityVerification()
+
+  return (
+    <Box
+      borderRadius="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      padding="l"
+    >
+      <IdentityVerificationStatusContent
+        status={identityVerificationStatus}
+        onStart={start}
+        unverifiedDescription="Verify your identity using a government-issued ID to confirm your account."
+      />
+    </Box>
+  )
+}
+
+export default IdentityVerificationSettings


### PR DESCRIPTION
Make it possible for a user to verify their identity outside of the org onboarding flow.
Verified identity is a prerequisite for ownership transfer and without this that's not possible.