### PR TITLE
amount v2: Migrate subscription product price amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-06-01-1130_add_subscription_product_prices_v2_amount_columns.py
+++ b/server/migrations/versions/2026-06-01-1130_add_subscription_product_prices_v2_amount_columns.py
@@ -1,0 +1,97 @@
+"""Add subscription_product_prices v2 amount columns (int → bigint widening)
+
+Revision ID: 8f2439326360
+Revises: 8e527b7e420a
+Create Date: 2026-05-29 11:30:00.000000
+
+Phase 1 of widening subscription_product_prices amount columns from integer
+to bigint via dual-column migration:
+
+  1. Add nullable *_v2 BIGINT columns for every INT4 amount column.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes
+         populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value
+         exceeds INT4_MAX (so new code's v2-only writes still populate
+         legacy for pods still running the previous version during
+         rollout of PR 2).
+  3. Backfill existing rows via
+     scripts.backfill_amount_v2_subscription_product_prices.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "8f2439326360"
+down_revision = "8e527b7e420a"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="subscription_product_prices_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="subscription_product_prices_sync_v2_amounts_trigger",
+    on_entity="public.subscription_product_prices",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON subscription_product_prices\n"
+        "    FOR EACH ROW EXECUTE FUNCTION subscription_product_prices_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "subscription_product_prices",
+        sa.Column("amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+    op.create_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+    op.drop_column("subscription_product_prices", "amount_v2")

--- a/server/polar/models/subscription_product_price.py
+++ b/server/polar/models/subscription_product_price.py
@@ -1,7 +1,10 @@
 from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Integer, Uuid
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
+from sqlalchemy import BigInteger, ForeignKey, Integer, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import RecordModel
@@ -32,6 +35,9 @@ class SubscriptionProductPrice(RecordModel):
         primary_key=True,
     )
     amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
 
     @declared_attr
     def product_price(cls) -> Mapped["ProductPrice"]:
@@ -59,3 +65,52 @@ class SubscriptionProductPrice(RecordModel):
         else:
             amount = 0
         return cls(product_price=price, amount=amount)
+
+
+subscription_product_prices_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="subscription_product_prices_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+subscription_product_prices_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="subscription_product_prices_sync_v2_amounts_trigger",
+    on_entity="subscription_product_prices",
+    definition="""
+    BEFORE INSERT OR UPDATE ON subscription_product_prices
+    FOR EACH ROW EXECUTE FUNCTION subscription_product_prices_sync_v2_amounts();
+    """,
+)
+
+register_entities(
+    (
+        subscription_product_prices_sync_v2_amounts_function,
+        subscription_product_prices_sync_v2_amounts_trigger,
+    )
+)

--- a/server/scripts/backfill_amount_v2_subscription_product_prices.py
+++ b/server/scripts/backfill_amount_v2_subscription_product_prices.py
@@ -1,0 +1,59 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import or_, select, update
+
+from polar.models import SubscriptionProductPrice
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill subscription_product_prices *_v2 amount columns from legacy INT4."""
+    await run_batched_update(
+        (
+            update(SubscriptionProductPrice)
+            .values(
+                amount_v2=SubscriptionProductPrice.amount,
+            )
+            .where(
+                SubscriptionProductPrice.id.in_(
+                    select(SubscriptionProductPrice.id)
+                    .where(
+                        or_(
+                            SubscriptionProductPrice.amount_v2.is_(None)
+                            & SubscriptionProductPrice.amount.is_not(None),
+                        )
+                    )
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Adds the new amount columns as _v2 and a backfill script. Reads will move over in the second PR and the legacy columns will be dropped in the third.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription product pricing system upgraded to support larger price values.
  * Implemented automatic synchronization to maintain consistency between pricing formats during the system transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->