### PR TITLE
chore: Account admin_id cleanup and ownership transfer flow update

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -892,8 +892,8 @@ export interface paths {
      * @description Change a member's role on an organization.
      *
      *     Only `admin` and `member` are accepted; ownership transfers go through
-     *     a separate flow (`Account.admin_id` mutation, today the backoffice
-     *     `change_admin` endpoint).
+     *     a separate flow (today the backoffice `change_owner` endpoint, which
+     *     calls `user_organization_service.transfer_ownership`).
      *
      *     **Scopes**: `members:write`
      */

--- a/server/migrations/versions/2026-05-20-1500_add_partial_unique_owner_index.py
+++ b/server/migrations/versions/2026-05-20-1500_add_partial_unique_owner_index.py
@@ -18,11 +18,9 @@ depends_on: tuple[str] | None = None
 
 
 def upgrade() -> None:
-    # Guards the invariant "at most one owner per organization" once
-    # `Account.admin_id` is no longer the source of truth.
     with op.get_context().autocommit_block():
         op.create_index(
-            op.f("ix_user_organizations_owner_per_org"),
+            "ix_user_organizations_owner_per_org",
             "user_organizations",
             ["organization_id"],
             unique=True,
@@ -34,7 +32,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     with op.get_context().autocommit_block():
         op.drop_index(
-            op.f("ix_user_organizations_owner_per_org"),
+            "ix_user_organizations_owner_per_org",
             table_name="user_organizations",
             postgresql_concurrently=True,
+            postgresql_where="role = 'owner' AND deleted_at IS NULL",
         )

--- a/server/migrations/versions/2026-05-20-1500_add_partial_unique_owner_index.py
+++ b/server/migrations/versions/2026-05-20-1500_add_partial_unique_owner_index.py
@@ -20,12 +20,21 @@ depends_on: tuple[str] | None = None
 def upgrade() -> None:
     # Guards the invariant "at most one owner per organization" once
     # `Account.admin_id` is no longer the source of truth.
-    op.execute(
-        "CREATE UNIQUE INDEX ix_user_organizations_owner_per_org "
-        "ON user_organizations (organization_id) "
-        "WHERE role = 'owner' AND deleted_at IS NULL"
-    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_user_organizations_owner_per_org"),
+            "user_organizations",
+            ["organization_id"],
+            unique=True,
+            postgresql_concurrently=True,
+            postgresql_where="role = 'owner' AND deleted_at IS NULL",
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX IF EXISTS ix_user_organizations_owner_per_org")
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            op.f("ix_user_organizations_owner_per_org"),
+            table_name="user_organizations",
+            postgresql_concurrently=True,
+        )

--- a/server/migrations/versions/2026-05-20-1500_add_partial_unique_owner_index.py
+++ b/server/migrations/versions/2026-05-20-1500_add_partial_unique_owner_index.py
@@ -1,0 +1,31 @@
+"""Add partial unique index on user_organizations.owner
+
+Revision ID: dd87a0bf956a
+Revises: 69a2e3ae542c
+Create Date: 2026-05-20 15:00:00.000000
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "dd87a0bf956a"
+down_revision = "69a2e3ae542c"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Guards the invariant "at most one owner per organization" once
+    # `Account.admin_id` is no longer the source of truth.
+    op.execute(
+        "CREATE UNIQUE INDEX ix_user_organizations_owner_per_org "
+        "ON user_organizations (organization_id) "
+        "WHERE role = 'owner' AND deleted_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_user_organizations_owner_per_org")

--- a/server/migrations/versions/2026-05-20-1505_drop_accounts_admin_id.py
+++ b/server/migrations/versions/2026-05-20-1505_drop_accounts_admin_id.py
@@ -1,0 +1,54 @@
+"""Drop accounts.admin_id
+
+Revision ID: fc013555b132
+Revises: dd87a0bf956a
+Create Date: 2026-05-20 15:05:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "fc013555b132"
+down_revision = "dd87a0bf956a"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '2s'")
+    op.drop_column("accounts", "admin_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "accounts",
+        sa.Column("admin_id", sa.Uuid(), nullable=True),
+    )
+    # Backfill from `user_organizations` to preserve the previous invariant
+    # "Account.admin_id matches the user holding `owner` on at least one of
+    # the account's organizations".
+    op.execute(
+        """
+        UPDATE accounts AS a
+        SET admin_id = uo.user_id
+        FROM organizations AS o
+        JOIN user_organizations AS uo
+          ON uo.organization_id = o.id
+         AND uo.role = 'owner'
+         AND uo.deleted_at IS NULL
+        WHERE o.account_id = a.id
+          AND a.admin_id IS NULL
+        """
+    )
+    op.create_foreign_key(
+        "accounts_admin_id_fkey",
+        "accounts",
+        "users",
+        ["admin_id"],
+        ["id"],
+        use_alter=True,
+    )

--- a/server/migrations/versions/2026-05-20-1505_drop_accounts_admin_id.py
+++ b/server/migrations/versions/2026-05-20-1505_drop_accounts_admin_id.py
@@ -20,17 +20,15 @@ depends_on: tuple[str] | None = None
 
 def upgrade() -> None:
     op.execute("SET LOCAL lock_timeout = '2s'")
+    op.drop_constraint(op.f("accounts_admin_id_fkey"), "accounts", type_="foreignkey")
     op.drop_column("accounts", "admin_id")
 
 
 def downgrade() -> None:
     op.add_column(
         "accounts",
-        sa.Column("admin_id", sa.Uuid(), nullable=True),
+        sa.Column("admin_id", sa.UUID(), autoincrement=False, nullable=True),
     )
-    # Backfill from `user_organizations` to preserve the previous invariant
-    # "Account.admin_id matches the user holding `owner` on at least one of
-    # the account's organizations".
     op.execute(
         """
         UPDATE accounts AS a
@@ -45,10 +43,5 @@ def downgrade() -> None:
         """
     )
     op.create_foreign_key(
-        "accounts_admin_id_fkey",
-        "accounts",
-        "users",
-        ["admin_id"],
-        ["id"],
-        use_alter=True,
+        op.f("accounts_admin_id_fkey"), "accounts", "users", ["admin_id"], ["id"]
     )

--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -26,9 +26,9 @@ class AccountServiceError(PolarError):
     pass
 
 
-class CannotChangeAdminError(AccountServiceError):
+class CannotChangeOwnerError(AccountServiceError):
     def __init__(self, reason: str) -> None:
-        super().__init__(f"Cannot change account admin: {reason}")
+        super().__init__(f"Cannot change account owner: {reason}")
 
 
 class AccountService:
@@ -101,7 +101,7 @@ class AccountService:
         session: AsyncSession,
         *,
         organization_id: uuid.UUID,
-        new_admin_user: User,
+        new_owner_user: User,
     ) -> None:
         if not settings.POLAR_SELF_ENABLED:
             return
@@ -115,17 +115,17 @@ class AccountService:
             str(organization_id), polar_organization_id
         )
         if customer is None:
-            raise CannotChangeAdminError(
+            raise CannotChangeOwnerError(
                 f"Polar self customer not found for organization {organization_id}"
             )
 
         member_repository = MemberRepository.from_session(session)
         target_member = await member_repository.get_by_customer_id_and_external_id(
-            customer.id, str(new_admin_user.id)
+            customer.id, str(new_owner_user.id)
         )
         if target_member is None:
-            raise CannotChangeAdminError(
-                f"Polar self member not found for user {new_admin_user.id}"
+            raise CannotChangeOwnerError(
+                f"Polar self member not found for user {new_owner_user.id}"
             )
 
         if target_member.role != MemberRole.owner:
@@ -136,23 +136,23 @@ class AccountService:
                 allow_ownership_transfer=True,
             )
 
-    async def change_admin(
+    async def change_owner(
         self,
         session: AsyncSession,
         account: Account,
-        new_admin_id: uuid.UUID,
+        new_owner_id: uuid.UUID,
         organization_id: uuid.UUID,
     ) -> Account:
-        new_admin_user = await user_organization_service.transfer_ownership(
+        new_owner_user = await user_organization_service.transfer_ownership(
             session,
-            new_owner_user_id=new_admin_id,
+            new_owner_user_id=new_owner_id,
             organization_id=organization_id,
         )
 
         await self._sync_polar_self_customer_owner(
             session,
             organization_id=organization_id,
-            new_admin_user=new_admin_user,
+            new_owner_user=new_owner_user,
         )
 
         return account

--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -58,12 +58,11 @@ class AccountService:
         repository = AccountRepository.from_session(session)
         return await repository.get_by_organization(organization_id)
 
-    async def create(self, session: AsyncSession, admin: User) -> Account:
+    async def create(self, session: AsyncSession) -> Account:
         repository = AccountRepository.from_session(session)
         return await repository.create(
             Account(
                 currency="usd",  # FIXME: main Polar currency
-                admin=admin,
                 _platform_fee_percent=settings.PLATFORM_FEE_BASIS_POINTS,
                 _platform_fee_fixed=settings.PLATFORM_FEE_FIXED,
                 _platform_subscription_fee_percent=settings.PLATFORM_SUBSCRIPTION_FEE_BASIS_POINTS,

--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import update
 from sqlalchemy.orm.strategy_options import joinedload
 
 from polar.account.repository import AccountRepository
@@ -13,12 +12,12 @@ from polar.customer.repository import CustomerRepository
 from polar.exceptions import PolarError
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
-from polar.models import Account, Organization, User, UserOrganization
+from polar.models import Account, Organization, User
 from polar.models.member import MemberRole
-from polar.models.user import IdentityVerificationStatus
-from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncReadSession, AsyncSession
-from polar.user.repository import UserRepository
+from polar.user_organization.service import (
+    user_organization as user_organization_service,
+)
 
 from .schemas import AccountUpdate
 
@@ -30,13 +29,6 @@ class AccountServiceError(PolarError):
 class CannotChangeAdminError(AccountServiceError):
     def __init__(self, reason: str) -> None:
         super().__init__(f"Cannot change account admin: {reason}")
-
-
-class UserNotOrganizationMemberError(AccountServiceError):
-    def __init__(self, user_id: uuid.UUID, organization_id: uuid.UUID) -> None:
-        super().__init__(
-            f"User {user_id} is not a member of organization {organization_id}"
-        )
 
 
 class AccountService:
@@ -65,14 +57,6 @@ class AccountService:
     ) -> Account | None:
         repository = AccountRepository.from_session(session)
         return await repository.get_by_organization(organization_id)
-
-    async def is_user_admin(
-        self, session: AsyncReadSession, account_id: uuid.UUID, user: User
-    ) -> bool:
-        account = await self._get_unrestricted(session, account_id)
-        if account is None:
-            return False
-        return account.admin_id == user.id
 
     async def create(self, session: AsyncSession, admin: User) -> Account:
         repository = AccountRepository.from_session(session)
@@ -160,42 +144,12 @@ class AccountService:
         new_admin_id: uuid.UUID,
         organization_id: uuid.UUID,
     ) -> Account:
-        user_repository = UserRepository.from_session(session)
-        is_member = await user_repository.is_organization_member(
-            new_admin_id, organization_id
-        )
-
-        if not is_member:
-            raise UserNotOrganizationMemberError(new_admin_id, organization_id)
-
-        new_admin_user = await user_repository.get_by_id(new_admin_id)
-
-        if new_admin_user is None:
-            raise UserNotOrganizationMemberError(new_admin_id, organization_id)
-
-        if (
-            new_admin_user.identity_verification_status
-            != IdentityVerificationStatus.verified
-        ):
-            raise CannotChangeAdminError(
-                f"New admin must be verified in Stripe. Current status: {new_admin_user.identity_verification_status.get_display_name()}"
-            )
-
-        if account.admin_id == new_admin_id:
-            raise CannotChangeAdminError("New admin is the same as current admin")
-
-        previous_admin_id = account.admin_id
-
-        repository = AccountRepository.from_session(session)
-        account = await repository.update(
-            account, update_dict={"admin_id": new_admin_id}
-        )
-        await self._swap_organization_owner_role(
+        new_admin_user = await user_organization_service.transfer_ownership(
             session,
+            new_owner_user_id=new_admin_id,
             organization_id=organization_id,
-            previous_admin_id=previous_admin_id,
-            new_admin_id=new_admin_id,
         )
+
         await self._sync_polar_self_customer_owner(
             session,
             organization_id=organization_id,
@@ -203,38 +157,6 @@ class AccountService:
         )
 
         return account
-
-    async def _swap_organization_owner_role(
-        self,
-        session: AsyncSession,
-        *,
-        organization_id: uuid.UUID,
-        previous_admin_id: uuid.UUID,
-        new_admin_id: uuid.UUID,
-    ) -> None:
-        """
-        Keep `UserOrganization.role` aligned with `Account.admin_id` during a
-        change_admin flow. Demote the previous admin from `owner` to `admin`
-        only if they currently carry `owner` (pre-backfill rows may still be
-        `member`); promote the new admin to `owner` unconditionally.
-        """
-        await session.execute(
-            update(UserOrganization)
-            .where(
-                UserOrganization.organization_id == organization_id,
-                UserOrganization.user_id == previous_admin_id,
-                UserOrganization.role == OrganizationRole.owner,
-            )
-            .values(role=OrganizationRole.admin)
-        )
-        await session.execute(
-            update(UserOrganization)
-            .where(
-                UserOrganization.organization_id == organization_id,
-                UserOrganization.user_id == new_admin_id,
-            )
-            .values(role=OrganizationRole.owner)
-        )
 
     async def _get_unrestricted(
         self,

--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -139,10 +139,10 @@ class AccountService:
     async def change_owner(
         self,
         session: AsyncSession,
-        account: Account,
+        *,
         new_owner_id: uuid.UUID,
         organization_id: uuid.UUID,
-    ) -> Account:
+    ) -> None:
         new_owner_user = await user_organization_service.transfer_ownership(
             session,
             new_owner_user_id=new_owner_id,
@@ -154,8 +154,6 @@ class AccountService:
             organization_id=organization_id,
             new_owner_user=new_owner_user,
         )
-
-        return account
 
     async def _get_unrestricted(
         self,

--- a/server/polar/backoffice/organizations/endpoints.py
+++ b/server/polar/backoffice/organizations/endpoints.py
@@ -901,12 +901,12 @@ async def create_plain_thread(
         if not organization:
             raise HTTPException(status_code=404)
 
-        admin_user = await org_repo.get_admin_user(organization)
-        if not admin_user:
-            raise HTTPException(status_code=404, detail="No admin user found")
+        owner_user = await org_repo.get_owner_user(organization)
+        if not owner_user:
+            raise HTTPException(status_code=404, detail="No owner user found")
 
         thread_id = await plain_service.create_manual_organization_thread(
-            session, organization, admin_user, title
+            session, organization, owner_user, title
         )
         logger.info(
             f"Created Plain thread {thread_id} for organization {organization.id}"
@@ -1273,7 +1273,7 @@ async def get(
                             with tag.h2(classes="card-title"):
                                 text(f"Team Members ({len(users)})")
 
-                        admin_user = await repository.get_admin_user(organization)
+                        owner_user = await repository.get_owner_user(organization)
 
                         if users:
                             # Users table
@@ -1294,8 +1294,8 @@ async def get(
                                     # Table body
                                     with tag.tbody():
                                         for user in users:
-                                            is_admin = (
-                                                admin_user and user.id == admin_user.id
+                                            is_owner = (
+                                                owner_user and user.id == owner_user.id
                                             )
                                             with tag.tr():
                                                 # User info
@@ -1318,11 +1318,11 @@ async def get(
 
                                                 # Role
                                                 with tag.td():
-                                                    if is_admin:
+                                                    if is_owner:
                                                         with tag.span(
                                                             classes="badge badge-primary"
                                                         ):
-                                                            text("Admin")
+                                                            text("Owner")
                                                     else:
                                                         with tag.span(
                                                             classes="badge badge-ghost"
@@ -1546,11 +1546,11 @@ async def get_plain_search_url(
     if not organization:
         raise HTTPException(status_code=404)
 
-    admin_user = await org_repo.get_admin_user(organization)
-    if not admin_user:
-        raise HTTPException(status_code=404, detail="No admin user found")
+    owner_user = await org_repo.get_owner_user(organization)
+    if not owner_user:
+        raise HTTPException(status_code=404, detail="No owner user found")
 
-    search_url = f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={admin_user.email}"
+    search_url = f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={owner_user.email}"
 
     return RedirectResponse(url=search_url, status_code=302)
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -89,7 +89,6 @@ from polar.organization_review.schemas import (
 from polar.payout_account.service import payout_account as payout_account_service
 from polar.postgres import AsyncSession, get_db_session
 from polar.transaction.service.transaction import transaction as transaction_service
-from polar.user.repository import UserRepository
 from polar.user.service import user as user_service
 from polar.worker import enqueue_job
 
@@ -633,12 +632,12 @@ async def get_organization_detail(
         parsed = agent_review.parsed_report
         ai_verdict = parsed.report.verdict.value
 
-    # Fetch admin user email for Plain search
-    admin_user = await repository.get_admin_user(organization)
-    admin_email = admin_user.email if admin_user else None
+    # Fetch owner user email for Plain search
+    owner_user = await repository.get_owner_user(organization)
+    owner_email = owner_user.email if owner_user else None
 
-    # Determine impersonation target: admin, or first member as fallback
-    impersonate_user = admin_user
+    # Determine impersonation target: owner, or first member as fallback
+    impersonate_user = owner_user
     if not impersonate_user and members:
         impersonate_user = members[0].user
 
@@ -646,7 +645,7 @@ async def get_organization_detail(
     detail_view = OrganizationDetailView(
         organization,
         ai_verdict=ai_verdict,
-        admin_email=admin_email,
+        owner_email=owner_email,
         impersonate_user=impersonate_user,
     )
 
@@ -811,12 +810,12 @@ async def get_organization_detail(
                     pass
             elif section == "team":
                 identity_country = None
-                if admin_user:
+                if owner_user:
                     identity_country = await user_service.get_identity_verified_country(
-                        admin_user
+                        owner_user
                     )
                 team_section = TeamSection(
-                    organization, admin_user, identity_country=identity_country
+                    organization, owner_user, identity_country=identity_country
                 )
                 with team_section.render(request):
                     pass
@@ -1963,9 +1962,9 @@ async def create_review_ticket(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    admin_user = await repository.get_admin_user(organization)
-    if not admin_user:
-        await add_toast(request, "No admin user found for this organization.", "error")
+    owner_user = await repository.get_owner_user(organization)
+    if not owner_user:
+        await add_toast(request, "No owner user found for this organization.", "error")
         return
 
     default_title = _default_review_ticket_title(organization)
@@ -1982,7 +1981,7 @@ async def create_review_ticket(
 
         try:
             thread_id = await plain_service.create_manual_organization_thread(
-                session, organization, admin_user, title
+                session, organization, owner_user, title
             )
         except AccountReviewThreadCreationError as e:
             logger.error(
@@ -3168,16 +3167,16 @@ async def impersonate_user(
 
 
 @router.post(
-    "/{organization_id}/make-admin/{user_id}",
-    name="organizations:make_admin",
+    "/{organization_id}/make-owner/{user_id}",
+    name="organizations:make_owner",
 )
-async def make_admin(
+async def make_owner(
     request: Request,
     organization_id: UUID4,
     user_id: UUID4,
     session: AsyncSession = Depends(get_db_session),
 ) -> HXRedirectResponse:
-    """Make a user an admin of the organization."""
+    """Make a user the owner of the organization."""
     repository = OrganizationRepository(session)
 
     organization = await repository.get_by_id(
@@ -3188,13 +3187,12 @@ async def make_admin(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    # Change the admin user
     try:
-        await account_service.change_admin(
+        await account_service.change_owner(
             session, organization.account, user_id, organization_id
         )
     except Exception as e:
-        logger.error("Failed to make user admin", error=str(e))
+        logger.error("Failed to make user owner", error=str(e))
         raise HTTPException(status_code=400, detail=str(e))
 
     redirect_url = (
@@ -3332,15 +3330,12 @@ async def setup_account(
         data = await request.form()
         country = str(data.get("country", "US")).upper()
 
-        user_repository = UserRepository.from_session(session)
-        users = await user_repository.get_all_by_organization(organization.id)
-        if not users:
-            raise HTTPException(status_code=400, detail="Organization has no users")
-
-        admin_user = users[0]
+        owner_user = await repository.get_owner_user(organization)
+        if owner_user is None:
+            raise HTTPException(status_code=400, detail="Organization has no owner")
 
         await payout_account_service.create_manual_account(
-            session, organization, admin_user, country=country, currency="usd"
+            session, organization, owner_user, country=country, currency="usd"
         )
 
         await add_toast(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -3179,17 +3179,13 @@ async def make_owner(
     """Make a user the owner of the organization."""
     repository = OrganizationRepository(session)
 
-    organization = await repository.get_by_id(
-        organization_id,
-        include_blocked=True,
-        options=(joinedload(Organization.account),),
-    )
+    organization = await repository.get_by_id(organization_id, include_blocked=True)
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
     try:
         await account_service.change_owner(
-            session, organization.account, user_id, organization_id
+            session, new_owner_id=user_id, organization_id=organization_id
         )
     except Exception as e:
         logger.error("Failed to make user owner", error=str(e))

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -40,12 +40,12 @@ class OrganizationDetailView:
         self,
         organization: Organization,
         ai_verdict: str = "",
-        admin_email: str | None = None,
+        owner_email: str | None = None,
         impersonate_user: User | None = None,
     ):
         self.org = organization
         self.ai_verdict = ai_verdict
-        self.admin_email = admin_email
+        self.owner_email = owner_email
         self.impersonate_user = impersonate_user
 
     @contextlib.contextmanager
@@ -678,7 +678,7 @@ class OrganizationDetailView:
                                     text("Run Review Agent")
                             with tag.li():
                                 with tag.a(
-                                    href=f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={self.admin_email or self.org.slug}",
+                                    href=f"https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/search/?q={self.owner_email or self.org.slug}",
                                     target="_blank",
                                 ):
                                     text("Search in Plain")

--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -18,11 +18,11 @@ class TeamSection:
     def __init__(
         self,
         organization: Organization,
-        admin_user: User | None = None,
+        owner_user: User | None = None,
         identity_country: str | None = None,
     ):
         self.org = organization
-        self.admin_user = admin_user
+        self.owner_user = owner_user
         self.identity_country = identity_country
 
     @contextlib.contextmanager
@@ -93,12 +93,12 @@ class TeamSection:
                                         with tag.div(
                                             classes="text-sm text-base-content/60"
                                         ):
-                                            is_admin = (
-                                                self.admin_user
-                                                and member.user_id == self.admin_user.id
+                                            is_owner = (
+                                                self.owner_user
+                                                and member.user_id == self.owner_user.id
                                             )
                                             role_text = (
-                                                "Admin" if is_admin else "Member"
+                                                "Owner" if is_owner else "Member"
                                             )
                                             text(
                                                 f"{role_text} · Joined {member.created_at.strftime('%Y-%m-%d')}"
@@ -133,23 +133,23 @@ class TeamSection:
                                             classes="dropdown-content menu shadow bg-base-100 rounded-box w-52 z-10",
                                             **{"tabindex": "0"},
                                         ):
-                                            member_is_admin = (
-                                                self.admin_user
-                                                and member.user_id == self.admin_user.id
+                                            member_is_owner = (
+                                                self.owner_user
+                                                and member.user_id == self.owner_user.id
                                             )
-                                            if not member_is_admin:
+                                            if not member_is_owner:
                                                 with tag.li():
                                                     with tag.a(
                                                         hx_post=str(
                                                             request.url_for(
-                                                                "organizations:make_admin",
+                                                                "organizations:make_owner",
                                                                 organization_id=self.org.id,
                                                                 user_id=member.user_id,
                                                             )
                                                         ),
-                                                        hx_confirm="Make this user an admin?",
+                                                        hx_confirm="Transfer ownership to this user?",
                                                     ):
-                                                        text("Make Admin")
+                                                        text("Make Owner")
                                             with tag.li():
                                                 with tag.a(
                                                     hx_delete=str(
@@ -167,10 +167,10 @@ class TeamSection:
                     with tag.div(classes="text-center py-8 text-base-content/60"):
                         text("No team members found")
 
-            # Admin change requirements (if applicable)
+            # Ownership transfer requirements (if applicable)
             with card(bordered=True):
                 with tag.h3(classes="text-md font-bold mb-3"):
-                    text("Admin Change Requirements")
+                    text("Ownership Transfer Requirements")
 
                 with tag.ul(classes="space-y-2 text-sm"):
                     with tag.li(classes="flex items-start gap-2"):
@@ -181,7 +181,7 @@ class TeamSection:
 
                     with tag.li(classes="flex items-start gap-2"):
                         with tag.span(classes="text-base-content/60"):
-                            text("• New admin must be verified")
+                            text("• New owner must be verified")
 
                     with tag.li(classes="flex items-start gap-2"):
                         with tag.span(classes="text-base-content/60"):

--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -170,22 +170,29 @@ class TeamSection:
             # Ownership transfer requirements (if applicable)
             with card(bordered=True):
                 with tag.h3(classes="text-md font-bold mb-3"):
-                    text("Ownership Transfer Requirements")
+                    text("Ownership Transfer")
 
                 with tag.ul(classes="space-y-2 text-sm"):
                     with tag.li(classes="flex items-start gap-2"):
                         with tag.span(classes="text-base-content/60"):
                             text(
-                                "• No Stripe account connected (restriction for alpha)"
+                                "• The new owner must already be a member "
+                                "of the organization"
                             )
 
                     with tag.li(classes="flex items-start gap-2"):
                         with tag.span(classes="text-base-content/60"):
-                            text("• New owner must be verified")
+                            text(
+                                "• The new owner must have completed Stripe "
+                                "identity verification"
+                            )
 
                     with tag.li(classes="flex items-start gap-2"):
                         with tag.span(classes="text-base-content/60"):
-                            text("• At least 2 team members required")
+                            text(
+                                "• The current owner is demoted to admin "
+                                "(they keep access to the org)"
+                            )
 
             yield
 

--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -137,7 +137,14 @@ class TeamSection:
                                                 self.owner_user
                                                 and member.user_id == self.owner_user.id
                                             )
-                                            if not member_is_owner:
+                                            member_is_verified = (
+                                                member.user.identity_verification_status
+                                                == IdentityVerificationStatus.verified
+                                            )
+                                            if (
+                                                not member_is_owner
+                                                and member_is_verified
+                                            ):
                                                 with tag.li():
                                                     with tag.a(
                                                         hx_post=str(

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -65,7 +65,6 @@ from polar.logging import Logger
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
 from polar.models import (
-    Account,
     Checkout,
     CheckoutLink,
     Customer,
@@ -1438,9 +1437,7 @@ class CheckoutService:
             org_ids,
             options=(
                 contains_eager(ProductPrice.product).options(
-                    joinedload(Product.organization)
-                    .joinedload(Organization.account)
-                    .joinedload(Account.admin),
+                    joinedload(Product.organization).joinedload(Organization.account),
                     selectinload(Product.prices),
                 ),
             ),

--- a/server/polar/models/account.py
+++ b/server/polar/models/account.py
@@ -61,12 +61,6 @@ class Account(RecordModel):
 
     credit_balance: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
-    admin_id: Mapped[UUID] = mapped_column(Uuid, ForeignKey("users.id", use_alter=True))
-
-    @declared_attr
-    def admin(cls) -> Mapped["User"]:
-        return relationship("User", lazy="raise", foreign_keys="[Account.admin_id]")
-
     @declared_attr
     def users(cls) -> Mapped[list["User"]]:
         return relationship(

--- a/server/polar/models/user_organization.py
+++ b/server/polar/models/user_organization.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Uuid
+from sqlalchemy import ForeignKey, Index, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import TimestampedModel
@@ -18,6 +18,14 @@ class OrganizationRole(StrEnum):
 
 class UserOrganization(TimestampedModel):
     __tablename__ = "user_organizations"
+    __table_args__ = (
+        Index(
+            "ix_user_organizations_owner_per_org",
+            "organization_id",
+            unique=True,
+            postgresql_where="role = 'owner' AND deleted_at IS NULL",
+        ),
+    )
 
     user_id: Mapped[UUID] = mapped_column(
         Uuid,

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -585,7 +585,7 @@ async def set_member_role(
     """Change a member's role on an organization.
 
     Only `admin` and `member` are accepted; ownership transfers go through
-    a separate flow (today the backoffice `change_admin` endpoint, which
+    a separate flow (today the backoffice `change_owner` endpoint, which
     calls `user_organization_service.transfer_ownership`).
     """
     try:

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -361,7 +361,7 @@ async def get_payment_status(
     organization = await organization_service.get_anonymous(
         session,
         id,
-        options=(joinedload(Organization.account).joinedload(Account.admin),),
+        options=(joinedload(Organization.account),),
     )
 
     if organization is None:
@@ -585,8 +585,8 @@ async def set_member_role(
     """Change a member's role on an organization.
 
     Only `admin` and `member` are accepted; ownership transfers go through
-    a separate flow (`Account.admin_id` mutation, today the backoffice
-    `change_admin` endpoint).
+    a separate flow (today the backoffice `change_admin` endpoint, which
+    calls `user_organization_service.transfer_ownership`).
     """
     try:
         return await user_organization_service.set_role(

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -15,7 +15,6 @@ from polar.kit.repository import (
 )
 from polar.kit.repository.base import Options
 from polar.models import (
-    Account,
     Customer,
     Order,
     Organization,
@@ -33,6 +32,7 @@ from polar.models.discount import (
 from polar.models.organization import OrganizationStatus, SnoozeType
 from polar.models.organization_review import OrganizationReview
 from polar.models.subscription import SubscriptionStatus
+from polar.models.user_organization import OrganizationRole
 
 from .sorting import OrganizationSortProperty
 
@@ -210,12 +210,13 @@ class OrganizationRepository(
         )
 
     async def get_admin_user(self, organization: Organization) -> User | None:
-        """Get the admin user of the organization from the associated account."""
+        """Get the owner of the organization."""
         statement = (
             select(User)
-            .join(Account, Account.admin_id == User.id)
+            .join(UserOrganization, UserOrganization.user_id == User.id)
             .where(
-                Account.id == organization.account_id,
+                UserOrganization.organization_id == organization.id,
+                UserOrganization.role == OrganizationRole.owner,
                 User.is_deleted.is_(False),
             )
         )

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -209,7 +209,7 @@ class OrganizationRepository(
             Organization.status != OrganizationStatus.BLOCKED,
         )
 
-    async def get_admin_user(self, organization: Organization) -> User | None:
+    async def get_owner_user(self, organization: Organization) -> User | None:
         """Get the owner of the organization."""
         statement = (
             select(User)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1346,7 +1346,7 @@ class OrganizationService:
             )
 
         organization_repository = OrganizationRepository.from_session(session)
-        admin_user = await organization_repository.get_admin_user(organization)
+        owner_user = await organization_repository.get_owner_user(organization)
 
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
@@ -1367,7 +1367,7 @@ class OrganizationService:
             self._build_product_description_check(organization),
             product_configuration_check,
             setup_readiness_check,
-            self._build_identity_verification_check(admin_user),
+            self._build_identity_verification_check(owner_user),
             self._build_payout_account_check(payout_account),
             self._build_socials_check(organization),
             await product_url_task,
@@ -1487,13 +1487,13 @@ class OrganizationService:
         return self._passed_check(key)
 
     def _build_identity_verification_check(
-        self, admin_user: User | None
+        self, owner_user: User | None
     ) -> OrganizationReviewCheck:
         key = OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION
-        if admin_user is None:
+        if owner_user is None:
             return self._not_started_check(key)
 
-        status = admin_user.identity_verification_status
+        status = owner_user.identity_verification_status
         match status:
             case IdentityVerificationStatus.verified:
                 return self._passed_check(key)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -322,9 +322,7 @@ class OrganizationService:
                     customer_invoice_prefix=create_schema.slug.upper(),
                 )
             )
-            organization.account = await account_service.create(
-                session, auth_subject.subject
-            )
+            organization.account = await account_service.create(session)
             await session.flush()
         except IntegrityError as e:
             await nested.rollback()

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -199,19 +199,19 @@ async def _collect_history(organization: Organization) -> HistoryData:
         org_repository = OrganizationRepository.from_session(session)
         review_repository = OrganizationReviewRepository.from_session(session)
 
-        admin_user = await org_repository.get_admin_user(organization)
-        admin_user_id = admin_user.id if admin_user else None
+        owner_user = await org_repository.get_owner_user(organization)
+        owner_user_id = owner_user.id if owner_user else None
 
         user = (
-            await review_repository.get_user_by_id(admin_user_id)
-            if admin_user_id
+            await review_repository.get_user_by_id(owner_user_id)
+            if owner_user_id
             else None
         )
         other_orgs = (
             await review_repository.get_other_organizations_for_user(
-                admin_user_id, organization.id
+                owner_user_id, organization.id
             )
-            if admin_user_id
+            if owner_user_id
             else []
         )
         return collect_history_data(user, other_orgs)

--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -2,11 +2,11 @@ from collections.abc import Sequence
 from typing import Self
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from polar.models import Organization, UserOrganization
 from polar.models.user_organization import OrganizationRole
-from polar.postgres import AsyncReadSession
+from polar.postgres import AsyncReadSession, AsyncSession
 
 
 class UserOrganizationRepository:
@@ -17,11 +17,11 @@ class UserOrganizationRepository:
     don't already live on `UserOrganizationService`.
     """
 
-    def __init__(self, session: AsyncReadSession) -> None:
+    def __init__(self, session: AsyncSession | AsyncReadSession) -> None:
         self.session = session
 
     @classmethod
-    def from_session(cls, session: AsyncReadSession) -> Self:
+    def from_session(cls, session: AsyncSession | AsyncReadSession) -> Self:
         return cls(session)
 
     async def get_organizations_with_role(
@@ -45,3 +45,25 @@ class UserOrganizationRepository:
         )
         result = await self.session.execute(statement)
         return [(row[0], row[1]) for row in result.all()]
+
+    async def demote_current_owner(self, organization_id: UUID) -> None:
+        """Demote whoever currently holds `owner` on the org to `admin`."""
+        await self.session.execute(
+            update(UserOrganization)
+            .where(
+                UserOrganization.organization_id == organization_id,
+                UserOrganization.role == OrganizationRole.owner,
+            )
+            .values(role=OrganizationRole.admin)
+        )
+
+    async def promote_to_owner(self, organization_id: UUID, user_id: UUID) -> None:
+        """Promote `user_id` on the org to `owner`."""
+        await self.session.execute(
+            update(UserOrganization)
+            .where(
+                UserOrganization.organization_id == organization_id,
+                UserOrganization.user_id == user_id,
+            )
+            .values(role=OrganizationRole.owner)
+        )

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import Select, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from polar.exceptions import PolarError
@@ -11,7 +12,6 @@ from polar.models import User, UserOrganization
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncReadSession, AsyncSession, sql
-from polar.user.repository import UserRepository
 
 
 class UserOrganizationError(PolarError): ...
@@ -221,16 +221,13 @@ class UserOrganizationService:
         Fires the `IdentityVerificationStatus.verified` gate on the new
         owner, since payouts route through whoever holds `owner`.
         """
-        user_repository = UserRepository.from_session(session)
-        new_owner_user = await user_repository.get_by_id(new_owner_user_id)
-        if new_owner_user is None:
-            raise UserNotMemberOfOrganization(new_owner_user_id, organization_id)
-
         new_owner_user_org = await self.get_by_user_and_org(
             session, new_owner_user_id, organization_id
         )
         if new_owner_user_org is None:
             raise UserNotMemberOfOrganization(new_owner_user_id, organization_id)
+
+        new_owner_user = new_owner_user_org.user
 
         if new_owner_user_org.role == OrganizationRole.owner:
             raise AlreadyOwner(new_owner_user_id, organization_id)
@@ -251,14 +248,22 @@ class UserOrganizationService:
             )
             .values(role=OrganizationRole.admin)
         )
-        await session.execute(
-            sql.update(UserOrganization)
-            .where(
-                UserOrganization.organization_id == organization_id,
-                UserOrganization.user_id == new_owner_user_id,
+        try:
+            await session.execute(
+                sql.update(UserOrganization)
+                .where(
+                    UserOrganization.organization_id == organization_id,
+                    UserOrganization.user_id == new_owner_user_id,
+                )
+                .values(role=OrganizationRole.owner)
             )
-            .values(role=OrganizationRole.owner)
-        )
+            await session.flush()
+        except IntegrityError as e:
+            # Partial unique index `ix_user_organizations_owner_per_org`
+            # rejected a concurrent transfer that beat us to setting a
+            # different user as owner. Surface as `AlreadyOwner` so the
+            # caller can refresh state and retry.
+            raise AlreadyOwner(new_owner_user_id, organization_id) from e
         return new_owner_user
 
     async def remove_member(

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -13,6 +13,8 @@ from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncReadSession, AsyncSession, sql
 
+from .repository import UserOrganizationRepository
+
 
 class UserOrganizationError(PolarError): ...
 
@@ -240,23 +242,10 @@ class UserOrganizationService:
                 new_owner_user_id, new_owner_user.identity_verification_status
             )
 
-        await session.execute(
-            sql.update(UserOrganization)
-            .where(
-                UserOrganization.organization_id == organization_id,
-                UserOrganization.role == OrganizationRole.owner,
-            )
-            .values(role=OrganizationRole.admin)
-        )
+        repository = UserOrganizationRepository.from_session(session)
+        await repository.demote_current_owner(organization_id)
         try:
-            await session.execute(
-                sql.update(UserOrganization)
-                .where(
-                    UserOrganization.organization_id == organization_id,
-                    UserOrganization.user_id == new_owner_user_id,
-                )
-                .values(role=OrganizationRole.owner)
-            )
+            await repository.promote_to_owner(organization_id, new_owner_user_id)
             await session.flush()
         except IntegrityError as e:
             # Partial unique index `ix_user_organizations_owner_per_org`

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -4,13 +4,14 @@ from uuid import UUID
 from sqlalchemy import Select, func
 from sqlalchemy.orm import joinedload
 
-from polar.account.repository import AccountRepository
 from polar.exceptions import PolarError
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.utils import utc_now
-from polar.models import UserOrganization
+from polar.models import User, UserOrganization
+from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncReadSession, AsyncSession, sql
+from polar.user.repository import UserRepository
 
 
 class UserOrganizationError(PolarError): ...
@@ -70,6 +71,27 @@ class OwnerRoleCannotBeRemoved(UserOrganizationError):
             f"User {user_id} carries the 'owner' role on organization "
             f"{organization_id} and cannot be moved off it directly. "
             f"Ownership must be transferred first."
+        )
+        super().__init__(message, 400)
+
+
+class NewOwnerNotVerified(UserOrganizationError):
+    def __init__(self, user_id: UUID, status: IdentityVerificationStatus) -> None:
+        self.user_id = user_id
+        message = (
+            f"User {user_id} cannot be promoted to 'owner': "
+            f"identity verification status is {status.get_display_name()}, "
+            f"must be {IdentityVerificationStatus.verified.get_display_name()}."
+        )
+        super().__init__(message, 400)
+
+
+class AlreadyOwner(UserOrganizationError):
+    def __init__(self, user_id: UUID, organization_id: UUID) -> None:
+        self.user_id = user_id
+        self.organization_id = organization_id
+        message = (
+            f"User {user_id} already holds 'owner' on organization {organization_id}."
         )
         super().__init__(message, 400)
 
@@ -155,29 +177,20 @@ class UserOrganizationService:
         """
         Set a user's role on an organization, with validation.
 
-        - `role == owner` is only allowed when `user_id` matches the org's
-          `Account.admin_id`.
+        - `role == owner` is rejected. Ownership transfers flow through
+          a dedicated path (today: backoffice `change_admin`), which
+          atomically demotes the previous owner.
         - A user that currently carries `owner` cannot be moved off it
-          directly; ownership transfer flows through `Account.admin_id`
-          mutations (today: backoffice `change_admin`).
-
-        Internal trusted flows that swap roles atomically with an
-        `Account.admin_id` change (`account_service.change_admin`) bypass
-        this method by design.
+          directly; ownership transfer must promote a replacement.
         """
         user_org = await self.get_by_user_and_org(session, user_id, organization_id)
         if user_org is None:
             raise UserNotMemberOfOrganization(user_id, organization_id)
 
-        account_repo = AccountRepository.from_session(session)
-        account = await account_repo.get_by_organization(organization_id)
-        if account is None:
-            raise OrganizationNotFound(organization_id)
-
-        if role == OrganizationRole.owner and user_id != account.admin_id:
+        if role == OrganizationRole.owner:
             raise InvalidOwnerRoleAssignment(user_id, organization_id)
 
-        if user_org.role == OrganizationRole.owner and role != OrganizationRole.owner:
+        if user_org.role == OrganizationRole.owner:
             raise OwnerRoleCannotBeRemoved(user_id, organization_id)
 
         if user_org.role == role:
@@ -193,6 +206,60 @@ class UserOrganizationService:
         )
         user_org.role = role
         return user_org
+
+    async def transfer_ownership(
+        self,
+        session: AsyncSession,
+        *,
+        new_owner_user_id: UUID,
+        organization_id: UUID,
+    ) -> User:
+        """
+        Atomically demote the current `owner` (if any) to `admin` and
+        promote `new_owner_user_id` to `owner`.
+
+        Fires the `IdentityVerificationStatus.verified` gate on the new
+        owner, since payouts route through whoever holds `owner`.
+        """
+        user_repository = UserRepository.from_session(session)
+        new_owner_user = await user_repository.get_by_id(new_owner_user_id)
+        if new_owner_user is None:
+            raise UserNotMemberOfOrganization(new_owner_user_id, organization_id)
+
+        new_owner_user_org = await self.get_by_user_and_org(
+            session, new_owner_user_id, organization_id
+        )
+        if new_owner_user_org is None:
+            raise UserNotMemberOfOrganization(new_owner_user_id, organization_id)
+
+        if new_owner_user_org.role == OrganizationRole.owner:
+            raise AlreadyOwner(new_owner_user_id, organization_id)
+
+        if (
+            new_owner_user.identity_verification_status
+            != IdentityVerificationStatus.verified
+        ):
+            raise NewOwnerNotVerified(
+                new_owner_user_id, new_owner_user.identity_verification_status
+            )
+
+        await session.execute(
+            sql.update(UserOrganization)
+            .where(
+                UserOrganization.organization_id == organization_id,
+                UserOrganization.role == OrganizationRole.owner,
+            )
+            .values(role=OrganizationRole.admin)
+        )
+        await session.execute(
+            sql.update(UserOrganization)
+            .where(
+                UserOrganization.organization_id == organization_id,
+                UserOrganization.user_id == new_owner_user_id,
+            )
+            .values(role=OrganizationRole.owner)
+        )
+        return new_owner_user
 
     async def remove_member(
         self,

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -178,7 +178,7 @@ class UserOrganizationService:
         Set a user's role on an organization, with validation.
 
         - `role == owner` is rejected. Ownership transfers flow through
-          a dedicated path (today: backoffice `change_admin`), which
+          a dedicated path (today: backoffice `change_owner`), which
           atomically demotes the previous owner.
         - A user that currently carries `owner` cannot be moved off it
           directly; ownership transfer must promote a replacement.

--- a/server/scripts/plain_comm.py
+++ b/server/scripts/plain_comm.py
@@ -188,29 +188,29 @@ async def _send_email(
     organization = await organization_repository.get_by_id(organization_id)
     if organization is None:
         raise PlainScriptError("Organization not found")
-    admin = await organization_repository.get_admin_user(organization)
-    if admin is None:
+    owner = await organization_repository.get_owner_user(organization)
+    if owner is None:
         user_repository = UserRepository.from_session(session)
         users = await user_repository.get_all_by_organization(organization_id)
         if not users:
-            raise PlainScriptError("Admin user not found")
-        admin = users[0]
+            raise PlainScriptError("Owner user not found")
+        owner = users[0]
 
     async with _get_plain_client() as plain:
         # By email
         customer_result = await plain.upsert_customer(
             pl.UpsertCustomerInput(
-                identifier=pl.UpsertCustomerIdentifierInput(email_address=admin.email),
+                identifier=pl.UpsertCustomerIdentifierInput(email_address=owner.email),
                 on_create=pl.UpsertCustomerOnCreateInput(
-                    external_id=str(admin.id),
-                    full_name=admin.email,
+                    external_id=str(owner.id),
+                    full_name=owner.email,
                     email=pl.EmailAddressInput(
-                        email=admin.email, is_verified=admin.email_verified
+                        email=owner.email, is_verified=owner.email_verified
                     ),
                 ),
                 on_update=pl.UpsertCustomerOnUpdateInput(
                     email=pl.EmailAddressInput(
-                        email=admin.email, is_verified=admin.email_verified
+                        email=owner.email, is_verified=owner.email_verified
                     ),
                 ),
             )
@@ -220,18 +220,18 @@ async def _send_email(
             customer_result = await plain.upsert_customer(
                 pl.UpsertCustomerInput(
                     identifier=pl.UpsertCustomerIdentifierInput(
-                        external_id=str(admin.id)
+                        external_id=str(owner.id)
                     ),
                     on_create=pl.UpsertCustomerOnCreateInput(
-                        external_id=str(admin.id),
-                        full_name=admin.email,
+                        external_id=str(owner.id),
+                        full_name=owner.email,
                         email=pl.EmailAddressInput(
-                            email=admin.email, is_verified=admin.email_verified
+                            email=owner.email, is_verified=owner.email_verified
                         ),
                     ),
                     on_update=pl.UpsertCustomerOnUpdateInput(
                         email=pl.EmailAddressInput(
-                            email=admin.email, is_verified=admin.email_verified
+                            email=owner.email, is_verified=owner.email_verified
                         ),
                     ),
                 )

--- a/server/tests/account/test_model.py
+++ b/server/tests/account/test_model.py
@@ -8,7 +8,6 @@ def generate_account(
     fee_fixed: int | None = None,
 ) -> Account:
     account = Account(
-        admin_id=user.id,
         currency="usd",
         _platform_fee_percent=fee_basis_points,
         _platform_fee_fixed=fee_fixed,

--- a/server/tests/account/test_service.py
+++ b/server/tests/account/test_service.py
@@ -15,11 +15,10 @@ from tests.fixtures.database import SaveFixture
 @pytest.mark.asyncio
 class TestChangeAdminRoleSwap:
     """
-    The `change_admin` flow keeps `UserOrganization.role` aligned with
-    `Account.admin_id`: previous admin's `owner` is demoted to `admin`,
-    new admin is promoted to `owner`. Pre-backfill rows where the previous
-    admin still carries `member` are left alone (the demote is conditional
-    on `role == owner`).
+    `change_admin` swaps `UserOrganization.role`: the previous `owner` is
+    demoted to `admin`, and the new admin is promoted to `owner`. The flow
+    no longer touches `Account.admin_id`; ownership is driven entirely
+    by `UserOrganization.role`.
     """
 
     async def test_swaps_owner_role_on_admin_change(
@@ -31,22 +30,19 @@ class TestChangeAdminRoleSwap:
         user: User,
         user_second: User,
     ) -> None:
-        # Previous admin row at `owner` (post-backfill state).
-        previous_admin_uo = UserOrganization(
+        previous_owner_uo = UserOrganization(
             user_id=user.id,
             organization_id=organization.id,
             role=OrganizationRole.owner,
         )
-        # New admin starts as a member.
         new_admin_uo = UserOrganization(
             user_id=user_second.id,
             organization_id=organization.id,
             role=OrganizationRole.member,
         )
-        await save_fixture(previous_admin_uo)
+        await save_fixture(previous_owner_uo)
         await save_fixture(new_admin_uo)
 
-        # `change_admin` requires the new admin to be Stripe-identity-verified.
         user_second.identity_verification_status = IdentityVerificationStatus.verified
         await save_fixture(user_second)
 
@@ -68,7 +64,7 @@ class TestChangeAdminRoleSwap:
         assert previous.role == OrganizationRole.admin
         assert new.role == OrganizationRole.owner
 
-    async def test_pre_backfill_previous_admin_left_alone(
+    async def test_no_previous_owner_promotes_new_admin(
         self,
         save_fixture: SaveFixture,
         session: Any,
@@ -77,10 +73,10 @@ class TestChangeAdminRoleSwap:
         user: User,
         user_second: User,
     ) -> None:
-        # Pre-backfill: previous Account.admin still carries the default
-        # `member`. The conditional demote should leave them as `member`,
-        # not push them to `admin`.
-        previous_admin_uo = UserOrganization(
+        # Edge case: org has no current `owner` (shouldn't happen in
+        # production post-backfill, but the swap should still promote
+        # the new admin rather than blow up).
+        previous_member_uo = UserOrganization(
             user_id=user.id,
             organization_id=organization.id,
             role=OrganizationRole.member,
@@ -90,7 +86,7 @@ class TestChangeAdminRoleSwap:
             organization_id=organization.id,
             role=OrganizationRole.member,
         )
-        await save_fixture(previous_admin_uo)
+        await save_fixture(previous_member_uo)
         await save_fixture(new_admin_uo)
 
         user_second.identity_verification_status = IdentityVerificationStatus.verified

--- a/server/tests/account/test_service.py
+++ b/server/tests/account/test_service.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from polar.account.service import account as account_service
-from polar.models import Account, Organization, User, UserOrganization
+from polar.models import Organization, User, UserOrganization
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.user_organization.service import (
@@ -25,7 +25,6 @@ class TestChangeOwnerRoleSwap:
         self,
         save_fixture: SaveFixture,
         session: Any,
-        account: Account,
         organization: Organization,
         user: User,
         user_second: User,
@@ -48,7 +47,6 @@ class TestChangeOwnerRoleSwap:
 
         await account_service.change_owner(
             session,
-            account=account,
             new_owner_id=user_second.id,
             organization_id=organization.id,
         )
@@ -68,7 +66,6 @@ class TestChangeOwnerRoleSwap:
         self,
         save_fixture: SaveFixture,
         session: Any,
-        account: Account,
         organization: Organization,
         user: User,
         user_second: User,
@@ -94,7 +91,6 @@ class TestChangeOwnerRoleSwap:
 
         await account_service.change_owner(
             session,
-            account=account,
             new_owner_id=user_second.id,
             organization_id=organization.id,
         )

--- a/server/tests/account/test_service.py
+++ b/server/tests/account/test_service.py
@@ -13,15 +13,15 @@ from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
-class TestChangeAdminRoleSwap:
+class TestChangeOwnerRoleSwap:
     """
-    `change_admin` swaps `UserOrganization.role`: the previous `owner` is
-    demoted to `admin`, and the new admin is promoted to `owner`. The flow
+    `change_owner` swaps `UserOrganization.role`: the previous `owner` is
+    demoted to `admin`, and the new owner is promoted to `owner`. The flow
     no longer touches `Account.admin_id`; ownership is driven entirely
     by `UserOrganization.role`.
     """
 
-    async def test_swaps_owner_role_on_admin_change(
+    async def test_swaps_owner_role_on_owner_change(
         self,
         save_fixture: SaveFixture,
         session: Any,
@@ -35,21 +35,21 @@ class TestChangeAdminRoleSwap:
             organization_id=organization.id,
             role=OrganizationRole.owner,
         )
-        new_admin_uo = UserOrganization(
+        new_owner_uo = UserOrganization(
             user_id=user_second.id,
             organization_id=organization.id,
             role=OrganizationRole.member,
         )
         await save_fixture(previous_owner_uo)
-        await save_fixture(new_admin_uo)
+        await save_fixture(new_owner_uo)
 
         user_second.identity_verification_status = IdentityVerificationStatus.verified
         await save_fixture(user_second)
 
-        await account_service.change_admin(
+        await account_service.change_owner(
             session,
             account=account,
-            new_admin_id=user_second.id,
+            new_owner_id=user_second.id,
             organization_id=organization.id,
         )
 
@@ -64,7 +64,7 @@ class TestChangeAdminRoleSwap:
         assert previous.role == OrganizationRole.admin
         assert new.role == OrganizationRole.owner
 
-    async def test_no_previous_owner_promotes_new_admin(
+    async def test_no_previous_owner_promotes_new_owner(
         self,
         save_fixture: SaveFixture,
         session: Any,
@@ -75,27 +75,27 @@ class TestChangeAdminRoleSwap:
     ) -> None:
         # Edge case: org has no current `owner` (shouldn't happen in
         # production post-backfill, but the swap should still promote
-        # the new admin rather than blow up).
+        # the new owner rather than blow up).
         previous_member_uo = UserOrganization(
             user_id=user.id,
             organization_id=organization.id,
             role=OrganizationRole.member,
         )
-        new_admin_uo = UserOrganization(
+        new_owner_uo = UserOrganization(
             user_id=user_second.id,
             organization_id=organization.id,
             role=OrganizationRole.member,
         )
         await save_fixture(previous_member_uo)
-        await save_fixture(new_admin_uo)
+        await save_fixture(new_owner_uo)
 
         user_second.identity_verification_status = IdentityVerificationStatus.verified
         await save_fixture(user_second)
 
-        await account_service.change_admin(
+        await account_service.change_owner(
             session,
             account=account,
-            new_admin_id=user_second.id,
+            new_owner_id=user_second.id,
             organization_id=organization.id,
         )
 

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -320,11 +320,10 @@ async def user_organization(
     organization: Organization,
     user: User,
 ) -> UserOrganization:
-    # `user` is `account.admin_id` by virtue of the fixture chain (the
-    # `account` fixture creates an Account with `user` as admin), so the
-    # owner-validity invariant says they carry `owner` on the membership.
-    # Tests that need a non-admin user should either downgrade the role
-    # explicitly or use `user_second` / `user_organization_second`.
+    # `user` carries the `owner` role on the org by convention here,
+    # matching the production invariant that every org has exactly one
+    # owner. Tests that need a non-owner user should either downgrade
+    # the role explicitly or use `user_second` / `user_organization_second`.
     user_organization = UserOrganization(
         user=user, organization=organization, role=OrganizationRole.owner
     )

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -152,7 +152,6 @@ async def create_account(
     billing_address: Address | None = None,
 ) -> Account:
     account = Account(
-        admin_id=user.id,
         currency=currency,
         processor_fees_applicable=processor_fees_applicable,
         _platform_fee_percent=fee_basis_points,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1372,6 +1372,16 @@ async def _setup_passing_org(
 
     user.identity_verification_status = IdentityVerificationStatus.verified
     await save_fixture(user)
+
+    # `get_admin_user` returns the user holding `owner` on the org.
+    await save_fixture(
+        UserOrganization(
+            user_id=user.id,
+            organization_id=organization.id,
+            role=OrganizationRole.owner,
+        )
+    )
+
     await create_payout_account(save_fixture, organization, user)
 
     # Product configuration + setup readiness: a product with a license-key
@@ -1593,6 +1603,7 @@ class TestGetReviewState:
         session: AsyncSession,
         organization: Organization,
         user: User,
+        user_organization: UserOrganization,
         identity_status: IdentityVerificationStatus,
         expected_status: OrganizationReviewCheckStatus,
         expected_reason: OrganizationReviewCheckReason | None,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1373,7 +1373,7 @@ async def _setup_passing_org(
     user.identity_verification_status = IdentityVerificationStatus.verified
     await save_fixture(user)
 
-    # `get_admin_user` returns the user holding `owner` on the org.
+    # `get_owner_user` returns the user holding `owner` on the org.
     await save_fixture(
         UserOrganization(
             user_id=user.id,

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -5,10 +5,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.models import Account, Organization, User, UserOrganization
+from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.user_organization.service import (
+    AlreadyOwner,
     CannotRemoveOrganizationOwner,
     InvalidOwnerRoleAssignment,
+    NewOwnerNotVerified,
     OrganizationNotFound,
     OrganizationWouldHaveNoAdmins,
     OwnerRoleCannotBeRemoved,
@@ -321,16 +324,15 @@ class TestSetRole:
 
         assert result.role == OrganizationRole.admin
 
-    async def test_owner_role_rejected_for_non_admin_user(
+    async def test_owner_role_rejected(
         self,
         save_fixture: SaveFixture,
         session: Any,
-        account: Account,
         organization: Organization,
         user_second: User,
     ) -> None:
-        # `account` fixture sets `account.admin_id = user`, so user_second is
-        # not the Account.admin_id user — assigning `owner` to them must fail.
+        # `set_role` no longer accepts `owner` for any user — ownership
+        # transfers flow through `transfer_ownership`.
         relation = UserOrganization(
             user_id=user_second.id, organization_id=organization.id
         )
@@ -343,28 +345,6 @@ class TestSetRole:
                 organization_id=organization.id,
                 role=OrganizationRole.owner,
             )
-
-    async def test_owner_role_allowed_for_admin_user(
-        self,
-        save_fixture: SaveFixture,
-        session: Any,
-        account: Account,
-        organization: Organization,
-        user: User,
-    ) -> None:
-        # `account.admin_id == user.id` from the fixture; assigning `owner`
-        # to the matching user is allowed.
-        relation = UserOrganization(user_id=user.id, organization_id=organization.id)
-        await save_fixture(relation)
-
-        result = await user_organization_service.set_role(
-            session,
-            user_id=user.id,
-            organization_id=organization.id,
-            role=OrganizationRole.owner,
-        )
-
-        assert result.role == OrganizationRole.owner
 
     async def test_owner_cannot_be_demoted_directly(
         self,
@@ -401,4 +381,109 @@ class TestSetRole:
                 user_id=user_second.id,
                 organization_id=organization.id,
                 role=OrganizationRole.member,
+            )
+
+
+@pytest.mark.asyncio
+class TestTransferOwnership:
+    async def test_promotes_new_owner_and_demotes_previous(
+        self,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user: User,
+        user_second: User,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+        await save_fixture(
+            UserOrganization(
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.member,
+            )
+        )
+        user_second.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user_second)
+
+        await user_organization_service.transfer_ownership(
+            session,
+            new_owner_user_id=user_second.id,
+            organization_id=organization.id,
+        )
+
+        previous = await user_organization_service.get_by_user_and_org(
+            session, user.id, organization.id
+        )
+        new = await user_organization_service.get_by_user_and_org(
+            session, user_second.id, organization.id
+        )
+        assert previous is not None
+        assert previous.role == OrganizationRole.admin
+        assert new is not None
+        assert new.role == OrganizationRole.owner
+
+    async def test_rejects_unverified_user(
+        self,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.member,
+            )
+        )
+        # user_second left at the default unverified status
+
+        with pytest.raises(NewOwnerNotVerified):
+            await user_organization_service.transfer_ownership(
+                session,
+                new_owner_user_id=user_second.id,
+                organization_id=organization.id,
+            )
+
+    async def test_rejects_non_member(
+        self,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        with pytest.raises(UserNotMemberOfOrganization):
+            await user_organization_service.transfer_ownership(
+                session,
+                new_owner_user_id=user_second.id,
+                organization_id=organization.id,
+            )
+
+    async def test_rejects_existing_owner(
+        self,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+
+        with pytest.raises(AlreadyOwner):
+            await user_organization_service.transfer_ownership(
+                session,
+                new_owner_user_id=user.id,
+                organization_id=organization.id,
             )


### PR DESCRIPTION
## Summary

**Related Issue**: #11404

Phase 6 of the RBAC rollout: retires `Account.admin_id` and routes ownership transfer entirely through `UserOrganization.role`.

## What

- New `UserOrganizationService.transfer_ownership` does the atomic demote-current-owner + promote-new-owner swap, with the `IdentityVerificationStatus.verified` gate fired inline on the role transition.
- `OrganizationRepository.get_admin_user` rewritten as `get_owner_user`, querying `UserOrganization WHERE role = 'owner'`. All 8 callers follow.
- `account_service.change_admin` → `change_owner`; backoffice `make_admin` route → `make_owner`. Stops writing `Account.admin_id`.
- Partial unique index `(organization_id) WHERE role = 'owner' AND deleted_at IS NULL` added (CONCURRENTLY) to enforce single-owner-per-org at the DB level.
- Destructive migration drops `accounts.admin_id`; model relationship and dual-write helper removed.
- Backoffice team section: requirements card refreshed to match what's actually enforced; "Make Owner" dropdown gated on the member being identity-verified.
- Manual-payout-account creation now picks the org owner instead of an arbitrary `users[0]`.

## Why

Phase 4 migrated the frontend to read `role` and Phase 5 retired the legacy `is_admin` API field. `Account.admin_id` is now the only authorization signal still living outside the role model — keeping it around invites drift and gives future code two sources of truth for "who owns this org".

## How

Three semantic commits plus follow-ups: (1) partial unique index, (2) re-home authorization reads off `Account.admin_id` (introduces `transfer_ownership`, refactors `change_admin`), (3) destructive column drop + remove dual-write. Then a rename pass (admin→owner across identifiers, routes, UI text, test classes), review-feedback cleanups, and backoffice UI polish.

**Pre-deploy check**: no org should have more than one live owner row.
```sql
SELECT organization_id, COUNT(*) FROM user_organizations
WHERE role = 'owner' AND deleted_at IS NULL
GROUP BY organization_id HAVING COUNT(*) > 1;
```

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included