### PR TITLE
alembic utils: Explicitly opt-in to the entity types we track

### DIFF
--- a/server/polar/kit/db/models/base.py
+++ b/server/polar/kit/db/models/base.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from uuid import UUID
 
 from alembic_utils.pg_extension import PGExtension
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
 from alembic_utils.replaceable_entity import register_entities
 from sqlalchemy import (
     TIMESTAMP,
@@ -108,4 +110,7 @@ class RateLimitGroupMixin:
 
 uuid_ossp = PGExtension(schema="public", signature="uuid-ossp")
 citext = PGExtension(schema="public", signature="citext")
-register_entities((uuid_ossp, citext))
+register_entities(
+    (uuid_ossp, citext),
+    entity_types=(PGExtension, PGFunction, PGTrigger),
+)


### PR DESCRIPTION
Otherwise we start detecting drift for other things, such as PGGrant for the polar_read role, which we are not tracking in alembic migrations.

This will make the autogenerate work (again/better) by not filling in all of those grants in the upgrade/downgrade.

If we add new entity types that we are tracking, we simply add them to the list of entities we track here.
