### PR TITLE
Add per-customer discount redemption limits

### DIFF
--- a/clients/apps/web/src/components/Discounts/DiscountForm.tsx
+++ b/clients/apps/web/src/components/Discounts/DiscountForm.tsx
@@ -457,6 +457,38 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                 </FormItem>
               )}
             />
+
+            <FormField
+              control={control}
+              name="max_redemptions_per_customer"
+              rules={{
+                min: { value: 1, message: 'This field must be at least 1' },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Maximum redemptions per customer</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="number"
+                      value={field.value ?? ''}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        field.onChange(
+                          value === '' ? null : parseInt(value, 10),
+                        )
+                      }}
+                      min={1}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                  <FormDescription>
+                    Limit applies to each customer individually, identified by
+                    their email, account, and payment method.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -17449,6 +17449,11 @@ export interface components {
        * @description Optional maximum number of times the discount can be redeemed.
        */
       max_redemptions?: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Optional maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer?: number | null
       /** Products */
       products?: string[] | null
       /**
@@ -17562,6 +17567,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -17646,6 +17656,11 @@ export interface components {
        * @description Maximum number of times the discount can be redeemed.
        */
       max_redemptions: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
       /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
@@ -17736,6 +17751,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -17823,6 +17843,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -17882,6 +17907,11 @@ export interface components {
        * @description Optional maximum number of times the discount can be redeemed.
        */
       max_redemptions?: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Optional maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer?: number | null
       /** Products */
       products?: string[] | null
       /**
@@ -17972,6 +18002,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -18039,6 +18074,11 @@ export interface components {
        * @description Maximum number of times the discount can be redeemed.
        */
       max_redemptions: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
       /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
@@ -18112,6 +18152,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -18181,6 +18226,11 @@ export interface components {
        * @description Maximum number of times the discount can be redeemed.
        */
       max_redemptions: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
       /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
@@ -18326,6 +18376,11 @@ export interface components {
        * @description Optional maximum number of times the discount can be redeemed.
        */
       max_redemptions?: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Optional maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer?: number | null
       duration?: components['schemas']['DiscountDuration'] | null
       /** Duration In Months */
       duration_in_months?: number | null

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -46872,6 +46872,19 @@
             "title": "Max Redemptions",
             "description": "Optional maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Optional maximum number of times the discount can be redeemed by a single customer."
+          },
           "products": {
             "anyOf": [
               {
@@ -47114,6 +47127,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -47157,6 +47182,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -47285,6 +47311,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -47321,6 +47359,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -47451,6 +47490,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -47495,6 +47546,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -47627,6 +47679,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -47664,6 +47728,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -47755,6 +47820,19 @@
             ],
             "title": "Max Redemptions",
             "description": "Optional maximum number of times the discount can be redeemed."
+          },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Optional maximum number of times the discount can be redeemed by a single customer."
           },
           "products": {
             "anyOf": [
@@ -47934,6 +48012,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -47975,6 +48065,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -48081,6 +48172,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -48115,6 +48218,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -48223,6 +48327,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -48265,6 +48381,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -48375,6 +48492,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -48410,6 +48539,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -48666,6 +48796,19 @@
             ],
             "title": "Max Redemptions",
             "description": "Optional maximum number of times the discount can be redeemed."
+          },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Optional maximum number of times the discount can be redeemed by a single customer."
           },
           "duration": {
             "anyOf": [

--- a/server/migrations/versions/2026-05-29-0600_add_max_redemptions_per_customer_to_discounts.py
+++ b/server/migrations/versions/2026-05-29-0600_add_max_redemptions_per_customer_to_discounts.py
@@ -1,0 +1,29 @@
+"""add max_redemptions_per_customer to discounts
+
+Revision ID: b7e3f9a21c84
+Revises: 0c12d2aaab31
+Create Date: 2026-05-29 06:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b7e3f9a21c84"
+down_revision = "0c12d2aaab31"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "discounts",
+        sa.Column("max_redemptions_per_customer", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("discounts", "max_redemptions_per_customer")

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -210,6 +210,16 @@ class TrialAlreadyRedeemed(CheckoutError):
         super().__init__(message, 403)
 
 
+class DiscountRedemptionLimitReached(CheckoutError):
+    def __init__(self, checkout: Checkout) -> None:
+        self.checkout = checkout
+        message = (
+            "You have already redeemed this discount the maximum number of "
+            "times allowed per customer."
+        )
+        super().__init__(message, 403)
+
+
 class CheckoutLocked(CheckoutError):
     """Raised when checkout is locked by another transaction."""
 
@@ -1062,6 +1072,40 @@ class CheckoutService:
                     **checkout.payment_processor_metadata,
                     "customer_id": stripe_customer_id,
                 }
+
+                # Enforce the per-customer discount redemption limit *before* creating
+                # any payment intent, so we never charge a customer we're about to
+                # reject. The card fingerprint is read from the confirmation token's
+                # payment method preview (no intent/charge required yet).
+                if (
+                    checkout.discount is not None
+                    and checkout.discount.max_redemptions_per_customer is not None
+                ):
+                    payment_method_fingerprint: str | None = None
+                    if checkout_confirm.confirmation_token_id is not None:
+                        try:
+                            confirmation_token = (
+                                await stripe_service.get_confirmation_token(
+                                    checkout_confirm.confirmation_token_id
+                                )
+                            )
+                            if confirmation_token.payment_method_preview is not None:
+                                payment_method_fingerprint = get_fingerprint(
+                                    typing.cast(
+                                        stripe_lib.PaymentMethod,
+                                        confirmation_token.payment_method_preview,
+                                    )
+                                )
+                        except stripe_lib.StripeError:
+                            pass
+                    if await discount_service.check_per_customer_limit_reached(
+                        session,
+                        checkout.discount,
+                        checkout=checkout,
+                        customer=customer,
+                        payment_method_fingerprint=payment_method_fingerprint,
+                    ):
+                        raise DiscountRedemptionLimitReached(checkout)
 
                 intent: stripe_lib.PaymentIntent | stripe_lib.SetupIntent | None = None
                 if checkout.is_payment_form_required:

--- a/server/polar/discount/repository.py
+++ b/server/polar/discount/repository.py
@@ -1,10 +1,10 @@
 from uuid import UUID
 
-from sqlalchemy import func, select, update
+from sqlalchemy import ColumnExpressionArgument, distinct, func, or_, select, update
 from sqlalchemy.orm import raiseload
 
 from polar.kit.repository import RepositoryBase, RepositoryIDMixin
-from polar.models import Discount, DiscountRedemption
+from polar.models import Checkout, Discount, DiscountRedemption, Payment
 
 
 class DiscountRepository(RepositoryBase[Discount], RepositoryIDMixin[Discount, UUID]):
@@ -57,3 +57,69 @@ class DiscountRedemptionRepository(
             .where(DiscountRedemption.checkout_id == checkout_id)
         )
         await self.session.execute(statement)
+
+    async def count_redemptions_by_customer(
+        self,
+        discount_id: UUID,
+        *,
+        exclude_checkout_id: UUID,
+        customer_id: UUID | None = None,
+        customer_email: str | None = None,
+        payment_method_fingerprint: str | None = None,
+    ) -> int:
+        """
+        Count past redemptions of a discount attributable to a given customer.
+
+        The customer is identified by any of the provided hints (OR logic), mirroring
+        the trial-abuse feature: customer ID, unaliased email, or payment method
+        fingerprint. Identity is derived by joining the redemption's linked checkout
+        (customer ID + email) and payment (card fingerprint, only present when a charge
+        occurred).
+
+        The current, in-progress redemption is excluded via ``exclude_checkout_id``.
+        """
+        clauses: list[ColumnExpressionArgument[bool]] = []
+
+        if customer_id is not None:
+            clauses.append(Checkout.customer_id == customer_id)
+
+        if customer_email is not None:
+            # Strip the `+alias` suffix from the local part in SQL, mirroring
+            # `polar.kit.email.unalias_email`. The provided `customer_email` is
+            # expected to be already unaliased and lowercased.
+            clauses.append(
+                func.regexp_replace(
+                    func.lower(Checkout.customer_email), r"\+[^@]*", ""
+                )
+                == customer_email
+            )
+
+        if payment_method_fingerprint is not None:
+            clauses.append(
+                Payment.method_metadata["fingerprint"].astext
+                == payment_method_fingerprint
+            )
+
+        # No hints to match against: nothing can be attributed to the customer.
+        if not clauses:
+            return 0
+
+        statement = (
+            select(func.count(distinct(DiscountRedemption.id)))
+            .join(Checkout, Checkout.id == DiscountRedemption.checkout_id)
+            .where(
+                DiscountRedemption.discount_id == discount_id,
+                DiscountRedemption.checkout_id != exclude_checkout_id,
+                or_(*clauses),
+            )
+        )
+
+        if payment_method_fingerprint is not None:
+            statement = statement.join(
+                Payment,
+                Payment.checkout_id == DiscountRedemption.checkout_id,
+                isouter=True,
+            )
+
+        result = await self.session.execute(statement)
+        return result.scalar_one()

--- a/server/polar/discount/schemas.py
+++ b/server/polar/discount/schemas.py
@@ -96,6 +96,16 @@ MaxRedemptions = Annotated[
     ),
     Ge(1),
 ]
+MaxRedemptionsPerCustomer = Annotated[
+    int | None,
+    Field(
+        description=(
+            "Optional maximum number of times the discount can be redeemed "
+            "by a single customer."
+        ),
+    ),
+    Ge(1),
+]
 DurationInMonths = Annotated[
     int,
     Field(
@@ -158,6 +168,7 @@ class DiscountCreateBase(MetadataInputMixin, Schema):
     starts_at: StartsAt = None
     ends_at: EndsAt = None
     max_redemptions: MaxRedemptions = None
+    max_redemptions_per_customer: MaxRedemptionsPerCustomer = None
 
     products: ProductsList | None = None
 
@@ -271,6 +282,7 @@ class DiscountUpdate(MetadataInputMixin, Schema):
     starts_at: StartsAt = None
     ends_at: EndsAt = None
     max_redemptions: MaxRedemptions = None
+    max_redemptions_per_customer: MaxRedemptionsPerCustomer = None
 
     duration: DiscountDuration | None = None
     duration_in_months: DurationInMonths | None = None
@@ -328,6 +340,11 @@ class DiscountBase(MetadataOutputMixin, IDSchema, TimestampedSchema):
     )
     max_redemptions: int | None = Field(
         description="Maximum number of times the discount can be redeemed."
+    )
+    max_redemptions_per_customer: int | None = Field(
+        description=(
+            "Maximum number of times the discount can be redeemed by a single customer."
+        )
     )
 
     redemptions_count: int = Field(

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -14,14 +14,19 @@ from polar.authz.service import (
     assert_organization_permission,
     assert_resource_permission,
 )
-from polar.discount.repository import DiscountRepository
+from polar.discount.repository import (
+    DiscountRedemptionRepository,
+    DiscountRepository,
+)
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.db.locking import is_lock_not_available_error
+from polar.kit.email import unalias_email
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
 from polar.models import (
+    Customer,
     Discount,
     DiscountProduct,
     Organization,
@@ -425,6 +430,37 @@ class DiscountService(ResourceServiceReader[Discount]):
             return discount.redemptions_count < discount.max_redemptions
 
         return True
+
+    async def check_per_customer_limit_reached(
+        self,
+        session: AsyncSession,
+        discount: Discount,
+        *,
+        checkout: Checkout,
+        customer: Customer,
+        payment_method_fingerprint: str | None = None,
+    ) -> bool:
+        """
+        Check whether a customer has reached the discount's per-customer redemption limit.
+
+        The customer is identified using the same signals as the trial-abuse feature:
+        customer ID, unaliased email, and payment method fingerprint (OR logic), scoped
+        to this specific discount. Returns ``False`` when no per-customer limit is set.
+        """
+        if discount.max_redemptions_per_customer is None:
+            return False
+
+        repository = DiscountRedemptionRepository.from_session(session)
+        count = await repository.count_redemptions_by_customer(
+            discount.id,
+            exclude_checkout_id=checkout.id,
+            customer_id=customer.id,
+            customer_email=unalias_email(customer.email).lower()
+            if customer.email
+            else None,
+            payment_method_fingerprint=payment_method_fingerprint,
+        )
+        return count >= discount.max_redemptions_per_customer
 
     @contextlib.asynccontextmanager
     async def redeem_discount(

--- a/server/polar/models/discount.py
+++ b/server/polar/models/discount.py
@@ -64,6 +64,9 @@ class Discount(MetadataMixin, RecordModel):
         TIMESTAMP(timezone=True), nullable=True
     )
     max_redemptions: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_redemptions_per_customer: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
 
     duration: Mapped[DiscountDuration] = mapped_column(String, nullable=False)
     duration_in_months: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -27,6 +27,7 @@ from polar.checkout.service import (
     AlreadyActiveSubscriptionError,
     CheckoutCustomerDeleted,
     CheckoutCustomerExternalIdMismatch,
+    DiscountRedemptionLimitReached,
     NotConfirmedCheckout,
     NotOpenCheckout,
     TrialAlreadyRedeemed,
@@ -106,6 +107,7 @@ from tests.fixtures.random_objects import (
     create_custom_field,
     create_customer,
     create_discount,
+    create_discount_redemption,
     create_product,
     create_product_price_fixed,
     create_product_price_seat_unit,
@@ -4971,6 +4973,75 @@ class TestConfirm:
                         "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
                         "customer_name": "Customer Name",
                         "customer_email": email,
+                        "customer_billing_address": {"country": "FR"},
+                    }
+                ),
+            )
+
+    async def test_discount_per_customer_limit_reached(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            code="LIMITEDPERCUSTOMER",
+            max_redemptions_per_customer=1,
+        )
+
+        # The same customer already redeemed this discount once.
+        existing_customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            customer=existing_customer,
+            discount=discount,
+        )
+        prior_checkout.customer_email = "customer@example.com"
+        await save_fixture(prior_checkout)
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        checkout = await create_checkout(
+            save_fixture, products=[product], discount=discount
+        )
+
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = MagicMock()
+        confirmation_token.payment_method_preview.billing_details.name = "Customer Name"
+        confirmation_token.payment_method_preview.card = SimpleNamespace(
+            fingerprint="FINGERPRINT"
+        )
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        with pytest.raises(DiscountRedemptionLimitReached):
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "customer@example.com",
                         "customer_billing_address": {"country": "FR"},
                     }
                 ),

--- a/server/tests/discount/test_endpoints.py
+++ b/server/tests/discount/test_endpoints.py
@@ -205,6 +205,58 @@ class TestCreateDiscount:
 
         assert response.status_code == 201
 
+    @pytest.mark.auth
+    async def test_valid_max_redemptions_per_customer(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "percentage",
+                "code": "DISCOUNT",
+                "duration": "once",
+                "basis_points": 1000,
+                "max_redemptions_per_customer": 3,
+                "organization_id": str(organization.id),
+            },
+        )
+
+        assert response.status_code == 201
+        json = response.json()
+        assert json["max_redemptions_per_customer"] == 3
+
+        repository = DiscountRepository.from_session(session)
+        discount = await repository.get_by_id(json["id"])
+        assert discount is not None
+        assert discount.max_redemptions_per_customer == 3
+
+    @pytest.mark.auth
+    async def test_max_redemptions_per_customer_zero_rejected(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "percentage",
+                "code": "DISCOUNT",
+                "duration": "once",
+                "basis_points": 1000,
+                "max_redemptions_per_customer": 0,
+                "organization_id": str(organization.id),
+            },
+        )
+
+        assert response.status_code == 422
+
     @pytest.mark.parametrize(
         "payload",
         [
@@ -376,6 +428,28 @@ class TestUpdateDiscount:
         )
 
         assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_update_max_redemptions_per_customer(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        discount_fixed_once: Discount,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/discounts/{discount_fixed_once.id}",
+            json={"max_redemptions_per_customer": 5},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["max_redemptions_per_customer"] == 5
+
+        repository = DiscountRepository.from_session(session)
+        updated = await repository.get_by_id(discount_fixed_once.id)
+        assert updated is not None
+        assert updated.max_redemptions_per_customer == 5
 
 
 @pytest.mark.asyncio

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -30,7 +30,12 @@ from polar.models.discount import (
 )
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_checkout, create_discount
+from tests.fixtures.random_objects import (
+    create_checkout,
+    create_customer,
+    create_discount,
+    create_payment,
+)
 
 
 async def create_discount_redemption(
@@ -656,3 +661,238 @@ class TestIsRepetitionExpired:
         assert discount.is_repetition_expired(now, within_duration) is False
         # Should expire after duration
         assert discount.is_repetition_expired(now, after_duration) is True
+
+
+@pytest.mark.asyncio
+class TestCheckPerCustomerLimitReached:
+    async def test_no_limit_set(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=None,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=checkout, customer=customer
+            )
+            is False
+        )
+
+    async def test_under_limit(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=2,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is False
+        )
+
+    async def test_limit_reached_by_customer_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is True
+        )
+
+    async def test_limit_reached_by_email_alias(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        # A *different* customer previously redeemed, but with the same base email.
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="someone-else@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=prior_customer
+        )
+        prior_checkout.customer_email = "customer@example.com"
+        await save_fixture(prior_checkout)
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        # Current customer uses a `+alias` variant of the same email.
+        current_customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer+alias@example.com",
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=current_customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session,
+                discount,
+                checkout=current_checkout,
+                customer=current_customer,
+            )
+            is True
+        )
+
+    async def test_limit_reached_by_fingerprint(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        # Different customer and email, but the same card fingerprint.
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=prior_customer
+        )
+        prior_checkout.customer_email = "other@example.com"
+        await save_fixture(prior_checkout)
+        await create_payment(
+            save_fixture,
+            organization,
+            checkout=prior_checkout,
+            method_metadata={"fingerprint": "FINGERPRINT"},
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        current_customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=current_customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session,
+                discount,
+                checkout=current_checkout,
+                customer=current_customer,
+                payment_method_fingerprint="FINGERPRINT",
+            )
+            is True
+        )
+
+    async def test_excludes_current_checkout(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        # The only redemption belongs to the in-progress checkout, so it must not count.
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=current_checkout
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is False
+        )

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -37,6 +37,7 @@ from polar.models import (
     CustomField,
     Discount,
     DiscountProduct,
+    DiscountRedemption,
     Dispute,
     Event,
     EventType,
@@ -744,6 +745,7 @@ async def create_discount(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     max_redemptions: int | None = None,
+    max_redemptions_per_customer: int | None = None,
     products: list[Product] | None = None,
 ) -> DiscountFixed: ...
 @typing.overload
@@ -760,6 +762,7 @@ async def create_discount(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     max_redemptions: int | None = None,
+    max_redemptions_per_customer: int | None = None,
     products: list[Product] | None = None,
 ) -> DiscountPercentage: ...
 async def create_discount(
@@ -776,6 +779,7 @@ async def create_discount(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     max_redemptions: int | None = None,
+    max_redemptions_per_customer: int | None = None,
     products: list[Product] | None = None,
 ) -> Discount:
     model = type.get_model()
@@ -790,6 +794,7 @@ async def create_discount(
         ends_at=ends_at,
         discount_products=[],
         max_redemptions=max_redemptions,
+        max_redemptions_per_customer=max_redemptions_per_customer,
         redemptions_count=0,
     )
     if isinstance(custom_field, DiscountFixed):
@@ -805,6 +810,22 @@ async def create_discount(
 
     await save_fixture(custom_field)
     return custom_field
+
+
+async def create_discount_redemption(
+    save_fixture: SaveFixture,
+    *,
+    discount: Discount,
+    checkout: Checkout | None = None,
+    subscription: Subscription | None = None,
+) -> DiscountRedemption:
+    discount_redemption = DiscountRedemption(
+        discount=discount,
+        checkout=checkout,
+        subscription=subscription,
+    )
+    await save_fixture(discount_redemption)
+    return discount_redemption
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary

Adds support for limiting the number of times a discount can be redeemed by a single customer, with customer identification using email, account ID, and payment method fingerprint (similar to trial abuse detection).

## What

- Added `max_redemptions_per_customer` field to the `Discount` model
- Implemented `check_per_customer_limit_reached()` service method to enforce per-customer limits
- Added `count_redemptions_by_customer()` repository method to count past redemptions by customer identity signals
- Integrated limit enforcement into checkout confirmation flow before payment intent creation
- Updated API schemas, OpenAPI documentation, and TypeScript client types
- Added comprehensive test coverage for limit checking with various customer identification scenarios

## Why

Prevents discount abuse by allowing merchants to limit how many times each customer can redeem a discount. Uses multiple identity signals (customer ID, email with alias stripping, payment fingerprint) to catch attempts to circumvent limits using different accounts or email aliases.

## How

1. **Database**: Added nullable `max_redemptions_per_customer` integer column to discounts table
2. **Repository**: Implemented `count_redemptions_by_customer()` with SQL logic to:
   - Match customers by ID, unaliased email (strips `+alias` suffixes), or card fingerprint
   - Exclude the current in-progress checkout from counts
   - Use OR logic across identity signals (any match counts as same customer)
3. **Service**: Added `check_per_customer_limit_reached()` that queries the repository and compares count against limit
4. **Checkout**: Integrated limit check in `_confirm_inner()` before creating payment intent, extracting fingerprint from Stripe confirmation token
5. **API**: Added field to create/update schemas with validation (minimum 1 when set)
6. **Tests**: Added 6 test cases covering no limit, under limit, limit reached by ID/email/fingerprint, and current checkout exclusion

## Checklist

- [x] This PR addresses a single concern (per-customer discount limits)
- [x] The diff is reasonably sized and focused
- [x] New functionality is covered by tests (6 new test cases in `TestCheckPerCustomerLimitReached`)
- [x] Linting and type checking should pass
- [x] No unrelated changes included

https://claude.ai/code/session_01FXLr4zCCefQQgQSmUf63eH