### PR TITLE
feat: propagate organization identity to AI gateway via OTel baggage

### DIFF
--- a/server/polar/observability/baggage.py
+++ b/server/polar/observability/baggage.py
@@ -1,0 +1,19 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import logfire
+
+
+@contextmanager
+def organization_baggage(
+    organization_id: str | None = None,
+    organization_slug: str | None = None,
+) -> Iterator[None]:
+    """Propagate organization identity as OTel baggage. None values are skipped."""
+    values: dict[str, str] = {}
+    if organization_id:
+        values["organization_id"] = organization_id
+    if organization_slug:
+        values["organization_slug"] = organization_slug
+    with logfire.set_baggage(**values):
+        yield

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -243,7 +243,11 @@ async def _collect_website(organization: Organization) -> WebsiteData | None:
         website_url=organization.website,
     )
     try:
-        website_data = await collect_website_data(organization.website)
+        website_data = await collect_website_data(
+            organization.website,
+            organization_id=str(organization.id),
+            organization_slug=organization.slug,
+        )
         log.debug(
             "organization_review.website_collector.complete",
             organization_id=str(organization.id),
@@ -312,7 +316,11 @@ async def _collect_webhook_host(
         webhook_host=host,
     )
     try:
-        data = await collect_website_data(f"https://{host}/")
+        data = await collect_website_data(
+            f"https://{host}/",
+            organization_id=str(organization.id),
+            organization_slug=organization.slug,
+        )
         log.debug(
             "organization_review.webhook_host_collector.complete",
             organization_id=str(organization.id),

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -4,6 +4,7 @@ import structlog
 from pydantic_ai import Agent
 
 from polar.config import settings
+from polar.observability.baggage import organization_baggage
 
 from .known_domains import known_domains_for_prompt, match_known_domain
 from .policy import fetch_policy_content
@@ -678,10 +679,14 @@ class ReviewAnalyzer:
         }.get(context)
 
         try:
-            result = await asyncio.wait_for(
-                self.agent.run(prompt, instructions=instructions),
-                timeout=timeout_seconds,
-            )
+            with organization_baggage(
+                organization_id=snapshot.organization.id,
+                organization_slug=snapshot.organization.slug,
+            ):
+                result = await asyncio.wait_for(
+                    self.agent.run(prompt, instructions=instructions),
+                    timeout=timeout_seconds,
+                )
             usage = UsageInfo.from_agent_usage(
                 result.usage(), self.model_provider, self.model_name
             )

--- a/server/polar/organization_review/collectors/organization.py
+++ b/server/polar/organization_review/collectors/organization.py
@@ -6,6 +6,7 @@ from ..schemas import OrganizationData
 def collect_organization_data(organization: Organization) -> OrganizationData:
     details = organization.details or {}
     return OrganizationData(
+        id=str(organization.id),
         name=organization.name,
         slug=organization.slug,
         website=organization.website,

--- a/server/polar/organization_review/collectors/website.py
+++ b/server/polar/organization_review/collectors/website.py
@@ -13,6 +13,7 @@ from pydantic_ai import Agent, RunContext
 
 from polar.config import settings
 from polar.kit.http import SSRFBlockedError, resolve_and_validate_ip
+from polar.observability.baggage import organization_baggage
 
 from ..schemas import UsageInfo, WebsiteData, WebsitePage
 
@@ -466,7 +467,12 @@ Slower but handles SPAs and JS-heavy sites. Use when fetch_page returns empty co
 # ---------------------------------------------------------------------------
 
 
-async def collect_website_data(website_url: str) -> WebsiteData:
+async def collect_website_data(
+    website_url: str,
+    *,
+    organization_id: str | None = None,
+    organization_slug: str | None = None,
+) -> WebsiteData:
     """Explore and summarize a website using an AI agent.
 
     The agent has two tools: a fast HTTP fetcher (default) and a headless
@@ -479,7 +485,11 @@ async def collect_website_data(website_url: str) -> WebsiteData:
 
     try:
         return await asyncio.wait_for(
-            _run_website_agent(base_url),
+            _run_website_agent(
+                base_url,
+                organization_id=organization_id,
+                organization_slug=organization_slug,
+            ),
             timeout=OVERALL_TIMEOUT_S,
         )
     except TimeoutError:
@@ -502,7 +512,12 @@ async def collect_website_data(website_url: str) -> WebsiteData:
 # ---------------------------------------------------------------------------
 
 
-async def _run_website_agent(base_url: str) -> WebsiteData:
+async def _run_website_agent(
+    base_url: str,
+    *,
+    organization_id: str | None = None,
+    organization_slug: str | None = None,
+) -> WebsiteData:
     """Run the AI agent with both HTTP and browser tools available."""
     allowed_domain = urlparse(base_url).hostname or ""
     # Strip www. so redirects between www and non-www are both allowed
@@ -516,10 +531,14 @@ async def _run_website_agent(base_url: str) -> WebsiteData:
     ) as client:
         deps = WebsiteDeps(client=client, allowed_domain=allowed_domain)
         try:
-            result = await _website_agent.run(
-                f"Analyze the website at: {base_url}",
-                deps=deps,
-            )
+            with organization_baggage(
+                organization_id=organization_id,
+                organization_slug=organization_slug,
+            ):
+                result = await _website_agent.run(
+                    f"Analyze the website at: {base_url}",
+                    deps=deps,
+                )
 
             return WebsiteData(
                 base_url=base_url,

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -79,6 +79,7 @@ class UsageInfo(Schema):
 
 
 class OrganizationData(Schema):
+    id: str | None = None
     name: str
     slug: str
     website: str | None = None

--- a/server/tests/observability/test_baggage.py
+++ b/server/tests/observability/test_baggage.py
@@ -1,0 +1,28 @@
+from opentelemetry import baggage as otel_baggage
+
+from polar.observability.baggage import organization_baggage
+
+
+class TestOrganizationBaggage:
+    def test_attaches_both_values(self) -> None:
+        with organization_baggage(
+            organization_id="org-123",
+            organization_slug="acme",
+        ):
+            assert otel_baggage.get_baggage("organization_id") == "org-123"
+            assert otel_baggage.get_baggage("organization_slug") == "acme"
+
+    def test_skips_none_values(self) -> None:
+        with organization_baggage(organization_id="org-123", organization_slug=None):
+            assert otel_baggage.get_baggage("organization_id") == "org-123"
+            assert otel_baggage.get_baggage("organization_slug") is None
+
+    def test_no_args_is_noop(self) -> None:
+        with organization_baggage():
+            assert otel_baggage.get_baggage("organization_id") is None
+            assert otel_baggage.get_baggage("organization_slug") is None
+
+    def test_clears_on_exit(self) -> None:
+        with organization_baggage(organization_id="org-123"):
+            pass
+        assert otel_baggage.get_baggage("organization_id") is None

--- a/server/tests/organization_review/collectors/test_website.py
+++ b/server/tests/organization_review/collectors/test_website.py
@@ -357,7 +357,11 @@ class TestCollectWebsiteData:
 
             result = await collect_website_data("example.com")
 
-            mock_run.assert_called_once_with("https://example.com")
+            mock_run.assert_called_once_with(
+                "https://example.com",
+                organization_id=None,
+                organization_slug=None,
+            )
             assert result.base_url == "https://example.com"
 
     @pytest.mark.asyncio
@@ -370,7 +374,11 @@ class TestCollectWebsiteData:
 
             await collect_website_data("https://example.com/")
 
-            mock_run.assert_called_once_with("https://example.com")
+            mock_run.assert_called_once_with(
+                "https://example.com",
+                organization_id=None,
+                organization_slug=None,
+            )
 
     @pytest.mark.asyncio
     async def test_timeout_returns_error_data(self) -> None:

--- a/server/tests/organization_review/test_agent.py
+++ b/server/tests/organization_review/test_agent.py
@@ -18,6 +18,7 @@ from polar.organization_review.schemas import (
 def _make_org(website: str | None) -> MagicMock:
     org = MagicMock()
     org.id = uuid4()
+    org.slug = "test-org"
     org.website = website
     return org
 
@@ -151,7 +152,11 @@ class TestCollectWebhookHost:
         ) as fetch:
             result = await _collect_webhook_host(org, setup)
         assert result is data
-        fetch.assert_awaited_once_with("https://api.different.com/")
+        fetch.assert_awaited_once_with(
+            "https://api.different.com/",
+            organization_id=str(org.id),
+            organization_slug=org.slug,
+        )
 
     @pytest.mark.asyncio
     async def test_swallows_fetch_exception(self) -> None:


### PR DESCRIPTION
## Summary

Make AI gateway requests originating from the organization review pipeline carry the triggering organization's identity, so PAIG spans in the ai-gateway Logfire project become attributable to a specific org.

## What

- New `polar.observability.baggage.organization_baggage` context manager wrapping `logfire.set_baggage`.
- Used around the two `pydantic-ai` `agent.run()` callsites: `ReviewAnalyzer.analyze` and `_run_website_agent`.
- `collect_website_data` threads optional `organization_id` / `organization_slug` from both callers in `agent.py`.
- `OrganizationData` gains an optional `id` field, populated by `collect_organization_data` so the analyzer can read it from the snapshot.

## Why

The gateway is shared infrastructure; without per-request org context, every PAIG span looks anonymous. Setting OTel baggage rides for free on the existing `traceparent` injection in pydantic-ai's gateway provider and ends up captured at the gateway side as `http.request.header.baggage`, making spans filterable by organization.

## How

`organization_baggage` builds a `dict[str, str]` (skipping None) and delegates to `logfire.set_baggage(**values)`. The gateway provider already calls `inject(headers)` on every outgoing request, so the baggage is serialized to the `baggage` HTTP header automatically. End-to-end verified with a live LLM call: the captured `http.request.header.baggage` attribute on the resulting PAIG span contained the exact values we set.

Search pattern in the ai-gateway Logfire project:

```sql
WHERE attributes->>'http.request.header.baggage' LIKE '%organization_id=<uuid>%'
```

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included