### PR TITLE
fix: raise on agent review failure instead of persisting synthetic DENY

### DIFF
--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -697,20 +697,15 @@ class ReviewAnalyzer:
                 result.usage(), self.model_provider, self.model_name
             )
             return result.output, usage
-        except TimeoutError:
-            log.warning(
-                "review_analyzer.timeout",
-                organization=snapshot.organization.slug,
-                timeout_seconds=timeout_seconds,
-            )
-            return _timeout_report(), UsageInfo()
         except Exception as e:
             log.error(
                 "review_analyzer.error",
                 organization=snapshot.organization.slug,
-                error=str(e),
+                error_class=type(e).__name__,
+                status_code=getattr(e, "status_code", None),
+                model_name=self.model_name,
             )
-            return _error_report(str(e)), UsageInfo()
+            raise
 
     def _build_prompt(self, snapshot: DataSnapshot) -> str:
         org = snapshot.organization
@@ -1092,45 +1087,6 @@ class ReviewAnalyzer:
         )
 
         return "\n".join(parts)
-
-
-def _fallback_report(summary: str, finding: str, action: str) -> ReviewAgentReport:
-    from .schemas import DimensionAssessment, ReviewDimension, ReviewVerdict, RiskLevel
-
-    return ReviewAgentReport(
-        verdict=ReviewVerdict.DENY,
-        summary=summary,
-        merchant_summary="Error occurred during analysis. Please contact support for assistance.",
-        violated_sections=[],
-        dimensions=[
-            DimensionAssessment(
-                dimension=ReviewDimension.POLICY_COMPLIANCE,
-                risk_level=RiskLevel.MEDIUM,
-                confidence=0.0,
-                findings=[finding],
-                recommendation="Human review required",
-            )
-        ],
-        overall_risk_level=RiskLevel.MEDIUM,
-        recommended_action=action,
-    )
-
-
-def _timeout_report() -> ReviewAgentReport:
-    return _fallback_report(
-        "Analysis timed out. Denied for human review.",
-        "Analysis timed out",
-        "Human review required due to timeout.",
-    )
-
-
-def _error_report(error: str) -> ReviewAgentReport:
-    msg = error[:200]
-    return _fallback_report(
-        f"Analysis failed with error: {msg}. Denied for human review.",
-        f"Analysis error: {msg}",
-        "Human review required due to analysis error.",
-    )
 
 
 # Module-level singleton

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -94,7 +94,8 @@ async def _persist_agent_result(
     actor_name="organization_review.run_agent",
     priority=TaskPriority.LOW,
     time_limit=180_000,  # 3 min timeout
-    max_retries=1,
+    max_retries=4,
+    min_backoff=30_000,
 )
 async def run_review_agent(
     organization_id: uuid.UUID,
@@ -118,20 +119,9 @@ async def run_review_agent(
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
 
-        # Run the review agent
-        try:
-            result = await run_organization_review(
-                session, organization, context=review_context
-            )
-        except Exception:
-            if review_context == ReviewContext.THRESHOLD and auto_approve_eligible:
-                log.exception(
-                    "organization_review.threshold.agent_failed",
-                    organization_id=str(organization_id),
-                    slug=organization.slug,
-                )
-                return
-            raise
+        result = await run_organization_review(
+            session, organization, context=review_context
+        )
 
         report = result.report
         agent_review_id = await _persist_agent_result(
@@ -247,7 +237,8 @@ async def run_review_agent(
     actor_name="organization_review.appeal_submitted",
     priority=TaskPriority.LOW,
     time_limit=180_000,
-    max_retries=1,
+    max_retries=4,
+    min_backoff=30_000,
 )
 async def review_appeal(organization_id: uuid.UUID) -> None:
     """Auto-review a submitted appeal with the AI agent.

--- a/server/tests/organization_review/test_analyzer.py
+++ b/server/tests/organization_review/test_analyzer.py
@@ -1,5 +1,28 @@
-from polar.organization_review.analyzer import _render_scraped_site
-from polar.organization_review.schemas import WebsiteData, WebsitePage
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from pydantic_ai.exceptions import (
+    ConcurrencyLimitExceeded,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+    UserError,
+)
+from pytest_mock import MockerFixture
+
+from polar.organization_review.analyzer import _render_scraped_site, review_analyzer
+from polar.organization_review.schemas import (
+    DataSnapshot,
+    HistoryData,
+    OrganizationData,
+    PaymentMetrics,
+    PayoutAccountData,
+    ProductsData,
+    ReviewContext,
+    WebsiteData,
+    WebsitePage,
+)
 
 
 def _make_website_data(
@@ -83,3 +106,87 @@ class TestRenderScrapedSite:
             empty_message="nothing here",
         )
         assert "nothing here" not in parts
+
+
+def _minimal_snapshot() -> DataSnapshot:
+    return DataSnapshot(
+        context=ReviewContext.SUBMISSION,
+        organization=OrganizationData(name="Test Org", slug="test-org"),
+        products=ProductsData(),
+        account=PayoutAccountData(),
+        metrics=PaymentMetrics(),
+        history=HistoryData(),
+        collected_at=datetime.now(UTC),
+    )
+
+
+def _stub_analyzer_io(mocker: MockerFixture, run_side_effect: BaseException) -> None:
+    """Patch the heavy I/O around `analyze` so a test can target just the
+    exception-handling path: prompt building, AUP file read, and the LLM
+    agent call. The mocked `agent.run` raises `run_side_effect`.
+    """
+    mocker.patch.object(review_analyzer, "_build_prompt", return_value="test-prompt")
+    mocker.patch(
+        "polar.organization_review.analyzer.fetch_policy_content",
+        return_value="test-policy",
+    )
+    mocker.patch.object(
+        review_analyzer.agent,
+        "run",
+        new=AsyncMock(side_effect=run_side_effect),
+    )
+
+
+@pytest.mark.asyncio
+class TestAnalyzeReraisesOnError:
+    """ReviewAnalyzer re-raises every non-timeout failure so the Dramatiq
+    actor retries it and Sentry captures the final failure. Persisting a
+    synthetic DENY here would silently block merchants either on transient
+    gateway outages or on deterministic bugs (config/programming errors).
+    """
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            # Transient classes
+            ModelHTTPError(
+                status_code=429,
+                model_name="gpt-5.5",
+                body={"message": "rate limited"},
+            ),
+            ModelHTTPError(
+                status_code=503,
+                model_name="gpt-5.5",
+                body={"message": "service unavailable"},
+            ),
+            httpx.ConnectError("connection refused"),
+            httpx.ReadTimeout("upstream slow"),
+            UnexpectedModelBehavior("output schema violation"),
+            ConcurrencyLimitExceeded("backpressure"),
+            # Per-run timeout (asyncio.wait_for raises TimeoutError)
+            TimeoutError("analysis exceeded 60s"),
+            # Deterministic classes (config / programming bugs)
+            UserError("invalid tool registration"),
+            AttributeError("'NoneType' object has no attribute 'output'"),
+            ValueError("bad usage shape"),
+        ],
+        ids=[
+            "model_http_error_429",
+            "model_http_error_503",
+            "httpx_connect_error",
+            "httpx_read_timeout",
+            "unexpected_model_behavior",
+            "concurrency_limit_exceeded",
+            "timeout_error",
+            "user_error",
+            "attribute_error",
+            "value_error",
+        ],
+    )
+    async def test_reraises(self, mocker: MockerFixture, exc: BaseException) -> None:
+        _stub_analyzer_io(mocker, exc)
+
+        with pytest.raises(type(exc)):
+            await review_analyzer.analyze(
+                _minimal_snapshot(), context=ReviewContext.SUBMISSION
+            )


### PR DESCRIPTION
## Summary

The org review analyzer used to swallow LLM gateway failures and persist a synthetic DENY. During a 429 outage that auto-denied real merchants and auto-rejected their appeals. Now it raises the exceptions, we retry, and sentry captures it

## What

- `ReviewAnalyzer.analyze` re-raises on any exception; removed the synthetic-DENY fallbacks (`_error_report`, `_timeout_report`, `_fallback_report`).
- Both review actors bumped to `max_retries=4, min_backoff=30_000` to ride out brief blips.
- Dropped the threshold-context swallow so threshold reviews retry and alert like every other context.
- Parametrized test class covers 10 exception classes.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)