### PR TITLE
Add Customer Portal API docs for payment methods and update customer

### DIFF
--- a/docs/api-reference/customer-portal/payment-methods/delete.mdx
+++ b/docs/api-reference/customer-portal/payment-methods/delete.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/customer-portal/customers/me/payment-methods/{id}
+---

--- a/docs/api-reference/customer-portal/payment-methods/list.mdx
+++ b/docs/api-reference/customer-portal/payment-methods/list.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/customer-portal/customers/me/payment-methods
+---

--- a/docs/api-reference/customer-portal/payment-methods/list.mdx
+++ b/docs/api-reference/customer-portal/payment-methods/list.mdx
@@ -1,3 +1,7 @@
 ---
 openapi: get /v1/customer-portal/customers/me/payment-methods
 ---
+
+<Note>
+  To change the default payment method, call the [`PATCH /v1/customer-portal/customers/me`](/api-reference/customer-portal/update-customer) endpoint with the desired `default_payment_method_id`.
+</Note>

--- a/docs/api-reference/customer-portal/update-customer.mdx
+++ b/docs/api-reference/customer-portal/update-customer.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/customer-portal/customers/me
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -469,6 +469,13 @@
                   "api-reference/customer-portal/seats/resend",
                   "api-reference/customer-portal/seats/list-subscriptions"
                 ]
+              },
+              {
+                "group": "Payment Methods",
+                "pages": [
+                  "api-reference/customer-portal/payment-methods/list",
+                  "api-reference/customer-portal/payment-methods/delete"
+                ]
               }
             ]
           },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -418,6 +418,7 @@
             "group": "Customer Portal API",
             "pages": [
               "api-reference/customer-portal/get-customer",
+              "api-reference/customer-portal/update-customer",
               "api-reference/customer-portal/get-organization",
               {
                 "group": "Sessions",


### PR DESCRIPTION
## Summary

Adds API documentation for customer payment method management and customer update endpoints in the Customer Portal API.

## What

- Added documentation for `GET /v1/customer-portal/customers/me/payment-methods` endpoint (list payment methods)
- Added documentation for `DELETE /v1/customer-portal/customers/me/payment-methods/{id}` endpoint (delete payment method)
- Added documentation for `PATCH /v1/customer-portal/customers/me` endpoint (update customer)
- Updated `docs/docs.json` to include these new endpoints in the Customer Portal API navigation structure under a new "Payment Methods" group

## Why

These endpoints are part of the Customer Portal API but were missing from the documentation. Adding them improves API discoverability and provides users with complete reference material for managing payment methods and customer information.

## How

Created three new MDX documentation files that reference the OpenAPI specifications for each endpoint. Updated the documentation navigation structure to organize payment method endpoints under a dedicated group and added the update customer endpoint to the main Customer Portal API section.

## Checklist

- [x] This PR addresses a single concern (documentation additions)
- [x] The diff is reasonably sized and easy to review
- [x] No code changes required (documentation only)
- [x] No unrelated changes included

https://claude.ai/code/session_01BQmr4dGRRHs5etxZRTAADy