### PR TITLE
fix: Ensure tasks with optional fields can be enqueued from backoffice

### DIFF
--- a/server/polar/backoffice/tasks/forms.py
+++ b/server/polar/backoffice/tasks/forms.py
@@ -36,8 +36,13 @@ def _get_function_arguments(
         if get_origin(type_hint) is Unpack:
             type_hints_args = get_args(type_hint)
             if is_typeddict(type_hints_args[0]):
-                for k, v in get_type_hints(type_hints_args[0]).items():
-                    yield k, v, inspect.Parameter.empty
+                typeddict_class = type_hints_args[0]
+                optional_keys = typeddict_class.__optional_keys__
+                for k, v in get_type_hints(typeddict_class).items():
+                    if k in optional_keys:
+                        yield k, v, None
+                    else:
+                        yield k, v, inspect.Parameter.empty
                 return
             elif issubclass(type_hints_args[0], dict):
                 yield from _get_function_arguments(type_hints_args[0].__init__)

--- a/server/tests/backoffice/tasks/test_forms.py
+++ b/server/tests/backoffice/tasks/test_forms.py
@@ -1,0 +1,51 @@
+import inspect
+from typing import NotRequired, Required, TypedDict, Unpack
+
+from polar.backoffice.tasks.forms import _get_function_arguments
+
+
+class _AllOptional(TypedDict, total=False):
+    first_name: str
+    last_name: str
+
+
+class _AllRequired(TypedDict):
+    user_id: str
+    email: str
+
+
+class _Mixed(TypedDict):
+    user_id: Required[str]
+    first_name: NotRequired[str]
+    last_name: NotRequired[str]
+
+
+def test_typeddict_total_false_yields_none_default() -> None:
+    def task(**kwargs: Unpack[_AllOptional]) -> None: ...
+
+    args = dict(((k, default) for k, _, default in _get_function_arguments(task)))
+
+    assert args == {"first_name": None, "last_name": None}
+
+
+def test_typeddict_total_true_yields_empty_default() -> None:
+    def task(**kwargs: Unpack[_AllRequired]) -> None: ...
+
+    args = {k: default for k, _, default in _get_function_arguments(task)}
+
+    assert args == {
+        "user_id": inspect.Parameter.empty,
+        "email": inspect.Parameter.empty,
+    }
+
+
+def test_typeddict_mixed_required_and_not_required() -> None:
+    def task(**kwargs: Unpack[_Mixed]) -> None: ...
+
+    args = {k: default for k, _, default in _get_function_arguments(task)}
+
+    assert args == {
+        "user_id": inspect.Parameter.empty,
+        "first_name": None,
+        "last_name": None,
+    }


### PR DESCRIPTION
## Summary

**Related Issue**: #11709

Ensure tasks with optional fields can be enqueued from backoffice