### PR TITLE
amount v2: Drop old product price amount columns

### DIFF
--- a/server/migrations/versions/2026-06-01-1110_cleanup_product_prices_v2_amount_columns.py
+++ b/server/migrations/versions/2026-06-01-1110_cleanup_product_prices_v2_amount_columns.py
@@ -1,0 +1,217 @@
+"""Cleanup product_prices v2 amount columns
+
+Revision ID: 8e527b7e420a
+Revises: 7ae06f5a0e16
+Create Date: 2026-05-29 15:20:00.000000
+
+Phase 3 of widening product_prices amount columns:
+
+  1. Inline catch-up backfill from legacy → v2 for any environment that
+     skipped the standalone backfill script (prod ran it; CI/dev did not).
+  2. Drop the bidirectional sync trigger + function.
+  3. Drop the five legacy INT4 columns.
+
+The amount columns are polymorphic (single-table inheritance) and stay
+nullable, so there is no NOT NULL tightening step.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "8e527b7e420a"
+down_revision = "7ae06f5a0e16"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+PRODUCT_PRICES_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="product_prices_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.price_amount_v2 IS NULL AND NEW.price_amount IS NOT NULL THEN
+                NEW.price_amount_v2 := NEW.price_amount;
+            END IF;
+            IF NEW.minimum_amount_v2 IS NULL AND NEW.minimum_amount IS NOT NULL THEN
+                NEW.minimum_amount_v2 := NEW.minimum_amount;
+            END IF;
+            IF NEW.maximum_amount_v2 IS NULL AND NEW.maximum_amount IS NOT NULL THEN
+                NEW.maximum_amount_v2 := NEW.maximum_amount;
+            END IF;
+            IF NEW.preset_amount_v2 IS NULL AND NEW.preset_amount IS NOT NULL THEN
+                NEW.preset_amount_v2 := NEW.preset_amount;
+            END IF;
+            IF NEW.cap_amount_v2 IS NULL AND NEW.cap_amount IS NOT NULL THEN
+                NEW.cap_amount_v2 := NEW.cap_amount;
+            END IF;
+            IF NEW.price_amount IS NULL
+               AND NEW.price_amount_v2 IS NOT NULL
+               AND NEW.price_amount_v2 <= 2147483647 THEN
+                NEW.price_amount := NEW.price_amount_v2::integer;
+            END IF;
+            IF NEW.minimum_amount IS NULL
+               AND NEW.minimum_amount_v2 IS NOT NULL
+               AND NEW.minimum_amount_v2 <= 2147483647 THEN
+                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
+            END IF;
+            IF NEW.maximum_amount IS NULL
+               AND NEW.maximum_amount_v2 IS NOT NULL
+               AND NEW.maximum_amount_v2 <= 2147483647 THEN
+                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
+            END IF;
+            IF NEW.preset_amount IS NULL
+               AND NEW.preset_amount_v2 IS NOT NULL
+               AND NEW.preset_amount_v2 <= 2147483647 THEN
+                NEW.preset_amount := NEW.preset_amount_v2::integer;
+            END IF;
+            IF NEW.cap_amount IS NULL
+               AND NEW.cap_amount_v2 IS NOT NULL
+               AND NEW.cap_amount_v2 <= 2147483647 THEN
+                NEW.cap_amount := NEW.cap_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.price_amount IS DISTINCT FROM OLD.price_amount THEN
+                NEW.price_amount_v2 := NEW.price_amount;
+            END IF;
+            IF NEW.minimum_amount IS DISTINCT FROM OLD.minimum_amount THEN
+                NEW.minimum_amount_v2 := NEW.minimum_amount;
+            END IF;
+            IF NEW.maximum_amount IS DISTINCT FROM OLD.maximum_amount THEN
+                NEW.maximum_amount_v2 := NEW.maximum_amount;
+            END IF;
+            IF NEW.preset_amount IS DISTINCT FROM OLD.preset_amount THEN
+                NEW.preset_amount_v2 := NEW.preset_amount;
+            END IF;
+            IF NEW.cap_amount IS DISTINCT FROM OLD.cap_amount THEN
+                NEW.cap_amount_v2 := NEW.cap_amount;
+            END IF;
+            IF NEW.price_amount_v2 IS DISTINCT FROM OLD.price_amount_v2
+               AND NEW.price_amount_v2 IS NOT NULL
+               AND NEW.price_amount_v2 <= 2147483647 THEN
+                NEW.price_amount := NEW.price_amount_v2::integer;
+            END IF;
+            IF NEW.minimum_amount_v2 IS DISTINCT FROM OLD.minimum_amount_v2
+               AND NEW.minimum_amount_v2 IS NOT NULL
+               AND NEW.minimum_amount_v2 <= 2147483647 THEN
+                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
+            END IF;
+            IF NEW.maximum_amount_v2 IS DISTINCT FROM OLD.maximum_amount_v2
+               AND NEW.maximum_amount_v2 IS NOT NULL
+               AND NEW.maximum_amount_v2 <= 2147483647 THEN
+                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
+            END IF;
+            IF NEW.preset_amount_v2 IS DISTINCT FROM OLD.preset_amount_v2
+               AND NEW.preset_amount_v2 IS NOT NULL
+               AND NEW.preset_amount_v2 <= 2147483647 THEN
+                NEW.preset_amount := NEW.preset_amount_v2::integer;
+            END IF;
+            IF NEW.cap_amount_v2 IS DISTINCT FROM OLD.cap_amount_v2
+               AND NEW.cap_amount_v2 IS NOT NULL
+               AND NEW.cap_amount_v2 <= 2147483647 THEN
+                NEW.cap_amount := NEW.cap_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="product_prices_sync_v2_amounts_trigger",
+    on_entity="public.product_prices",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON product_prices\n"
+        "    FOR EACH ROW EXECUTE FUNCTION product_prices_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.execute(
+        """
+        UPDATE product_prices
+        SET price_amount_v2 = COALESCE(price_amount_v2, price_amount::bigint),
+            minimum_amount_v2 = COALESCE(minimum_amount_v2, minimum_amount::bigint),
+            maximum_amount_v2 = COALESCE(maximum_amount_v2, maximum_amount::bigint),
+            preset_amount_v2 = COALESCE(preset_amount_v2, preset_amount::bigint),
+            cap_amount_v2 = COALESCE(cap_amount_v2, cap_amount::bigint)
+        WHERE (price_amount_v2 IS NULL AND price_amount IS NOT NULL)
+           OR (minimum_amount_v2 IS NULL AND minimum_amount IS NOT NULL)
+           OR (maximum_amount_v2 IS NULL AND maximum_amount IS NOT NULL)
+           OR (preset_amount_v2 IS NULL AND preset_amount IS NOT NULL)
+           OR (cap_amount_v2 IS NULL AND cap_amount IS NOT NULL)
+        """
+    )
+
+    op.drop_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+
+    op.drop_column("product_prices", "cap_amount")
+    op.drop_column("product_prices", "preset_amount")
+    op.drop_column("product_prices", "maximum_amount")
+    op.drop_column("product_prices", "minimum_amount")
+    op.drop_column("product_prices", "price_amount")
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "product_prices", sa.Column("price_amount", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "product_prices", sa.Column("minimum_amount", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "product_prices", sa.Column("maximum_amount", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "product_prices", sa.Column("preset_amount", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "product_prices", sa.Column("cap_amount", sa.Integer(), nullable=True)
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM product_prices
+                WHERE price_amount_v2 NOT BETWEEN -2147483648 AND 2147483647
+                   OR minimum_amount_v2 NOT BETWEEN -2147483648 AND 2147483647
+                   OR maximum_amount_v2 NOT BETWEEN -2147483648 AND 2147483647
+                   OR preset_amount_v2 NOT BETWEEN -2147483648 AND 2147483647
+                   OR cap_amount_v2 NOT BETWEEN -2147483648 AND 2147483647
+            ) THEN
+                RAISE EXCEPTION 'Cannot downgrade product_prices amount columns with values outside int4 range';
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        UPDATE product_prices
+        SET price_amount = price_amount_v2::integer,
+            minimum_amount = minimum_amount_v2::integer,
+            maximum_amount = maximum_amount_v2::integer,
+            preset_amount = preset_amount_v2::integer,
+            cap_amount = cap_amount_v2::integer
+        """
+    )
+
+    op.create_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+    op.create_entity(PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -3,16 +3,12 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 from uuid import UUID
 
-from alembic_utils.pg_function import PGFunction
-from alembic_utils.pg_trigger import PGTrigger
-from alembic_utils.replaceable_entity import register_entities
 from babel.numbers import format_decimal
 from sqlalchemy import (
     BigInteger,
     Boolean,
     ColumnElement,
     ForeignKey,
-    Integer,
     Numeric,
     String,
     Uuid,
@@ -241,15 +237,6 @@ class _ProductPriceFixed(ProductPrice):
     price_amount: Mapped[int] = mapped_column(
         "price_amount_v2", BigInteger, nullable=True
     )
-
-    # Legacy int4 columns retained while the dual-column sync trigger is active.
-    # Deferred so they never appear in default SELECTs. No default — that
-    # would force SQLAlchemy to include the column in every INSERT, which
-    # would break running pods once the cleanup migration drops the column.
-    # The bidirectional trigger keeps these in sync with the v2 columns.
-    legacy_price_amount: Mapped[int] = mapped_column(
-        "price_amount", Integer, nullable=True, deferred=True
-    )
     amount_type: Mapped[Literal[ProductPriceAmountType.fixed]] = mapped_column(
         use_existing_column=True, default=ProductPriceAmountType.fixed
     )
@@ -286,15 +273,6 @@ class _ProductPriceCustom(ProductPrice):
     )
     preset_amount: Mapped[int | None] = mapped_column(
         "preset_amount_v2", BigInteger, nullable=True
-    )
-    legacy_minimum_amount: Mapped[int] = mapped_column(
-        "minimum_amount", Integer, nullable=True, deferred=True
-    )
-    legacy_maximum_amount: Mapped[int | None] = mapped_column(
-        "maximum_amount", Integer, nullable=True, deferred=True
-    )
-    legacy_preset_amount: Mapped[int | None] = mapped_column(
-        "preset_amount", Integer, nullable=True, deferred=True
     )
 
     __mapper_args__ = {
@@ -359,9 +337,6 @@ class ProductPriceMeteredUnit(ProductPrice, NewProductPrice):
     )
     cap_amount: Mapped[int | None] = mapped_column(
         "cap_amount_v2", BigInteger, nullable=True
-    )
-    legacy_cap_amount: Mapped[int | None] = mapped_column(
-        "cap_amount", Integer, nullable=True, deferred=True
     )
     meter_id: Mapped[UUID] = mapped_column(
         Uuid,
@@ -496,116 +471,3 @@ def set_identity(instance: ProductPrice, *arg: Any, **kw: Any) -> None:
         instance.recurring_interval = None
 
     instance.amount_type = ProductPriceAmountType(identity)
-
-
-product_prices_sync_v2_amounts_function = PGFunction(
-    schema="public",
-    signature="product_prices_sync_v2_amounts()",
-    definition="""
-    RETURNS trigger AS $$
-    BEGIN
-        IF TG_OP = 'INSERT' THEN
-            IF NEW.price_amount_v2 IS NULL AND NEW.price_amount IS NOT NULL THEN
-                NEW.price_amount_v2 := NEW.price_amount;
-            END IF;
-            IF NEW.minimum_amount_v2 IS NULL AND NEW.minimum_amount IS NOT NULL THEN
-                NEW.minimum_amount_v2 := NEW.minimum_amount;
-            END IF;
-            IF NEW.maximum_amount_v2 IS NULL AND NEW.maximum_amount IS NOT NULL THEN
-                NEW.maximum_amount_v2 := NEW.maximum_amount;
-            END IF;
-            IF NEW.preset_amount_v2 IS NULL AND NEW.preset_amount IS NOT NULL THEN
-                NEW.preset_amount_v2 := NEW.preset_amount;
-            END IF;
-            IF NEW.cap_amount_v2 IS NULL AND NEW.cap_amount IS NOT NULL THEN
-                NEW.cap_amount_v2 := NEW.cap_amount;
-            END IF;
-            IF NEW.price_amount IS NULL
-               AND NEW.price_amount_v2 IS NOT NULL
-               AND NEW.price_amount_v2 <= 2147483647 THEN
-                NEW.price_amount := NEW.price_amount_v2::integer;
-            END IF;
-            IF NEW.minimum_amount IS NULL
-               AND NEW.minimum_amount_v2 IS NOT NULL
-               AND NEW.minimum_amount_v2 <= 2147483647 THEN
-                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
-            END IF;
-            IF NEW.maximum_amount IS NULL
-               AND NEW.maximum_amount_v2 IS NOT NULL
-               AND NEW.maximum_amount_v2 <= 2147483647 THEN
-                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
-            END IF;
-            IF NEW.preset_amount IS NULL
-               AND NEW.preset_amount_v2 IS NOT NULL
-               AND NEW.preset_amount_v2 <= 2147483647 THEN
-                NEW.preset_amount := NEW.preset_amount_v2::integer;
-            END IF;
-            IF NEW.cap_amount IS NULL
-               AND NEW.cap_amount_v2 IS NOT NULL
-               AND NEW.cap_amount_v2 <= 2147483647 THEN
-                NEW.cap_amount := NEW.cap_amount_v2::integer;
-            END IF;
-        ELSIF TG_OP = 'UPDATE' THEN
-            IF NEW.price_amount IS DISTINCT FROM OLD.price_amount THEN
-                NEW.price_amount_v2 := NEW.price_amount;
-            END IF;
-            IF NEW.minimum_amount IS DISTINCT FROM OLD.minimum_amount THEN
-                NEW.minimum_amount_v2 := NEW.minimum_amount;
-            END IF;
-            IF NEW.maximum_amount IS DISTINCT FROM OLD.maximum_amount THEN
-                NEW.maximum_amount_v2 := NEW.maximum_amount;
-            END IF;
-            IF NEW.preset_amount IS DISTINCT FROM OLD.preset_amount THEN
-                NEW.preset_amount_v2 := NEW.preset_amount;
-            END IF;
-            IF NEW.cap_amount IS DISTINCT FROM OLD.cap_amount THEN
-                NEW.cap_amount_v2 := NEW.cap_amount;
-            END IF;
-            IF NEW.price_amount_v2 IS DISTINCT FROM OLD.price_amount_v2
-               AND NEW.price_amount_v2 IS NOT NULL
-               AND NEW.price_amount_v2 <= 2147483647 THEN
-                NEW.price_amount := NEW.price_amount_v2::integer;
-            END IF;
-            IF NEW.minimum_amount_v2 IS DISTINCT FROM OLD.minimum_amount_v2
-               AND NEW.minimum_amount_v2 IS NOT NULL
-               AND NEW.minimum_amount_v2 <= 2147483647 THEN
-                NEW.minimum_amount := NEW.minimum_amount_v2::integer;
-            END IF;
-            IF NEW.maximum_amount_v2 IS DISTINCT FROM OLD.maximum_amount_v2
-               AND NEW.maximum_amount_v2 IS NOT NULL
-               AND NEW.maximum_amount_v2 <= 2147483647 THEN
-                NEW.maximum_amount := NEW.maximum_amount_v2::integer;
-            END IF;
-            IF NEW.preset_amount_v2 IS DISTINCT FROM OLD.preset_amount_v2
-               AND NEW.preset_amount_v2 IS NOT NULL
-               AND NEW.preset_amount_v2 <= 2147483647 THEN
-                NEW.preset_amount := NEW.preset_amount_v2::integer;
-            END IF;
-            IF NEW.cap_amount_v2 IS DISTINCT FROM OLD.cap_amount_v2
-               AND NEW.cap_amount_v2 IS NOT NULL
-               AND NEW.cap_amount_v2 <= 2147483647 THEN
-                NEW.cap_amount := NEW.cap_amount_v2::integer;
-            END IF;
-        END IF;
-        RETURN NEW;
-    END
-    $$ LANGUAGE plpgsql;
-    """,
-)
-
-product_prices_sync_v2_amounts_trigger = PGTrigger(
-    schema="public",
-    signature="product_prices_sync_v2_amounts_trigger",
-    on_entity="product_prices",
-    definition="""
-    BEFORE INSERT OR UPDATE ON product_prices
-    FOR EACH ROW EXECUTE FUNCTION product_prices_sync_v2_amounts();
-    """,
-)
-
-register_entities(
-    (
-        product_prices_sync_v2_amounts_function,
-        product_prices_sync_v2_amounts_trigger,
-    )
-)


### PR DESCRIPTION
Third step in widening the amounts, we drop the legacy columns and keep the new ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database cleanup and consolidation of product pricing data structure to remove legacy columns and streamline internal data organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->