### PR TITLE
amount v2: Drop old subscription product price amount columns

### DIFF
--- a/server/migrations/versions/2026-06-01-1253_cleanup_subscription_product_prices_v2_amount_columns.py
+++ b/server/migrations/versions/2026-06-01-1253_cleanup_subscription_product_prices_v2_amount_columns.py
@@ -1,0 +1,159 @@
+"""Cleanup subscription_product_prices v2 amount columns
+
+Revision ID: 928fd5653fc9
+Revises: 8f2439326360
+Create Date: 2026-05-29 15:35:00.000000
+
+Phase 3 of widening subscription_product_prices amount columns:
+
+  1. Inline catch-up backfill from legacy → v2 for any environment that
+     skipped the standalone backfill script (prod ran it; CI/dev did not).
+  2. Tighten the v2 columns to NOT NULL via NOT VALID CHECK + VALIDATE
+     + ALTER COLUMN, so no rewrite-time ACCESS EXCLUSIVE lock.
+  3. Drop the bidirectional sync trigger + function.
+  4. Drop the legacy INT4 column.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "928fd5653fc9"
+down_revision = "8f2439326360"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="subscription_product_prices_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="subscription_product_prices_sync_v2_amounts_trigger",
+    on_entity="public.subscription_product_prices",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON subscription_product_prices\n"
+        "    FOR EACH ROW EXECUTE FUNCTION subscription_product_prices_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.execute(
+        """
+        UPDATE subscription_product_prices
+        SET amount_v2 = COALESCE(amount_v2, amount::bigint)
+        WHERE amount_v2 IS NULL AND amount IS NOT NULL
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE subscription_product_prices
+            ADD CONSTRAINT subscription_product_prices_amount_v2_not_null
+                CHECK (amount_v2 IS NOT NULL) NOT VALID
+        """
+    )
+    op.execute(
+        "ALTER TABLE subscription_product_prices "
+        "VALIDATE CONSTRAINT subscription_product_prices_amount_v2_not_null"
+    )
+
+    op.alter_column(
+        "subscription_product_prices",
+        "amount_v2",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+    )
+
+    op.execute(
+        "ALTER TABLE subscription_product_prices "
+        "DROP CONSTRAINT subscription_product_prices_amount_v2_not_null"
+    )
+
+    op.drop_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+
+    op.drop_column("subscription_product_prices", "amount")
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "subscription_product_prices",
+        sa.Column("amount", sa.Integer(), nullable=True),
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM subscription_product_prices
+                WHERE amount_v2 NOT BETWEEN -2147483648 AND 2147483647
+            ) THEN
+                RAISE EXCEPTION 'Cannot downgrade subscription_product_prices amount columns with values outside int4 range';
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        UPDATE subscription_product_prices
+        SET amount = amount_v2::integer
+        """
+    )
+
+    op.alter_column(
+        "subscription_product_prices",
+        "amount",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+
+    op.alter_column(
+        "subscription_product_prices",
+        "amount_v2",
+        existing_type=sa.BigInteger(),
+        nullable=True,
+    )
+
+    op.create_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS)
+    op.create_entity(SUBSCRIPTION_PRODUCT_PRICES_SYNC_V2_AMOUNTS_TRIGGER)

--- a/server/polar/models/subscription_product_price.py
+++ b/server/polar/models/subscription_product_price.py
@@ -1,10 +1,7 @@
 from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
-from alembic_utils.pg_function import PGFunction
-from alembic_utils.pg_trigger import PGTrigger
-from alembic_utils.replaceable_entity import register_entities
-from sqlalchemy import BigInteger, ForeignKey, Integer, Uuid
+from sqlalchemy import BigInteger, ForeignKey, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import RecordModel
@@ -34,18 +31,7 @@ class SubscriptionProductPrice(RecordModel):
         ForeignKey("product_prices.id", ondelete="restrict"),
         primary_key=True,
     )
-    amount: Mapped[int] = mapped_column("amount_v2", BigInteger, nullable=True)
-
-    # Legacy int4 columns retained while the dual-column sync trigger is active.
-    # Deferred so they never appear in default SELECTs. No default — that
-    # would force SQLAlchemy to include the column in every INSERT, which
-    # would break running pods once the cleanup migration drops the column.
-    # The bidirectional trigger fills these from the v2 columns on INSERT,
-    # so the NOT NULL constraints on legacy columns are still satisfied even
-    # when ORM code only sets the (v2-backed) primary attributes.
-    legacy_amount: Mapped[int] = mapped_column(
-        "amount", Integer, nullable=False, deferred=True
-    )
+    amount: Mapped[int] = mapped_column("amount_v2", BigInteger, nullable=False)
 
     @declared_attr
     def product_price(cls) -> Mapped["ProductPrice"]:
@@ -73,52 +59,3 @@ class SubscriptionProductPrice(RecordModel):
         else:
             amount = 0
         return cls(product_price=price, amount=amount)
-
-
-subscription_product_prices_sync_v2_amounts_function = PGFunction(
-    schema="public",
-    signature="subscription_product_prices_sync_v2_amounts()",
-    definition="""
-    RETURNS trigger AS $$
-    BEGIN
-        IF TG_OP = 'INSERT' THEN
-            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
-                NEW.amount_v2 := NEW.amount;
-            END IF;
-            IF NEW.amount IS NULL
-               AND NEW.amount_v2 IS NOT NULL
-               AND NEW.amount_v2 <= 2147483647 THEN
-                NEW.amount := NEW.amount_v2::integer;
-            END IF;
-        ELSIF TG_OP = 'UPDATE' THEN
-            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
-                NEW.amount_v2 := NEW.amount;
-            END IF;
-            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
-               AND NEW.amount_v2 IS NOT NULL
-               AND NEW.amount_v2 <= 2147483647 THEN
-                NEW.amount := NEW.amount_v2::integer;
-            END IF;
-        END IF;
-        RETURN NEW;
-    END
-    $$ LANGUAGE plpgsql;
-    """,
-)
-
-subscription_product_prices_sync_v2_amounts_trigger = PGTrigger(
-    schema="public",
-    signature="subscription_product_prices_sync_v2_amounts_trigger",
-    on_entity="subscription_product_prices",
-    definition="""
-    BEFORE INSERT OR UPDATE ON subscription_product_prices
-    FOR EACH ROW EXECUTE FUNCTION subscription_product_prices_sync_v2_amounts();
-    """,
-)
-
-register_entities(
-    (
-        subscription_product_prices_sync_v2_amounts_function,
-        subscription_product_prices_sync_v2_amounts_trigger,
-    )
-)


### PR DESCRIPTION
Third step in widening the amounts, we drop the legacy columns and keep the new ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed a backend database maintenance update to optimize subscription product pricing storage. This internal cleanup improves system stability without any changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->