### PR TITLE
Add <Truncate /> component

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -17,6 +17,7 @@ import { getChartRangeParams } from '@/utils/metrics'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
+import { Truncated } from '@polar-sh/orbit'
 import Avatar from '@polar-sh/ui/components/atoms/Avatar'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import {
@@ -141,9 +142,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
               avatar_url={customer.avatar_url}
               name={customer.email ?? customer.name ?? '—'}
             />
-            <div className="fw-medium overflow-hidden text-ellipsis whitespace-nowrap">
-              {customer.name || customer.email || '—'}
-            </div>
+            <Truncated>{customer.name || customer.email || '—'}</Truncated>
           </div>
         )
       },

--- a/clients/packages/checkout/src/components/DetailRow.tsx
+++ b/clients/packages/checkout/src/components/DetailRow.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@polar-sh/ui/lib/utils'
 import { PropsWithChildren } from 'react'
+import Truncated from './Truncated'
 
 const DetailRow = ({
   title,
@@ -23,7 +24,7 @@ const DetailRow = ({
       )}
     >
       <div className="flex min-w-0 flex-row items-baseline gap-x-1">
-        <span className="min-w-0 truncate">{title}</span>
+        <Truncated>{title}</Truncated>
         {subtitle && (
           <span className="dark:text-polar-500 shrink-0 text-gray-400">
             {subtitle}

--- a/clients/packages/checkout/src/components/Truncated.tsx
+++ b/clients/packages/checkout/src/components/Truncated.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@polar-sh/ui/components/ui/tooltip'
+import { useEffect, useId, useRef, useState } from 'react'
+
+export interface Props {
+  children: React.ReactNode
+  lines?: number
+  tooltip?: React.ReactNode
+  className?: string
+}
+
+const Truncated = ({ children, lines = 1, tooltip, className }: Props) => {
+  const ref = useRef<HTMLSpanElement | null>(null)
+  const [shouldRenderTooltip, setShouldRenderTooltip] = useState(false)
+  const id = useId()
+
+  useEffect(() => {
+    // We only render the tooltip if the content actually overflows
+    const el = ref.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+
+    const overflows = (node: Element) =>
+      lines === 1
+        ? node.scrollWidth > node.clientWidth
+        : node.scrollHeight > node.clientHeight
+
+    const measure = () => {
+      let truncated = overflows(el)
+      if (!truncated) {
+        for (const child of Array.from(el.children)) {
+          if (overflows(child)) {
+            truncated = true
+            break
+          }
+        }
+      }
+      setShouldRenderTooltip(truncated)
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [lines, children])
+
+  // CSS madness so that we can apply the CSS truncation to the wrapper and its direct children
+  const scope = `tr${id.replace(/:/g, '')}`
+  const css =
+    lines === 1
+      ? `.${scope},.${scope}>*{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}`
+      : `.${scope},.${scope}>*{display:-webkit-box;-webkit-line-clamp:${lines};-webkit-box-orient:vertical;overflow:hidden;min-width:0}`
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              ref={ref}
+              className={className ? `${scope} ${className}` : scope}
+              tabIndex={shouldRenderTooltip ? 0 : undefined}
+            >
+              {children}
+            </span>
+          </TooltipTrigger>
+          {shouldRenderTooltip && (
+            <TooltipContent className="max-w-xs">
+              {tooltip ?? children}
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
+    </>
+  )
+}
+
+export default Truncated

--- a/clients/packages/orbit/package.json
+++ b/clients/packages/orbit/package.json
@@ -39,6 +39,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@stylexjs/stylex": "^0.18.2",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",

--- a/clients/packages/orbit/src/components/Truncated.tsx
+++ b/clients/packages/orbit/src/components/Truncated.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+
+import { Box } from './Box'
+import { useEffect, useRef, useState, useId } from 'react'
+import { Text } from './Text'
+
+export interface Props {
+  children: React.ReactNode
+  lines?: number
+  tooltip?: React.ReactNode
+  className?: string
+}
+
+export const Truncated = ({
+  children,
+  lines = 1,
+  tooltip,
+  className,
+}: Props) => {
+  const ref = useRef<HTMLElement | null>(null)
+  const [shouldRenderTooltip, setShouldRenderTooltip] = useState(false)
+  const id = useId()
+
+  useEffect(() => {
+    // We only render the tooltip if the content actually overflows
+    const el = ref.current
+    if (!el) return
+
+    const overflows = (node: Element) =>
+      lines === 1
+        ? node.scrollWidth > node.clientWidth
+        : node.scrollHeight > node.clientHeight
+
+    const measure = () => {
+      let truncated = overflows(el)
+      if (!truncated) {
+        for (const child of Array.from(el.children)) {
+          if (overflows(child)) {
+            truncated = true
+            break
+          }
+        }
+      }
+      setShouldRenderTooltip(truncated)
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [lines, children])
+
+  // CSS madness so that we can apply the CSS truncation to the wrapper and its direct children
+  const scope = `tr${id.replace(/:/g, '')}`
+  const css =
+    lines === 1
+      ? `.${scope},.${scope}>*{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}`
+      : `.${scope},.${scope}>*{display:-webkit-box;-webkit-line-clamp:${lines};-webkit-box-orient:vertical;overflow:hidden;min-width:0}`
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+      <TooltipPrimitive.Provider delayDuration={200}>
+        <TooltipPrimitive.Root>
+          <TooltipPrimitive.Trigger asChild>
+            <Box
+              ref={ref as React.Ref<HTMLElement>}
+              as="span"
+              className={className ? `${scope} ${className}` : scope}
+              tabIndex={shouldRenderTooltip ? 0 : undefined}
+            >
+              {children}
+            </Box>
+          </TooltipPrimitive.Trigger>
+          {shouldRenderTooltip && (
+            <TooltipPrimitive.Portal>
+              <TooltipPrimitive.Content sideOffset={4} style={{ zIndex: 50 }}>
+                {tooltip ?? (
+                  <Box
+                    backgroundColor="background-card"
+                    color="text-primary"
+                    borderColor="border-primary"
+                    borderWidth={1}
+                    borderStyle="solid"
+                    borderRadius="s"
+                    paddingHorizontal="m"
+                    paddingVertical="s"
+                    boxShadow="m"
+                    maxWidth={320}
+                  >
+                    <Text>{children}</Text>
+                  </Box>
+                )}
+              </TooltipPrimitive.Content>
+            </TooltipPrimitive.Portal>
+          )}
+        </TooltipPrimitive.Root>
+      </TooltipPrimitive.Provider>
+    </>
+  )
+}

--- a/clients/packages/orbit/src/index.ts
+++ b/clients/packages/orbit/src/index.ts
@@ -44,6 +44,8 @@ export type {
 } from './components/Status'
 export { Text } from './components/Text'
 export type { TextColor, TextStyleProps, TextVariant } from './components/Text'
+export { Truncated } from './components/Truncated'
+export type { Props as TruncatedProps } from './components/Truncated'
 
 // ─── Primitives ───────────────────────────────────────────────────────────────
 export { createText } from './primitives/createText'

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -787,6 +787,9 @@ importers:
 
   packages/orbit:
     dependencies:
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@stylexjs/stylex':
         specifier: ^0.18.2
         version: 0.18.2


### PR DESCRIPTION
We sometime truncate text in our dashboard/checkout, however there's no way for the user to actually see the full length text.

This PR fixes that by adding a new shared component: `<Truncate />`. This component will automatically truncate any text, as well as (if needed) render a tooltip with the full length text.

The `<Truncate />` component currently lives in two places: Orbit and Checkout. The reason for that is that I don't want to include the Orbit package in Checkout just yet, since it will have an affect on the bundle size. So for now this component is duplicated.


## Screenshots

| Dashboard | Checkout  |
|--------|--------|
| <img width="391" height="154" alt="Screenshot 2026-05-28 at 12 42 20" src="https://github.com/user-attachments/assets/8c52dd19-c8fc-4987-87cc-73372aec977b" /> | <img width="567" height="510" alt="Screenshot 2026-05-28 at 13 41 52" src="https://github.com/user-attachments/assets/572886cc-a765-43e5-bc00-36dc2a2d1887" /> |







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent text truncation with conditional tooltips that show only when content is visually cut off, improving readability in tables and detail rows.

* **Refactor**
  * Consolidated truncation behavior into a single reusable component for consistent trimming and tooltip behavior across the sales dashboard and checkout UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->