### PR TITLE
Clarify Polar's proactive chargeback prevention refund policy

### DIFF
--- a/docs/features/refunds.mdx
+++ b/docs/features/refunds.mdx
@@ -9,7 +9,9 @@ No matter what refund policy you offer to customers, Polar makes it easy to issu
 <Note>
 **Polar can issue refunds on your behalf**
 
-Polar reserves the right to issue refunds within 60 days of purchase, at its own discretion, in order to prevent chargebacks. So if you choose to have a "no refunds" policy, be aware that Polar may still issue refunds in an effort to proactively prevent chargebacks.
+Polar reserves the right to issue refunds within 60 days of purchase, at its own discretion, in order to prevent chargebacks. We integrate with credit card networks to receive early chargeback signals before a dispute is officially filed, and for lower-value transactions we'll automatically refund the order — and cancel any related subscription — on your behalf to head off the chargeback.
+
+This applies even if you have a "no refunds" policy: keeping chargebacks low protects your account, so Polar may still refund proactively. See [Chargeback Management](/merchant-of-record/account-reviews#chargeback-management) for the wider context.
 </Note>
 
 ## What's refundable


### PR DESCRIPTION
## Summary

Updates the refunds documentation to provide clearer details about Polar's proactive chargeback prevention approach and when refunds may be issued automatically.

## What

Expanded the "Polar can issue refunds on your behalf" note in `docs/features/refunds.mdx` to:
- Explain that Polar integrates with credit card networks to receive early chargeback signals
- Clarify that lower-value transactions are automatically refunded and related subscriptions cancelled to prevent chargebacks
- Emphasize that this applies even with a "no refunds" policy
- Add a reference link to the Chargeback Management section for additional context

## Why

The previous documentation was vague about *how* and *when* Polar issues refunds proactively. This change provides merchants with a clearer understanding of:
1. The mechanism (early chargeback signals from credit card networks)
2. The scope (lower-value transactions)
3. The impact (automatic refunds and subscription cancellation)
4. The rationale (protecting the merchant account from chargebacks)

This helps set proper expectations and reduces confusion about refund behavior.

## How

Rewrote the note content to be more specific and informative while maintaining the key message that chargebacks are a priority even for merchants with strict refund policies.

## Checklist

- [x] This PR addresses a single concern (documentation clarification)
- [x] The diff is reasonably sized and easy to review
- [x] No testing needed (documentation only)

https://claude.ai/code/session_01LFc8m3gbtoAagvYeE7wPGy