### PR TITLE
Fix auth rate limits

### DIFF
--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -90,8 +90,19 @@ export const getGitHubRepositoryBenefitAuthorizeURL = (
 export const checkAuthenticationSession = async (
   api: Client,
 ): Promise<schemas['AuthenticationSession'] | null> => {
-  const { error, data: authenticationSession } =
-    await api.GET('/v1/auth/status')
+  const {
+    error,
+    data: authenticationSession,
+    response,
+  } = await api.GET('/v1/auth/status')
+
+  // Handle 429 errors which return empty responses and no error object
+  if (!response.ok && !error) {
+    throw new Error(
+      `Unexpected response from /v1/auth/status: ${response.status}`,
+    )
+  }
+
   if (error) {
     if (error.error !== 'InvalidAuthenticationSession') {
       throw new Error(`Failed to check authentication session: ${error.error}`)

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -135,6 +135,36 @@ _BASE_RULES: dict[str, Sequence[Rule]] = {
             zone="login-code",
         ),
     ],
+    "^/v1/auth/email-otp": [
+        Rule(minute=6, hour=12, block_time=900, zone="auth-email-otp"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="auth-email-otp",
+        ),
+    ],
+    "^/v1/auth/totp": [
+        Rule(minute=6, hour=12, block_time=900, zone="auth-totp"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="auth-totp",
+        ),
+    ],
+    "^/v1/auth/backup-codes": [
+        Rule(minute=6, hour=12, block_time=900, zone="auth-backup-codes"),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="auth-backup-codes",
+        ),
+    ],
     "^/v1/customer-portal/customer-session/(request|authenticate)": [
         Rule(minute=6, hour=12, block_time=900, zone="customer-session-login"),
         Rule(


### PR DESCRIPTION

- clients/web: handle 429 error gracefully when checking auth session
- auth: set rate limits for auth endpoints
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session validation to correctly detect and handle rate limit responses from the API.

* **Chores**
  * Applied rate limiting to authentication endpoints (email OTP, TOTP, backup codes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->