### PR TITLE
bug(organization): exclude soft-deleted memberships in owner lookups

### DIFF
--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -217,6 +217,7 @@ class OrganizationRepository(
             .where(
                 UserOrganization.organization_id == organization.id,
                 UserOrganization.role == OrganizationRole.owner,
+                UserOrganization.is_deleted.is_(False),
                 User.is_deleted.is_(False),
             )
         )

--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -56,6 +56,7 @@ class UserOrganizationRepository:
             .where(
                 UserOrganization.organization_id == organization_id,
                 UserOrganization.role == OrganizationRole.owner,
+                UserOrganization.is_deleted.is_(False),
             )
             .values(role=OrganizationRole.admin)
             .returning(UserOrganization.user_id)

--- a/server/tests/organization/test_repository.py
+++ b/server/tests/organization/test_repository.py
@@ -1,0 +1,49 @@
+import pytest
+
+from polar.models import Organization, User, UserOrganization
+from polar.models.user_organization import OrganizationRole
+from polar.organization.repository import OrganizationRepository
+from polar.postgres import AsyncSession
+from polar.user_organization.service import (
+    user_organization as user_organization_service,
+)
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestGetOwnerUser:
+    async def test_excludes_soft_deleted_membership(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        user_second: User,
+    ) -> None:
+        # Owner A + Admin B.
+        owner_membership = UserOrganization(
+            user_id=user.id,
+            organization_id=organization.id,
+            role=OrganizationRole.owner,
+        )
+        await save_fixture(owner_membership)
+
+        admin_membership = UserOrganization(
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.admin,
+        )
+        await save_fixture(admin_membership)
+
+        # Soft-delete the owner via raw `remove_member` (allowed because
+        # admin B keeps the admin-capability invariant satisfied).
+        await user_organization_service.remove_member(
+            session,
+            user_id=user.id,
+            organization_id=organization.id,
+        )
+        await session.flush()
+
+        repo = OrganizationRepository.from_session(session)
+        owner_after_removal = await repo.get_owner_user(organization)
+        assert owner_after_removal is None


### PR DESCRIPTION
## Summary

**Related Issue**: #11860

`OrganizationRepository.get_owner_user` and `UserOrganizationRepository.demote_current_owner` filtered by `UserOrganization.role == owner` but not by `UserOrganization.is_deleted.is_(False)`. After a raw `remove_member` call (which soft-deletes the membership), the org has no active owner, but these queries kept returning the stale row. That stale identity then flowed into payout account setup, organization review tickets, and the Plain support integration.

## What

- Add `UserOrganization.is_deleted.is_(False)` to the `get_owner_user` query (`server/polar/organization/repository.py`).
- Add the same filter to the `demote_current_owner` update (`server/polar/user_organization/repository.py`) so a soft-deleted owner row isn't silently demoted in place of the (non-existent) active owner.
- Add a regression test (`server/tests/organization/test_repository.py::TestGetOwnerUser::test_excludes_soft_deleted_membership`) that soft-deletes an owner via `remove_member` and asserts `get_owner_user` returns `None`.

## Why

Introduced in #11810 when ownership tracking moved from `Account.admin_id` to `UserOrganization.role`. The new join to `UserOrganization` needs an `is_deleted` filter to match the partial unique index `ix_user_organizations_owner_per_org` (`role = 'owner' AND deleted_at IS NULL`) — a consideration that didn't exist when the query joined `Account.admin_id`. Every other read of `UserOrganization` in the codebase already applies this filter; `get_owner_user`/`demote_current_owner` were the outliers.

## How

Two-line filter additions plus a regression test. Confirmed the test fails on `main` and passes with the fix. All 394 tests in `tests/organization/` and `tests/user_organization/` still pass; `lint` and `lint_types` are clean.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included