### PR TITLE
feat(organization_review): switch default model to gpt-5.5

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -234,7 +234,7 @@ class Settings(BaseSettings):
 
     # Pydantic AI Gateway
     PYDANTIC_AI_GATEWAY_API_KEY: str = "DummyKey"
-    PYDANTIC_AI_GATEWAY_MODEL: str = "openai:gpt-5.2-2025-12-11"
+    PYDANTIC_AI_GATEWAY_MODEL: str = "openai:gpt-5.5"
 
     # Stripe
     STRIPE_SECRET_KEY: str = ""

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
   "arabic-reshaper>=3.0.0",
   "python-bidi>=0.6.9",
   "pydantic-ai-slim[openai]>=1.90.0",
+  "genai-prices>=0.0.59",
   "asgi-ratelimit>=0.10.0",
   "aiocsv>=1.4.0",
   "alembic-utils>=0.8.8",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-15T09:44:32.555373Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -967,15 +967,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.55"
+version = "0.0.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/67/de9d9be180db6d80b298c281dff71502095c0776d7cc9286f486f667f61a/genai_prices-0.0.55.tar.gz", hash = "sha256:8692c65d0deefe2ad0680d71841eb12822a35945a6060d2b6adbcbdf4945e1cb", size = 59987, upload-time = "2026-02-26T17:56:41.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c8/b61a028b8d8ee286ffab3f9b9f1c9229087184e7d543cea4e349e11375b0/genai_prices-0.0.59.tar.gz", hash = "sha256:3e1c7dcd9b38163589c8cf4a9bcfd286c52ea57a3becdc062a2cbaa8295b08c4", size = 67406, upload-time = "2026-05-07T12:08:40.475Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/98/66a06b82a5c840f896490d5ef9c7691776b147589f2e8d2fa66c67a3db9c/genai_prices-0.0.55-py3-none-any.whl", hash = "sha256:ccd795c90c926b3c71066bf5656f14c67fc11fdba6d71e072c7fb4fa311e1b12", size = 62603, upload-time = "2026-02-26T17:56:40.502Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/4693c127f9fab0a8d39c47c198e378ecafcb043463e6dd73df205eacbc13/genai_prices-0.0.59-py3-none-any.whl", hash = "sha256:88fd8818e6807374e5a5c03f293b574ade5f18a3060622080cdd94a03cf43115", size = 70509, upload-time = "2026-05-07T12:08:39.075Z" },
 ]
 
 [[package]]
@@ -2149,6 +2149,7 @@ dependencies = [
     { name = "exponent-server-sdk" },
     { name = "fastapi" },
     { name = "fpdf2" },
+    { name = "genai-prices" },
     { name = "githubkit" },
     { name = "greenlet" },
     { name = "httpx" },
@@ -2243,6 +2244,7 @@ requires-dist = [
     { name = "exponent-server-sdk", specifier = ">=2.1.0" },
     { name = "fastapi", specifier = ">=0.136.1" },
     { name = "fpdf2", specifier = ">=2.8.3" },
+    { name = "genai-prices", specifier = ">=0.0.59" },
     { name = "githubkit", specifier = "==0.15.4" },
     { name = "greenlet", specifier = ">=3.1.1" },
     { name = "httpx", specifier = ">=0.23.0" },


### PR DESCRIPTION
## Summary

Switch to GPT 5.5 for org reviews. This improved accuracy from 57% to 62% on the evals.

## What

- `PYDANTIC_AI_GATEWAY_MODEL` default flips to `openai:gpt-5.5` (`server/polar/config.py`).
- Add `genai-prices>=0.0.59` as a direct dependency in `server/pyproject.toml`. Previously it was only present transitively at 0.0.55, which cannot resolve `gpt-5.5`.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)