### PR TITLE
fix: partial unique index on organization_reviews

### DIFF
--- a/server/migrations/versions/2026-05-27-1150_organization_reviews_partial_unique_.py
+++ b/server/migrations/versions/2026-05-27-1150_organization_reviews_partial_unique_.py
@@ -1,0 +1,74 @@
+"""organization_reviews_partial_unique_index
+
+Revision ID: a102bf8a2204
+Revises: 1635867d733d
+Create Date: 2026-05-27 11:50:15.163992
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "a102bf8a2204"
+down_revision = "1635867d733d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Swap the total unique index on organization_id for a partial one
+    # (WHERE deleted_at IS NULL). The total form blocked re-INSERTs after
+    # soft-deleted rows accumulated. Same pattern as
+    # add_partial_unique_owner_index and discount_ignore_soft_deletes.
+    #
+    # CONCURRENTLY requires autocommit_block. Steps are idempotent
+    # (IF EXISTS guards + temp _new name), so a failed deploy retries
+    # cleanly.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "ix_organization_reviews_organization_id_new"
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY "
+            "ix_organization_reviews_organization_id_new "
+            "ON organization_reviews (organization_id) "
+            "WHERE deleted_at IS NULL"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_organization_reviews_organization_id"
+        )
+        op.execute(
+            "ALTER INDEX IF EXISTS "
+            "ix_organization_reviews_organization_id_new "
+            "RENAME TO ix_organization_reviews_organization_id"
+        )
+
+
+def downgrade() -> None:
+    # Mirror image of upgrade — re-create the total unique index under
+    # a temp name, drop the partial, rename back. Same re-runnability
+    # discipline. NOTE: the CREATE will fail if any organization has
+    # both a live and a soft-deleted review row by the time downgrade
+    # runs; that's intentional — the data state would need to be
+    # cleaned up before reverting the swap.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "ix_organization_reviews_organization_id_old"
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY "
+            "ix_organization_reviews_organization_id_old "
+            "ON organization_reviews (organization_id)"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_organization_reviews_organization_id"
+        )
+        op.execute(
+            "ALTER INDEX IF EXISTS "
+            "ix_organization_reviews_organization_id_old "
+            "RENAME TO ix_organization_reviews_organization_id"
+        )

--- a/server/polar/models/organization_review.py
+++ b/server/polar/models/organization_review.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from sqlalchemy import TIMESTAMP, ForeignKey, String, Text, Uuid
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, String, Text, Uuid, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
@@ -26,13 +26,22 @@ class OrganizationReview(RecordModel):
         REJECTED = "rejected"
 
     __tablename__ = "organization_reviews"
+    __table_args__ = (
+        # Partial unique index: at most one live (non-soft-deleted) review
+        # per organization. Soft-deleted rows are allowed to coexist with
+        # a new live row, so a re-review after cleanup can INSERT cleanly.
+        Index(
+            "ix_organization_reviews_organization_id",
+            "organization_id",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
 
     organization_id: Mapped[UUID] = mapped_column(
         Uuid,
         ForeignKey("organizations.id", ondelete="cascade"),
         nullable=False,
-        unique=True,
-        index=True,
     )
 
     verdict: Mapped[Verdict] = mapped_column(String, nullable=False)


### PR DESCRIPTION
## Summary

The unique index on `organization_reviews(organization_id)` did not filter on `deleted_at`, so a soft-deleted row blocked any subsequent INSERT for the same organization. The SUBMISSION review worker then crashed with `UniqueViolationError`, retried once, and DLQed; affected dashboards polled `/review-status` indefinitely showing "Reviewing organization…" with no verdict and no recovery path.

## What

- Drop the total unique index `ix_organization_reviews_organization_id`.
- Recreate it as a partial unique index with `WHERE deleted_at IS NULL`.
- Update the `OrganizationReview` model's `__table_args__` to match.

Migration uses `CREATE/DROP INDEX CONCURRENTLY` inside `autocommit_block` so no table-level write lock is held. Each step is idempotent (IF EXISTS guards + temp `_new` name), so a failed deploy retries cleanly.

## Why

This is the established pattern in Polar for soft-deletable models with per-parent uniqueness (`members`, `subscription_update`, `user_organization`, `discount`, `organization_review_feedback`, and others).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (\`uv run task lint && uv run task lint_types\`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database constraint handling for organization reviews so soft-deleted entries no longer block new reviews, allowing multiple stored reviews per organization with only one active at a time.
* **Chores**
  * Added a database migration to apply the constraint change safely without downtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->