### PR TITLE
Allow changing plans during trial

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
@@ -6,6 +6,7 @@ import {
   useCustomerUpdateSubscription,
 } from '@/hooks/queries/customerPortal'
 import { hasLegacyRecurringPrices } from '@/utils/product'
+import { formatTrialEnd, useTrialChangeOutcome } from '@/utils/trial-change'
 import { Client, schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { List, ListItem } from '@polar-sh/ui/components/atoms/List'
@@ -15,30 +16,6 @@ import { useCallback, useMemo, useState } from 'react'
 import { resolveBenefitIcon } from '../Benefit/utils'
 import ProductPriceLabel from '../Products/ProductPriceLabel'
 import { toast } from '../Toast/use-toast'
-
-const computeTrialEnd = (
-  trialStart: string,
-  product: schemas['CustomerProduct'],
-): Date | null => {
-  if (!product.trial_interval || !product.trial_interval_count) return null
-  const d = new Date(trialStart)
-  const count = product.trial_interval_count
-  switch (product.trial_interval) {
-    case 'day':
-      d.setUTCDate(d.getUTCDate() + count)
-      break
-    case 'week':
-      d.setUTCDate(d.getUTCDate() + 7 * count)
-      break
-    case 'month':
-      d.setUTCMonth(d.getUTCMonth() + count)
-      break
-    case 'year':
-      d.setUTCFullYear(d.getUTCFullYear() + count)
-      break
-  }
-  return d
-}
 
 const ProductPriceListItem = ({
   product,
@@ -129,24 +106,7 @@ const CustomerChangePlanModal = ({
     [organization],
   )
 
-  const trialOutcome = useMemo<
-    { kind: 'continues'; trialEnd: Date } | { kind: 'ends' } | null
-  >(() => {
-    if (subscription.status !== 'trialing') return null
-    if (!selectedProduct || selectedProduct.id === subscription.product.id)
-      return null
-    if (!subscription.trial_start) return null
-
-    const newTrialEnd = computeTrialEnd(
-      subscription.trial_start,
-      selectedProduct,
-    )
-    // eslint-disable-next-line react-hooks/purity
-    if (newTrialEnd && newTrialEnd.getTime() > Date.now()) {
-      return { kind: 'continues', trialEnd: newTrialEnd }
-    }
-    return { kind: 'ends' }
-  }, [subscription, selectedProduct])
+  const trialOutcome = useTrialChangeOutcome(subscription, selectedProduct)
 
   const isTrialing = subscription.status === 'trialing'
 
@@ -182,15 +142,7 @@ const CustomerChangePlanModal = ({
     if (!selectedProduct) return null
 
     if (trialOutcome?.kind === 'continues') {
-      const formatted = trialOutcome.trialEnd.toLocaleDateString('en-US', {
-        month: 'long',
-        day: 'numeric',
-        year:
-          trialOutcome.trialEnd.getFullYear() === new Date().getFullYear()
-            ? undefined
-            : 'numeric',
-      })
-      return `Your trial will continue until ${formatted}. You won't be charged before then.`
+      return `Your trial will continue until ${formatTrialEnd(trialOutcome.trialEnd)}. You won't be charged before then.`
     }
 
     if (trialOutcome?.kind === 'ends') {

--- a/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
@@ -16,6 +16,30 @@ import { resolveBenefitIcon } from '../Benefit/utils'
 import ProductPriceLabel from '../Products/ProductPriceLabel'
 import { toast } from '../Toast/use-toast'
 
+const computeTrialEnd = (
+  trialStart: string,
+  product: schemas['CustomerProduct'],
+): Date | null => {
+  if (!product.trial_interval || !product.trial_interval_count) return null
+  const d = new Date(trialStart)
+  const count = product.trial_interval_count
+  switch (product.trial_interval) {
+    case 'day':
+      d.setUTCDate(d.getUTCDate() + count)
+      break
+    case 'week':
+      d.setUTCDate(d.getUTCDate() + 7 * count)
+      break
+    case 'month':
+      d.setUTCMonth(d.getUTCMonth() + count)
+      break
+    case 'year':
+      d.setUTCFullYear(d.getUTCFullYear() + count)
+      break
+  }
+  return d
+}
+
 const ProductPriceListItem = ({
   product,
   currency,
@@ -105,10 +129,32 @@ const CustomerChangePlanModal = ({
     [organization],
   )
 
+  const trialOutcome = useMemo<
+    { kind: 'continues'; trialEnd: Date } | { kind: 'ends' } | null
+  >(() => {
+    if (subscription.status !== 'trialing') return null
+    if (!selectedProduct || selectedProduct.id === subscription.product.id)
+      return null
+    if (!subscription.trial_start) return null
+
+    const newTrialEnd = computeTrialEnd(
+      subscription.trial_start,
+      selectedProduct,
+    )
+    // eslint-disable-next-line react-hooks/purity
+    if (newTrialEnd && newTrialEnd.getTime() > Date.now()) {
+      return { kind: 'continues', trialEnd: newTrialEnd }
+    }
+    return { kind: 'ends' }
+  }, [subscription, selectedProduct])
+
+  const isTrialing = subscription.status === 'trialing'
+
   const [willTriggerImmediateCycle, nextInvoiceType] = useMemo(():
     | [false, null]
     | [true, 'charge' | 'credit'] => {
     if (!selectedProduct) return [false, null]
+    if (isTrialing) return [false, null]
 
     const willTrigger =
       prorationBehavior !== 'next_period' &&
@@ -130,10 +176,26 @@ const CustomerChangePlanModal = ({
     const chargeOrCredit = newPrice > currentPrice ? 'charge' : 'credit'
 
     return [willTrigger, chargeOrCredit]
-  }, [selectedProduct, prorationBehavior, subscription])
+  }, [selectedProduct, prorationBehavior, subscription, isTrialing])
 
   const invoicingMessage = useMemo(() => {
     if (!selectedProduct) return null
+
+    if (trialOutcome?.kind === 'continues') {
+      const formatted = trialOutcome.trialEnd.toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year:
+          trialOutcome.trialEnd.getFullYear() === new Date().getFullYear()
+            ? undefined
+            : 'numeric',
+      })
+      return `Your trial will continue until ${formatted}. You won't be charged before then.`
+    }
+
+    if (trialOutcome?.kind === 'ends') {
+      return `This will end my trial and charge me immediately for ${selectedProduct.name}.`
+    }
 
     if (willTriggerImmediateCycle) {
       const newPeriod =
@@ -159,10 +221,13 @@ const CustomerChangePlanModal = ({
     prorationBehavior,
     willTriggerImmediateCycle,
     nextInvoiceType,
+    trialOutcome,
   ])
 
   const willIssueInvoice =
-    willTriggerImmediateCycle || prorationBehavior === 'invoice'
+    trialOutcome?.kind === 'ends' ||
+    willTriggerImmediateCycle ||
+    prorationBehavior === 'invoice'
   const [approveImmediateInvoice, setApproveImmediateInvoice] = useState(false)
 
   const canChangePlan = useMemo(() => {
@@ -305,17 +370,19 @@ const CustomerChangePlanModal = ({
             </div>
           )}
           {invoicingMessage && (
-            <label className="flex flex-row items-center gap-x-2">
+            <label className="flex flex-row items-start gap-x-2">
               {willIssueInvoice && (
-                <Checkbox
-                  checked={approveImmediateInvoice}
-                  onCheckedChange={(checked) =>
-                    setApproveImmediateInvoice(checked === true)
-                  }
-                />
+                <div>
+                  <Checkbox
+                    checked={approveImmediateInvoice}
+                    onCheckedChange={(checked) =>
+                      setApproveImmediateInvoice(checked === true)
+                    }
+                  />
+                </div>
               )}
 
-              <span className="dark:text-polar-500 text-sm text-gray-500">
+              <span className="dark:text-polar-500 text-sm text-pretty text-gray-500">
                 {invoicingMessage}
               </span>
             </label>
@@ -333,7 +400,9 @@ const CustomerChangePlanModal = ({
           onClick={onConfirm}
           size="lg"
         >
-          Change Plan
+          {trialOutcome?.kind === 'ends'
+            ? 'Change Plan & End Trial'
+            : 'Change Plan'}
         </Button>
       </div>
     </div>

--- a/clients/apps/web/src/components/CustomerPortal/CustomerSubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerSubscriptionDetails.tsx
@@ -219,16 +219,14 @@ const CustomerSubscriptionDetails = ({
           <Button>Manage subscription</Button>
         </Link>
 
-        {showSubscriptionUpdates &&
-          !isCanceled &&
-          subscription.status !== 'trialing' && (
-            <Button
-              onClick={() => setShowChangePlanModal(true)}
-              variant="secondary"
-            >
-              Change plan
-            </Button>
-          )}
+        {showSubscriptionUpdates && !isCanceled && (
+          <Button
+            onClick={() => setShowChangePlanModal(true)}
+            variant="secondary"
+          >
+            Change plan
+          </Button>
+        )}
 
         <CustomerCancellationModal
           isShown={showCancelModal}

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -108,7 +108,6 @@ const UpdateProduct = ({
   )
   const products = useMemo(() => {
     if (!allProducts) return []
-    const isTrialing = subscription.status === 'trialing'
 
     return allProducts.items
       .filter((product) => !hasLegacyRecurringPrices(product))
@@ -127,17 +126,6 @@ const UpdateProduct = ({
         }
         return !productPriceIds.every((id) => activePriceIds.includes(id))
       })
-      .filter((product) => {
-        // During a trial, only allow targets whose trial period still has
-        // time remaining given the current trial usage — anything that would
-        // already be over is rejected by the backend with a 403.
-        if (!isTrialing || !subscription.trial_start) {
-          return true
-        }
-        const newTrialEnd = computeTrialEnd(subscription.trial_start, product)
-        if (newTrialEnd === null) return false
-        return newTrialEnd.getTime() > Date.now()
-      })
   }, [allProducts, activePriceIds, subscription])
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -146,6 +134,26 @@ const UpdateProduct = ({
     () => products.find((product) => product.id === selectedProductId),
     [products, selectedProductId],
   )
+
+  // When changing product during a trial, determine whether the trial
+  // continues with the new product or ends immediately (triggering a charge).
+  const trialOutcome = useMemo<
+    { kind: 'continues'; trialEnd: Date } | { kind: 'ends' } | null
+  >(() => {
+    if (subscription.status !== 'trialing') return null
+    if (!selectedProduct || selectedProduct.id === subscription.product.id)
+      return null
+    if (!subscription.trial_start) return null
+
+    const newTrialEnd = computeTrialEnd(
+      subscription.trial_start,
+      selectedProduct,
+    )
+    if (newTrialEnd && newTrialEnd.getTime() > Date.now()) {
+      return { kind: 'continues', trialEnd: newTrialEnd }
+    }
+    return { kind: 'ends' }
+  }, [subscription, selectedProduct])
 
   const onSubmit = useCallback(
     async (body: schemas['SubscriptionUpdateProduct']) => {
@@ -226,19 +234,6 @@ const UpdateProduct = ({
                     </Select>
                   </div>
                 </FormControl>
-                {subscription.status === 'trialing' && (
-                  <FormDescription>
-                    <Box
-                      padding="m"
-                      borderRadius="m"
-                      backgroundColor="background-secondary"
-                    >
-                      Only products with a trial long enough to carry over the
-                      time already elapsed are shown. End the trial to switch to
-                      any other product.
-                    </Box>
-                  </FormDescription>
-                )}
                 <FormMessage />
               </FormItem>
             )}
@@ -273,7 +268,9 @@ const UpdateProduct = ({
             loading={updateSubscription.isPending}
             disabled={updateSubscription.isPending}
           >
-            Update Subscription
+            {trialOutcome?.kind === 'ends'
+              ? 'Update Subscription & End Trial'
+              : 'Update Subscription'}
           </Button>
           {selectedProduct &&
             selectedProduct.id !== subscription.product.id && (
@@ -281,7 +278,40 @@ const UpdateProduct = ({
                 padding="m"
                 borderRadius="m"
                 backgroundColor="background-warning"
+                display="flex"
+                flexDirection="column"
+                rowGap="s"
               >
+                {trialOutcome?.kind === 'ends' && (
+                  <p className="text-sm text-yellow-700">
+                    This change will end the current trial and{' '}
+                    <strong className="font-medium">
+                      charge the customer immediately
+                    </strong>{' '}
+                    for the first billing period of{' '}
+                    <strong className="font-medium">
+                      {selectedProduct.name}
+                    </strong>
+                    .
+                  </p>
+                )}
+                {trialOutcome?.kind === 'continues' && (
+                  <p className="text-sm text-yellow-700">
+                    The trial will continue until{' '}
+                    <strong className="font-medium">
+                      {trialOutcome.trialEnd.toLocaleDateString('en-US', {
+                        month: 'long',
+                        day: 'numeric',
+                        year:
+                          trialOutcome.trialEnd.getFullYear() ===
+                          new Date().getFullYear()
+                            ? undefined
+                            : 'numeric',
+                      })}
+                    </strong>
+                    . The customer won&apos;t be charged before then.
+                  </p>
+                )}
                 <p className="text-sm text-yellow-700">
                   By updating this subscription, the customer will get access to{' '}
                   <strong className="font-medium">

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -40,6 +40,7 @@ import { useModal } from '../Modal/useModal'
 import ProductPriceLabel from '../Products/ProductPriceLabel'
 import { ProrationBehavior } from '../Settings/ProrationBehavior'
 import { toast } from '../Toast/use-toast'
+import { Box } from '@polar-sh/orbit/Box'
 
 const validationDiscriminators = [
   'SubscriptionUpdateProduct',
@@ -227,44 +228,45 @@ const UpdateProduct = ({
                 </FormControl>
                 {subscription.status === 'trialing' && (
                   <FormDescription>
-                    Only products whose trial period still has remaining time
-                    given your current trial usage are shown. To switch to
-                    another product, end the trial first.
+                    <Box
+                      padding="m"
+                      borderRadius="m"
+                      backgroundColor="background-secondary"
+                    >
+                      Only products with a trial long enough to carry over the
+                      time already elapsed are shown. End the trial to switch to
+                      any other product.
+                    </Box>
                   </FormDescription>
                 )}
                 <FormMessage />
               </FormItem>
             )}
           />
-          <FormField
-            control={control}
-            name="proration_behavior"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Proration behavior</FormLabel>
-                <FormControl>
-                  <div>
-                    {/* We need an extra div or the space-y-2 from FormItem adds spacing between the Radix select button & the hidden select */}
-                    <ProrationBehavior
-                      organization={organization}
-                      value={field.value || defaultProrationBehavior}
-                      onValueChange={field.onChange}
-                    />
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          {subscription.status !== 'trialing' && (
+            <FormField
+              control={control}
+              name="proration_behavior"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Proration behavior</FormLabel>
+                  <FormControl>
+                    <div>
+                      {/* We need an extra div or the space-y-2 from FormItem adds spacing between the Radix select button & the hidden select */}
+                      <ProrationBehavior
+                        organization={organization}
+                        value={field.value || defaultProrationBehavior}
+                        onValueChange={field.onChange}
+                      />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
         </div>
         <div className="flex flex-col gap-4">
-          {selectedProduct &&
-            selectedProduct.id !== subscription.product.id && (
-              <div className="rounded-2xl bg-yellow-50 px-4 py-3 text-sm text-yellow-500 dark:bg-yellow-950">
-                The customer will get access to {selectedProduct.name} benefits,
-                and lose access to {subscription.product.name} benefits.
-              </div>
-            )}
           <Button
             type="submit"
             size="lg"
@@ -273,6 +275,26 @@ const UpdateProduct = ({
           >
             Update Subscription
           </Button>
+          {selectedProduct &&
+            selectedProduct.id !== subscription.product.id && (
+              <Box
+                padding="m"
+                borderRadius="m"
+                backgroundColor="background-warning"
+              >
+                <p className="text-sm text-yellow-700">
+                  By updating this subscription, the customer will get access to{' '}
+                  <strong className="font-medium">
+                    {selectedProduct.name}
+                  </strong>{' '}
+                  benefits, and lose access to{' '}
+                  <strong className="font-medium">
+                    {subscription.product.name}
+                  </strong>{' '}
+                  benefits.
+                </p>
+              </Box>
+            )}
         </div>
       </form>
     </Form>

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -48,6 +48,30 @@ const validationDiscriminators = [
   'SubscriptionUpdateBillingPeriod',
 ]
 
+const computeTrialEnd = (
+  trialStart: string,
+  product: schemas['Product'],
+): Date | null => {
+  if (!product.trial_interval || !product.trial_interval_count) return null
+  const d = new Date(trialStart)
+  const count = product.trial_interval_count
+  switch (product.trial_interval) {
+    case 'day':
+      d.setUTCDate(d.getUTCDate() + count)
+      break
+    case 'week':
+      d.setUTCDate(d.getUTCDate() + 7 * count)
+      break
+    case 'month':
+      d.setUTCMonth(d.getUTCMonth() + count)
+      break
+    case 'year':
+      d.setUTCFullYear(d.getUTCFullYear() + count)
+      break
+  }
+  return d
+}
+
 const UpdateProduct = ({
   subscription,
   onUpdate,
@@ -81,29 +105,47 @@ const UpdateProduct = ({
     () => subscription.prices.map(({ id }) => id),
     [subscription],
   )
-  const products = useMemo(
-    () =>
-      allProducts
-        ? allProducts.items
-            .filter((product) => !hasLegacyRecurringPrices(product))
-            .filter((product) => {
-              // If it's a different product, include it
-              if (subscription.product_id !== product.id) {
-                return true
-              }
+  const products = useMemo(() => {
+    if (!allProducts) return []
+    const isTrialing = subscription.status === 'trialing'
+    const currentTrialEndMs =
+      isTrialing && subscription.trial_end
+        ? new Date(subscription.trial_end).getTime()
+        : null
 
-              // For the same product, only include if the price sets are different
-              const productPriceIds = product.prices.map(({ id }) => id)
+    return allProducts.items
+      .filter((product) => !hasLegacyRecurringPrices(product))
+      .filter((product) => {
+        // If it's a different product, include it
+        if (subscription.product_id !== product.id) {
+          return true
+        }
 
-              // Check if price sets are identical (same length and same IDs)
-              if (productPriceIds.length !== activePriceIds.length) {
-                return true
-              }
-              return !productPriceIds.every((id) => activePriceIds.includes(id))
-            })
-        : [],
-    [allProducts, activePriceIds, subscription],
-  )
+        // For the same product, only include if the price sets are different
+        const productPriceIds = product.prices.map(({ id }) => id)
+
+        // Check if price sets are identical (same length and same IDs)
+        if (productPriceIds.length !== activePriceIds.length) {
+          return true
+        }
+        return !productPriceIds.every((id) => activePriceIds.includes(id))
+      })
+      .filter((product) => {
+        // During a trial, only allow targets whose trial period is at least
+        // as long as the current trial — anything shorter is rejected by the
+        // backend with a 403.
+        if (
+          !isTrialing ||
+          !subscription.trial_start ||
+          currentTrialEndMs === null
+        ) {
+          return true
+        }
+        const newTrialEnd = computeTrialEnd(subscription.trial_start, product)
+        if (newTrialEnd === null) return false
+        return newTrialEnd.getTime() >= currentTrialEndMs
+      })
+  }, [allProducts, activePriceIds, subscription])
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const selectedProductId = watch('product_id')
@@ -193,7 +235,9 @@ const UpdateProduct = ({
                 </FormControl>
                 {subscription.status === 'trialing' && (
                   <FormDescription>
-                    Product changes are not supported during a trial period
+                    Only products with a trial period at least as long as the
+                    current one are shown. To switch to another product, end the
+                    trial first.
                   </FormDescription>
                 )}
                 <FormMessage />
@@ -233,9 +277,7 @@ const UpdateProduct = ({
             type="submit"
             size="lg"
             loading={updateSubscription.isPending}
-            disabled={
-              updateSubscription.isPending || subscription.status === 'trialing'
-            }
+            disabled={updateSubscription.isPending}
           >
             Update Subscription
           </Button>

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -157,33 +157,39 @@ const UpdateProduct = ({
               <FormItem>
                 <FormLabel>New product</FormLabel>
                 <FormControl>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                    disabled={subscription.status === 'trialing'}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select a new product" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {products.map((product) => (
-                        <SelectItem key={product.id} value={product.id}>
-                          <div className="flex flex-row items-center justify-between gap-1">
-                            {product.name}
-                            {product.id === subscription.product_id && (
-                              <Pill color="green" className="px-3 py-1 text-xs">
-                                New Pricing
-                              </Pill>
-                            )}
-                          </div>
-                          <ProductPriceLabel
-                            product={product}
-                            currency={subscription.currency}
-                          />
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <div>
+                    {/* We need an extra div or the space-y-2 from FormItem adds spacing between the Radix select button & the hidden select */}
+
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <SelectTrigger className="h-14">
+                        <SelectValue placeholder="Select a new product" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {products.map((product) => (
+                          <SelectItem key={product.id} value={product.id}>
+                            <div className="flex flex-row items-center justify-between gap-1">
+                              {product.name}
+                              {product.id === subscription.product_id && (
+                                <Pill
+                                  color="green"
+                                  className="px-3 py-1 text-xs"
+                                >
+                                  New Pricing
+                                </Pill>
+                              )}
+                            </div>
+                            <ProductPriceLabel
+                              product={product}
+                              currency={subscription.currency}
+                            />
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </FormControl>
                 {subscription.status === 'trialing' && (
                   <FormDescription>
@@ -198,16 +204,17 @@ const UpdateProduct = ({
             control={control}
             name="proration_behavior"
             render={({ field }) => (
-              <FormItem className="flex flex-col gap-y-2">
-                <div className="flex flex-col gap-2">
-                  <FormLabel>Proration behavior</FormLabel>
-                </div>
+              <FormItem>
+                <FormLabel>Proration behavior</FormLabel>
                 <FormControl>
-                  <ProrationBehavior
-                    organization={organization}
-                    value={field.value || defaultProrationBehavior}
-                    onValueChange={field.onChange}
-                  />
+                  <div>
+                    {/* We need an extra div or the space-y-2 from FormItem adds spacing between the Radix select button & the hidden select */}
+                    <ProrationBehavior
+                      organization={organization}
+                      value={field.value || defaultProrationBehavior}
+                      onValueChange={field.onChange}
+                    />
+                  </div>
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -108,10 +108,6 @@ const UpdateProduct = ({
   const products = useMemo(() => {
     if (!allProducts) return []
     const isTrialing = subscription.status === 'trialing'
-    const currentTrialEndMs =
-      isTrialing && subscription.trial_end
-        ? new Date(subscription.trial_end).getTime()
-        : null
 
     return allProducts.items
       .filter((product) => !hasLegacyRecurringPrices(product))
@@ -131,19 +127,15 @@ const UpdateProduct = ({
         return !productPriceIds.every((id) => activePriceIds.includes(id))
       })
       .filter((product) => {
-        // During a trial, only allow targets whose trial period is at least
-        // as long as the current trial — anything shorter is rejected by the
-        // backend with a 403.
-        if (
-          !isTrialing ||
-          !subscription.trial_start ||
-          currentTrialEndMs === null
-        ) {
+        // During a trial, only allow targets whose trial period still has
+        // time remaining given the current trial usage — anything that would
+        // already be over is rejected by the backend with a 403.
+        if (!isTrialing || !subscription.trial_start) {
           return true
         }
         const newTrialEnd = computeTrialEnd(subscription.trial_start, product)
         if (newTrialEnd === null) return false
-        return newTrialEnd.getTime() >= currentTrialEndMs
+        return newTrialEnd.getTime() > Date.now()
       })
   }, [allProducts, activePriceIds, subscription])
 
@@ -235,9 +227,9 @@ const UpdateProduct = ({
                 </FormControl>
                 {subscription.status === 'trialing' && (
                   <FormDescription>
-                    Only products with a trial period at least as long as the
-                    current one are shown. To switch to another product, end the
-                    trial first.
+                    Only products whose trial period still has remaining time
+                    given your current trial usage are shown. To switch to
+                    another product, end the trial first.
                   </FormDescription>
                 )}
                 <FormMessage />

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -5,7 +5,9 @@ import { useUpdateSubscription } from '@/hooks/queries/subscriptions'
 import { setValidationErrors } from '@/utils/api/errors'
 import { getDiscountDisplay } from '@/utils/discount'
 import { hasLegacyRecurringPrices } from '@/utils/product'
+import { formatTrialEnd, useTrialChangeOutcome } from '@/utils/trial-change'
 import { isValidationError, schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import { Combobox } from '@polar-sh/ui/components/atoms/Combobox'
 import DateTimePicker from '@polar-sh/ui/components/atoms/DateTimePicker'
@@ -40,7 +42,6 @@ import { useModal } from '../Modal/useModal'
 import ProductPriceLabel from '../Products/ProductPriceLabel'
 import { ProrationBehavior } from '../Settings/ProrationBehavior'
 import { toast } from '../Toast/use-toast'
-import { Box } from '@polar-sh/orbit/Box'
 
 const validationDiscriminators = [
   'SubscriptionUpdateProduct',
@@ -48,30 +49,6 @@ const validationDiscriminators = [
   'SubscriptionUpdateTrial',
   'SubscriptionUpdateBillingPeriod',
 ]
-
-const computeTrialEnd = (
-  trialStart: string,
-  product: schemas['Product'],
-): Date | null => {
-  if (!product.trial_interval || !product.trial_interval_count) return null
-  const d = new Date(trialStart)
-  const count = product.trial_interval_count
-  switch (product.trial_interval) {
-    case 'day':
-      d.setUTCDate(d.getUTCDate() + count)
-      break
-    case 'week':
-      d.setUTCDate(d.getUTCDate() + 7 * count)
-      break
-    case 'month':
-      d.setUTCMonth(d.getUTCMonth() + count)
-      break
-    case 'year':
-      d.setUTCFullYear(d.getUTCFullYear() + count)
-      break
-  }
-  return d
-}
 
 const UpdateProduct = ({
   subscription,
@@ -135,25 +112,7 @@ const UpdateProduct = ({
     [products, selectedProductId],
   )
 
-  // When changing product during a trial, determine whether the trial
-  // continues with the new product or ends immediately (triggering a charge).
-  const trialOutcome = useMemo<
-    { kind: 'continues'; trialEnd: Date } | { kind: 'ends' } | null
-  >(() => {
-    if (subscription.status !== 'trialing') return null
-    if (!selectedProduct || selectedProduct.id === subscription.product.id)
-      return null
-    if (!subscription.trial_start) return null
-
-    const newTrialEnd = computeTrialEnd(
-      subscription.trial_start,
-      selectedProduct,
-    )
-    if (newTrialEnd && newTrialEnd.getTime() > Date.now()) {
-      return { kind: 'continues', trialEnd: newTrialEnd }
-    }
-    return { kind: 'ends' }
-  }, [subscription, selectedProduct])
+  const trialOutcome = useTrialChangeOutcome(subscription, selectedProduct)
 
   const onSubmit = useCallback(
     async (body: schemas['SubscriptionUpdateProduct']) => {
@@ -299,15 +258,7 @@ const UpdateProduct = ({
                   <p className="text-sm text-yellow-700">
                     The trial will continue until{' '}
                     <strong className="font-medium">
-                      {trialOutcome.trialEnd.toLocaleDateString('en-US', {
-                        month: 'long',
-                        day: 'numeric',
-                        year:
-                          trialOutcome.trialEnd.getFullYear() ===
-                          new Date().getFullYear()
-                            ? undefined
-                            : 'numeric',
-                      })}
+                      {formatTrialEnd(trialOutcome.trialEnd)}
                     </strong>
                     . The customer won&apos;t be charged before then.
                   </p>

--- a/clients/apps/web/src/utils/trial-change.ts
+++ b/clients/apps/web/src/utils/trial-change.ts
@@ -1,0 +1,85 @@
+'use client'
+
+import { UTCDate } from '@date-fns/utc'
+import { schemas } from '@polar-sh/client'
+import { addDays, addMonths, addWeeks, addYears } from 'date-fns'
+import { useMemo, useState } from 'react'
+
+type TrialConfig = {
+  trial_interval: schemas['TrialInterval'] | null
+  trial_interval_count: number | null
+}
+
+type TrialSubscriptionLike = {
+  status: schemas['SubscriptionStatus']
+  trial_start: string | null
+  product: { id: string }
+}
+
+type TrialProductLike = TrialConfig & { id: string }
+
+export type TrialChangeOutcome =
+  | { kind: 'continues'; trialEnd: Date }
+  | { kind: 'ends' }
+  | null
+
+export const computeTrialEnd = (
+  trialStart: string,
+  product: TrialConfig,
+): Date | null => {
+  if (!product.trial_interval || !product.trial_interval_count) return null
+  // UTCDate keeps date-fns arithmetic in UTC, matching the backend's
+  // `dateutil.relativedelta` semantics (e.g. Jan 31 + 1 month → Feb 28/29).
+  const start = new UTCDate(trialStart)
+  const count = product.trial_interval_count
+  switch (product.trial_interval) {
+    case 'day':
+      return addDays(start, count)
+    case 'week':
+      return addWeeks(start, count)
+    case 'month':
+      return addMonths(start, count)
+    case 'year':
+      return addYears(start, count)
+  }
+}
+
+export const formatTrialEnd = (date: Date): string =>
+  date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year:
+      date.getUTCFullYear() === new Date().getUTCFullYear()
+        ? undefined
+        : 'numeric',
+  })
+
+/**
+ * When changing the product on a trialing subscription, determine whether the
+ * trial continues with the new product (recomputed against the original
+ * trial_start) or ends immediately, triggering a charge.
+ */
+export const useTrialChangeOutcome = (
+  subscription: TrialSubscriptionLike,
+  selectedProduct: TrialProductLike | null | undefined,
+): TrialChangeOutcome => {
+  // Capture once when the hook mounts — trials don't expire mid-session, and
+  // pinning `now` keeps the memo pure.
+  const [now] = useState(() => Date.now())
+
+  return useMemo<TrialChangeOutcome>(() => {
+    if (subscription.status !== 'trialing') return null
+    if (!selectedProduct || selectedProduct.id === subscription.product.id)
+      return null
+    if (!subscription.trial_start) return null
+
+    const newTrialEnd = computeTrialEnd(
+      subscription.trial_start,
+      selectedProduct,
+    )
+    if (newTrialEnd && newTrialEnd.getTime() > now) {
+      return { kind: 'continues', trialEnd: newTrialEnd }
+    }
+    return { kind: 'ends' }
+  }, [subscription, selectedProduct, now])
+}

--- a/docs/features/subscriptions/manage.mdx
+++ b/docs/features/subscriptions/manage.mdx
@@ -14,7 +14,8 @@ Switch a subscription to a different recurring product — the standard upgrade 
 
 - When the change takes effect depends on the [proration behavior](/features/subscriptions/proration): `invoice` and `prorate` apply the new product immediately, while `next_period` schedules a pending update that's only applied at the start of the next billing cycle.
 - The new product must share the subscription's currency and must either both be seat-based or both not be — you can't switch a flat subscription to a seat-based product or vice versa.
-- You can't change the plan on a **trialing** subscription or on one that's already canceled or scheduled to cancel. End the trial or uncancel first.
+- You can't change the plan on a subscription that's already canceled or scheduled to cancel — uncancel first.
+- Plan changes on a **trialing** subscription are allowed. The trial carries over with its end recomputed from the new product's trial length (anchored to the original `trial_start`). If the new product has no trial — or its trial would already have elapsed — the trial ends immediately and a fresh billing cycle starts on the new product.
 - Custom-priced products (pay-what-you-want) aren't valid destinations for a plan change.
 
 <CodeGroup>

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1129,10 +1129,10 @@ class SubscriptionService:
             new_trial_end = product.trial_interval.get_end(
                 subscription.trial_start, product.trial_interval_count
             )
-            if new_trial_end < subscription.trial_end:
+            if new_trial_end <= utc_now():
                 raise TrialingSubscription(
                     subscription,
-                    "Can't change to a product with a shorter trial period during a trial.",
+                    "Can't change to a product whose trial period would already be over given the current trial usage.",
                 )
 
         # Add event for the subscription plan change

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -163,12 +163,6 @@ class AlreadyCanceledSubscription(SubscriptionError):
         super().__init__(message, 403)
 
 
-class TrialingSubscription(SubscriptionError):
-    def __init__(self, subscription: Subscription, message: str) -> None:
-        self.subscription = subscription
-        super().__init__(message, 403)
-
-
 class SubscriptionLocked(SubscriptionError):
     def __init__(self, subscription: Subscription) -> None:
         self.subscription = subscription
@@ -1118,22 +1112,20 @@ class SubscriptionService:
 
         was_trialing = subscription.status == SubscriptionStatus.trialing
         new_trial_end: datetime | None = None
+        ends_trial = False
         if was_trialing:
             assert subscription.trial_start is not None
             assert subscription.trial_end is not None
             if product.trial_interval is None or product.trial_interval_count is None:
-                raise TrialingSubscription(
-                    subscription,
-                    "Can't change to a product without a trial period during a trial.",
+                ends_trial = True
+            else:
+                candidate_trial_end = product.trial_interval.get_end(
+                    subscription.trial_start, product.trial_interval_count
                 )
-            new_trial_end = product.trial_interval.get_end(
-                subscription.trial_start, product.trial_interval_count
-            )
-            if new_trial_end <= utc_now():
-                raise TrialingSubscription(
-                    subscription,
-                    "Can't change to a product whose trial period would already be over given the current trial usage.",
-                )
+                if candidate_trial_end <= utc_now():
+                    ends_trial = True
+                else:
+                    new_trial_end = candidate_trial_end
 
         # Add event for the subscription plan change
         event = await event_service.create_event(
@@ -1191,18 +1183,25 @@ class SubscriptionService:
             interval_changed = subscription_update.is_interval_changed()
             subscription = subscription_update.apply_update()
             if was_trialing:
-                assert new_trial_end is not None
-                subscription.trial_end = new_trial_end
-                subscription.current_period_end = new_trial_end
+                if ends_trial:
+                    # End the trial immediately - cycle() below will transition
+                    # to active and bill the customer for the new period.
+                    subscription.trial_end = subscription.current_period_end = utc_now()
+                else:
+                    assert new_trial_end is not None
+                    subscription.trial_end = new_trial_end
+                    subscription.current_period_end = new_trial_end
             session.add(subscription)
             await session.flush()
 
-            # Invoice and attempt to pay immediately
-            if (
+            if was_trialing and ends_trial:
+                subscription = await self.cycle(session, subscription)
+            elif (
                 (proration_behavior.is_immediate() or interval_changed)
                 and not was_trialing
                 and billing_entries
             ):
+                # Invoice and attempt to pay immediately
                 await self._create_subscription_update_order(session, subscription)
 
             await self.enqueue_benefits_grants(session, subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -164,11 +164,8 @@ class AlreadyCanceledSubscription(SubscriptionError):
 
 
 class TrialingSubscription(SubscriptionError):
-    def __init__(self, subscription: Subscription) -> None:
+    def __init__(self, subscription: Subscription, message: str) -> None:
         self.subscription = subscription
-        message = (
-            "This subscription is currently in a trial period and cannot be updated."
-        )
         super().__init__(message, 403)
 
 
@@ -1006,9 +1003,6 @@ class SubscriptionService:
         if subscription.revoked or subscription.cancel_at_period_end:
             raise AlreadyCanceledSubscription(subscription)
 
-        if subscription.trialing:
-            raise TrialingSubscription(subscription)
-
         previous_product = subscription.product
         previous_status = subscription.status
         previous_is_canceled = subscription.canceled
@@ -1122,6 +1116,25 @@ class SubscriptionService:
                 ]
             )
 
+        was_trialing = subscription.status == SubscriptionStatus.trialing
+        new_trial_end: datetime | None = None
+        if was_trialing:
+            assert subscription.trial_start is not None
+            assert subscription.trial_end is not None
+            if product.trial_interval is None or product.trial_interval_count is None:
+                raise TrialingSubscription(
+                    subscription,
+                    "Can't change to a product without a trial period during a trial.",
+                )
+            new_trial_end = product.trial_interval.get_end(
+                subscription.trial_start, product.trial_interval_count
+            )
+            if new_trial_end < subscription.trial_end:
+                raise TrialingSubscription(
+                    subscription,
+                    "Can't change to a product with a shorter trial period during a trial.",
+                )
+
         # Add event for the subscription plan change
         event = await event_service.create_event(
             session,
@@ -1169,19 +1182,27 @@ class SubscriptionService:
             )
             subscription.pending_update = None
 
-            for entry in billing_entries:
-                entry.event = event
-                session.add(entry)
+            # Skip proration for trialing subscriptions - no billing during trial
+            if not was_trialing:
+                for entry in billing_entries:
+                    entry.event = event
+                    session.add(entry)
 
             interval_changed = subscription_update.is_interval_changed()
             subscription = subscription_update.apply_update()
+            if was_trialing:
+                assert new_trial_end is not None
+                subscription.trial_end = new_trial_end
+                subscription.current_period_end = new_trial_end
             session.add(subscription)
             await session.flush()
 
             # Invoice and attempt to pay immediately
             if (
-                proration_behavior.is_immediate() or interval_changed
-            ) and billing_entries:
+                (proration_behavior.is_immediate() or interval_changed)
+                and not was_trialing
+                and billing_entries
+            ):
                 await self._create_subscription_update_order(session, subscription)
 
             await self.enqueue_benefits_grants(session, subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1115,7 +1115,6 @@ class SubscriptionService:
         ends_trial = False
         if was_trialing:
             assert subscription.trial_start is not None
-            assert subscription.trial_end is not None
             if product.trial_interval is None or product.trial_interval_count is None:
                 ends_trial = True
             else:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2449,7 +2449,7 @@ class TestUpdateProduct:
         assert updated.trial_end == expected_trial_end
         assert updated.current_period_end == expected_trial_end
 
-    async def test_trial_to_shorter_trial_rejected(
+    async def test_trial_to_shorter_trial_with_remaining_time_succeeds(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -2457,13 +2457,17 @@ class TestUpdateProduct:
         organization: Organization,
         product: Product,
     ) -> None:
-        subscription = await create_trialing_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            trial_interval=TrialInterval.month,
-            trial_interval_count=1,
-        )
+        trial_creation_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        with freezegun.freeze_time(trial_creation_time):
+            subscription = await create_trialing_subscription(
+                save_fixture,
+                product=product,
+                customer=customer,
+                trial_interval=TrialInterval.day,
+                trial_interval_count=30,
+            )
+        trial_start = subscription.trial_start
+        assert trial_start is not None
 
         new_product = await create_product(
             save_fixture,
@@ -2473,10 +2477,48 @@ class TestUpdateProduct:
             trial_interval_count=7,
         )
 
-        with pytest.raises(TrialingSubscription):
-            await subscription_service.update_product(
+        with freezegun.freeze_time(trial_creation_time + timedelta(days=1)):
+            updated = await subscription_service.update_product(
                 session, subscription, product_id=new_product.id
             )
+
+        expected_trial_end = TrialInterval.day.get_end(trial_start, 7)
+        assert updated.product == new_product
+        assert updated.status == SubscriptionStatus.trialing
+        assert updated.trial_end == expected_trial_end
+        assert updated.current_period_end == expected_trial_end
+
+    async def test_trial_to_shorter_trial_already_elapsed_rejected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        trial_creation_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        with freezegun.freeze_time(trial_creation_time):
+            subscription = await create_trialing_subscription(
+                save_fixture,
+                product=product,
+                customer=customer,
+                trial_interval=TrialInterval.day,
+                trial_interval_count=30,
+            )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=7,
+        )
+
+        with freezegun.freeze_time(trial_creation_time + timedelta(days=10)):
+            with pytest.raises(TrialingSubscription):
+                await subscription_service.update_product(
+                    session, subscription, product_id=new_product.id
+                )
 
     async def test_trial_to_no_trial_product_rejected(
         self,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2379,21 +2379,180 @@ class TestList:
 
 @pytest.mark.asyncio
 class TestUpdateProduct:
-    async def test_trialing_subscription(
+    async def test_trial_to_equal_trial_succeeds(
         self,
-        save_fixture: SaveFixture,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         customer: Customer,
+        organization: Organization,
         product: Product,
     ) -> None:
         subscription = await create_trialing_subscription(
-            save_fixture, product=product, customer=customer
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.month,
+            trial_interval_count=1,
+        )
+        original_trial_end = subscription.trial_end
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            trial_interval=TrialInterval.month,
+            trial_interval_count=1,
+        )
+
+        updated = await subscription_service.update_product(
+            session, subscription, product_id=new_product.id
+        )
+
+        assert updated.product == new_product
+        assert updated.status == SubscriptionStatus.trialing
+        assert updated.trial_end == original_trial_end
+        assert updated.current_period_end == original_trial_end
+
+    async def test_trial_to_longer_trial_extends(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=7,
+        )
+        trial_start = subscription.trial_start
+        assert trial_start is not None
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=14,
+        )
+
+        updated = await subscription_service.update_product(
+            session, subscription, product_id=new_product.id
+        )
+
+        expected_trial_end = TrialInterval.day.get_end(trial_start, 14)
+        assert updated.product == new_product
+        assert updated.status == SubscriptionStatus.trialing
+        assert updated.trial_end == expected_trial_end
+        assert updated.current_period_end == expected_trial_end
+
+    async def test_trial_to_shorter_trial_rejected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.month,
+            trial_interval_count=1,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=7,
         )
 
         with pytest.raises(TrialingSubscription):
             await subscription_service.update_product(
-                session, subscription, product_id=uuid.uuid4()
+                session, subscription, product_id=new_product.id
             )
+
+    async def test_trial_to_no_trial_product_rejected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.month,
+            trial_interval_count=1,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+
+        with pytest.raises(TrialingSubscription):
+            await subscription_service.update_product(
+                session, subscription, product_id=new_product.id
+            )
+
+    async def test_trial_product_change_skips_proration_billing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        create_subscription_update_order_mock = mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.month,
+            trial_interval_count=1,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            trial_interval=TrialInterval.month,
+            trial_interval_count=2,
+        )
+
+        await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=new_product.id,
+            proration_behavior=SubscriptionProrationBehavior.invoice,
+        )
+
+        create_subscription_update_order_mock.assert_not_called()
+
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        billing_entries = await billing_entry_repository.get_pending_by_subscription(
+            subscription.id
+        )
+        proration_entries = [
+            entry
+            for entry in billing_entries
+            if entry.type == BillingEntryType.proration
+        ]
+        assert proration_entries == []
 
     async def test_meters(
         self,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -82,7 +82,6 @@ from polar.subscription.service import (
     NotARecurringProduct,
     NotASeatBasedSubscription,
     SeatsAlreadyAssigned,
-    TrialingSubscription,
 )
 from polar.subscription.service import subscription as subscription_service
 from polar.subscription.update import generate_subscription_update
@@ -2488,8 +2487,9 @@ class TestUpdateProduct:
         assert updated.trial_end == expected_trial_end
         assert updated.current_period_end == expected_trial_end
 
-    async def test_trial_to_shorter_trial_already_elapsed_rejected(
+    async def test_trial_to_shorter_trial_already_elapsed_ends_trial(
         self,
+        enqueue_job_mock: MagicMock,
         session: AsyncSession,
         save_fixture: SaveFixture,
         customer: Customer,
@@ -2514,14 +2514,24 @@ class TestUpdateProduct:
             trial_interval_count=7,
         )
 
-        with freezegun.freeze_time(trial_creation_time + timedelta(days=10)):
-            with pytest.raises(TrialingSubscription):
-                await subscription_service.update_product(
-                    session, subscription, product_id=new_product.id
-                )
+        change_time = trial_creation_time + timedelta(days=10)
+        with freezegun.freeze_time(change_time):
+            updated = await subscription_service.update_product(
+                session, subscription, product_id=new_product.id
+            )
 
-    async def test_trial_to_no_trial_product_rejected(
+        assert updated.product == new_product
+        assert updated.status == SubscriptionStatus.active
+        assert updated.trial_end == change_time
+        enqueue_job_mock.assert_any_call(
+            "order.create_subscription_order",
+            updated.id,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+        )
+
+    async def test_trial_to_no_trial_product_ends_trial(
         self,
+        enqueue_job_mock: MagicMock,
         session: AsyncSession,
         save_fixture: SaveFixture,
         customer: Customer,
@@ -2542,10 +2552,17 @@ class TestUpdateProduct:
             recurring_interval=SubscriptionRecurringInterval.month,
         )
 
-        with pytest.raises(TrialingSubscription):
-            await subscription_service.update_product(
-                session, subscription, product_id=new_product.id
-            )
+        updated = await subscription_service.update_product(
+            session, subscription, product_id=new_product.id
+        )
+
+        assert updated.product == new_product
+        assert updated.status == SubscriptionStatus.active
+        enqueue_job_mock.assert_any_call(
+            "order.create_subscription_order",
+            updated.id,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+        )
 
     async def test_trial_product_change_skips_proration_billing(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#132

I approached it incrementally, so if you go through the commits one by one, it might be a bit easier to follow. First, allow changing to plans with equal or longer trials, then, compare against trial elapsed instead of total trial length, then allow any product changes.

Includes client-side notices in the situations where the customer will be charged immediately.

Allowed from both merchant dashboard & customer portal.