### PR TITLE
Add enforced dark mode support in StyleX

### DIFF
--- a/clients/apps/web/src/app/providers.tsx
+++ b/clients/apps/web/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { DISTINCT_ID_COOKIE } from '@/experiments/constants'
 import { NavigationHistoryProvider } from '@/providers/navigationHistory'
 import { getQueryClient } from '@/utils/api/query'
 import { CONFIG } from '@/utils/config'
+import { OrbitThemeBinder } from '@polar-sh/orbit'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
 import { usePathname, useSearchParams } from 'next/navigation'
@@ -39,6 +40,31 @@ export function PolarPostHogProvider({
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
 
+// URL prefixes for the marketing-style "landing" surface. These pages have
+// no theme toggle: they always render in the dark palette regardless of
+// system preference. The dashboard (anything not matched here) is the
+// inverse — it honors next-themes' user/system theme choice.
+const LANDING_PATH_PREFIXES: string[] = [
+  '/features',
+  '/customers',
+  '/blog',
+  '/resources',
+  '/company',
+  '/startup-program',
+  '/downloads',
+  '/legal',
+]
+
+// Additional non-landing paths that should also be locked to dark.
+const PAGES_WITH_FORCED_DARK_THEME: string[] = ['/midday/portal']
+
+const isLandingPath = (pathname: string): boolean =>
+  pathname === '/' ||
+  LANDING_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+
+const isForcedDarkPath = (pathname: string): boolean =>
+  PAGES_WITH_FORCED_DARK_THEME.some((path) => pathname.includes(path))
+
 export function PolarThemeProvider({
   children,
   forceTheme,
@@ -48,23 +74,22 @@ export function PolarThemeProvider({
 }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const theme = searchParams.get('theme')
+  const themeOverride = searchParams.get('theme')
 
-  const PAGES_WITH_FORCED_DARK_THEME: string[] = ['/midday/portal']
-  const forcedTheme = PAGES_WITH_FORCED_DARK_THEME.some((path) =>
-    pathname.includes(path),
-  )
-    ? 'dark'
-    : forceTheme
+  // Landing pages + the legacy forced-dark routes lock to dark. Everything
+  // else (dashboard, settings, checkout, etc.) falls through to the
+  // caller-supplied `forceTheme` or next-themes' system/user choice.
+  const forcedTheme =
+    isLandingPath(pathname) || isForcedDarkPath(pathname) ? 'dark' : forceTheme
 
   return (
     <ThemeProvider
       defaultTheme="system"
       enableSystem
       attribute="class"
-      forcedTheme={theme ?? forcedTheme}
+      forcedTheme={themeOverride ?? forcedTheme}
     >
-      {children}
+      <OrbitThemeBinder>{children}</OrbitThemeBinder>
     </ThemeProvider>
   )
 }

--- a/clients/packages/orbit/src/components/OrbitThemeBinder.tsx
+++ b/clients/packages/orbit/src/components/OrbitThemeBinder.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import * as stylex from '@stylexjs/stylex'
+import { useTheme } from 'next-themes'
+import * as React from 'react'
+import {
+  darkBackgroundTheme,
+  darkBorderTheme,
+  darkTextTheme,
+} from '../tokens/tokens.stylex'
+
+/**
+ * Binds Orbit's design-token themes to next-themes' resolved theme.
+ *
+ * Mount once inside next-themes' `<ThemeProvider />`. When the resolved
+ * theme is `dark`, the dark `createTheme` overrides are applied via a
+ * `display: contents` wrapper so all descendants pick up the dark color
+ * variables without any layout impact.
+ *
+ * Dashboard (light/dark per user choice) and landing (forcedTheme=dark)
+ * both flow through the same mechanism — there is no per-route theming
+ * code anywhere else.
+ */
+export const OrbitThemeBinder = ({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactElement => {
+  const { resolvedTheme, forcedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark' || forcedTheme === 'dark'
+  const themeProps = isDark
+    ? stylex.props(darkBackgroundTheme, darkTextTheme, darkBorderTheme)
+    : null
+
+  return React.createElement(
+    'div',
+    {
+      ...themeProps,
+      style: { display: 'contents' },
+    },
+    children,
+  )
+}

--- a/clients/packages/orbit/src/index.ts
+++ b/clients/packages/orbit/src/index.ts
@@ -7,6 +7,7 @@ export { BarChart } from './components/BarChart'
 export type { BarChartItem } from './components/BarChart'
 export { Button } from './components/Button'
 export type { ButtonProps } from './components/Button'
+export { OrbitThemeBinder } from './components/OrbitThemeBinder'
 
 // ─── Tokens ───────────────────────────────────────────────────────────────────
 export { animationDelays, animations } from './tokens/animations'

--- a/clients/packages/orbit/src/tokens/tokens.stylex.ts
+++ b/clients/packages/orbit/src/tokens/tokens.stylex.ts
@@ -21,90 +21,73 @@ export const spacing = stylex.defineVars({
 })
 
 // ─── Colors ───────────────────────────────────────────────────────────────────
-// Light values are the default. Dark values are applied via prefers-color-scheme.
+// Light values are the unconditional defaults in `defineVars`. The dark
+// palette lives in the `dark*Theme` exports below and activates only when
+// `<OrbitThemeBinder />` (or a caller-applied `stylex.props(...)` className)
+// is in scope — i.e. when next-themes resolves to `dark`.
+//
+// One source of truth per palette; switching is React-driven via
+// next-themes rather than `prefers-color-scheme`, so explicit user choice
+// always wins on the dashboard and the landing pages can lock to dark.
 // ──────────────────────────────────────────────────────────────────────────────
 
-const DARK = '@media (prefers-color-scheme: dark)'
-
 export const backgroundColors = stylex.defineVars({
-  'background-primary': {
-    default: '#ffffff',
-    [DARK]: 'hsl(233, 4%, 3.5%)',
-  },
-  'background-secondary': {
-    default: 'oklch(0.985 0.002 247.839)',
-    [DARK]: 'hsl(233, 4%, 6.5%)',
-  },
-  'background-card': {
-    default: 'oklch(96.7% 0.003 264.54)',
-    [DARK]: 'hsl(233, 4%, 9.5%)',
-  },
-  'background-inverse': {
-    default: 'oklch(0.21 0.034 264.665)',
-    [DARK]: 'oklch(1.000 0.000 263.3)',
-  },
-  'background-warning': {
-    default: 'oklch(0.97 0.026 102.5)',
-    [DARK]: 'oklch(0.445 0.1 82.5 / 0.2)',
-  },
-  'background-success': {
-    default: 'oklch(0.97 0.04 162)',
-    [DARK]: 'oklch(0.696 0.17 162 / 0.2)',
-  },
-  'background-danger': {
-    default: 'oklch(0.97 0.04 25)',
-    [DARK]: 'oklch(0.637 0.237 25 / 0.2)',
-  },
-  'background-pending': {
-    default: 'oklch(0.96 0.005 264)',
-    [DARK]: 'oklch(0.6 0.02 264 / 0.2)',
-  },
+  'background-primary': '#ffffff',
+  'background-secondary': 'oklch(0.985 0.002 247.839)',
+  'background-card': 'oklch(96.7% 0.003 264.54)',
+  'background-inverse': 'oklch(0.21 0.034 264.665)',
+  'background-warning': 'oklch(0.97 0.026 102.5)',
+  'background-success': 'oklch(0.97 0.04 162)',
+  'background-danger': 'oklch(0.97 0.04 25)',
+  'background-pending': 'oklch(0.96 0.005 264)',
 })
 
 export const textColors = stylex.defineVars({
-  'text-primary': {
-    default: '#000000',
-    [DARK]: '#ffffff',
-  },
-  'text-secondary': {
-    default: 'oklch(0.551 0.027 264.364)',
-    [DARK]: 'oklch(0.599 0.020 279.8)',
-  },
-  'text-tertiary': {
-    default: 'oklch(0.707 0.022 261.325)',
-    [DARK]: 'hsl(233, 4%, 46%)',
-  },
-  'text-success': {
-    default: 'oklch(0.696 0.17 162)',
-    [DARK]: 'oklch(0.696 0.17 162)',
-  },
-  'text-danger': {
-    default: 'oklch(0.637 0.237 25)',
-    [DARK]: 'oklch(0.637 0.237 25)',
-  },
-  'text-warning': {
-    default: 'oklch(0.769 0.188 70)',
-    [DARK]: 'oklch(0.769 0.188 70)',
-  },
-  'text-pending': {
-    default: 'oklch(0.65 0.02 264)',
-    [DARK]: 'oklch(0.7 0.02 264)',
-  },
+  'text-primary': '#000000',
+  'text-secondary': 'oklch(0.551 0.027 264.364)',
+  'text-tertiary': 'oklch(0.707 0.022 261.325)',
+  'text-success': 'oklch(0.696 0.17 162)',
+  'text-danger': 'oklch(0.637 0.237 25)',
+  'text-warning': 'oklch(0.769 0.188 70)',
+  'text-pending': 'oklch(0.65 0.02 264)',
 })
 
 export const borderColors = stylex.defineVars({
-  'border-primary': {
-    default: 'oklch(0.928 0.006 264.531)',
-    [DARK]: 'hsl(233, 4%, 12%)',
-  },
-  'border-secondary': {
-    default: '#f6f6f6',
-    [DARK]: 'oklch(0.206 0.005 279.9)',
-  },
-  'border-warning': {
-    default: 'oklch(0.836 0.138 100)',
-    [DARK]: 'oklch(0.572 0.14 91)',
-  },
+  'border-primary': 'oklch(0.928 0.006 264.531)',
+  'border-secondary': '#f6f6f6',
+  'border-warning': 'oklch(0.836 0.138 100)',
+})
+
+// ─── Dark theme overrides ─────────────────────────────────────────────────────
+// Applied by `<OrbitThemeBinder />` when the active theme is `dark`. Keep
+// each theme aligned to its corresponding `defineVars` block (same keys).
+// ──────────────────────────────────────────────────────────────────────────────
+
+export const darkBackgroundTheme = stylex.createTheme(backgroundColors, {
+  'background-primary': 'hsl(233, 4%, 3.5%)',
+  'background-secondary': 'hsl(233, 4%, 6.5%)',
+  'background-card': 'hsl(233, 4%, 9.5%)',
+  'background-inverse': 'oklch(1.000 0.000 263.3)',
+  'background-warning': 'oklch(0.445 0.1 82.5 / 0.2)',
+  'background-success': 'oklch(0.696 0.17 162 / 0.2)',
+  'background-danger': 'oklch(0.637 0.237 25 / 0.2)',
+  'background-pending': 'oklch(0.6 0.02 264 / 0.2)',
+})
+
+export const darkTextTheme = stylex.createTheme(textColors, {
+  'text-primary': '#ffffff',
+  'text-secondary': 'oklch(0.599 0.020 279.8)',
+  'text-tertiary': 'hsl(233, 4%, 46%)',
+  'text-success': 'oklch(0.696 0.17 162)',
+  'text-danger': 'oklch(0.637 0.237 25)',
+  'text-warning': 'oklch(0.769 0.188 70)',
+  'text-pending': 'oklch(0.7 0.02 264)',
+})
+
+export const darkBorderTheme = stylex.createTheme(borderColors, {
+  'border-primary': 'hsl(233, 4%, 12%)',
+  'border-secondary': 'oklch(0.206 0.005 279.9)',
+  'border-warning': 'oklch(0.572 0.14 91)',
 })
 
 // ─── Border Radius ────────────────────────────────────────────────────────────

--- a/clients/packages/orbit/src/tokens/tokens.stylex.ts
+++ b/clients/packages/orbit/src/tokens/tokens.stylex.ts
@@ -5,6 +5,25 @@
 
 import * as stylex from '@stylexjs/stylex'
 
+// ─── Type helpers ─────────────────────────────────────────────────────────────
+// Pulled to the top so they can be used by the color palette guards below.
+// ──────────────────────────────────────────────────────────────────────────────
+
+type StyleXTokenKeys<T> = Exclude<
+  keyof T,
+  '__opaqueId' | '__tokens' | symbol | 'toString' | 'valueOf' | 'description'
+>
+
+/**
+ * Shape a dark-theme override must satisfy: exactly the same keys as the
+ * matching light palette, every one declared, no extras. Drift between
+ * the `stylex.defineVars` palette and the `stylex.createTheme` override
+ * becomes a compile-time error rather than a silent visual bug.
+ */
+type DarkOverrideOf<Palette> = {
+  [K in StyleXTokenKeys<Palette>]: string
+}
+
 // ─── Spacing ──────────────────────────────────────────────────────────────────
 
 export const spacing = stylex.defineVars({
@@ -72,7 +91,7 @@ export const darkBackgroundTheme = stylex.createTheme(backgroundColors, {
   'background-success': 'oklch(0.696 0.17 162 / 0.2)',
   'background-danger': 'oklch(0.637 0.237 25 / 0.2)',
   'background-pending': 'oklch(0.6 0.02 264 / 0.2)',
-})
+} satisfies DarkOverrideOf<typeof backgroundColors>)
 
 export const darkTextTheme = stylex.createTheme(textColors, {
   'text-primary': '#ffffff',
@@ -82,13 +101,13 @@ export const darkTextTheme = stylex.createTheme(textColors, {
   'text-danger': 'oklch(0.637 0.237 25)',
   'text-warning': 'oklch(0.769 0.188 70)',
   'text-pending': 'oklch(0.7 0.02 264)',
-})
+} satisfies DarkOverrideOf<typeof textColors>)
 
 export const darkBorderTheme = stylex.createTheme(borderColors, {
   'border-primary': 'hsl(233, 4%, 12%)',
   'border-secondary': 'oklch(0.206 0.005 279.9)',
   'border-warning': 'oklch(0.572 0.14 91)',
-})
+} satisfies DarkOverrideOf<typeof borderColors>)
 
 // ─── Border Radius ────────────────────────────────────────────────────────────
 
@@ -121,11 +140,8 @@ export const breakpoints = stylex.defineConsts({
 })
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-
-type StyleXTokenKeys<T> = Exclude<
-  keyof T,
-  '__opaqueId' | '__tokens' | symbol | 'toString' | 'valueOf' | 'description'
->
+// `StyleXTokenKeys` is declared at the top of the file (used by the
+// dark-theme drift guard).
 
 export type SpacingToken = StyleXTokenKeys<typeof spacing>
 export type BackgroundColorToken = StyleXTokenKeys<typeof backgroundColors>

--- a/clients/packages/orbit/src/utils/resolvers.test.ts
+++ b/clients/packages/orbit/src/utils/resolvers.test.ts
@@ -5,11 +5,13 @@ vi.mock('@stylexjs/stylex', () => ({
     defineVars: <T extends Record<string, unknown>>(obj: T) => obj,
     defineConsts: <T extends Record<string, unknown>>(obj: T) => obj,
     create: <T extends Record<string, unknown>>(obj: T) => obj,
+    createTheme: <T extends Record<string, unknown>>(_: unknown, obj: T) => obj,
     props: () => ({ className: '', style: {} }),
   },
   defineVars: <T extends Record<string, unknown>>(obj: T) => obj,
   defineConsts: <T extends Record<string, unknown>>(obj: T) => obj,
   create: <T extends Record<string, unknown>>(obj: T) => obj,
+  createTheme: <T extends Record<string, unknown>>(_: unknown, obj: T) => obj,
   props: () => ({ className: '', style: {} }),
 }))
 


### PR DESCRIPTION
### Why

  Orbit's design tokens swapped via `@media (prefers-color-scheme: dark)`, which meant Orbit-built UI ignored
  next-themes' user/forced theme choice and instead followed the OS preference. Landing pages forced to `dark`
  (via `PolarThemeProvider`) still rendered Orbit `<Box />` in light when the user's OS was light, and the
  dashboard's user theme toggle had no effect on Orbit components.

  ### What changed

  **`packages/orbit/src/tokens/tokens.stylex.ts`** — single source of truth
  - `defineVars` for `backgroundColors` / `textColors` / `borderColors` now carries light values as
  unconditional defaults. The `@media (prefers-color-scheme: dark)` branches are gone.
  - New `darkBackgroundTheme` / `darkTextTheme` / `darkBorderTheme` exports built with `stylex.createTheme(...)`
   hold the dark palette in one place per token family.

  **`packages/orbit/src/components/OrbitThemeBinder.tsx`** — new
  - Reads next-themes' `resolvedTheme` / `forcedTheme`.
  - When either is `'dark'`, applies the three `createTheme` overrides via `stylex.props(...)` on a `display:
  contents` wrapper (zero layout impact).
  - Mounted once inside `<ThemeProvider />` in `providers.tsx`; every Orbit `<Box />` / `<Text />` underneath
  picks up the dark vars without per-component changes.
  - Exported from `@polar-sh/orbit`.

  **`apps/web/src/app/providers.tsx`** — the only place that knows about the landing/dashboard split
  - New `LANDING_PATH_PREFIXES` list (`/`, `/features`, `/customers`, `/blog`, `/resources`, `/company`,
  `/startup-program`, `/downloads`, `/legal`) and the existing `PAGES_WITH_FORCED_DARK_THEME` are checked once
  via `isLandingPath` / `isForcedDarkPath`.
  - `PolarThemeProvider` sets `forcedTheme='dark'` for those paths; otherwise it falls through to the caller's
  `forceTheme` or next-themes' system/user choice.
  - `<OrbitThemeBinder />` is rendered as the immediate child of `<ThemeProvider />` so Orbit theming flows
  through the same single chain.

  ### Result by surface

  | Surface | next-themes behavior | Orbit tokens | Tailwind `.dark` |
  |---|---|---|---|
  | Dashboard | user / system choice | follows resolved theme | follows class on `<html>` |
  | Landing pages | forced to `dark` | always dark | always `.dark` on `<html>` |
  | `?theme=light` / `?theme=dark` | overrides everything | follows | follows |

  ### Cleanups

  - Deleted the per-page `landing-dark-theme.stylex.ts` override.
  - Removed the wrapper div in `LandingLayout.tsx`.
  - Removed the previous `prefers-color-scheme` branches and any duplicated dark color values.

  ### Adding a new surface

  - New landing route: add the URL prefix to `LANDING_PATH_PREFIXES`.
  - New always-dark non-landing route: add to `PAGES_WITH_FORCED_DARK_THEME`.
  - New color token: add the light value to the matching `defineVars` block and the dark value to the matching
  `createTheme` block in `tokens.stylex.ts`.