### PR TITLE
clients/web: implement auth pages for new factors

### DIFF
--- a/clients/apps/web/src/app/(main)/auth/AppleLoginButton.tsx
+++ b/clients/apps/web/src/app/(main)/auth/AppleLoginButton.tsx
@@ -1,0 +1,55 @@
+import { useAuthSessionStart } from '@/hooks'
+import { usePostHog, type EventName } from '@/hooks/posthog'
+import { getPublicServerURL } from '@/utils/api'
+import Apple from '@mui/icons-material/Apple'
+import { schemas } from '@polar-sh/client'
+import Button, { type ButtonProps } from '@polar-sh/ui/components/atoms/Button'
+
+interface AppleLoginButtonProps {
+  authenticationSession: schemas['AuthenticationSession'] | null
+  returnTo?: string
+  signup?: boolean
+  variant?: ButtonProps['variant']
+}
+
+const AppleLoginButton = ({
+  authenticationSession,
+  returnTo,
+  signup,
+  variant,
+}: AppleLoginButtonProps) => {
+  const posthog = usePostHog()
+  const authSessionStart = useAuthSessionStart()
+
+  const onClick = async () => {
+    let eventName: EventName = 'global:user:login:submit'
+    if (signup) {
+      eventName = 'global:user:signup:submit'
+    }
+    posthog.capture(eventName, {
+      method: 'apple',
+    })
+
+    if (!authenticationSession) {
+      await authSessionStart.mutateAsync(returnTo)
+    }
+    window.location.href = `${getPublicServerURL()}/v1/auth/apple/authorize`
+  }
+
+  return (
+    <a onClick={onClick}>
+      <Button
+        variant={variant}
+        wrapperClassNames="space-x-2 p-2.5 px-5"
+        fullWidth
+      >
+        <Apple />
+        <div className="w-32 text-left">
+          {signup ? 'Sign up with Apple' : 'Sign in with Apple'}
+        </div>
+      </Button>
+    </a>
+  )
+}
+
+export default AppleLoginButton

--- a/clients/apps/web/src/app/(main)/auth/AppleLoginButton.tsx
+++ b/clients/apps/web/src/app/(main)/auth/AppleLoginButton.tsx
@@ -1,5 +1,6 @@
 import { useAuthSessionStart } from '@/hooks'
 import { usePostHog, type EventName } from '@/hooks/posthog'
+import { useToast } from '@/components/Toast/use-toast'
 import { getPublicServerURL } from '@/utils/api'
 import Apple from '@mui/icons-material/Apple'
 import { schemas } from '@polar-sh/client'
@@ -20,6 +21,7 @@ const AppleLoginButton = ({
 }: AppleLoginButtonProps) => {
   const posthog = usePostHog()
   const authSessionStart = useAuthSessionStart()
+  const { toast } = useToast()
 
   const onClick = async () => {
     let eventName: EventName = 'global:user:login:submit'
@@ -31,7 +33,16 @@ const AppleLoginButton = ({
     })
 
     if (!authenticationSession) {
-      await authSessionStart.mutateAsync(returnTo)
+      try {
+        await authSessionStart.mutateAsync(returnTo)
+      } catch {
+        toast({
+          title: 'Sign in failed',
+          description:
+            'Could not start authentication session. Please try again.',
+        })
+        return
+      }
     }
     window.location.href = `${getPublicServerURL()}/v1/auth/apple/authorize`
   }

--- a/clients/apps/web/src/app/(main)/auth/Auth.tsx
+++ b/clients/apps/web/src/app/(main)/auth/Auth.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { type EventName } from '@/hooks/posthog'
+import { schemas } from '@polar-sh/client'
+import { Fragment } from 'react'
+import GoogleLoginButton from './GoogleLoginButton'
+import EmailOTPForm from './EmailOTPForm'
+import AppleLoginButton from './AppleLoginButton'
+import GitHubLoginButton from './GitHubLoginButton'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useImpressionEvent } from '@/hooks/useImpressionEvent'
+import { type JsonType } from '@posthog/core'
+
+type OAuthFactor = Exclude<schemas['Factor'], 'email_otp' | 'totp'>
+const OAUTH_FACTORS: OAuthFactor[] = ['apple', 'github', 'google']
+
+const isOAuthFactor = (
+  value: schemas['Factor'] | null | undefined,
+): value is OAuthFactor =>
+  !!value && (OAUTH_FACTORS as string[]).includes(value)
+
+const Auth = ({
+  authenticationSession,
+  lastLoginMethod,
+  returnTo,
+  signup,
+}: {
+  authenticationSession: schemas['AuthenticationSession'] | null
+  lastLoginMethod?: schemas['Factor'] | null
+  returnTo?: string
+  signup?: boolean
+}) => {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const eventName: EventName = signup
+    ? 'global:user:signup:view'
+    : 'global:user:login:view'
+  const eventData: Record<string, JsonType> = signup
+    ? {
+        signup: {
+          path: pathname,
+          host: typeof window !== 'undefined' ? window.location.host : '',
+          campaign: searchParams.get('campaign') ?? '',
+          utm_source: searchParams.get('utm_source') ?? '',
+          utm_medium: searchParams.get('utm_medium') ?? '',
+          utm_campaign: searchParams.get('utm_campaign') ?? '',
+        },
+      }
+    : {}
+  useImpressionEvent({
+    event: eventName,
+    build: () => eventData,
+  })
+
+  const primaryOAuthFactor: OAuthFactor = isOAuthFactor(lastLoginMethod)
+    ? lastLoginMethod
+    : 'google'
+  const orderedOAuthFactors: OAuthFactor[] = [
+    primaryOAuthFactor,
+    ...OAUTH_FACTORS.filter(
+      (f) => isOAuthFactor(f) && f !== primaryOAuthFactor,
+    ),
+  ]
+
+  const renderOAuth = (factor: OAuthFactor, isPrimary: boolean) => {
+    const variant = isPrimary ? 'default' : 'secondary'
+    switch (factor) {
+      case 'apple':
+        return (
+          <AppleLoginButton
+            authenticationSession={authenticationSession}
+            variant={variant}
+            returnTo={returnTo}
+            signup={signup}
+          />
+        )
+      case 'github':
+        return (
+          <GitHubLoginButton
+            authenticationSession={authenticationSession}
+            variant={variant}
+            returnTo={returnTo}
+            signup={signup}
+          />
+        )
+      case 'google':
+        return (
+          <GoogleLoginButton
+            authenticationSession={authenticationSession}
+            variant={variant}
+            returnTo={returnTo}
+            signup={signup}
+          />
+        )
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex w-full flex-col gap-y-4">
+        {orderedOAuthFactors.map((factor, index) => (
+          <Fragment key={factor}>
+            <LastUsedWrapper show={lastLoginMethod === factor}>
+              {renderOAuth(factor, index === 0)}
+            </LastUsedWrapper>
+          </Fragment>
+        ))}
+        <div className="flex w-full flex-row items-center gap-6">
+          <div className="dark:border-polar-700 grow border-t border-gray-200" />
+          <div className="text-sm text-gray-500">or</div>
+          <div className="dark:border-polar-700 grow border-t border-gray-200" />
+        </div>
+        <LastUsedWrapper show={lastLoginMethod === 'email_otp'}>
+          <EmailOTPForm
+            authenticationSession={authenticationSession}
+            returnTo={returnTo}
+            signup={signup}
+          />
+        </LastUsedWrapper>
+      </div>
+      <div className="dark:text-polar-500 mt-6 text-center text-xs text-balance text-gray-400">
+        By using Polar, you agree to our{' '}
+        <a
+          className="dark:text-polar-300 text-gray-600"
+          href="https://polar.sh/legal/master-services-terms"
+        >
+          Terms of Service
+        </a>{' '}
+        &amp;{' '}
+        <a
+          className="dark:text-polar-300 text-gray-600"
+          href="https://polar.sh/legal/privacy-policy"
+        >
+          Privacy Policy
+        </a>
+        .
+      </div>
+    </div>
+  )
+}
+
+const LastUsedWrapper = ({
+  show,
+  children,
+}: {
+  show: boolean
+  children: React.ReactNode
+}) => (
+  <div className="relative">
+    {show && (
+      <span className="dark:bg-polar-900 dark:border-polar-600 absolute -top-3 -right-2 z-20 rounded-full border border-gray-200 bg-white px-2 py-0.5 text-xs text-black dark:text-white">
+        Last used
+      </span>
+    )}
+    {children}
+  </div>
+)
+
+export default Auth

--- a/clients/apps/web/src/app/(main)/auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/app/(main)/auth/EmailOTPForm.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useAuthSessionStart, useEmailOTPRequest } from '@/hooks'
+import { usePostHog, type EventName } from '@/hooks/posthog'
+import { setValidationErrors } from '@/utils/api/errors'
+import { isValidationError, schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import Input from '@polar-sh/ui/components/atoms/Input'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+interface EmailOTPFormProps {
+  authenticationSession: schemas['AuthenticationSession'] | null
+  returnTo?: string
+  signup?: boolean
+}
+
+const EmailOTPForm = ({
+  authenticationSession,
+  returnTo,
+  signup,
+}: EmailOTPFormProps) => {
+  const form = useForm<{ email: string }>({
+    defaultValues: {
+      email: '',
+    },
+  })
+  const { control, handleSubmit, setError } = form
+  const [loading, setLoading] = useState(false)
+  const authSessionStart = useAuthSessionStart()
+  const emailOTPRequest = useEmailOTPRequest()
+  const posthog = usePostHog()
+  const router = useRouter()
+
+  const onSubmit: SubmitHandler<{ email: string }> = async ({ email }) => {
+    setLoading(true)
+    let eventName: EventName = 'global:user:login:submit'
+    if (signup) {
+      eventName = 'global:user:signup:submit'
+    }
+
+    posthog.capture(eventName, {
+      method: 'email_otp',
+    })
+
+    if (!authenticationSession) {
+      await authSessionStart.mutateAsync(returnTo)
+    }
+
+    const { error } = await emailOTPRequest.mutateAsync(email)
+    if (error) {
+      if (isValidationError(error.detail)) {
+        setValidationErrors(error.detail, setError)
+      }
+    }
+    setLoading(false)
+
+    const urlSearchParams = new URLSearchParams({
+      email,
+      intent: signup ? 'signup' : 'login',
+    })
+    router.push(`/auth/email-otp?${urlSearchParams.toString()}`)
+  }
+
+  return (
+    <Form {...form}>
+      <form className="flex w-full flex-col" onSubmit={handleSubmit(onSubmit)}>
+        <FormField
+          control={control}
+          name="email"
+          render={({ field }) => {
+            return (
+              <FormItem>
+                <FormControl className="w-full">
+                  <div className="flex w-full flex-col gap-2">
+                    <Input
+                      type="email"
+                      required
+                      placeholder="Email"
+                      autoComplete="off"
+                      data-1p-ignore
+                      {...field}
+                    />
+                    <Button
+                      type="submit"
+                      variant="secondary"
+                      fullWidth
+                      loading={loading}
+                      disabled={loading}
+                    >
+                      {signup ? 'Sign up with email' : 'Sign in with email'}
+                    </Button>
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )
+          }}
+        />
+      </form>
+    </Form>
+  )
+}
+
+export default EmailOTPForm

--- a/clients/apps/web/src/app/(main)/auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/app/(main)/auth/EmailOTPForm.tsx
@@ -42,32 +42,42 @@ const EmailOTPForm = ({
 
   const onSubmit: SubmitHandler<{ email: string }> = async ({ email }) => {
     setLoading(true)
-    let eventName: EventName = 'global:user:login:submit'
-    if (signup) {
-      eventName = 'global:user:signup:submit'
-    }
-
-    posthog.capture(eventName, {
-      method: 'email_otp',
-    })
-
-    if (!authenticationSession) {
-      await authSessionStart.mutateAsync(returnTo)
-    }
-
-    const { error } = await emailOTPRequest.mutateAsync(email)
-    if (error) {
-      if (isValidationError(error.detail)) {
-        setValidationErrors(error.detail, setError)
+    try {
+      let eventName: EventName = 'global:user:login:submit'
+      if (signup) {
+        eventName = 'global:user:signup:submit'
       }
-    }
-    setLoading(false)
 
-    const urlSearchParams = new URLSearchParams({
-      email,
-      intent: signup ? 'signup' : 'login',
-    })
-    router.push(`/auth/email-otp?${urlSearchParams.toString()}`)
+      posthog.capture(eventName, {
+        method: 'email_otp',
+      })
+
+      if (!authenticationSession) {
+        await authSessionStart.mutateAsync(returnTo)
+      }
+
+      const { error } = await emailOTPRequest.mutateAsync(email)
+      if (error) {
+        if (isValidationError(error.detail)) {
+          setValidationErrors(error.detail, setError)
+        } else if (error.detail) {
+          setError('email', { message: error.detail })
+        }
+        return
+      }
+
+      const urlSearchParams = new URLSearchParams({
+        email,
+        intent: signup ? 'signup' : 'login',
+      })
+      router.push(`/auth/email-otp?${urlSearchParams.toString()}`)
+    } catch {
+      setError('email', {
+        message: 'An unexpected error occurred. Please try again.',
+      })
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (

--- a/clients/apps/web/src/app/(main)/auth/GitHubLoginButton.tsx
+++ b/clients/apps/web/src/app/(main)/auth/GitHubLoginButton.tsx
@@ -1,5 +1,6 @@
 import { useAuthSessionStart } from '@/hooks'
 import { usePostHog, type EventName } from '@/hooks/posthog'
+import { useToast } from '@/components/Toast/use-toast'
 import { getPublicServerURL } from '@/utils/api'
 import GitHub from '@mui/icons-material/GitHub'
 import { schemas } from '@polar-sh/client'
@@ -20,6 +21,7 @@ const GitHubLoginButton = ({
 }: GitHubLoginButtonProps) => {
   const posthog = usePostHog()
   const authSessionStart = useAuthSessionStart()
+  const { toast } = useToast()
 
   const onClick = async () => {
     let eventName: EventName = 'global:user:login:submit'
@@ -31,7 +33,16 @@ const GitHubLoginButton = ({
     })
 
     if (!authenticationSession) {
-      await authSessionStart.mutateAsync(returnTo)
+      try {
+        await authSessionStart.mutateAsync(returnTo)
+      } catch {
+        toast({
+          title: 'Sign in failed',
+          description:
+            'Could not start authentication session. Please try again.',
+        })
+        return
+      }
     }
     window.location.href = `${getPublicServerURL()}/v1/auth/github/authorize`
   }

--- a/clients/apps/web/src/app/(main)/auth/GitHubLoginButton.tsx
+++ b/clients/apps/web/src/app/(main)/auth/GitHubLoginButton.tsx
@@ -1,0 +1,55 @@
+import { useAuthSessionStart } from '@/hooks'
+import { usePostHog, type EventName } from '@/hooks/posthog'
+import { getPublicServerURL } from '@/utils/api'
+import GitHub from '@mui/icons-material/GitHub'
+import { schemas } from '@polar-sh/client'
+import Button, { type ButtonProps } from '@polar-sh/ui/components/atoms/Button'
+
+interface GitHubLoginButtonProps {
+  authenticationSession: schemas['AuthenticationSession'] | null
+  returnTo?: string
+  signup?: boolean
+  variant?: ButtonProps['variant']
+}
+
+const GitHubLoginButton = ({
+  authenticationSession,
+  returnTo,
+  signup,
+  variant,
+}: GitHubLoginButtonProps) => {
+  const posthog = usePostHog()
+  const authSessionStart = useAuthSessionStart()
+
+  const onClick = async () => {
+    let eventName: EventName = 'global:user:login:submit'
+    if (signup) {
+      eventName = 'global:user:signup:submit'
+    }
+    posthog.capture(eventName, {
+      method: 'github',
+    })
+
+    if (!authenticationSession) {
+      await authSessionStart.mutateAsync(returnTo)
+    }
+    window.location.href = `${getPublicServerURL()}/v1/auth/github/authorize`
+  }
+
+  return (
+    <a onClick={onClick}>
+      <Button
+        variant={variant}
+        wrapperClassNames="space-x-2 p-2.5 px-5"
+        fullWidth
+      >
+        <GitHub />
+        <div className="w-32 text-left">
+          {signup ? 'Sign up with GitHub' : 'Sign in with GitHub'}
+        </div>
+      </Button>
+    </a>
+  )
+}
+
+export default GitHubLoginButton

--- a/clients/apps/web/src/app/(main)/auth/GoogleLoginButton.tsx
+++ b/clients/apps/web/src/app/(main)/auth/GoogleLoginButton.tsx
@@ -1,0 +1,55 @@
+import { useAuthSessionStart } from '@/hooks'
+import { usePostHog, type EventName } from '@/hooks/posthog'
+import { getPublicServerURL } from '@/utils/api'
+import Google from '@mui/icons-material/Google'
+import { schemas } from '@polar-sh/client'
+import Button, { type ButtonProps } from '@polar-sh/ui/components/atoms/Button'
+
+interface GoogleLoginButtonProps {
+  authenticationSession: schemas['AuthenticationSession'] | null
+  returnTo?: string
+  signup?: boolean
+  variant?: ButtonProps['variant']
+}
+
+const GoogleLoginButton = ({
+  authenticationSession,
+  returnTo,
+  signup,
+  variant,
+}: GoogleLoginButtonProps) => {
+  const posthog = usePostHog()
+  const authSessionStart = useAuthSessionStart()
+
+  const onClick = async () => {
+    let eventName: EventName = 'global:user:login:submit'
+    if (signup) {
+      eventName = 'global:user:signup:submit'
+    }
+    posthog.capture(eventName, {
+      method: 'google',
+    })
+
+    if (!authenticationSession) {
+      await authSessionStart.mutateAsync(returnTo)
+    }
+    window.location.href = `${getPublicServerURL()}/v1/auth/google/authorize`
+  }
+
+  return (
+    <a onClick={onClick}>
+      <Button
+        variant={variant}
+        wrapperClassNames="space-x-2 p-2.5 px-5"
+        fullWidth
+      >
+        <Google />
+        <div className="w-32 text-left">
+          {signup ? 'Sign up with Google' : 'Sign in with Google'}
+        </div>
+      </Button>
+    </a>
+  )
+}
+
+export default GoogleLoginButton

--- a/clients/apps/web/src/app/(main)/auth/GoogleLoginButton.tsx
+++ b/clients/apps/web/src/app/(main)/auth/GoogleLoginButton.tsx
@@ -1,5 +1,6 @@
 import { useAuthSessionStart } from '@/hooks'
 import { usePostHog, type EventName } from '@/hooks/posthog'
+import { useToast } from '@/components/Toast/use-toast'
 import { getPublicServerURL } from '@/utils/api'
 import Google from '@mui/icons-material/Google'
 import { schemas } from '@polar-sh/client'
@@ -20,6 +21,7 @@ const GoogleLoginButton = ({
 }: GoogleLoginButtonProps) => {
   const posthog = usePostHog()
   const authSessionStart = useAuthSessionStart()
+  const { toast } = useToast()
 
   const onClick = async () => {
     let eventName: EventName = 'global:user:login:submit'
@@ -31,7 +33,16 @@ const GoogleLoginButton = ({
     })
 
     if (!authenticationSession) {
-      await authSessionStart.mutateAsync(returnTo)
+      try {
+        await authSessionStart.mutateAsync(returnTo)
+      } catch {
+        toast({
+          title: 'Sign in failed',
+          description:
+            'Could not start authentication session. Please try again.',
+        })
+        return
+      }
     }
     window.location.href = `${getPublicServerURL()}/v1/auth/google/authorize`
   }

--- a/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
@@ -30,17 +30,24 @@ const VerifyPage = ({ intent = 'login' }: { intent?: 'login' | 'signup' }) => {
   const [loading, setLoading] = useState(false)
   const onSubmit: SubmitHandler<{ code: string }> = async ({ code }) => {
     setLoading(true)
-    const { error } = await emailOTPVerify.mutateAsync(code)
-    if (error) {
-      if (isValidationError(error.detail)) {
-        setValidationErrors(error.detail, setError)
-      } else if (error.detail) {
-        setError('code', { message: error.detail })
+    try {
+      const { error } = await emailOTPVerify.mutateAsync(code)
+      if (error) {
+        if (isValidationError(error.detail)) {
+          setValidationErrors(error.detail, setError)
+        } else if (error.detail) {
+          setError('code', { message: error.detail })
+        }
+        return
       }
+      router.push('/auth')
+    } catch {
+      setError('code', {
+        message: 'An unexpected error occurred. Please try again.',
+      })
+    } finally {
       setLoading(false)
-      return
     }
-    router.push('/auth')
   }
 
   return (

--- a/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useEmailOTPVerify } from '@/hooks'
+import { setValidationErrors } from '@/utils/api/errors'
+import { CONFIG } from '@/utils/config'
+import { isValidationError } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from '@polar-sh/ui/components/atoms/InputOTP'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+const VerifyPage = ({ intent = 'login' }: { intent?: 'login' | 'signup' }) => {
+  const form = useForm<{ code: string }>()
+  const { control, handleSubmit, setError } = form
+  const emailOTPVerify = useEmailOTPVerify()
+  const router = useRouter()
+
+  const [loading, setLoading] = useState(false)
+  const onSubmit: SubmitHandler<{ code: string }> = async ({ code }) => {
+    setLoading(true)
+    const { error } = await emailOTPVerify.mutateAsync(code)
+    if (error) {
+      if (isValidationError(error.detail)) {
+        setValidationErrors(error.detail, setError)
+      } else if (error.detail) {
+        setError('code', { message: error.detail })
+      }
+      setLoading(false)
+      return
+    }
+    router.push('/auth')
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex w-full flex-col items-center gap-y-6"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <FormField
+          control={control}
+          name="code"
+          render={({ field }) => {
+            return (
+              <FormItem>
+                <FormControl>
+                  <InputOTP
+                    maxLength={6}
+                    pattern="^[a-zA-Z0-9]+$"
+                    inputMode="text"
+                    autoComplete="one-time-code"
+                    {...field}
+                    autoFocus={true}
+                    onChange={(value) => field.onChange(value.toUpperCase())}
+                    onComplete={handleSubmit(onSubmit)}
+                  >
+                    <InputOTPGroup>
+                      {Array.from({ length: 6 }).map((_, index) => (
+                        <InputOTPSlot
+                          key={index}
+                          index={index}
+                          className="dark:border-polar-600 h-12 w-12 border-gray-300 text-xl md:h-16 md:w-16 md:text-2xl"
+                        />
+                      ))}
+                    </InputOTPGroup>
+                  </InputOTP>
+                </FormControl>
+                <FormMessage className="text-center" />
+              </FormItem>
+            )
+          }}
+        />
+        <Button type="submit" size="lg" className="w-full" loading={loading}>
+          {intent === 'signup' ? 'Sign up' : 'Sign in'}
+          {CONFIG.IS_SANDBOX && ' to Sandbox'}
+        </Button>
+      </form>
+    </Form>
+  )
+}
+
+export default VerifyPage

--- a/clients/apps/web/src/app/(main)/auth/email-otp/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/email-otp/page.tsx
@@ -1,0 +1,49 @@
+import LogoIcon from '@/components/Brand/logos/LogoIcon'
+import { Metadata } from 'next'
+import VerifyPage from './VerifyPage'
+import { checkAuthenticationSession } from '@/utils/auth'
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { redirect } from 'next/navigation'
+
+export const metadata: Metadata = {
+  title: 'Enter verification code',
+}
+
+export default async function Page(props: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const api = await getServerSideAPI()
+  const authenticationSession = await checkAuthenticationSession(api)
+  if (!authenticationSession) {
+    redirect('/auth')
+  }
+
+  const searchParams = await props.searchParams
+  const email = searchParams.email as string
+  const intent = searchParams.intent as 'login' | 'signup' | undefined
+
+  return (
+    <div className="dark:bg-polar-950 flex h-screen w-full grow items-center justify-center bg-white">
+      <div className="flex w-80 flex-col items-center">
+        <LogoIcon size={60} className="mb-6 text-black dark:text-white" />
+        {intent === 'signup' && (
+          <h1 className="mb-1 text-xl font-medium text-gray-700 dark:text-white">
+            Welcome to Polar!
+          </h1>
+        )}
+        <div className="dark:text-polar-400 mb-2 text-center text-gray-500">
+          {intent === 'signup'
+            ? 'To get started, we sent a verification code to '
+            : 'We sent a verification code to '}
+          <span className="dark:text-polar-300 font-medium text-gray-600">
+            {email}
+          </span>
+        </div>
+        <div className="dark:text-polar-400 mb-6 text-center text-sm text-gray-500">
+          Please enter the 6-character code below
+        </div>
+        <VerifyPage intent={intent} />
+      </div>
+    </div>
+  )
+}

--- a/clients/apps/web/src/app/(main)/auth/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/page.tsx
@@ -1,0 +1,75 @@
+import { PolarLogotype } from '@/components/Layout/Public/PolarLogotype'
+import { CONFIG } from '@/utils/config'
+import { Metadata } from 'next'
+import { cookies } from 'next/headers'
+import Auth from './Auth'
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { checkAuthenticationSession } from '@/utils/auth'
+import { schemas } from '@polar-sh/client'
+import { redirect } from 'next/navigation'
+
+export const metadata: Metadata = {
+  title: 'Log in to Polar',
+}
+
+export default async function Page(props: {
+  searchParams: Promise<{
+    error?: string
+    return_to?: string
+    from?: string
+  }>
+}) {
+  const api = await getServerSideAPI()
+  const authenticationSession = await checkAuthenticationSession(api)
+  const searchParams = await props.searchParams
+
+  if (
+    authenticationSession &&
+    authenticationSession.available_factors.includes('totp')
+  ) {
+    redirect('/auth/totp')
+  }
+
+  const { return_to } = searchParams
+
+  const cookieStore = await cookies()
+  const lastLoginMethod =
+    cookieStore.get('polar_last_login_method')?.value ?? null
+
+  return (
+    <div className="flex h-screen w-full grow items-center justify-center">
+      <div className="dark:bg-polar-900 flex w-full max-w-md flex-col justify-between gap-8 rounded-3xl bg-gray-50 p-12">
+        <div className="flex flex-col gap-y-4">
+          <PolarLogotype logoVariant="icon" size={60} />
+          <div className="flex flex-col gap-4">
+            <h2 className="text-2xl text-black dark:text-white">
+              {CONFIG.IS_SANDBOX
+                ? 'Welcome to the Polar Sandbox'
+                : 'Welcome to Polar'}
+            </h2>
+            <span className="dark:text-polar-400 text-lg text-balance text-gray-500">
+              {CONFIG.IS_SANDBOX ? (
+                <>
+                  This is a testing environment. Changes here won&rsquo;t affect
+                  your live account and payments are not processed.
+                </>
+              ) : (
+                'Monetize your software'
+              )}
+            </span>
+          </div>
+          {searchParams.error && (
+            <div className="rounded-lg bg-red-50 p-4 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+              {searchParams.error}
+            </div>
+          )}
+        </div>
+        <Auth
+          authenticationSession={authenticationSession}
+          lastLoginMethod={lastLoginMethod as schemas['Factor'] | null}
+          returnTo={return_to}
+        />
+      </div>
+    </div>
+  )
+}

--- a/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useTOTPVerify } from '@/hooks'
+import { setValidationErrors } from '@/utils/api/errors'
+import { CONFIG } from '@/utils/config'
+import { isValidationError } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from '@polar-sh/ui/components/atoms/InputOTP'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+const VerifyPage = () => {
+  const form = useForm<{ code: string }>()
+  const { control, handleSubmit, setError } = form
+  const totpVerify = useTOTPVerify()
+  const router = useRouter()
+
+  const [loading, setLoading] = useState(false)
+  const onSubmit: SubmitHandler<{ code: string }> = async ({ code }) => {
+    setLoading(true)
+    const { error } = await totpVerify.mutateAsync(code)
+    if (error) {
+      if (isValidationError(error.detail)) {
+        setValidationErrors(error.detail, setError)
+      } else if (error.detail) {
+        setError('code', { message: error.detail })
+      }
+      setLoading(false)
+      return
+    }
+    router.push('/auth')
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex w-full flex-col items-center gap-y-6"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <FormField
+          control={control}
+          name="code"
+          render={({ field }) => {
+            return (
+              <FormItem>
+                <FormControl>
+                  <InputOTP
+                    maxLength={6}
+                    pattern="^[a-zA-Z0-9]+$"
+                    inputMode="text"
+                    autoComplete="one-time-code"
+                    {...field}
+                    autoFocus={true}
+                    onChange={(value) => field.onChange(value.toUpperCase())}
+                    onComplete={handleSubmit(onSubmit)}
+                  >
+                    <InputOTPGroup>
+                      {Array.from({ length: 6 }).map((_, index) => (
+                        <InputOTPSlot
+                          key={index}
+                          index={index}
+                          className="dark:border-polar-600 h-12 w-12 border-gray-300 text-xl md:h-16 md:w-16 md:text-2xl"
+                        />
+                      ))}
+                    </InputOTPGroup>
+                  </InputOTP>
+                </FormControl>
+                <FormMessage className="text-center" />
+              </FormItem>
+            )
+          }}
+        />
+        <Button type="submit" size="lg" className="w-full" loading={loading}>
+          Sign in
+          {CONFIG.IS_SANDBOX && ' to Sandbox'}
+        </Button>
+      </form>
+    </Form>
+  )
+}
+
+export default VerifyPage

--- a/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
@@ -30,17 +30,24 @@ const VerifyPage = () => {
   const [loading, setLoading] = useState(false)
   const onSubmit: SubmitHandler<{ code: string }> = async ({ code }) => {
     setLoading(true)
-    const { error } = await totpVerify.mutateAsync(code)
-    if (error) {
-      if (isValidationError(error.detail)) {
-        setValidationErrors(error.detail, setError)
-      } else if (error.detail) {
-        setError('code', { message: error.detail })
+    try {
+      const { error } = await totpVerify.mutateAsync(code)
+      if (error) {
+        if (isValidationError(error.detail)) {
+          setValidationErrors(error.detail, setError)
+        } else if (error.detail) {
+          setError('code', { message: error.detail })
+        }
+        return
       }
+      router.push('/auth')
+    } catch {
+      setError('code', {
+        message: 'An unexpected error occurred. Please try again.',
+      })
+    } finally {
       setLoading(false)
-      return
     }
-    router.push('/auth')
   }
 
   return (
@@ -58,12 +65,13 @@ const VerifyPage = () => {
                 <FormControl>
                   <InputOTP
                     maxLength={6}
-                    pattern="^[a-zA-Z0-9]+$"
-                    inputMode="text"
+                    minLength={6}
+                    pattern="^\d{6}$"
+                    inputMode="numeric"
                     autoComplete="one-time-code"
                     {...field}
                     autoFocus={true}
-                    onChange={(value) => field.onChange(value.toUpperCase())}
+                    onChange={field.onChange}
                     onComplete={handleSubmit(onSubmit)}
                   >
                     <InputOTPGroup>

--- a/clients/apps/web/src/app/(main)/auth/totp/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/totp/page.tsx
@@ -1,0 +1,30 @@
+import LogoIcon from '@/components/Brand/logos/LogoIcon'
+import { Metadata } from 'next'
+import VerifyPage from './VerifyPage'
+import { checkAuthenticationSession } from '@/utils/auth'
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { redirect } from 'next/navigation'
+
+export const metadata: Metadata = {
+  title: 'Enter OTP code',
+}
+
+export default async function Page() {
+  const api = await getServerSideAPI()
+  const authenticationSession = await checkAuthenticationSession(api)
+  if (!authenticationSession) {
+    redirect('/auth')
+  }
+
+  return (
+    <div className="dark:bg-polar-950 flex h-screen w-full grow items-center justify-center bg-white">
+      <div className="flex w-80 flex-col items-center">
+        <LogoIcon size={60} className="mb-6 text-black dark:text-white" />
+        <div className="dark:text-polar-400 mb-6 text-center text-sm text-gray-500">
+          Enter the 6-digit code from your authenticator app
+        </div>
+        <VerifyPage />
+      </div>
+    </div>
+  )
+}

--- a/clients/apps/web/src/components/Auth/Login.tsx
+++ b/clients/apps/web/src/components/Auth/Login.tsx
@@ -129,7 +129,10 @@ const Login = ({
           <div className="text-sm text-gray-500">or</div>
           <div className="dark:border-polar-700 grow border-t border-gray-200" />
         </div>
-        <LastUsedWrapper show={lastLoginMethod === 'email'}>
+        <LastUsedWrapper
+          // Both email_otp and email for backward compatibility since we renamed email to email_otp but some users might still have the old value in their cookies
+          show={lastLoginMethod === 'email_otp' || lastLoginMethod === 'email'}
+        >
           <LoginCodeForm {...loginProps} />
         </LastUsedWrapper>
       </div>

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -3,6 +3,7 @@ import { AuthContext } from '@/providers/auth'
 import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
 import * as Sentry from '@sentry/nextjs'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { useContext, useEffect } from 'react'
 
 export const useAuth = (): {
@@ -48,3 +49,35 @@ export const useAuth = (): {
     setUserOrganizations,
   }
 }
+
+export const useAuthSessionStart = () =>
+  useMutation({
+    mutationFn: (return_to?: string) =>
+      api.POST('/v1/auth/start', { body: { return_to } }),
+  })
+
+export const useAuthSessionStatus = () => {
+  return useQuery({
+    queryKey: ['auth', 'session'],
+    queryFn: () => api.GET('/v1/auth/status'),
+    retry: false,
+  })
+}
+
+export const useEmailOTPRequest = () =>
+  useMutation({
+    mutationFn: (email: string) =>
+      api.POST('/v1/auth/email-otp/request', { body: { email } }),
+  })
+
+export const useEmailOTPVerify = () =>
+  useMutation({
+    mutationFn: (code: string) =>
+      api.POST('/v1/auth/email-otp/verify', { body: { code } }),
+  })
+
+export const useTOTPVerify = () =>
+  useMutation({
+    mutationFn: (code: string) =>
+      api.POST('/v1/auth/totp/verify', { body: { code } }),
+  })

--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -1,5 +1,6 @@
-import { getPublicServerURL } from '@/utils/api'
-import { operations } from '@polar-sh/client'
+import { getPublicServerURL, getServerURL } from '@/utils/api'
+import { Client, operations, schemas } from '@polar-sh/client'
+import { redirect } from 'next/navigation'
 
 export const getGitHubAuthorizeLoginURL = (
   params: NonNullable<
@@ -92,4 +93,26 @@ export const getGitHubRepositoryBenefitAuthorizeURL = (
     searchParams.set('return_to', params.return_to)
   }
   return `${getPublicServerURL()}/v1/integrations/github_repository_benefit/user/authorize?${searchParams}`
+}
+
+export const checkAuthenticationSession = async (
+  api: Client,
+): Promise<schemas['AuthenticationSession'] | null> => {
+  const { error, data: authenticationSession } =
+    await api.GET('/v1/auth/status')
+  if (error) {
+    if (error.error !== 'InvalidAuthenticationSession') {
+      throw new Error(`Failed to check authentication session: ${error.error}`)
+    }
+    return null
+  }
+
+  if (
+    authenticationSession.identity_id &&
+    authenticationSession.available_factors.length === 0
+  ) {
+    redirect(`${getServerURL()}/v1/auth/complete`)
+  }
+
+  return authenticationSession
 }


### PR DESCRIPTION

Implement new authentication pages and components to support our new authentication factors, including TOTP.

I duplicated the existing auth pages and components on purpose, so the new flow and the current flow can coexist without interfering with each other; until the new auth flow is fully ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apple, GitHub, and Google sign-in buttons with clear "Sign in"/"Sign up" labeling
  * Added email one-time-password (OTP) request and verification flow (enter code page)
  * Added TOTP (authenticator app) verification flow and pages
  * New consolidated Auth/login page with last-used method indicator and error banner
  * Improved session checks and error handling during authentication flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->