### PR TITLE
Fix activation gating to check organization owner identity verification

### DIFF
--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -367,18 +367,17 @@ class OrganizationRepository(
         )
         return await self.get_all(statement)
 
-    async def get_all_by_payout_account_admin(
-        self, user_id: UUID
-    ) -> Sequence[Organization]:
+    async def get_all_by_owner_user(self, user_id: UUID) -> Sequence[Organization]:
         statement = (
             self.get_base_statement()
             .join(
-                PayoutAccount,
-                PayoutAccount.id == Organization.payout_account_id,
+                UserOrganization,
+                UserOrganization.organization_id == Organization.id,
             )
             .where(
-                PayoutAccount.admin_id == user_id,
-                PayoutAccount.deleted_at.is_(None),
+                UserOrganization.user_id == user_id,
+                UserOrganization.role == OrganizationRole.owner,
+                UserOrganization.is_deleted.is_(False),
             )
         )
         return await self.get_all(statement)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -11,7 +11,6 @@ import structlog
 from pydantic import BaseModel, Field, TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload
 
 from polar.account.service import account as account_service
 from polar.auth.models import AuthSubject
@@ -1050,15 +1049,16 @@ class OrganizationService:
         payout_account_repository = PayoutAccountRepository.from_session(session)
         payout_account = await payout_account_repository.get_by_id(
             organization.payout_account_id,
-            options=(joinedload(PayoutAccount.admin),),
         )
         if payout_account is None or not payout_account.is_payout_ready:
             return False
 
-        admin = payout_account.admin
+        organization_repository = OrganizationRepository.from_session(session)
+        owner_user = await organization_repository.get_owner_user(organization)
         if (
-            admin is None
-            or admin.identity_verification_status != IdentityVerificationStatus.verified
+            owner_user is None
+            or owner_user.identity_verification_status
+            != IdentityVerificationStatus.verified
         ):
             return False
 
@@ -1073,7 +1073,7 @@ class OrganizationService:
           1. Status is CREATED.
           2. Review is approved: verdict PASS, or verdict FAIL with an
              APPROVED appeal.
-          3. Details submitted, payout account ready, admin identity
+          3. Details submitted, payout account ready, owner identity
              verified (see `_is_activation_ready`).
 
         Idempotent — safe to call from automated triggers (AI review, Stripe

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -191,9 +191,7 @@ class UserService:
         )
 
         organization_repository = OrganizationRepository.from_session(session)
-        organizations = await organization_repository.get_all_by_payout_account_admin(
-            user.id
-        )
+        organizations = await organization_repository.get_all_by_owner_user(user.id)
         for organization in organizations:
             await organization_service.maybe_activate(session, organization)
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1285,6 +1285,115 @@ class TestMaybeActivate:
         assert result is True
         assert organization.status == OrganizationStatus.ACTIVE
 
+    async def test_activates_when_owner_verified_but_payout_admin_unverified(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        user_second: User,
+    ) -> None:
+        """Activation keys off the org owner's identity verification, not the
+        (static) payout account admin's.
+
+        Scenario: ``user`` (A) created the org and payout account (A is the
+        admin) but never completed identity verification. Ownership was
+        transferred to ``user_second`` (B), who is verified. Activation must
+        succeed because the owner is verified.
+        """
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        # A (payout account admin) is NOT identity-verified.
+        user.identity_verification_status = IdentityVerificationStatus.unverified
+        await save_fixture(user)
+
+        # Transfer ownership: demote A, promote verified B to owner.
+        owner_uo = await user_organization_service.get_by_user_and_org(
+            session, user.id, organization.id
+        )
+        assert owner_uo is not None
+        owner_uo.role = OrganizationRole.admin
+        await save_fixture(owner_uo)
+
+        user_second.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user_second)
+        await save_fixture(
+            UserOrganization(
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.PASS,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="Clean",
+            model_used="test",
+        )
+        session.add(review)
+        await session.flush()
+
+        result = await organization_service.maybe_activate(session, organization)
+
+        assert result is True
+        assert organization.status == OrganizationStatus.ACTIVE
+
+    async def test_does_not_activate_when_owner_unverified_but_payout_admin_verified(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        user_second: User,
+    ) -> None:
+        """The reverse: a verified payout account admin must not unlock
+        activation when the current owner is unverified.
+        """
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        # A (payout account admin) stays verified, but the new owner B isn't.
+        owner_uo = await user_organization_service.get_by_user_and_org(
+            session, user.id, organization.id
+        )
+        assert owner_uo is not None
+        owner_uo.role = OrganizationRole.admin
+        await save_fixture(owner_uo)
+
+        user_second.identity_verification_status = IdentityVerificationStatus.unverified
+        await save_fixture(user_second)
+        await save_fixture(
+            UserOrganization(
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.PASS,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="Clean",
+            model_used="test",
+        )
+        session.add(review)
+        await session.flush()
+
+        result = await organization_service.maybe_activate(session, organization)
+
+        assert result is False
+        assert organization.status == OrganizationStatus.CREATED
+
 
 @pytest.mark.asyncio
 class TestBackofficeApprove:
@@ -2401,6 +2510,13 @@ class TestApproveAppeal:
 
         user.identity_verification_status = IdentityVerificationStatus.verified
         await save_fixture(user)
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
 
         await create_payout_account(save_fixture, organization, user)
 
@@ -3728,6 +3844,13 @@ class TestStatusTransitions:
 
         user.identity_verification_status = IdentityVerificationStatus.verified
         await save_fixture(user)
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
 
         await create_payout_account(save_fixture, organization, user)
 

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -1,4 +1,5 @@
 import pytest
+import stripe as stripe_lib
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 
@@ -10,7 +11,8 @@ from polar.models import (
     User,
     UserOrganization,
 )
-from polar.models.user import OAuthPlatform
+from polar.models.user import IdentityVerificationStatus, OAuthPlatform
+from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
 from polar.user.schemas import UserDeletionBlockedReason, UserUpdate
 from polar.user.service import user as user_service
@@ -18,6 +20,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_notification_recipient,
     create_oauth_account,
+    create_payout_account,
 )
 
 
@@ -275,3 +278,65 @@ class TestRequestDeletion:
         recipients = result.scalars().all()
         assert len(recipients) == 2
         assert all(r.deleted_at is not None for r in recipients)
+
+
+@pytest.mark.asyncio
+class TestIdentityVerificationVerified:
+    async def test_activates_organizations_owned_by_user(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        """The webhook activates orgs where the verified user is the owner,
+        not orgs where they are merely the (static) payout account admin.
+        """
+        user.identity_verification_id = "vs_owner_test"
+        await save_fixture(user)
+
+        # User owns `organization`.
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+
+        # User is only the payout account admin of `organization_second`
+        # (not the owner) — the old behavior would have tried to activate it.
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization_second.id,
+                role=OrganizationRole.member,
+            )
+        )
+        await create_payout_account(save_fixture, organization_second, user)
+
+        maybe_activate_mock = mocker.patch(
+            "polar.user.service.organization_service.maybe_activate",
+            new_callable=mocker.AsyncMock,
+        )
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_owner_test", "status": "verified"}, None
+        )
+
+        updated_user = await user_service.identity_verification_verified(
+            session, verification_session
+        )
+
+        assert (
+            updated_user.identity_verification_status
+            == IdentityVerificationStatus.verified
+        )
+
+        activated_org_ids = {
+            call.args[1].id for call in maybe_activate_mock.call_args_list
+        }
+        assert organization.id in activated_org_ids
+        assert organization_second.id not in activated_org_ids


### PR DESCRIPTION
## Summary

**Related Issue**: #11858

Activation readiness was gated on the wrong user's identity verification. Both the `_is_activation_ready` check and the `identity_verification_verified` Stripe webhook keyed off the static `PayoutAccount.admin` instead of the current organization `owner`.

## What

- `_is_activation_ready` (`server/polar/organization/service.py`) now resolves the organization owner via `get_owner_user` and checks *that* user's `identity_verification_status`, instead of `payout_account.admin`.
- The `identity_verification_verified` webhook (`server/polar/user/service.py`) now finds organizations to activate by owner.
- Renamed `OrganizationRepository.get_all_by_payout_account_admin` → `get_all_by_owner_user` (joins `UserOrganization` on `role == owner`); the old method was left unused after the webhook change.
- Updated the `maybe_activate` docstring ("admin identity" → "owner identity") and dropped a now-unused `joinedload` import.

## Why

A prior RBAC migration (#11810) moved the "who must be identity-verified" requirement from `Account.admin_id` semantics to the organization `owner` role, and updated `get_review_state` accordingly — but `_is_activation_ready` and the identity-verification webhook were missed.

`PayoutAccount.admin_id` is set at payout-account creation and does **not** change on organization ownership transfer, while the `owner` role can. As a result activation could be:
- **incorrectly blocked** when the owner is verified but the payout account admin is not, or
- **incorrectly allowed** when the reverse is true.

## How

Both activation gates now go through the same owner-based lookup that `get_review_state` already uses, so all three are consistent.

Test coverage added:
- `TestMaybeActivate` — two cases covering both directions (owner verified + payout admin unverified → activates; owner unverified + payout admin verified → does not). Both were confirmed to fail against the old logic.
- `TestIdentityVerificationVerified` — verifies the webhook activates owned orgs and skips orgs where the user is only the payout admin.
- Fixed two pre-existing tests (`TestApproveAppeal`, `TestStatusTransitions` reactivation) that set up a verified payout admin but never assigned the `owner` role.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated organization activation to verify the organization owner's identity status instead of the payout account administrator's verification during activation workflows.
  * Improved organization ownership validation to use owner-based role checking rather than payout account relationship verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->