### PR TITLE
Add active customers filter to customers view

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
@@ -11,6 +11,8 @@ import { getServerURL } from '@/utils/api'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import ArrowDownward from '@mui/icons-material/ArrowDownward'
 import ArrowUpward from '@mui/icons-material/ArrowUpward'
+import CheckOutlined from '@mui/icons-material/CheckOutlined'
+import FilterList from '@mui/icons-material/FilterList'
 import MoreVert from '@mui/icons-material/MoreVert'
 import Search from '@mui/icons-material/Search'
 import { schemas } from '@polar-sh/client'
@@ -51,12 +53,17 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
     ] as const).withDefault('-created_at'),
   )
   const [query, setQuery] = useQueryState('query', parseAsString)
+  const [activeFilter, setActiveFilter] = useQueryState(
+    'filter',
+    parseAsStringLiteral(['all', 'active'] as const).withDefault('all'),
+  )
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCustomers(
     organization.id,
     {
       query: query ?? undefined,
       sorting: [sorting],
+      active: activeFilter === 'all' ? undefined : true,
     },
   )
 
@@ -101,7 +108,7 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
       const queryString = new URLSearchParams()
 
       for (const [key, value] of searchParams.entries()) {
-        if (['query', 'sorting'].includes(key)) {
+        if (['query', 'sorting', 'filter'].includes(key)) {
           queryString.append(key, value)
         }
       }
@@ -121,6 +128,34 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
         <div className="flex flex-row items-center justify-between gap-6 px-4 py-4">
           <div>Customers</div>
           <div className="flex flex-row items-center gap-4">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="icon" className="h-6 w-6" variant="ghost">
+                  <FilterList fontSize="small" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setActiveFilter('all')}>
+                  <CheckOutlined
+                    className={twMerge(
+                      'h-4 w-4',
+                      activeFilter !== 'all' && 'invisible',
+                    )}
+                  />
+                  <span>All</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setActiveFilter('active')}>
+                  <CheckOutlined
+                    className={twMerge(
+                      'h-4 w-4',
+                      activeFilter !== 'active' && 'invisible',
+                    )}
+                  />
+                  <span>Active</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
             <Button
               variant="ghost"
               size="icon"

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -40186,7 +40186,7 @@ export interface operations {
         email?: string | null
         /** @description Filter by name, email, or external ID. */
         query?: string | null
-        /** @description Filter by active customers, i.e. customers with at least one order. */
+        /** @description Filter by active customers, i.e. customers with at least one active or past_due subscription. */
         active?: boolean | null
         /** @description Page number, defaults to 1. */
         page?: number

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -40186,6 +40186,8 @@ export interface operations {
         email?: string | null
         /** @description Filter by name, email, or external ID. */
         query?: string | null
+        /** @description Filter by active customers, i.e. customers with at least one order. */
+        active?: boolean | null
         /** @description Page number, defaults to 1. */
         page?: number
         /** @description Size of a page, defaults to 10. Maximum is 100. */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -40186,7 +40186,7 @@ export interface operations {
         email?: string | null
         /** @description Filter by name, email, or external ID. */
         query?: string | null
-        /** @description Filter by active customers, i.e. customers with at least one active or past_due subscription. */
+        /** @description Filter by active customers, i.e. customers with at least one trialing, active or past_due subscription. */
         active?: boolean | null
         /** @description Page number, defaults to 1. */
         page?: number

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -78,7 +78,7 @@ async def list(
         None,
         description=(
             "Filter by active customers, i.e. customers with at least one "
-            "active or past_due subscription."
+            "trialing, active or past_due subscription."
         ),
     ),
     session: AsyncReadSession = Depends(get_db_read_session),

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -77,7 +77,8 @@ async def list(
     active: bool | None = Query(
         None,
         description=(
-            "Filter by active customers, i.e. customers with at least one order."
+            "Filter by active customers, i.e. customers with at least one "
+            "active or past_due subscription."
         ),
     ),
     session: AsyncReadSession = Depends(get_db_read_session),

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -74,6 +74,12 @@ async def list(
     query: str | None = Query(
         None, description="Filter by name, email, or external ID."
     ),
+    active: bool | None = Query(
+        None,
+        description=(
+            "Filter by active customers, i.e. customers with at least one order."
+        ),
+    ),
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[CustomerSchema]:
     """List customers."""
@@ -84,6 +90,7 @@ async def list(
         email=email,
         metadata=metadata,
         query=query,
+        active=active,
         pagination=pagination,
         sorting=sorting,
     )

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -292,16 +292,14 @@ class CustomerRepository(
         """
         Return a clause to filter customers by activity.
 
-        An active customer is one with at least one active or past_due
-        subscription.
+        An active customer is one with at least one billable subscription,
+        i.e. a subscription in `trialing`, `active` or `past_due` status.
         """
         subscription_exists = (
             select(Subscription.id)
             .where(
                 Subscription.customer_id == Customer.id,
-                Subscription.status.in_(
-                    (SubscriptionStatus.active, SubscriptionStatus.past_due)
-                ),
+                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
             )
             .exists()
         )

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator, Sequence
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Select, String, cast, func, or_, update
+from sqlalchemy import ColumnElement, Select, String, cast, func, or_, select, update
 from sqlalchemy import inspect as orm_inspect
 from sqlalchemy.orm import InstanceState
 
@@ -16,7 +16,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import Customer
+from polar.models import Customer, Order
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.worker import enqueue_job
 
@@ -286,6 +286,15 @@ class CustomerRepository(
         statement = self.get_base_statement()
         statement = statement.where(Customer.organization_id.in_(org_ids))
         return statement
+
+    def get_active_clause(self, active: bool) -> ColumnElement[bool]:
+        """
+        Return a clause to filter customers by activity.
+
+        An active customer is one with at least one order.
+        """
+        order_exists = select(Order.id).where(Order.customer_id == Customer.id).exists()
+        return order_exists if active else ~order_exists
 
     async def increment_invoice_next_number(self, customer_id: UUID) -> int:
         """

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -16,7 +16,8 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import Customer, Order
+from polar.models import Customer, Subscription
+from polar.models.subscription import SubscriptionStatus
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.worker import enqueue_job
 
@@ -291,10 +292,20 @@ class CustomerRepository(
         """
         Return a clause to filter customers by activity.
 
-        An active customer is one with at least one order.
+        An active customer is one with at least one active or past_due
+        subscription.
         """
-        order_exists = select(Order.id).where(Order.customer_id == Customer.id).exists()
-        return order_exists if active else ~order_exists
+        subscription_exists = (
+            select(Subscription.id)
+            .where(
+                Subscription.customer_id == Customer.id,
+                Subscription.status.in_(
+                    (SubscriptionStatus.active, SubscriptionStatus.past_due)
+                ),
+            )
+            .exists()
+        )
+        return subscription_exists if active else ~subscription_exists
 
     async def increment_invoice_next_number(self, customer_id: UUID) -> int:
         """

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -300,6 +300,7 @@ class CustomerRepository(
             .where(
                 Subscription.customer_id == Customer.id,
                 Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.deleted_at.is_(None),
             )
             .exists()
         )

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -77,6 +77,7 @@ class CustomerService:
         email: str | None = None,
         metadata: MetadataQuery | None = None,
         query: str | None = None,
+        active: bool | None = None,
         pagination: PaginationParams,
         sorting: list[Sorting[CustomerSortProperty]] = [
             (CustomerSortProperty.created_at, True)
@@ -105,6 +106,9 @@ class CustomerService:
                     Customer.external_id.ilike(f"{query}%"),
                 )
             )
+
+        if active is not None:
+            statement = statement.where(repository.get_active_clause(active))
 
         order_by_clauses: list[UnaryExpression[Any]] = []
         for criterion, is_desc in sorting:

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -11,6 +11,7 @@ from polar.models import (
     Product,
     UserOrganization,
 )
+from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.tax.tax_id import TaxIDFormat
 from tests.fixtures.auth import AuthSubjectFixture
@@ -19,7 +20,7 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_benefit_grant,
     create_customer,
-    create_order,
+    create_subscription,
 )
 
 
@@ -118,40 +119,68 @@ class TestListCustomers:
         user_organization: UserOrganization,
         product: Product,
     ) -> None:
-        customer_with_order = await create_customer(
+        customer_active = await create_customer(
             save_fixture,
             organization=organization,
             email="active@example.com",
         )
-        await create_order(save_fixture, customer=customer_with_order, product=product)
-        customer_without_order = await create_customer(
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer_active,
+            status=SubscriptionStatus.active,
+        )
+        customer_past_due = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="past-due@example.com",
+        )
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer_past_due,
+            status=SubscriptionStatus.past_due,
+        )
+        customer_inactive = await create_customer(
             save_fixture,
             organization=organization,
             email="inactive@example.com",
         )
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer_inactive,
+            status=SubscriptionStatus.canceled,
+        )
 
-        # active=true returns only customers with at least one order
+        # active=true returns customers with an active or past_due subscription
         response = await client.get("/v1/customers/", params={"active": True})
 
         assert response.status_code == 200
         ids = {item["id"] for item in response.json()["items"]}
-        assert str(customer_with_order.id) in ids
-        assert str(customer_without_order.id) not in ids
+        assert str(customer_active.id) in ids
+        assert str(customer_past_due.id) in ids
+        assert str(customer_inactive.id) not in ids
 
-        # active=false excludes customers with at least one order
+        # active=false excludes customers with an active or past_due subscription
         response = await client.get("/v1/customers/", params={"active": False})
 
         assert response.status_code == 200
         ids = {item["id"] for item in response.json()["items"]}
-        assert str(customer_without_order.id) in ids
-        assert str(customer_with_order.id) not in ids
+        assert str(customer_inactive.id) in ids
+        assert str(customer_active.id) not in ids
+        assert str(customer_past_due.id) not in ids
 
         # no filter returns all customers
         response = await client.get("/v1/customers/")
 
         assert response.status_code == 200
         ids = {item["id"] for item in response.json()["items"]}
-        assert {str(customer_with_order.id), str(customer_without_order.id)} <= ids
+        assert {
+            str(customer_active.id),
+            str(customer_past_due.id),
+            str(customer_inactive.id),
+        } <= ids
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -130,6 +130,17 @@ class TestListCustomers:
             customer=customer_active,
             status=SubscriptionStatus.active,
         )
+        customer_trialing = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="trialing@example.com",
+        )
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer_trialing,
+            status=SubscriptionStatus.trialing,
+        )
         customer_past_due = await create_customer(
             save_fixture,
             organization=organization,
@@ -153,22 +164,25 @@ class TestListCustomers:
             status=SubscriptionStatus.canceled,
         )
 
-        # active=true returns customers with an active or past_due subscription
+        # active=true returns customers with a trialing, active or past_due
+        # subscription
         response = await client.get("/v1/customers/", params={"active": True})
 
         assert response.status_code == 200
         ids = {item["id"] for item in response.json()["items"]}
         assert str(customer_active.id) in ids
+        assert str(customer_trialing.id) in ids
         assert str(customer_past_due.id) in ids
         assert str(customer_inactive.id) not in ids
 
-        # active=false excludes customers with an active or past_due subscription
+        # active=false excludes customers with a billable subscription
         response = await client.get("/v1/customers/", params={"active": False})
 
         assert response.status_code == 200
         ids = {item["id"] for item in response.json()["items"]}
         assert str(customer_inactive.id) in ids
         assert str(customer_active.id) not in ids
+        assert str(customer_trialing.id) not in ids
         assert str(customer_past_due.id) not in ids
 
         # no filter returns all customers
@@ -178,6 +192,7 @@ class TestListCustomers:
         ids = {item["id"] for item in response.json()["items"]}
         assert {
             str(customer_active.id),
+            str(customer_trialing.id),
             str(customer_past_due.id),
             str(customer_inactive.id),
         } <= ids

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -19,6 +19,7 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_benefit_grant,
     create_customer,
+    create_order,
 )
 
 
@@ -107,6 +108,50 @@ class TestListCustomers:
         json = response.json()
         assert json["pagination"]["total_count"] == 1
         assert json["items"][0]["external_id"] == "ext_456"
+
+    @pytest.mark.auth
+    async def test_active_filter(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        customer_with_order = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="active@example.com",
+        )
+        await create_order(save_fixture, customer=customer_with_order, product=product)
+        customer_without_order = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="inactive@example.com",
+        )
+
+        # active=true returns only customers with at least one order
+        response = await client.get("/v1/customers/", params={"active": True})
+
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert str(customer_with_order.id) in ids
+        assert str(customer_without_order.id) not in ids
+
+        # active=false excludes customers with at least one order
+        response = await client.get("/v1/customers/", params={"active": False})
+
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert str(customer_without_order.id) in ids
+        assert str(customer_with_order.id) not in ids
+
+        # no filter returns all customers
+        response = await client.get("/v1/customers/")
+
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert {str(customer_with_order.id), str(customer_without_order.id)} <= ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
GitHub managed to close the earlier PR with no way to reopen it because I referenced the PR with a `Fix #{number}` comment. I thought that only worked on issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an active status filter dropdown to the customer list sidebar, allowing users to toggle between viewing all customers or only those with active subscriptions. The current filter selection is visually indicated.
  * Extended the customer API endpoint with filtering capability based on subscription activity status, enabling more granular customer queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->