### PR TITLE
Allow /to/ on sandbox

### DIFF
--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -30,6 +30,7 @@ const SANDBOX_ALLOWED_PATHS: (string | RegExp)[] = [
   '/embed',
   '/verify-email',
   '/api',
+  '/to',
   /^\/favicon[\w-]*\.\w+$/, // /favicon.png, /favicon-dark.png, etc.
   /^\/[^/]+\/portal(\/|$)/, // /:organization/portal
 ]


### PR DESCRIPTION
`/to/` was missing from `SANDBOX_ALLOWED_PATHS`, so any `/to/*` request on https://sandbox.polar.sh would get a 404



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sandbox mode to permit access to additional routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->