### PR TITLE
ci: Allow changes to scripts in migration check

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -122,11 +122,14 @@ jobs:
         run: |
           DISALLOWED=""
           for file in $(echo "$SERVER_FILES" | jq -r '.[]'); do
-            # Allow: migrations, models, and the workflow file itself
+            # Allow: migrations, models, scripts, and the workflow file itself
             if [[ "$file" == server/migrations/* ]]; then
               continue
             fi
             if [[ "$file" == server/polar/models/* ]]; then
+              continue
+            fi
+            if [[ "$file" == server/scripts/* ]]; then
               continue
             fi
             if [[ "$file" == .github/* ]]; then


### PR DESCRIPTION
The scripts have no impact on the db migration, so we can allow it without posting a big warning
