### PR TITLE
amount v2: Migrate payments amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-06-01-0854_add_payments_v2_amount_columns.py
+++ b/server/migrations/versions/2026-06-01-0854_add_payments_v2_amount_columns.py
@@ -1,0 +1,96 @@
+"""Add payments v2 amount columns (int → bigint widening)
+
+Revision ID: 59df6fc5b268
+Revises: 56fdad219161
+Create Date: 2026-05-29 11:00:00.000000
+
+Phase 1 of widening payments amount columns from integer to bigint via
+dual-column migration:
+
+  1. Add nullable *_v2 BIGINT columns for every INT4 amount column.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes
+         populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value
+         exceeds INT4_MAX (so new code's v2-only writes still populate
+         legacy for pods still running the previous version during
+         rollout of PR 2).
+  3. Backfill existing rows via scripts.backfill_amount_v2_payments.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "59df6fc5b268"
+down_revision = "56fdad219161"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+PAYMENTS_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="payments_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+PAYMENTS_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="payments_sync_v2_amounts_trigger",
+    on_entity="public.payments",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON payments\n"
+        "    FOR EACH ROW EXECUTE FUNCTION payments_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "payments",
+        sa.Column("amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(PAYMENTS_SYNC_V2_AMOUNTS)
+    op.create_entity(PAYMENTS_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(PAYMENTS_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(PAYMENTS_SYNC_V2_AMOUNTS)
+    op.drop_column("payments", "amount_v2")

--- a/server/polar/models/payment.py
+++ b/server/polar/models/payment.py
@@ -2,7 +2,10 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, Self
 from uuid import UUID
 
-from sqlalchemy import ColumnElement, ForeignKey, SmallInteger, String, Uuid
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
+from sqlalchemy import BigInteger, ColumnElement, ForeignKey, SmallInteger, String, Uuid
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
@@ -107,6 +110,9 @@ class Payment(RecordModel):
         StrEnumType(PaymentStatus), index=True, nullable=False
     )
     amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     method: Mapped[str] = mapped_column(String, index=True, nullable=False)
     method_metadata: Mapped[dict[str, Any]] = mapped_column(
@@ -206,3 +212,52 @@ class Payment(RecordModel):
             self.decline_reason is not None
             and self.decline_reason in UNRECOVERABLE_DECLINE_CODES
         )
+
+
+payments_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="payments_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+payments_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="payments_sync_v2_amounts_trigger",
+    on_entity="payments",
+    definition="""
+    BEFORE INSERT OR UPDATE ON payments
+    FOR EACH ROW EXECUTE FUNCTION payments_sync_v2_amounts();
+    """,
+)
+
+register_entities(
+    (
+        payments_sync_v2_amounts_function,
+        payments_sync_v2_amounts_trigger,
+    )
+)

--- a/server/scripts/backfill_amount_v2_payments.py
+++ b/server/scripts/backfill_amount_v2_payments.py
@@ -1,0 +1,54 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import select, update
+
+from polar.models import Payment
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill payments *_v2 amount columns from their legacy INT4 counterparts."""
+    await run_batched_update(
+        (
+            update(Payment)
+            .values(
+                amount_v2=Payment.amount,
+            )
+            .where(
+                Payment.id.in_(
+                    select(Payment.id)
+                    .where(Payment.amount_v2.is_(None) & Payment.amount.is_not(None))
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Adds the new amount columns as _v2 and a backfill script. Reads will move over in the second PR and the legacy columns will be dropped in the third.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded payment amount capacity from 32-bit to 64-bit integers, enabling support for larger transaction values.
  * Automatic synchronization between legacy and new amount fields for seamless data handling.

* **Chores**
  * Added database migration and backfill utility to populate payment amounts in the new field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->