### PR TITLE
amount v2: Migrate refunds to BigInt

### DIFF
--- a/server/migrations/versions/2026-05-28-0841_widen_refunds_amounts_to_bigint.py
+++ b/server/migrations/versions/2026-05-28-0841_widen_refunds_amounts_to_bigint.py
@@ -1,0 +1,52 @@
+"""widen refunds amounts to bigint
+
+Revision ID: d652417d5266
+Revises: 8f4d6b9a2c31
+Create Date: 2026-05-28 08:41:05.146185
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "d652417d5266"
+down_revision = "8f4d6b9a2c31"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "refunds",
+        "amount",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "refunds",
+        "tax_amount",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "refunds",
+        "tax_amount",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "refunds",
+        "amount",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )

--- a/server/polar/models/refund.py
+++ b/server/polar/models/refund.py
@@ -4,10 +4,10 @@ from uuid import UUID
 
 import stripe as stripe_lib
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     ColumnElement,
     ForeignKey,
-    Integer,
     String,
     Uuid,
     type_coerce,
@@ -118,8 +118,8 @@ class Refund(MetadataMixin, RecordModel):
 
     status: Mapped[RefundStatus] = mapped_column(String, nullable=False)
     reason: Mapped[RefundReason] = mapped_column(String, nullable=False)
-    amount: Mapped[int] = mapped_column(Integer, nullable=False)
-    tax_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    tax_amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
 
     comment: Mapped[str | None] = mapped_column(String, nullable=True)


### PR DESCRIPTION
Since the refunds table is so small, we can do this as an online alter table without having to create a separate column and backfill



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refund monetary fields now support much larger values (amount and tax) to prevent overflow for high-value refunds. A database migration accompanies this change to update stored column types safely and preserve non-null constraints, ensuring existing data remains intact and future large refunds are handled correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->