### PR TITLE
Switch to new auth flow

### DIFF
--- a/.claude/commands/create-changelog.md
+++ b/.claude/commands/create-changelog.md
@@ -7,11 +7,13 @@ Produce a polished changelog entry for `docs/changelog/recent.mdx` covering rece
 `$ARGUMENTS` may contain a time range and an optional `--confirm` flag.
 
 Time range (optional):
+
 - Nothing (default: last 7 days)
 - A number of days (e.g. `14`)
 - A date range (e.g. `2026-04-15..2026-04-22`)
 
 Confirmation flag (optional):
+
 - `--confirm` enables the user confirmation step (step 3). **Off by default.** When omitted, proceed straight from research to screenshots with the subagent's chosen classifications.
 
 ## Style Rules (non-negotiable)
@@ -26,6 +28,7 @@ Confirmation flag (optional):
 ## What to Include
 
 High-signal, externally visible changes:
+
 - New merchant features (dashboard, API, webhooks, invoicing).
 - New customer features (checkout, customer portal, seats).
 - New localization, currency, or i18n coverage.
@@ -46,7 +49,7 @@ When in doubt, leave it out. It is much better to ship a short changelog than a 
 
 ## Verifying scope claims
 
-PR descriptions and design docs frequently list the *eventual* scope of a feature alongside what was actually shipped in that PR. If you take the prose at face value, you will hallucinate scope. Before writing copy that names specific surfaces (checkout, customer portal, emails, dashboard, mobile app, API, webhooks, invoices, etc.):
+PR descriptions and design docs frequently list the _eventual_ scope of a feature alongside what was actually shipped in that PR. If you take the prose at face value, you will hallucinate scope. Before writing copy that names specific surfaces (checkout, customer portal, emails, dashboard, mobile app, API, webhooks, invoices, etc.):
 
 1. List the changed files in the PR (`gh pr view <n> --json files`).
 2. Confirm each surface you name has a matching file in the diff. Customer portal copy lives under `clients/apps/web/src/components/CustomerPortal` and similar; emails live under `server/emails` and `clients/packages/email`; checkout under `clients/packages/checkout` and `clients/apps/web/src/app/(checkout)`; etc.
@@ -74,7 +77,7 @@ Launch a `general-purpose` subagent with the full commit list. Also pass it the 
 - For each candidate, run `gh pr view <n> --json files,body` and inspect the actual changed files to confirm the feature is real, user-visible, and shipped in this window (not a docs update for a feature that shipped earlier).
 - **Apply the smell test**: would a merchant or customer notice this in their week? Items that pass on technicality but read as filler (e.g. "delete account from web" matching mobile, "full description on checkout" removing a truncation, "name your webhook endpoints" labels) should be dropped. Prefer 4 sharp items to 10 mixed ones.
 - **Verify scope by reading the diff.** Do not paraphrase the PR description if it lists multiple surfaces (checkout, portal, emails, mobile, etc.). Confirm each surface you name has matching files in the diff. See the "Verifying scope claims" section above.
-- **Dedupe against the monthly log**: drop anything already announced. An *enhancement* to a previously-announced feature is fine to include if it is materially new (e.g. new filters added to a list that shipped last month), but say so clearly and frame it as an enhancement.
+- **Dedupe against the monthly log**: drop anything already announced. An _enhancement_ to a previously-announced feature is fine to include if it is materially new (e.g. new filters added to a list that shipped last month), but say so clearly and frame it as an enhancement.
 - **Cap is 10, not a target.** If only 3 items pass the bar, return 3.
 - Decide which are **MAJOR** (warrants a screenshot) and which are **MINOR**. Decide yourself, do not ask the user.
 - For MAJOR items, describe the exact URL to screenshot and what must be visible on screen.
@@ -111,7 +114,7 @@ docker exec polar-dev-<N>-api-1 bash -c "cd /app/server && uv run python -m scri
 
 Launch a `general-purpose` subagent with the list of accepted MAJOR features. Tell it:
 
-- Log in at `http://localhost:<web-port>/login` as `admin@polar.sh`. The email domain must be real (polar.sh works) or login validation rejects it. Grab the login code with `docker logs polar-dev-<N>-api-1 --since 30s 2>&1 | grep -oE 'LOGIN CODE: [A-Z0-9]+' | tail -1`.
+- Log in at `http://localhost:<web-port>/auth` as `admin@polar.sh`. The email domain must be real (polar.sh works) or login validation rejects it. Grab the login code with `docker logs polar-dev-<N>-api-1 --since 30s 2>&1 | grep -oE 'LOGIN CODE: [A-Z0-9]+' | tail -1`.
 - If a feature lives in an org that `admin@polar.sh` is not a member of, rename the seeded owner's email to a real `@polar.sh` domain (e.g. `UPDATE users SET email='merchant@polar.sh' WHERE email='support@meltedsql.com'`) and restart the web container so Next.js re-fetches the user's org list: `docker restart polar-dev-<N>-web-1`.
 - **Prefer clicking through the UI or calling documented API endpoints to create the state you need.** That path exercises real validation and produces screenshots that will not drift when schemas change. Fall back to direct SQL only for states the product does not let you reach through normal flows (e.g. placing a subscription into a pre-scheduled update that is applied by a cron job), or for minor tidy-up so the UI reads clearly (e.g. removing placeholder rows that distract from what the screenshot is about).
 - Read the relevant frontend component first to understand what data the screenshot actually needs, then pick the shortest path to get there.
@@ -135,6 +138,7 @@ Order: MAJOR features (with screenshots) first, then MINOR features.
 ### 7. Verify
 
 Inside the new block only:
+
 - `grep -nE '—|–'` must return nothing.
 - `grep -nE '[Ss]tripe'` must return nothing.
 - Every `<img src=...>` path must exist on disk.

--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -183,7 +183,7 @@ const nextConfig = {
       // dashboard.polar.sh redirections
       {
         source: '/',
-        destination: '/login',
+        destination: '/auth',
         has: [
           {
             type: 'host',
@@ -401,7 +401,7 @@ const nextConfig = {
 
       {
         source: '/signup',
-        destination: '/login',
+        destination: '/auth',
         permanent: false,
       },
     ]

--- a/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
@@ -66,7 +66,6 @@ const VerifyPage = () => {
                   <InputOTP
                     maxLength={6}
                     minLength={6}
-                    pattern="^\d{6}$"
                     inputMode="numeric"
                     autoComplete="one-time-code"
                     {...field}

--- a/clients/apps/web/src/app/(main)/oauth2/authorize/page.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/page.tsx
@@ -47,7 +47,7 @@ export default async function Page(props: {
     if (searchParams.do_not_track) {
       locationSearchParam.set('do_not_track', searchParams.do_not_track)
     }
-    const location = `/login?${locationSearchParam.toString()}`
+    const location = `/auth?${locationSearchParam.toString()}`
     redirect(location)
   }
 

--- a/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
+++ b/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
@@ -24,7 +24,7 @@ export default function Page() {
       { mode: 'sandbox', source: 'onboarding_start' },
       { send_instantly: true },
     )
-    window.location.href = `${CONFIG.SANDBOX_FRONTEND_BASE_URL}/login?return_to=/onboarding/sandbox&from=onboarding`
+    window.location.href = `${CONFIG.SANDBOX_FRONTEND_BASE_URL}/auth?return_to=/onboarding/sandbox&from=onboarding`
   }
 
   const handleGetStarted = () => {

--- a/clients/apps/web/src/app/(main)/verify-email/page.tsx
+++ b/clients/apps/web/src/app/(main)/verify-email/page.tsx
@@ -21,7 +21,7 @@ export default async function Page(props: {
 
   if (!user) {
     const returnTo = `/verify-email?${new URLSearchParams({ token, ...(return_to && { return_to }) })}`
-    const loginHref = `/login?${new URLSearchParams({ return_to: returnTo })}`
+    const loginHref = `/auth?${new URLSearchParams({ return_to: returnTo })}`
 
     return (
       <div className="dark:bg-polar-950 flex h-screen w-full grow items-center justify-center bg-white px-4">

--- a/clients/apps/web/src/app/robots.ts
+++ b/clients/apps/web/src/app/robots.ts
@@ -15,7 +15,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/dashboard/', '/login/', '/verify-email/'],
+      disallow: ['/dashboard/', '/login/', '/auth/', '/verify-email/'],
     },
     sitemap: 'https://polar.sh/sitemap.xml',
   }

--- a/clients/apps/web/src/components/Auth/AuthModal.tsx
+++ b/clients/apps/web/src/components/Auth/AuthModal.tsx
@@ -1,22 +1,18 @@
-import { schemas } from '@polar-sh/client'
-import Login from './Login'
+import Auth from '@/app/(main)/auth/Auth'
+import { type schemas } from '@polar-sh/client'
 
 interface AuthModalProps {
   returnTo?: string
-  returnParams?: Record<string, string>
-  signup?: schemas['UserSignupAttribution']
+  signup?: boolean
 }
 
-export const AuthModal = ({
-  returnTo,
-  returnParams,
-  signup,
-}: AuthModalProps) => {
+export const AuthModal = ({ returnTo, signup }: AuthModalProps) => {
   const isSignup = signup !== undefined
 
   const lastLoginMethod =
     typeof document !== 'undefined'
-      ? (document.cookie.match(/polar_last_login_method=(\w+)/)?.[1] ?? null)
+      ? ((document.cookie.match(/polar_last_login_method=(\w+)/)?.[1] ??
+          null) as schemas['Factor'])
       : null
 
   return (
@@ -32,9 +28,9 @@ export const AuthModal = ({
         )}
 
         <div className="flex flex-col gap-y-12">
-          <Login
+          <Auth
+            authenticationSession={null}
             returnTo={returnTo}
-            returnParams={returnParams}
             signup={signup}
             lastLoginMethod={lastLoginMethod}
           />

--- a/clients/apps/web/src/components/Auth/GetStartedButton.tsx
+++ b/clients/apps/web/src/components/Auth/GetStartedButton.tsx
@@ -12,13 +12,11 @@ import { AuthModal } from './AuthModal'
 
 interface GetStartedButtonProps extends ComponentProps<typeof Button> {
   text?: string
-  orgSlug?: string
 }
 
 const GetStartedButton = ({
   text: _text,
   wrapperClassNames,
-  orgSlug: slug,
   size = 'lg',
   ...props
 }: GetStartedButtonProps) => {
@@ -48,7 +46,7 @@ const GetStartedButton = ({
       { mode: 'sandbox', source: 'landing_modal' },
       { send_instantly: true },
     )
-    window.location.href = `${CONFIG.SANDBOX_FRONTEND_BASE_URL}/login?return_to=/onboarding/start&from=onboarding`
+    window.location.href = `${CONFIG.SANDBOX_FRONTEND_BASE_URL}/auth?return_to=/onboarding/start`
   }
 
   const handleGetStarted = () => {
@@ -74,13 +72,7 @@ const GetStartedButton = ({
         onLogin={() => setView('login')}
       />
     ),
-    signup: (
-      <AuthModal
-        returnTo="/onboarding/personal"
-        returnParams={slug ? { slug, auto: 'true' } : {}}
-        signup={{ intent: 'creator' }}
-      />
-    ),
+    signup: <AuthModal returnTo="/onboarding/personal" signup />,
     login: <AuthModal returnTo="/dashboard" />,
   }
   const modalContent = modalContents[view]

--- a/clients/apps/web/src/components/Sandbox/SandboxBanner.tsx
+++ b/clients/apps/web/src/components/Sandbox/SandboxBanner.tsx
@@ -5,6 +5,9 @@ import { usePathname } from 'next/navigation'
 const PUBLIC_PAGES = [
   '/',
   '/login',
+  '/auth',
+  '/auth/email-otp',
+  '/auth/totp',
   '/onboarding/sandbox',
   '/login/code/verify',
 ]

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -198,7 +198,7 @@ describe('middleware function', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/login')
+    expect(response.headers.get('location')).toContain('/auth')
     expect(response.headers.get('location')).toContain('return_to=%2Fdashboard')
   })
 
@@ -240,7 +240,7 @@ describe('middleware function', () => {
 
     expect(response.status).toBe(307)
     const location = response.headers.get('location')
-    expect(location).toContain('/login')
+    expect(location).toContain('/auth')
     expect(location).toContain('return_to=%2Fdashboard%3Ffoo%3Dbar%26baz%3Dqux')
   })
 
@@ -279,7 +279,7 @@ describe('middleware function', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/login')
+    expect(response.headers.get('location')).toContain('/auth')
   })
 
   it('should redirect unauthenticated /to/* requests to login preserving the deep link', async () => {
@@ -291,7 +291,7 @@ describe('middleware function', () => {
 
     expect(response.status).toBe(307)
     const location = response.headers.get('location')
-    expect(location).toContain('/login')
+    expect(location).toContain('/auth')
     expect(location).toContain(
       'return_to=%2Fto%2Fdashboard%2Fsettings%2Fbilling',
     )
@@ -332,7 +332,7 @@ describe('the /to/ dance', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/login')
+    expect(response.headers.get('location')).toContain('/auth')
   })
 
   it('ignores invalid polar_env cookie values', async () => {
@@ -342,7 +342,7 @@ describe('the /to/ dance', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/login')
+    expect(response.headers.get('location')).toContain('/auth')
   })
 
   it('does not bounce non-/to/ paths even with a mismatching cookie', async () => {
@@ -352,6 +352,6 @@ describe('the /to/ dance', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/login')
+    expect(response.headers.get('location')).toContain('/auth')
   })
 })

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -20,6 +20,7 @@ const IS_SANDBOX =
 // Strings match by prefix, RegExps are tested directly
 const SANDBOX_ALLOWED_PATHS: (string | RegExp)[] = [
   '/login',
+  '/auth',
   '/dashboard',
   '/start',
   '/onboarding',
@@ -87,7 +88,7 @@ const requiresAuthentication = (request: NextRequest): boolean => {
 
 const getLoginResponse = (request: NextRequest): NextResponse => {
   const redirectURL = request.nextUrl.clone()
-  redirectURL.pathname = '/login'
+  redirectURL.pathname = '/auth'
   redirectURL.search = ''
   const returnTo = `${request.nextUrl.pathname}${request.nextUrl.search}`
   redirectURL.searchParams.set('return_to', returnTo)
@@ -125,7 +126,7 @@ export async function proxy(request: NextRequest) {
 
     if (pathname === '/') {
       const url = request.nextUrl.clone()
-      url.pathname = '/login'
+      url.pathname = '/auth'
       url.search = ''
       return NextResponse.redirect(url)
     }

--- a/clients/apps/web/src/utils/config.ts
+++ b/clients/apps/web/src/utils/config.ts
@@ -18,7 +18,7 @@ const defaults = {
   AUTH_COOKIE_KEY: process.env.POLAR_AUTH_COOKIE_KEY || 'polar_session',
   AUTH_MCP_COOKIE_KEY:
     process.env.POLAR_AUTH_MCP_COOKIE_KEY || 'polar_mcp_session',
-  LOGIN_PATH: process.env.NEXT_PUBLIC_LOGIN_PATH || '/login',
+  LOGIN_PATH: process.env.NEXT_PUBLIC_LOGIN_PATH || '/auth',
   GOOGLE_ANALYTICS_ID: process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || undefined,
   GITHUB_APP_NAMESPACE:
     process.env.NEXT_PUBLIC_GITHUB_APP_NAMESPACE || 'polar-sh',


### PR DESCRIPTION

Switch from `/login` to `/auth` to use the new auth flow compatible with TOTP.

Existing one is still retained at the moment, but will be dropped in a follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated authentication routes to use `/auth` endpoint
  * Updated TOTP verification field validation constraints
  * Streamlined authentication modal and signup button component architecture
  * Updated middleware and proxy routing to reflect authentication path changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->