### PR TITLE
amount v2: Migrate subscription_meters to BigInt

### DIFF
--- a/server/migrations/versions/2026-05-27-1540_widen_subscription_meters_amount_to_bigint.py
+++ b/server/migrations/versions/2026-05-27-1540_widen_subscription_meters_amount_to_bigint.py
@@ -1,0 +1,38 @@
+"""widen subscription_meters amount to bigint
+
+Revision ID: f2d8090bf7c2
+Revises: f28bbb86dcf1
+Create Date: 2026-05-27 15:40:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "f2d8090bf7c2"
+down_revision = "f28bbb86dcf1"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "subscription_meters",
+        "amount",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "subscription_meters",
+        "amount",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )

--- a/server/polar/models/subscription_meter.py
+++ b/server/polar/models/subscription_meter.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Numeric, UniqueConstraint, Uuid
+from sqlalchemy import BigInteger, ForeignKey, Numeric, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 from sqlalchemy.sql.sqltypes import Integer
 
@@ -19,7 +19,7 @@ class SubscriptionMeter(RecordModel):
 
     consumed_units: Mapped[Decimal] = mapped_column(Numeric, nullable=False, default=0)
     credited_units: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    amount: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    amount: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
     subscription_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("subscriptions.id", ondelete="cascade"), nullable=False


### PR DESCRIPTION
Since the subscription_meters table is so small, we can do this as an online alter table without having to create a separate column and backfill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Increased storage capacity for subscription meter amounts to support larger values.
  * Applied a database migration to expand the amount column and updated the data model mapping accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->