### PR TITLE
fix(transactions): hide blocked org transactions from members

### DIFF
--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -3,11 +3,12 @@ from collections.abc import Sequence
 from enum import StrEnum
 from typing import Any, cast
 
-from sqlalchemy import Select, UnaryExpression, and_, asc, desc, func, or_, select
+from sqlalchemy import Select, UnaryExpression, asc, desc, func, or_, select
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import aliased, joinedload, subqueryload
+from sqlalchemy.orm import joinedload, subqueryload
 
-from polar.auth.permission import OrganizationPermission, roles_with_permission
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.sorting import Sorting
@@ -20,7 +21,6 @@ from polar.models import (
 )
 from polar.models.organization import Organization
 from polar.models.transaction import PlatformFeeType, TransactionType
-from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncReadSession, AsyncSession
 
 from ..schemas import (
@@ -273,7 +273,9 @@ class TransactionService(BaseTransactionService):
         return int(result.scalar_one())
 
     def _get_readable_transactions_statement(self, user: User) -> Select[Any]:
-        PaymentUserOrganization = aliased(UserOrganization)
+        readable_org_ids = select_user_org_ids(
+            user.id, permission=OrganizationPermission.finance_read
+        )
         statement = (
             select(Transaction)
             .join(Transaction.account, isouter=True)
@@ -282,36 +284,13 @@ class TransactionService(BaseTransactionService):
                 onclause=Organization.account_id == Account.id,
                 isouter=True,
             )
-            .join(
-                UserOrganization,
-                onclause=Organization.id == UserOrganization.organization_id,
-                isouter=True,
-            )
             .join(User, onclause=User.account_id == Account.id, isouter=True)
-            .join(
-                PaymentUserOrganization,
-                onclause=Transaction.payment_organization_id
-                == PaymentUserOrganization.organization_id,
-                isouter=True,
-            )
             .where(
                 or_(
                     User.id == user.id,
-                    and_(
-                        UserOrganization.user_id == user.id,
-                        UserOrganization.is_deleted.is_(False),
-                        UserOrganization.role.in_(
-                            roles_with_permission(OrganizationPermission.finance_read)
-                        ),
-                    ),
+                    Organization.id.in_(readable_org_ids),
                     Transaction.payment_user_id == user.id,
-                    and_(
-                        PaymentUserOrganization.user_id == user.id,
-                        PaymentUserOrganization.is_deleted.is_(False),
-                        PaymentUserOrganization.role.in_(
-                            roles_with_permission(OrganizationPermission.finance_read)
-                        ),
-                    ),
+                    Transaction.payment_organization_id.in_(readable_org_ids),
                 )
             )
         )

--- a/server/tests/transaction/service/test_blocked_org_access.py
+++ b/server/tests/transaction/service/test_blocked_org_access.py
@@ -1,0 +1,94 @@
+import pytest
+
+from polar.kit.pagination import PaginationParams
+from polar.models import (
+    Account,
+    Organization,
+    User,
+    UserOrganization,
+)
+from polar.models.organization import OrganizationStatus
+from polar.models.transaction import TransactionType
+from polar.postgres import AsyncSession
+from polar.transaction.service.transaction import transaction as transaction_service
+from tests.fixtures.database import SaveFixture
+from tests.transaction.conftest import create_transaction
+
+
+@pytest.mark.asyncio
+class TestBlockedOrganizationTransactionAccess:
+    async def test_blocked_org_account_transactions_hidden(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+        account: Account,
+    ) -> None:
+        transaction = await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+        )
+
+        organization.set_status(OrganizationStatus.BLOCKED)
+        await save_fixture(organization)
+
+        results, count = await transaction_service.search(
+            session, user, pagination=PaginationParams(1, 10)
+        )
+
+        result_ids = [t.id for t in results]
+        assert transaction.id not in result_ids
+        assert count == 0
+
+    async def test_blocked_org_payment_transactions_hidden(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        transaction = await create_transaction(
+            save_fixture,
+            type=TransactionType.payment,
+            payment_organization=organization,
+        )
+
+        organization.set_status(OrganizationStatus.BLOCKED)
+        await save_fixture(organization)
+
+        results, count = await transaction_service.search(
+            session, user, pagination=PaginationParams(1, 10)
+        )
+
+        result_ids = [t.id for t in results]
+        assert transaction.id not in result_ids
+        assert count == 0
+
+    async def test_direct_payment_transactions_visible_after_org_blocked(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        transaction = await create_transaction(
+            save_fixture,
+            type=TransactionType.payment,
+            payment_user=user,
+        )
+
+        organization.set_status(OrganizationStatus.BLOCKED)
+        await save_fixture(organization)
+
+        results, count = await transaction_service.search(
+            session, user, pagination=PaginationParams(1, 10)
+        )
+
+        result_ids = [t.id for t in results]
+        assert transaction.id in result_ids
+        assert count == 1


### PR DESCRIPTION
## Summary

**Related Issue**: #11862

`/v1/transactions/search` exposed transactions from blocked organizations to their members. This PR closes that gap by routing the org-scoped readability checks through `select_user_org_ids`, which already filters out blocked / soft-deleted organizations.

## What

- Rewrite `_get_readable_transactions_statement` in `server/polar/transaction/service/transaction.py` to delegate both org-scoped access paths (member of the transaction's org, member of the paying org) to `select_user_org_ids(..., permission=OrganizationPermission.finance_read)`.
- Drop the now-unused `UserOrganization` / `PaymentUserOrganization` joins and the `and_` / `aliased` / `roles_with_permission` imports.
- Add `server/tests/transaction/service/test_blocked_org_access.py` covering: blocked org's account transactions hidden, blocked org's payment transactions hidden, and direct-payee transactions still visible after the org is blocked.

## Why

`_get_readable_transactions_statement` only checked `UserOrganization.role` and `is_deleted` on the org membership paths — it never enforced `Organization.can_authenticate`. As a result, members of a `BLOCKED` organization could still retrieve that org's transaction details (amounts, types, balances, payment customer info) via the search endpoint, despite other read paths (e.g. `/v1/organizations/{id}/account`, checkout service) returning 404 / `NotPermitted` for blocked orgs.

The regression was introduced in #11674 (`a20651d79`), which added role-based permission filtering but did not pick up the blocked-org filter that ships with `select_user_org_ids`.

## How

`select_user_org_ids` joins `Organization` and already enforces `is_deleted=False`, `can_authenticate`, and (when a permission is provided) role membership. Using it as a subquery inside `Organization.id.in_(...)` and `Transaction.payment_organization_id.in_(...)` collapses the previous bespoke join logic into a single source of truth that's consistent with the rest of the auth-aware repositories (e.g. `OrderRepository.get_readable_statement`).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included