### PR TITLE
fix(rate-limit): isolate pending_auth requests to per-endpoint zones

### DIFF
--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -121,24 +121,77 @@ async def _authenticate(scope: Scope, *, redis: Redis) -> tuple[str, RateLimitGr
         return _ANONYMOUS_IDENTITY, RateLimitGroup.default
 
 
+# Each sensitive endpoint gets a `pending_auth` twin so requests with an
+# unvalidated bearer token / cookie are counted in the endpoint's own zone
+# instead of falling through to the catch-all `api` zone on `^/v1`.
 _BASE_RULES: dict[str, Sequence[Rule]] = {
-    "^/v1/login-code": [Rule(minute=6, hour=12, block_time=900, zone="login-code")],
+    "^/v1/login-code": [
+        Rule(minute=6, hour=12, block_time=900, zone="login-code"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="login-code",
+        ),
+    ],
     "^/v1/customer-portal/customer-session/(request|authenticate)": [
-        Rule(minute=6, hour=12, block_time=900, zone="customer-session-login")
+        Rule(minute=6, hour=12, block_time=900, zone="customer-session-login"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="customer-session-login",
+        ),
     ],
     "^/v1/customer-portal/customers/me/email-update/(request|check|verify)": [
-        Rule(minute=6, hour=12, block_time=900, zone="customer-email-update")
+        Rule(minute=6, hour=12, block_time=900, zone="customer-email-update"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="customer-email-update",
+        ),
     ],
     "^/v1/customer-portal/license-keys/(validate|activate|deactivate)": [
-        Rule(second=3, block_time=60, zone="customer-license-key")
+        Rule(second=3, block_time=60, zone="customer-license-key"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            second=3,
+            block_time=60,
+            zone="customer-license-key",
+        ),
     ],
     "^/v1/customer-seats/claim/.+/stream": [
-        Rule(minute=10, block_time=300, zone="seat-claim-stream")
+        Rule(minute=10, block_time=300, zone="seat-claim-stream"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=10,
+            block_time=300,
+            zone="seat-claim-stream",
+        ),
     ],
     "^/v1/checkouts/.+/confirm": [
-        Rule(minute=6, hour=20, block_time=1800, zone="checkout-confirm")
+        Rule(minute=6, hour=20, block_time=1800, zone="checkout-confirm"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=20,
+            block_time=1800,
+            zone="checkout-confirm",
+        ),
     ],
-    "^/v1/feedbacks/": [Rule(hour=5, block_time=3600, zone="feedback-submit")],
+    "^/v1/feedbacks/": [
+        Rule(hour=5, block_time=3600, zone="feedback-submit"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            hour=5,
+            block_time=3600,
+            zone="feedback-submit",
+        ),
+    ],
 }
 
 _SANDBOX_RULES: dict[str, Sequence[Rule]] = {

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -1,12 +1,16 @@
-from collections.abc import AsyncIterator
+import re
+from collections.abc import AsyncIterator, Sequence
 
 import pytest
 import pytest_asyncio
 from fakeredis import FakeAsyncRedis
+from ratelimit import Rule
 
 from polar.config import settings
 from polar.enums import RateLimitGroup
 from polar.rate_limit import (
+    _PRODUCTION_RULES,
+    _SANDBOX_RULES,
     _authenticate,
     _bearer_token,
     _identity_cache_key,
@@ -215,3 +219,60 @@ class TestAuthenticate:
 
         assert ident_a == ("user:a", RateLimitGroup.default)
         assert ident_b == ("organization:b", RateLimitGroup.elevated)
+
+
+def _select_rule(
+    rules: dict[str, Sequence[Rule]], path: str, group: RateLimitGroup
+) -> Rule | None:
+    """Mirror the rule selection in ratelimit/core.py for GET requests."""
+    for pattern, pattern_rules in rules.items():
+        if not re.compile(pattern).match(path):
+            continue
+        for rule in pattern_rules:
+            if rule.group == group and rule.method.lower() in ("get", "*"):
+                return rule
+    return None
+
+
+_SENSITIVE_PATHS: list[tuple[str, str]] = [
+    ("/v1/login-code/request", "login-code"),
+    ("/v1/customer-portal/customer-session/request", "customer-session-login"),
+    ("/v1/customer-portal/customer-session/authenticate", "customer-session-login"),
+    (
+        "/v1/customer-portal/customers/me/email-update/request",
+        "customer-email-update",
+    ),
+    ("/v1/customer-portal/license-keys/validate", "customer-license-key"),
+    ("/v1/customer-seats/claim/abc-123/stream", "seat-claim-stream"),
+    ("/v1/checkouts/xyz-789/confirm", "checkout-confirm"),
+    ("/v1/feedbacks/", "feedback-submit"),
+]
+
+
+@pytest.mark.parametrize("rules", [_PRODUCTION_RULES, _SANDBOX_RULES])
+@pytest.mark.parametrize(("path", "expected_zone"), _SENSITIVE_PATHS)
+@pytest.mark.parametrize(
+    "group", [RateLimitGroup.default, RateLimitGroup.pending_auth]
+)
+class TestSensitiveEndpointZoneIsolation:
+    """Pending-auth requests (unvalidated bearer/cookie) must use the
+    endpoint's own zone, not fall through to the shared "api" zone.
+
+    Regression coverage for https://github.com/polarsource/polar/issues/11704.
+    """
+
+    def test_resolves_to_endpoint_zone(
+        self,
+        rules: dict[str, Sequence[Rule]],
+        path: str,
+        expected_zone: str,
+        group: RateLimitGroup,
+    ) -> None:
+        rule = _select_rule(rules, path, group)
+        assert rule is not None, (
+            f"No rule selected for path={path!r} group={group.value!r}"
+        )
+        assert rule.zone == expected_zone, (
+            f"Path {path!r} for group {group.value!r} resolved to "
+            f"zone {rule.zone!r}, expected {expected_zone!r}"
+        )

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -251,9 +251,7 @@ _SENSITIVE_PATHS: list[tuple[str, str]] = [
 
 @pytest.mark.parametrize("rules", [_PRODUCTION_RULES, _SANDBOX_RULES])
 @pytest.mark.parametrize(("path", "expected_zone"), _SENSITIVE_PATHS)
-@pytest.mark.parametrize(
-    "group", [RateLimitGroup.default, RateLimitGroup.pending_auth]
-)
+@pytest.mark.parametrize("group", [RateLimitGroup.default, RateLimitGroup.pending_auth])
 class TestSensitiveEndpointZoneIsolation:
     """Pending-auth requests (unvalidated bearer/cookie) must use the
     endpoint's own zone, not fall through to the shared "api" zone.


### PR DESCRIPTION
## Summary

**Related Issue**: #11704

Pending-auth requests (unvalidated bearer tokens / session cookies) bypassed endpoint-specific rate-limit zones and landed in the shared `api` zone, defeating the per-endpoint isolation and block_time on sensitive endpoints like `/v1/login-code/request`, `/v1/checkouts/.../confirm`, etc.

## What

- `server/polar/rate_limit.py`: added a `pending_auth` `Rule` twin to every entry in `_BASE_RULES` with the same `zone`, limits, and `block_time` as the existing default-group rule.
- `server/tests/test_rate_limit.py`: added `TestSensitiveEndpointZoneIsolation`, parametrized 32 ways (2 rule sets × 8 paths × 2 groups), asserting each sensitive path resolves to its dedicated zone for both `default` and `pending_auth`.

No production rule values changed; existing behaviour for `default` / `web` / `elevated` / `restricted` groups is unaffected.

## Why

The `ratelimit` middleware walks patterns in dict order. For each matched pattern it filters rules by `group`; if **no** rule matches the group it falls through to the next pattern. With `_BASE_RULES` defining only default-group rules, a `pending_auth` request to `/v1/login-code/request`:

1. Matched `^/v1/login-code` but found no `pending_auth` rule there.
2. Fell through to the catch-all `^/v1` rule with `zone="api"`, `minute=10`, no `block_time`.

Because the Redis key includes the zone (`ratelimit:{zone}:{identity}`), counts/blocks landed in `ratelimit:api:token:<hash>` instead of `ratelimit:login-code:token:<hash>`. An attacker rotating fake bearer tokens spread requests across separate token-hash buckets in the lax `api` zone, completely sidestepping the endpoint's 6/min, 12/hour, 900s-block intent.

Introduced in #11513 (commit `86a2f16c09`), which added the `pending_auth` group + catch-all rule but didn't add corresponding entries to `_BASE_RULES`.

## How

Each sensitive endpoint pattern in `_BASE_RULES` now has two rules: the original default-group rule, plus a `pending_auth` rule with identical parameters. Because the middleware breaks out of the pattern loop only when at least one rule matches both the path AND the request's group, this ensures pending-auth requests stick to the endpoint-specific zone.

All 7 patterns get the twin (not just the 3 called out in the bug report) — every endpoint deemed worth its own zone today is still worth that zone when the requester waves a fake bearer.

Verification: ran `tests/test_rate_limit.py` (55 passed including the new 32 parametrized combinations), `ruff check`, and `mypy` against both touched files.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included