### PR TITLE
tf: Enable memory profiling everywhere

### DIFF
--- a/server/polar/worker/_metrics.py
+++ b/server/polar/worker/_metrics.py
@@ -8,6 +8,10 @@ from polar.observability import (
     TASK_EXECUTIONS,
     TASK_RETRIES,
 )
+from polar.observability.memory_profile import (
+    start_memory_profiler,
+    stop_memory_profiler,
+)
 from polar.observability.remote_write import start_remote_write_pusher
 
 
@@ -24,7 +28,13 @@ class PrometheusMiddleware(dramatiq.Middleware):
         # Clearing here would break Counter metrics because they eagerly create .db
         # files during import (before this hook runs), and clearing would delete them.
         start_remote_write_pusher()
+        start_memory_profiler()
         # See commit d37c274 for Prometheus GC metrics
+
+    def after_worker_shutdown(
+        self, broker: dramatiq.Broker, worker: dramatiq.Worker
+    ) -> None:
+        stop_memory_profiler()
 
     def before_process_message(
         self, broker: dramatiq.Broker, message: dramatiq.MessageProxy

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -484,5 +484,5 @@ resource "render_env_group_link" "polar_self" {
 resource "render_env_group_link" "memory_profile" {
   count        = var.memory_profile_config != null ? 1 : 0
   env_group_id = render_env_group.memory_profile[0].id
-  service_ids  = [render_web_service.api.id]
+  service_ids  = local.all_service_ids
 }

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -484,5 +484,5 @@ resource "render_env_group_link" "polar_self" {
 resource "render_env_group_link" "memory_profile" {
   count        = var.memory_profile_config != null ? 1 : 0
   env_group_id = render_env_group.memory_profile[0].id
-  service_ids  = local.all_service_ids
+  service_ids  = concat([render_web_service.api.id], local.worker_ids)
 }

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -257,6 +257,10 @@ module "sandbox" {
     password = var.grafana_cloud_prometheus_password
   }
 
+  memory_profile_config = {
+    s3_bucket_name = "polar-sandbox-logs"
+  }
+
   polar_self_config = {
     access_token    = var.polar_access_token
     webhook_secret  = var.polar_webhook_secret


### PR DESCRIPTION
We enable the memory profiling that we've been running only in api in prod on all services. This will allow us to get some insights into why we run out of memory in different places.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended memory profiling to additional Render services and worker processes, including lifecycle start/stop during worker boot and shutdown.
  * Configured sandbox environment to send logs to an S3 bucket for centralized log storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->