### PR TITLE
feat(organization): limit slug length to 64 characters

### DIFF
--- a/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
@@ -22,7 +22,10 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm, useFormContext, useWatch } from 'react-hook-form'
 import slugify from 'slugify'
-import { containsBlockedWord } from '@/utils/blocked-words'
+import {
+  ORGANIZATION_SLUG_MAX_LENGTH,
+  containsBlockedWord,
+} from '@/utils/blocked-words'
 import { CurrencySelector } from '../CurrencySelector'
 import { useOnboardingData } from './OnboardingContext'
 import { OnboardingShell } from './OnboardingShell'
@@ -68,7 +71,13 @@ function OrgNameSync({
 
   useEffect(() => {
     if (!editedSlug && name) {
-      setValue('slug', slugify(name, { lower: true, strict: true }))
+      setValue(
+        'slug',
+        slugify(name, { lower: true, strict: true }).slice(
+          0,
+          ORGANIZATION_SLUG_MAX_LENGTH,
+        ),
+      )
     }
   }, [name, editedSlug, setValue])
 
@@ -350,6 +359,10 @@ export function BusinessDetailsStep() {
               name="slug"
               rules={{
                 required: 'Slug is required',
+                maxLength: {
+                  value: ORGANIZATION_SLUG_MAX_LENGTH,
+                  message: `Slug must be ${ORGANIZATION_SLUG_MAX_LENGTH} characters or fewer.`,
+                },
                 validate: async (v) => {
                   if (containsBlockedWord(v)) return 'This slug is not allowed.'
                   const { data: result, error } = await api.POST(
@@ -372,6 +385,7 @@ export function BusinessDetailsStep() {
                     <Input
                       {...field}
                       placeholder="acme-inc"
+                      maxLength={ORGANIZATION_SLUG_MAX_LENGTH}
                       onChange={(e) => {
                         field.onChange(
                           slugify(e.target.value, {

--- a/clients/apps/web/src/components/Onboarding/SandboxFormFields.tsx
+++ b/clients/apps/web/src/components/Onboarding/SandboxFormFields.tsx
@@ -14,6 +14,7 @@ import {
 import { useEffect } from 'react'
 import { type UseFormReturn, useFormContext, useWatch } from 'react-hook-form'
 import slugify from 'slugify'
+import { ORGANIZATION_SLUG_MAX_LENGTH } from '@/utils/blocked-words'
 import { CurrencySelector } from '../CurrencySelector'
 import { useOnboardingData } from './OnboardingContext'
 
@@ -35,7 +36,13 @@ export function OrgNameSlugSync({ editedSlug }: { editedSlug: boolean }) {
 
   useEffect(() => {
     if (!editedSlug && orgName) {
-      setValue('orgSlug', slugify(orgName, { lower: true, strict: true }))
+      setValue(
+        'orgSlug',
+        slugify(orgName, { lower: true, strict: true }).slice(
+          0,
+          ORGANIZATION_SLUG_MAX_LENGTH,
+        ),
+      )
     }
   }, [orgName, editedSlug, setValue])
 
@@ -70,6 +77,7 @@ function SlugPreview({
       {editingSlug ? (
         <input
           value={orgSlug}
+          maxLength={ORGANIZATION_SLUG_MAX_LENGTH}
           onChange={(e) => {
             setValue(
               'orgSlug',
@@ -77,7 +85,7 @@ function SlugPreview({
                 lower: true,
                 trim: false,
                 strict: true,
-              }),
+              }).slice(0, ORGANIZATION_SLUG_MAX_LENGTH),
             )
             onEditSlug()
           }}

--- a/clients/apps/web/src/utils/blocked-words.ts
+++ b/clients/apps/web/src/utils/blocked-words.ts
@@ -1,3 +1,6 @@
+// Source of truth: server/polar/organization/schemas.py (SLUG_MAX_LENGTH).
+export const ORGANIZATION_SLUG_MAX_LENGTH = 64
+
 // Source of truth: server/polar/config.py, keep in sync.
 // Backend validates regardless, but this is to give the user immediate feedback in the onboarding
 // since org creation (and validation) is in the last step.

--- a/server/polar/backoffice/forms.py
+++ b/server/polar/backoffice/forms.py
@@ -6,7 +6,7 @@ from inspect import isclass
 from typing import Any, Self
 
 from fastapi.datastructures import FormData
-from pydantic import AfterValidator, BaseModel, ValidationError
+from pydantic import AfterValidator, BaseModel, StringConstraints, ValidationError
 from pydantic.fields import FieldInfo
 from pydantic_core import ErrorDetails
 from tagflow import classes, tag, text
@@ -492,6 +492,21 @@ def _is_skipped_field(field: FieldInfo) -> bool:
     return False
 
 
+def _string_constraint_attrs(field: FieldInfo) -> dict[str, Any]:
+    """Surface Pydantic `StringConstraints` as native HTML input attributes."""
+    attrs: dict[str, Any] = {}
+    for meta in field.metadata:
+        if not isinstance(meta, StringConstraints):
+            continue
+        if meta.min_length is not None:
+            attrs["minlength"] = meta.min_length
+        if meta.max_length is not None:
+            attrs["maxlength"] = meta.max_length
+        if meta.pattern is not None:
+            attrs["pattern"] = meta.pattern
+    return attrs
+
+
 def _get_input_field(field: FieldInfo) -> FormField:
     for meta in field.metadata:
         if isinstance(meta, FormField):
@@ -508,7 +523,7 @@ def _get_input_field(field: FieldInfo) -> FormField:
                     options=[(item.value, item.name) for item in field.annotation]
                 )
 
-    return InputField()
+    return InputField(**_string_constraint_attrs(field))
 
 
 CurrencyValidator = AfterValidator(lambda x: x * 100)

--- a/server/polar/backoffice/organizations/forms.py
+++ b/server/polar/backoffice/organizations/forms.py
@@ -13,7 +13,12 @@ from pydantic import (
 
 from polar.enums import RateLimitGroup
 from polar.kit.schemas import HttpUrlToStr, Schema
-from polar.organization.schemas import NameInput, OrganizationFeatureSettings, SlugInput
+from polar.organization.schemas import (
+    SLUG_MAX_LENGTH,
+    NameInput,
+    OrganizationFeatureSettings,
+    SlugInput,
+)
 
 from .. import forms
 
@@ -99,7 +104,7 @@ class UpdateOrganizationBasicForm(forms.BaseForm):
     """Form for editing basic organization settings (name, slug, invoice prefix)."""
 
     name: NameInput
-    slug: SlugInput
+    slug: Annotated[SlugInput, forms.InputField(maxlength=SLUG_MAX_LENGTH)]
     customer_invoice_prefix: Annotated[
         str,
         StringConstraints(
@@ -112,7 +117,7 @@ class UpdateOrganizationForm(forms.BaseForm):
     """Form for editing organization settings including feature flags."""
 
     name: NameInput
-    slug: SlugInput
+    slug: Annotated[SlugInput, forms.InputField(maxlength=SLUG_MAX_LENGTH)]
     customer_invoice_prefix: Annotated[
         str,
         StringConstraints(

--- a/server/polar/backoffice/organizations/forms.py
+++ b/server/polar/backoffice/organizations/forms.py
@@ -13,12 +13,7 @@ from pydantic import (
 
 from polar.enums import RateLimitGroup
 from polar.kit.schemas import HttpUrlToStr, Schema
-from polar.organization.schemas import (
-    SLUG_MAX_LENGTH,
-    NameInput,
-    OrganizationFeatureSettings,
-    SlugInput,
-)
+from polar.organization.schemas import NameInput, OrganizationFeatureSettings, SlugInput
 
 from .. import forms
 
@@ -104,7 +99,7 @@ class UpdateOrganizationBasicForm(forms.BaseForm):
     """Form for editing basic organization settings (name, slug, invoice prefix)."""
 
     name: NameInput
-    slug: Annotated[SlugInput, forms.InputField(maxlength=SLUG_MAX_LENGTH)]
+    slug: SlugInput
     customer_invoice_prefix: Annotated[
         str,
         StringConstraints(
@@ -117,7 +112,7 @@ class UpdateOrganizationForm(forms.BaseForm):
     """Form for editing organization settings including feature flags."""
 
     name: NameInput
-    slug: Annotated[SlugInput, forms.InputField(maxlength=SLUG_MAX_LENGTH)]
+    slug: SlugInput
     customer_invoice_prefix: Annotated[
         str,
         StringConstraints(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -75,9 +75,12 @@ def validate_reserved_keywords(value: str) -> str:
     return value
 
 
+SLUG_MAX_LENGTH = 64
+
+
 SlugInput = Annotated[
     str,
-    StringConstraints(to_lower=True, min_length=3),
+    StringConstraints(to_lower=True, min_length=3, max_length=SLUG_MAX_LENGTH),
     SlugValidator,
     AfterValidator(validate_reserved_keywords),
     AfterValidator(validate_blocked_words),
@@ -85,7 +88,10 @@ SlugInput = Annotated[
 
 
 class OrganizationSlugCheck(Schema):
-    slug: str = Field(description="The slug to check availability for.")
+    slug: str = Field(
+        description="The slug to check availability for.",
+        max_length=SLUG_MAX_LENGTH,
+    )
 
 
 class OrganizationSlugAvailability(Schema):

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -88,7 +88,7 @@ SlugInput = Annotated[
 
 
 class OrganizationSlugCheck(Schema):
-    slug: SlugInput = Field(description="The slug to check availability for.")
+    slug: str = Field(description="The slug to check availability for.")
 
 
 class OrganizationSlugAvailability(Schema):

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -88,10 +88,7 @@ SlugInput = Annotated[
 
 
 class OrganizationSlugCheck(Schema):
-    slug: str = Field(
-        description="The slug to check availability for.",
-        max_length=SLUG_MAX_LENGTH,
-    )
+    slug: SlugInput = Field(description="The slug to check availability for.")
 
 
 class OrganizationSlugAvailability(Schema):

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import email_validator
 import structlog
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
@@ -98,10 +98,13 @@ from .schemas import (
     OrganizationReviewVerdict,
     OrganizationSlugAvailability,
     OrganizationUpdate,
+    SlugInput,
 )
 from .sorting import OrganizationSortProperty
 
 log = structlog.get_logger()
+
+_slug_input_adapter: TypeAdapter[str] = TypeAdapter(SlugInput)
 
 _MIN_REVIEW_THRESHOLD = 10_000
 SNOOZE_MIN_DAYS = 1
@@ -267,13 +270,19 @@ class OrganizationService:
     async def check_slug_availability(
         self, session: AsyncReadSession, slug: str
     ) -> OrganizationSlugAvailability:
-        """Check whether a slug is available for a new organization.
+        """Check whether a slug is valid and available for a new organization.
 
-        Format validation is handled by the `SlugInput` schema; this only
-        checks that no existing (or soft-deleted) organization owns it.
+        Runs the slug through `SlugInput` (the same validator used when
+        creating an organization) and reports invalid slugs as unavailable
+        rather than as a 422.
         """
+        try:
+            normalized = _slug_input_adapter.validate_python(slug)
+        except PydanticValidationError:
+            return OrganizationSlugAvailability(available=False)
+
         repository = OrganizationRepository.from_session(session)
-        if await repository.slug_exists(slug):
+        if await repository.slug_exists(normalized):
             return OrganizationSlugAvailability(available=False)
 
         return OrganizationSlugAvailability(available=True)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -85,6 +85,7 @@ from polar.worker import enqueue_job
 
 from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (
+    SLUG_MAX_LENGTH,
     OrganizationCreate,
     OrganizationDeletionBlockedReason,
     OrganizationReviewAppeal,
@@ -277,7 +278,11 @@ class OrganizationService:
         """
         normalized = slug.lower()
 
-        if len(normalized) < 3 or slugify(normalized) != normalized:
+        if (
+            len(normalized) < 3
+            or len(normalized) > SLUG_MAX_LENGTH
+            or slugify(normalized) != normalized
+        ):
             return OrganizationSlugAvailability(available=False)
 
         try:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -10,7 +10,6 @@ import email_validator
 import structlog
 from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
-from slugify import slugify
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
@@ -85,7 +84,6 @@ from polar.worker import enqueue_job
 
 from .repository import OrganizationRepository, OrganizationReviewRepository
 from .schemas import (
-    SLUG_MAX_LENGTH,
     OrganizationCreate,
     OrganizationDeletionBlockedReason,
     OrganizationReviewAppeal,
@@ -100,8 +98,6 @@ from .schemas import (
     OrganizationReviewVerdict,
     OrganizationSlugAvailability,
     OrganizationUpdate,
-    validate_blocked_words,
-    validate_reserved_keywords,
 )
 from .sorting import OrganizationSortProperty
 
@@ -271,28 +267,13 @@ class OrganizationService:
     async def check_slug_availability(
         self, session: AsyncReadSession, slug: str
     ) -> OrganizationSlugAvailability:
-        """Check whether a slug is valid and available for a new organization.
+        """Check whether a slug is available for a new organization.
 
-        Mirrors the validation rules of the `SlugInput` type plus a
-        check against existing (and soft-deleted) organizations.
+        Format validation is handled by the `SlugInput` schema; this only
+        checks that no existing (or soft-deleted) organization owns it.
         """
-        normalized = slug.lower()
-
-        if (
-            len(normalized) < 3
-            or len(normalized) > SLUG_MAX_LENGTH
-            or slugify(normalized) != normalized
-        ):
-            return OrganizationSlugAvailability(available=False)
-
-        try:
-            validate_reserved_keywords(normalized)
-            validate_blocked_words(normalized)
-        except ValueError:
-            return OrganizationSlugAvailability(available=False)
-
         repository = OrganizationRepository.from_session(session)
-        if await repository.slug_exists(normalized):
+        if await repository.slug_exists(slug):
             return OrganizationSlugAvailability(available=False)
 
         return OrganizationSlugAvailability(available=True)

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1181,7 +1181,8 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "ab"}
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 200
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_too_long(self, client: AsyncClient) -> None:
@@ -1189,7 +1190,8 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "a" * 65}
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 200
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_invalid_format(self, client: AsyncClient) -> None:
@@ -1197,7 +1199,8 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "Invalid Slug!"}
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 200
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_reserved(self, client: AsyncClient) -> None:
@@ -1205,7 +1208,8 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "dashboard"}
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 200
+        assert response.json() == {"available": False}
 
     @pytest.mark.auth
     async def test_blocked_word(self, client: AsyncClient) -> None:
@@ -1213,4 +1217,5 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "porn-shop"}
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 200
+        assert response.json() == {"available": False}

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1181,8 +1181,15 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "ab"}
         )
 
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_too_long(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/organizations/check-slug", json={"slug": "a" * 65}
+        )
+
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_invalid_format(self, client: AsyncClient) -> None:
@@ -1190,8 +1197,7 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "Invalid Slug!"}
         )
 
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_reserved(self, client: AsyncClient) -> None:
@@ -1199,8 +1205,7 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "dashboard"}
         )
 
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_blocked_word(self, client: AsyncClient) -> None:
@@ -1208,5 +1213,4 @@ class TestCheckSlugAvailability:
             "/v1/organizations/check-slug", json={"slug": "porn-shop"}
         )
 
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
+        assert response.status_code == 422

--- a/server/tests/organization/test_schemas.py
+++ b/server/tests/organization/test_schemas.py
@@ -89,3 +89,15 @@ class TestBlockedWords:
     def test_update_without_name_skips_validation(self) -> None:
         org = OrganizationUpdate(name=None)
         assert org.name is None
+
+
+class TestSlugMaxLength:
+    def test_slug_at_max_length_allowed(self) -> None:
+        slug = "a" * 64
+        org = OrganizationCreate(name="Clean Name", slug=slug)
+        assert org.slug == slug
+
+    def test_slug_too_long_rejected(self) -> None:
+        slug = "a" * 65
+        with pytest.raises(ValidationError, match="at most 64 characters"):
+            OrganizationCreate(name="Clean Name", slug=slug)


### PR DESCRIPTION
Enforce a 64-character cap on organization slugs in the Pydantic SlugInput, mirror the limit in the slug availability check and in the backoffice forms, and update the onboarding/sandbox forms so longer values can't be entered or auto-generated client-side.

The rationale behind 64 characters is that according to [RFC 2821](https://www.ietf.org/rfc/rfc2821.txt) the local-part of an email address can be maximum 64 characters, and we currently use `organization-slug@notifications.polar.sh` as the sender of merchant notifications.

I already cleaned up our database to fix the organization names that are currently longer than 64 characters.