### PR TITLE
amount v2: Migrate account credit_balance to BigInt

### DIFF
--- a/server/migrations/versions/2026-05-28-0945_widen_accounts_credit_balance_to_bigint.py
+++ b/server/migrations/versions/2026-05-28-0945_widen_accounts_credit_balance_to_bigint.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     # accounts is read on hot auth/balance paths. Bound the ACCESS EXCLUSIVE
     # wait so a busy lock queue fails the migration fast instead of stalling
     # every concurrent query behind it.
-    op.execute("SET lock_timeout = '2s'")
+    op.execute("SET LOCAL lock_timeout = '2s'")
     op.alter_column(
         "accounts",
         "credit_balance",
@@ -34,7 +34,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute("SET lock_timeout = '2s'")
+    op.execute("SET LOCAL lock_timeout = '2s'")
+    # WARNING: Rolling back this migration will FAIL if any credit_balance value
+    # exceeds INTEGER max (2,147,483,647). Check data before downgrading.
     op.alter_column(
         "accounts",
         "credit_balance",

--- a/server/migrations/versions/2026-05-28-0945_widen_accounts_credit_balance_to_bigint.py
+++ b/server/migrations/versions/2026-05-28-0945_widen_accounts_credit_balance_to_bigint.py
@@ -1,0 +1,45 @@
+"""widen accounts credit_balance to bigint
+
+Revision ID: 706d2bab5ee4
+Revises: d652417d5266
+Create Date: 2026-05-28 09:45:01.297852
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "706d2bab5ee4"
+down_revision = "d652417d5266"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # accounts is read on hot auth/balance paths. Bound the ACCESS EXCLUSIVE
+    # wait so a busy lock queue fails the migration fast instead of stalling
+    # every concurrent query behind it.
+    op.execute("SET lock_timeout = '2s'")
+    op.alter_column(
+        "accounts",
+        "credit_balance",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        existing_server_default=sa.text("0"),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '2s'")
+    op.alter_column(
+        "accounts",
+        "credit_balance",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+        existing_server_default=sa.text("0"),
+    )

--- a/server/polar/models/account.py
+++ b/server/polar/models/account.py
@@ -2,7 +2,16 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import Boolean, ForeignKey, Integer, Interval, String, Text, Uuid
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    ForeignKey,
+    Integer,
+    Interval,
+    String,
+    Text,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.config import settings
@@ -59,7 +68,7 @@ class Account(RecordModel):
     )
     billing_notes: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
 
-    credit_balance: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    credit_balance: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
     @declared_attr
     def users(cls) -> Mapped[list["User"]]:


### PR DESCRIPTION
The migration does an online migration on the table, but with a 2s lock. The assumption is that based on the usage of this table and the data in it it should go fast. If it doesn't the migration will fail and we'll need to fall back to the second column + backfill + drop approach instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased account credit balance storage capacity so accounts can hold larger credit amounts; existing balances preserved. A database migration updates underlying storage to support bigger values. No changes to user workflows; users can now store and display larger balances without truncation or overflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->