### PR TITLE
Add compact mode to mobile checkout

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -43,6 +43,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Slideshow } from '../Products/Slideshow'
 import { CheckoutDiscountInput } from './CheckoutDiscountInput'
 import { CheckoutProductDescription } from './CheckoutProductDescription'
+import { MobileOrderSummaryBar } from './MobileOrderSummaryBar'
+import { useMobileSummaryState } from './useMobileSummaryState'
 import { twMerge } from 'tailwind-merge'
 
 const PaymentNotReadyBanner = ({
@@ -227,6 +229,14 @@ const Checkout = ({
     [_confirm, checkoutConfirmedRedirect],
   )
 
+  const {
+    mode: mobileLayout,
+    collapses: mobileCollapses,
+    hasTrial,
+    isOpen: mobileSummaryOpen,
+    toggle: toggleMobileSummary,
+  } = useMobileSummaryState(checkout)
+
   if (embed) {
     return (
       <ShadowBox className="dark:md:bg-polar-900 flex flex-col gap-y-12 divide-gray-200 overflow-hidden rounded-3xl md:bg-white dark:divide-transparent">
@@ -335,12 +345,26 @@ const Checkout = ({
   return (
     <div className="md:grid md:min-h-screen md:grid-cols-2">
       <div className="md:flex md:justify-end">
-        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-8 px-4 py-6 md:mx-0 md:py-12 md:pr-12 md:pl-4">
+        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-6 px-4 pt-6 pb-0 md:mx-0 md:py-12 md:pr-12 md:pl-4">
           {orgHeader}
           <div className="flex flex-col gap-y-8 md:sticky md:top-8">
             {hasProductCheckout(checkout) && (
               <>
-                <div className="flex flex-col gap-y-2">
+                {mobileLayout === 'collapsed-bar' && (
+                  <MobileOrderSummaryBar
+                    checkout={checkout}
+                    locale={locale}
+                    hasTrial={hasTrial}
+                    isOpen={mobileSummaryOpen}
+                    onToggle={toggleMobileSummary}
+                  />
+                )}
+                <div
+                  className={twMerge(
+                    'flex flex-col gap-y-2',
+                    mobileCollapses && !mobileSummaryOpen && 'hidden md:flex',
+                  )}
+                >
                   <div className="flex flex-row items-center gap-x-3">
                     {hasMedia && checkout.product.medias[0]?.public_url && (
                       <Dialog>
@@ -389,62 +413,69 @@ const Checkout = ({
                     <CheckoutHeroPrice checkout={checkout} locale={locale} />
                   </span>
                 </div>
-                <CheckoutProductSwitcher
-                  checkout={checkout}
-                  update={
-                    update as (
-                      data: schemas['CheckoutUpdatePublic'],
-                    ) => Promise<ProductCheckoutPublic>
-                  }
-                  themePreset={themePreset}
-                  locale={locale}
-                />
-                {checkout.product_price.amount_type === 'custom' && (
-                  <CheckoutPWYWForm
+                <div
+                  className={twMerge(
+                    'flex flex-col gap-y-8',
+                    mobileCollapses && !mobileSummaryOpen && 'hidden md:flex',
+                  )}
+                >
+                  <CheckoutProductSwitcher
                     checkout={checkout}
-                    update={update}
-                    productPrice={
-                      checkout.product_price as schemas['ProductPriceCustom']
+                    update={
+                      update as (
+                        data: schemas['CheckoutUpdatePublic'],
+                      ) => Promise<ProductCheckoutPublic>
                     }
+                    themePreset={themePreset}
                     locale={locale}
                   />
-                )}
-                {!checkout.is_free_product_price && (
-                  <div className="flex flex-col gap-4 text-sm">
-                    {checkout.product_price.amount_type === 'seat_based' && (
-                      <CheckoutSeatSelector
+                  {checkout.product_price.amount_type === 'custom' && (
+                    <CheckoutPWYWForm
+                      checkout={checkout}
+                      update={update}
+                      productPrice={
+                        checkout.product_price as schemas['ProductPriceCustom']
+                      }
+                      locale={locale}
+                    />
+                  )}
+                  {!checkout.is_free_product_price && (
+                    <div className="flex flex-col gap-4 text-sm">
+                      {checkout.product_price.amount_type === 'seat_based' && (
+                        <CheckoutSeatSelector
+                          checkout={checkout}
+                          update={update}
+                          locale={locale}
+                          compact
+                        />
+                      )}
+                      <CheckoutPricingBreakdown
+                        checkout={checkout}
+                        locale={locale}
+                      />
+                      <CheckoutDiscountInput
                         checkout={checkout}
                         update={update}
                         locale={locale}
-                        compact
+                        collapsible
                       />
-                    )}
-                    <CheckoutPricingBreakdown
-                      checkout={checkout}
+                    </div>
+                  )}
+                  {checkout.product.description && (
+                    <CheckoutProductDescription
+                      description={checkout.product.description}
+                      productName={checkout.product.name}
                       locale={locale}
                     />
-                    <CheckoutDiscountInput
-                      checkout={checkout}
-                      update={update}
-                      locale={locale}
-                      collapsible
-                    />
-                  </div>
-                )}
-                {checkout.product.description && (
-                  <CheckoutProductDescription
-                    description={checkout.product.description}
-                    productName={checkout.product.name}
-                    locale={locale}
-                  />
-                )}
+                  )}
+                </div>
               </>
             )}
           </div>
         </div>
       </div>
       <div className="dark:md:bg-polar-900 md:bg-white">
-        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-8 px-4 py-6 md:mx-0 md:py-12 md:pr-4 md:pl-12">
+        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-8 px-4 pt-6 pb-6 md:mx-0 md:py-12 md:pr-4 md:pl-12">
           {shouldBlockCheckout && (
             <PaymentNotReadyBanner
               organizationStatus={paymentStatus?.organization_status}

--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -347,7 +347,7 @@ const Checkout = ({
       <div className="md:flex md:justify-end">
         <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-6 px-4 pt-6 pb-0 md:mx-0 md:py-12 md:pr-12 md:pl-4">
           {orgHeader}
-          <div className="flex flex-col gap-y-8 md:sticky md:top-8">
+          <div className="flex flex-col md:sticky md:top-8 md:gap-y-8">
             {hasProductCheckout(checkout) && (
               <>
                 {mobileLayout === 'collapsed-bar' && (
@@ -361,64 +361,61 @@ const Checkout = ({
                 )}
                 <div
                   className={twMerge(
-                    'flex flex-col gap-y-2',
-                    mobileCollapses && !mobileSummaryOpen && 'hidden md:flex',
-                  )}
-                >
-                  <div className="flex flex-row items-center gap-x-3">
-                    {hasMedia && checkout.product.medias[0]?.public_url && (
-                      <Dialog>
-                        <DialogTrigger
-                          asChild
-                          disabled={checkout.product.medias.length <= 1}
-                        >
-                          <button
-                            className={`relative h-10 w-10 shrink-0 ${checkout.product.medias.length > 1 ? 'cursor-pointer' : 'cursor-default'}`}
-                          >
-                            <UploadImage
-                              src={checkout.product.medias[0].public_url}
-                              approximateWidth={40}
-                              alt={checkout.product.name}
-                              className="h-10 w-10 rounded-lg object-cover"
-                            />
-                            {checkout.product.medias.length > 1 && (
-                              <span className="absolute right-0 bottom-0 rounded bg-black/60 px-1 py-0.5 text-[10px] leading-none font-medium text-white">
-                                +{checkout.product.medias.length - 1}
-                              </span>
-                            )}
-                          </button>
-                        </DialogTrigger>
-                        <DialogContent className="dark:bg-polar-900 max-w-2xl">
-                          <DialogHeader>
-                            <DialogTitle>{checkout.product.name}</DialogTitle>
-                            <DialogDescription className="sr-only">
-                              Product images
-                            </DialogDescription>
-                          </DialogHeader>
-                          <Slideshow
-                            images={checkout.product.medias.map((m) =>
-                              getResizedImage(m.public_url, 672),
-                            )}
-                          />
-                        </DialogContent>
-                      </Dialog>
-                    )}
-                    <div className="flex min-w-0 flex-col gap-y-1">
-                      <span className="text-sm font-medium text-gray-900 dark:text-white">
-                        {checkout.product.name}
-                      </span>
-                    </div>
-                  </div>
-                  <span className="text-3xl font-medium">
-                    <CheckoutHeroPrice checkout={checkout} locale={locale} />
-                  </span>
-                </div>
-                <div
-                  className={twMerge(
                     'flex flex-col gap-y-8',
                     mobileCollapses && !mobileSummaryOpen && 'hidden md:flex',
+                    mobileCollapses &&
+                      'dark:border-polar-700 dark:bg-polar-800 -mx-4 border-b border-gray-200 bg-gray-50 px-4 pt-6 pb-6 md:mx-0 md:border-0 md:bg-transparent md:p-0 md:dark:bg-transparent',
                   )}
                 >
+                  <div className="flex flex-col gap-y-2">
+                    <div className="flex flex-row items-center gap-x-3">
+                      {hasMedia && checkout.product.medias[0]?.public_url && (
+                        <Dialog>
+                          <DialogTrigger
+                            asChild
+                            disabled={checkout.product.medias.length <= 1}
+                          >
+                            <button
+                              className={`relative h-10 w-10 shrink-0 ${checkout.product.medias.length > 1 ? 'cursor-pointer' : 'cursor-default'}`}
+                            >
+                              <UploadImage
+                                src={checkout.product.medias[0].public_url}
+                                approximateWidth={40}
+                                alt={checkout.product.name}
+                                className="h-10 w-10 rounded-lg object-cover"
+                              />
+                              {checkout.product.medias.length > 1 && (
+                                <span className="absolute right-0 bottom-0 rounded bg-black/60 px-1 py-0.5 text-[10px] leading-none font-medium text-white">
+                                  +{checkout.product.medias.length - 1}
+                                </span>
+                              )}
+                            </button>
+                          </DialogTrigger>
+                          <DialogContent className="dark:bg-polar-900 max-w-2xl">
+                            <DialogHeader>
+                              <DialogTitle>{checkout.product.name}</DialogTitle>
+                              <DialogDescription className="sr-only">
+                                Product images
+                              </DialogDescription>
+                            </DialogHeader>
+                            <Slideshow
+                              images={checkout.product.medias.map((m) =>
+                                getResizedImage(m.public_url, 672),
+                              )}
+                            />
+                          </DialogContent>
+                        </Dialog>
+                      )}
+                      <div className="flex min-w-0 flex-col gap-y-1">
+                        <span className="text-sm font-medium text-gray-900 dark:text-white">
+                          {checkout.product.name}
+                        </span>
+                      </div>
+                    </div>
+                    <span className="text-3xl font-medium">
+                      <CheckoutHeroPrice checkout={checkout} locale={locale} />
+                    </span>
+                  </div>
                   <CheckoutProductSwitcher
                     checkout={checkout}
                     update={

--- a/clients/apps/web/src/components/Checkout/MobileOrderSummaryBar.test.tsx
+++ b/clients/apps/web/src/components/Checkout/MobileOrderSummaryBar.test.tsx
@@ -1,0 +1,124 @@
+import { createCheckout } from '@polar-sh/checkout/test-utils'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileOrderSummaryBar } from './MobileOrderSummaryBar'
+
+afterEach(cleanup)
+
+const nonTrialCheckout = createCheckout({
+  amount: 1999,
+  net_amount: 1999,
+  total_amount: 1999,
+})
+
+const baseProduct = createCheckout().product
+const trialCheckout = createCheckout({
+  amount: 9999,
+  net_amount: 9999,
+  total_amount: 9999,
+  active_trial_interval: 'month',
+  active_trial_interval_count: 1,
+  trial_end: '2026-04-05T00:00:00Z',
+  product: {
+    ...baseProduct,
+    recurring_interval: 'year',
+    is_recurring: true,
+    trial_interval: 'month',
+    trial_interval_count: 1,
+  },
+})
+
+describe('MobileOrderSummaryBar', () => {
+  it('renders an "Order summary" button', () => {
+    render(
+      <MobileOrderSummaryBar
+        checkout={nonTrialCheckout}
+        locale="en"
+        hasTrial={false}
+        isOpen={false}
+        onToggle={() => {}}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /order summary/i })).toBeDefined()
+  })
+
+  it('renders the formatted total when hasTrial is false', () => {
+    render(
+      <MobileOrderSummaryBar
+        checkout={nonTrialCheckout}
+        locale="en"
+        hasTrial={false}
+        isOpen={false}
+        onToggle={() => {}}
+      />,
+    )
+    expect(screen.getByText('$19.99')).toBeDefined()
+  })
+
+  it('renders the compact trial copy when hasTrial is true', () => {
+    render(
+      <MobileOrderSummaryBar
+        checkout={trialCheckout}
+        locale="en"
+        hasTrial={true}
+        isOpen={false}
+        onToggle={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('1 month free')).toBeDefined()
+    const button = screen.getByRole('button')
+    expect(button.textContent).toContain('$99.99/yr')
+    expect(button.textContent).not.toContain('starting')
+    expect(button.textContent).not.toContain('April')
+  })
+
+  it('does NOT render the plain non-trial total when hasTrial is true', () => {
+    render(
+      <MobileOrderSummaryBar
+        checkout={trialCheckout}
+        locale="en"
+        hasTrial={true}
+        isOpen={false}
+        onToggle={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText('$99.99 / year')).toBeNull()
+  })
+
+  it('aria-expanded reflects isOpen', () => {
+    const props = {
+      checkout: nonTrialCheckout,
+      locale: 'en' as const,
+      hasTrial: false,
+      onToggle: () => {},
+    }
+    const { rerender } = render(
+      <MobileOrderSummaryBar {...props} isOpen={false} />,
+    )
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
+      'false',
+    )
+
+    rerender(<MobileOrderSummaryBar {...props} isOpen={true} />)
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
+      'true',
+    )
+  })
+
+  it('calls onToggle when the bar is clicked', () => {
+    const onToggle = vi.fn()
+    render(
+      <MobileOrderSummaryBar
+        checkout={nonTrialCheckout}
+        locale="en"
+        hasTrial={false}
+        isOpen={false}
+        onToggle={onToggle}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/apps/web/src/components/Checkout/MobileOrderSummaryBar.tsx
+++ b/clients/apps/web/src/components/Checkout/MobileOrderSummaryBar.tsx
@@ -29,13 +29,16 @@ export const MobileOrderSummaryBar = ({
       type="button"
       onClick={onToggle}
       aria-expanded={isOpen}
-      className="dark:border-polar-700 dark:bg-polar-800 -mx-4 flex items-center justify-between gap-x-4 border-y border-gray-200 bg-gray-50 px-4 py-4 text-sm md:hidden"
+      className={twMerge(
+        'dark:border-polar-700 dark:bg-polar-800 -mx-4 flex items-center justify-between gap-x-4 border-y border-gray-200 bg-gray-50 px-4 py-4 text-sm md:hidden',
+      )}
     >
       <span className="flex items-center gap-x-2 font-medium whitespace-nowrap text-gray-900 dark:text-white">
         {t('checkout.pricing.orderSummary')}
         <ChevronDown
           size={16}
-          className={twMerge('transition-transform', isOpen && 'rotate-180')}
+          className="transition-transform duration-200"
+          style={{ transform: `rotate(${isOpen ? 180 : 0}deg)` }}
         />
       </span>
       <span className="flex flex-col items-end text-right whitespace-nowrap text-gray-900 dark:text-white">

--- a/clients/apps/web/src/components/Checkout/MobileOrderSummaryBar.tsx
+++ b/clients/apps/web/src/components/Checkout/MobileOrderSummaryBar.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { CheckoutHeroPrice } from '@polar-sh/checkout/components'
+import type { ProductCheckoutPublic } from '@polar-sh/checkout/guards'
+import { formatCurrency } from '@polar-sh/currency'
+import { type AcceptedLocale, useTranslations } from '@polar-sh/i18n'
+import { ChevronDown } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+
+interface MobileOrderSummaryBarProps {
+  checkout: ProductCheckoutPublic
+  locale: AcceptedLocale
+  hasTrial: boolean
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export const MobileOrderSummaryBar = ({
+  checkout,
+  locale,
+  hasTrial,
+  isOpen,
+  onToggle,
+}: MobileOrderSummaryBarProps) => {
+  const t = useTranslations(locale)
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={isOpen}
+      className="dark:border-polar-700 dark:bg-polar-800 -mx-4 flex items-center justify-between gap-x-4 border-y border-gray-200 bg-gray-50 px-4 py-4 text-sm md:hidden"
+    >
+      <span className="flex items-center gap-x-2 font-medium whitespace-nowrap text-gray-900 dark:text-white">
+        {t('checkout.pricing.orderSummary')}
+        <ChevronDown
+          size={16}
+          className={twMerge('transition-transform', isOpen && 'rotate-180')}
+        />
+      </span>
+      <span className="flex flex-col items-end text-right whitespace-nowrap text-gray-900 dark:text-white">
+        {hasTrial ? (
+          <CheckoutHeroPrice checkout={checkout} locale={locale} compact />
+        ) : (
+          <span className="font-semibold">
+            {formatCurrency('standard', locale)(
+              checkout.total_amount ?? 0,
+              checkout.currency ?? checkout.product_price.price_currency,
+            )}
+          </span>
+        )}
+      </span>
+    </button>
+  )
+}

--- a/clients/apps/web/src/components/Checkout/useMobileSummaryState.test.ts
+++ b/clients/apps/web/src/components/Checkout/useMobileSummaryState.test.ts
@@ -1,0 +1,107 @@
+import type { schemas } from '@polar-sh/client'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useMobileSummaryState } from './useMobileSummaryState'
+
+type AmountType = schemas['ProductPrice']['amount_type']
+
+function makeCheckout(
+  overrides: {
+    amountType?: AmountType
+    isFreeProductPrice?: boolean
+    activeTrialInterval?: schemas['SubscriptionRecurringInterval'] | null
+    activeTrialIntervalCount?: number | null
+    hasProduct?: boolean
+  } = {},
+): schemas['CheckoutPublic'] {
+  const {
+    amountType = 'fixed',
+    isFreeProductPrice = false,
+    activeTrialInterval = null,
+    activeTrialIntervalCount = null,
+    hasProduct = true,
+  } = overrides
+
+  return {
+    product: hasProduct ? {} : null,
+    prices: hasProduct ? {} : null,
+    product_price: { amount_type: amountType },
+    is_free_product_price: isFreeProductPrice,
+    active_trial_interval: activeTrialInterval,
+    active_trial_interval_count: activeTrialIntervalCount,
+  } as unknown as schemas['CheckoutPublic']
+}
+
+describe('useMobileSummaryState', () => {
+  describe('mode resolution', () => {
+    it('returns "collapsed-bar" for a fixed-price product', () => {
+      const { result } = renderHook(() => useMobileSummaryState(makeCheckout()))
+      expect(result.current.mode).toBe('collapsed-bar')
+      expect(result.current.collapses).toBe(true)
+    })
+
+    it('returns "collapsed-bar" for a trial (trial gets the bar, not full)', () => {
+      const { result } = renderHook(() =>
+        useMobileSummaryState(
+          makeCheckout({
+            activeTrialInterval: 'month',
+            activeTrialIntervalCount: 1,
+          }),
+        ),
+      )
+      expect(result.current.mode).toBe('collapsed-bar')
+      expect(result.current.hasTrial).toBe(true)
+    })
+
+    it('returns "full" for seat-based products', () => {
+      const { result } = renderHook(() =>
+        useMobileSummaryState(makeCheckout({ amountType: 'seat_based' })),
+      )
+      expect(result.current.mode).toBe('full')
+      expect(result.current.collapses).toBe(false)
+    })
+
+    it('returns "full" for PWYW (custom amount) products', () => {
+      const { result } = renderHook(() =>
+        useMobileSummaryState(makeCheckout({ amountType: 'custom' })),
+      )
+      expect(result.current.mode).toBe('full')
+    })
+
+    it('returns "full" for free products', () => {
+      const { result } = renderHook(() =>
+        useMobileSummaryState(makeCheckout({ isFreeProductPrice: true })),
+      )
+      expect(result.current.mode).toBe('full')
+    })
+  })
+
+  describe('hasTrial', () => {
+    it('is true only when both active_trial_interval and count are set', () => {
+      const { result: bothSet } = renderHook(() =>
+        useMobileSummaryState(
+          makeCheckout({
+            activeTrialInterval: 'month',
+            activeTrialIntervalCount: 1,
+          }),
+        ),
+      )
+      expect(bothSet.current.hasTrial).toBe(true)
+
+      const { result: missingCount } = renderHook(() =>
+        useMobileSummaryState(
+          makeCheckout({
+            activeTrialInterval: 'month',
+            activeTrialIntervalCount: null,
+          }),
+        ),
+      )
+      expect(missingCount.current.hasTrial).toBe(false)
+
+      const { result: neither } = renderHook(() =>
+        useMobileSummaryState(makeCheckout()),
+      )
+      expect(neither.current.hasTrial).toBe(false)
+    })
+  })
+})

--- a/clients/apps/web/src/components/Checkout/useMobileSummaryState.ts
+++ b/clients/apps/web/src/components/Checkout/useMobileSummaryState.ts
@@ -1,0 +1,40 @@
+'use client'
+
+import { hasProductCheckout } from '@polar-sh/checkout/guards'
+import type { schemas } from '@polar-sh/client'
+import { useCallback, useState } from 'react'
+
+type MobileSummaryMode = 'full' | 'collapsed-bar'
+
+export interface MobileSummaryState {
+  mode: MobileSummaryMode
+  collapses: boolean
+  hasTrial: boolean
+  isOpen: boolean
+  setOpen: (open: boolean) => void
+  toggle: () => void
+}
+
+export const useMobileSummaryState = (
+  checkout: schemas['CheckoutPublic'],
+): MobileSummaryState => {
+  const isSeatBased =
+    hasProductCheckout(checkout) &&
+    checkout.product_price.amount_type === 'seat_based'
+  const isPWYW =
+    hasProductCheckout(checkout) &&
+    checkout.product_price.amount_type === 'custom'
+  const hasTrial =
+    !!checkout.active_trial_interval && !!checkout.active_trial_interval_count
+
+  const mode: MobileSummaryMode =
+    isSeatBased || isPWYW || checkout.is_free_product_price
+      ? 'full'
+      : 'collapsed-bar'
+  const collapses = mode === 'collapsed-bar'
+
+  const [isOpen, setOpen] = useState(false)
+  const toggle = useCallback(() => setOpen((o) => !o), [])
+
+  return { mode, collapses, hasTrial, isOpen, setOpen, toggle }
+}

--- a/clients/packages/checkout/package.json
+++ b/clients/packages/checkout/package.json
@@ -44,6 +44,10 @@
     "./providers": {
       "types": "./dist/providers/index.d.ts",
       "default": "./src/providers/index.ts"
+    },
+    "./test-utils": {
+      "types": "./src/test-utils/makeCheckout.ts",
+      "default": "./src/test-utils/makeCheckout.ts"
     }
   },
   "publishConfig": {

--- a/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
@@ -9,16 +9,27 @@ import CheckoutTrialHeroPrice from './CheckoutTrialHeroPrice'
 export interface CheckoutHeroPriceProps {
   checkout: ProductCheckoutPublic
   locale?: AcceptedLocale
+  compact?: boolean
 }
 
-const CheckoutHeroPrice = ({ checkout, locale }: CheckoutHeroPriceProps) => {
+const CheckoutHeroPrice = ({
+  checkout,
+  locale,
+  compact,
+}: CheckoutHeroPriceProps) => {
   const { product, product_price } = checkout
 
   const hasTrial =
     checkout.active_trial_interval && checkout.active_trial_interval_count
 
   if (hasTrial) {
-    return <CheckoutTrialHeroPrice checkout={checkout} locale={locale} />
+    return (
+      <CheckoutTrialHeroPrice
+        checkout={checkout}
+        locale={locale}
+        compact={compact}
+      />
+    )
   }
 
   return (

--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.test.tsx
@@ -254,4 +254,104 @@ describe('CheckoutTrialHeroPrice', () => {
       expect(container.textContent).toContain('$199.99 / 2nd yr')
     })
   })
+
+  describe('compact variant (used by the mobile order-summary bar)', () => {
+    it('omits the "starting <date>" suffix', () => {
+      const checkout = createTrialCheckout({
+        trial_end: '2026-04-05T00:00:00Z',
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(container.textContent).not.toContain('starting')
+      expect(container.textContent).not.toContain('April')
+      expect(container.textContent).not.toContain('2026')
+    })
+
+    it('uses the short interval form ("/mo") for monthly trials', () => {
+      const checkout = createTrialCheckout({
+        amount: 999,
+        net_amount: 999,
+        total_amount: 999,
+        product: {
+          ...trialProduct,
+          recurring_interval: 'month',
+        },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(container.textContent).toContain('$9.99/mo')
+      expect(container.textContent).not.toContain('$9.99/month')
+    })
+
+    it('uses the short interval form ("/yr") for yearly trials', () => {
+      const checkout = createTrialCheckout()
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(container.textContent).toContain('$99.99/yr')
+      expect(container.textContent).not.toContain('$99.99/year')
+    })
+
+    it('preserves the ordinal short form when recurring_interval_count > 1', () => {
+      const checkout = createTrialCheckout({
+        amount: 4106,
+        net_amount: 4106,
+        total_amount: 4106,
+        product: {
+          ...trialProduct,
+          recurring_interval: 'month',
+          recurring_interval_count: 3,
+        },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(container.textContent).toContain('$41.06 / 3rd mo')
+    })
+
+    it('applies font-semibold to the trial label headline', () => {
+      const checkout = createTrialCheckout()
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      const headline = container.querySelector('span')
+      expect(headline?.className ?? '').toMatch(/font-semibold/)
+    })
+
+    it('does not apply font-semibold to the headline when compact is omitted', () => {
+      const checkout = createTrialCheckout()
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" />,
+      )
+
+      const headline = container.querySelector('span')
+      expect(headline?.className ?? '').not.toMatch(/font-semibold/)
+    })
+
+    it('still includes the date and long interval when compact is omitted', () => {
+      const checkout = createTrialCheckout({
+        trial_end: '2026-04-05T00:00:00Z',
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('starting')
+      expect(container.textContent).toContain('$99.99/year')
+    })
+  })
 })

--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
@@ -9,12 +9,14 @@ import {
 } from '@polar-sh/i18n'
 import { formatDate } from '@polar-sh/i18n/formatters/date'
 import { formatOrdinal } from '@polar-sh/i18n/formatters/ordinal'
+import { cn } from '@polar-sh/ui/lib/utils'
 import type { ProductCheckoutPublic } from '../guards'
 import { isLegacyRecurringPrice } from '../utils/product'
 
 export interface CheckoutTrialHeroPriceProps {
   checkout: ProductCheckoutPublic
   locale?: AcceptedLocale
+  compact?: boolean
 }
 
 const TRIAL_FREE_KEYS = {
@@ -33,6 +35,7 @@ const INTERVAL_SUFFIX_KEYS = {
 const CheckoutTrialHeroPrice = ({
   checkout,
   locale,
+  compact,
 }: CheckoutTrialHeroPriceProps) => {
   const { product, product_price } = checkout
   const effectiveLocale = locale ?? DEFAULT_LOCALE
@@ -57,10 +60,13 @@ const CheckoutTrialHeroPrice = ({
   const intervalCount = product.recurring_interval_count
   const intervalSuffix = (() => {
     if (!interval || !(interval in INTERVAL_SUFFIX_KEYS)) return ''
+    const shortInterval =
+      getTranslations(effectiveLocale).intervals.short[interval]
     if (intervalCount && intervalCount > 1) {
-      const shortInterval =
-        getTranslations(effectiveLocale).intervals.short[interval]
       return ` / ${formatOrdinal(intervalCount, effectiveLocale)} ${shortInterval}`
+    }
+    if (compact) {
+      return `/${shortInterval}`
     }
     return t(
       INTERVAL_SUFFIX_KEYS[interval as keyof typeof INTERVAL_SUFFIX_KEYS],
@@ -69,18 +75,26 @@ const CheckoutTrialHeroPrice = ({
   const format = formatCurrency('standard', effectiveLocale)
   const priceStr = `${format(recurringAmount, currency)}${intervalSuffix}`
 
-  const dateStr = checkout.trial_end
-    ? formatDate(checkout.trial_end, effectiveLocale, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
-    : null
+  const dateStr =
+    !compact && checkout.trial_end
+      ? formatDate(checkout.trial_end, effectiveLocale, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })
+      : null
 
   return (
     <div className="flex flex-col gap-y-1">
-      <span>{trialLabel}</span>
-      <span className="dark:text-polar-500 text-sm font-normal text-gray-500">
+      <span className={compact ? 'font-semibold' : undefined}>
+        {trialLabel}
+      </span>
+      <span
+        className={cn(
+          'dark:text-polar-500 text-sm font-normal text-gray-500',
+          compact && 'text-xs',
+        )}
+      >
         {t('checkout.trial.hero.then')}{' '}
         <strong className="font-semibold">{priceStr}</strong>
         {dateStr

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -181,7 +181,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -365,7 +366,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -549,7 +551,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -733,7 +736,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -917,7 +921,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1093,7 +1098,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1269,7 +1275,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1445,7 +1452,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1621,7 +1629,8 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1797,6 +1806,7 @@
     "embedPaymentMethod.errors.invalidRequest": "Missing required parameters.",
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
-    "embedPaymentMethod.errors.unknown": "Something went wrong."
+    "embedPaymentMethod.errors.unknown": "Something went wrong.",
+    "checkout.pricing.orderSummary": "Order summary"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Plätze konnten nicht aktualisiert werden',
       },
       inclTax: 'MwSt. (inklusive)',
+      orderSummary: 'Bestellübersicht',
     },
     trial: {
       ends: 'Testphase endet am {endDate}',

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -69,6 +69,11 @@ export default {
           'A pricing type where the customer can choose how much to pay.',
       },
       total: 'Total',
+      orderSummary: {
+        value: 'Order summary',
+        _llmContext:
+          'Label for the mobile-only collapsible bar that reveals the full order breakdown when tapped. Appears at the top of the checkout page on small screens.',
+      },
       everyInterval: {
         day: {
           _mode: 'plural',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'No se pudieron actualizar los asientos',
       },
       inclTax: 'Impuestos (incluidos)',
+      orderSummary: 'Resumen del pedido',
     },
     trial: {
       ends: 'La prueba finaliza el {endDate}',

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Échec de la mise à jour des postes',
       },
       inclTax: 'TVA (incluse)',
+      orderSummary: 'Récapitulatif de la commande',
     },
     trial: {
       ends: "L'essai se termine le {endDate}",

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'A felhasználói helyek frissítése nem sikerült',
       },
       inclTax: 'ÁFA (tartalmazza)',
+      orderSummary: 'Rendelés összegzése',
     },
     trial: {
       ends: 'A próbaidőszak ekkor jár le: {endDate}',

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Impossibile aggiornare le postazioni',
       },
       inclTax: 'IVA (inclusa)',
+      orderSummary: 'Riepilogo ordine',
     },
     trial: {
       ends: 'La prova termina il {endDate}',

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: '좌석 수를 업데이트하지 못했습니다',
       },
       inclTax: '부가세 (포함)',
+      orderSummary: '주문 요약',
     },
     trial: {
       ends: '체험 종료일: {endDate}',

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Stoelen bijwerken mislukt',
       },
       inclTax: 'Btw (inbegrepen)',
+      orderSummary: 'Besteloverzicht',
     },
     trial: {
       ends: 'Proefperiode eindigt op {endDate}',

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Não foi possível atualizar as licenças',
       },
       inclTax: 'IVA (incluído)',
+      orderSummary: 'Resumo da encomenda',
     },
     trial: {
       ends: 'Teste termina a {endDate}',

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Falha ao atualizar os assentos',
       },
       inclTax: 'Impostos (inclusos)',
+      orderSummary: 'Resumo do pedido',
     },
     trial: {
       ends: 'Teste termina a {endDate}',

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -103,6 +103,7 @@ export default {
         updateFailed: 'Det gick inte att uppdatera platserna',
       },
       inclTax: 'Moms (ingår)',
+      orderSummary: 'Ordersammanfattning',
     },
     trial: {
       ends: 'Testperioden slutar {endDate}',


### PR DESCRIPTION
This PR will simplify the mobile checkout view by only surfacing the most important details, and hiding the details behind a summary view.

For all non seats and pwyw checkouts, we will hide pricing breakdown behind a `Order summary` toggle to reduce the visual noice and bring the payment section into focus.

⚠️ Diff is best viewed with the [?w=1](https://github.com/polarsource/polar/pull/11979/changes?w=1) parameter.


<img width="3910" height="3072" alt="compact-comp" src="https://github.com/user-attachments/assets/0ac3c9e3-41d6-4014-99e4-f9611974e272" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile checkout adds a collapsible order summary bar and responsive layout for streamlined mobile viewing
  * Compact trial pricing view for condensed mobile displays
  * Added localized "Order summary" labels across multiple languages

* **Tests**
  * New unit and component tests for mobile summary state and the mobile order summary bar

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->