### PR TITLE
refactor: move AUP into agent instructions

### DIFF
--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -650,11 +650,14 @@ class ReviewAnalyzer:
         model_instance, model_provider, model_name = (
             settings.get_pydantic_gateway_model(model)
         )
+        # gpt-5.5+ reasoning models reject any non-default temperature.
         self.agent = Agent(
             model_instance,
             output_type=ReviewAgentReport,
             system_prompt=SYSTEM_PROMPT,
-            model_settings={"temperature": 0},
+            model_settings=(
+                {} if model_name.startswith("gpt-5.5") else {"temperature": 0}
+            ),
         )
         self.model_provider = model_provider
         self.model_name = model_name
@@ -668,14 +671,17 @@ class ReviewAnalyzer:
     ) -> tuple[ReviewAgentReport, UsageInfo]:
         policy_content = policy_override or fetch_policy_content()
 
-        prompt = self._build_prompt(snapshot, policy_content)
+        prompt = self._build_prompt(snapshot)
 
-        instructions = {
+        preamble = {
             ReviewContext.SUBMISSION: SUBMISSION_PREAMBLE,
             ReviewContext.THRESHOLD: THRESHOLD_PREAMBLE,
             ReviewContext.MANUAL: MANUAL_PREAMBLE,
             ReviewContext.APPEAL: APPEAL_PREAMBLE,
         }.get(context)
+
+        policy_block = f"## Acceptable Use Policy\n\n{policy_content}"
+        instructions = f"{preamble}\n\n{policy_block}" if preamble else policy_block
 
         try:
             result = await asyncio.wait_for(
@@ -701,7 +707,7 @@ class ReviewAnalyzer:
             )
             return _error_report(str(e)), UsageInfo()
 
-    def _build_prompt(self, snapshot: DataSnapshot, policy_content: str) -> str:
+    def _build_prompt(self, snapshot: DataSnapshot) -> str:
         org = snapshot.organization
         products = snapshot.products
         identity = snapshot.identity
@@ -1072,10 +1078,6 @@ class ReviewAnalyzer:
                         )
                 if entry.reason:
                     parts.append(f"- Reviewer Reason: {entry.reason}")
-
-        # Policy
-        parts.append("\n## Acceptable Use Policy")
-        parts.append(policy_content)
 
         parts.append(
             "\n## Instructions"

--- a/server/tests/organization_review/test_feedback.py
+++ b/server/tests/organization_review/test_feedback.py
@@ -317,7 +317,7 @@ class TestBuildPromptPriorFeedback:
         from polar.organization_review.analyzer import ReviewAnalyzer
 
         analyzer = ReviewAnalyzer.__new__(ReviewAnalyzer)
-        return analyzer._build_prompt(snapshot, policy_content="(policy omitted)")
+        return analyzer._build_prompt(snapshot)
 
     def test_no_feedback_omits_section(self) -> None:
         prompt = self._build(_make_snapshot())

--- a/server/tests/organization_review/test_feedback.py
+++ b/server/tests/organization_review/test_feedback.py
@@ -483,23 +483,6 @@ class TestBuildPromptPriorFeedback:
         prompt = self._build(_make_snapshot(prior_feedback=feedback))
         assert "unknown date" in prompt
 
-    def test_feedback_placed_before_policy(self) -> None:
-        feedback = PriorFeedbackData(
-            entries=[
-                PriorFeedbackEntry(
-                    actor_type="human",
-                    decision="APPROVE",
-                    review_context="threshold",
-                    created_at=datetime(2026, 1, 10, tzinfo=UTC),
-                )
-            ]
-        )
-        prompt = self._build(_make_snapshot(prior_feedback=feedback))
-
-        pos_feedback = prompt.index("## Prior Review Decisions")
-        pos_policy = prompt.index("## Acceptable Use Policy")
-        assert pos_feedback < pos_policy
-
 
 # ---------------------------------------------------------------------------
 # Schema backward compatibility


### PR DESCRIPTION
## Summary

- Pass AUP as part of system prompt
- Move to GPT 5.5

This improved accuracy from 59% (gpt 5.2) to 70% (gpt 5.5). 

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included