### PR TITLE
Fix discount truncation in checkout

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -153,7 +153,8 @@ describe('CheckoutPricingBreakdown', () => {
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
       expect(getRowValue('Subtotal')).toBe('$20')
-      expect(getRowValue('20% off (-20%)')).toBe('-$4')
+      expect(getRowValue('20% off')).toBe('-$4')
+      expect(screen.getByText('(-20%)')).toBeInTheDocument()
       expect(getRowValue('Taxable amount')).toBe('$16')
       expect(getRowValue('Taxes')).toBe('—')
       expect(getRowValue('Total')).toBe('$16')
@@ -181,7 +182,8 @@ describe('CheckoutPricingBreakdown', () => {
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
       expect(getRowValue('Subtotal')).toBe('$20')
-      expect(getRowValue('20% off (-20%)')).toBe('-$4')
+      expect(getRowValue('20% off')).toBe('-$4')
+      expect(screen.getByText('(-20%)')).toBeInTheDocument()
       expect(getRowValue('Taxable amount')).toBe('$16')
       expect(getRowValue('Taxes')).toBe('$4')
       expect(getRowValue('Total')).toBe('$20')
@@ -339,7 +341,7 @@ describe('CheckoutPricingBreakdown', () => {
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
-      expect(screen.getByText(/Until/i)).toBeInTheDocument()
+      expect(screen.getByText(/^\(-20%\) Until/)).toBeInTheDocument()
     })
 
     it('shows "Until" date for repeating discount', () => {
@@ -368,7 +370,7 @@ describe('CheckoutPricingBreakdown', () => {
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
-      expect(screen.getByText(/Until/i)).toBeInTheDocument()
+      expect(screen.getByText(/^\(-20%\) Until/)).toBeInTheDocument()
     })
 
     it('does not show "Until" for forever discount', () => {

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -212,8 +212,17 @@ const CheckoutPricingBreakdown = ({
           {checkout.discount && (
             <>
               <DetailRow
-                title={`${checkout.discount.name}${checkout.discount.type === 'percentage' ? ` (${getDiscountDisplay(checkout.discount, locale)})` : ''}`}
-                subtitle={discountEndLabel || undefined}
+                title={checkout.discount.name}
+                subtitle={
+                  [
+                    checkout.discount.type === 'percentage'
+                      ? `(${getDiscountDisplay(checkout.discount, locale)})`
+                      : null,
+                    discountEndLabel,
+                  ]
+                    .filter(Boolean)
+                    .join(' ') || undefined
+                }
                 className="text-gray-600"
               >
                 {formatCurrency('standard', locale)(

--- a/clients/packages/checkout/src/components/DetailRow.tsx
+++ b/clients/packages/checkout/src/components/DetailRow.tsx
@@ -22,14 +22,14 @@ const DetailRow = ({
         className,
       )}
     >
-      <span className="min-w-0 truncate">
-        {title}
+      <div className="flex min-w-0 flex-row items-baseline gap-x-1">
+        <span className="min-w-0 truncate">{title}</span>
         {subtitle && (
-          <span className="dark:text-polar-500 ml-1 text-gray-400">
+          <span className="dark:text-polar-500 shrink-0 text-gray-400">
             {subtitle}
           </span>
         )}
-      </span>
+      </div>
       <span className="shrink-0">{children}</span>
     </div>
   )


### PR DESCRIPTION
Currently if a discount name is _very_ long we will truncate both the **discount amount** and the **discount expiration** which can lead to confusion.

This PR fixes that by _only_ truncating the **discount name**.

| Before | After  |
|--------|--------|
| <img width="502" height="447" alt="Screenshot 2026-05-28 at 13 02 52" src="https://github.com/user-attachments/assets/9383c0e8-92f5-438b-b918-67848eccbd98" /> | <img width="498" height="451" alt="Screenshot 2026-05-28 at 13 02 06" src="https://github.com/user-attachments/assets/062fc31a-ba18-4348-9e35-39d966fc791c" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Checkout pricing now shows the discount name as the main label, with percentage and expiration details moved into a clearer subtitle for consistent display and improved truncation/alignment.
  * Detail rows throughout checkout have improved layout and text alignment for better readability.

* **Tests**
  * Updated tests to reflect the revised discount presentation and stricter expiration formatting checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->