### PR TITLE
amount v2: Migrate order items amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-05-29-1747_add_order_items_v2_amount_columns.py
+++ b/server/migrations/versions/2026-05-29-1747_add_order_items_v2_amount_columns.py
@@ -1,0 +1,138 @@
+"""Add order_items v2 amount columns (int → bigint widening)
+
+Revision ID: 5f832e2ae1da
+Revises: 84253a03dcb4
+Create Date: 2026-05-29 10:45:00.000000
+
+Phase 1 of widening order_items amount columns from integer to bigint via
+dual-column migration:
+
+  1. Add nullable *_v2 BIGINT columns for every INT4 amount column.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes
+         populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value
+         exceeds INT4_MAX (so new code's v2-only writes still populate
+         legacy for pods still running the previous version during
+         rollout of PR 2).
+  3. Backfill existing rows via scripts.backfill_amount_v2_order_items.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "5f832e2ae1da"
+down_revision = "84253a03dcb4"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+ORDER_ITEMS_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="order_items_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount_v2 IS NULL AND NEW.tax_amount IS NOT NULL THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount IS NULL
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount IS DISTINCT FROM OLD.tax_amount THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount_v2 IS DISTINCT FROM OLD.tax_amount_v2
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+ORDER_ITEMS_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="order_items_sync_v2_amounts_trigger",
+    on_entity="public.order_items",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON order_items\n"
+        "    FOR EACH ROW EXECUTE FUNCTION order_items_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "order_items",
+        sa.Column("amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "order_items",
+        sa.Column("net_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "order_items",
+        sa.Column("tax_amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(ORDER_ITEMS_SYNC_V2_AMOUNTS)
+    op.create_entity(ORDER_ITEMS_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(ORDER_ITEMS_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(ORDER_ITEMS_SYNC_V2_AMOUNTS)
+    op.drop_column("order_items", "tax_amount_v2")
+    op.drop_column("order_items", "net_amount_v2")
+    op.drop_column("order_items", "amount_v2")

--- a/server/polar/models/order_item.py
+++ b/server/polar/models/order_item.py
@@ -2,8 +2,11 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
 from babel.dates import format_date
-from sqlalchemy import Boolean, ForeignKey, Integer, String, Uuid
+from sqlalchemy import BigInteger, Boolean, ForeignKey, Integer, String, Uuid
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
@@ -28,8 +31,17 @@ class OrderItem(RecordModel):
 
     label: Mapped[str] = mapped_column(String, nullable=False)
     amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     net_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    net_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     tax_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    tax_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     proration: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     order_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("orders.id", ondelete="cascade"), index=True
@@ -103,3 +115,84 @@ class OrderItem(RecordModel):
             net_amount=amount,
             proration=False,
         )
+
+
+order_items_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="order_items_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount_v2 IS NULL AND NEW.tax_amount IS NOT NULL THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount IS NULL
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.tax_amount IS DISTINCT FROM OLD.tax_amount THEN
+                NEW.tax_amount_v2 := NEW.tax_amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+            IF NEW.tax_amount_v2 IS DISTINCT FROM OLD.tax_amount_v2
+               AND NEW.tax_amount_v2 IS NOT NULL
+               AND NEW.tax_amount_v2 <= 2147483647 THEN
+                NEW.tax_amount := NEW.tax_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+order_items_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="order_items_sync_v2_amounts_trigger",
+    on_entity="order_items",
+    definition="""
+    BEFORE INSERT OR UPDATE ON order_items
+    FOR EACH ROW EXECUTE FUNCTION order_items_sync_v2_amounts();
+    """,
+)
+
+register_entities(
+    (
+        order_items_sync_v2_amounts_function,
+        order_items_sync_v2_amounts_trigger,
+    )
+)

--- a/server/scripts/backfill_amount_v2_order_items.py
+++ b/server/scripts/backfill_amount_v2_order_items.py
@@ -1,0 +1,65 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import or_, select, update
+
+from polar.models import OrderItem
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill order_items *_v2 amount columns from their legacy INT4 counterparts."""
+    await run_batched_update(
+        (
+            update(OrderItem)
+            .values(
+                amount_v2=OrderItem.amount,
+                net_amount_v2=OrderItem.net_amount,
+                tax_amount_v2=OrderItem.tax_amount,
+            )
+            .where(
+                OrderItem.id.in_(
+                    select(OrderItem.id)
+                    .where(
+                        or_(
+                            OrderItem.amount_v2.is_(None)
+                            & OrderItem.amount.is_not(None),
+                            OrderItem.net_amount_v2.is_(None)
+                            & OrderItem.net_amount.is_not(None),
+                            OrderItem.tax_amount_v2.is_(None)
+                            & OrderItem.tax_amount.is_not(None),
+                        )
+                    )
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Adds the new amount columns as _v2 and a backfill script. Reads will move over in the second PR and the legacy columns will be dropped in the third.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended support for handling significantly larger order amounts with improved monetary precision and expanded value range capabilities.
  * Seamless bidirectional data synchronization maintains backward compatibility while safely transitioning to enhanced data storage formats.

* **Chores**
  * Database infrastructure enhanced to support expanded monetary value handling and storage requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/11995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->