### PR TITLE
Reduce API database pool size from 20 to 10

### DIFF
--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -32,7 +32,7 @@ variable "api_service_config" {
     image_digest           = string
     web_concurrency        = optional(string, "2")
     forwarded_allow_ips    = optional(string, "*")
-    database_pool_size     = optional(string, "20")
+    database_pool_size     = optional(string, "10")
     postgres_database      = optional(string, "polar_cpit")
     postgres_read_database = optional(string, "polar_cpit")
     redis_db               = optional(string, "0")

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -120,7 +120,7 @@ module "sandbox" {
     image_digest           = data.render_web_service.sandbox_api.runtime_source.image.digest
     web_concurrency        = "2"
     forwarded_allow_ips    = "*"
-    database_pool_size     = "20"
+    database_pool_size     = "10"
     postgres_database      = "polar_sandbox"
     postgres_read_database = "polar_sandbox"
     redis_db               = "1"

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -158,7 +158,7 @@ module "test" {
     image_digest           = data.render_web_service.test_api[0].runtime_source.image.digest
     web_concurrency        = "2"
     forwarded_allow_ips    = "*"
-    database_pool_size     = "20"
+    database_pool_size     = "10"
     postgres_database      = local.db_name
     postgres_read_database = local.db_name
     redis_db               = "0"


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

Reduce the database connection pool size for the API service from 20 to 10 across all environments.

## What

Changes `database_pool_size` for the API service from `20` to `10` in:

- `terraform/modules/render_service/variables.tf` — the `api_service_config` default (used by **production**, which does not override it)
- `terraform/sandbox/render.tf` — **sandbox** API
- `terraform/test/render.tf` — **test** API

Worker pool sizes are untouched.

## Why

We're maxing out our DB's max connections (500) now and then. The API's pool size seems overdimensioned so the reduction _should_ be friction free.

## How

Updated the Terraform `database_pool_size` values feeding the `POLAR_DATABASE_POOL_SIZE` env var on the API service. Production relies on the module default, so updating the default propagates the change there.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted database connection pool configuration defaults across deployment environments to optimize resource allocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->