### PR TITLE
feat: Add full audit trail for org team changes

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -802,18 +802,20 @@ class OrganizationService:
             session.add(relation)
             await session.flush()
             log.info(
-                "organization.add_user.created",
+                "organization.member.added",
                 user_id=user.id,
                 organization_id=organization.id,
+                role=role,
             )
         except IntegrityError:
             # TODO: Currently, we treat this as success since the connection
             # exists. However, once we use status to distinguish active/inactive
             # installations we need to change this.
             log.info(
-                "organization.add_user.already_exists",
+                "organization.member.re_added",
                 organization_id=organization.id,
                 user_id=user.id,
+                role=role,
             )
             await nested.rollback()
             # Update

--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -46,16 +46,21 @@ class UserOrganizationRepository:
         result = await self.session.execute(statement)
         return [(row[0], row[1]) for row in result.all()]
 
-    async def demote_current_owner(self, organization_id: UUID) -> None:
-        """Demote whoever currently holds `owner` on the org to `admin`."""
-        await self.session.execute(
+    async def demote_current_owner(self, organization_id: UUID) -> UUID | None:
+        """Demote whoever currently holds `owner` on the org to `admin`.
+
+        Returns the demoted user's id, or `None` if the org had no owner.
+        """
+        result = await self.session.execute(
             update(UserOrganization)
             .where(
                 UserOrganization.organization_id == organization_id,
                 UserOrganization.role == OrganizationRole.owner,
             )
             .values(role=OrganizationRole.admin)
+            .returning(UserOrganization.user_id)
         )
+        return result.scalar_one_or_none()
 
     async def promote_to_owner(self, organization_id: UUID, user_id: UUID) -> None:
         """Promote `user_id` on the org to `owner`."""

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
+import structlog
 from sqlalchemy import Select, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
@@ -14,6 +15,8 @@ from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncReadSession, AsyncSession, sql
 
 from .repository import UserOrganizationRepository
+
+log = structlog.get_logger()
 
 
 class UserOrganizationError(PolarError): ...
@@ -198,6 +201,7 @@ class UserOrganizationService:
         if user_org.role == role:
             return user_org
 
+        previous_role = user_org.role
         await session.execute(
             sql.update(UserOrganization)
             .where(
@@ -207,6 +211,13 @@ class UserOrganizationService:
             .values(role=role)
         )
         user_org.role = role
+        log.info(
+            "organization.member.role_changed",
+            organization_id=organization_id,
+            user_id=user_id,
+            previous_role=previous_role,
+            role=role,
+        )
         return user_org
 
     async def transfer_ownership(
@@ -243,7 +254,7 @@ class UserOrganizationService:
             )
 
         repository = UserOrganizationRepository.from_session(session)
-        await repository.demote_current_owner(organization_id)
+        previous_owner_user_id = await repository.demote_current_owner(organization_id)
         try:
             await repository.promote_to_owner(organization_id, new_owner_user_id)
             await session.flush()
@@ -253,6 +264,12 @@ class UserOrganizationService:
             # different user as owner. Surface as `AlreadyOwner` so the
             # caller can refresh state and retry.
             raise AlreadyOwner(new_owner_user_id, organization_id) from e
+        log.info(
+            "organization.ownership.transferred",
+            organization_id=organization_id,
+            new_owner_user_id=new_owner_user_id,
+            previous_owner_user_id=previous_owner_user_id,
+        )
         return new_owner_user
 
     async def remove_member(
@@ -265,6 +282,8 @@ class UserOrganizationService:
         await self._assert_admin_capability_after_removal(
             session, user_id=user_id, organization_id=organization_id
         )
+
+        existing = await self.get_by_user_and_org(session, user_id, organization_id)
 
         stmt = (
             sql.update(UserOrganization)
@@ -279,6 +298,12 @@ class UserOrganizationService:
         result = await session.execute(stmt)
         removed_user_id = result.scalar_one_or_none()
         if removed_user_id is not None:
+            log.info(
+                "organization.member.removed",
+                organization_id=organization_id,
+                user_id=user_id,
+                role=existing.role if existing is not None else None,
+            )
             polar_self_service.enqueue_remove_member(
                 external_customer_id=str(organization_id),
                 external_id=str(user_id),


### PR DESCRIPTION
## Summary

Follow up to #6646

Add full audit trails for org team changes, including role changes and ownership transfers

## What

Add the following log events:
- `organization.members.role_changed`
- `organization.ownership.transferred`
- `organization.member.removed`

Rename the following events (for consistency):
- ~`organization.add_user.created`~ -> `organization.member.added`
- ~`organization.add_user.already_exists`~ -> `organization.member.re_added`

## Why

To get complete audit trails for team management, including role changes and ownership transfers

## How

See code.

Assuming actor (i.e. who did it) is populated through the entire span. So we get actor from `auth_subject` in http requests and task/other from elsewhere (i.e. when the system did it).


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
