### PR TITLE
fix(auth): handle Apple OAuth update without userinfo endpoint

### DIFF
--- a/server/polar/auth/oauth2/apple.py
+++ b/server/polar/auth/oauth2/apple.py
@@ -4,6 +4,7 @@ from fastapi import Depends
 from reauth.factors.oauth2.apple import AppleOAuth2Factor as AppleOAuth2FactorBase
 from reauth.factors.oauth2.base import OAuth2Account
 from reauth.factors.oauth2.base import OAuth2Enrollment as OAuth2EnrollmentDataclass
+from sqlalchemy import update
 
 from polar.config import settings
 from polar.models import OAuthAccount
@@ -51,6 +52,25 @@ class AppleFactor(OAuth2FactorMixin, AppleOAuth2FactorBase):
         self.session.add(enrollment_orm)
         await self.session.flush()
         return enrollment_orm.id
+
+    async def update(self, enrollment: OAuth2EnrollmentDataclass) -> None:
+        statement = (
+            update(OAuthAccount)
+            .where(
+                OAuthAccount.user_id == enrollment.identity_id,
+                OAuthAccount.platform == OAuthPlatform(self.identifier),
+            )
+            .values(
+                access_token=enrollment.access_token,
+                expires_at=enrollment.expires_at,
+                refresh_token=enrollment.refresh_token,
+                refresh_token_expires_at=enrollment.refresh_token_expires_at,
+                # Apple doesn't provide profile information on subsequent login,
+                # so we don't update account_email and account_username on update.
+            )
+        )
+        await self.session.execute(statement)
+        await self.session.flush()
 
     async def get_email(
         self, callback_result: OAuth2EnrollmentDataclass | OAuth2Account


### PR DESCRIPTION
Fix #11989

## Summary

**Related Issue**: Fixes SERVER-4NA

Fix NotImplementedError when Apple OAuth callback tries to update existing enrollment.

## What

Added a custom `update()` method to `AppleFactor` class that overrides the base `OAuth2FactorMixin.update()` method. The Apple-specific implementation only updates token fields without attempting to call `get_profile()`, which Apple does not support (Apple uses id_token instead of userinfo endpoint).

## Why

The base `OAuth2FactorMixin.update()` method calls `self.get_profile(enrollment.access_token)` to fetch user profile information. However, Apple OAuth does not support the userinfo endpoint and instead requires using the id_token from the authorization response. When the base method was called for Apple OAuth, it would raise `NotImplementedError: Apple requires id_token, does not support userinfo endpoint`.

Note that Apple doesn't provide profile information on subsequent logins, so the update method intentionally does not update `account_email` and `account_username` fields.

## How

- Added `update()` method to `AppleFactor` class in `server/polar/auth/oauth2/apple.py`
- Method only updates: access_token, expires_at, refresh_token, refresh_token_expires_at
- Uses SQLAlchemy update statement directly without calling `get_profile()`
- Added required import for `sqlalchemy.update`

## Checklist

- [x] This PR addresses a single concern (one bug fix)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to Apple Sign-In credential management and token refresh handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->