### PR TITLE
Move @polar-sh/checkout out from beta

### DIFF
--- a/clients/.changeset/pre.json
+++ b/clients/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@polar-sh/app": "1.2.0",


### PR DESCRIPTION
The payment method feature in `@polar-sh/checkout` has now been tested and documented, so this PR will move it out from beta and we'll create a `0.3.0` release with the feature.