### PR TITLE
posthog: refactor how we deal with billing telemetry in the dashboard

### DIFF
--- a/clients/apps/web/package.json
+++ b/clients/apps/web/package.json
@@ -106,6 +106,7 @@
     "@polar-sh/typescript-config": "workspace:*",
     "@stylexjs/babel-plugin": "^0.18.2",
     "@stylexjs/postcss-plugin": "^0.18.2",
+    "@testing-library/react": "^16.3.2",
     "@types/big.js": "^6.2.2",
     "@types/dom-to-image": "^2.6.7",
     "@types/mdx": "^2.0.13",

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
@@ -14,6 +14,7 @@ import { LoadingBox } from '@/components/Shared/LoadingBox'
 import { toast } from '@/components/Toast/use-toast'
 import { useHasPermission } from '@/hooks/permissions'
 import { usePostHog } from '@/hooks/posthog'
+import { useBillingPlanCompleteListener } from '@/hooks/useBillingPlanTelemetry'
 import {
   useOrganizationCustomerSession,
   useOrganizationOrders,
@@ -27,8 +28,8 @@ import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTheme } from 'next-themes'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
 
 export default function BillingPage({
   organization,
@@ -36,7 +37,6 @@ export default function BillingPage({
   organization: schemas['Organization']
 }) {
   const router = useRouter()
-  const searchParams = useSearchParams()
   const queryClient = useQueryClient()
   const theme = useTheme()
   const posthog = usePostHog()
@@ -57,13 +57,15 @@ export default function BillingPage({
     string | null
   >(null)
 
-  useEffect(() => {
-    if (searchParams.get('checkout_success') !== 'true') return
-    queryClient.invalidateQueries({
-      queryKey: ['organization-billing', organization.id],
-    })
-    router.replace(`/dashboard/${organization.slug}/settings/billing`)
-  }, [searchParams, queryClient, organization.id, organization.slug, router])
+  useBillingPlanCompleteListener({
+    organizationId: organization.id,
+    redirectPath: `/dashboard/${organization.slug}/settings/billing`,
+    onComplete: useCallback(() => {
+      queryClient.invalidateQueries({
+        queryKey: ['organization-billing', organization.id],
+      })
+    }, [queryClient, organization.id]),
+  })
 
   usePaymentMethodRedirectResult({
     onSuccess: () => toast({ title: 'Payment method added' }),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -7,6 +7,7 @@ import { useModal } from '@/components/Modal/useModal'
 import { LoadingBox } from '@/components/Shared/LoadingBox'
 import { toast } from '@/components/Toast/use-toast'
 import { useHasPermission } from '@/hooks/permissions'
+import { usePostHog } from '@/hooks/posthog'
 import {
   useCancelSubscription,
   useChangeSubscriptionPlan,
@@ -14,6 +15,7 @@ import {
   useOrganizationSubscription,
   useStartSubscriptionCheckout,
 } from '@/hooks/queries/billing'
+import { useBillingPlanTelemetry } from '@/hooks/useBillingPlanTelemetry'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined'
 import { schemas } from '@polar-sh/client'
@@ -35,10 +37,16 @@ export default function ChangePlanPage({
   organization: schemas['Organization']
 }) {
   const router = useRouter()
+  const posthog = usePostHog()
   const canManageBilling = useHasPermission(
     organization.id,
     'organization:manage',
   )
+  const { buildUrls } = useBillingPlanTelemetry({
+    source: 'change_plan',
+    organizationId: organization.id,
+    successPath: `/dashboard/${organization.slug}/settings/billing`,
+  })
   const gatedOrgId = canManageBilling ? organization.id : undefined
   const subscriptionQuery = useOrganizationSubscription(gatedOrgId)
   const plansQuery = useOrganizationPlans(gatedOrgId)
@@ -114,10 +122,24 @@ export default function ChangePlanPage({
 
     if (requiresCheckout) {
       if (!selectedPlan.product_id) return
+      posthog.capture('dashboard:subscriptions:checkout:start', {
+        organization_id: organization.id,
+        source: 'change_plan',
+        plan_name: selectedPlan.name,
+        plan_product_id: selectedPlan.product_id,
+        plan_amount_cents: selectedPlan.price?.amount ?? null,
+      })
+      const urls = buildUrls({
+        plan_name: selectedPlan.name,
+        plan_product_id: selectedPlan.product_id,
+        from_plan_name: subscription?.plan.name ?? null,
+        from_plan_product_id: subscription?.product_id ?? null,
+        from_plan_amount_cents: subscription?.amount ?? null,
+      })
       const result = await startCheckout.mutateAsync({
         product_id: selectedPlan.product_id,
-        success_url: `${window.location.origin}${billingHref}`,
-        return_url: window.location.href,
+        success_url: urls.success_url,
+        return_url: urls.return_url,
       })
       if (result.error || !result.data) {
         toast({
@@ -142,6 +164,13 @@ export default function ChangePlanPage({
         })
         return
       }
+      posthog.capture('dashboard:subscriptions:plan:cancel', {
+        organization_id: organization.id,
+        source: 'change_plan',
+        from_plan_name: subscription?.plan.name ?? null,
+        from_plan_product_id: subscription?.product_id ?? null,
+        from_plan_amount_cents: subscription?.amount ?? null,
+      })
       toast({
         title: 'Subscription cancellation scheduled',
         description:
@@ -162,6 +191,17 @@ export default function ChangePlanPage({
       })
       return
     }
+    posthog.capture('dashboard:subscriptions:plan:update', {
+      organization_id: organization.id,
+      source: 'change_plan',
+      change_kind: changeKind ?? null,
+      from_plan_name: subscription?.plan.name ?? null,
+      from_plan_product_id: subscription?.product_id ?? null,
+      from_plan_amount_cents: subscription?.amount ?? null,
+      to_plan_name: selectedPlan.name,
+      to_plan_product_id: selectedPlan.product_id ?? null,
+      to_plan_amount_cents: selectedPlan.price?.amount ?? null,
+    })
     toast({
       title:
         changeKind === 'downgrade' ? 'Plan change scheduled' : 'Plan changed',

--- a/clients/apps/web/src/components/Auth/Login.tsx
+++ b/clients/apps/web/src/components/Auth/Login.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { usePostHog, type EventName } from '@/hooks/posthog'
+import { type EventName } from '@/hooks/posthog'
+import { useImpressionEvent } from '@/hooks/useImpressionEvent'
 import { schemas } from '@polar-sh/client'
 import { usePathname, useSearchParams } from 'next/navigation'
-import { Fragment, useEffect, useMemo } from 'react'
+import { Fragment, useMemo } from 'react'
 
 import GithubLoginButton from '../Auth/GithubLoginButton'
 import LoginCodeForm from '../Auth/LoginCodeForm'
@@ -30,8 +31,6 @@ const Login = ({
   signup?: schemas['UserSignupAttribution']
   lastLoginMethod?: string | null
 }) => {
-  const posthog = usePostHog()
-
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
@@ -89,9 +88,10 @@ const Login = ({
     return { returnTo: resolvedReturnTo, ...eventData }
   }, [pathname, resolvedReturnTo, searchParams, signup])
 
-  useEffect(() => {
-    posthog.capture(eventName, loginProps)
-  }, [eventName, loginProps, posthog])
+  useImpressionEvent({
+    event: eventName,
+    build: () => loginProps,
+  })
 
   const primaryOAuthMethod: OAuthMethod = isOAuthMethod(lastLoginMethod)
     ? lastLoginMethod

--- a/clients/apps/web/src/components/Upsell/PlanUpsell.tsx
+++ b/clients/apps/web/src/components/Upsell/PlanUpsell.tsx
@@ -9,7 +9,9 @@ import {
 } from '@/hooks/queries/billing'
 import { useHasPermission } from '@/hooks/permissions'
 import { usePostHog } from '@/hooks/posthog'
+import { useBillingPlanTelemetry } from '@/hooks/useBillingPlanTelemetry'
 import { useDismissed } from '@/hooks/useDismissed'
+import { useImpressionEvent } from '@/hooks/useImpressionEvent'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import {
   CurrentPlanContext,
@@ -27,7 +29,7 @@ import { Box } from '@polar-sh/orbit/Box'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { subDays } from 'date-fns'
 import Link from 'next/link'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { CycleArrow } from '../Landing/graphics/CycleArrow'
 
 interface PlanUpsellProps {
@@ -45,6 +47,11 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
   const subscriptionQuery = useOrganizationSubscription(gatedOrgId)
   const plansQuery = useOrganizationPlans(gatedOrgId)
   const startCheckout = useStartSubscriptionCheckout(organization.id)
+  const { buildUrls } = useBillingPlanTelemetry({
+    source: 'plan_upsell',
+    organizationId: organization.id,
+    successPath: `/dashboard/${organization.slug}/settings/billing`,
+  })
 
   const { startDate, endDate } = useMemo(() => {
     const now = new Date()
@@ -93,18 +100,17 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
   const isVisible =
     !!recommendation && !isDismissed && organization.status === 'active'
 
-  const impressionFiredRef = useRef(false)
-  useEffect(() => {
-    if (!isVisible || !recommendation || impressionFiredRef.current) return
-    impressionFiredRef.current = true
-    posthog.capture('dashboard:subscriptions:plan_upsell:view', {
+  useImpressionEvent({
+    event: 'dashboard:subscriptions:plan_upsell:view',
+    enabled: isVisible,
+    build: () => ({
       organization_id: organization.id,
-      recommended_plan: recommendation.plan.name,
-      recommended_plan_product_id: recommendation.plan.product_id ?? null,
-      monthly_savings_cents: recommendation.savings,
+      recommended_plan: recommendation?.plan.name ?? null,
+      recommended_plan_product_id: recommendation?.plan.product_id ?? null,
+      monthly_savings_cents: recommendation?.savings ?? null,
       monthly_revenue_cents: monthlyRevenue,
-    })
-  }, [isVisible, recommendation, monthlyRevenue, organization.id, posthog])
+    }),
+  })
 
   if (!isVisible || !recommendation) return null
 
@@ -129,11 +135,19 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
       ...trackingProps,
       variant: 'upgrade',
     })
-    const billingHref = `/dashboard/${organization.slug}/settings/billing?checkout_success=true`
+    const subscription = subscriptionQuery.data
+    const urls = buildUrls({
+      plan_name: plan.name,
+      plan_product_id: plan.product_id,
+      monthly_savings_cents: savings,
+      from_plan_name: subscription?.plan.name ?? null,
+      from_plan_product_id: subscription?.product_id ?? null,
+      from_plan_amount_cents: subscription?.amount ?? null,
+    })
     const result = await startCheckout.mutateAsync({
       product_id: plan.product_id,
-      success_url: `${window.location.origin}${billingHref}`,
-      return_url: window.location.href,
+      success_url: urls.success_url,
+      return_url: urls.return_url,
     })
     if (result.error || !result.data) {
       toast({

--- a/clients/apps/web/src/hooks/posthog.ts
+++ b/clients/apps/web/src/hooks/posthog.ts
@@ -82,6 +82,9 @@ export const usePostHog = (): PolarHog => {
 
   const capture: PolarHog['capture'] = useCallback(
     (event, properties, options) => {
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(`[posthog] ${event}`, properties ?? {})
+      }
       posthog.capture(event, properties, options)
     },
     [posthog],

--- a/clients/apps/web/src/hooks/useBillingPlanTelemetry.test.ts
+++ b/clients/apps/web/src/hooks/useBillingPlanTelemetry.test.ts
@@ -1,0 +1,223 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useBillingPlanCompleteListener,
+  useBillingPlanTelemetry,
+} from './useBillingPlanTelemetry'
+
+const captureMock = vi.fn()
+const replaceMock = vi.fn()
+let currentSearchParams = new URLSearchParams()
+
+vi.mock('@/hooks/posthog', () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => currentSearchParams,
+}))
+
+beforeEach(() => {
+  captureMock.mockClear()
+  replaceMock.mockClear()
+  currentSearchParams = new URLSearchParams()
+  // The hooks read window.location.origin/pathname; jsdom provides both.
+  // Pinning ensures URLs built in tests are predictable.
+  Object.defineProperty(window, 'location', {
+    value: {
+      origin: 'https://app.example.com',
+      pathname: '/dashboard/acme',
+      href: 'https://app.example.com/dashboard/acme',
+    },
+    writable: true,
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useBillingPlanTelemetry', () => {
+  it('buildUrls returns success/return URLs with source + attribution baked in', () => {
+    const { result } = renderHook(() =>
+      useBillingPlanTelemetry({
+        source: 'plan_upsell',
+        organizationId: 'org_1',
+        successPath: '/dashboard/acme/settings/billing',
+      }),
+    )
+
+    const urls = result.current.buildUrls({
+      plan_name: 'Growth',
+      plan_product_id: 'prod_growth',
+      monthly_savings_cents: 30000,
+    })
+
+    const success = new URL(urls.success_url)
+    expect(success.origin).toBe('https://app.example.com')
+    expect(success.pathname).toBe('/dashboard/acme/settings/billing')
+    expect(success.searchParams.get('checkout_success')).toBe('true')
+    expect(success.searchParams.get('source')).toBe('plan_upsell')
+    expect(success.searchParams.get('plan_name')).toBe('Growth')
+    expect(success.searchParams.get('monthly_savings_cents')).toBe('30000')
+    // utm_* is reserved for external marketing attribution.
+    expect(success.searchParams.get('utm_source')).toBeNull()
+
+    const cancel = new URL(urls.return_url)
+    expect(cancel.pathname).toBe('/dashboard/acme')
+    expect(cancel.searchParams.get('checkout_canceled')).toBe('true')
+    expect(cancel.searchParams.get('source')).toBe('plan_upsell')
+    expect(cancel.searchParams.get('utm_source')).toBeNull()
+  })
+
+  it('fires the cancel event and strips params when returning with canceled=true and matching source', () => {
+    currentSearchParams = new URLSearchParams(
+      '?checkout_canceled=true&source=plan_upsell&plan_name=Growth&plan_product_id=prod_growth',
+    )
+    renderHook(() =>
+      useBillingPlanTelemetry({
+        source: 'plan_upsell',
+        organizationId: 'org_1',
+        successPath: '/x',
+      }),
+    )
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(captureMock).toHaveBeenCalledWith(
+      'dashboard:subscriptions:checkout:cancel',
+      expect.objectContaining({
+        organization_id: 'org_1',
+        source: 'plan_upsell',
+        plan_name: 'Growth',
+        plan_product_id: 'prod_growth',
+      }),
+    )
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard/acme')
+  })
+
+  it('does not fire when the cancel return is for a different source', () => {
+    currentSearchParams = new URLSearchParams(
+      '?checkout_canceled=true&source=change_plan',
+    )
+    renderHook(() =>
+      useBillingPlanTelemetry({
+        source: 'plan_upsell',
+        organizationId: 'org_1',
+        successPath: '/x',
+      }),
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fire on a clean URL with no cancel marker', () => {
+    currentSearchParams = new URLSearchParams()
+    renderHook(() =>
+      useBillingPlanTelemetry({
+        source: 'plan_upsell',
+        organizationId: 'org_1',
+        successPath: '/x',
+      }),
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('fires at most once per mount even if the cancel-URL effect runs twice (StrictMode / re-render before router.replace lands)', () => {
+    currentSearchParams = new URLSearchParams(
+      '?checkout_canceled=true&source=plan_upsell&plan_name=Growth&plan_product_id=prod_growth',
+    )
+    const { rerender } = renderHook(() =>
+      useBillingPlanTelemetry({
+        source: 'plan_upsell',
+        organizationId: 'org_1',
+        successPath: '/x',
+      }),
+    )
+    // The router.replace is async; in dev StrictMode the effect re-runs
+    // before the URL actually updates. The guard should still keep the
+    // capture at exactly one.
+    rerender()
+    rerender()
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(replaceMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useBillingPlanCompleteListener', () => {
+  it('fires complete and runs onComplete + replace when URL carries success + source', () => {
+    currentSearchParams = new URLSearchParams(
+      '?checkout_success=true&source=plan_upsell&plan_name=Growth&plan_product_id=prod_growth&monthly_savings_cents=30000',
+    )
+    const onComplete = vi.fn()
+    renderHook(() =>
+      useBillingPlanCompleteListener({
+        organizationId: 'org_1',
+        redirectPath: '/dashboard/acme/settings/billing',
+        onComplete,
+      }),
+    )
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(captureMock).toHaveBeenCalledWith(
+      'dashboard:subscriptions:checkout:complete',
+      expect.objectContaining({
+        organization_id: 'org_1',
+        source: 'plan_upsell',
+        plan_name: 'Growth',
+        plan_product_id: 'prod_growth',
+        monthly_savings_cents: 30000,
+      }),
+    )
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard/acme/settings/billing')
+  })
+
+  it('runs onComplete and replace without firing when checkout_success is set but source is missing (internal nav)', () => {
+    currentSearchParams = new URLSearchParams('?checkout_success=true')
+    const onComplete = vi.fn()
+    renderHook(() =>
+      useBillingPlanCompleteListener({
+        organizationId: 'org_1',
+        redirectPath: '/dashboard/acme/settings/billing',
+        onComplete,
+      }),
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(replaceMock).toHaveBeenCalled()
+  })
+
+  it('is a no-op when checkout_success is absent', () => {
+    currentSearchParams = new URLSearchParams('?source=plan_upsell')
+    const onComplete = vi.fn()
+    renderHook(() =>
+      useBillingPlanCompleteListener({
+        organizationId: 'org_1',
+        redirectPath: '/dashboard/acme/settings/billing',
+        onComplete,
+      }),
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('fires at most once per mount even if the complete-URL effect runs twice (StrictMode / re-render before router.replace lands)', () => {
+    currentSearchParams = new URLSearchParams(
+      '?checkout_success=true&source=plan_upsell&plan_name=Growth&plan_product_id=prod_growth&monthly_savings_cents=30000',
+    )
+    const onComplete = vi.fn()
+    const { rerender } = renderHook(() =>
+      useBillingPlanCompleteListener({
+        organizationId: 'org_1',
+        redirectPath: '/dashboard/acme/settings/billing',
+        onComplete,
+      }),
+    )
+    rerender()
+    rerender()
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(replaceMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/apps/web/src/hooks/useBillingPlanTelemetry.ts
+++ b/clients/apps/web/src/hooks/useBillingPlanTelemetry.ts
@@ -1,0 +1,104 @@
+'use client'
+
+import { usePostHog } from '@/hooks/posthog'
+import {
+  BillingPlanAttribution,
+  BillingPlanSource,
+  BillingPlanUrls,
+  buildBillingPlanUrls,
+  readBillingPlanCancelPayload,
+  readBillingPlanCompletePayload,
+} from '@/utils/billingPlanTelemetry'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useRef } from 'react'
+
+export type { BillingPlanAttribution, BillingPlanSource, BillingPlanUrls }
+
+interface UseBillingPlanTelemetryOptions {
+  source: BillingPlanSource
+  organizationId: string
+  successPath: string
+}
+
+/**
+ * For components that initiate a Polar billing-plan checkout redirect.
+ * Returns a builder for the success/return URLs (UTM + attribution baked
+ * in), and silently listens on the current page for the cancellation
+ * return — firing `dashboard:subscriptions:checkout:cancel` and stripping
+ * the URL params.
+ */
+export const useBillingPlanTelemetry = ({
+  source,
+  organizationId,
+  successPath,
+}: UseBillingPlanTelemetryOptions): {
+  buildUrls: (attribution: BillingPlanAttribution) => BillingPlanUrls
+} => {
+  const posthog = usePostHog()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    if (firedRef.current) return
+    const payload = readBillingPlanCancelPayload(
+      searchParams,
+      organizationId,
+      source,
+    )
+    if (!payload) return
+    firedRef.current = true
+    posthog.capture('dashboard:subscriptions:checkout:cancel', payload)
+    router.replace(window.location.pathname)
+  }, [searchParams, router, posthog, organizationId, source])
+
+  const buildUrls = useCallback(
+    (attribution: BillingPlanAttribution): BillingPlanUrls =>
+      buildBillingPlanUrls({
+        source,
+        attribution,
+        origin: window.location.origin,
+        successPath,
+        cancelPath: window.location.pathname,
+      }),
+    [source, successPath],
+  )
+
+  return { buildUrls }
+}
+
+interface UseBillingPlanCompleteListenerOptions {
+  organizationId: string
+  redirectPath: string
+  onComplete?: () => void
+}
+
+/**
+ * For the page hit by `success_url` after a Polar billing-plan checkout.
+ * Fires `dashboard:subscriptions:checkout:complete` only when both
+ * `checkout_success=true` AND `utm_source` are present. Runs `onComplete`
+ * for any side-effect (cache invalidation), then strips the params via
+ * `router.replace`.
+ */
+export const useBillingPlanCompleteListener = ({
+  organizationId,
+  redirectPath,
+  onComplete,
+}: UseBillingPlanCompleteListenerOptions): void => {
+  const posthog = usePostHog()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    if (firedRef.current) return
+    if (searchParams.get('checkout_success') !== 'true') return
+    firedRef.current = true
+    const payload = readBillingPlanCompletePayload(searchParams, organizationId)
+    if (payload) {
+      posthog.capture('dashboard:subscriptions:checkout:complete', payload)
+    }
+    onComplete?.()
+    router.replace(redirectPath)
+  }, [searchParams, router, posthog, organizationId, redirectPath, onComplete])
+}

--- a/clients/apps/web/src/hooks/useImpressionEvent.test.ts
+++ b/clients/apps/web/src/hooks/useImpressionEvent.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useImpressionEvent } from './useImpressionEvent'
+
+const captureMock = vi.fn()
+
+vi.mock('@/hooks/posthog', () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}))
+
+beforeEach(() => {
+  captureMock.mockClear()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useImpressionEvent', () => {
+  it('fires once when `enabled` is omitted (defaults to true)', () => {
+    renderHook(() =>
+      useImpressionEvent({
+        event: 'dashboard:subscriptions:plan_upsell:view',
+        build: () => ({ ok: true }),
+      }),
+    )
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(captureMock).toHaveBeenCalledWith(
+      'dashboard:subscriptions:plan_upsell:view',
+      { ok: true },
+    )
+  })
+
+  it('fires the event once when enabled is true on mount', () => {
+    const build = vi.fn(() => ({ org_id: 'org_1', value: 1 }))
+    renderHook(() =>
+      useImpressionEvent({
+        event: 'dashboard:subscriptions:plan_upsell:view',
+        enabled: true,
+        build,
+      }),
+    )
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(captureMock).toHaveBeenCalledWith(
+      'dashboard:subscriptions:plan_upsell:view',
+      { org_id: 'org_1', value: 1 },
+    )
+    expect(build).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() =>
+      useImpressionEvent({
+        event: 'dashboard:subscriptions:plan_upsell:view',
+        enabled: false,
+        build: () => ({}),
+      }),
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+  })
+
+  it('fires exactly once even after multiple re-renders with enabled true', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useImpressionEvent({
+          event: 'dashboard:subscriptions:plan_upsell:view',
+          enabled,
+          build: () => ({ tick: Math.random() }),
+        }),
+      { initialProps: { enabled: true } },
+    )
+    rerender({ enabled: true })
+    rerender({ enabled: true })
+    expect(captureMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires on the false→true transition, then stays silent', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useImpressionEvent({
+          event: 'dashboard:subscriptions:plan_upsell:view',
+          enabled,
+          build: () => ({ ok: true }),
+        }),
+      { initialProps: { enabled: false } },
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+    expect(captureMock).toHaveBeenCalledTimes(1)
+
+    // Toggling enabled back doesn't re-fire when it becomes true again.
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+    expect(captureMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire on remount until enabled becomes true', () => {
+    const { unmount } = renderHook(() =>
+      useImpressionEvent({
+        event: 'dashboard:subscriptions:plan_upsell:view',
+        enabled: false,
+        build: () => ({}),
+      }),
+    )
+    expect(captureMock).not.toHaveBeenCalled()
+    act(() => unmount())
+
+    renderHook(() =>
+      useImpressionEvent({
+        event: 'dashboard:subscriptions:plan_upsell:view',
+        enabled: true,
+        build: () => ({ ok: true }),
+      }),
+    )
+    expect(captureMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/apps/web/src/hooks/useImpressionEvent.ts
+++ b/clients/apps/web/src/hooks/useImpressionEvent.ts
@@ -1,0 +1,40 @@
+'use client'
+
+import { EventName, usePostHog } from '@/hooks/posthog'
+import type { JsonType } from '@posthog/core'
+import { useEffect, useRef } from 'react'
+
+interface UseImpressionEventOptions {
+  event: EventName
+  // Defaults to true. Pass false to suppress the impression until the
+  // condition becomes true (e.g. data loaded, component visible).
+  enabled?: boolean
+  // Invoked exactly when the event fires, so properties never go stale and
+  // we don't pay the cost on renders where the impression is suppressed.
+  build: () => Record<string, JsonType>
+}
+
+/**
+ * Fire a PostHog event exactly once, the first time `enabled` is true. Use
+ * for impression / "was shown" telemetry where we want a single capture per
+ * mount, regardless of re-renders from data refetches.
+ */
+export const useImpressionEvent = ({
+  event,
+  enabled = true,
+  build,
+}: UseImpressionEventOptions): void => {
+  const posthog = usePostHog()
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    if (!enabled) return
+    if (firedRef.current) return
+    firedRef.current = true
+    posthog.capture(event, build())
+    // Intentionally only re-run when `enabled` flips — `build`, `event`,
+    // and `posthog` are read freshly via the closure but should not cause
+    // refires.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled])
+}

--- a/clients/apps/web/src/utils/billingPlanTelemetry.test.ts
+++ b/clients/apps/web/src/utils/billingPlanTelemetry.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBillingPlanUrls,
+  readBillingPlanCancelPayload,
+  readBillingPlanCompletePayload,
+} from './billingPlanTelemetry'
+
+const ORIGIN = 'https://app.example.com'
+
+const sp = (query: string) => new URLSearchParams(query)
+
+describe('buildBillingPlanUrls', () => {
+  it('encodes source + attribution on the success URL', () => {
+    const { success_url } = buildBillingPlanUrls({
+      source: 'plan_upsell',
+      attribution: {
+        plan_name: 'Growth',
+        plan_product_id: 'prod_growth',
+        monthly_savings_cents: 30000,
+      },
+      origin: ORIGIN,
+      successPath: '/dashboard/acme/settings/billing',
+      cancelPath: '/dashboard/acme',
+    })
+
+    const url = new URL(success_url)
+    expect(url.origin).toBe(ORIGIN)
+    expect(url.pathname).toBe('/dashboard/acme/settings/billing')
+    expect(url.searchParams.get('checkout_success')).toBe('true')
+    expect(url.searchParams.get('source')).toBe('plan_upsell')
+    expect(url.searchParams.get('plan_name')).toBe('Growth')
+    expect(url.searchParams.get('plan_product_id')).toBe('prod_growth')
+    expect(url.searchParams.get('monthly_savings_cents')).toBe('30000')
+  })
+
+  it('does not pollute the URL with utm_* params', () => {
+    const { success_url, return_url } = buildBillingPlanUrls({
+      source: 'plan_upsell',
+      attribution: { plan_name: 'Pro', plan_product_id: 'prod_pro' },
+      origin: ORIGIN,
+      successPath: '/x',
+      cancelPath: '/y',
+    })
+    for (const url of [new URL(success_url), new URL(return_url)]) {
+      expect(url.searchParams.get('utm_source')).toBeNull()
+      expect(url.searchParams.get('utm_medium')).toBeNull()
+      expect(url.searchParams.get('utm_campaign')).toBeNull()
+    }
+  })
+
+  it('encodes source + attribution on the cancel URL pointing back to cancelPath', () => {
+    const { return_url } = buildBillingPlanUrls({
+      source: 'change_plan',
+      attribution: { plan_name: 'Pro', plan_product_id: 'prod_pro' },
+      origin: ORIGIN,
+      successPath: '/dashboard/acme/settings/billing',
+      cancelPath: '/dashboard/acme/settings/billing/change-plan',
+    })
+
+    const url = new URL(return_url)
+    expect(url.pathname).toBe('/dashboard/acme/settings/billing/change-plan')
+    expect(url.searchParams.get('checkout_canceled')).toBe('true')
+    expect(url.searchParams.get('source')).toBe('change_plan')
+    expect(url.searchParams.get('plan_name')).toBe('Pro')
+  })
+
+  it('omits monthly_savings_cents when not provided', () => {
+    const { success_url } = buildBillingPlanUrls({
+      source: 'change_plan',
+      attribution: { plan_name: 'Pro', plan_product_id: 'prod_pro' },
+      origin: ORIGIN,
+      successPath: '/x',
+      cancelPath: '/y',
+    })
+    expect(
+      new URL(success_url).searchParams.get('monthly_savings_cents'),
+    ).toBeNull()
+  })
+
+  it('treats null monthly_savings_cents as absent', () => {
+    const { success_url } = buildBillingPlanUrls({
+      source: 'plan_upsell',
+      attribution: {
+        plan_name: 'Pro',
+        plan_product_id: 'prod_pro',
+        monthly_savings_cents: null,
+      },
+      origin: ORIGIN,
+      successPath: '/x',
+      cancelPath: '/y',
+    })
+    expect(
+      new URL(success_url).searchParams.get('monthly_savings_cents'),
+    ).toBeNull()
+  })
+
+  it('encodes the from_plan_* fields when provided', () => {
+    const { success_url } = buildBillingPlanUrls({
+      source: 'change_plan',
+      attribution: {
+        plan_name: 'Growth',
+        plan_product_id: 'prod_growth',
+        from_plan_name: 'Pro',
+        from_plan_product_id: 'prod_pro',
+        from_plan_amount_cents: 2000,
+      },
+      origin: ORIGIN,
+      successPath: '/x',
+      cancelPath: '/y',
+    })
+    const params = new URL(success_url).searchParams
+    expect(params.get('from_plan_name')).toBe('Pro')
+    expect(params.get('from_plan_product_id')).toBe('prod_pro')
+    expect(params.get('from_plan_amount_cents')).toBe('2000')
+  })
+
+  it('omits from_plan_* fields when null/undefined (e.g. checkout from free)', () => {
+    const { success_url } = buildBillingPlanUrls({
+      source: 'plan_upsell',
+      attribution: {
+        plan_name: 'Pro',
+        plan_product_id: 'prod_pro',
+        from_plan_name: null,
+        from_plan_product_id: null,
+        from_plan_amount_cents: null,
+      },
+      origin: ORIGIN,
+      successPath: '/x',
+      cancelPath: '/y',
+    })
+    const params = new URL(success_url).searchParams
+    expect(params.get('from_plan_name')).toBeNull()
+    expect(params.get('from_plan_product_id')).toBeNull()
+    expect(params.get('from_plan_amount_cents')).toBeNull()
+  })
+
+  it('round-trips zero savings (a real value, not absent)', () => {
+    const { success_url } = buildBillingPlanUrls({
+      source: 'plan_upsell',
+      attribution: {
+        plan_name: 'Pro',
+        plan_product_id: 'prod_pro',
+        monthly_savings_cents: 0,
+      },
+      origin: ORIGIN,
+      successPath: '/x',
+      cancelPath: '/y',
+    })
+    expect(new URL(success_url).searchParams.get('monthly_savings_cents')).toBe(
+      '0',
+    )
+  })
+})
+
+describe('readBillingPlanCancelPayload', () => {
+  it('returns the full payload when canceled and source matches', () => {
+    const params = sp(
+      '?checkout_canceled=true&source=plan_upsell&plan_name=Growth&plan_product_id=prod_growth&from_plan_name=Pro&from_plan_product_id=prod_pro&from_plan_amount_cents=2000',
+    )
+    const payload = readBillingPlanCancelPayload(params, 'org_1', 'plan_upsell')
+    expect(payload).toEqual({
+      organization_id: 'org_1',
+      source: 'plan_upsell',
+      plan_name: 'Growth',
+      plan_product_id: 'prod_growth',
+      from_plan_name: 'Pro',
+      from_plan_product_id: 'prod_pro',
+      from_plan_amount_cents: 2000,
+    })
+  })
+
+  it('returns null when checkout_canceled flag is missing', () => {
+    const params = sp('?source=plan_upsell')
+    expect(
+      readBillingPlanCancelPayload(params, 'org_1', 'plan_upsell'),
+    ).toBeNull()
+  })
+
+  it('returns null when source does not match (different surface)', () => {
+    const params = sp('?checkout_canceled=true&source=change_plan')
+    expect(
+      readBillingPlanCancelPayload(params, 'org_1', 'plan_upsell'),
+    ).toBeNull()
+  })
+
+  it('fills missing optional fields with null', () => {
+    const params = sp('?checkout_canceled=true&source=plan_upsell')
+    expect(
+      readBillingPlanCancelPayload(params, 'org_1', 'plan_upsell'),
+    ).toEqual({
+      organization_id: 'org_1',
+      source: 'plan_upsell',
+      plan_name: null,
+      plan_product_id: null,
+      from_plan_name: null,
+      from_plan_product_id: null,
+      from_plan_amount_cents: null,
+    })
+  })
+})
+
+describe('readBillingPlanCompletePayload', () => {
+  it('returns the full payload including parsed savings and previous plan', () => {
+    const params = sp(
+      '?checkout_success=true&source=plan_upsell&plan_name=Growth&plan_product_id=prod_growth&monthly_savings_cents=30000&from_plan_name=Pro&from_plan_product_id=prod_pro&from_plan_amount_cents=2000',
+    )
+    expect(readBillingPlanCompletePayload(params, 'org_1')).toEqual({
+      organization_id: 'org_1',
+      source: 'plan_upsell',
+      plan_name: 'Growth',
+      plan_product_id: 'prod_growth',
+      monthly_savings_cents: 30000,
+      from_plan_name: 'Pro',
+      from_plan_product_id: 'prod_pro',
+      from_plan_amount_cents: 2000,
+    })
+  })
+
+  it('fills from_plan_* with null when absent (e.g. upgrade from free)', () => {
+    const params = sp(
+      '?checkout_success=true&source=plan_upsell&plan_name=Pro&plan_product_id=prod_pro',
+    )
+    const payload = readBillingPlanCompletePayload(params, 'org_1')
+    expect(payload?.from_plan_name).toBeNull()
+    expect(payload?.from_plan_product_id).toBeNull()
+    expect(payload?.from_plan_amount_cents).toBeNull()
+  })
+
+  it('returns null when checkout_success flag is missing', () => {
+    const params = sp('?source=plan_upsell')
+    expect(readBillingPlanCompletePayload(params, 'org_1')).toBeNull()
+  })
+
+  it('returns null when source is missing (gated against accidental fires)', () => {
+    const params = sp('?checkout_success=true')
+    expect(readBillingPlanCompletePayload(params, 'org_1')).toBeNull()
+  })
+
+  it('parses savings as a number', () => {
+    const params = sp(
+      '?checkout_success=true&source=change_plan&monthly_savings_cents=18000',
+    )
+    const payload = readBillingPlanCompletePayload(params, 'org_1')
+    expect(payload?.monthly_savings_cents).toBe(18000)
+  })
+
+  it('leaves savings null when absent', () => {
+    const params = sp('?checkout_success=true&source=change_plan')
+    const payload = readBillingPlanCompletePayload(params, 'org_1')
+    expect(payload?.monthly_savings_cents).toBeNull()
+  })
+})

--- a/clients/apps/web/src/utils/billingPlanTelemetry.ts
+++ b/clients/apps/web/src/utils/billingPlanTelemetry.ts
@@ -1,0 +1,161 @@
+import type { JsonType } from '@posthog/core'
+
+/**
+ * Utilities for telemetry around Polar's *own* billing-plan upgrade flow
+ * (the checkout that lives behind the dashboard's Pricing settings and the
+ * dashboard upsell). Not to be confused with the customer-facing Polar
+ * Checkout product — these helpers are exclusively about us tracking how
+ * Polar's organizations move between Polar's plans.
+ *
+ * Attribution is encoded as plain `source=...` query params, not UTM tags.
+ * UTM is reserved for external marketing attribution; mixing internal
+ * surfaces into UTM pollutes that data.
+ */
+
+/**
+ * Source — the specific in-product surface that started the billing plan
+ * checkout. Persisted as `source` on the redirect URLs and re-emitted on
+ * the explicit complete/cancel events so funnels filter cleanly.
+ */
+export type BillingPlanSource = 'plan_upsell' | 'change_plan'
+
+export interface BillingPlanAttribution {
+  /** Target plan name (the one the user is upgrading to). */
+  plan_name: string
+  /** Target plan product id. */
+  plan_product_id: string
+  /** Projected monthly savings, when the action originates from the upsell. */
+  monthly_savings_cents?: number | null
+  /** Name of the plan the user was on when checkout started. Null = free. */
+  from_plan_name?: string | null
+  /** Product id of the previous plan. Null = free. */
+  from_plan_product_id?: string | null
+  /** Monthly amount of the previous plan, in cents. Null = free. */
+  from_plan_amount_cents?: number | null
+}
+
+export interface BillingPlanUrls {
+  success_url: string
+  return_url: string
+}
+
+interface BuildBillingPlanUrlsInput {
+  source: BillingPlanSource
+  attribution: BillingPlanAttribution
+  origin: string
+  successPath: string
+  cancelPath: string
+}
+
+const appendIfPresent = (
+  target: Record<string, string>,
+  key: string,
+  value: number | string | null | undefined,
+): void => {
+  if (value === null || value === undefined) return
+  target[key] = String(value)
+}
+
+export const buildBillingPlanUrls = ({
+  source,
+  attribution,
+  origin,
+  successPath,
+  cancelPath,
+}: BuildBillingPlanUrlsInput): BillingPlanUrls => {
+  const shared: Record<string, string> = {
+    source,
+    plan_name: attribution.plan_name,
+    plan_product_id: attribution.plan_product_id,
+  }
+  appendIfPresent(
+    shared,
+    'monthly_savings_cents',
+    attribution.monthly_savings_cents,
+  )
+  appendIfPresent(shared, 'from_plan_name', attribution.from_plan_name)
+  appendIfPresent(
+    shared,
+    'from_plan_product_id',
+    attribution.from_plan_product_id,
+  )
+  appendIfPresent(
+    shared,
+    'from_plan_amount_cents',
+    attribution.from_plan_amount_cents,
+  )
+  const successParams = new URLSearchParams({
+    checkout_success: 'true',
+    ...shared,
+  })
+  const cancelParams = new URLSearchParams({
+    checkout_canceled: 'true',
+    ...shared,
+  })
+  return {
+    success_url: `${origin}${successPath}?${successParams.toString()}`,
+    return_url: `${origin}${cancelPath}?${cancelParams.toString()}`,
+  }
+}
+
+interface URLSearchParamsLike {
+  get: (key: string) => string | null
+}
+
+/**
+ * Reads the cancel-event payload from URL search params. Returns null when
+ * the URL isn't a cancellation return for the given source, so the caller
+ * can short-circuit before firing.
+ */
+const parseIntOrNull = (raw: string | null): number | null =>
+  raw === null ? null : Number(raw)
+
+export const readBillingPlanCancelPayload = (
+  searchParams: URLSearchParamsLike,
+  organizationId: string,
+  source: BillingPlanSource,
+): Record<string, JsonType> | null => {
+  if (searchParams.get('checkout_canceled') !== 'true') return null
+  if (searchParams.get('source') !== source) return null
+  return {
+    organization_id: organizationId,
+    source,
+    plan_name: searchParams.get('plan_name') ?? null,
+    plan_product_id: searchParams.get('plan_product_id') ?? null,
+    from_plan_name: searchParams.get('from_plan_name') ?? null,
+    from_plan_product_id: searchParams.get('from_plan_product_id') ?? null,
+    from_plan_amount_cents: parseIntOrNull(
+      searchParams.get('from_plan_amount_cents'),
+    ),
+  }
+}
+
+/**
+ * Reads the complete-event payload. Returns null when there's no
+ * `checkout_success=true` OR no `source` (the marker we attach when
+ * building the success_url). Internal navigations that use
+ * `?checkout_success=true` purely for cache invalidation don't have
+ * `source` and therefore don't masquerade as conversions.
+ */
+export const readBillingPlanCompletePayload = (
+  searchParams: URLSearchParamsLike,
+  organizationId: string,
+): Record<string, JsonType> | null => {
+  if (searchParams.get('checkout_success') !== 'true') return null
+  const source = searchParams.get('source')
+  if (!source) return null
+  return {
+    organization_id: organizationId,
+    source,
+    plan_name: searchParams.get('plan_name') ?? null,
+    plan_product_id: searchParams.get('plan_product_id') ?? null,
+    monthly_savings_cents: parseIntOrNull(
+      searchParams.get('monthly_savings_cents'),
+    ),
+    from_plan_name: searchParams.get('from_plan_name') ?? null,
+    from_plan_product_id: searchParams.get('from_plan_product_id') ?? null,
+    from_plan_amount_cents: parseIntOrNull(
+      searchParams.get('from_plan_amount_cents'),
+    ),
+  }
+}

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -515,6 +515,9 @@ importers:
       '@stylexjs/postcss-plugin':
         specifier: ^0.18.2
         version: 0.18.2
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/big.js':
         specifier: ^6.2.2
         version: 6.2.2
@@ -16719,7 +16722,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -21227,7 +21230,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -21955,12 +21958,12 @@ snapshots:
 
   metro-runtime@0.83.2:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.83.3:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.83.2:


### PR DESCRIPTION
## Summary

  Adds end-to-end PostHog telemetry for Polar's **own billing-plan upgrade flow** (the upsell card on the dashboard home + the Pricing settings page), extracts the wiring into reusable hooks, and adds tests.

  This is distinct from the customer-facing Polar Checkout product, these helpers are scoped to *us* tracking how
  Polar's organizations move between Polar's plans.

  ## What's tracked

  | Event | Fires from | Notes |
  |---|---|---|
  | `dashboard:subscriptions:plan_upsell:view` | Dashboard home upsell card | One per mount, ref-guarded |
  | `dashboard:subscriptions:plan_upsell:click` | Upsell card buttons | `variant: 'upgrade' \| 'compare'` |
  | `dashboard:subscriptions:plan_upsell:close` | Upsell dismiss | |
  | `dashboard:subscriptions:change_plan:click` | "Change plan" button on `BillingPage` | |
  | `dashboard:subscriptions:checkout:start` | Right before `startCheckout.mutateAsync` (both surfaces) | |
  | `dashboard:subscriptions:checkout:complete` | Landing on success URL | Includes `from_plan_*` +
  `monthly_savings_cents` |
  | `dashboard:subscriptions:checkout:cancel` | Landing on cancel URL | Includes `from_plan_*` |
  | `dashboard:subscriptions:plan:update` | `changePlan` mutation resolves (paid → paid) | `change_kind: 'upgrade' or 'downgrade'`, `from_plan_*`, `to_plan_*` |
  | `dashboard:subscriptions:plan:cancel` | `cancelSubscription` resolves (paid → free) | `from_plan_*` |

  Every event carries `source` (`plan_upsell` or `change_plan`) and `organization_id` so funnels filter cleanly.

  ## Architecture

  **New hooks**

  - **`useImpressionEvent`** — fires a PostHog event once when `enabled` is true (defaults to true). Uses a ref guard so React Strict Mode double-effects don't double-fire. Replaces a buggy ad-hoc `useEffect(posthog.capture, [...])` in `Login.tsx` that fired twice on every modal mount.
  - **`useBillingPlanTelemetry`** — for components initiating a billing-plan checkout redirect. Returns a `buildUrls`
  helper that bakes the source + plan attribution into both `success_url` and `return_url`, and silently listens for the
  cancellation return on the current page.
  - **`useBillingPlanCompleteListener`** — for the page hit by `success_url`. Fires `checkout:complete`, runs the caller's `onComplete` for cache invalidation, then `router.replace`s to a clean URL. Both hooks use a `firedRef` so the cancel/complete event captures at most once per mount (fixing a Strict-Mode double-fire on cancel).

  **Pure helpers** (`utils/billingPlanTelemetry.ts`)

  - `buildBillingPlanUrls(...)`, `readBillingPlanCancelPayload(...)`, `readBillingPlanCompletePayload(...)`, pure
  URL/payload functions extracted from the hooks so they're unit-testable without a React DOM.

  **Attribution carrier**

  URLs use plain `source=plan_upsell` (not `utm_*`). UTM tags are reserved for external marketing attribution; mixing internal surfaces into UTM pollutes that data.

  **Dev visibility**

  `usePostHog().capture(...)` now logs `[posthog] <event> <props>` to the console when `NODE_ENV === 'development'` so engineers can see events without leaving the browser.