### PR TITLE
amount v2: Migrate account_credits to bigint

### DIFF
--- a/server/migrations/versions/2026-05-27-1524_widen_account_credits_amount_to_bigint.py
+++ b/server/migrations/versions/2026-05-27-1524_widen_account_credits_amount_to_bigint.py
@@ -1,0 +1,52 @@
+"""widen account_credits amount to bigint
+
+Revision ID: f28bbb86dcf1
+Revises: a102bf8a2204
+Create Date: 2026-05-27 15:24:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "f28bbb86dcf1"
+down_revision = "a102bf8a2204"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "account_credits",
+        "amount",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "account_credits",
+        "used",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "account_credits",
+        "used",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "account_credits",
+        "amount",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )

--- a/server/polar/models/account_credit.py
+++ b/server/polar/models/account_credit.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import TIMESTAMP, ForeignKey, Index, Integer, String, Text, Uuid
+from sqlalchemy import TIMESTAMP, BigInteger, ForeignKey, Index, String, Text, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import RecordModel
@@ -32,8 +32,8 @@ class AccountCredit(MetadataMixin, RecordModel):
         Uuid, ForeignKey("campaigns.id", ondelete="set null"), nullable=True, index=True
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
-    amount: Mapped[int] = mapped_column(Integer, nullable=False)
-    used: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    used: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
     granted_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow


### PR DESCRIPTION
Since the account_credits table is so small, we can do this as an online alter table without having to create a separate column and backfill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased numeric capacity for account credit values across the application so larger credit and used amounts can be stored.
  * Updated the data model and included a database migration to apply the schema change and to revert it if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->