### PR TITLE
amount v2: Migrate subscription amounts to BigInt

### DIFF
--- a/server/migrations/versions/2026-06-01-1312_add_subscriptions_v2_amount_columns.py
+++ b/server/migrations/versions/2026-06-01-1312_add_subscriptions_v2_amount_columns.py
@@ -1,0 +1,117 @@
+"""Add subscriptions v2 amount columns (int → bigint widening)
+
+Revision ID: dccf7215745f
+Revises: 928fd5653fc9
+Create Date: 2026-05-29 11:45:00.000000
+
+Phase 1 of widening subscriptions amount columns from integer to bigint via
+dual-column migration:
+
+  1. Add nullable *_v2 BIGINT columns for every INT4 amount column.
+  2. Install a bidirectional sync trigger:
+       - legacy → v2 on every INSERT/UPDATE (so old code's writes
+         populate v2).
+       - v2 → legacy on every INSERT/UPDATE, skipped when the v2 value
+         exceeds INT4_MAX (so new code's v2-only writes still populate
+         legacy for pods still running the previous version during
+         rollout of PR 2).
+  3. Backfill existing rows via scripts.backfill_amount_v2_subscriptions.
+
+A follow-up PR remaps the Python attributes to the v2 columns; a final
+PR drops the trigger and old columns.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "dccf7215745f"
+down_revision = "928fd5653fc9"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+SUBSCRIPTIONS_SYNC_V2_AMOUNTS = PGFunction(
+    schema="public",
+    signature="subscriptions_sync_v2_amounts()",
+    definition="""RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql""",
+)
+
+
+SUBSCRIPTIONS_SYNC_V2_AMOUNTS_TRIGGER = PGTrigger(
+    schema="public",
+    signature="subscriptions_sync_v2_amounts_trigger",
+    on_entity="public.subscriptions",
+    is_constraint=False,
+    definition=(
+        "BEFORE INSERT OR UPDATE ON subscriptions\n"
+        "    FOR EACH ROW EXECUTE FUNCTION subscriptions_sync_v2_amounts()"
+    ),
+)
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.add_column(
+        "subscriptions",
+        sa.Column("amount_v2", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("net_amount_v2", sa.BigInteger(), nullable=True),
+    )
+
+    op.create_entity(SUBSCRIPTIONS_SYNC_V2_AMOUNTS)
+    op.create_entity(SUBSCRIPTIONS_SYNC_V2_AMOUNTS_TRIGGER)
+
+
+def downgrade() -> None:
+    op.drop_entity(SUBSCRIPTIONS_SYNC_V2_AMOUNTS_TRIGGER)
+    op.drop_entity(SUBSCRIPTIONS_SYNC_V2_AMOUNTS)
+    op.drop_column("subscriptions", "net_amount_v2")
+    op.drop_column("subscriptions", "amount_v2")

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -7,8 +7,12 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Self, TypeVar
 from uuid import UUID
 
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
 from sqlalchemy import (
     TIMESTAMP,
+    BigInteger,
     Boolean,
     ColumnElement,
     ForeignKey,
@@ -116,7 +120,13 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
     )
 
     amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     net_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    net_amount_v2: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     recurring_interval: Mapped[SubscriptionRecurringInterval] = mapped_column(
         StringEnum(SubscriptionRecurringInterval), nullable=False, index=True
@@ -490,3 +500,68 @@ def _discount_set(
     # expiration will be tracked from its first use in a billing cycle
     if value != oldvalue:
         target.discount_applied_at = None
+
+
+subscriptions_sync_v2_amounts_function = PGFunction(
+    schema="public",
+    signature="subscriptions_sync_v2_amounts()",
+    definition="""
+    RETURNS trigger AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            IF NEW.amount_v2 IS NULL AND NEW.amount IS NOT NULL THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount_v2 IS NULL AND NEW.net_amount IS NOT NULL THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.amount IS NULL
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount IS NULL
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+        ELSIF TG_OP = 'UPDATE' THEN
+            IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+                NEW.amount_v2 := NEW.amount;
+            END IF;
+            IF NEW.net_amount IS DISTINCT FROM OLD.net_amount THEN
+                NEW.net_amount_v2 := NEW.net_amount;
+            END IF;
+            IF NEW.amount_v2 IS DISTINCT FROM OLD.amount_v2
+               AND NEW.amount_v2 IS NOT NULL
+               AND NEW.amount_v2 <= 2147483647 THEN
+                NEW.amount := NEW.amount_v2::integer;
+            END IF;
+            IF NEW.net_amount_v2 IS DISTINCT FROM OLD.net_amount_v2
+               AND NEW.net_amount_v2 IS NOT NULL
+               AND NEW.net_amount_v2 <= 2147483647 THEN
+                NEW.net_amount := NEW.net_amount_v2::integer;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """,
+)
+
+subscriptions_sync_v2_amounts_trigger = PGTrigger(
+    schema="public",
+    signature="subscriptions_sync_v2_amounts_trigger",
+    on_entity="subscriptions",
+    definition="""
+    BEFORE INSERT OR UPDATE ON subscriptions
+    FOR EACH ROW EXECUTE FUNCTION subscriptions_sync_v2_amounts();
+    """,
+)
+
+register_entities(
+    (
+        subscriptions_sync_v2_amounts_function,
+        subscriptions_sync_v2_amounts_trigger,
+    )
+)

--- a/server/scripts/backfill_amount_v2_subscriptions.py
+++ b/server/scripts/backfill_amount_v2_subscriptions.py
@@ -1,0 +1,62 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import or_, select, update
+
+from polar.models import Subscription
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill subscriptions *_v2 amount columns from their legacy INT4 counterparts."""
+    await run_batched_update(
+        (
+            update(Subscription)
+            .values(
+                amount_v2=Subscription.amount,
+                net_amount_v2=Subscription.net_amount,
+            )
+            .where(
+                Subscription.id.in_(
+                    select(Subscription.id)
+                    .where(
+                        or_(
+                            Subscription.amount_v2.is_(None)
+                            & Subscription.amount.is_not(None),
+                            Subscription.net_amount_v2.is_(None)
+                            & Subscription.net_amount.is_not(None),
+                        )
+                    )
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Adds the new amount columns as _v2 and a backfill script. Reads will move over in the second PR and the legacy columns will be dropped in the third.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription amounts now support larger values (64-bit integers) to prevent overflow.
  * Automatic bidirectional synchronization maintains compatibility between legacy and new amount fields.
  * Data migration support for existing subscriptions with configurable backfill options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->