### PR TITLE
amount v2: Migrate product price amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-06-01-1010_add_product_prices_v2_amount_columns.py
+++ b/server/migrations/versions/2026-06-01-1010_add_product_prices_v2_amount_columns.py
@@ -1,0 +1,184 @@
+"""Add product_prices v2 amount columns (int → bigint widening)
+
+Revision ID: 7ae06f5a0e16
+Revises: 7fd113226949
+Create Date: 2026-05-29 11:15:00.000000
+
+Phase 1 of widening product_prices amount columns from integer to bigint
+via dual-column migration:
+
+  1. Add nullable *_v2 BIGINT columns for every INT4 amount column.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes
+         populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value
+         exceeds INT4_MAX (so new code's v2-only writes still populate
+         legacy for pods still running the previous version during
+         rollout of PR 2).
+  3. Backfill existing rows via scripts.backfill_amount_v2_product_prices.
+
+The amount columns are polymorphic (single-table inheritance) and already
+nullable, so the v2 columns stay nullable too — no NOT NULL tightening in
+the cleanup PR.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "7ae06f5a0e16"
+down_revision = "7fd113226949"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+PRODUCT_PRICES_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="product_prices_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.price_amount_v2 IS NULL AND NEW.price_amount IS NOT NULL THEN
+                NEW.price_amount_v2 := NEW.price_amount;
+            END IF;
+            IF NEW.minimum_amount_v2 IS NULL AND NEW.minimum_amount IS NOT NULL THEN
+                NEW.minimum_amount_v2 := NEW.minimum_amount;
+            END IF;
+            IF NEW.maximum_amount_v2 IS NULL AND NEW.maximum_amount IS NOT NULL THEN
+                NEW.maximum_amount_v2 := NEW.maximum_amount;
+            END IF;
+            IF NEW.preset_amount_v2 IS NULL AND NEW.preset_amount IS NOT NULL THEN
+                NEW.preset_amount_v2 := NEW.preset_amount;
+            END IF;
+            IF NEW.cap_amount_v2 IS NULL AND NEW.cap_amount IS NOT NULL THEN
+                NEW.cap_amount_v2 := NEW.cap_amount;
+            END IF;
+            IF NEW.price_amount IS NULL
+               AND NEW.price_amount_v2 IS NOT NULL
+               AND NEW.price_amount_v2 <= 2147483647 THEN
+                NEW.price_amount := NEW.price_amount_v2::integer;
+            END IF;
+            IF NEW.minimum_amount IS NULL
+               AND NEW.minimum_amount_v2 IS NOT NULL
+               AND NEW.minimum_amount_v2 <= 2147483647 THEN
+                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
+            END IF;
+            IF NEW.maximum_amount IS NULL
+               AND NEW.maximum_amount_v2 IS NOT NULL
+               AND NEW.maximum_amount_v2 <= 2147483647 THEN
+                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
+            END IF;
+            IF NEW.preset_amount IS NULL
+               AND NEW.preset_amount_v2 IS NOT NULL
+               AND NEW.preset_amount_v2 <= 2147483647 THEN
+                NEW.preset_amount := NEW.preset_amount_v2::integer;
+            END IF;
+            IF NEW.cap_amount IS NULL
+               AND NEW.cap_amount_v2 IS NOT NULL
+               AND NEW.cap_amount_v2 <= 2147483647 THEN
+                NEW.cap_amount := NEW.cap_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.price_amount IS DISTINCT FROM OLD.price_amount THEN
+                NEW.price_amount_v2 := NEW.price_amount;
+            END IF;
+            IF NEW.minimum_amount IS DISTINCT FROM OLD.minimum_amount THEN
+                NEW.minimum_amount_v2 := NEW.minimum_amount;
+            END IF;
+            IF NEW.maximum_amount IS DISTINCT FROM OLD.maximum_amount THEN
+                NEW.maximum_amount_v2 := NEW.maximum_amount;
+            END IF;
+            IF NEW.preset_amount IS DISTINCT FROM OLD.preset_amount THEN
+                NEW.preset_amount_v2 := NEW.preset_amount;
+            END IF;
+            IF NEW.cap_amount IS DISTINCT FROM OLD.cap_amount THEN
+                NEW.cap_amount_v2 := NEW.cap_amount;
+            END IF;
+            IF NEW.price_amount_v2 IS DISTINCT FROM OLD.price_amount_v2
+               AND NEW.price_amount_v2 IS NOT NULL
+               AND NEW.price_amount_v2 <= 2147483647 THEN
+                NEW.price_amount := NEW.price_amount_v2::integer;
+            END IF;
+            IF NEW.minimum_amount_v2 IS DISTINCT FROM OLD.minimum_amount_v2
+               AND NEW.minimum_amount_v2 IS NOT NULL
+               AND NEW.minimum_amount_v2 <= 2147483647 THEN
+                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
+            END IF;
+            IF NEW.maximum_amount_v2 IS DISTINCT FROM OLD.maximum_amount_v2
+               AND NEW.maximum_amount_v2 IS NOT NULL
+               AND NEW.maximum_amount_v2 <= 2147483647 THEN
+                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
+            END IF;
+            IF NEW.preset_amount_v2 IS DISTINCT FROM OLD.preset_amount_v2
+               AND NEW.preset_amount_v2 IS NOT NULL
+               AND NEW.preset_amount_v2 <= 2147483647 THEN
+                NEW.preset_amount := NEW.preset_amount_v2::integer;
+            END IF;
+            IF NEW.cap_amount_v2 IS DISTINCT FROM OLD.cap_amount_v2
+               AND NEW.cap_amount_v2 IS NOT NULL
+               AND NEW.cap_amount_v2 <= 2147483647 THEN
+                NEW.cap_amount := NEW.cap_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="product_prices_sync_v2_amounts_trigger",
+    on_entity="public.product_prices",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON product_prices\n"
+        "    FOR EACH ROW EXECUTE FUNCTION product_prices_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "product_prices",
+        sa.Column("price_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "product_prices",
+        sa.Column("minimum_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "product_prices",
+        sa.Column("maximum_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "product_prices",
+        sa.Column("preset_amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "product_prices",
+        sa.Column("cap_amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+    op.create_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+    op.drop_column("product_prices", "cap_amount_v2")
+    op.drop_column("product_prices", "preset_amount_v2")
+    op.drop_column("product_prices", "maximum_amount_v2")
+    op.drop_column("product_prices", "minimum_amount_v2")
+    op.drop_column("product_prices", "price_amount_v2")

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -3,8 +3,12 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 from uuid import UUID
 
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
 from babel.numbers import format_decimal
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     ColumnElement,
     ForeignKey,
@@ -235,6 +239,9 @@ class NewProductPrice:
 
 class _ProductPriceFixed(ProductPrice):
     price_amount: Mapped[int] = mapped_column(Integer, nullable=True)
+    price_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     amount_type: Mapped[Literal[ProductPriceAmountType.fixed]] = mapped_column(
         use_existing_column=True, default=ProductPriceAmountType.fixed
     )
@@ -264,11 +271,20 @@ class _ProductPriceCustom(ProductPrice):
         use_existing_column=True, default=ProductPriceAmountType.custom
     )
     minimum_amount: Mapped[int] = mapped_column(Integer, nullable=True, default=None)
+    minimum_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     maximum_amount: Mapped[int | None] = mapped_column(
         Integer, nullable=True, default=None
     )
+    maximum_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     preset_amount: Mapped[int | None] = mapped_column(
         Integer, nullable=True, default=None
+    )
+    preset_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
     )
 
     __mapper_args__ = {
@@ -332,6 +348,9 @@ class ProductPriceMeteredUnit(ProductPrice, NewProductPrice):
         nullable=True,
     )
     cap_amount: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    cap_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     meter_id: Mapped[UUID] = mapped_column(
         Uuid,
         ForeignKey("meters.id"),
@@ -465,3 +484,116 @@ def set_identity(instance: ProductPrice, *arg: Any, **kw: Any) -> None:
         instance.recurring_interval = None
 
     instance.amount_type = ProductPriceAmountType(identity)
+
+
+product_prices_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="product_prices_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.price_amount_v2 IS NULL AND NEW.price_amount IS NOT NULL THEN
+                NEW.price_amount_v2 := NEW.price_amount;
+            END IF;
+            IF NEW.minimum_amount_v2 IS NULL AND NEW.minimum_amount IS NOT NULL THEN
+                NEW.minimum_amount_v2 := NEW.minimum_amount;
+            END IF;
+            IF NEW.maximum_amount_v2 IS NULL AND NEW.maximum_amount IS NOT NULL THEN
+                NEW.maximum_amount_v2 := NEW.maximum_amount;
+            END IF;
+            IF NEW.preset_amount_v2 IS NULL AND NEW.preset_amount IS NOT NULL THEN
+                NEW.preset_amount_v2 := NEW.preset_amount;
+            END IF;
+            IF NEW.cap_amount_v2 IS NULL AND NEW.cap_amount IS NOT NULL THEN
+                NEW.cap_amount_v2 := NEW.cap_amount;
+            END IF;
+            IF NEW.price_amount IS NULL
+               AND NEW.price_amount_v2 IS NOT NULL
+               AND NEW.price_amount_v2 <= 2147483647 THEN
+                NEW.price_amount := NEW.price_amount_v2::integer;
+            END IF;
+            IF NEW.minimum_amount IS NULL
+               AND NEW.minimum_amount_v2 IS NOT NULL
+               AND NEW.minimum_amount_v2 <= 2147483647 THEN
+                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
+            END IF;
+            IF NEW.maximum_amount IS NULL
+               AND NEW.maximum_amount_v2 IS NOT NULL
+               AND NEW.maximum_amount_v2 <= 2147483647 THEN
+                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
+            END IF;
+            IF NEW.preset_amount IS NULL
+               AND NEW.preset_amount_v2 IS NOT NULL
+               AND NEW.preset_amount_v2 <= 2147483647 THEN
+                NEW.preset_amount := NEW.preset_amount_v2::integer;
+            END IF;
+            IF NEW.cap_amount IS NULL
+               AND NEW.cap_amount_v2 IS NOT NULL
+               AND NEW.cap_amount_v2 <= 2147483647 THEN
+                NEW.cap_amount := NEW.cap_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.price_amount IS DISTINCT FROM OLD.price_amount THEN
+                NEW.price_amount_v2 := NEW.price_amount;
+            END IF;
+            IF NEW.minimum_amount IS DISTINCT FROM OLD.minimum_amount THEN
+                NEW.minimum_amount_v2 := NEW.minimum_amount;
+            END IF;
+            IF NEW.maximum_amount IS DISTINCT FROM OLD.maximum_amount THEN
+                NEW.maximum_amount_v2 := NEW.maximum_amount;
+            END IF;
+            IF NEW.preset_amount IS DISTINCT FROM OLD.preset_amount THEN
+                NEW.preset_amount_v2 := NEW.preset_amount;
+            END IF;
+            IF NEW.cap_amount IS DISTINCT FROM OLD.cap_amount THEN
+                NEW.cap_amount_v2 := NEW.cap_amount;
+            END IF;
+            IF NEW.price_amount_v2 IS DISTINCT FROM OLD.price_amount_v2
+               AND NEW.price_amount_v2 IS NOT NULL
+               AND NEW.price_amount_v2 <= 2147483647 THEN
+                NEW.price_amount := NEW.price_amount_v2::integer;
+            END IF;
+            IF NEW.minimum_amount_v2 IS DISTINCT FROM OLD.minimum_amount_v2
+               AND NEW.minimum_amount_v2 IS NOT NULL
+               AND NEW.minimum_amount_v2 <= 2147483647 THEN
+                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
+            END IF;
+            IF NEW.maximum_amount_v2 IS DISTINCT FROM OLD.maximum_amount_v2
+               AND NEW.maximum_amount_v2 IS NOT NULL
+               AND NEW.maximum_amount_v2 <= 2147483647 THEN
+                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
+            END IF;
+            IF NEW.preset_amount_v2 IS DISTINCT FROM OLD.preset_amount_v2
+               AND NEW.preset_amount_v2 IS NOT NULL
+               AND NEW.preset_amount_v2 <= 2147483647 THEN
+                NEW.preset_amount := NEW.preset_amount_v2::integer;
+            END IF;
+            IF NEW.cap_amount_v2 IS DISTINCT FROM OLD.cap_amount_v2
+               AND NEW.cap_amount_v2 IS NOT NULL
+               AND NEW.cap_amount_v2 <= 2147483647 THEN
+                NEW.cap_amount := NEW.cap_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+product_prices_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="product_prices_sync_v2_amounts_trigger",
+    on_entity="product_prices",
+    definition="""
+    BEFORE INSERT OR UPDATE ON product_prices
+    FOR EACH ROW EXECUTE FUNCTION product_prices_sync_v2_amounts();
+    """,
+)
+
+register_entities(
+    (
+        product_prices_sync_v2_amounts_function,
+        product_prices_sync_v2_amounts_trigger,
+    )
+)

--- a/server/scripts/backfill_amount_v2_product_prices.py
+++ b/server/scripts/backfill_amount_v2_product_prices.py
@@ -1,0 +1,75 @@
+import asyncio
+from functools import wraps
+from typing import cast
+
+import typer
+from sqlalchemy import Table, or_, select, update
+
+from polar.models import ProductPrice
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill product_prices *_v2 amount columns from their legacy INT4 counterparts."""
+    # The amount columns live on single-table-inheritance subclasses, so go
+    # through the shared table rather than the base ORM entity.
+    table = cast(Table, ProductPrice.__table__)
+    await run_batched_update(
+        (
+            update(table)
+            .values(
+                price_amount_v2=table.c.price_amount,
+                minimum_amount_v2=table.c.minimum_amount,
+                maximum_amount_v2=table.c.maximum_amount,
+                preset_amount_v2=table.c.preset_amount,
+                cap_amount_v2=table.c.cap_amount,
+            )
+            .where(
+                table.c.id.in_(
+                    select(table.c.id)
+                    .where(
+                        or_(
+                            table.c.price_amount_v2.is_(None)
+                            & table.c.price_amount.is_not(None),
+                            table.c.minimum_amount_v2.is_(None)
+                            & table.c.minimum_amount.is_not(None),
+                            table.c.maximum_amount_v2.is_(None)
+                            & table.c.maximum_amount.is_not(None),
+                            table.c.preset_amount_v2.is_(None)
+                            & table.c.preset_amount.is_not(None),
+                            table.c.cap_amount_v2.is_(None)
+                            & table.c.cap_amount.is_not(None),
+                        )
+                    )
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Adds the new amount columns as _v2 and a backfill script. Reads will move over in the second PR and the legacy columns will be dropped in the third.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product pricing system now supports larger amount values.

* **Chores**
  * Added database infrastructure updates and data migration tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->