### PR TITLE
Handle sandbox on /to/ redirects

### DIFF
--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -5,7 +5,8 @@ import { Modal } from '@/components/Modal'
 import { useModal } from '@/components/Modal/useModal'
 import { useAuth } from '@/hooks/auth'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
-import { setLastVisitedOrg } from '@/utils/cookies'
+import { CONFIG } from '@/utils/config'
+import { setLastVisitedEnv, setLastVisitedOrg } from '@/utils/cookies'
 import ViewSidebarOutlined from '@mui/icons-material/ViewSidebarOutlined'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
@@ -41,6 +42,7 @@ const DashboardLayout = (
   const { organization, organizations } = useContext(OrganizationContext)
 
   useEffect(() => {
+    setLastVisitedEnv(CONFIG.IS_SANDBOX ? 'sandbox' : 'production')
     if (organization) {
       setLastVisitedOrg(organization.slug)
     }

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -297,3 +297,61 @@ describe('middleware function', () => {
     )
   })
 })
+
+describe('the /to/ dance', () => {
+  it('bounces /to/* to the sandbox host when polar_env cookie does not match the current env', async () => {
+    const request = new NextRequest('https://polar.sh/to/dashboard/products')
+    request.cookies.set('polar_env', 'sandbox')
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe(
+      'https://sandbox.polar.sh/to/dashboard/products',
+    )
+  })
+
+  it('preserves query string when bouncing /to/*', async () => {
+    const request = new NextRequest(
+      'https://polar.sh/to/dashboard/products?foo=bar',
+    )
+    request.cookies.set('polar_env', 'sandbox')
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe(
+      'https://sandbox.polar.sh/to/dashboard/products?foo=bar',
+    )
+  })
+
+  it('does not bounce when polar_env cookie matches the current env', async () => {
+    const request = new NextRequest('https://polar.sh/to/dashboard/products')
+    request.cookies.set('polar_env', 'production')
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain('/login')
+  })
+
+  it('ignores invalid polar_env cookie values', async () => {
+    const request = new NextRequest('https://polar.sh/to/dashboard/products')
+    request.cookies.set('polar_env', 'narnia')
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain('/login')
+  })
+
+  it('does not bounce non-/to/ paths even with a mismatching cookie', async () => {
+    const request = new NextRequest('https://polar.sh/dashboard')
+    request.cookies.set('polar_env', 'sandbox')
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain('/login')
+  })
+})

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -5,6 +5,8 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { COOKIE_MAX_AGE, DISTINCT_ID_COOKIE } from './experiments/constants'
 import { createServerSideAPI } from './utils/client'
+import { CONFIG } from './utils/config'
+import { POLAR_ENV_COOKIE } from './utils/cookies'
 
 const POLAR_AUTH_COOKIE_KEY =
   process.env.POLAR_AUTH_COOKIE_KEY || 'polar_session'
@@ -97,6 +99,23 @@ export async function proxy(request: NextRequest) {
   // doesn't appear to be working consistently with Vercel rewrites
   if (isForwardedRoute(request)) {
     return NextResponse.next()
+  }
+
+  if (request.nextUrl.pathname.startsWith('/to/')) {
+    const lastEnv = request.cookies.get(POLAR_ENV_COOKIE)?.value
+    const currentEnv = IS_SANDBOX ? 'sandbox' : 'production'
+    if (
+      (lastEnv === 'sandbox' || lastEnv === 'production') &&
+      lastEnv !== currentEnv
+    ) {
+      const targetBase =
+        lastEnv === 'sandbox'
+          ? CONFIG.SANDBOX_FRONTEND_BASE_URL
+          : CONFIG.FRONTEND_BASE_URL
+      return NextResponse.redirect(
+        `${targetBase}${request.nextUrl.pathname}${request.nextUrl.search}`,
+      )
+    }
   }
 
   // Sandbox: rewrite root to login, block non-app routes

--- a/clients/apps/web/src/utils/cookies.ts
+++ b/clients/apps/web/src/utils/cookies.ts
@@ -2,6 +2,9 @@ import { schemas } from '@polar-sh/client'
 import { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies'
 
 const lastVisitedOrg = 'last_visited_org'
+export const POLAR_ENV_COOKIE = 'polar_env'
+
+export type PolarEnv = 'production' | 'sandbox'
 
 export const setLastVisitedOrg = (
   organization: string,
@@ -19,4 +22,14 @@ export const getLastVisitedOrg = (
     return undefined
   }
   return organizations.find((org) => org.slug === lastVisitedOrgSlug)
+}
+
+export const setLastVisitedEnv = (
+  env: PolarEnv,
+  maxAge: number = 30 * 60, // Expires in 30 minutes
+) => {
+  const hostname = window.location.hostname
+  const domainAttr = hostname.endsWith('.polar.sh') ? '; domain=.polar.sh' : ''
+  const secureAttr = window.location.protocol === 'https:' ? '; secure' : ''
+  document.cookie = `${POLAR_ENV_COOKIE}=${env}; max-age=${maxAge}; path=/; samesite=lax${domainAttr}${secureAttr}`
 }

--- a/clients/apps/web/vitest.config.ts
+++ b/clients/apps/web/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],
+    env: {
+      NEXT_PUBLIC_FRONTEND_BASE_URL: 'https://polar.sh',
+      NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL: 'https://sandbox.polar.sh',
+    },
   },
 })


### PR DESCRIPTION
We have an issue with our `/to/` redirect links (e.g https://polar.sh/to/dashboard/products) which is that if the user is in our sandbox environment, they will be redirected to production which can be confusing. This PR solves that by setting a `polar_env` cookie which our proxy then handles.

For a sandbox user clicking https://polar.sh/to/dashboard/products from the docs:

1. Browser requests https://polar.sh/to/dashboard/products
2. Our proxy reads `polar_env=sandbox` cookie and sees the current host is `production` meaning they mismatch
3. We redirect to https://sandbox.polar.sh/to/dashboard/products
4. Our proxy passes the env check (`sandbox === sandbox`)
5. `/to/[...path]/page.tsx` reads the org cookie and redirects to https://sandbox.polar.sh/dashboard/acme/products