### PR TITLE
Re-sync seat-based benefits on subscription product change

### DIFF
--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -1107,5 +1107,34 @@ class SeatService:
             )
             index += 1
 
+    async def update_subscription_benefits_grants(
+        self, session: AsyncReadSession, subscription: Subscription
+    ) -> None:
+        """Re-sync benefit grants for claimed seats of a single subscription.
+
+        Used when a subscription's product changes mid-cycle: existing
+        seat holders must pick up the new product's benefits (and lose any
+        outdated grants from the previous product).
+        """
+        repository = CustomerSeatRepository.from_session(session)
+        seats = await repository.list_by_subscription_id(subscription.id)
+        claimed_seats = [
+            seat
+            for seat in seats
+            if seat.status == SeatStatus.claimed and seat.customer_id is not None
+        ]
+
+        calculate_delay = make_bulk_job_delay_calculator(len(claimed_seats))
+        for index, seat in enumerate(claimed_seats):
+            enqueue_job(
+                "benefit.enqueue_benefits_grants",
+                task="grant",
+                customer_id=seat.customer_id,
+                product_id=subscription.product_id,
+                member_id=seat.member_id,
+                subscription_id=seat.subscription_id,
+                delay=calculate_delay(index),
+            )
+
 
 seat_service = SeatService()

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1205,6 +1205,14 @@ class SubscriptionService:
 
             await self.enqueue_benefits_grants(session, subscription)
 
+            # Seat-based subscriptions short-circuit enqueue_benefits_grants
+            # while active, so existing claimed seats won't pick up the new
+            # product's benefits without an explicit re-sync.
+            if product.has_seat_based_price and subscription.active:
+                await seat_service.update_subscription_benefits_grants(
+                    session, subscription
+                )
+
             # Send product change email notification
             await self.send_subscription_updated_email(
                 session, subscription, product, proration_behavior

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2728,6 +2728,78 @@ class TestUpdateProduct:
         assert updated_subscription.product == new_seat_product
         create_subscription_update_order_mock.assert_called_once()
 
+    async def test_seat_to_seat_product_change_resyncs_claimed_seat_benefits(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+
+        old_seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        new_seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 2000, "usd")],
+        )
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=old_seat_product,
+            customer=customer,
+            seats=3,
+        )
+
+        seat_holder = await create_customer(
+            save_fixture, organization=organization, email="member@test.com"
+        )
+        await create_customer_seat(
+            save_fixture,
+            subscription=subscription,
+            customer=seat_holder,
+            status=SeatStatus.claimed,
+            claimed_at=utc_now(),
+        )
+        # Pending and revoked seats should be ignored
+        await create_customer_seat(save_fixture, subscription=subscription)
+        await create_customer_seat(
+            save_fixture,
+            subscription=subscription,
+            status=SeatStatus.revoked,
+            revoked_at=utc_now(),
+        )
+
+        enqueue_job_mock = mocker.patch("polar.customer_seat.service.enqueue_job")
+
+        await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=new_seat_product.id,
+            proration_behavior=SubscriptionProrationBehavior.invoice,
+        )
+
+        benefit_grant_calls = [
+            c
+            for c in enqueue_job_mock.call_args_list
+            if c.args and c.args[0] == "benefit.enqueue_benefits_grants"
+        ]
+        assert len(benefit_grant_calls) == 1
+        call_kwargs = benefit_grant_calls[0].kwargs
+        assert call_kwargs["task"] == "grant"
+        assert call_kwargs["customer_id"] == seat_holder.id
+        assert call_kwargs["product_id"] == new_seat_product.id
+        assert call_kwargs["subscription_id"] == subscription.id
+
     async def test_unavailable_currency(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

**Related Issue**: #11808

When a seat-based subscription was moved from product A → product B mid-cycle, existing claimed seats kept A's benefit grants indefinitely. This wires the seat re-sync into the product change path.

## What

- New `seat_service.update_subscription_benefits_grants(subscription)` helper that enqueues `benefit.enqueue_benefits_grants` (task=`grant`) for each claimed seat of a single subscription, scoped to the subscription's current product.
- `subscription_service.update_product()` calls the new helper after `enqueue_benefits_grants` when the new product is seat-based and the subscription is active.
- Test in `TestUpdateProduct` confirming the re-sync fires for a claimed seat (and ignores pending/revoked seats) with the new product's id.

## Why

`subscription_service.enqueue_benefits_grants` short-circuits for active seat-based subscriptions on the assumption that benefits are granted at seat-claim time. That invariant breaks under a product change: the underlying product (and its benefit set) swapped out, but no one re-synced the existing seat holders' grants. Re-claiming a seat (revoke + reclaim) worked, confirming the gap is specific to the plan-change path.

## How

A per-subscription seat helper mirrors the existing `update_product_benefits_grants(product)` used by the merchant-edits-product-benefits flow, but scoped to a single subscription instead of sweeping every subscription on the product. Each enqueued grant job flows through `benefit_grant_service.enqueue_benefits_grants`, which:

1. Computes the new product's benefits to grant.
2. Calls `list_outdated_grants(new_product, subscription=...)` to find still-granted benefits no longer attached to the new product.
3. Runs revoke-then-grant as a Dramatiq pipeline.

This delegates grant/revoke logic to the same pipeline the merchant-benefit-edit flow already uses, so behavior matches the existing well-tested code path.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included