### PR TITLE
fix(user_organization): exclude blocked orgs from /v1/users/me

### DIFF
--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -27,6 +27,9 @@ class UserOrganizationRepository:
     async def get_organizations_with_role(
         self, user_id: UUID
     ) -> Sequence[tuple[Organization, OrganizationRole]]:
+        """Return the user's active organizations with their role, ordered
+        by organization name.
+        """
         statement = (
             select(Organization, UserOrganization.role)
             .join(

--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -27,13 +27,6 @@ class UserOrganizationRepository:
     async def get_organizations_with_role(
         self, user_id: UUID
     ) -> Sequence[tuple[Organization, OrganizationRole]]:
-        """Return the user's active organizations with their role, ordered
-        by organization name.
-
-        Mirrors the `can_authenticate` filter used by `/v1/organizations/`
-        so blocked orgs don't slip into the embedded list on `/v1/users/me`
-        and become 404'ing redirect targets in the dashboard.
-        """
         statement = (
             select(Organization, UserOrganization.role)
             .join(

--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -29,6 +29,10 @@ class UserOrganizationRepository:
     ) -> Sequence[tuple[Organization, OrganizationRole]]:
         """Return the user's active organizations with their role, ordered
         by organization name.
+
+        Mirrors the `can_authenticate` filter used by `/v1/organizations/`
+        so blocked orgs don't slip into the embedded list on `/v1/users/me`
+        and become 404'ing redirect targets in the dashboard.
         """
         statement = (
             select(Organization, UserOrganization.role)
@@ -39,7 +43,7 @@ class UserOrganizationRepository:
             .where(
                 UserOrganization.user_id == user_id,
                 UserOrganization.is_deleted.is_(False),
-                Organization.deleted_at.is_(None),
+                Organization.can_authenticate,
             )
             .order_by(Organization.name)
         )

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -4,6 +4,7 @@ from httpx import AsyncClient
 from polar.auth.scope import READ_ONLY_SCOPES
 from polar.kit.utils import utc_now
 from polar.models import Organization, User, UserOrganization
+from polar.models.organization import OrganizationStatus
 from polar.models.user_organization import OrganizationRole
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -40,6 +41,26 @@ async def test_get_users_me_embeds_organizations_with_role(
     assert len(organizations) == 1
     assert organizations[0]["id"] == str(organization.id)
     assert organizations[0]["role"] == OrganizationRole.admin.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.auth
+async def test_get_users_me_excludes_blocked_organizations(
+    client: AsyncClient,
+    save_fixture: SaveFixture,
+    organization: Organization,
+    user_organization: UserOrganization,
+) -> None:
+    # Blocked orgs are filtered out by `GET /v1/organizations/`; mirror
+    # that here so frontend redirect targets stay consistent and users
+    # don't land on a dashboard that 404s on the org slug lookup.
+    organization.set_status(OrganizationStatus.BLOCKED)
+    await save_fixture(organization)
+
+    response = await client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    assert response.json()["organizations"] == []
 
 
 @pytest.mark.asyncio

--- a/server/tests/user_organization/test_repository.py
+++ b/server/tests/user_organization/test_repository.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+import pytest
+
+from polar.models import Organization, User, UserOrganization
+from polar.models.organization import OrganizationStatus
+from polar.user_organization.repository import UserOrganizationRepository
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestGetOrganizationsWithRole:
+    async def test_returns_active_org(
+        self,
+        session: Any,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        repository = UserOrganizationRepository.from_session(session)
+        result = await repository.get_organizations_with_role(user.id)
+
+        assert len(result) == 1
+
+    async def test_excludes_blocked_org(
+        self,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Block the org the user is a member of. The frontend uses this
+        # list to pick redirect targets; blocked orgs would otherwise be
+        # selected and 404 at `GET /v1/organizations/?slug=...`.
+        organization.set_status(OrganizationStatus.BLOCKED)
+        await save_fixture(organization)
+
+        repository = UserOrganizationRepository.from_session(session)
+        result = await repository.get_organizations_with_role(user.id)
+
+        assert result == []
+
+    async def test_excludes_soft_deleted_membership(
+        self,
+        session: Any,
+        user_second: User,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        from polar.kit.utils import utc_now
+
+        user_organization_second.deleted_at = utc_now()
+        await session.flush()
+
+        repository = UserOrganizationRepository.from_session(session)
+        result = await repository.get_organizations_with_role(user_second.id)
+
+        assert result == []


### PR DESCRIPTION
## Summary

**Related Issue**: #11863

Filters BLOCKED organizations out of the `organizations` array embedded on `GET /v1/users/me` so the frontend's `getUserOrganizations()` no longer hands the dashboard a redirect target that 404s.

## What

- Add `Organization.can_authenticate` to the filter in `UserOrganizationRepository.get_organizations_with_role()` (replaces the weaker `Organization.deleted_at.is_(None)` check).
- Repository tests covering active / blocked / soft-deleted-membership cases.
- Endpoint test asserting `/v1/users/me` omits orgs the user belongs to once those orgs are blocked.

## Why

`GET /v1/organizations/` already filters by `Organization.can_authenticate` (which is `False` for BLOCKED orgs since their `api_access` capability is `False`). `GET /v1/users/me` did not — so the frontend's `getUserOrganizations()` (introduced in #11718) embedded BLOCKED orgs into the list it picks redirect targets from. If `last_visited_org` matched a BLOCKED org, the dashboard layout would call `GET /v1/organizations/?slug=...`, get an empty list, and `notFound()` before any membership/RBAC check could run — users hit a dead-end 404.

## How

Fix it at the source rather than defensively re-filtering on the frontend: the two endpoints should agree on what an "accessible org" is, and `can_authenticate` is the existing canonical predicate. The frontend, the dashboard layout, and any future consumer of `get_organizations_with_role` are all correct by default after this change.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included