### PR TITLE
fix(order): correct off-by-one in dunning retry exhaustion

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2233,8 +2233,11 @@ class OrderService:
         now = utc_now()
         subscription = order.subscription
 
+        # failed_attempts includes the current failure (upserted by the Stripe
+        # webhook handler before we get here) and the initial cycle failure
+        # which _handle_first_dunning_attempt already paired with intervals[0].
         if (
-            failed_attempts >= len(settings.DUNNING_RETRY_INTERVALS)
+            failed_attempts > len(settings.DUNNING_RETRY_INTERVALS)
             or (
                 subscription is not None
                 and subscription.past_due_deadline
@@ -2253,7 +2256,7 @@ class OrderService:
             return order
 
         # Schedule next retry using the appropriate interval
-        next_interval = settings.DUNNING_RETRY_INTERVALS[failed_attempts]
+        next_interval = settings.DUNNING_RETRY_INTERVALS[failed_attempts - 1]
         next_retry_date = now + next_interval
 
         order = await repository.update(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
 from polar.checkout.eventstream import CheckoutEvent
+from polar.config import settings
 from polar.email.schemas import OrderConfirmationEmail
 from polar.enums import (
     InvoiceNumbering,
@@ -2774,8 +2775,6 @@ class TestHandlePaymentFailure:
         Initial cycle failure + all DUNNING_RETRY_INTERVALS retries have
         failed, so the configured retry budget is exhausted.
         """
-        from polar.config import settings
-
         # Given
         subscription = await create_active_subscription(
             save_fixture,
@@ -2825,8 +2824,6 @@ class TestHandlePaymentFailure:
         mocker: MockerFixture,
     ) -> None:
         """Test that order service cancels subscription after final retry attempt"""
-        from polar.config import settings
-
         # Given
         subscription = await create_canceled_subscription(
             save_fixture,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2659,7 +2659,11 @@ class TestHandlePaymentFailure:
         product: Product,
         mocker: MockerFixture,
     ) -> None:
-        """Test that order service schedules first retry after one failed payment"""
+        """Test that the second retry is scheduled after the first retry fails.
+
+        At this point there are 2 failed payments on the order: the initial
+        subscription_cycle failure and the just-failed first retry.
+        """
         # Given
         subscription = await create_active_subscription(
             save_fixture,
@@ -2676,14 +2680,15 @@ class TestHandlePaymentFailure:
         order.next_payment_attempt_at = utc_now() - timedelta(days=1)  # Past due
         await save_fixture(order)
 
-        # Create one failed payment for this order
-        await create_payment(
-            save_fixture,
-            order.organization,
-            status=PaymentStatus.failed,
-            trigger=PaymentTrigger.purchase,
-            order=order,
-        )
+        # Initial cycle failure + just-failed first retry already recorded
+        for _ in range(2):
+            await create_payment(
+                save_fixture,
+                order.organization,
+                status=PaymentStatus.failed,
+                trigger=PaymentTrigger.purchase,
+                order=order,
+            )
 
         mock_mark_past_due = mocker.patch(
             "polar.subscription.service.subscription.mark_past_due"
@@ -2709,7 +2714,11 @@ class TestHandlePaymentFailure:
         product: Product,
         mocker: MockerFixture,
     ) -> None:
-        """Test that order service schedules second retry after two failed payments"""
+        """Test that the third retry is scheduled after the second retry fails.
+
+        At this point there are 3 failed payments on the order: the initial
+        subscription_cycle failure and the two retries that have failed.
+        """
         # Given
         subscription = await create_active_subscription(
             save_fixture,
@@ -2726,21 +2735,15 @@ class TestHandlePaymentFailure:
         order.next_payment_attempt_at = utc_now() - timedelta(days=1)  # Past due
         await save_fixture(order)
 
-        # Create two failed payments for this order
-        await create_payment(
-            save_fixture,
-            order.organization,
-            status=PaymentStatus.failed,
-            trigger=PaymentTrigger.purchase,
-            order=order,
-        )
-        await create_payment(
-            save_fixture,
-            order.organization,
-            status=PaymentStatus.failed,
-            trigger=PaymentTrigger.purchase,
-            order=order,
-        )
+        # Initial cycle failure + two failed retries already recorded
+        for _ in range(3):
+            await create_payment(
+                save_fixture,
+                order.organization,
+                status=PaymentStatus.failed,
+                trigger=PaymentTrigger.purchase,
+                order=order,
+            )
 
         mock_mark_past_due = mocker.patch(
             "polar.subscription.service.subscription.mark_past_due"
@@ -2766,7 +2769,13 @@ class TestHandlePaymentFailure:
         product: Product,
         mocker: MockerFixture,
     ) -> None:
-        """Test that order service cancels subscription after final retry attempt"""
+        """Test that order service cancels subscription after final retry attempt.
+
+        Initial cycle failure + all DUNNING_RETRY_INTERVALS retries have
+        failed, so the configured retry budget is exhausted.
+        """
+        from polar.config import settings
+
         # Given
         subscription = await create_active_subscription(
             save_fixture,
@@ -2783,8 +2792,8 @@ class TestHandlePaymentFailure:
         order.next_payment_attempt_at = utc_now() - timedelta(days=1)  # Past due
         await save_fixture(order)
 
-        # Create 4 failed payments for this order (equal to DUNNING_RETRY_INTERVALS length)
-        for _ in range(4):
+        # Initial cycle failure + DUNNING_RETRY_INTERVALS retries all failed
+        for _ in range(len(settings.DUNNING_RETRY_INTERVALS) + 1):
             await create_payment(
                 save_fixture,
                 order.organization,
@@ -2816,6 +2825,8 @@ class TestHandlePaymentFailure:
         mocker: MockerFixture,
     ) -> None:
         """Test that order service cancels subscription after final retry attempt"""
+        from polar.config import settings
+
         # Given
         subscription = await create_canceled_subscription(
             save_fixture,
@@ -2833,8 +2844,8 @@ class TestHandlePaymentFailure:
         order.next_payment_attempt_at = utc_now() - timedelta(days=1)  # Past due
         await save_fixture(order)
 
-        # Create 4 failed payments for this order (equal to DUNNING_RETRY_INTERVALS length)
-        for _ in range(4):
+        # Initial cycle failure + DUNNING_RETRY_INTERVALS retries all failed
+        for _ in range(len(settings.DUNNING_RETRY_INTERVALS) + 1):
             await create_payment(
                 save_fixture,
                 order.organization,
@@ -2882,14 +2893,15 @@ class TestHandlePaymentFailure:
         order.next_payment_attempt_at = utc_now() - timedelta(days=1)  # Past due
         await save_fixture(order)
 
-        # Create one failed payment and one successful payment for this order
-        await create_payment(
-            save_fixture,
-            order.organization,
-            status=PaymentStatus.failed,
-            trigger=PaymentTrigger.purchase,
-            order=order,
-        )
+        # 2 failed payments (cycle + first retry) and 1 unrelated success
+        for _ in range(2):
+            await create_payment(
+                save_fixture,
+                order.organization,
+                status=PaymentStatus.failed,
+                trigger=PaymentTrigger.purchase,
+                order=order,
+            )
         await create_payment(
             save_fixture,
             order.organization,
@@ -2906,7 +2918,7 @@ class TestHandlePaymentFailure:
 
         # Then
         assert result_order.next_payment_attempt_at is not None
-        # Should schedule second retry (5 days) since only 1 failed payment exists
+        # Should schedule second retry (5 days) since 2 failed payments exist
         expected_retry_date = utc_now() + timedelta(days=5)
         assert result_order.next_payment_attempt_at == expected_retry_date
 

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -6,6 +6,7 @@ import stripe as stripe_lib
 from dramatiq import Retry
 from pytest_mock import MockerFixture
 
+from polar.config import settings
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.utils import utc_now
 from polar.models import Organization, Product
@@ -411,8 +412,6 @@ class TestProcessDunningOrder:
         await save_fixture(order)
 
         # Initial cycle failure + all DUNNING_RETRY_INTERVALS retries failed
-        from polar.config import settings
-
         for _ in range(len(settings.DUNNING_RETRY_INTERVALS) + 1):
             await create_payment(
                 save_fixture,

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -360,6 +360,13 @@ class TestProcessDunningOrder:
             trigger=PaymentTrigger.purchase,
             order=order,
         )
+        await create_payment(
+            save_fixture,
+            organization,
+            status=PaymentStatus.failed,
+            trigger=PaymentTrigger.purchase,
+            order=order,
+        )
 
         # When: retry attempt fails
         result_order = await order_service.handle_payment_failure(session, order)
@@ -403,8 +410,10 @@ class TestProcessDunningOrder:
         order.next_payment_attempt_at = very_old_time
         await save_fixture(order)
 
-        # Create 4 failed payments to exhaust all retry attempts
-        for _ in range(4):
+        # Initial cycle failure + all DUNNING_RETRY_INTERVALS retries failed
+        from polar.config import settings
+
+        for _ in range(len(settings.DUNNING_RETRY_INTERVALS) + 1):
             await create_payment(
                 save_fixture,
                 organization,

--- a/server/tests/payment/test_repository.py
+++ b/server/tests/payment/test_repository.py
@@ -266,8 +266,8 @@ class TestCountFailedPaymentsForOrder:
         count = await repository.count_failed_payments_for_order(order.id)
 
         # Only the original purchase + the cron-fired retry_dunning count.
-        # 2 < 4 (len of DUNNING_RETRY_INTERVALS), so the subscription stays
-        # in dunning instead of being revoked.
+        # 2 is not greater than 4 (len of DUNNING_RETRY_INTERVALS), so the
+        # subscription stays in dunning instead of being revoked.
         assert count == 2
 
 


### PR DESCRIPTION
The Stripe webhook handler upserts the failed Payment row before
delegating to the order's dunning state machine, so
count_failed_payments_for_order returns a count that already includes
the current failure (and the initial subscription_cycle failure).

The previous logic used `failed_attempts >= len(DUNNING_RETRY_INTERVALS)`
and `intervals[failed_attempts]`, which silently skipped intervals[1]
(the 5d wait) and revoked subscriptions after only 3 retries instead of
4, finalizing dunning ~5 days before the configured past_due_deadline.

Use `>` for the exhaustion check and `failed_attempts - 1` for the
interval index. Update the affected tests to seed the database with the
extra failure row that production always records first.

https://claude.ai/code/session_015sepPrBrdWi2vCKiyce8Ts