### PR TITLE
chore(backoffice): remove dead Create Thread button from orgs list

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -23,7 +23,6 @@ from ... import formatters
 from ...components import (
     Tab,
     action_bar,
-    button,
     empty_state,
     status_badge,
     tab_nav,
@@ -350,12 +349,6 @@ class OrganizationListView:
                     classes="btn btn-ghost btn-sm",
                 ):
                     text("Switch to Classic View")
-                with button(
-                    variant="primary",
-                    hx_get=str(request.url_for("organizations:list")) + "/new",
-                    hx_target="#modal",
-                ):
-                    text("+ Create Thread")
 
         # Status tabs
         tabs = [


### PR DESCRIPTION
## Summary

Remove the **+ Create Thread** button from the v2 backoffice organizations list view. It was pointing at a `/new` modal endpoint that doesn't exist

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)