### PR TITLE
amount v2: Migrate orders amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-05-29-1030_add_orders_v2_amount_columns.py
+++ b/server/migrations/versions/2026-05-29-1030_add_orders_v2_amount_columns.py
@@ -1,0 +1,243 @@
+"""Add orders v2 amount columns (int → bigint widening)
+
+Revision ID: 56294184ba8f
+Revises: 5579239c38c0
+Create Date: 2026-05-28 10:00:00.000000
+
+Phase 1 of widening orders amount columns from integer to bigint via
+dual-column migration:
+
+  1. Add nullable *_v2 BIGINT columns for every INT4 amount column.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes
+         populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value
+         exceeds INT4_MAX (so new code's v2-only writes still populate
+         legacy for pods still running the previous version during
+         rollout of PR 2).
+  3. Backfill existing rows via scripts.backfill_amount_v2_orders.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "56294184ba8f"
+down_revision = "5579239c38c0"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+ORDERS_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="orders_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.subtotal_amount_v2 IS NULL AND NEW.subtotal_amount IS NOT NULL THEN
+                NEW.subtotal_amount_v2 := NEW.subtotal_amount;
+            END IF;
+            IF NEW.discount_amount_v2 IS NULL AND NEW.discount_amount IS NOT NULL THEN
+                NEW.discount_amount_v2 := NEW.discount_amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount_v2 IS NULL AND NEW.tax_amount IS NOT NULL THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.applied_balance_amount_v2 IS NULL AND NEW.applied_balance_amount IS NOT NULL THEN
+                NEW.applied_balance_amount_v2 := NEW.applied_balance_amount;
+            END IF;
+            IF NEW.refunded_amount_v2 IS NULL AND NEW.refunded_amount IS NOT NULL THEN
+                NEW.refunded_amount_v2 := NEW.refunded_amount;
+            END IF;
+            IF NEW.refunded_tax_amount_v2 IS NULL AND NEW.refunded_tax_amount IS NOT NULL THEN
+                NEW.refunded_tax_amount_v2 := NEW.refunded_tax_amount;
+            END IF;
+            IF NEW.platform_fee_amount_v2 IS NULL AND NEW.platform_fee_amount IS NOT NULL THEN
+                NEW.platform_fee_amount_v2 := NEW.platform_fee_amount;
+            END IF;
+            IF NEW.subtotal_amount IS NULL
+               AND NEW.subtotal_amount_v2 IS NOT NULL
+               AND NEW.subtotal_amount_v2 <= 2147483647 THEN
+                NEW.subtotal_amount := NEW.subtotal_amount_v2::integer;
+            END IF;
+            IF NEW.discount_amount IS NULL
+               AND NEW.discount_amount_v2 IS NOT NULL
+               AND NEW.discount_amount_v2 <= 2147483647 THEN
+                NEW.discount_amount := NEW.discount_amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount IS NULL
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+            IF NEW.applied_balance_amount IS NULL
+               AND NEW.applied_balance_amount_v2 IS NOT NULL
+               AND NEW.applied_balance_amount_v2 <= 2147483647 THEN
+                NEW.applied_balance_amount := NEW.applied_balance_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_amount IS NULL
+               AND NEW.refunded_amount_v2 IS NOT NULL
+               AND NEW.refunded_amount_v2 <= 2147483647 THEN
+                NEW.refunded_amount := NEW.refunded_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_tax_amount IS NULL
+               AND NEW.refunded_tax_amount_v2 IS NOT NULL
+               AND NEW.refunded_tax_amount_v2 <= 2147483647 THEN
+                NEW.refunded_tax_amount := NEW.refunded_tax_amount_v2::integer;
+            END IF;
+            IF NEW.platform_fee_amount IS NULL
+               AND NEW.platform_fee_amount_v2 IS NOT NULL
+               AND NEW.platform_fee_amount_v2 <= 2147483647 THEN
+                NEW.platform_fee_amount := NEW.platform_fee_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.subtotal_amount IS DISTINCT FROM OLD.subtotal_amount THEN
+                NEW.subtotal_amount_v2 := NEW.subtotal_amount;
+            END IF;
+            IF NEW.discount_amount IS DISTINCT FROM OLD.discount_amount THEN
+                NEW.discount_amount_v2 := NEW.discount_amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount IS DISTINCT FROM OLD.tax_amount THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.applied_balance_amount IS DISTINCT FROM OLD.applied_balance_amount THEN
+                NEW.applied_balance_amount_v2 := NEW.applied_balance_amount;
+            END IF;
+            IF NEW.refunded_amount IS DISTINCT FROM OLD.refunded_amount THEN
+                NEW.refunded_amount_v2 := NEW.refunded_amount;
+            END IF;
+            IF NEW.refunded_tax_amount IS DISTINCT FROM OLD.refunded_tax_amount THEN
+                NEW.refunded_tax_amount_v2 := NEW.refunded_tax_amount;
+            END IF;
+            IF NEW.platform_fee_amount IS DISTINCT FROM OLD.platform_fee_amount THEN
+                NEW.platform_fee_amount_v2 := NEW.platform_fee_amount;
+            END IF;
+            IF NEW.subtotal_amount_v2 IS DISTINCT FROM OLD.subtotal_amount_v2
+               AND NEW.subtotal_amount_v2 IS NOT NULL
+               AND NEW.subtotal_amount_v2 <= 2147483647 THEN
+                NEW.subtotal_amount := NEW.subtotal_amount_v2::integer;
+            END IF;
+            IF NEW.discount_amount_v2 IS DISTINCT FROM OLD.discount_amount_v2
+               AND NEW.discount_amount_v2 IS NOT NULL
+               AND NEW.discount_amount_v2 <= 2147483647 THEN
+                NEW.discount_amount := NEW.discount_amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount_v2 IS DISTINCT FROM OLD.tax_amount_v2
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+            IF NEW.applied_balance_amount_v2 IS DISTINCT FROM OLD.applied_balance_amount_v2
+               AND NEW.applied_balance_amount_v2 IS NOT NULL
+               AND NEW.applied_balance_amount_v2 <= 2147483647 THEN
+                NEW.applied_balance_amount := NEW.applied_balance_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_amount_v2 IS DISTINCT FROM OLD.refunded_amount_v2
+               AND NEW.refunded_amount_v2 IS NOT NULL
+               AND NEW.refunded_amount_v2 <= 2147483647 THEN
+                NEW.refunded_amount := NEW.refunded_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_tax_amount_v2 IS DISTINCT FROM OLD.refunded_tax_amount_v2
+               AND NEW.refunded_tax_amount_v2 IS NOT NULL
+               AND NEW.refunded_tax_amount_v2 <= 2147483647 THEN
+                NEW.refunded_tax_amount := NEW.refunded_tax_amount_v2::integer;
+            END IF;
+            IF NEW.platform_fee_amount_v2 IS DISTINCT FROM OLD.platform_fee_amount_v2
+               AND NEW.platform_fee_amount_v2 IS NOT NULL
+               AND NEW.platform_fee_amount_v2 <= 2147483647 THEN
+                NEW.platform_fee_amount := NEW.platform_fee_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+ORDERS_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="orders_sync_v2_amounts_trigger",
+    on_entity="public.orders",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON orders\n"
+        "    FOR EACH ROW EXECUTE FUNCTION orders_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "orders",
+        sa.Column("subtotal_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("discount_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("net_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("tax_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("applied_balance_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("refunded_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("refunded_tax_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("platform_fee_amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(ORDERS_SYNC_V2_AMOUNTS)
+    op.create_entity(ORDERS_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(ORDERS_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(ORDERS_SYNC_V2_AMOUNTS)
+    op.drop_column("orders", "platform_fee_amount_v2")
+    op.drop_column("orders", "refunded_tax_amount_v2")
+    op.drop_column("orders", "refunded_amount_v2")
+    op.drop_column("orders", "applied_balance_amount_v2")
+    op.drop_column("orders", "tax_amount_v2")
+    op.drop_column("orders", "net_amount_v2")
+    op.drop_column("orders", "discount_amount_v2")
+    op.drop_column("orders", "subtotal_amount_v2")

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -8,6 +8,7 @@ from alembic_utils.pg_trigger import PGTrigger
 from alembic_utils.replaceable_entity import register_entities
 from sqlalchemy import (
     TIMESTAMP,
+    BigInteger,
     ColumnElement,
     ForeignKey,
     Index,
@@ -109,11 +110,26 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
         String, nullable=False, default=OrderStatus.pending, index=True
     )
     subtotal_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    subtotal_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     discount_amount: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    discount_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     net_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    net_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     tax_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    tax_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     applied_balance_amount: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0
+    )
+    applied_balance_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
     )
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     billing_reason: Mapped[OrderBillingReasonInternal] = mapped_column(
@@ -121,9 +137,18 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
     )
 
     refunded_amount: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    refunded_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     refunded_tax_amount: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    refunded_tax_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
 
     platform_fee_amount: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    platform_fee_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     platform_fee_currency: Mapped[str | None] = mapped_column(
         String(3), nullable=True, default=None
     )
@@ -449,9 +474,165 @@ orders_search_vector_trigger = PGTrigger(
     """,
 )
 
+
+orders_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="orders_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.subtotal_amount_v2 IS NULL AND NEW.subtotal_amount IS NOT NULL THEN
+                NEW.subtotal_amount_v2 := NEW.subtotal_amount;
+            END IF;
+            IF NEW.discount_amount_v2 IS NULL AND NEW.discount_amount IS NOT NULL THEN
+                NEW.discount_amount_v2 := NEW.discount_amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount_v2 IS NULL AND NEW.tax_amount IS NOT NULL THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.applied_balance_amount_v2 IS NULL AND NEW.applied_balance_amount IS NOT NULL THEN
+                NEW.applied_balance_amount_v2 := NEW.applied_balance_amount;
+            END IF;
+            IF NEW.refunded_amount_v2 IS NULL AND NEW.refunded_amount IS NOT NULL THEN
+                NEW.refunded_amount_v2 := NEW.refunded_amount;
+            END IF;
+            IF NEW.refunded_tax_amount_v2 IS NULL AND NEW.refunded_tax_amount IS NOT NULL THEN
+                NEW.refunded_tax_amount_v2 := NEW.refunded_tax_amount;
+            END IF;
+            IF NEW.platform_fee_amount_v2 IS NULL AND NEW.platform_fee_amount IS NOT NULL THEN
+                NEW.platform_fee_amount_v2 := NEW.platform_fee_amount;
+            END IF;
+            IF NEW.subtotal_amount IS NULL
+               AND NEW.subtotal_amount_v2 IS NOT NULL
+               AND NEW.subtotal_amount_v2 <= 2147483647 THEN
+                NEW.subtotal_amount := NEW.subtotal_amount_v2::integer;
+            END IF;
+            IF NEW.discount_amount IS NULL
+               AND NEW.discount_amount_v2 IS NOT NULL
+               AND NEW.discount_amount_v2 <= 2147483647 THEN
+                NEW.discount_amount := NEW.discount_amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount IS NULL
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+            IF NEW.applied_balance_amount IS NULL
+               AND NEW.applied_balance_amount_v2 IS NOT NULL
+               AND NEW.applied_balance_amount_v2 <= 2147483647 THEN
+                NEW.applied_balance_amount := NEW.applied_balance_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_amount IS NULL
+               AND NEW.refunded_amount_v2 IS NOT NULL
+               AND NEW.refunded_amount_v2 <= 2147483647 THEN
+                NEW.refunded_amount := NEW.refunded_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_tax_amount IS NULL
+               AND NEW.refunded_tax_amount_v2 IS NOT NULL
+               AND NEW.refunded_tax_amount_v2 <= 2147483647 THEN
+                NEW.refunded_tax_amount := NEW.refunded_tax_amount_v2::integer;
+            END IF;
+            IF NEW.platform_fee_amount IS NULL
+               AND NEW.platform_fee_amount_v2 IS NOT NULL
+               AND NEW.platform_fee_amount_v2 <= 2147483647 THEN
+                NEW.platform_fee_amount := NEW.platform_fee_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.subtotal_amount IS DISTINCT FROM OLD.subtotal_amount THEN
+                NEW.subtotal_amount_v2 := NEW.subtotal_amount;
+            END IF;
+            IF NEW.discount_amount IS DISTINCT FROM OLD.discount_amount THEN
+                NEW.discount_amount_v2 := NEW.discount_amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount IS DISTINCT FROM OLD.tax_amount THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.applied_balance_amount IS DISTINCT FROM OLD.applied_balance_amount THEN
+                NEW.applied_balance_amount_v2 := NEW.applied_balance_amount;
+            END IF;
+            IF NEW.refunded_amount IS DISTINCT FROM OLD.refunded_amount THEN
+                NEW.refunded_amount_v2 := NEW.refunded_amount;
+            END IF;
+            IF NEW.refunded_tax_amount IS DISTINCT FROM OLD.refunded_tax_amount THEN
+                NEW.refunded_tax_amount_v2 := NEW.refunded_tax_amount;
+            END IF;
+            IF NEW.platform_fee_amount IS DISTINCT FROM OLD.platform_fee_amount THEN
+                NEW.platform_fee_amount_v2 := NEW.platform_fee_amount;
+            END IF;
+            IF NEW.subtotal_amount_v2 IS DISTINCT FROM OLD.subtotal_amount_v2
+               AND NEW.subtotal_amount_v2 IS NOT NULL
+               AND NEW.subtotal_amount_v2 <= 2147483647 THEN
+                NEW.subtotal_amount := NEW.subtotal_amount_v2::integer;
+            END IF;
+            IF NEW.discount_amount_v2 IS DISTINCT FROM OLD.discount_amount_v2
+               AND NEW.discount_amount_v2 IS NOT NULL
+               AND NEW.discount_amount_v2 <= 2147483647 THEN
+                NEW.discount_amount := NEW.discount_amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount_v2 IS DISTINCT FROM OLD.tax_amount_v2
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+            IF NEW.applied_balance_amount_v2 IS DISTINCT FROM OLD.applied_balance_amount_v2
+               AND NEW.applied_balance_amount_v2 IS NOT NULL
+               AND NEW.applied_balance_amount_v2 <= 2147483647 THEN
+                NEW.applied_balance_amount := NEW.applied_balance_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_amount_v2 IS DISTINCT FROM OLD.refunded_amount_v2
+               AND NEW.refunded_amount_v2 IS NOT NULL
+               AND NEW.refunded_amount_v2 <= 2147483647 THEN
+                NEW.refunded_amount := NEW.refunded_amount_v2::integer;
+            END IF;
+            IF NEW.refunded_tax_amount_v2 IS DISTINCT FROM OLD.refunded_tax_amount_v2
+               AND NEW.refunded_tax_amount_v2 IS NOT NULL
+               AND NEW.refunded_tax_amount_v2 <= 2147483647 THEN
+                NEW.refunded_tax_amount := NEW.refunded_tax_amount_v2::integer;
+            END IF;
+            IF NEW.platform_fee_amount_v2 IS DISTINCT FROM OLD.platform_fee_amount_v2
+               AND NEW.platform_fee_amount_v2 IS NOT NULL
+               AND NEW.platform_fee_amount_v2 <= 2147483647 THEN
+                NEW.platform_fee_amount := NEW.platform_fee_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+orders_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="orders_sync_v2_amounts_trigger",
+    on_entity="orders",
+    definition="""
+    BEFORE INSERT OR UPDATE ON orders
+    FOR EACH ROW EXECUTE FUNCTION orders_sync_v2_amounts();
+    """,
+)
+
 register_entities(
     (
         orders_search_vector_update_function,
         orders_search_vector_trigger,
+        orders_sync_v2_amounts_function,
+        orders_sync_v2_amounts_trigger,
     )
 )

--- a/server/scripts/backfill_amount_v2_orders.py
+++ b/server/scripts/backfill_amount_v2_orders.py
@@ -1,0 +1,80 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import or_, select, update
+
+from polar.models import Order
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill orders *_v2 amount columns from their legacy INT4 counterparts."""
+    await run_batched_update(
+        (
+            update(Order)
+            .values(
+                subtotal_amount_v2=Order.subtotal_amount,
+                discount_amount_v2=Order.discount_amount,
+                net_amount_v2=Order.net_amount,
+                tax_amount_v2=Order.tax_amount,
+                applied_balance_amount_v2=Order.applied_balance_amount,
+                refunded_amount_v2=Order.refunded_amount,
+                refunded_tax_amount_v2=Order.refunded_tax_amount,
+                platform_fee_amount_v2=Order.platform_fee_amount,
+            )
+            .where(
+                Order.id.in_(
+                    select(Order.id)
+                    .where(
+                        or_(
+                            Order.subtotal_amount_v2.is_(None)
+                            & Order.subtotal_amount.is_not(None),
+                            Order.discount_amount_v2.is_(None)
+                            & Order.discount_amount.is_not(None),
+                            Order.net_amount_v2.is_(None)
+                            & Order.net_amount.is_not(None),
+                            Order.tax_amount_v2.is_(None)
+                            & Order.tax_amount.is_not(None),
+                            Order.applied_balance_amount_v2.is_(None)
+                            & Order.applied_balance_amount.is_not(None),
+                            Order.refunded_amount_v2.is_(None)
+                            & Order.refunded_amount.is_not(None),
+                            Order.refunded_tax_amount_v2.is_(None)
+                            & Order.refunded_tax_amount.is_not(None),
+                            Order.platform_fee_amount_v2.is_(None)
+                            & Order.platform_fee_amount.is_not(None),
+                        )
+                    )
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Adds the new amount columns as _v2 and a backfill script. Reads will move over in the second PR and the legacy columns will be dropped in the third.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded order system financial infrastructure to support larger monetary amounts and prevent potential overflow issues in calculations
  * Implemented bidirectional field synchronization mechanisms to maintain complete data consistency across all order financial fields and transactions
  * Added automated database migration and comprehensive backfill utilities to seamlessly transition existing orders to the new enhanced system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->