### PR TITLE
Add pricing on landing navigation

### DIFF
--- a/clients/apps/web/src/components/Landing/LandingLayout.tsx
+++ b/clients/apps/web/src/components/Landing/LandingLayout.tsx
@@ -77,21 +77,48 @@ const NavLink = ({
   children,
   isActive: _isActive,
   target,
+  onClick,
   ...props
 }: ComponentProps<typeof Link> & {
   isActive?: (pathname: string) => boolean
 }) => {
   const pathname = usePathname()
+  const hrefString = href.toString()
   const isActive = _isActive
     ? _isActive(pathname)
-    : pathname.startsWith(href.toString())
-  const isExternal = href.toString().startsWith('http')
+    : pathname.startsWith(hrefString)
+  const isExternal = hrefString.startsWith('http')
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event)
+    if (event.defaultPrevented) return
+
+    const hashIndex = hrefString.indexOf('#')
+    if (hashIndex === -1) return
+
+    const targetPath = hrefString.slice(0, hashIndex) || '/'
+    if (targetPath !== pathname) return
+
+    const targetId = hrefString.slice(hashIndex + 1)
+    if (!targetId) return
+
+    event.preventDefault()
+    // Toggle sidebar hack for mobile
+    const delay = onClick ? 350 : 0
+    window.setTimeout(() => {
+      const element = document.getElementById(targetId)
+      if (!element) return
+      element.scrollIntoView()
+      window.history.replaceState(null, '', hrefString)
+    }, delay)
+  }
 
   return (
     <Link
       href={href}
       target={isExternal ? '_blank' : target}
       prefetch
+      onClick={handleClick}
       className={twMerge(
         'dark:text-polar-500 -m-1 flex items-center gap-x-2 p-1 text-gray-500 transition-colors hover:text-black dark:hover:text-white',
         isActive && 'text-black dark:text-white',
@@ -121,6 +148,10 @@ const mobileNavigationItems: NavigationItem[] = [
     title: 'Documentation',
     href: 'https://polar.sh/docs',
     target: '_blank',
+  },
+  {
+    title: 'Pricing',
+    href: '/#pricing',
   },
   {
     title: 'Blog',
@@ -363,6 +394,9 @@ const LandingPageDesktopNavigation = () => {
           </li>
           <li>
             <NavPopover trigger="Docs" sections={docsSections} layout="flex" />
+          </li>
+          <li>
+            <NavLink href="/#pricing">Pricing</NavLink>
           </li>
           <li>
             <NavLink href="/blog">Blog</NavLink>

--- a/clients/apps/web/src/components/Landing/Pricing.tsx
+++ b/clients/apps/web/src/components/Landing/Pricing.tsx
@@ -51,44 +51,41 @@ const TIERS: Tier[] = [
 ]
 
 export const Pricing = () => (
-  <Box
-    as="section"
-    id="pricing"
-    display="flex"
-    flexDirection="column"
-    rowGap="5xl"
-  >
-    <Box display="flex" flexDirection="column" rowGap="xl">
-      <Text variant="heading-xl" as="h2" wrap="balance">
-        Built to scale with you.
-      </Text>
-      <Box maxWidth="56rem">
-        <Text variant="heading-xs" wrap="balance" color="muted">
-          Start free. Upgrade as you grow. Enterprise needs? Let&apos;s talk.
+  <>
+    <span id="pricing" className="block scroll-mt-12 md:scroll-mt-28" />
+    <Box as="section" display="flex" flexDirection="column" rowGap="5xl">
+      <Box display="flex" flexDirection="column" rowGap="xl">
+        <Text variant="heading-xl" as="h2" wrap="balance">
+          Built to scale with you.
         </Text>
+        <Box maxWidth="56rem">
+          <Text variant="heading-xs" wrap="balance" color="muted">
+            Start free. Upgrade as you grow. Enterprise needs? Let&apos;s talk.
+          </Text>
+        </Box>
+        <Box display="flex" alignItems="center" columnGap="m" paddingTop="m">
+          <GetStartedButton size="default" />
+          <Link href="mailto:support@polar.sh">
+            <Button variant="secondary">Contact Sales</Button>
+          </Link>
+        </Box>
       </Box>
-      <Box display="flex" alignItems="center" columnGap="m" paddingTop="m">
-        <GetStartedButton size="default" />
-        <Link href="mailto:support@polar.sh">
-          <Button variant="secondary">Contact Sales</Button>
-        </Link>
-      </Box>
-    </Box>
 
-    <Box
-      display="grid"
-      gridTemplateColumns={{
-        base: '1fr',
-        sm: 'repeat(2, 1fr)',
-        xl: 'repeat(4, 1fr)',
-      }}
-      gap="l"
-    >
-      {TIERS.map((tier) => (
-        <TierCard key={tier.name} tier={tier} />
-      ))}
+      <Box
+        display="grid"
+        gridTemplateColumns={{
+          base: '1fr',
+          sm: 'repeat(2, 1fr)',
+          xl: 'repeat(4, 1fr)',
+        }}
+        gap="l"
+      >
+        {TIERS.map((tier) => (
+          <TierCard key={tier.name} tier={tier} />
+        ))}
+      </Box>
     </Box>
-  </Box>
+  </>
 )
 
 const TierCard = ({ tier }: { tier: Tier }) => (


### PR DESCRIPTION
☝️ Simply scrolls down to the bottom parts of the landing page. Diff best viewed with the [?w=1](https://github.com/polarsource/polar/pull/11896/changes?w=1) parameter.

<img width="1840" height="1133" alt="Screenshot 2026-05-26 at 12 40 16" src="https://github.com/user-attachments/assets/7c32913d-5322-46c5-8ef9-82be4c29d124" />
