### PR TITLE
ci(deploy): diff against last-deployed SHA via git tags

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -153,3 +153,82 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+  # Tag-advance jobs: after a successful deploy of a component, push a
+  # lightweight git tag deployed/{component}-{environment} pointing at the
+  # SHA we just deployed. The next workflow run's `changes` job uses this
+  # tag as the diff base, so cancelled intermediate runs never cause a
+  # commit to be skipped silently — the next run still sees the pending
+  # changes because the tag hasn't advanced.
+  #
+  # Each component has its own job, gated only on its own deploy's success.
+  # This way a frontend failure doesn't pin the backend tag at a stale SHA
+  # (which would cause Render to be re-deployed redundantly on the next
+  # push), and vice versa.
+
+  update-backend-tag:
+    name: "Update deployed/backend-${{ inputs.environment }} tag"
+    needs: deploy-backend
+    if: always() && needs.deploy-backend.result == 'success' && inputs.skip-backend != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Push deploy tag
+        env:
+          TAG: deployed/backend-${{ inputs.environment }}
+          DEPLOYED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Retry a few times in case of transient push failures. A failed
+          # tag push means the next deploy will redundantly redeploy this
+          # SHA (safe, idempotent, but noisy) — worth retrying.
+          for attempt in 1 2 3; do
+            git tag -f "$TAG" "$DEPLOYED_SHA"
+            if git push -f origin "refs/tags/$TAG"; then
+              echo "Advanced $TAG -> $DEPLOYED_SHA"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; retrying..."
+            sleep 2
+          done
+          echo "Failed to push $TAG after 3 attempts"
+          exit 1
+
+  update-frontend-tag:
+    name: "Update deployed/frontend-${{ inputs.environment }} tag"
+    needs: promote-frontend
+    if: always() && needs.promote-frontend.result == 'success' && inputs.skip-frontend != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Push deploy tag
+        env:
+          TAG: deployed/frontend-${{ inputs.environment }}
+          DEPLOYED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for attempt in 1 2 3; do
+            git tag -f "$TAG" "$DEPLOYED_SHA"
+            if git push -f origin "refs/tags/$TAG"; then
+              echo "Advanced $TAG -> $DEPLOYED_SHA"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; retrying..."
+            sleep 2
+          done
+          echo "Failed to push $TAG after 3 attempts"
+          exit 1

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -129,9 +129,14 @@ jobs:
     needs: deploy-backend
     if: always() && needs.deploy-backend.result == 'success' && inputs.skip-backend != true
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    # Sentry release is best-effort: a missing release annotation is
-    # observability noise, not a deploy regression. Don't fail the workflow.
+    # No `environment:` here on purpose. A standalone job that references a
+    # protected GitHub Environment (required reviewers / wait timer) would
+    # PAUSE for approval, and because this job lives inside the reusable
+    # workflow, a pending approval would stall deploy-sandbox and block
+    # deploy-production. The Sentry-side environment label is passed via the
+    # action's own `environment:` input below, so tracking is unaffected.
+    # Sentry release is best-effort: a missing annotation is observability
+    # noise, not a deploy regression. Don't fail the workflow.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -185,7 +190,10 @@ jobs:
   update-backend-tag:
     name: "Update deployed/backend-${{ inputs.environment }} tag"
     needs: deploy-backend
-    if: always() && needs.deploy-backend.result == 'success' && inputs.skip-backend != true
+    # Guarded to main: a workflow_dispatch from a non-main ref would otherwise
+    # push deployed/* to a commit that isn't on main, poisoning the diff base
+    # for every subsequent main push (silent skips).
+    if: always() && needs.deploy-backend.result == 'success' && inputs.skip-backend != true && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -198,10 +206,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Need depth >= 2 so we can fetch the target tag's remote ref
-          # for --force-with-lease without errors on the lease check.
+          # Depth 1 is sufficient: we only ever tag github.sha (HEAD), which
+          # checkout fetches by default.
           fetch-depth: 1
-          fetch-tags: true
 
       - name: Push deploy tag
         env:
@@ -209,41 +216,30 @@ jobs:
           DEPLOYED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          shopt -s inherit_errexit
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Retry on transient push failures. Re-fetch the remote tag between
-          # attempts so --force-with-lease has the latest known-remote SHA
-          # (otherwise a concurrent unrelated tag advance would be silently
-          # overwritten on retry).
+          git tag -f "$TAG" "$DEPLOYED_SHA"
+          # Plain force-push is safe here: the top-level `build-deploy`
+          # concurrency group serializes deploy runs, so no two runs' tag
+          # pushes overlap, and this job is guarded to main. Retry covers
+          # transient push failures (force handles both create and update,
+          # unlike a plain push which is rejected for an existing tag).
           for attempt in 1 2 3; do
-            # Refresh local view of the tag (if it exists remotely).
-            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
-            # Use force-with-lease so a concurrent push that advanced the
-            # tag is rejected rather than blindly overwritten.
-            REMOTE_SHA="$(git rev-parse --verify --quiet "refs/tags/${TAG}^{commit}" || true)"
-            git tag -f "$TAG" "$DEPLOYED_SHA"
-            if [ -n "$REMOTE_SHA" ]; then
-              push_args=(--force-with-lease="refs/tags/${TAG}:${REMOTE_SHA}")
-            else
-              # Tag doesn't exist remotely yet (first deploy after rollout
-              # or post-cleanup). A plain push creates it.
-              push_args=()
-            fi
-            if git push "${push_args[@]}" origin "refs/tags/${TAG}"; then
-              echo "Advanced ${TAG} -> ${DEPLOYED_SHA}"
+            if git push -f origin "refs/tags/$TAG"; then
+              echo "Advanced $TAG -> $DEPLOYED_SHA"
               exit 0
             fi
-            echo "Push attempt ${attempt} failed; retrying..."
+            echo "Push attempt $attempt failed; retrying..."
             sleep 2
           done
-          echo "Failed to push ${TAG} after 3 attempts (workflow continues; next push will redeploy)"
+          echo "Failed to push $TAG after 3 attempts (workflow continues; next push will redeploy)"
           exit 1
 
   update-frontend-tag:
     name: "Update deployed/frontend-${{ inputs.environment }} tag"
     needs: promote-frontend
-    if: always() && needs.promote-frontend.result == 'success' && inputs.skip-frontend != true
+    # Guarded to main: see update-backend-tag.
+    if: always() && needs.promote-frontend.result == 'success' && inputs.skip-frontend != true && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -254,7 +250,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          fetch-tags: true
 
       - name: Push deploy tag
         env:
@@ -262,24 +257,18 @@ jobs:
           DEPLOYED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          shopt -s inherit_errexit
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "$TAG" "$DEPLOYED_SHA"
+          # See update-backend-tag: plain force is safe under the serialized
+          # build-deploy concurrency group + main guard.
           for attempt in 1 2 3; do
-            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
-            REMOTE_SHA="$(git rev-parse --verify --quiet "refs/tags/${TAG}^{commit}" || true)"
-            git tag -f "$TAG" "$DEPLOYED_SHA"
-            if [ -n "$REMOTE_SHA" ]; then
-              push_args=(--force-with-lease="refs/tags/${TAG}:${REMOTE_SHA}")
-            else
-              push_args=()
-            fi
-            if git push "${push_args[@]}" origin "refs/tags/${TAG}"; then
-              echo "Advanced ${TAG} -> ${DEPLOYED_SHA}"
+            if git push -f origin "refs/tags/$TAG"; then
+              echo "Advanced $TAG -> $DEPLOYED_SHA"
               exit 0
             fi
-            echo "Push attempt ${attempt} failed; retrying..."
+            echo "Push attempt $attempt failed; retrying..."
             sleep 2
           done
-          echo "Failed to push ${TAG} after 3 attempts (workflow continues; next push will redeploy)"
+          echo "Failed to push $TAG after 3 attempts (workflow continues; next push will redeploy)"
           exit 1

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -118,8 +118,24 @@ jobs:
         env:
           RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
 
-      - name: Sentry Release
-        uses: getsentry/action-release@v3.6.0
+  # Sentry release is split into its own job so that a Sentry hiccup (auth
+  # expired, rate limit) does not mark deploy-backend as failed. If they
+  # share a job, a Sentry failure causes update-backend-tag to skip (because
+  # it gates on deploy-backend.result == 'success'), which means the next
+  # push redundantly redeploys the same SHA — and via the workflow_call
+  # failure-propagation, would block production.
+  sentry-release:
+    name: "Backend: Sentry Release (${{ inputs.environment }})"
+    needs: deploy-backend
+    if: always() && needs.deploy-backend.result == 'success' && inputs.skip-backend != true
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    # Sentry release is best-effort: a missing release annotation is
+    # observability noise, not a deploy regression. Don't fail the workflow.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: getsentry/action-release@v3.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -173,10 +189,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Tag advancement is bookkeeping. If it fails (transient API, permission
+    # drift, tag-protection rule), the worst outcome is the next push
+    # redundantly redeploys the same SHA — safe and idempotent. Do NOT fail
+    # the workflow_call, otherwise the !failure() gate on deploy-production
+    # would turn this into a hard production-deploy outage.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:
+          # Need depth >= 2 so we can fetch the target tag's remote ref
+          # for --force-with-lease without errors on the lease check.
           fetch-depth: 1
+          fetch-tags: true
 
       - name: Push deploy tag
         env:
@@ -184,21 +209,35 @@ jobs:
           DEPLOYED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          shopt -s inherit_errexit
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Retry a few times in case of transient push failures. A failed
-          # tag push means the next deploy will redundantly redeploy this
-          # SHA (safe, idempotent, but noisy) — worth retrying.
+          # Retry on transient push failures. Re-fetch the remote tag between
+          # attempts so --force-with-lease has the latest known-remote SHA
+          # (otherwise a concurrent unrelated tag advance would be silently
+          # overwritten on retry).
           for attempt in 1 2 3; do
+            # Refresh local view of the tag (if it exists remotely).
+            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
+            # Use force-with-lease so a concurrent push that advanced the
+            # tag is rejected rather than blindly overwritten.
+            REMOTE_SHA="$(git rev-parse --verify --quiet "refs/tags/${TAG}^{commit}" || true)"
             git tag -f "$TAG" "$DEPLOYED_SHA"
-            if git push -f origin "refs/tags/$TAG"; then
-              echo "Advanced $TAG -> $DEPLOYED_SHA"
+            if [ -n "$REMOTE_SHA" ]; then
+              push_args=(--force-with-lease="refs/tags/${TAG}:${REMOTE_SHA}")
+            else
+              # Tag doesn't exist remotely yet (first deploy after rollout
+              # or post-cleanup). A plain push creates it.
+              push_args=()
+            fi
+            if git push "${push_args[@]}" origin "refs/tags/${TAG}"; then
+              echo "Advanced ${TAG} -> ${DEPLOYED_SHA}"
               exit 0
             fi
-            echo "Push attempt $attempt failed; retrying..."
+            echo "Push attempt ${attempt} failed; retrying..."
             sleep 2
           done
-          echo "Failed to push $TAG after 3 attempts"
+          echo "Failed to push ${TAG} after 3 attempts (workflow continues; next push will redeploy)"
           exit 1
 
   update-frontend-tag:
@@ -208,10 +247,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # See update-backend-tag for rationale: tag advance is bookkeeping and
+    # must not fail the workflow_call.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          fetch-tags: true
 
       - name: Push deploy tag
         env:
@@ -219,16 +262,24 @@ jobs:
           DEPLOYED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          shopt -s inherit_errexit
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           for attempt in 1 2 3; do
+            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
+            REMOTE_SHA="$(git rev-parse --verify --quiet "refs/tags/${TAG}^{commit}" || true)"
             git tag -f "$TAG" "$DEPLOYED_SHA"
-            if git push -f origin "refs/tags/$TAG"; then
-              echo "Advanced $TAG -> $DEPLOYED_SHA"
+            if [ -n "$REMOTE_SHA" ]; then
+              push_args=(--force-with-lease="refs/tags/${TAG}:${REMOTE_SHA}")
+            else
+              push_args=()
+            fi
+            if git push "${push_args[@]}" origin "refs/tags/${TAG}"; then
+              echo "Advanced ${TAG} -> ${DEPLOYED_SHA}"
               exit 0
             fi
-            echo "Push attempt $attempt failed; retrying..."
+            echo "Push attempt ${attempt} failed; retrying..."
             sleep 2
           done
-          echo "Failed to push $TAG after 3 attempts"
+          echo "Failed to push ${TAG} after 3 attempts (workflow continues; next push will redeploy)"
           exit 1

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -109,8 +109,8 @@ jobs:
       - name: Deploy Backend to Render
         run: |
           ./.github/workflows/deploy_server.sh \
-            ${{ inputs.docker-digest }} \
-            ${{ inputs.has-migrations }} \
+            "${{ inputs.docker-digest }}" \
+            "${{ inputs.has-migrations }}" \
             "${{ inputs.render-api-service-id }}" \
             "${{ inputs.render-worker-service-ids }}" \
             "${{ inputs.docker-digest-playwright }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
   changes:
     name: "Detect Changes 🔍"
     runs-on: ubuntu-latest
+    # Read-only: this job only checks out, fetches tags, and runs paths-filter.
+    # Narrow it explicitly so it doesn't inherit the workflow-level
+    # contents: write (which exists only for the tag-push jobs).
+    permissions:
+      contents: read
     outputs:
       # Per-component-per-environment outputs: each diffs HEAD against the
       # SHA of the last successful deploy for that component + environment
@@ -73,7 +78,10 @@ jobs:
           shopt -s inherit_errexit
           # Re-fetch tags with prune so a remote-side deletion drops the
           # local copy (defensive against cached/self-hosted runners).
-          git fetch --tags --force --prune --prune-tags origin
+          # Non-fatal: checkout (fetch-depth: 0) already fetched all tags, so
+          # this is belt-and-suspenders. A transient failure here must NOT
+          # abort the changes job, otherwise it would block ALL deploys.
+          git fetch --tags --force --prune --prune-tags origin || true
           # Resolve the safe fallback once. We prefer event.before, but on
           # workflow_dispatch / new-branch pushes it's empty or zero-SHA;
           # fall back to HEAD~1 which always exists on a fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,82 @@ jobs:
     name: "Detect Changes 🔍"
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      migrations: ${{ steps.filter.outputs.migrations }}
+      # Per-environment outputs: each diffs HEAD against the SHA of the last
+      # successful deploy for that component + environment (tracked via
+      # deployed/{component}-{environment} git tags). Falls back to
+      # github.event.before on first deploy or when the tag is missing.
+      #
+      # Why per-env: sandbox can be ahead of production (failed prod deploy
+      # leaves sandbox tag advanced while prod tag stays). Each env needs its
+      # own diff base to compute its own pending changes correctly.
+      #
+      # Why per-component: a frontend-only push must not advance the backend
+      # tag, otherwise a later cancelled backend run's commits would be lost.
+      backend-sandbox: ${{ steps.filter-sandbox.outputs.backend }}
+      frontend-sandbox: ${{ steps.filter-sandbox.outputs.frontend }}
+      migrations-sandbox: ${{ steps.filter-sandbox.outputs.migrations }}
+      backend-production: ${{ steps.filter-production.outputs.backend }}
+      frontend-production: ${{ steps.filter-production.outputs.frontend }}
+      migrations-production: ${{ steps.filter-production.outputs.migrations }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
         with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve deploy bases from tags
+        id: bases
+        env:
+          # github.event.before is the parent SHA before this push (or
+          # workflow_dispatch fallback). Bind via env to avoid any
+          # template-into-shell interpolation in the run: body.
+          EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          # Force-fetch tags in case checkout's cache is stale.
+          git fetch --tags --force origin
+          resolve() {
+            local tag="$1"
+            if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+              git rev-parse "refs/tags/${tag}"
+            else
+              # First deploy after rollout, or tag was deleted: fall back to
+              # the immediate parent (today's behavior). This is correct on
+              # the very first run and surfaces a one-time "missing tag"
+              # condition without breaking the pipeline.
+              echo "${EVENT_BEFORE}"
+            fi
+          }
+          {
+            echo "backend-sandbox=$(resolve deployed/backend-sandbox)"
+            echo "frontend-sandbox=$(resolve deployed/frontend-sandbox)"
+            echo "backend-production=$(resolve deployed/backend-production)"
+            echo "frontend-production=$(resolve deployed/frontend-production)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect changes since last sandbox deploy
+        uses: dorny/paths-filter@v4
+        id: filter-sandbox
+        with:
+          base: ${{ steps.bases.outputs.backend-sandbox }}
+          filters: |
+            backend:
+              - 'server/**'
+              - '.github/workflows/deploy.yml'
+              - '.github/workflows/deploy-environment.yml'
+              - '.github/workflows/deploy_server.sh'
+            frontend:
+              - 'clients/**'
+              - '.github/workflows/deploy.yml'
+              - '.github/workflows/deploy-environment.yml'
+            migrations:
+              - 'server/migrations/**'
+
+      - name: Detect changes since last production deploy
+        uses: dorny/paths-filter@v4
+        id: filter-production
+        with:
+          base: ${{ steps.bases.outputs.backend-production }}
           filters: |
             backend:
               - 'server/**'
@@ -44,7 +112,11 @@ jobs:
   build:
     name: "Build Docker Image 🐳"
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    # Build if EITHER environment needs backend deployed. Most common case is
+    # both flip together (sandbox and prod tags advance in lockstep), but if a
+    # sandbox deploy succeeded and prod failed previously, only prod still
+    # needs the build.
+    if: needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.backend-production == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
@@ -122,7 +194,7 @@ jobs:
   deploy-sandbox:
     name: "Deploy to Sandbox 🧪"
     needs: [changes, build]
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.frontend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: sandbox
@@ -131,9 +203,9 @@ jobs:
       render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng,srv-d7unnjhj2pic73c2vr60"
       docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d089jj7diees73934kgg"
-      has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
-      skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
-      skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
+      has-migrations: ${{ needs.changes.outputs.migrations-sandbox == 'true' || github.event_name == 'workflow_dispatch' }}
+      skip-backend: ${{ needs.changes.outputs.backend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
+      skip-frontend: ${{ needs.changes.outputs.frontend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
     secrets:
       RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -145,7 +217,7 @@ jobs:
   deploy-production:
     name: "Deploy to Production 🚀"
     needs: [changes, build, deploy-sandbox]
-    if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend-production == 'true' || needs.changes.outputs.frontend-production == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: production
@@ -154,9 +226,9 @@ jobs:
       render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g,srv-d7us9je7r5hc73be5ieg"
       docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
-      has-migrations: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
-      skip-backend: ${{ needs.changes.outputs.backend != 'true' && github.event_name != 'workflow_dispatch' }}
-      skip-frontend: ${{ needs.changes.outputs.frontend != 'true' && github.event_name != 'workflow_dispatch' }}
+      has-migrations: ${{ needs.changes.outputs.migrations-production == 'true' || github.event_name == 'workflow_dispatch' }}
+      skip-backend: ${{ needs.changes.outputs.backend-production != 'true' && github.event_name != 'workflow_dispatch' }}
+      skip-frontend: ${{ needs.changes.outputs.frontend-production != 'true' && github.event_name != 'workflow_dispatch' }}
     secrets:
       RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,15 +15,23 @@ on:
 concurrency:
   group: build-deploy
 
+# Tag-update jobs in deploy-environment.yml need contents: write to push
+# deployed/{component}-{environment} tags. Declared here at the workflow
+# level because a reusable workflow's per-job permissions are capped by
+# the caller's effective token scope.
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   changes:
     name: "Detect Changes 🔍"
     runs-on: ubuntu-latest
     outputs:
-      # Per-environment outputs: each diffs HEAD against the SHA of the last
-      # successful deploy for that component + environment (tracked via
-      # deployed/{component}-{environment} git tags). Falls back to
-      # github.event.before on first deploy or when the tag is missing.
+      # Per-component-per-environment outputs: each diffs HEAD against the
+      # SHA of the last successful deploy for that component + environment
+      # (tracked via deployed/{component}-{environment} git tags). Falls
+      # back to HEAD~1 if no tag exists and the push has no parent SHA.
       #
       # Why per-env: sandbox can be ahead of production (failed prod deploy
       # leaves sandbox tag advanced while prod tag stays). Each env needs its
@@ -31,12 +39,17 @@ jobs:
       #
       # Why per-component: a frontend-only push must not advance the backend
       # tag, otherwise a later cancelled backend run's commits would be lost.
-      backend-sandbox: ${{ steps.filter-sandbox.outputs.backend }}
-      frontend-sandbox: ${{ steps.filter-sandbox.outputs.frontend }}
-      migrations-sandbox: ${{ steps.filter-sandbox.outputs.migrations }}
-      backend-production: ${{ steps.filter-production.outputs.backend }}
-      frontend-production: ${{ steps.filter-production.outputs.frontend }}
-      migrations-production: ${{ steps.filter-production.outputs.migrations }}
+      # Crucially, the frontend FILTER must use the frontend tag (not backend
+      # tag) as its base — otherwise a frontend deploy that failed after a
+      # successful backend deploy would be permanently dropped from future
+      # diffs (its pending frontend changes sit "before" the backend tag).
+      # This is why each component has its own paths-filter invocation.
+      backend-sandbox: ${{ steps.filter-backend-sandbox.outputs.backend }}
+      migrations-sandbox: ${{ steps.filter-backend-sandbox.outputs.migrations }}
+      frontend-sandbox: ${{ steps.filter-frontend-sandbox.outputs.frontend }}
+      backend-production: ${{ steps.filter-backend-production.outputs.backend }}
+      migrations-production: ${{ steps.filter-backend-production.outputs.migrations }}
+      frontend-production: ${{ steps.filter-frontend-production.outputs.frontend }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,24 +59,44 @@ jobs:
       - name: Resolve deploy bases from tags
         id: bases
         env:
-          # github.event.before is the parent SHA before this push (or
-          # workflow_dispatch fallback). Bind via env to avoid any
+          # github.event.before is the parent SHA before this push. On
+          # workflow_dispatch it is empty; on the very first push to a
+          # branch it can be the zero SHA. Bind via env to avoid any
           # template-into-shell interpolation in the run: body.
           EVENT_BEFORE: ${{ github.event.before }}
+          ZERO_SHA: "0000000000000000000000000000000000000000"
         run: |
           set -euo pipefail
-          # Force-fetch tags in case checkout's cache is stale.
-          git fetch --tags --force origin
+          # Bash command substitution does NOT propagate set -e failures by
+          # default; without this, a transient git failure inside resolve()
+          # would silently emit "key=" (empty value) instead of aborting.
+          shopt -s inherit_errexit
+          # Re-fetch tags with prune so a remote-side deletion drops the
+          # local copy (defensive against cached/self-hosted runners).
+          git fetch --tags --force --prune --prune-tags origin
+          # Resolve the safe fallback once. We prefer event.before, but on
+          # workflow_dispatch / new-branch pushes it's empty or zero-SHA;
+          # fall back to HEAD~1 which always exists on a fetch-depth: 0
+          # checkout. Last resort: HEAD itself (zero diff vs HEAD, lets the
+          # workflow_dispatch override paths take over downstream).
+          fallback_base() {
+            if [ -n "${EVENT_BEFORE}" ] \
+               && [ "${EVENT_BEFORE}" != "${ZERO_SHA}" ] \
+               && git rev-parse --verify --quiet "${EVENT_BEFORE}^{commit}" >/dev/null; then
+              echo "${EVENT_BEFORE}"
+            elif git rev-parse --verify --quiet "HEAD~1^{commit}" >/dev/null; then
+              git rev-parse "HEAD~1"
+            else
+              git rev-parse "HEAD"
+            fi
+          }
+          FALLBACK="$(fallback_base)"
           resolve() {
             local tag="$1"
-            if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
-              git rev-parse "refs/tags/${tag}"
+            if git rev-parse --verify --quiet "refs/tags/${tag}^{commit}" >/dev/null; then
+              git rev-parse "refs/tags/${tag}^{commit}"
             else
-              # First deploy after rollout, or tag was deleted: fall back to
-              # the immediate parent (today's behavior). This is correct on
-              # the very first run and surfaces a one-time "missing tag"
-              # condition without breaking the pipeline.
-              echo "${EVENT_BEFORE}"
+              echo "${FALLBACK}"
             fi
           }
           {
@@ -73,9 +106,13 @@ jobs:
             echo "frontend-production=$(resolve deployed/frontend-production)"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Detect changes since last sandbox deploy
+      # Four paths-filter invocations: one per component per env. We can't
+      # combine them because dorny/paths-filter@v4 uses a single base for
+      # all filters in one invocation, but our design requires the frontend
+      # filter to diff against the frontend tag, not the backend tag.
+      - name: Detect backend changes since last sandbox backend deploy
         uses: dorny/paths-filter@v4
-        id: filter-sandbox
+        id: filter-backend-sandbox
         with:
           base: ${{ steps.bases.outputs.backend-sandbox }}
           filters: |
@@ -84,16 +121,23 @@ jobs:
               - '.github/workflows/deploy.yml'
               - '.github/workflows/deploy-environment.yml'
               - '.github/workflows/deploy_server.sh'
+            migrations:
+              - 'server/migrations/**'
+
+      - name: Detect frontend changes since last sandbox frontend deploy
+        uses: dorny/paths-filter@v4
+        id: filter-frontend-sandbox
+        with:
+          base: ${{ steps.bases.outputs.frontend-sandbox }}
+          filters: |
             frontend:
               - 'clients/**'
               - '.github/workflows/deploy.yml'
               - '.github/workflows/deploy-environment.yml'
-            migrations:
-              - 'server/migrations/**'
 
-      - name: Detect changes since last production deploy
+      - name: Detect backend changes since last production backend deploy
         uses: dorny/paths-filter@v4
-        id: filter-production
+        id: filter-backend-production
         with:
           base: ${{ steps.bases.outputs.backend-production }}
           filters: |
@@ -102,12 +146,19 @@ jobs:
               - '.github/workflows/deploy.yml'
               - '.github/workflows/deploy-environment.yml'
               - '.github/workflows/deploy_server.sh'
+            migrations:
+              - 'server/migrations/**'
+
+      - name: Detect frontend changes since last production frontend deploy
+        uses: dorny/paths-filter@v4
+        id: filter-frontend-production
+        with:
+          base: ${{ steps.bases.outputs.frontend-production }}
+          filters: |
             frontend:
               - 'clients/**'
               - '.github/workflows/deploy.yml'
               - '.github/workflows/deploy-environment.yml'
-            migrations:
-              - 'server/migrations/**'
 
   build:
     name: "Build Docker Image 🐳"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,8 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # fetch-depth: 0 already fetches all tags, so no separate
+          # fetch-tags is needed here.
           fetch-depth: 0
-          fetch-tags: true
 
       - name: Resolve deploy bases from tags
         id: bases
@@ -253,7 +254,11 @@ jobs:
   deploy-sandbox:
     name: "Deploy to Sandbox 🧪"
     needs: [changes, build]
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.frontend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
+    # `!failure() && !cancelled()` mirrors deploy-production: if the `changes`
+    # job fails, `build` is skipped (no `if: always()`), and on a
+    # workflow_dispatch the OR-clause below would otherwise let this job run
+    # with an EMPTY docker-digest. Guarding on !failure() blocks that path.
+    if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.frontend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: sandbox


### PR DESCRIPTION
## Problem

The current deploy workflow can silently drop commits when GitHub Actions concurrency cancels a pending run.

**The mechanics:**
- `concurrency: group: build-deploy` allows only one in-progress + one pending run per group. When a third push lands, the pending one is **cancelled**.
- `dorny/paths-filter@v4` on `push` events diffs against `github.event.before` (the immediate parent of the new push).
- Combined: if commit B's run is cancelled, the next commit C's filter only diffs `C..B`. Any backend/frontend changes that were in B (and earlier dropped commits) are never detected as "changed" and never deployed.

**Real incident** (run [26517009590](https://github.com/polarsource/polar/actions/runs/26517009590)):

| Time | Commit | PR | Type | Outcome |
|------|--------|----|------|--------|
| 14:02:29 | `8a6c421f6` | #11952 | backend | ✅ deployed (bundled #11944's migration with it) |
| 14:02:59 | `8d58080a0` | #11943 | backend-only | ❌ run cancelled, **changes never deployed** |
| 14:07:09 | `bde397456` | #11951 | frontend | ❌ run cancelled |
| 14:14:55 | `cdead53d8` | #11953 | frontend | ✅ frontend deployed, backend skipped (paths-filter saw only `cdead53d8..bde397456` = frontend) |

PR #11943's backend changes sat in `main` but never reached Render.

## Fix

Replace the implicit "diff against parent" diff base with an explicit "diff against the last successfully deployed SHA for this component + environment." State lives in four lightweight git tags:

```
deployed/backend-sandbox
deployed/backend-production
deployed/frontend-sandbox
deployed/frontend-production
```

Each tag advances only when its component deploys successfully to its environment. The `changes` job in [deploy.yml](.github/workflows/deploy.yml) reads each tag and passes it as `base:` to `dorny/paths-filter@v4` — once per environment. Cancelled intermediate runs are now harmless: the next run still sees the dropped commits because the tag hasn't moved.

### Walk-through of the same incident under this fix

After the `8a6c421f6` deploy: `backend-prod = 8a6c421f6`, `frontend-prod = 8a6c421f6`.

The runs for `8d58080a0` and `bde397456` get cancelled by concurrency. `cdead53d8` runs:
- Backend filter: `git diff 8a6c421f6..cdead53d8 -- server/` → **server/ files changed** (8d58080a0's commit) → backend = true ✅
- Frontend filter: `git diff 8a6c421f6..cdead53d8 -- clients/` → clients/ files changed → frontend = true

Backend image builds with 8d58080a0's fix baked in, both deploy, both tags advance to `cdead53d8`. No commit lost.

### Why per-environment

Sandbox can be ahead of production (failed prod deploy leaves sandbox tag advanced, prod tag stays). Each environment needs its own diff base to compute its own pending changes correctly. The `changes` job runs `paths-filter` twice — once per env — and emits per-env outputs (`backend-sandbox`, `backend-production`, etc.) consumed by the respective deploy jobs.

### Why per-component tag-update jobs

The tag-update logic lives in `deploy-environment.yml` as two separate jobs:
- `update-backend-tag` — `needs: deploy-backend`, gated on `deploy-backend.result == 'success' && skip-backend != true`
- `update-frontend-tag` — `needs: promote-frontend`, gated on `promote-frontend.result == 'success' && skip-frontend != true`

Splitting them ensures a frontend failure doesn't pin the backend tag at a stale SHA. If they shared a single job gated on overall success, a Vercel hiccup would leave the backend tag at the old SHA, causing the next push to redundantly redeploy backend to Render.

### Bonus: free observability win

Any engineer can run this locally to see exactly what's pending deploy:

```bash
git fetch --tags
git log deployed/backend-production..main -- server/
git log deployed/frontend-production..main -- clients/
```

## Bootstrap (REQUIRED before merge)

The four tags don't exist yet. Workflow falls back to `github.event.before` when a tag is missing, so a missing-tag is degraded behavior (today's behavior), not broken. But for the first deploy after merge to behave correctly, create the tags pointing at the current `main` HEAD just before merging:

```bash
SHA=$(git rev-parse origin/main)
for tag in deployed/backend-sandbox deployed/backend-production \
           deployed/frontend-sandbox deployed/frontend-production; do
  git tag "$tag" "$SHA"
  git push origin "refs/tags/$tag"
done
```

The first push after merge will then see no diff against the tags (correctly: nothing has been deployed since the tag was created) and skip both components. The deploy will not happen — that's expected, since nothing has changed. The next real change advances the tag and the system is in steady state.

## Rollback story

If something goes wrong after merge:
1. Revert this PR. Workflow goes back to old behavior immediately on next push.
2. The `deployed/*` tags can stay or be deleted — they're orphaned but harmless.

If a tag gets force-pushed or deleted accidentally during normal operation:
```bash
git tag -f deployed/backend-production <known-good-sha>
git push -f origin refs/tags/deployed/backend-production
```

## Permissions

The new tag-update jobs in `deploy-environment.yml` declare `permissions: contents: write` so `GITHUB_TOKEN` can push tags. No org-level changes needed. The `changes` job in `deploy.yml` doesn't push anything and keeps the default permissions.

## Testing

Tested via:
- YAML parses cleanly (`yaml.safe_load`)
- Walked through the bug scenario above by hand against the new diff logic
- Walked through frontend-only, backend-only, and mixed PR scenarios

## Checklist

- [x] Workflow YAML parses
- [x] No regression to manual `workflow_dispatch` (still forces all deploys via existing `|| github.event_name == 'workflow_dispatch'` guards)
- [x] No regression to migration ordering (migrations filter is per-env and still drives the API-first behavior in [deploy_server.sh](.github/workflows/deploy_server.sh))
- [x] No regression to sandbox-before-production gate
- [x] Per-component tag updates are independent (frontend failure won't pin backend tag)
- [ ] Bootstrap tags created (do this just before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Deployment**
  * Automatic lightweight git tags now mark deployed frontend and backend commits; tag updates run with retry attempts, are gated to main branch for promoted runs, and are best-effort.
  * Error-tracking release publishing is best-effort and won’t fail deployments on auth/rate issues.
  * Change detection is environment-aware (sandbox vs production) for more precise deploy decisions.
  * Workflow permissions updated to allow necessary write operations for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->