### PR TITLE
Extract visibility enum to shared kit module

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27367,7 +27367,7 @@ export interface components {
         | null
     }
     /**
-     * ProductVisibility
+     * Visibility
      * @enum {string}
      */
     ProductVisibility: 'draft' | 'private' | 'public'
@@ -30942,6 +30942,11 @@ export interface components {
         [key: string]: string
       }
     }
+    /**
+     * Visibility
+     * @enum {string}
+     */
+    Visibility: 'draft' | 'private' | 'public'
     /**
      * Wallet
      * @description A wallet represents a customer's balance in your organization.
@@ -57713,6 +57718,9 @@ export const userUpdateCountryAnyOf0Values: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const visibilityValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['Visibility']
+> = ['draft', 'private', 'public']
 export const walletSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['WalletSortProperty']
 > = ['created_at', '-created_at', 'balance', '-balance']

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -61,6 +61,7 @@ from polar.kit.operator import attrgetter
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
+from polar.kit.visibility import Visibility
 from polar.logging import Logger
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
@@ -74,7 +75,6 @@ from polar.models import (
     PaymentMethod,
     Product,
     ProductPrice,
-    ProductVisibility,
     Subscription,
     User,
 )
@@ -662,10 +662,7 @@ class CheckoutService:
     ) -> Checkout:
         products: list[Product] = []
         for product in checkout_link.products:
-            if (
-                not product.is_archived
-                and product.visibility != ProductVisibility.draft
-            ):
+            if not product.is_archived and product.visibility != Visibility.draft:
                 products.append(product)
 
         if len(products) == 0:
@@ -1518,7 +1515,7 @@ class CheckoutService:
                 ]
             )
 
-        if product.visibility == ProductVisibility.draft:
+        if product.visibility == Visibility.draft:
             raise PolarRequestValidationError(
                 [
                     {
@@ -1586,7 +1583,7 @@ class CheckoutService:
                 )
                 continue
 
-            if product.visibility == ProductVisibility.draft:
+            if product.visibility == Visibility.draft:
                 errors.append(
                     {
                         "type": "value_error",

--- a/server/polar/checkout_link/service.py
+++ b/server/polar/checkout_link/service.py
@@ -19,6 +19,7 @@ from polar.kit.crypto import generate_token
 from polar.kit.pagination import PaginationParams
 from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
+from polar.kit.visibility import Visibility
 from polar.models import (
     CheckoutLink,
     CheckoutLinkProduct,
@@ -26,7 +27,6 @@ from polar.models import (
     Organization,
     Product,
     ProductPrice,
-    ProductVisibility,
     User,
 )
 from polar.postgres import AsyncSession
@@ -284,7 +284,7 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
                 )
                 continue
 
-            if product.visibility == ProductVisibility.draft:
+            if product.visibility == Visibility.draft:
                 errors.append(
                     {
                         "type": "value_error",
@@ -362,7 +362,7 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
                 ]
             )
 
-        if product.visibility == ProductVisibility.draft:
+        if product.visibility == Visibility.draft:
             raise PolarRequestValidationError(
                 [
                     {

--- a/server/polar/customer_portal/service/organization.py
+++ b/server/polar/customer_portal/service/organization.py
@@ -2,7 +2,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from polar.kit.services import ResourceServiceReader
-from polar.models import Organization, Product, ProductVisibility
+from polar.kit.visibility import Visibility
+from polar.models import Organization, Product
 from polar.postgres import AsyncSession
 
 
@@ -21,7 +22,7 @@ class CustomerOrganizationService(ResourceServiceReader[Organization]):
                     Organization.products.and_(
                         Product.is_deleted.is_(False),
                         Product.is_archived.is_(False),
-                        Product.visibility == ProductVisibility.public,
+                        Product.visibility == Visibility.public,
                     )
                 ).options(
                     selectinload(Product.product_medias),

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -12,13 +12,13 @@ from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
+from polar.kit.visibility import Visibility
 from polar.models import (
     Organization,
     Product,
     Subscription,
     SubscriptionMeter,
 )
-from polar.models.product import ProductVisibility
 from polar.models.subscription import CustomerCancellationReason
 from polar.subscription.service import subscription as subscription_service
 
@@ -196,7 +196,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
             session,
             subscription,
             product_id=product_id,
-            allowed_visibilities=frozenset({ProductVisibility.public}),
+            allowed_visibilities=frozenset({Visibility.public}),
         )
 
     async def uncancel(

--- a/server/polar/kit/visibility.py
+++ b/server/polar/kit/visibility.py
@@ -1,0 +1,19 @@
+from enum import StrEnum
+
+from sqlalchemy.orm import Mapped, mapped_column
+
+from polar.kit.extensions.sqlalchemy import StringEnum
+
+
+class Visibility(StrEnum):
+    draft = "draft"
+    private = "private"
+    public = "public"
+
+
+class VisibilityMixin:
+    visibility: Mapped[Visibility] = mapped_column(
+        StringEnum(Visibility),
+        nullable=False,
+        default=Visibility.public,
+    )

--- a/server/polar/models/product.py
+++ b/server/polar/models/product.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
 from alembic_utils.pg_function import PGFunction
@@ -26,8 +26,9 @@ from polar.enums import SubscriptionRecurringInterval
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import StringEnum
 from polar.kit.metadata import MetadataMixin
+from polar.kit.schemas import SetSchemaReference
 from polar.kit.trial import TrialConfigurationMixin
-from polar.kit.visibility import VisibilityMixin
+from polar.kit.visibility import Visibility, VisibilityMixin
 from polar.models.product_price import ProductPriceAmountType, ProductPriceType
 from polar.tax.calculation import TaxCode
 
@@ -49,13 +50,9 @@ class ProductBillingType(StrEnum):
     recurring = "recurring"
 
 
-# Kept as a distinct enum (rather than reusing `Visibility`) so the public
-# OpenAPI/SDK component stays named `ProductVisibility`. The product schemas
-# reference this; the DB column comes from `VisibilityMixin` (`Visibility`).
-class ProductVisibility(StrEnum):
-    draft = "draft"
-    private = "private"
-    public = "public"
+# Alias over the shared `Visibility` enum that keeps the public OpenAPI/SDK
+# component named `ProductVisibility` for backwards compatibility.
+ProductVisibility = Annotated[Visibility, SetSchemaReference("ProductVisibility")]
 
 
 class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordModel):

--- a/server/polar/models/product.py
+++ b/server/polar/models/product.py
@@ -27,6 +27,7 @@ from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import StringEnum
 from polar.kit.metadata import MetadataMixin
 from polar.kit.trial import TrialConfigurationMixin
+from polar.kit.visibility import VisibilityMixin
 from polar.models.product_price import ProductPriceAmountType, ProductPriceType
 from polar.tax.calculation import TaxCode
 
@@ -48,13 +49,16 @@ class ProductBillingType(StrEnum):
     recurring = "recurring"
 
 
+# Kept as a distinct enum (rather than reusing `Visibility`) so the public
+# OpenAPI/SDK component stays named `ProductVisibility`. The product schemas
+# reference this; the DB column comes from `VisibilityMixin` (`Visibility`).
 class ProductVisibility(StrEnum):
     draft = "draft"
     private = "private"
     public = "public"
 
 
-class Product(TrialConfigurationMixin, MetadataMixin, RecordModel):
+class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordModel):
     __tablename__ = "products"
     __table_args__ = (
         Index(
@@ -69,11 +73,6 @@ class Product(TrialConfigurationMixin, MetadataMixin, RecordModel):
     name: Mapped[str] = mapped_column(CITEXT(), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    visibility: Mapped[ProductVisibility] = mapped_column(
-        StringEnum(ProductVisibility),
-        nullable=False,
-        default=ProductVisibility.public,
-    )
     recurring_interval: Mapped[SubscriptionRecurringInterval | None] = mapped_column(
         StringEnum(SubscriptionRecurringInterval),
         nullable=True,

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -45,6 +45,7 @@ from polar.kit.schemas import (
     TimestampedSchema,
 )
 from polar.kit.trial import TrialConfigurationInputMixin, TrialConfigurationOutputMixin
+from polar.kit.visibility import Visibility
 from polar.meter.unit import MeterUnit
 from polar.models.product import ProductVisibility
 from polar.models.product_price import (
@@ -402,7 +403,7 @@ class ProductCreateBase(MetadataInputMixin, Schema):
     name: ProductName
     description: ProductDescription = None
     visibility: ProductVisibility = Field(
-        default=ProductVisibility.public,
+        default=Visibility.public,
         description="The visibility of the product.",
     )
     prices: ProductPriceCreateList = Field(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -58,6 +58,7 @@ from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
+from polar.kit.visibility import Visibility
 from polar.locker import Locker
 from polar.logging import Logger
 from polar.models import (
@@ -80,7 +81,6 @@ from polar.models import (
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.customer import CustomerType
 from polar.models.order import OrderBillingReasonInternal
-from polar.models.product import ProductVisibility
 from polar.models.product_price import ProductPrice, ProductPriceSeatUnit
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.models.webhook_endpoint import WebhookEventType
@@ -990,9 +990,7 @@ class SubscriptionService:
         *,
         product_id: uuid.UUID,
         proration_behavior: SubscriptionProrationBehavior | None = None,
-        allowed_visibilities: frozenset[ProductVisibility] = frozenset(
-            ProductVisibility
-        ),
+        allowed_visibilities: frozenset[Visibility] = frozenset(Visibility),
     ) -> Subscription:
         if subscription.revoked or subscription.cancel_at_period_end:
             raise AlreadyCanceledSubscription(subscription)

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -50,6 +50,7 @@ from polar.kit.crypto import generate_token, generate_token_hash_pair
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.kit.utils import generate_uuid, utc_now
+from polar.kit.visibility import Visibility
 from polar.member.schemas import MemberOwnerCreate
 from polar.meter.aggregation import CountAggregation
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
@@ -70,7 +71,7 @@ from polar.models.organization import (
 from polar.models.organization_access_token import OrganizationAccessToken
 from polar.models.organization_review import OrganizationReview
 from polar.models.payout_account import PayoutAccount
-from polar.models.product import Product, ProductVisibility
+from polar.models.product import Product
 from polar.models.product_price import (
     ProductPriceAmountType,
     ProductPriceFixed,
@@ -940,9 +941,9 @@ async def _seed_polar_self_billing_catalog(
         benefit_descriptions = product_data["benefits"]
         visibility_value = product_data.get("visibility")
         visibility = (
-            ProductVisibility(visibility_value)
+            Visibility(visibility_value)
             if isinstance(visibility_value, str)
-            else ProductVisibility.public
+            else Visibility.public
         )
         assert isinstance(name, str)
         assert description is None or isinstance(description, str)

--- a/server/tests/customer_portal/endpoints/test_subscription.py
+++ b/server/tests/customer_portal/endpoints/test_subscription.py
@@ -4,8 +4,8 @@ import pytest
 from httpx import AsyncClient
 
 from polar.enums import SubscriptionRecurringInterval
+from polar.kit.visibility import Visibility
 from polar.models import Customer, Member, Organization, Product, Subscription
-from polar.models.product import ProductVisibility
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import (
@@ -89,7 +89,7 @@ class TestCustomerSubscriptionProductUpdate:
             save_fixture,
             organization=organization,
             recurring_interval=SubscriptionRecurringInterval.month,
-            visibility=ProductVisibility.private,
+            visibility=Visibility.private,
         )
         response = await client.patch(
             f"/v1/customer-portal/subscriptions/{subscription.id}",

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -22,6 +22,7 @@ from polar.kit.address import Address
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.trial import TrialInterval
 from polar.kit.utils import utc_now
+from polar.kit.visibility import Visibility
 from polar.meter.aggregation import Aggregation, CountAggregation
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
 from polar.models import (
@@ -63,7 +64,6 @@ from polar.models import (
     ProductPriceFree,
     ProductPriceMeteredUnit,
     ProductPriceSeatUnit,
-    ProductVisibility,
     Refund,
     Subscription,
     SubscriptionProductPrice,
@@ -434,7 +434,7 @@ async def create_product(
     recurring_interval_count: int | None = 1,
     name: str = "Product",
     is_archived: bool = False,
-    visibility: ProductVisibility = ProductVisibility.public,
+    visibility: Visibility = Visibility.public,
     prices: Sequence[PriceFixtureType] = [(1000, "usd")],
     attached_custom_fields: Sequence[tuple[CustomField, bool]] = [],
     trial_interval: TrialInterval | None = None,

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -6,6 +6,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 
 from polar.enums import SubscriptionRecurringInterval
+from polar.kit.visibility import Visibility
 from polar.models import (
     Customer,
     Organization,
@@ -14,7 +15,6 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.customer_seat import SeatStatus
-from polar.models.product import ProductVisibility
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -469,7 +469,7 @@ class TestSubscriptionProductUpdate:
             save_fixture,
             organization=organization,
             recurring_interval=SubscriptionRecurringInterval.month,
-            visibility=ProductVisibility.private,
+            visibility=Visibility.private,
         )
         subscription = await create_active_subscription(
             save_fixture,


### PR DESCRIPTION
I want to roll out visibility to benefits & meters as well, so I thought it's best to reuse what we already have from products.

## How

Refactors the `ProductVisibility` enum into a reusable `Visibility` enum in the kit module, with a `VisibilityMixin` for database column mapping. This enables visibility to be used across multiple models while maintaining backward compatibility with the `ProductVisibility` enum for API schemas.

This change enables visibility to be a shared concept across multiple models (not just products) while maintaining the existing API contract. The `ProductVisibility` enum remains for backwards compatibility in the SDK, but the actual database column and business logic now use the shared `Visibility` enum.

## What

- Created `polar/kit/visibility.py` with:
  - `Visibility` enum (draft, private, public)
  - `VisibilityMixin` for SQLAlchemy column mapping
- Updated `Product` model to use `VisibilityMixin` instead of defining its own visibility column
- Kept `ProductVisibility` enum as a distinct type for OpenAPI/SDK schema naming
- Updated all service and test files to import and use `Visibility` instead of `ProductVisibility`

https://claude.ai/code/session_01TPxMM4dmcLwC64LLMExcRG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal visibility state management system across product-related services and models for better code organization and reusability.
  * Updated test fixtures and seed data to align with refactored visibility system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->