### PR TITLE
Allow upgrading from non-seat to seat

### DIFF
--- a/docs/features/subscriptions/manage.mdx
+++ b/docs/features/subscriptions/manage.mdx
@@ -13,7 +13,8 @@ All of these actions are available under **Sales → Subscriptions** in the dash
 Switch a subscription to a different recurring product — the standard upgrade or downgrade flow.
 
 - When the change takes effect depends on the [proration behavior](/features/subscriptions/proration): `invoice` and `prorate` apply the new product immediately, while `next_period` schedules a pending update that's only applied at the start of the next billing cycle.
-- The new product must share the subscription's currency and must either both be seat-based or both not be — you can't switch a flat subscription to a seat-based product or vice versa.
+- The new product must share the subscription's currency.
+- You can upgrade a non-seat subscription to a seat-based product — the billing customer is auto-promoted to a `team` customer and claims a seat — but you can't switch a seat-based subscription back to a non-seat product. Non-seat → seat changes must apply immediately, so `next_period` proration isn't allowed for that transition.
 - You can't change the plan on a subscription that's already canceled or scheduled to cancel — uncancel first.
 - Plan changes on a **trialing** subscription are allowed. The trial carries over with its end recomputed from the new product's trial length (anchored to the original `trial_start`). If the new product has no trial — or its trial would already have elapsed — the trial ends immediately and a fresh billing cycle starts on the new product.
 - Custom-priced products (pay-what-you-want) aren't valid destinations for a plan change.

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1098,13 +1098,15 @@ class SubscriptionService:
 
         old_has_seat_prices = any(is_seat_price(p) for p in previous_prices)
         new_has_seat_prices = any(is_seat_price(p) for p in currency_prices)
-        if old_has_seat_prices != new_has_seat_prices:
+
+        # Seat → non-seat plan changes are not yet supported.
+        if old_has_seat_prices and not new_has_seat_prices:
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "product_id"),
-                        "msg": "Can't switch between seat-based and non-seat-based products.",
+                        "msg": "Can't switch from a seat-based to a non-seat-based product.",
                         "input": product_id,
                     }
                 ]
@@ -1154,6 +1156,29 @@ class SubscriptionService:
         if proration_behavior is None:
             proration_behavior = organization.proration_behavior
 
+        # Non-seat → seat upgrades: promote `subscription.seats` to the new
+        # product's first seat-price tier minimum so the proration debit and
+        # `apply_update`'s product-branch rebuild both see a valid seat count.
+        # Block `next_period` because the post-apply seat auto-claim has to run
+        # immediately so the billing customer doesn't lose benefit access.
+        is_initial_seat_transition = not old_has_seat_prices and new_has_seat_prices
+        if is_initial_seat_transition:
+            if proration_behavior == SubscriptionProrationBehavior.next_period:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "proration_behavior"),
+                            "msg": "Switching from a non-seat to a seat-based product must apply immediately and can't use the 'next_period' proration behavior.",
+                            "input": proration_behavior,
+                        }
+                    ]
+                )
+            for price in currency_prices:
+                if is_seat_price(price):
+                    subscription.seats = price.get_minimum_seats()
+                    break
+
         subscription_update_repository = SubscriptionUpdateRepository.from_session(
             session
         )
@@ -1202,6 +1227,20 @@ class SubscriptionService:
             ):
                 # Invoice and attempt to pay immediately
                 await self._create_subscription_update_order(session, subscription)
+
+            # When transitioning from non-seat to seat-based pricing, promote
+            # the billing customer to a 'team' customer and claim a seat for
+            # them so they keep benefit access immediately after the switch.
+            if is_initial_seat_transition:
+                await self._maybe_upgrade_customer_to_team(
+                    session, subscription.customer
+                )
+                await seat_service.assign_seat(
+                    session,
+                    subscription,
+                    customer_id=subscription.customer_id,
+                    immediate_claim=True,
+                )
 
             await self.enqueue_benefits_grants(session, subscription)
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -490,13 +490,7 @@ class SubscriptionService:
 
         # Auto-upgrade customer to 'team' type when subscribing to a seat-based product
         if product.has_seat_based_price:
-            customer_type = customer.type or CustomerType.individual
-            if customer_type == CustomerType.individual:
-                await customer_repository.update(
-                    customer,
-                    update_dict={"type": CustomerType.team},
-                    flush=True,
-                )
+            await self._maybe_upgrade_customer_to_team(session, customer)
 
         await self._after_subscription_created(session, subscription)
         # ⚠️ Some users are relying on `subscription.updated` for everything
@@ -628,14 +622,7 @@ class SubscriptionService:
 
         # Auto-upgrade customer to 'team' type when subscribing to a seat-based product
         if product.has_seat_based_price:
-            customer_type = customer.type or CustomerType.individual
-            if customer_type == CustomerType.individual:
-                customer_repository = CustomerRepository.from_session(session)
-                await customer_repository.update(
-                    customer,
-                    update_dict={"type": CustomerType.team},
-                    flush=True,
-                )
+            await self._maybe_upgrade_customer_to_team(session, customer)
 
         # Link potential discount redemption to the subscription
         if subscription.discount is not None:
@@ -848,6 +835,19 @@ class SubscriptionService:
                         },
                     ),
                 )
+
+    async def _maybe_upgrade_customer_to_team(
+        self, session: AsyncSession, customer: Customer
+    ) -> None:
+        customer_type = customer.type or CustomerType.individual
+        if customer_type != CustomerType.individual:
+            return
+        customer_repository = CustomerRepository.from_session(session)
+        await customer_repository.update(
+            customer,
+            update_dict={"type": CustomerType.team},
+            flush=True,
+        )
 
     async def _after_subscription_created(
         self, session: AsyncSession, subscription: Subscription

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.util.typing import TypeAlias
 from polar.auth.models import AuthSubject
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.checkout.eventstream import CheckoutEvent
+from polar.customer_seat.repository import CustomerSeatRepository
 from polar.email.schemas import SubscriptionRevokedEmail
 from polar.enums import (
     PaymentProcessor,
@@ -3268,8 +3269,6 @@ class TestUpdateProduct:
         assert updated.product == seat_product
         assert updated.seats == 1
 
-        from polar.customer_seat.repository import CustomerSeatRepository
-
         seat_repository = CustomerSeatRepository.from_session(session)
         seats = await seat_repository.list_by_subscription_id(updated.id)
         claimed = [s for s in seats if s.status == SeatStatus.claimed]
@@ -3380,6 +3379,12 @@ class TestUpdateProduct:
         organization: Organization,
         product: Product,
     ) -> None:
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
         subscription = await create_active_subscription(
             save_fixture, product=product, customer=customer
         )
@@ -3391,13 +3396,20 @@ class TestUpdateProduct:
             prices=[("seat", 1500, "usd")],
         )
 
-        with pytest.raises(PolarRequestValidationError):
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             await subscription_service.update_product(
                 session,
                 subscription,
                 product_id=seat_product.id,
                 proration_behavior=SubscriptionProrationBehavior.next_period,
             )
+
+        errors = exc_info.value.errors()
+        assert any(
+            error["loc"] == ("body", "proration_behavior")
+            and "next_period" in error["msg"]
+            for error in errors
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2903,39 +2903,6 @@ class TestUpdateProduct:
                 product_id=fixed_product.id,
             )
 
-    async def test_fixed_to_seat_based_not_allowed(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        customer: Customer,
-    ) -> None:
-        fixed_product = await create_product(
-            save_fixture,
-            organization=organization,
-            recurring_interval=SubscriptionRecurringInterval.month,
-            prices=[(20000, "usd")],
-        )
-        seat_product = await create_product(
-            save_fixture,
-            organization=organization,
-            recurring_interval=SubscriptionRecurringInterval.month,
-            prices=[("seat", 10000, "usd")],
-        )
-
-        subscription = await create_active_subscription(
-            save_fixture,
-            product=fixed_product,
-            customer=customer,
-        )
-
-        with pytest.raises(PolarRequestValidationError):
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=seat_product.id,
-            )
-
     async def test_upgrade_from_legacy_recurring_product_to_new_recurring_product(
         self,
         session: AsyncSession,
@@ -3249,6 +3216,188 @@ class TestUpdateProduct:
         assert pending is not None
         assert pending.product_id == product_b.id
         assert pending.seats == 8
+
+    async def test_non_seat_to_seat_upgrade_succeeds(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[],
+        )
+        seat_price = ProductPriceSeatUnit(
+            price_currency=PresentmentCurrency.usd,
+            seat_tiers={
+                "tiers": [
+                    {"min_seats": 1, "max_seats": None, "price_per_seat": 1500},
+                ]
+            },
+            product=seat_product,
+        )
+        await save_fixture(seat_price)
+        seat_product.prices.append(seat_price)
+        await save_fixture(seat_product)
+
+        updated = await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=seat_product.id,
+            proration_behavior=SubscriptionProrationBehavior.invoice,
+        )
+
+        assert updated.product == seat_product
+        assert updated.seats == 1
+
+        from polar.customer_seat.repository import CustomerSeatRepository
+
+        seat_repository = CustomerSeatRepository.from_session(session)
+        seats = await seat_repository.list_by_subscription_id(updated.id)
+        claimed = [s for s in seats if s.status == SeatStatus.claimed]
+        assert len(claimed) == 1
+        assert claimed[0].customer_id == customer.id
+
+    async def test_non_seat_to_seat_upgrade_promotes_customer_to_team(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        customer.type = CustomerType.individual
+        await save_fixture(customer)
+
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1500, "usd")],
+        )
+
+        updated = await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=seat_product.id,
+            proration_behavior=SubscriptionProrationBehavior.invoice,
+        )
+
+        await session.refresh(updated.customer)
+        assert updated.customer.type == CustomerType.team
+
+    async def test_non_seat_to_seat_upgrade_generates_seat_debit_proration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 2000, "usd")],
+        )
+
+        updated = await subscription_service.update_product(
+            session,
+            subscription,
+            product_id=seat_product.id,
+            proration_behavior=SubscriptionProrationBehavior.prorate,
+        )
+
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        entries = await billing_entry_repository.get_pending_by_subscription(updated.id)
+        seat_price_id = next(
+            spp.product_price_id
+            for spp in updated.subscription_product_prices
+            if spp.product_price.amount_type == ProductPriceAmountType.seat_based
+        )
+        seat_debits = [
+            e
+            for e in entries
+            if e.product_price_id == seat_price_id
+            and e.direction == BillingEntryDirection.debit
+            and e.type == BillingEntryType.proration
+        ]
+        assert len(seat_debits) == 1
+        assert seat_debits[0].amount is not None
+        assert seat_debits[0].amount > 0
+
+    async def test_non_seat_to_seat_upgrade_rejects_next_period(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1500, "usd")],
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            await subscription_service.update_product(
+                session,
+                subscription,
+                product_id=seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan upgrades from standard to seat-based subscriptions are now fully supported with automatic customer and seat assignment.

* **Bug Fixes**
  * Enhanced validation to clearly reject incompatible subscription plan transitions.

* **Documentation**
  * Clarified plan change requirements including currency matching and seat-based transition rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->