### PR TITLE
Nest task parameters to avoid collision with task selector

### DIFF
--- a/server/polar/backoffice/tasks/endpoints.py
+++ b/server/polar/backoffice/tasks/endpoints.py
@@ -94,9 +94,10 @@ async def enqueue(request: Request, task: str | None = Query(None)) -> Any:
         data = await request.form()
         try:
             enqueue_task_payload = form_class.model_validate_form(data)
+            parameters = getattr(enqueue_task_payload, "parameters", None)
             enqueue_job(
                 enqueue_task_payload.task,
-                **enqueue_task_payload.model_dump(exclude={"task"}),
+                **(parameters.model_dump() if parameters is not None else {}),
             )
             await add_toast(request, "Task has been enqueued.", "success")
             return

--- a/server/polar/backoffice/tasks/forms.py
+++ b/server/polar/backoffice/tasks/forms.py
@@ -13,7 +13,7 @@ from typing import (
 
 import dramatiq
 from fastapi import Request
-from pydantic import Field, create_model
+from pydantic import Field, create_model, model_validator
 
 from polar import tasks  # noqa
 
@@ -23,6 +23,18 @@ _TASK_DEFINITIONS: dict[str, dramatiq.Actor[Any, Any]] = {
     name: actor for name, actor in dramatiq.get_broker().actors.items()
 }
 _TaskName = Literal[tuple(_TASK_DEFINITIONS.keys())]  # type: ignore[valid-type]
+
+
+class EnqueueTaskParametersFormBase(forms.BaseForm):
+    @model_validator(mode="before")
+    @classmethod
+    def _ignore_blank_values(cls, data: Any) -> Any:
+        # Blank text inputs are submitted as empty strings. Treat them as
+        # "not provided" so optional parameters fall back to their defaults
+        # instead of failing type validation (e.g. "" is not a valid UUID).
+        if isinstance(data, dict):
+            return {key: value for key, value in data.items() if value != ""}
+        return data
 
 
 def _get_function_arguments(
@@ -74,6 +86,7 @@ def build_enqueue_task_form_class(
     }
     if task is not None:
         task_function = _TASK_DEFINITIONS[task]
+        parameter_definitions: dict[str, tuple[type, Any]] = {}
         for key, type_hint, param_default in _get_function_arguments(task_function.fn):
             if param_default is not inspect.Parameter.empty:
                 default = param_default
@@ -81,7 +94,21 @@ def build_enqueue_task_form_class(
                 default = False
             else:
                 default = ...
-            field_definitions[key] = (type_hint, default)
+            parameter_definitions[key] = (type_hint, default)
+
+        # Nest the task's own arguments under a dedicated sub-form so they can
+        # never collide with the `task` selector field above. Some tasks accept
+        # a parameter named `task` themselves (e.g. benefit.enqueue_benefits_grants).
+        if parameter_definitions:
+            parameters_model = create_model(
+                "EnqueueTaskParametersForm",
+                **parameter_definitions,  # type: ignore
+                __base__=EnqueueTaskParametersFormBase,
+            )
+            field_definitions["parameters"] = (
+                parameters_model,
+                Field(title="Parameters"),
+            )
 
     return create_model(
         "EnqueueTaskForm",

--- a/server/tests/backoffice/tasks/test_forms.py
+++ b/server/tests/backoffice/tasks/test_forms.py
@@ -1,7 +1,19 @@
 import inspect
 from typing import NotRequired, Required, TypedDict, Unpack
+from unittest.mock import MagicMock
 
-from polar.backoffice.tasks.forms import _get_function_arguments
+from starlette.datastructures import FormData
+
+from polar.backoffice.tasks.forms import (
+    _get_function_arguments,
+    build_enqueue_task_form_class,
+)
+
+
+def _request() -> MagicMock:
+    request = MagicMock()
+    request.url_for.return_value = "http://test/backoffice/tasks/enqueue"
+    return request
 
 
 class _AllOptional(TypedDict, total=False):
@@ -49,3 +61,55 @@ def test_typeddict_mixed_required_and_not_required() -> None:
         "first_name": None,
         "last_name": None,
     }
+
+
+def test_task_parameters_are_nested_to_avoid_task_collision() -> None:
+    form_class = build_enqueue_task_form_class(
+        _request(), "benefit.enqueue_benefits_grants"
+    )
+
+    # The top-level `task` field stays the task selector and is not clobbered by
+    # the task's own `task` parameter.
+    assert "task" in form_class.model_fields
+    assert "parameters" in form_class.model_fields
+
+    parameters_model = form_class.model_fields["parameters"].annotation
+    assert parameters_model is not None
+    # The task's own `task` argument lives in the nested parameters sub-form.
+    assert "task" in parameters_model.model_fields
+    assert "customer_id" in parameters_model.model_fields
+
+
+def test_no_parameters_field_when_task_has_no_arguments() -> None:
+    form_class = build_enqueue_task_form_class(_request(), None)
+
+    assert "task" in form_class.model_fields
+    assert "parameters" not in form_class.model_fields
+
+
+def test_blank_optional_parameters_fall_back_to_default() -> None:
+    form_class = build_enqueue_task_form_class(
+        _request(), "benefit.enqueue_benefits_grants"
+    )
+
+    payload = form_class.model_validate_form(
+        FormData(
+            [
+                ("task", "benefit.enqueue_benefits_grants"),
+                ("parameters[task]", "grant"),
+                ("parameters[customer_id]", "123e4567-e89b-12d3-a456-426614174000"),
+                ("parameters[product_id]", "223e4567-e89b-12d3-a456-426614174000"),
+                # Optional parameters left blank.
+                ("parameters[member_id]", ""),
+                ("parameters[subscription_id]", ""),
+                ("parameters[order_id]", ""),
+            ]
+        )
+    )
+
+    assert payload.task == "benefit.enqueue_benefits_grants"
+    parameters = payload.parameters.model_dump()  # type: ignore[attr-defined]
+    assert parameters["task"] == "grant"
+    assert parameters["member_id"] is None
+    assert parameters["subscription_id"] is None
+    assert parameters["order_id"] is None

--- a/server/tests/backoffice/tasks/test_forms.py
+++ b/server/tests/backoffice/tasks/test_forms.py
@@ -80,8 +80,16 @@ def test_task_parameters_are_nested_to_avoid_task_collision() -> None:
     assert "customer_id" in parameters_model.model_fields
 
 
-def test_no_parameters_field_when_task_has_no_arguments() -> None:
+def test_no_parameters_field_when_no_task_selected() -> None:
     form_class = build_enqueue_task_form_class(_request(), None)
+
+    assert "task" in form_class.model_fields
+    assert "parameters" not in form_class.model_fields
+
+
+def test_no_parameters_field_when_selected_task_has_no_arguments() -> None:
+    # `auth.delete_expired` is a registered actor that takes no arguments.
+    form_class = build_enqueue_task_form_class(_request(), "auth.delete_expired")
 
     assert "task" in form_class.model_fields
     assert "parameters" not in form_class.model_fields


### PR DESCRIPTION
## Summary

Fixes a bug where tasks with a `task` parameter (e.g., `benefit.enqueue_benefits_grants`) would have their parameter clobbered by the top-level task selector field in the enqueue form.

## What

- Created `EnqueueTaskParametersFormBase` with a validator that treats blank form inputs as "not provided" so optional parameters fall back to defaults instead of failing validation
- Modified `build_enqueue_task_form_class` to nest task parameters under a dedicated `parameters` sub-form instead of mixing them with top-level form fields
- Updated the enqueue endpoint to extract parameters from the nested `parameters` field when present
- Added comprehensive tests covering parameter nesting, optional parameter handling, and the case where a task has no parameters

## Why

Tasks can have parameters named `task`, which would collide with the top-level task selector field. Nesting parameters under a dedicated sub-form prevents this collision while keeping the form structure clean.

Additionally, blank form inputs (empty strings) need special handling to allow optional parameters to use their defaults rather than failing UUID/type validation.

## How

- Task parameters are now collected into a dynamically created `EnqueueTaskParametersForm` model that inherits from `EnqueueTaskParametersFormBase`
- The base form class includes a `@model_validator` that filters out empty string values before validation
- The top-level form always has a `task` field for selection, and optionally a `parameters` field containing the nested parameter model
- The endpoint extracts the nested parameters and passes them to `enqueue_job`

## Checklist

- [x] This PR addresses a single concern (fixing task parameter collision)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (3 new test cases added)
- [ ] Linting and type checking pass (to be verified)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_016Ni6n1ijRDehxyoh1USgPr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blank task parameter inputs are now treated as “not provided” and resolve to appropriate defaults instead of empty strings.

* **Refactor**
  * Task enqueue form restructured to nest task arguments under a dedicated parameters sub-form, preventing name collisions with the task selector.

* **Tests**
  * Added tests covering nested parameters, omission for parameterless tasks, and blank-optional-parameter default handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->