### PR TITLE
tf/db: Ignore changes to db 

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -69,7 +69,7 @@ resource "render_postgres" "db" {
   plan           = "pro_64gb"
   region         = "ohio"
   version        = "15"
-  disk_size_gb   = 300
+  disk_size_gb   = 500
 
   high_availability_enabled = true
 

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -81,6 +81,7 @@ resource "render_postgres" "db" {
   lifecycle {
     ignore_changes = [
       ip_allow_list,
+      disk_size_gb,
     ]
   }
 


### PR DESCRIPTION
Since we've switched to auto scaling the disk in Render,
it doesn't make sense to allow regression of the disk size
via Terraform