### PR TITLE
amount v2: Migrate checkouts amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-05-27-0929_add_checkouts_v2_amount_columns.py
+++ b/server/migrations/versions/2026-05-27-0929_add_checkouts_v2_amount_columns.py
@@ -1,0 +1,138 @@
+"""Add checkouts v2 amount columns (int → bigint widening)
+
+Revision ID: 1635867d733d
+Revises: c89b877bd235
+Create Date: 2026-05-26 13:06:00.000000
+
+Phase 1 of widening checkouts.amount, checkouts.net_amount and
+checkouts.tax_amount from integer to bigint via dual-column migration:
+
+  1. Add nullable amount_v2 / net_amount_v2 / tax_amount_v2 BIGINT columns.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value exceeds
+         INT4_MAX (so new code's v2-only writes still populate legacy for
+         pods still running the previous version during rollout of PR 2).
+  3. Backfill existing rows via scripts.backfill_amount_v2_checkouts.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "1635867d733d"
+down_revision = "c89b877bd235"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+CHECKOUTS_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="checkouts_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount_v2 IS NULL AND NEW.tax_amount IS NOT NULL THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount IS NULL
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount IS DISTINCT FROM OLD.tax_amount THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount_v2 IS DISTINCT FROM OLD.tax_amount_v2 THEN
+                IF NEW.tax_amount_v2 IS NULL THEN
+                    NEW.tax_amount := NULL;
+                ELSIF NEW.tax_amount_v2 <= 2147483647 THEN
+                    NEW.tax_amount := NEW.tax_amount_v2::integer;
+                END IF;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+CHECKOUTS_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="checkouts_sync_v2_amounts_trigger",
+    on_entity="public.checkouts",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON checkouts\n"
+        "    FOR EACH ROW EXECUTE FUNCTION checkouts_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "checkouts",
+        sa.Column("amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "checkouts",
+        sa.Column("net_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "checkouts",
+        sa.Column("tax_amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(CHECKOUTS_SYNC_V2_AMOUNTS)
+    op.create_entity(CHECKOUTS_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(CHECKOUTS_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(CHECKOUTS_SYNC_V2_AMOUNTS)
+    op.drop_column("checkouts", "tax_amount_v2")
+    op.drop_column("checkouts", "net_amount_v2")
+    op.drop_column("checkouts", "amount_v2")

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -5,8 +5,12 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, TypedDict
 from uuid import UUID
 
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
 from sqlalchemy import (
     TIMESTAMP,
+    BigInteger,
     Boolean,
     ColumnElement,
     Connection,
@@ -135,13 +139,22 @@ class Checkout(
     )
 
     amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     seats: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     min_seats: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     max_seats: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
 
     net_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    net_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     tax_amount: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    tax_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     tax_processor: Mapped[TaxProcessor | None] = mapped_column(
         StringEnum(TaxProcessor), default=None, nullable=True
     )
@@ -473,3 +486,86 @@ def check_expiration(
 ) -> None:
     if target.expires_at < utc_now() and target.status == CheckoutStatus.open:
         target.status = CheckoutStatus.expired
+
+
+checkouts_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="checkouts_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount_v2 IS NULL AND NEW.tax_amount IS NOT NULL THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount IS NULL
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount IS DISTINCT FROM OLD.tax_amount THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount_v2 IS DISTINCT FROM OLD.tax_amount_v2 THEN
+                IF NEW.tax_amount_v2 IS NULL THEN
+                    NEW.tax_amount := NULL;
+                ELSIF NEW.tax_amount_v2 <= 2147483647 THEN
+                    NEW.tax_amount := NEW.tax_amount_v2::integer;
+                END IF;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+checkouts_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="checkouts_sync_v2_amounts_trigger",
+    on_entity="checkouts",
+    definition="""
+    BEFORE INSERT OR UPDATE ON checkouts
+    FOR EACH ROW EXECUTE FUNCTION checkouts_sync_v2_amounts();
+    """,
+)
+
+register_entities(
+    (
+        checkouts_sync_v2_amounts_function,
+        checkouts_sync_v2_amounts_trigger,
+    )
+)

--- a/server/scripts/backfill_amount_v2_checkouts.py
+++ b/server/scripts/backfill_amount_v2_checkouts.py
@@ -1,0 +1,64 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import or_, select, update
+
+from polar.models import Checkout
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill amount_v2, net_amount_v2 and tax_amount_v2 from the legacy columns."""
+    await run_batched_update(
+        (
+            update(Checkout)
+            .values(
+                amount_v2=Checkout.amount,
+                net_amount_v2=Checkout.net_amount,
+                tax_amount_v2=Checkout.tax_amount,
+            )
+            .where(
+                Checkout.id.in_(
+                    select(Checkout.id)
+                    .where(
+                        or_(
+                            Checkout.amount_v2.is_(None) & Checkout.amount.is_not(None),
+                            Checkout.net_amount_v2.is_(None)
+                            & Checkout.net_amount.is_not(None),
+                            Checkout.tax_amount_v2.is_(None)
+                            & Checkout.tax_amount.is_not(None),
+                        )
+                    )
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Since the checkout amounts are not nullable, we will remove the nullability on the new columns and add it to the old columns in the following PR. The new columns are added as nullable so that we can run the backfill.
