### PR TITLE
Use /to/ links in our docs

### DIFF
--- a/docs/features/benefits/feature-flags.mdx
+++ b/docs/features/benefits/feature-flags.mdx
@@ -15,7 +15,7 @@ The Feature Flag benefit is a lightweight way to grant feature access to custome
 
 ## Create Feature Flag Benefit
 
-1. Go to `Benefits` in the sidebar
+1. Go to [`Benefits`](https://polar.sh/to/dashboard/products/benefits)
 2. Click `+ New Benefit` to create a new benefit
 3. Choose `Feature Flag` as the `Type`
 4. Give it a short description (e.g. "Premium Features" or "Beta Access")

--- a/docs/features/benefits/file-downloads.mdx
+++ b/docs/features/benefits/file-downloads.mdx
@@ -19,7 +19,7 @@ You can easily offer customers and subscribers access to downloadable files with
 Create Downloadable Benefit
 ----------------------------------
 
-1. Go to `Benefits` in the Dashboard sidebar
+1. Go to [`Benefits`](https://polar.sh/to/dashboard/products/benefits)
 2. Click `+ Add Benefit` to create a new benefit
 3. Choose `File Downloads` as the `Type`
 

--- a/docs/features/benefits/github-access.mdx
+++ b/docs/features/benefits/github-access.mdx
@@ -28,7 +28,7 @@ With Polar you can seamlessly offer your customers and subscribers automated acc
 Create GitHub Repository Benefit
 ---------------------------------------
 
-1. Go to `Benefits` in the sidebar
+1. Go to [`Benefits`](https://polar.sh/to/dashboard/products/benefits)
 2. Click `+ New Benefit` to create a new benefit
 3. Choose `GitHub Repository Access` as the `Type`
 

--- a/docs/features/benefits/license-keys.mdx
+++ b/docs/features/benefits/license-keys.mdx
@@ -18,7 +18,7 @@ You can easily sell software license keys with Polar without having to deal with
 Create License Key Benefit
 ---------------------------------
 
-1. Go to `Benefits` in the sidebar
+1. Go to [`Benefits`](https://polar.sh/to/dashboard/products/benefits)
 2. Click `+ New Benefit` to create a new benefit
 3. Choose `License Keys` as the `Type`
 
@@ -126,7 +126,7 @@ curl -X POST https://api.polar.sh/v1/customer-portal/license-keys/activate
 ```
 ### Validate License Keys
 
-For each session of your premium app, library or API, we recommend you validate the users license key via the 
+For each session of your premium app, library or API, we recommend you validate the users license key via the
 [`/v1/customer-portal/license-keys/validate`](/api-reference/customer-portal/license-keys/validate) endpoint.
 
 ```bash Terminal

--- a/docs/features/checkout/links.mdx
+++ b/docs/features/checkout/links.mdx
@@ -24,7 +24,7 @@ Each visit produces a brand new Checkout Session. Always share the Checkout Link
 
 ## Create a Checkout Link
 
-Checkout Links are managed from the **Checkout Links** tab of the Products section. Click on **New Link** to create one.
+Checkout Links are managed from the [**Checkout Links**](https://polar.sh/to/dashboard/products/checkout-links) page. Click on **New Link** to create one.
 
 ### Products
 

--- a/docs/features/custom-fields.mdx
+++ b/docs/features/custom-fields.mdx
@@ -14,7 +14,7 @@ With Polar, you can easily add such fields to your checkout using **Custom Field
 
 ## Create Custom Fields
 
-Custom Fields are managed at an organization's level. To create them, go to **Settings** and **Custom Fields**. You'll see the list of all the available fields on your organization.
+Custom Fields are managed at an organization's level. To create them, go to [**Settings → Custom Fields**](https://polar.sh/to/dashboard/settings/custom-fields). You'll see the list of all the available fields on your organization.
 
 <img
   className="block dark:hidden"

--- a/docs/features/customer-portal/settings.mdx
+++ b/docs/features/customer-portal/settings.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Settings"
 description: "Configure what customers can do from the Customer Portal"
 ---
 
-All Customer Portal settings live under **Settings → Customer portal** in your Polar dashboard. Each setting is a toggle that enables or disables a specific capability for your customers.
+All Customer Portal settings live under [**Settings → Customer portal**](https://polar.sh/to/dashboard/settings) in your Polar dashboard. Each setting is a toggle that enables or disables a specific capability for your customers.
 
 ## Show metered usage
 

--- a/docs/features/discounts.mdx
+++ b/docs/features/discounts.mdx
@@ -16,7 +16,7 @@ Discounts are a way to reduce the price of a product or subscription. They can b
 
 ## Create a discount
 
-Go to the **Products** page and click on the **Discounts** tab.
+Go to the [**Discounts**](https://polar.sh/to/dashboard/products/discounts) page
 
 #### Name
 

--- a/docs/features/finance/accounts.mdx
+++ b/docs/features/finance/accounts.mdx
@@ -12,7 +12,7 @@ You need to connect a payout account **before Polar can accept money on your beh
 
 ## Connecting a Payout Account
 
-1. Open the **Finance → Account** page in your Polar dashboard.
+1. Open the [**Finance → Account**](https://polar.sh/to/dashboard/finance/account) page in your Polar dashboard.
 2. Click **Continue with account setup**.
 3. Select your country:
     - If this is a personal account, pick your **country of residence**.
@@ -26,7 +26,7 @@ The user who completes onboarding becomes the **owner** of the payout account. T
 
 A single payout account can be linked to **multiple organizations**. If you run several organizations on Polar and want all of their earnings to settle into the same bank account, you don't need to repeat Stripe onboarding for each one.
 
-From the **Finance → Account** page of a new organization, you can either:
+From the [**Finance → Account**](https://polar.sh/to/dashboard/finance/account) page of a new organization, you can either:
 
 - Connect a brand-new payout account, or
 - Select an existing payout account from one of your other organizations.
@@ -35,7 +35,7 @@ Only one payout account is active per organization at a time, but you can switch
 
 ## Managing Your Account
 
-From **Finance → Account → Manage payout accounts** you can:
+From [**Finance → Account → Manage payout accounts**](https://polar.sh/to/dashboard/finance/account) you can:
 
 - **Open in Stripe** — jump into the Stripe-hosted dashboard to update your bank account and business details.
 - **Make Active** — switch the organization to a different payout account you already own.

--- a/docs/features/integrations/affonso.mdx
+++ b/docs/features/integrations/affonso.mdx
@@ -23,7 +23,7 @@ account to track and manage affiliate-driven sales for your SaaS business.
 First, you'll need to create an API token in Polar that Affonso can use to communicate with your account:
 
 1. Login to your **Polar Dashboard**
-2. Navigate to **Settings** in the main menu
+2. Navigate to [**Settings**](https://polar.sh/to/dashboard/settings)
 3. Scroll down to the **Developers** section on the Settings page
 4. Click the **New token** button
 5. Give your token a name (e.g., "Affonso Integration")
@@ -54,7 +54,7 @@ First, you'll need to create an API token in Polar that Affonso can use to commu
 
 After connecting your Polar account with Affonso, you'll [receive a webhook URL and secret from Affonso](https://affonso.io/app/affiliate-program/connect). Add these to your Polar account:
 
-1. Go to **Settings** → **Developers** → **Webhooks** in your Polar Dashboard
+1. Go to [**Settings → Webhooks**](https://polar.sh/to/dashboard/settings/webhooks) in your Polar Dashboard
 2. Click the **"Add Endpoint"** button
 3. In the URL field, paste the webhook URL provided by Affonso
 4. For Format, select **RAW** from the dropdown

--- a/docs/features/seat-based-pricing.mdx
+++ b/docs/features/seat-based-pricing.mdx
@@ -48,7 +48,7 @@ Use **subscriptions** for ongoing team access. Use **one-time purchases** for pe
 
 <Steps>
   <Step title="Create a new product">
-    From your dashboard, navigate to Products and click **Create Product**.
+    From your dashboard, [create a new product](https://polar.sh/to/dashboard/products/new).
   </Step>
   <Step title="Configure basic settings">
     Set your product name, description, and media as usual.

--- a/docs/features/subscriptions/introduction.mdx
+++ b/docs/features/subscriptions/introduction.mdx
@@ -35,7 +35,7 @@ For subscriptions on long billing cycles — six months or more — Polar emails
 
 The threshold is six months, however it is expressed: yearly plans, monthly plans with an interval of 6 or more, weekly plans of 25 or more, and daily plans of 180 or more all get the reminder. Reminders are skipped for free subscriptions and for subscriptions already scheduled to cancel at period end.
 
-You can turn renewal reminders off under **Settings → Customer notifications** if you prefer to handle that communication yourself.
+You can turn renewal reminders off under [**Settings → Customer notifications**](https://polar.sh/to/dashboard/settings) if you prefer to handle that communication yourself.
 
 ## Cancellation
 

--- a/docs/features/subscriptions/trials.mdx
+++ b/docs/features/subscriptions/trials.mdx
@@ -75,7 +75,7 @@ When the reminder goes out depends on the length of the trial:
 
 Reminders are skipped for fully free subscriptions and for trialing subscriptions already scheduled to cancel at period end.
 
-You can turn trial conversion reminders off under **Settings → Customer notifications** if you prefer to handle that communication yourself.
+You can turn trial conversion reminders off under [**Settings → Customer notifications**](https://polar.sh/to/dashboard/settings) if you prefer to handle that communication yourself.
 
 ## Preventing trial abuse
 
@@ -94,7 +94,7 @@ A customer will be blocked from starting a new trial if they have previously red
 
 ### Enabling the feature
 
-1. Go to your organization's **Settings** page
+1. Open your organization's [**Settings**](https://polar.sh/to/dashboard/settings) page
 2. Navigate to the **Subscription** section
 3. Toggle on **Prevent trial abuse**
 

--- a/docs/features/team-management.mdx
+++ b/docs/features/team-management.mdx
@@ -6,7 +6,7 @@ description: "Invite teammates to your organization, manage their roles, and con
 
 Polar organizations support multiple users. You can invite teammates to collaborate on products, orders, customers, and other parts of your business — each with a role that determines what they're allowed to do.
 
-Team management lives under **Settings → Members** in your dashboard.
+Team management lives under [**Settings → Members**](https://polar.sh/to/dashboard/settings/members) in your dashboard.
 
 ## Roles
 
@@ -38,7 +38,7 @@ The exact permissions granted by each role:
 
 ## Inviting a member
 
-1. Go to **Settings → Members** in your organization's dashboard.
+1. Go to [**Settings → Members**](https://polar.sh/to/dashboard/settings/members) in your organization's dashboard.
 2. Click **Invite**.
 3. Enter the email address of the person you want to add.
 4. Click **Send Invite**.
@@ -55,7 +55,7 @@ New members join with the **Member** role by default. To grant additional access
 
 Only **admins** and **owners** can change roles.
 
-1. Go to **Settings → Members**.
+1. Go to [**Settings → Members**](https://polar.sh/to/dashboard/settings/members).
 2. Click the **⋯** menu on the member's row.
 3. Choose **Change role**.
 4. Select **Admin** or **Member** and click **Save**.
@@ -70,7 +70,7 @@ The role picker shows a side-by-side permissions matrix so you can confirm what 
 
 Only **admins** and **owners** can remove other members.
 
-1. Go to **Settings → Members**.
+1. Go to [**Settings → Members**](https://polar.sh/to/dashboard/settings/members).
 2. Click the **⋯** menu on the member's row.
 3. Choose **Remove from organization**.
 4. Confirm the removal.
@@ -85,7 +85,7 @@ The removed member immediately loses access to the organization. They keep their
 
 If you want to leave an organization yourself:
 
-1. Go to **Settings → Members**.
+1. Go to [**Settings → Members**](https://polar.sh/to/dashboard/settings/members).
 2. Click the **⋯** menu on your own row.
 3. Choose **Leave organization** and confirm.
 

--- a/docs/features/usage-based-billing/meters.mdx
+++ b/docs/features/usage-based-billing/meters.mdx
@@ -9,7 +9,7 @@ import Meters from "/snippets/usage/meters.mdx";
 
 ## Creating a Meter
 
-To create a meter, navigate to the Meters page in the sidebar and click the "Create Meter" button.
+To create a meter, [open the Meters page](https://polar.sh/to/dashboard/products/meters) and click the "Create Meter" button.
 
 <img
   className="block dark:hidden"

--- a/docs/guides/grant-meter-credits-after-purchase.mdx
+++ b/docs/guides/grant-meter-credits-after-purchase.mdx
@@ -54,7 +54,7 @@ Create a product and attach the Meter Credits benefit to it.
 
 <Steps>
   <Step title="Create a product">
-    Navigate to **Products** > **Catalogue** and click **New Product**.
+    Open [**Products → New Product**](https://polar.sh/to/dashboard/products/new) in the dashboard.
   </Step>
   <Step title="Configure the product">
     - Set a name and description
@@ -113,7 +113,7 @@ First, create a meter that will track your customers' usage.
 
 <Steps>
   <Step title="Navigate to Meters">
-    In the Polar dashboard sidebar, click on **Products** > **Meters**.
+    Open [**Products → Meters**](https://polar.sh/to/dashboard/products/meters) in the dashboard.
   </Step>
   <Step title="Create a new meter">
     Click **Create Meter** and configure:

--- a/docs/guides/grant-meter-credits-before-purchase.mdx
+++ b/docs/guides/grant-meter-credits-before-purchase.mdx
@@ -33,7 +33,7 @@ First, create a meter that will track your customers' usage.
 
 <Steps>
   <Step title="Navigate to Meters">
-    In the Polar dashboard sidebar, click on **Products** > **Meters**.
+    Open [**Products → Meters**](https://polar.sh/to/dashboard/products/meters) in the dashboard.
   </Step>
   <Step title="Create a new meter">
     Click **Create Meter** and configure:
@@ -60,7 +60,7 @@ If your customer doesn't already exist in Polar, you need to create them first.
 
 <Steps>
   <Step title="Navigate to Customers">
-    In the Polar dashboard sidebar, click on **Customers**.
+    Open [**Customers**](https://polar.sh/to/dashboard/customers) in the dashboard.
   </Step>
   <Step title="Add new customer">
     Click **Add Customer** and fill in:

--- a/docs/guides/seat-based-pricing.mdx
+++ b/docs/guides/seat-based-pricing.mdx
@@ -68,7 +68,7 @@ This guide covers both **subscription** and **one-time purchase** seat-based pro
 
 <Steps>
   <Step title="Navigate to Products">
-    In the Polar dashboard, go to **Products** and click **Create Product**.
+    Open the dashboard and [create a new product](https://polar.sh/to/dashboard/products/new).
   </Step>
 
   <Step title="Configure pricing">

--- a/docs/integrate/oat.mdx
+++ b/docs/integrate/oat.mdx
@@ -14,9 +14,7 @@ You can create them from your organization settings as follows:
 <Steps>
     <Step title="Go to Organization Settings">
 
-        In the Polar dashboard sidebar, navigate to **Settings** > **General** for your organization.
-        You can also go directly to:  
-        `https://polar.sh/dashboard/${org_slug}/settings`
+        Open [**Settings**](https://polar.sh/to/dashboard/settings) for your organization in the Polar dashboard.
 
         <img height="200" src="/assets/integrate/authentication/settings.png" />
 

--- a/docs/integrate/sandbox.mdx
+++ b/docs/integrate/sandbox.mdx
@@ -73,5 +73,5 @@ Our official SDK supports the sandbox environment through a dedicated parameter.
 
 The limitations listed below only apply to sandbox and doesn't reflect the behavior in production.
 
-* Customer-facing emails (order confirmations, subscription renewal reminders, etc.) are only delivered to recipients who are members of your organization. Manage these in **Settings → Members**. Sub-addressing aliases like `you+test@example.com` are accepted.
+* Customer-facing emails (order confirmations, subscription renewal reminders, etc.) are only delivered to recipients who are members of your organization. Manage these in [**Settings → Members**](https://polar.sh/to/dashboard/settings/members). Sub-addressing aliases like `you+test@example.com` are accepted.
 

--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -167,7 +167,7 @@ Webhook endpoints are automatically disabled after **10 consecutive failed deliv
 - The endpoint is marked as disabled and will no longer receive new events.
 - Admin of the organization will receive an email notification.
 
-To re-enable a disabled endpoint, go to your organization's webhook settings in the dashboard and manually enable it. Before re-enabling, ensure your endpoint is properly configured and reachable to avoid repeated disabling.
+To re-enable a disabled endpoint, open your organization's [webhook settings](https://polar.sh/to/dashboard/settings/webhooks) and manually enable it. Before re-enabling, ensure your endpoint is properly configured and reachable to avoid repeated disabling.
 
 ## Troubleshooting
 

--- a/docs/merchant-of-record/account-reviews.mdx
+++ b/docs/merchant-of-record/account-reviews.mdx
@@ -8,7 +8,7 @@ We process every review as quickly as we can and resolve every single one.
   **Build first, submit second.** It's tempting to get approved before doing the integration work, but a complete setup is what makes a review fast and clean. Configure your [products and benefits](/features/products), wire up your integration (checkout links, API keys, webhooks), and have a live website pointing to it. The more we can see end-to-end, the more confidently — and quickly — we can approve your account.
 </Tip>
 
-Before your first payout, you'll go through our main account review. You can submit everything yourself from **Finance → Account** in your Polar dashboard, in three steps:
+Before your first payout, you'll go through our main account review. You can submit everything yourself from [**Finance → Account**](https://polar.sh/to/dashboard/finance/account) in your Polar dashboard, in three steps:
 
 1. **Submit for approval.** Tell us about your business, your products, and how you intend to use Polar.
 2. **Identity verification (KYC).** Verify your identity with a passport, ID card, or driver's license along with a selfie — secure, easy, and quick through Stripe Identity.


### PR DESCRIPTION
With our new `/to/` links we can make our docs better by instead of asking the user to navigate to a specific page, simply create a link to that page.

| Before | After  |
|--------|--------|
| <img width="1108" height="924" alt="Monosnap Team Management - Polar 2026-05-25 16-17-04" src="https://github.com/user-attachments/assets/a8468079-19b5-484b-8784-60899ecdddbc" /> | <img width="1110" height="923" alt="Monosnap Team Management - Polar 2026-05-25 16-17-28" src="https://github.com/user-attachments/assets/dbd2c161-017d-45df-a650-00b7c4b36d81" /> |




