### PR TITLE
Tweak seat assignment post-checkout

### DIFF
--- a/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
@@ -50,6 +50,10 @@ const CheckoutBenefits = ({
     return () => clearInterval(intervalId)
   }, [benefitGrants, expectedBenefits, maxWaitingTimeMs, refetch])
 
+  if (expectedBenefits === 0) {
+    return null
+  }
+
   return (
     <div className="flex w-full flex-col gap-4 text-left">
       <List className="rounded-3xl">
@@ -65,7 +69,7 @@ const CheckoutBenefits = ({
             />
           </ListItem>
         ))}
-        {benefitGrants && benefitGrants.items.length < expectedBenefits && (
+        {(benefitGrants?.items?.length || 0) < expectedBenefits && (
           <ListItem className="flex flex-row items-center justify-center gap-2">
             <SpinnerNoMargin className="h-4 w-4" />
             <p className="dark:text-polar-500 text-gray-500">

--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -229,19 +229,21 @@ export const CheckoutConfirmation = ({
           )}
           {status === 'succeeded' && (
             <>
-              <CheckoutSeatInvitations
-                checkout={checkout}
-                customerSessionToken={customerSessionToken}
-              />
               {hasProductCheckout(checkout) &&
-                checkout.product_price.amount_type !== 'seat_based' && (
+                (checkout.product_price.amount_type === 'seat_based' &&
+                (checkout.seats ?? 0) > 1 ? (
+                  <CheckoutSeatInvitations
+                    checkout={checkout}
+                    customerSessionToken={customerSessionToken}
+                  />
+                ) : (
                   <CheckoutBenefits
                     checkout={checkout}
                     locale={locale}
                     customerSessionToken={customerSessionToken}
                     maxWaitingTimeMs={maxWaitingTimeMs}
                   />
-                )}
+                ))}
               <p className="dark:text-polar-500 text-center text-xs text-gray-500">
                 {t('checkout.footer.merchantOfRecord')}
               </p>

--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -227,23 +227,21 @@ export const CheckoutConfirmation = ({
               )}
             </div>
           )}
-          {status === 'succeeded' && (
+          {status === 'succeeded' && hasProductCheckout(checkout) && (
             <>
-              {hasProductCheckout(checkout) &&
-                (checkout.product_price.amount_type === 'seat_based' &&
-                (checkout.seats ?? 0) > 1 ? (
+              <CheckoutBenefits
+                checkout={checkout}
+                locale={locale}
+                customerSessionToken={customerSessionToken}
+                maxWaitingTimeMs={maxWaitingTimeMs}
+              />
+              {checkout.product_price.amount_type === 'seat_based' &&
+                (checkout.seats ?? 0) > 1 && (
                   <CheckoutSeatInvitations
                     checkout={checkout}
                     customerSessionToken={customerSessionToken}
                   />
-                ) : (
-                  <CheckoutBenefits
-                    checkout={checkout}
-                    locale={locale}
-                    customerSessionToken={customerSessionToken}
-                    maxWaitingTimeMs={maxWaitingTimeMs}
-                  />
-                ))}
+                )}
               <p className="dark:text-polar-500 text-center text-xs text-gray-500">
                 {t('checkout.footer.merchantOfRecord')}
               </p>

--- a/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutConfirmation.tsx
@@ -191,23 +191,26 @@ export const CheckoutConfirmation = ({
             avatar_url={organization.avatar_url}
             name={organization.name}
           />
-          <h1 className="text-2xl font-medium">
-            {status === 'confirmed' &&
-              t('checkout.confirmation.processingTitle')}
-            {status === 'succeeded' && t('checkout.confirmation.successTitle')}
-            {status === 'failed' && t('checkout.confirmation.failedTitle')}
-          </h1>
-          <p className="dark:text-polar-500 text-gray-500">
-            {status === 'confirmed' &&
-              t('checkout.confirmation.processingDescription')}
-            {status === 'succeeded' &&
-              hasProductCheckout(checkout) &&
-              t('checkout.confirmation.successDescription', {
-                product: checkout.product.name,
-              })}
-            {status === 'failed' &&
-              t('checkout.confirmation.failedDescription')}
-          </p>
+          <div className="flex flex-col items-center gap-y-4">
+            <h1 className="text-2xl font-medium">
+              {status === 'confirmed' &&
+                t('checkout.confirmation.processingTitle')}
+              {status === 'succeeded' &&
+                t('checkout.confirmation.successTitle')}
+              {status === 'failed' && t('checkout.confirmation.failedTitle')}
+            </h1>
+            <p className="dark:text-polar-500 text-gray-500">
+              {status === 'confirmed' &&
+                t('checkout.confirmation.processingDescription')}
+              {status === 'succeeded' &&
+                hasProductCheckout(checkout) &&
+                t('checkout.confirmation.successDescription', {
+                  product: checkout.product.name,
+                })}
+              {status === 'failed' &&
+                t('checkout.confirmation.failedDescription')}
+            </p>
+          </div>
           {status === 'confirmed' && (
             <div className="flex items-center justify-center">
               {checkout.payment_processor === 'stripe' ? (

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -93,8 +93,9 @@ const SeatInvitationsPanel = ({
 
   const sendInvitations = async () => {
     const validatedInputs = emailInputs.map((input) => {
-      if (input.value.trim() && !validateEmail(input.value)) {
-        return { ...input, error: 'Invalid email format' }
+      const trimmed = input.value.trim()
+      if (trimmed && !validateEmail(trimmed)) {
+        return { ...input, value: trimmed, error: 'Invalid email format' }
       }
 
       return input

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -28,7 +28,12 @@ const CheckoutSeatInvitations = ({
 }: CheckoutSeatInvitationsProps) => {
   const isSeatBased = getSeatPrice(checkout) !== null
 
-  if (!isSeatBased || !checkout.seats || !customerSessionToken) {
+  if (
+    !isSeatBased ||
+    !checkout.seats ||
+    checkout.seats === 1 ||
+    !customerSessionToken
+  ) {
     return null
   }
 

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -40,7 +40,6 @@ const CheckoutSeatInvitations = ({
   return (
     <SeatInvitationsPanel
       checkoutId={checkout.id}
-      customerEmail={checkout.customer_email}
       seats={checkout.seats}
       customerSessionToken={customerSessionToken}
     />
@@ -49,38 +48,28 @@ const CheckoutSeatInvitations = ({
 
 interface SeatInvitationsPanelProps {
   checkoutId: string
-  customerEmail: string | null
   seats: number
   customerSessionToken: string
 }
 
 const SeatInvitationsPanel = ({
   checkoutId,
-  customerEmail,
   seats,
   customerSessionToken,
 }: SeatInvitationsPanelProps) => {
-  const [emailInputs, setEmailInputs] = useState<EmailInput[]>(
-    [
-      {
-        id: '1',
-        value: customerEmail || '',
-      },
-      seats > 1 && customerEmail
-        ? {
-            id: '2',
-            value: '',
-          }
-        : null,
-    ].filter(Boolean) as EmailInput[],
-  )
+  const [emailInputs, setEmailInputs] = useState<EmailInput[]>([
+    { id: '1', value: '' },
+  ])
 
   const [isSending, setIsSending] = useState(false)
   const [sentCount, setSentCount] = useState(0)
 
   const assignSeat = useAssignSeatFromCheckout(checkoutId, customerSessionToken)
 
-  const availableSeats = seats - sentCount
+  // The buyer's own seat is auto-claimed at checkout, so only the remaining
+  // seats are available to invite teammates to.
+  const remainingSeats = seats - 1
+  const availableSeats = remainingSeats - sentCount
   const canAddMore =
     emailInputs.filter((input) => !input.sent).length < availableSeats
 
@@ -157,10 +146,14 @@ const SeatInvitationsPanel = ({
   return (
     <Well className="dark:border-polar-700 dark:bg-polar-800 w-full border border-gray-200 bg-white">
       <WellHeader className="gap-y-2 pb-4 text-center">
-        <h2 className="text-xl font-medium">Invite team members</h2>
+        <h2 className="text-xl font-medium">Invite your team</h2>
         <p className="dark:text-polar-500 text-sm text-gray-500">
-          Invite {seats > 1 ? `${seats} team members` : 'one team member'} to
-          access your purchase.
+          You&apos;ve claimed your seat. Invite{' '}
+          {remainingSeats === 1
+            ? 'one more team member'
+            : `up to ${remainingSeats} more team members`}{' '}
+          to the remaining seats. You can always manage this later through the
+          Customer Portal.
         </p>
       </WellHeader>
 

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -125,7 +125,7 @@ const SeatInvitationsPanel = ({
       if (input.value.trim() === '') continue
 
       try {
-        await assignSeat.mutateAsync({ email: input.value })
+        await assignSeat.mutateAsync({ email: input.value.trim() })
         setEmailInputs((prev) =>
           prev.map((i) => (i.id === input.id ? { ...i, sent: true } : i)),
         )

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -56,20 +56,28 @@ const SeatInvitationsPanel = ({
   customerSessionToken,
 }: SeatInvitationsPanelProps) => {
   const [emailInputs, setEmailInputs] = useState<EmailInput[]>(
-    customerEmail
-      ? [
-          { id: '1', value: customerEmail },
-          { id: '2', value: '' },
-        ]
-      : [{ id: '1', value: '' }],
+    [
+      {
+        id: '1',
+        value: customerEmail || '',
+      },
+      seats > 1 && customerEmail
+        ? {
+            id: '2',
+            value: '',
+          }
+        : null,
+    ].filter(Boolean) as EmailInput[],
   )
+
   const [isSending, setIsSending] = useState(false)
   const [sentCount, setSentCount] = useState(0)
 
   const assignSeat = useAssignSeatFromCheckout(checkoutId, customerSessionToken)
 
   const availableSeats = seats - sentCount
-  const canAddMore = emailInputs.length < availableSeats
+  const canAddMore =
+    emailInputs.filter((input) => !input.sent).length < availableSeats
 
   const addEmailInput = () => {
     if (canAddMore) {
@@ -91,12 +99,10 @@ const SeatInvitationsPanel = ({
 
   const sendInvitations = async () => {
     const validatedInputs = emailInputs.map((input) => {
-      if (!input.value.trim()) {
-        return { ...input, error: 'Email is required' }
-      }
-      if (!validateEmail(input.value)) {
+      if (input.value.trim() && !validateEmail(input.value)) {
         return { ...input, error: 'Invalid email format' }
       }
+
       return input
     })
 
@@ -110,6 +116,8 @@ const SeatInvitationsPanel = ({
 
     for (const input of emailInputs) {
       if (input.sent) continue
+
+      if (input.value.trim() === '') continue
 
       try {
         await assignSeat.mutateAsync({ email: input.value })
@@ -133,28 +141,28 @@ const SeatInvitationsPanel = ({
   }
 
   const validEmails = emailInputs.filter(
-    (input) => input.value.trim() && !input.error && !input.sent,
+    (input) =>
+      input.value.trim() &&
+      validateEmail(input.value.trim()) &&
+      !input.error &&
+      !input.sent,
   ).length
   const canSend = validEmails > 0 && !isSending
 
   return (
     <Well className="dark:border-polar-700 dark:bg-polar-800 w-full border border-gray-200 bg-white">
-      <WellHeader className="gap-y-4 text-left">
-        <h2 className="text-xl">Invite team members</h2>
+      <WellHeader className="gap-y-2 pb-4 text-center">
+        <h2 className="text-xl font-medium">Invite team members</h2>
         <p className="dark:text-polar-500 text-sm text-gray-500">
-          Invite team members to access your purchase.
+          Invite {seats > 1 ? `${seats} team members` : 'one team member'} to
+          access your purchase.
         </p>
-        <div className="flex items-center justify-between">
-          <p className="text-sm">
-            {availableSeats} {availableSeats === 1 ? 'seat' : 'seats'} available
-          </p>
-        </div>
       </WellHeader>
 
       <WellContent className="flex flex-col gap-6">
         <div className="flex flex-col gap-3">
           {emailInputs.map((input) => (
-            <div key={input.id} className="flex items-center gap-4">
+            <div key={input.id} className="flex items-center gap-2">
               <div className="flex-1">
                 <Input
                   type="email"
@@ -165,12 +173,17 @@ const SeatInvitationsPanel = ({
                   className={`${input.error ? 'border-red-500' : ''}`}
                 />
                 {input.error && (
-                  <p className="mt-1 text-xs text-red-500">{input.error}</p>
+                  <p className="mt-1 text-left text-xs text-red-500">
+                    {input.error}
+                  </p>
                 )}
               </div>
               {input.sent ? (
-                <div className="flex h-8 w-8 items-center justify-center">
-                  <MailCheckIcon className="dark:text-polar-400 h-5 w-5 text-gray-700" />
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-green-50 dark:bg-green-900">
+                  <MailCheckIcon
+                    className="h-4 w-4 text-green-500 dark:text-green-500"
+                    strokeWidth={1.5}
+                  />
                 </div>
               ) : (
                 emailInputs.length > 1 &&
@@ -191,11 +204,10 @@ const SeatInvitationsPanel = ({
 
           {canAddMore && (
             <Button
-              variant="secondary"
-              size="sm"
+              variant="ghost"
               onClick={addEmailInput}
               disabled={isSending}
-              className="self-start"
+              className="rounded-xl"
             >
               <PlusIcon className="mr-2 h-4 w-4" />
               Add another email
@@ -217,8 +229,8 @@ const SeatInvitationsPanel = ({
 
         {sentCount > 0 && (
           <p className="dark:text-polar-500 mx-auto max-w-xs text-center text-xs text-pretty text-gray-500">
-            Successfully assigned {sentCount}{' '}
-            {sentCount === 1 ? 'seat' : 'seats'}.
+            Successfully assigned{' '}
+            {sentCount === 1 ? 'one seat' : `${sentCount} seats`}.
             {availableSeats > 0 && (
               <>
                 {' '}

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -28,6 +28,7 @@ from polar.checkout.schemas import (
 from polar.config import settings
 from polar.custom_field.data import validate_custom_field_data
 from polar.customer.repository import CustomerRepository
+from polar.customer_seat.service import seat_service
 from polar.customer_session.service import customer_session as customer_session_service
 from polar.discount.service import DiscountNotRedeemableError
 from polar.discount.service import discount as discount_service
@@ -67,6 +68,7 @@ from polar.models import (
     CheckoutLink,
     Customer,
     Discount,
+    Order,
     Organization,
     Payment,
     PaymentMethod,
@@ -1227,6 +1229,7 @@ class CheckoutService:
 
         product = checkout.product
         subscription: Subscription | None = None
+        order: Order | None = None
         if product.is_recurring:
             (
                 subscription,
@@ -1234,7 +1237,7 @@ class CheckoutService:
             ) = await subscription_service.create_or_update_from_checkout(
                 session, checkout, payment_method
             )
-            await order_service.create_from_checkout_subscription(
+            order = await order_service.create_from_checkout_subscription(
                 session,
                 checkout,
                 subscription,
@@ -1244,9 +1247,11 @@ class CheckoutService:
                 payment,
             )
         else:
-            await order_service.create_from_checkout_one_time(
+            order = await order_service.create_from_checkout_one_time(
                 session, checkout, payment
             )
+
+        await self._maybe_auto_claim_single_seat(session, checkout, subscription, order)
 
         # Create trial redemption record if this checkout had a trial period
         if checkout.trial_end is not None:
@@ -1317,6 +1322,46 @@ class CheckoutService:
             log.error("Failed to capture PostHog event", error=str(e))
 
         return checkout
+
+    async def _maybe_auto_claim_single_seat(
+        self,
+        session: AsyncSession,
+        checkout: Checkout,
+        subscription: Subscription | None,
+        order: Order | None,
+    ) -> None:
+        """When a buyer purchases exactly one seat through the default Polar
+        confirmation flow, immediately claim that seat for themselves so they
+        get access without going through the invitation email loop.
+        """
+        if checkout.seats != 1:
+            return
+        product_price = checkout.product_price
+        if product_price is None or not is_seat_price(product_price):
+            return
+        # Only apply to the default internal confirmation flow. If the merchant
+        # set a custom success_url, they own the post-checkout seat-assignment
+        # UX and we leave things alone.
+        if checkout._success_url is not None:
+            return
+
+        container: Subscription | Order | None = subscription or order
+        if container is None or container.customer is None:
+            return
+
+        try:
+            await seat_service.assign_seat(
+                session,
+                container,
+                email=container.customer.email,
+                immediate_claim=True,
+            )
+        except Exception as e:
+            log.exception(
+                "Failed to auto-claim single seat after checkout",
+                checkout_id=str(checkout.id),
+                error=str(e),
+            )
 
     async def handle_failure(
         self, session: AsyncSession, checkout: Checkout, payment: Payment | None = None

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1369,11 +1369,16 @@ class CheckoutService:
                 if already_claimed:
                     return
 
+        # Team customers can have no email of their own; in that case the
+        # checkout's customer_email was backfilled from the owner member earlier
+        # in the confirmation flow, so prefer that as the claim target.
+        email = container.customer.email or checkout.customer_email
+
         try:
             await seat_service.assign_seat(
                 session,
                 container,
-                email=container.customer.email,
+                email=email,
                 immediate_claim=True,
             )
         except Exception as e:

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1253,7 +1253,7 @@ class CheckoutService:
                 session, checkout, payment
             )
 
-        await self._maybe_auto_claim_single_seat(session, checkout, subscription, order)
+        await self._maybe_auto_claim_buyer_seat(session, checkout, subscription, order)
 
         # Create trial redemption record if this checkout had a trial period
         if checkout.trial_end is not None:
@@ -1325,18 +1325,19 @@ class CheckoutService:
 
         return checkout
 
-    async def _maybe_auto_claim_single_seat(
+    async def _maybe_auto_claim_buyer_seat(
         self,
         session: AsyncSession,
         checkout: Checkout,
         subscription: Subscription | None,
         order: Order | None,
     ) -> None:
-        """When a buyer purchases exactly one seat through the default Polar
-        confirmation flow, immediately claim that seat for themselves so they
-        get access without going through the invitation email loop.
+        """When a buyer purchases one or more seats through the default Polar
+        confirmation flow, immediately claim a single seat for themselves so
+        they get access without going through the invitation email loop. Any
+        remaining seats stay available for them to invite teammates.
         """
-        if checkout.seats != 1:
+        if checkout.seats is None or checkout.seats < 1:
             return
         product_price = checkout.product_price
         if product_price is None or not is_seat_price(product_price):

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -98,6 +98,7 @@ from polar.product.guard import (
     SeatPrice,
     is_custom_price,
     is_discount_applicable,
+    is_seat_price,
 )
 from polar.product.price_set import (
     NoPricesForCurrencies,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -29,6 +29,7 @@ from polar.checkout.schemas import (
 from polar.config import settings
 from polar.custom_field.data import validate_custom_field_data
 from polar.customer.repository import CustomerRepository
+from polar.customer_seat.repository import CustomerSeatRepository
 from polar.customer_seat.service import seat_service
 from polar.customer_session.service import customer_session as customer_session_service
 from polar.discount.service import DiscountNotRedeemableError
@@ -1349,6 +1350,23 @@ class CheckoutService:
         container: Subscription | Order | None = subscription or order
         if container is None or container.customer is None:
             return
+
+        # One-time seat purchases mint a fresh order (and thus a fresh seat
+        # container) on every checkout, so the per-container assignment guards
+        # can't tell that a repeat buyer already self-claimed a seat for this
+        # product on an earlier order. Bail out if they did, to avoid claiming
+        # a duplicate seat for the same person.
+        if isinstance(container, Order):
+            product = container.product
+            if product is not None:
+                seat_repository = CustomerSeatRepository.from_session(session)
+                already_claimed = (
+                    await seat_repository.has_claimed_seat_for_product_via_orders(
+                        product.id, container.customer_id
+                    )
+                )
+                if already_claimed:
+                    return
 
         try:
             await seat_service.assign_seat(

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -3,6 +3,7 @@ import typing
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 
+import sentry_sdk
 import stripe as stripe_lib
 import structlog
 from pydantic import UUID4
@@ -1357,10 +1358,9 @@ class CheckoutService:
                 immediate_claim=True,
             )
         except Exception as e:
-            log.exception(
-                "Failed to auto-claim single seat after checkout",
-                checkout_id=str(checkout.id),
-                error=str(e),
+            sentry_sdk.capture_exception(
+                e,
+                extras={"checkout_id": str(checkout.id)},
             )
 
     async def handle_failure(

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -465,6 +465,24 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         result = await self.session.execute(stmt.with_only_columns(func.count()))
         return result.scalar_one()
 
+    async def has_claimed_seat_for_product_via_orders(
+        self, product_id: UUID, customer_id: UUID
+    ) -> bool:
+        """Whether a customer already holds a claimed seat for a product via orders.
+
+        Used to avoid re-claiming a seat for a buyer who purchases the same
+        one-time seat product more than once: each purchase mints a new order
+        (a fresh seat container), so the per-container assignment guards can't
+        see the seat claimed on a previous order.
+        """
+        stmt = (
+            self.get_claimed_by_product_via_orders(product_id)
+            .where(CustomerSeat.customer_id == customer_id)
+            .with_only_columns(func.count())
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one() > 0
+
     def get_eager_options_with_prices(self) -> Options:
         return (
             *self.get_eager_options(),

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -69,8 +69,9 @@ from polar.models import (
 from polar.models.checkout import CheckoutStatus
 from polar.models.custom_field import CustomFieldType
 from polar.models.customer import CustomerType
+from polar.models.customer_seat import SeatStatus
 from polar.models.discount import DiscountDuration, DiscountType
-from polar.models.order import OrderBillingReasonInternal
+from polar.models.order import OrderBillingReasonInternal, OrderStatus
 from polar.models.organization import OrganizationStatus
 from polar.models.product_price import (
     ProductPriceAmountType,
@@ -106,7 +107,9 @@ from tests.fixtures.random_objects import (
     create_checkout_link,
     create_custom_field,
     create_customer,
+    create_customer_seat,
     create_discount,
+    create_order,
     create_product,
     create_product_price_fixed,
     create_product_price_seat_unit,
@@ -358,6 +361,18 @@ async def product_seat_based(
         save_fixture,
         organization=organization,
         recurring_interval=SubscriptionRecurringInterval.month,
+        prices=[("seat", 1000, "usd")],
+    )
+
+
+@pytest_asyncio.fixture
+async def product_one_time_seat_based(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    return await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=None,
         prices=[("seat", 1000, "usd")],
     )
 
@@ -6007,6 +6022,82 @@ class TestHandleSuccess:
 
         await checkout_service.handle_success(
             session, checkout_confirmed_recurring, payment
+        )
+
+        seat_service_mock.assign_seat.assert_not_called()
+
+    async def test_seat_based_one_time_first_purchase_auto_claims(
+        self,
+        save_fixture: SaveFixture,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        product_one_time_seat_based: Product,
+        customer: Customer,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_one_time_seat_based],
+            status=CheckoutStatus.confirmed,
+            seats=1,
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product_one_time_seat_based,
+            status=OrderStatus.paid,
+        )
+
+        await checkout_service._maybe_auto_claim_single_seat(
+            session, checkout, None, order
+        )
+
+        seat_service_mock.assign_seat.assert_called_once_with(
+            ANY,
+            order,
+            email=customer.email,
+            immediate_claim=True,
+        )
+
+    async def test_seat_based_one_time_repeat_purchase_does_not_reclaim(
+        self,
+        save_fixture: SaveFixture,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        product_one_time_seat_based: Product,
+        customer: Customer,
+    ) -> None:
+        # An earlier one-time purchase already auto-claimed a seat for this
+        # buyer on its own order.
+        previous_order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product_one_time_seat_based,
+            status=OrderStatus.paid,
+        )
+        await create_customer_seat(
+            save_fixture,
+            order=previous_order,
+            customer=customer,
+            status=SeatStatus.claimed,
+            email=customer.email,
+        )
+
+        # The buyer purchases the same product again, minting a fresh order.
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_one_time_seat_based],
+            status=CheckoutStatus.confirmed,
+            seats=1,
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product_one_time_seat_based,
+            status=OrderStatus.paid,
+        )
+
+        await checkout_service._maybe_auto_claim_single_seat(
+            session, checkout, None, order
         )
 
         seat_service_mock.assign_seat.assert_not_called()

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -5953,7 +5953,7 @@ class TestHandleSuccess:
             immediate_claim=True,
         )
 
-    async def test_seat_based_multi_seat_does_not_auto_claim(
+    async def test_seat_based_multi_seat_auto_claims_buyer_seat(
         self,
         save_fixture: SaveFixture,
         subscription_service_mock: MagicMock,
@@ -5977,7 +5977,14 @@ class TestHandleSuccess:
 
         await checkout_service.handle_success(session, checkout)
 
-        seat_service_mock.assign_seat.assert_not_called()
+        # A single seat is claimed for the buyer; the remaining seats stay
+        # available for them to invite teammates.
+        seat_service_mock.assign_seat.assert_called_once_with(
+            ANY,
+            subscription_mock,
+            email=customer.email,
+            immediate_claim=True,
+        )
 
     async def test_seat_based_custom_success_url_does_not_auto_claim(
         self,
@@ -6047,7 +6054,7 @@ class TestHandleSuccess:
             status=OrderStatus.paid,
         )
 
-        await checkout_service._maybe_auto_claim_single_seat(
+        await checkout_service._maybe_auto_claim_buyer_seat(
             session, checkout, None, order
         )
 
@@ -6096,7 +6103,7 @@ class TestHandleSuccess:
             status=OrderStatus.paid,
         )
 
-        await checkout_service._maybe_auto_claim_single_seat(
+        await checkout_service._maybe_auto_claim_buyer_seat(
             session, checkout, None, order
         )
 

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -33,6 +33,7 @@ from polar.checkout.service import (
 )
 from polar.checkout.service import checkout as checkout_service
 from polar.config import Environment
+from polar.customer_seat.service import SeatService
 from polar.customer_session.service import customer_session as customer_session_service
 from polar.discount.repository import DiscountRedemptionRepository
 from polar.discount.service import discount as discount_service
@@ -135,6 +136,13 @@ def subscription_service_mock(mocker: MockerFixture) -> MagicMock:
 def order_service_mock(mocker: MockerFixture) -> MagicMock:
     mock = MagicMock(spec=OrderService)
     mocker.patch("polar.checkout.service.order_service", new=mock)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def seat_service_mock(mocker: MockerFixture) -> MagicMock:
+    mock = MagicMock(spec=SeatService)
+    mocker.patch("polar.checkout.service.seat_service", new=mock)
     return mock
 
 
@@ -5897,6 +5905,111 @@ class TestHandleSuccess:
         assert len(trial_redemptions) == 1
         trial_redemption = trial_redemptions[0]
         assert trial_redemption.customer_id == customer.id
+
+    async def test_seat_based_single_seat_auto_claims(
+        self,
+        save_fixture: SaveFixture,
+        order_service_mock: MagicMock,
+        subscription_service_mock: MagicMock,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        product_seat_based: Product,
+        customer: Customer,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based],
+            status=CheckoutStatus.confirmed,
+            seats=1,
+        )
+        subscription_mock = MagicMock()
+        subscription_mock.customer = customer
+        subscription_service_mock.create_or_update_from_checkout.return_value = (
+            subscription_mock,
+            True,
+        )
+
+        await checkout_service.handle_success(session, checkout)
+
+        seat_service_mock.assign_seat.assert_called_once_with(
+            ANY,
+            subscription_mock,
+            email=customer.email,
+            immediate_claim=True,
+        )
+
+    async def test_seat_based_multi_seat_does_not_auto_claim(
+        self,
+        save_fixture: SaveFixture,
+        subscription_service_mock: MagicMock,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        product_seat_based: Product,
+        customer: Customer,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based],
+            status=CheckoutStatus.confirmed,
+            seats=3,
+        )
+        subscription_mock = MagicMock()
+        subscription_mock.customer = customer
+        subscription_service_mock.create_or_update_from_checkout.return_value = (
+            subscription_mock,
+            True,
+        )
+
+        await checkout_service.handle_success(session, checkout)
+
+        seat_service_mock.assign_seat.assert_not_called()
+
+    async def test_seat_based_custom_success_url_does_not_auto_claim(
+        self,
+        save_fixture: SaveFixture,
+        subscription_service_mock: MagicMock,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        product_seat_based: Product,
+        customer: Customer,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based],
+            status=CheckoutStatus.confirmed,
+            seats=1,
+            success_url="https://example.com/thanks",
+        )
+        subscription_mock = MagicMock()
+        subscription_mock.customer = customer
+        subscription_service_mock.create_or_update_from_checkout.return_value = (
+            subscription_mock,
+            True,
+        )
+
+        await checkout_service.handle_success(session, checkout)
+
+        seat_service_mock.assign_seat.assert_not_called()
+
+    async def test_non_seat_based_does_not_auto_claim(
+        self,
+        order_service_mock: MagicMock,
+        subscription_service_mock: MagicMock,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        checkout_confirmed_recurring: Checkout,
+        payment: Payment,
+    ) -> None:
+        subscription_service_mock.create_or_update_from_checkout.return_value = (
+            MagicMock(),
+            True,
+        )
+
+        await checkout_service.handle_success(
+            session, checkout_confirmed_recurring, payment
+        )
+
+        seat_service_mock.assign_seat.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -6065,16 +6065,56 @@ class TestHandleSuccess:
             immediate_claim=True,
         )
 
-    async def test_seat_based_one_time_repeat_purchase_does_not_reclaim(
+    async def test_seat_based_one_time_multi_seat_first_purchase_auto_claims_via_handle_success(
         self,
         save_fixture: SaveFixture,
+        order_service_mock: MagicMock,
         seat_service_mock: MagicMock,
         session: AsyncSession,
         product_one_time_seat_based: Product,
         customer: Customer,
     ) -> None:
-        # An earlier one-time purchase already auto-claimed a seat for this
-        # buyer on its own order.
+        # Exercise the public ``handle_success`` entry point (not the private
+        # ``_maybe_auto_claim_buyer_seat`` helper directly) so we verify the
+        # one-time Order minted inside ``handle_success`` is correctly wired
+        # into the auto-claim helper for a multi-seat purchase.
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_one_time_seat_based],
+            status=CheckoutStatus.confirmed,
+            seats=3,
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product_one_time_seat_based,
+            status=OrderStatus.paid,
+        )
+        order_service_mock.create_from_checkout_one_time.return_value = order
+
+        await checkout_service.handle_success(session, checkout)
+
+        # A single seat is claimed for the buyer; the remaining seats stay
+        # available for them to invite teammates.
+        seat_service_mock.assign_seat.assert_called_once_with(
+            ANY,
+            order,
+            email=customer.email,
+            immediate_claim=True,
+        )
+
+    async def test_seat_based_one_time_repeat_purchase_does_not_reclaim_via_handle_success(
+        self,
+        save_fixture: SaveFixture,
+        order_service_mock: MagicMock,
+        seat_service_mock: MagicMock,
+        session: AsyncSession,
+        product_one_time_seat_based: Product,
+        customer: Customer,
+    ) -> None:
+        # As above, drive the public ``handle_success`` entry point so the
+        # repeat-purchase guard inside ``_maybe_auto_claim_buyer_seat`` sees the
+        # freshly minted one-time Order.
         previous_order = await create_order(
             save_fixture,
             customer=customer,
@@ -6089,12 +6129,11 @@ class TestHandleSuccess:
             email=customer.email,
         )
 
-        # The buyer purchases the same product again, minting a fresh order.
         checkout = await create_checkout(
             save_fixture,
             products=[product_one_time_seat_based],
             status=CheckoutStatus.confirmed,
-            seats=1,
+            seats=3,
         )
         order = await create_order(
             save_fixture,
@@ -6102,10 +6141,9 @@ class TestHandleSuccess:
             product=product_one_time_seat_based,
             status=OrderStatus.paid,
         )
+        order_service_mock.create_from_checkout_one_time.return_value = order
 
-        await checkout_service._maybe_auto_claim_buyer_seat(
-            session, checkout, None, order
-        )
+        await checkout_service.handle_success(session, checkout)
 
         seat_service_mock.assign_seat.assert_not_called()
 


### PR DESCRIPTION
Experiment. Auto-assign seat to the purchaser when a single seat is purchased.

The customer UX is basically the same as a non-seat-based purchase then, which I like.

I'm thinking to maybe always auto-claim the first seat for the purchaser as, and show both their own benefits + the option to invite others on the checkout confirmation page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic immediate assignment of the buyer’s seat for qualifying seat-based purchases on successful checkout.

* **Improvements**
  * Checkout confirmation now cleanly shows either seat invitations or benefits based on product/seat context.
  * Invitations UI: improved email trimming/validation, smarter add/send behavior, clearer sent success copy.
  * Benefits UI hides when none expected and shows accurate granting state.

* **Tests**
  * Added coverage for seat auto-assignment and related checkout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->