### PR TITLE
feat: OAuth2 account linking endpoints and frontend integration

### DIFF
--- a/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
@@ -26,25 +26,32 @@ const AuthenticationMethod = ({
   subtitle,
   action,
   hideTitle = false,
+  error,
 }: {
   icon: React.ReactNode
   title: React.ReactNode
   subtitle: React.ReactNode
   action: React.ReactNode
   hideTitle?: boolean
+  error?: string
 }) => {
   return (
-    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-center">
-      <div className="self-start">{icon}</div>
-      {!hideTitle && (
-        <div className="grow">
-          <div className="font-medium">{title}</div>
-          <div className="dark:text-polar-500 text-sm text-gray-500">
-            {subtitle}
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-center">
+        <div className="self-start">{icon}</div>
+        {!hideTitle && (
+          <div className="grow">
+            <div className="font-medium">{title}</div>
+            <div className="dark:text-polar-500 text-sm text-gray-500">
+              {subtitle}
+            </div>
           </div>
-        </div>
+        )}
+        <div className={hideTitle ? 'w-full' : 'flex-0'}>{action}</div>
+      </div>
+      {error && (
+        <div className="flex justify-end text-sm text-red-500">{error}</div>
       )}
-      <div className={hideTitle ? 'w-full' : 'flex-0'}>{action}</div>
     </div>
   )
 }
@@ -54,13 +61,15 @@ const GitHubAuthenticationMethod = ({
   returnTo,
   onDisconnect,
   isDisconnecting,
+  error,
 }: {
   oauthAccount: schemas['OAuthAccountRead'] | undefined
   returnTo: string
   onDisconnect: () => void
   isDisconnecting: boolean
+  error?: string
 }) => {
-  const authorizeURL = getGitHubAuthorizeLinkURL({ return_to: returnTo })
+  const authorizeURL = getGitHubAuthorizeLinkURL(returnTo)
 
   return (
     <AuthenticationMethod
@@ -92,6 +101,7 @@ const GitHubAuthenticationMethod = ({
           </Button>
         )
       }
+      error={error}
     />
   )
 }
@@ -101,13 +111,15 @@ const GoogleAuthenticationMethod = ({
   returnTo,
   onDisconnect,
   isDisconnecting,
+  error,
 }: {
   oauthAccount: schemas['OAuthAccountRead'] | undefined
   returnTo: string
   onDisconnect: () => void
   isDisconnecting: boolean
+  error?: string
 }) => {
-  const authorizeURL = getGoogleAuthorizeLinkURL({ return_to: returnTo })
+  const authorizeURL = getGoogleAuthorizeLinkURL(returnTo)
 
   return (
     <AuthenticationMethod
@@ -133,6 +145,7 @@ const GoogleAuthenticationMethod = ({
           </Button>
         )
       }
+      error={error}
     />
   )
 }
@@ -143,6 +156,7 @@ const AuthenticationSettings = () => {
   const githubAccount = useGitHubAccount()
   const googleAccount = useGoogleAccount()
   const disconnectOAuth = useDisconnectOAuthAccount()
+  const listGroupRef = useRef<HTMLDivElement>(null)
 
   const searchParams = useSearchParams()
   const [updateEmailStage, setUpdateEmailStage] = useState<
@@ -150,12 +164,27 @@ const AuthenticationSettings = () => {
   >((searchParams.get('update_email') as 'verified' | null) || 'off')
   const userReloaded = useRef(false)
 
+  const oauthLinkError =
+    searchParams.get('type') === 'oauth_link_error' && searchParams.get('error')
+  const oauthLinkFactor = searchParams.get('factor')
+
   useEffect(() => {
     if (!userReloaded.current && updateEmailStage === 'verified') {
       reloadUser()
       userReloaded.current = true
     }
   }, [updateEmailStage, reloadUser])
+
+  useEffect(() => {
+    if (oauthLinkError && listGroupRef.current) {
+      requestAnimationFrame(() => {
+        listGroupRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        })
+      })
+    }
+  }, [oauthLinkError])
 
   const updateEmailContent: Record<
     'off' | 'form' | 'request' | 'verified',
@@ -190,35 +219,47 @@ const AuthenticationSettings = () => {
   }
 
   return (
-    <ListGroup>
-      <ListGroup.Item>
-        <GitHubAuthenticationMethod
-          oauthAccount={githubAccount}
-          returnTo={pathname || '/start'}
-          onDisconnect={() => disconnectOAuth.mutate('github')}
-          isDisconnecting={disconnectOAuth.isPending}
-        />
-      </ListGroup.Item>
+    <div ref={listGroupRef}>
+      <ListGroup>
+        <ListGroup.Item>
+          <GitHubAuthenticationMethod
+            oauthAccount={githubAccount}
+            returnTo={pathname || '/start'}
+            onDisconnect={() => disconnectOAuth.mutate('github')}
+            isDisconnecting={disconnectOAuth.isPending}
+            error={
+              oauthLinkError && oauthLinkFactor === 'github'
+                ? oauthLinkError
+                : undefined
+            }
+          />
+        </ListGroup.Item>
 
-      <ListGroup.Item>
-        <GoogleAuthenticationMethod
-          oauthAccount={googleAccount}
-          returnTo={pathname || '/start'}
-          onDisconnect={() => disconnectOAuth.mutate('google')}
-          isDisconnecting={disconnectOAuth.isPending}
-        />
-      </ListGroup.Item>
+        <ListGroup.Item>
+          <GoogleAuthenticationMethod
+            oauthAccount={googleAccount}
+            returnTo={pathname || '/start'}
+            onDisconnect={() => disconnectOAuth.mutate('google')}
+            isDisconnecting={disconnectOAuth.isPending}
+            error={
+              oauthLinkError && oauthLinkFactor === 'google'
+                ? oauthLinkError
+                : undefined
+            }
+          />
+        </ListGroup.Item>
 
-      <ListGroup.Item>
-        <AuthenticationMethod
-          icon={<AlternateEmailOutlined />}
-          title={currentUser?.email}
-          subtitle="You can sign in with OTP codes sent to your email."
-          action={updateEmailContent[updateEmailStage]}
-          hideTitle={updateEmailStage !== 'off'}
-        />
-      </ListGroup.Item>
-    </ListGroup>
+        <ListGroup.Item>
+          <AuthenticationMethod
+            icon={<AlternateEmailOutlined />}
+            title={currentUser?.email}
+            subtitle="You can sign in with OTP codes sent to your email."
+            action={updateEmailContent[updateEmailStage]}
+            hideTitle={updateEmailStage !== 'off'}
+          />
+        </ListGroup.Item>
+      </ListGroup>
+    </div>
   )
 }
 

--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -17,16 +17,12 @@ export const getGitHubAuthorizeLoginURL = (
   return `${getPublicServerURL()}/v1/integrations/github/login/authorize?${searchParams}`
 }
 
-export const getGitHubAuthorizeLinkURL = (
-  params: NonNullable<
-    operations['integrations_github:integrations_github_link:integrations.github.link.authorize']['parameters']['query']
-  >,
-): string => {
+export const getGitHubAuthorizeLinkURL = (return_to?: string): string => {
   const searchParams = new URLSearchParams()
-  if (params.return_to) {
-    searchParams.set('return_to', params.return_to)
+  if (return_to) {
+    searchParams.set('return_to', return_to)
   }
-  return `${getPublicServerURL()}/v1/integrations/github/link/authorize?${searchParams}`
+  return `${getPublicServerURL()}/v1/auth/github/link/authorize?${searchParams}`
 }
 
 export const getGoogleAuthorizeLoginURL = (
@@ -44,16 +40,12 @@ export const getGoogleAuthorizeLoginURL = (
   return `${getPublicServerURL()}/v1/integrations/google/login/authorize?${searchParams}`
 }
 
-export const getGoogleAuthorizeLinkURL = (
-  params: NonNullable<
-    operations['integrations_google:integrations_google_link:integrations.google.link.authorize']['parameters']['query']
-  >,
-): string => {
+export const getGoogleAuthorizeLinkURL = (return_to?: string): string => {
   const searchParams = new URLSearchParams()
-  if (params.return_to) {
-    searchParams.set('return_to', params.return_to)
+  if (return_to) {
+    searchParams.set('return_to', return_to)
   }
-  return `${getPublicServerURL()}/v1/integrations/google/link/authorize?${searchParams}`
+  return `${getPublicServerURL()}/v1/auth/google/link/authorize?${searchParams}`
 }
 
 export const getAppleAuthorizeURL = (

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -38,7 +38,7 @@ from .factors import (
     get_totp_factor,
 )
 from .oauth2.apple import get_apple_factor
-from .oauth2.router import get_oauth_router
+from .oauth2.router import get_oauth_link_router, get_oauth_login_router
 from .schemas import AuthenticationSession as AuthenticationSessionSchema
 from .schemas import (
     AuthenticationSessionStart,
@@ -51,10 +51,12 @@ from .service import auth as auth_service
 
 router = APIRouter(prefix="/auth", tags=["auth", APITag.private])
 router.include_router(
-    get_oauth_router(get_apple_factor, "apple", callback_method="POST")
+    get_oauth_login_router(get_apple_factor, "apple", callback_method="POST")
 )
-router.include_router(get_oauth_router(get_github_factor, "github"))
-router.include_router(get_oauth_router(get_google_factor, "google"))
+router.include_router(get_oauth_login_router(get_github_factor, "github"))
+router.include_router(get_oauth_link_router(get_github_factor, "github"))
+router.include_router(get_oauth_login_router(get_google_factor, "google"))
+router.include_router(get_oauth_link_router(get_google_factor, "google"))
 
 
 @router.get("/logout")

--- a/server/polar/auth/exception_handlers.py
+++ b/server/polar/auth/exception_handlers.py
@@ -1,9 +1,7 @@
-from urllib.parse import urlencode
-
 from fastapi import Request, Response
 from fastapi.responses import RedirectResponse
 
-from polar.config import settings
+from polar.kit.http import add_query_parameters
 
 from .exceptions import PolarAuthRedirectionError
 
@@ -12,8 +10,7 @@ async def auth_redirection_error_exception_handler(
     request: Request, exc: Exception
 ) -> Response:
     assert isinstance(exc, PolarAuthRedirectionError)
-    error_url_params = urlencode({"error": exc.message})
-    error_url = f"{settings.generate_frontend_url('/auth')}?{error_url_params}"
+    error_url = add_query_parameters(exc.url, error=exc.message, **exc.extra)
     return RedirectResponse(error_url, 303)
 
 

--- a/server/polar/auth/exceptions.py
+++ b/server/polar/auth/exceptions.py
@@ -1,3 +1,4 @@
+from polar.config import settings
 from polar.exceptions import PolarError
 
 
@@ -24,6 +25,21 @@ class PolarAuthRedirectionError(PolarError):
     Exception class for authentication errors
     that should be displayed nicely to the user through our UI.
 
-    A specific exception handler will redirect to `/auth` page in the client app
-    with an error message.
+    Args:
+        message (str): The error message to display to the user.
+        url (str, optional): The path to redirect to in the client app. Defaults to "/auth".
+        **extra: Additional keyword arguments that'll be added as query parameters to the redirection URL.
+
+    A specific exception handler will redirect to the specified path in the client app
+    with the provided error message.
     """
+
+    def __init__(
+        self,
+        message: str,
+        url: str = settings.generate_frontend_url("/auth"),
+        **extra: str,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.extra = extra

--- a/server/polar/auth/oauth2/router.py
+++ b/server/polar/auth/oauth2/router.py
@@ -9,11 +9,13 @@ from reauth.factors import FactorBase
 from reauth.factors.oauth2.base import (
     OAuth2CallbackException,
     OAuth2Factor,
+    OAuth2IdentityMismatchException,
     OAuth2TokenException,
 )
 
+from polar.authz.dependencies import AuthorizeWebUserWrite
 from polar.config import settings
-from polar.kit.http import is_localhost
+from polar.kit.http import ReturnTo, is_localhost
 from polar.user.service import user as user_service
 
 from ..authentication_session import (
@@ -49,7 +51,7 @@ def _check_factor(
     raise PolarAuthRedirectionError("Factor not available for this session")
 
 
-def get_oauth_router(
+def get_oauth_login_router(
     factor_dependency: typing.Callable[..., Awaitable[OAuth2Factor[typing.Any]]],
     identifier: str,
     *,
@@ -176,6 +178,103 @@ def get_oauth_router(
         response = RedirectResponse(
             settings.generate_frontend_url("/auth"), status_code=303
         )
+        _set_state_cookie(request, response, "", 0)
+        return response
+
+    return router
+
+
+def get_oauth_link_router(
+    factor_dependency: typing.Callable[..., Awaitable[OAuth2Factor[typing.Any]]],
+    identifier: str,
+) -> APIRouter:
+    router = APIRouter(prefix=f"/{identifier}/link", include_in_schema=False)
+
+    @router.get("/authorize", name=f"auth.{identifier}.link_authorize")
+    async def _authorize(
+        request: Request,
+        auth_subject: AuthorizeWebUserWrite,
+        return_to: ReturnTo,
+        factor: OAuth2Factor[typing.Any] = Depends(factor_dependency),
+    ) -> RedirectResponse:
+        redirect_uri = str(request.url_for(f"auth.{identifier}.link_callback"))
+
+        authorization_url, state, oauth2_state = await factor.start(
+            redirect_uri=redirect_uri,
+            scope=typing.cast(OAuth2FactorMixin, factor).SCOPE,
+            identity_id=auth_subject.subject.id,
+            nonce=secrets.token_urlsafe(16),
+            extra={"prompt": "select_account"},
+            return_to=return_to,
+        )
+
+        response = RedirectResponse(authorization_url, status_code=303)
+        _set_state_cookie(request, response, state, oauth2_state.expires_at)
+        return response
+
+    @router.get("/callback", name=f"auth.{identifier}.link_callback")
+    async def _callback(
+        request: Request,
+        auth_subject: AuthorizeWebUserWrite,
+        code: str | None = Query(None),
+        error: str | None = Query(None),
+        error_description: str | None = Query(None),
+        error_uri: str | None = Query(None),
+        state: str | None = Query(None),
+        factor: OAuth2Factor[typing.Any] = Depends(factor_dependency),
+    ) -> RedirectResponse:
+        default_return_to = settings.generate_frontend_url(
+            "/dashboard/account/preferences"
+        )
+        error_parameters = {"type": "oauth_link_error", "factor": identifier}
+        if state is None:
+            raise PolarAuthRedirectionError(
+                "Missing OAuth2 state", url=default_return_to, **error_parameters
+            )
+
+        state_cookie = request.cookies.get(settings.OAUTH2_SESSION_STATE_COOKIE_KEY)
+        if state_cookie is None:
+            raise PolarAuthRedirectionError(
+                "Missing OAuth2 state cookie", url=default_return_to, **error_parameters
+            )
+
+        if state != state_cookie:
+            raise PolarAuthRedirectionError(
+                "Invalid OAuth2 state", url=default_return_to, **error_parameters
+            )
+
+        try:
+            _, _, oauth_state = await factor.callback(
+                code=code,
+                state=state,
+                error=error,
+                error_description=error_description,
+                error_uri=error_uri,
+            )
+        except OAuth2IdentityMismatchException as e:
+            return_to = e.state.context.get("return_to") if e.state.context else None
+            raise PolarAuthRedirectionError(
+                "This account is already linked to another user",
+                url=return_to or default_return_to,
+                **error_parameters,
+            ) from e
+        except OAuth2CallbackException as e:
+            return_to = e.state.context.get("return_to") if e.state.context else None
+            raise PolarAuthRedirectionError(
+                e.message or "OAuth2 callback error",
+                url=return_to or default_return_to,
+                **error_parameters,
+            ) from e
+        except OAuth2TokenException as e:
+            return_to = e.state.context.get("return_to") if e.state.context else None
+            raise PolarAuthRedirectionError(
+                "OAuth2 error", url=return_to or default_return_to, **error_parameters
+            ) from e
+
+        return_to = (
+            oauth_state.context.get("return_to") if oauth_state.context else None
+        )
+        response = RedirectResponse(return_to or default_return_to, status_code=303)
         _set_state_cookie(request, response, "", 0)
         return response
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
   "anyio>=4.13.0",
   "markdown-it-py>=4.2.0",
   "tzdata>=2026.2",
-  "reauth==0.1.5",
+  "reauth==0.1.6",
 ]
 
 [dependency-groups]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-21T11:44:10.166212Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -2437,7 +2437,7 @@ requires-dist = [
     { name = "python-slugify", specifier = ">=8.0.1" },
     { name = "python-snappy", specifier = ">=0.7.3" },
     { name = "python-stdnum", specifier = ">=2.1" },
-    { name = "reauth", specifier = "==0.1.5" },
+    { name = "reauth", specifier = "==0.1.6" },
     { name = "redis", specifier = ">=5.0.4" },
     { name = "safe-redirect-url", specifier = ">=0.1.1" },
     { name = "sentry-sdk", extras = ["fastapi", "sqlalchemy"], specifier = ">=2.60.0" },
@@ -3158,7 +3158,7 @@ wheels = [
 
 [[package]]
 name = "reauth"
-version = "0.1.5"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3166,9 +3166,9 @@ dependencies = [
     { name = "httpx" },
     { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/5e/6b501ad2afee295d11eb6137220711789a53bcaf2259e922929cadea3333/reauth-0.1.5.tar.gz", hash = "sha256:88c487b0337dd2f93d0843e92e9fa6306a7dac0d6c22beb06fd28d17fa4e60a2", size = 501053, upload-time = "2026-05-26T09:54:02.422Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/72/289a0dcadf0f7bdbc9da06e4f6f7e33ceb1080125b0bf1a60aba4e3b9649/reauth-0.1.6.tar.gz", hash = "sha256:579611d54dd3ffda4fe590e5905ef816a847edaedfdbec9b569369183741b2e2", size = 501342, upload-time = "2026-05-28T09:46:32.567Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/bf/add4f1b7538c5fd92275d44e40f849e8bf5c8dfe1f0b3dda5eb719ee1fb4/reauth-0.1.5-py3-none-any.whl", hash = "sha256:5957bc388c62905bc148255efdeb2a8b1c20d730ce89d52f23d70c4826c9faee", size = 34878, upload-time = "2026-05-26T09:54:01.151Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1b/706e336b4fc939fcc4ba19c0760baff33361810fa0b4d8ad2b5acb84492f/reauth-0.1.6-py3-none-any.whl", hash = "sha256:8f26ad08f6e719fe8570cb26a11c5cb96043effbd293d46f4b449d8c8ccac91f", size = 35035, upload-time = "2026-05-28T09:46:31.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**Related Issue**: #

Implements OAuth2 account linking functionality with backend endpoints and frontend integration.

## What

- Add OAuth2 link endpoints in `server/polar/auth/oauth2/router.py`
- Wire OAuth account management to the new auth router in `clients/apps/web/src/components/Settings/AuthenticationSettings.tsx`
- Update auth utilities in `clients/apps/web/src/utils/auth.ts`
- Update backend auth endpoints and exception handling
- Add new OAuth2-related exceptions
- Update dependencies in `server/pyproject.toml` and `server/uv.lock`

## Why

Enables users to link their OAuth accounts, improving the authentication flow and allowing better account management. This is part of the ongoing work to enhance the authentication system.

## How

- Implemented new OAuth2 link endpoints following existing patterns in `server/polar/auth/oauth2/router.py`
- Updated frontend AuthenticationSettings component to use the new auth router
- Refactored auth utilities to support the new OAuth linking flow
- Added appropriate exception handling for OAuth2 linking scenarios

## Checklist

- [x] This PR addresses a single concern (OAuth2 linking feature)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated link flows to connect existing GitHub and Google accounts to your Polar account.

* **Bug Fixes**
  * OAuth errors now surface inline on provider rows and auto-scroll into view for visibility.
  * OAuth callbacks preserve richer error context and return clearer error redirects for troubleshooting.

* **Chores**
  * Updated an authentication-related dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->