### PR TITLE
Wait for fulfillment before emitting embed success event

### DIFF
--- a/clients/apps/web/src/hooks/checkout.ts
+++ b/clients/apps/web/src/hooks/checkout.ts
@@ -44,15 +44,21 @@ export const useCheckoutConfirmedRedirect = (
         )
       }
 
-      // For external success URL, make sure the checkout is processed before redirecting
-      // It ensures the user will have an up-to-date status when they are redirected,
-      // especially if the external URL doesn't implement proper webhook handling
-      if (!isInternalSuccessURL && listenFulfillment) {
+      // Wait for actual payment fulfillment before declaring success when
+      // either the redirect destination can't observe in flight state
+      // (external success URL) or a merchant is listening on the parent
+      // page (embed_origin). confirm() returning only means the payment
+      // intent was dispatched to Stripe.
+      // Without this gate, embed_origin receives a success postMessage on
+      // a non-terminal state and merchants treat declined payments as
+      // completed purchases.
+      if ((!isInternalSuccessURL || embed) && listenFulfillment) {
         try {
           await listenFulfillment()
         } catch {
-          // The fullfillment listener timed out.
-          // Redirect to confirm page where we'll be able to recover
+          // Fulfillment didn't complete within the timeout. Fall back to
+          // our /confirmation page where the live state is rendered. Don't
+          // emit a `success` postMessage to the merchant.
           router.push(
             `/checkout/${checkout.client_secret}/confirmation?${parsedURL.searchParams}`,
           )


### PR DESCRIPTION
Our embedded checkout iframe was posting `event: 'success'` to the parent the moment `confirm()` returned (`status === 'confirmed'`), not when the payment actually settled (`status === 'succeeded'`). Merchants listening for that event were fulfilling customers whose charges later got blocked by Stripe risk rules or declined.


👇 Notice how the `success` event is fired immediately after `confirmed` before the fix

| Before the fix | After the fix  |
|--------|--------|
| <img width="1840" height="1133" alt="without-fix" src="https://github.com/user-attachments/assets/9040a1f7-4b01-4f91-9622-649b01573a89" /> | <img width="1840" height="1133" alt="with-fix" src="https://github.com/user-attachments/assets/50055f57-4532-4b7a-858d-8f6a3ea1ed7b" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout confirmation now waits for actual fulfillment more broadly (including embed/internal and external flows) before showing success.
  * If fulfillment fails or times out, users are redirected to the confirmation page to prevent premature success state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->