### PR TITLE
chore(http): switch URL reachability checks from HEAD to GET

### DIFF
--- a/server/polar/kit/http.py
+++ b/server/polar/kit/http.py
@@ -82,10 +82,11 @@ class UrlReachability:
 async def check_url_reachable(
     url: HttpUrl | str, *, timeout: float = 5.0
 ) -> UrlReachability:
-    """Validate the URL and HEAD it, following redirects.
+    """Validate the URL and GET it, following redirects.
 
     The check rejects URLs that resolve to private/reserved IPs (including any
-    redirect target) and treats HTTP 2xx/3xx as reachable.
+    redirect target) and treats HTTP 2xx/3xx as reachable. We use GET rather
+    than HEAD because some sites block HEAD requests.
     """
     try:
         validated_url = await validate_crawlable_url(url)
@@ -104,7 +105,7 @@ async def check_url_reachable(
             headers={"User-Agent": settings.POLAR_USER_AGENT},
             event_hooks={"response": [_check_redirect]},
         ) as client:
-            response = await client.head(str(validated_url))
+            response = await client.get(str(validated_url))
         return UrlReachability(
             reachable=200 <= response.status_code < 400,
             status=response.status_code,

--- a/server/polar/organization_review/collectors/setup.py
+++ b/server/polar/organization_review/collectors/setup.py
@@ -102,10 +102,11 @@ async def _resolve_redirect(
 
     async with semaphore:
         try:
-            # Use manual redirect loop so we can validate each hop
+            # Use manual redirect loop so we can validate each hop.
+            # We use GET rather than HEAD because some sites block HEAD requests.
             current_url = url
             for _ in range(10):  # max redirect hops
-                response = await client.head(current_url)
+                response = await client.get(current_url)
                 if response.is_redirect and response.has_redirect_location:
                     next_url = str(response.headers["location"])
                     # Resolve relative redirects
@@ -240,7 +241,7 @@ async def resolve_url_redirects(urls: list[str]) -> list[UrlRedirectInfo]:
     """Follow redirects for a sample of URLs (one per hostname).
 
     Uses a two-pass approach:
-    1. Fast HEAD requests to detect HTTP-level redirects (301/302).
+    1. GET requests to detect HTTP-level redirects (301/302).
     2. For URLs that returned 200 (no HTTP redirect), a headless browser
        check to detect client-side redirects (meta refresh, JS).
     """
@@ -250,7 +251,7 @@ async def resolve_url_redirects(urls: list[str]) -> list[UrlRedirectInfo]:
     urls_to_check = _pick_one_per_hostname(urls)[:_MAX_URLS_TO_RESOLVE]
     semaphore = asyncio.Semaphore(_MAX_CONCURRENT)
 
-    # Pass 1: HEAD requests (fast)
+    # Pass 1: GET requests (fast)
     async with httpx.AsyncClient(
         follow_redirects=False,  # We follow manually to validate each hop
         timeout=_REDIRECT_TIMEOUT,

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -511,9 +511,7 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.get("https://slow.com/timeout").mock(
-                side_effect=Exception("timeout")
-            )
+            respx.get("https://slow.com/timeout").mock(side_effect=Exception("timeout"))
             results = await resolve_url_redirects(["https://slow.com/timeout"])
 
         assert len(results) == 1

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -380,7 +380,7 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://example.com/thanks").respond(200)
+            respx.get("https://example.com/thanks").respond(200)
             results = await resolve_url_redirects(["https://example.com/thanks"])
 
         assert len(results) == 1
@@ -398,10 +398,10 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://api.legit.com/success").respond(
+            respx.get("https://api.legit.com/success").respond(
                 302, headers={"Location": "https://porn-site.com/landing"}
             )
-            respx.head("https://porn-site.com/landing").respond(200)
+            respx.get("https://porn-site.com/landing").respond(200)
             results = await resolve_url_redirects(["https://api.legit.com/success"])
 
         assert len(results) == 1
@@ -429,10 +429,10 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://example.com/old").respond(
+            respx.get("https://example.com/old").respond(
                 301, headers={"Location": "https://example.com/new"}
             )
-            respx.head("https://example.com/new").respond(200)
+            respx.get("https://example.com/new").respond(200)
             results = await resolve_url_redirects(["https://example.com/old"])
 
         assert len(results) == 1
@@ -458,10 +458,10 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://example.com/thanks").respond(
+            respx.get("https://example.com/thanks").respond(
                 301, headers={"Location": "https://www.example.com/thanks"}
             )
-            respx.head("https://www.example.com/thanks").respond(200)
+            respx.get("https://www.example.com/thanks").respond(200)
             results = await resolve_url_redirects(["https://example.com/thanks"])
 
         assert len(results) == 1
@@ -490,10 +490,10 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://www.example.com/thanks").respond(
+            respx.get("https://www.example.com/thanks").respond(
                 301, headers={"Location": "https://example.com/thanks"}
             )
-            respx.head("https://example.com/thanks").respond(200)
+            respx.get("https://example.com/thanks").respond(200)
             results = await resolve_url_redirects(["https://www.example.com/thanks"])
 
         assert len(results) == 1
@@ -511,7 +511,7 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://slow.com/timeout").mock(
+            respx.get("https://slow.com/timeout").mock(
                 side_effect=Exception("timeout")
             )
             results = await resolve_url_redirects(["https://slow.com/timeout"])
@@ -531,7 +531,7 @@ class TestResolveUrlRedirects:
             "polar.organization_review.collectors.setup._validate_url_host",
             return_value=None,
         )
-        # HEAD returns 200 (no HTTP redirect) — browser pass will be triggered
+        # GET returns 200 (no HTTP redirect) — browser pass will be triggered
         # Browser detects the client-side redirect to a different domain
         mocker.patch(
             "polar.organization_review.collectors.setup._resolve_redirect_with_browser",
@@ -544,7 +544,7 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://legit-api.com/success").respond(200)
+            respx.get("https://legit-api.com/success").respond(200)
             results = await resolve_url_redirects(["https://legit-api.com/success"])
 
         assert len(results) == 1
@@ -570,7 +570,7 @@ class TestResolveUrlRedirects:
         )
 
         with respx.mock:
-            respx.head("https://flaky-site.com/page").respond(200)
+            respx.get("https://flaky-site.com/page").respond(200)
             results = await resolve_url_redirects(["https://flaky-site.com/page"])
 
         assert len(results) == 1


### PR DESCRIPTION
Some sites block HEAD requests, causing valid URLs to be reported as unreachable. GET requests are more universally accepted.