### PR TITLE
 meter: treat LIKE/NOT LIKE values literally in SQL clauses

### DIFF
--- a/server/polar/meter/filter.py
+++ b/server/polar/meter/filter.py
@@ -116,9 +116,9 @@ class FilterClause(BaseModel):
         elif self.operator == FilterOperator.lte:
             return attr <= value
         elif self.operator == FilterOperator.like:
-            return attr.like(f"%{value}%")
+            return attr.contains(value, autoescape=True)
         elif self.operator == FilterOperator.not_like:
-            return attr.notlike(f"%{value}%")
+            return ~attr.contains(value, autoescape=True)
         raise ValueError(f"Unsupported operator: {self.operator}")
 
     def _get_str_value(self) -> str:

--- a/server/tests/meter/test_filter.py
+++ b/server/tests/meter/test_filter.py
@@ -332,6 +332,87 @@ class TestFilter:
         assert len(matching_events) == 1
         assert matching_events[0].id == events[1].id
 
+    async def test_like_treats_wildcards_as_literal(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """`_` must be matched literally, not as a SQL LIKE wildcard, so the
+        SQL path agrees with `FilterClause.matches()`."""
+        literal_match = await create_event(
+            save_fixture, organization=organization, name="api_test"
+        )
+        wildcard_only = await create_event(
+            save_fixture, organization=organization, name="apiXtest"
+        )
+
+        clause = FilterClause(
+            property="name", operator=FilterOperator.like, value="api_test"
+        )
+        filter = Filter(conjunction=FilterConjunction.and_, clauses=[clause])
+
+        repository = EventRepository.from_session(session)
+        statement = repository.get_base_statement().where(filter.get_sql_clause(Event))
+        matching_events = await repository.get_all(statement)
+
+        assert {e.id for e in matching_events} == {literal_match.id}
+        assert clause.matches(literal_match) is True
+        assert clause.matches(wildcard_only) is False
+
+    async def test_not_like_treats_wildcards_as_literal(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        literal_match = await create_event(
+            save_fixture, organization=organization, name="api_test"
+        )
+        wildcard_only = await create_event(
+            save_fixture, organization=organization, name="apiXtest"
+        )
+
+        clause = FilterClause(
+            property="name", operator=FilterOperator.not_like, value="api_test"
+        )
+        filter = Filter(conjunction=FilterConjunction.and_, clauses=[clause])
+
+        repository = EventRepository.from_session(session)
+        statement = repository.get_base_statement().where(filter.get_sql_clause(Event))
+        matching_events = await repository.get_all(statement)
+
+        assert {e.id for e in matching_events} == {wildcard_only.id}
+        assert clause.matches(literal_match) is False
+        assert clause.matches(wildcard_only) is True
+
+    async def test_like_treats_percent_as_literal_in_metadata(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """`%` must be matched literally on metadata properties too."""
+        literal_match = await create_event(
+            save_fixture, organization=organization, metadata={"path": "/a%b"}
+        )
+        wildcard_only = await create_event(
+            save_fixture, organization=organization, metadata={"path": "/axxb"}
+        )
+
+        clause = FilterClause(
+            property="path", operator=FilterOperator.like, value="a%b"
+        )
+        filter = Filter(conjunction=FilterConjunction.and_, clauses=[clause])
+
+        repository = EventRepository.from_session(session)
+        statement = repository.get_base_statement().where(filter.get_sql_clause(Event))
+        matching_events = await repository.get_all(statement)
+
+        assert {e.id for e in matching_events} == {literal_match.id}
+        assert clause.matches(literal_match) is True
+        assert clause.matches(wildcard_only) is False
+
 
 class TestFilterClauseMatches:
     def test_matches_name_eq(self, organization: Organization) -> None:


### PR DESCRIPTION
Fix #12024

The `like`/`not_like` operators generated SQL `LIKE '%value%'`, so `%` and `_` in the filter value were interpreted as SQL wildcards. The ingestion-time `FilterClause.matches()` check, however, treats them as literal characters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LIKE and NOT LIKE string pattern matching to treat underscore and percent characters as literal values instead of wildcards.

* **Tests**
  * Added test cases validating wildcard character handling in string filters across SQL and in-memory filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->