### PR TITLE
fix(benefit): stop resetting meters when refreshing benefit grants

### DIFF
--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -439,7 +439,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
             "benefit.reset_meters_and_enqueue_grants"
         )
 
-        # Pipeline: revoke group → enqueue_grants (resets meters for subs, then grants)
+        # Pipeline: revoke group → enqueue_grants callback (then per-benefit grants)
         if revoke_benefit_ids:
             revoke_actor = broker.get_actor("benefit.revoke")
             revoke_messages = [

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -435,9 +435,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
 
         scope_args = scope_to_args(scope)
         broker = dramatiq.get_broker()
-        enqueue_grants_actor = broker.get_actor(
-            "benefit.reset_meters_and_enqueue_grants"
-        )
+        enqueue_grants_actor = broker.get_actor("benefit.enqueue_grants")
 
         # Pipeline: revoke group → enqueue_grants callback (then per-benefit grants)
         if revoke_benefit_ids:
@@ -463,7 +461,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
             revoke_group.run()
         else:
             enqueue_job(
-                "benefit.reset_meters_and_enqueue_grants",
+                "benefit.enqueue_grants",
                 customer_id=customer.id,
                 grant_benefit_ids=grant_benefit_ids,
                 member_id=member_id,

--- a/server/polar/benefit/tasks.py
+++ b/server/polar/benefit/tasks.py
@@ -11,8 +11,6 @@ from polar.exceptions import PolarTaskError
 from polar.logging import Logger
 from polar.models.benefit_grant import BenefitGrantScopeArgs
 from polar.product.repository import ProductRepository
-from polar.subscription.repository import SubscriptionRepository
-from polar.subscription.service import subscription as subscription_service
 from polar.worker import (
     AsyncSessionMaker,
     RedisMiddleware,
@@ -100,6 +98,11 @@ async def enqueue_benefits_grants(
         )
 
 
+# Actor name kept for backwards compatibility with in-flight Dramatiq messages;
+# this task no longer resets meters. Meter resets happen on
+# subscription_cycle / subscription_cycle_after_trial / subscription_cancel
+# orders (see order.service.create_subscription_order) and via
+# meter_credit.cycle() per benefit grant.
 @actor(
     actor_name="benefit.reset_meters_and_enqueue_grants", priority=TaskPriority.MEDIUM
 )
@@ -109,15 +112,6 @@ async def benefit_enqueue_grants(
     member_id: uuid.UUID | None = None,
     **scope: Unpack[BenefitGrantScopeArgs],
 ) -> None:
-    if subscription_id := scope.get("subscription_id"):
-        async with AsyncSessionMaker() as session:
-            repository = SubscriptionRepository.from_session(session)
-            subscription = await repository.get_by_id(
-                subscription_id, options=repository.get_eager_options()
-            )
-            if subscription:
-                await subscription_service.reset_meters(session, subscription)
-
     for benefit_id in grant_benefit_ids:
         enqueue_job(
             "benefit.grant",

--- a/server/polar/benefit/tasks.py
+++ b/server/polar/benefit/tasks.py
@@ -98,14 +98,7 @@ async def enqueue_benefits_grants(
         )
 
 
-# Actor name kept for backwards compatibility with in-flight Dramatiq messages;
-# this task no longer resets meters. Meter resets happen on
-# subscription_cycle / subscription_cycle_after_trial / subscription_cancel
-# orders (see order.service.create_subscription_order) and via
-# meter_credit.cycle() per benefit grant.
-@actor(
-    actor_name="benefit.reset_meters_and_enqueue_grants", priority=TaskPriority.MEDIUM
-)
+@actor(actor_name="benefit.enqueue_grants", priority=TaskPriority.MEDIUM)
 async def benefit_enqueue_grants(
     customer_id: uuid.UUID,
     grant_benefit_ids: list[uuid.UUID],
@@ -120,6 +113,25 @@ async def benefit_enqueue_grants(
             member_id=member_id,
             **scope,
         )
+
+
+# Deprecated alias. Kept registered to drain in-flight Dramatiq messages
+# enqueued before the rename. Remove once the queue is drained after deploy.
+# This task previously also reset meters; resets are now the responsibility
+# of order.service.create_subscription_order (cycle/cancel orders) and
+# meter_credit.cycle() per benefit grant.
+@actor(
+    actor_name="benefit.reset_meters_and_enqueue_grants", priority=TaskPriority.MEDIUM
+)
+async def benefit_reset_meters_and_enqueue_grants(
+    customer_id: uuid.UUID,
+    grant_benefit_ids: list[uuid.UUID],
+    member_id: uuid.UUID | None = None,
+    **scope: Unpack[BenefitGrantScopeArgs],
+) -> None:
+    await benefit_enqueue_grants(
+        customer_id, grant_benefit_ids, member_id=member_id, **scope
+    )
 
 
 @actor(actor_name="benefit.grant", priority=TaskPriority.MEDIUM)

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -403,7 +403,7 @@ class TestEnqueueBenefitsGrants:
 
         enqueue_job_mock.assert_called_once()
         call_args = enqueue_job_mock.call_args
-        assert call_args[0][0] == "benefit.reset_meters_and_enqueue_grants"
+        assert call_args[0][0] == "benefit.enqueue_grants"
         assert call_args[1]["customer_id"] == customer.id
         assert set(call_args[1]["grant_benefit_ids"]) == {b.id for b in benefits}
         assert call_args[1]["subscription_id"] == subscription.id
@@ -436,7 +436,7 @@ class TestEnqueueBenefitsGrants:
         )
 
         call_args = enqueue_job_mock.call_args
-        assert call_args[0][0] == "benefit.reset_meters_and_enqueue_grants"
+        assert call_args[0][0] == "benefit.enqueue_grants"
         grant_benefit_ids = call_args[1]["grant_benefit_ids"]
         assert benefits[0].id not in grant_benefit_ids
         assert set(grant_benefit_ids) == {b.id for b in benefits[1:]}
@@ -469,7 +469,7 @@ class TestEnqueueBenefitsGrants:
         )
 
         call_args = enqueue_job_mock.call_args
-        assert call_args[0][0] == "benefit.reset_meters_and_enqueue_grants"
+        assert call_args[0][0] == "benefit.enqueue_grants"
         grant_benefit_ids = call_args[1]["grant_benefit_ids"]
         assert benefits[0].id not in grant_benefit_ids
         assert set(grant_benefit_ids) == {b.id for b in benefits[1:]}
@@ -492,7 +492,7 @@ class TestEnqueueBenefitsGrants:
         enqueue_grants_actor = MagicMock()
         actors = {
             "benefit.revoke": revoke_actor,
-            "benefit.reset_meters_and_enqueue_grants": enqueue_grants_actor,
+            "benefit.enqueue_grants": enqueue_grants_actor,
         }
         broker_mock.return_value.get_actor.side_effect = lambda name: actors.get(
             name, MagicMock()
@@ -578,7 +578,7 @@ class TestEnqueueBenefitsGrants:
         enqueue_grants_actor = MagicMock()
         actors = {
             "benefit.revoke": revoke_actor,
-            "benefit.reset_meters_and_enqueue_grants": enqueue_grants_actor,
+            "benefit.enqueue_grants": enqueue_grants_actor,
         }
         broker_mock.return_value.get_actor.side_effect = lambda name: actors.get(
             name, MagicMock()

--- a/server/tests/benefit/strategies/test_meter_credit.py
+++ b/server/tests/benefit/strategies/test_meter_credit.py
@@ -2,12 +2,20 @@ import pytest
 
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.customer_meter.repository import CustomerMeterRepository
+from polar.customer_meter.service import customer_meter as customer_meter_service
+from polar.meter.aggregation import AggregationFunction, PropertyAggregation
+from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
 from polar.models import Customer, Organization, Product, Subscription
 from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_benefit, create_meter, create_order
+from tests.fixtures.random_objects import (
+    create_benefit,
+    create_event,
+    create_meter,
+    create_order,
+)
 
 
 @pytest.mark.asyncio
@@ -190,3 +198,95 @@ class TestMeterCreditBenefitIntegration:
         )
         assert customer_meter is not None
         assert customer_meter.balance == 1000
+
+    async def test_upgrade_usage_persists_mid_cycle(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        subscription: Subscription,
+    ) -> None:
+        """
+        Regression test for the design intent established by 6e1d2513e (#9037):
+        on a mid-cycle subscription update, meter credits AND usage both persist.
+        The customer's prior usage counts toward the new product's allowance;
+        they don't get a fresh slate.
+
+        Inverse check against commit 311ade8ec: that commit added a meter_reset
+        into the benefit pipeline as a side effect of fixing an unrelated
+        ordering race. If anything re-introduces a reset on the update path,
+        the final balance becomes 1000 instead of 920 and this test fails.
+        """
+        meter = await create_meter(
+            save_fixture,
+            organization=organization,
+            filter=Filter(
+                conjunction=FilterConjunction.and_,
+                clauses=[
+                    FilterClause(
+                        property="name", operator=FilterOperator.eq, value="usage"
+                    )
+                ],
+            ),
+            aggregation=PropertyAggregation(
+                func=AggregationFunction.sum, property="tokens"
+            ),
+        )
+
+        old_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={"meter_id": str(meter.id), "units": 100, "rollover": False},
+        )
+        new_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={"meter_id": str(meter.id), "units": 1000, "rollover": False},
+        )
+
+        customer_meter_repo = CustomerMeterRepository.from_session(session)
+
+        # Customer subscribes to the old plan (100 credits)
+        await benefit_grant_service.grant_benefit(
+            session, redis, customer, old_benefit, subscription=subscription
+        )
+
+        # Customer uses 80 units on the old plan
+        await create_event(
+            save_fixture,
+            organization=organization,
+            customer=customer,
+            name="usage",
+            metadata={"tokens": 80},
+        )
+        await customer_meter_service.update_customer_meter(session, customer, meter)
+
+        customer_meter = await customer_meter_repo.get_by_customer_and_meter(
+            customer.id, meter.id
+        )
+        assert customer_meter is not None
+        assert customer_meter.credited_units == 100
+        assert customer_meter.consumed_units == 80
+        assert customer_meter.balance == 20
+
+        # Mid-cycle upgrade: revoke old, grant new (the pipeline ordering)
+        await benefit_grant_service.revoke_benefit(
+            session, redis, customer, old_benefit, subscription=subscription
+        )
+        await benefit_grant_service.grant_benefit(
+            session, redis, customer, new_benefit, subscription=subscription
+        )
+
+        customer_meter = await customer_meter_repo.get_by_customer_and_meter(
+            customer.id, meter.id
+        )
+        assert customer_meter is not None
+        # credit events [+100, -100, +1000] running sum clamped at 0 → 1000
+        assert customer_meter.credited_units == 1000
+        # 80 units of pre-upgrade usage carry over against the new allowance
+        assert customer_meter.consumed_units == 80
+        assert customer_meter.balance == 920

--- a/server/tests/benefit/strategies/test_meter_credit.py
+++ b/server/tests/benefit/strategies/test_meter_credit.py
@@ -129,3 +129,64 @@ class TestMeterCreditBenefitIntegration:
         assert customer_meter.credited_units == 100
         assert customer_meter.consumed_units == 0
         assert customer_meter.balance == 100
+
+    async def test_upgrade_balance_without_meter_reset(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        subscription: Subscription,
+    ) -> None:
+        """
+        Regression test for issue #11427.
+
+        Revoke-then-grant on a product change must land at the new product's
+        credit total without relying on a `meter_reset` event. Verifies that
+        meter_credit.revoke() emits the matching negative-units event so the
+        balance is symmetric across an upgrade.
+        """
+        meter = await create_meter(save_fixture, organization=organization)
+
+        old_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={"meter_id": str(meter.id), "units": 100, "rollover": False},
+        )
+        new_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={"meter_id": str(meter.id), "units": 1000, "rollover": False},
+        )
+
+        customer_meter_repo = CustomerMeterRepository.from_session(session)
+
+        await benefit_grant_service.grant_benefit(
+            session, redis, customer, old_benefit, subscription=subscription
+        )
+        customer_meter = await customer_meter_repo.get_by_customer_and_meter(
+            customer.id, meter.id
+        )
+        assert customer_meter is not None
+        assert customer_meter.balance == 100
+
+        await benefit_grant_service.revoke_benefit(
+            session, redis, customer, old_benefit, subscription=subscription
+        )
+        customer_meter = await customer_meter_repo.get_by_customer_and_meter(
+            customer.id, meter.id
+        )
+        assert customer_meter is not None
+        assert customer_meter.balance == 0
+
+        await benefit_grant_service.grant_benefit(
+            session, redis, customer, new_benefit, subscription=subscription
+        )
+        customer_meter = await customer_meter_repo.get_by_customer_and_meter(
+            customer.id, meter.id
+        )
+        assert customer_meter is not None
+        assert customer_meter.balance == 1000

--- a/server/tests/benefit/test_tasks.py
+++ b/server/tests/benefit/test_tasks.py
@@ -438,3 +438,16 @@ class TestBenefitEnqueueGrants:
         )
 
         enqueue_job_mock.assert_not_called()
+
+    async def test_deprecated_alias_registered_for_in_flight_messages(self) -> None:
+        """
+        The legacy `benefit.reset_meters_and_enqueue_grants` actor must remain
+        registered on the broker so Dramatiq messages enqueued under the old
+        name (before the rename) can still be picked up by workers.
+        """
+        import dramatiq
+
+        broker = dramatiq.get_broker()
+        actors = broker.get_declared_actors()
+        assert "benefit.enqueue_grants" in actors
+        assert "benefit.reset_meters_and_enqueue_grants" in actors

--- a/server/tests/benefit/test_tasks.py
+++ b/server/tests/benefit/test_tasks.py
@@ -360,12 +360,17 @@ class TestBenefitDeleteGrant:
 
 @pytest.mark.asyncio
 class TestBenefitEnqueueGrants:
-    async def test_resets_meters_for_subscription(
+    async def test_does_not_reset_meters(
         self,
         mocker: MockerFixture,
         subscription: Subscription,
         session: AsyncSession,
     ) -> None:
+        """
+        The benefit grant pipeline must NOT reset meters. Resets are handled
+        by order.service.create_subscription_order for cycle/cancel orders
+        and by meter_credit.cycle() for per-grant renewal. See issue #11427.
+        """
         reset_meters_mock = mocker.patch.object(
             subscription_service,
             "reset_meters",
@@ -378,24 +383,6 @@ class TestBenefitEnqueueGrants:
             subscription.customer_id, [], subscription_id=subscription.id
         )
 
-        reset_meters_mock.assert_called_once()
-
-    async def test_skips_meter_reset_without_subscription(
-        self,
-        mocker: MockerFixture,
-        customer: Customer,
-        session: AsyncSession,
-    ) -> None:
-        reset_meters_mock = mocker.patch.object(
-            subscription_service,
-            "reset_meters",
-            spec=SubscriptionService.reset_meters,
-        )
-
-        session.expunge_all()
-
-        await benefit_enqueue_grants(customer.id, [], order_id=uuid.uuid4())
-
         reset_meters_mock.assert_not_called()
 
     async def test_enqueues_grants(
@@ -406,11 +393,6 @@ class TestBenefitEnqueueGrants:
         benefit_organization_second: Benefit,
         session: AsyncSession,
     ) -> None:
-        mocker.patch.object(
-            subscription_service,
-            "reset_meters",
-            spec=SubscriptionService.reset_meters,
-        )
         enqueue_job_mock = mocker.patch("polar.benefit.tasks.enqueue_job")
 
         benefit_ids = [benefit_organization.id, benefit_organization_second.id]
@@ -445,11 +427,6 @@ class TestBenefitEnqueueGrants:
         subscription: Subscription,
         session: AsyncSession,
     ) -> None:
-        mocker.patch.object(
-            subscription_service,
-            "reset_meters",
-            spec=SubscriptionService.reset_meters,
-        )
         enqueue_job_mock = mocker.patch("polar.benefit.tasks.enqueue_job")
 
         session.expunge_all()


### PR DESCRIPTION
## Summary

**Related Issue**: #11427

Editing a product's benefits no longer wipes customer meter balances. The benefit grant pipeline no longer emits a global `meter_reset` event; meter resets are now scoped to the order layer (cycle/cancel orders) and per-grant cycle events, where they belong.

## What

- `server/polar/benefit/tasks.py` — removed the `subscription_service.reset_meters` call from the `benefit.reset_meters_and_enqueue_grants` task body. Dropped two now-unused imports. Actor name retained for in-flight Dramatiq message compatibility (documented inline).
- `server/polar/benefit/grant/service.py` — refreshed the pipeline comment (no behavior change).
- `server/tests/benefit/test_tasks.py` — collapsed three reset-related tests into one regression test (`test_does_not_reset_meters`) that asserts `subscription_service.reset_meters` is never called from the pipeline.
- `server/tests/benefit/strategies/test_meter_credit.py` — added `test_upgrade_balance_without_meter_reset` asserting the revoke→grant balance trajectory (100 → 0 → 1000) on an upgrade, locking in that the math is symmetric without a reset.

## Why

The previous implementation called `subscription_service.reset_meters` whenever the pipeline ran with a `subscription_id` scope. Because `meter_reset` is scoped to `(customer, meter)` globally — not `(customer, meter, subscription)` — *any* meter reset wiped the customer's balance across every subscription, including credits the customer had paid for via separate subscriptions. The pipeline fires from many triggers (product benefit edits, dunning, refunds, customer seat updates, subscription product changes, …), so the impact was wide-ranging.

The repro from the issue:
- Customer has subscriptions on products ABC (50 credits on meter M via benefit Z) and DEF (3000 credits on meter M via benefit Z'). Balance: 3050.
- Merchant edits ABC and removes benefit Y. The pipeline ran for ABC's subscription and called `reset_meters`, emitting a `meter_reset` for (customer, M). Balance: 0.

This also aligns the benefit pipeline with the explicit "`subscription_update` is intentionally excluded" design already documented in `server/polar/order/service.py:820-823`.

## How

Removed the `reset_meters` block from `benefit_enqueue_grants` entirely. The math still settles correctly because `meter_credit.revoke()` emits a matching negative-units event for the previously credited amount, so revoke→grant on a product change nets to exactly the new product's credit total. The new test exercises this end-to-end.

Meter resets continue to fire on:
- `subscription_cycle`, `subscription_cycle_after_trial`, `subscription_cancel` orders (`order.service.create_subscription_order`)
- per-grant renewal via `meter_credit.cycle()` (with dedup against the order-layer reset)

The Dramatiq actor name `benefit.reset_meters_and_enqueue_grants` is now stale but kept to avoid orphaning in-flight messages during deploy. A rename can land in a follow-up PR after this is fully rolled out.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included