### PR TITLE
chore: Bundle dependabot updates into groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,33 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "uv"
     directory: "/server"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/clients"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/server/emails"
     schedule:
@@ -22,16 +43,9 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      react-email:
+      all:
         patterns:
-          - "react-email"
-          - "@react-email/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
+          - "*"
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
@@ -41,6 +55,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
@@ -50,6 +68,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      actions:
         patterns:
           - "*"
   - package-ecosystem: "uv"
@@ -20,7 +20,12 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      server-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      server-development:
+        dependency-type: "development"
         patterns:
           - "*"
   - package-ecosystem: "npm"
@@ -30,7 +35,12 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      clients-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      clients-development:
+        dependency-type: "development"
         patterns:
           - "*"
     ignore:
@@ -43,7 +53,12 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      emails-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      emails-development:
+        dependency-type: "development"
         patterns:
           - "*"
     ignore:
@@ -56,7 +71,12 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      docs-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      docs-development:
+        dependency-type: "development"
         patterns:
           - "*"
     ignore:
@@ -69,7 +89,12 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      handbook-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      handbook-development:
+        dependency-type: "development"
         patterns:
           - "*"
     ignore:


### PR DESCRIPTION
… instead of one PR per dependency.

The groups this will result in (🤞):
- GitHub Actions
- `server-production` (`uv`)
- `server-development` (`uv`)
- `clients-production` (`npm`, **new** - clients weren't covered by dependabot before)
- `clients-development` (`npm`, **new** - clients weren't covered by dependabot before)
- `emails-production` (`npm`)
- `emails-development` (`npm`)
- `docs-production` (`npm`)
- `docs-development` (`npm`)
- `handbook-production` (`npm`)
- `handbook-development` (`npm`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to organize updates across multiple project areas using grouping strategies for better maintainability and control of release cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->