### PR TITLE
server/auth: create user if does not exist when requesting email OTP

### DIFF
--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -25,6 +25,7 @@ from polar.logging import Logger
 from polar.models import BackupCodesEnrollment, EmailOTP, TOTPEnrollment
 from polar.postgres import AsyncSession, get_db_session
 from polar.user.repository import UserRepository
+from polar.user.service import user as user_service
 
 from .oauth2.apple import AppleFactor, get_apple_factor
 from .oauth2.github import GitHubFactor, get_github_factor
@@ -94,10 +95,7 @@ class EmailOTPFactor(EmailOTPFactorBase):
     async def request(
         self, request: "EmailOTPRequest", authentication_session: AuthenticationSession
     ) -> None:
-        user_repository = UserRepository.from_session(self.session)
-        user = await user_repository.get_by_email(request.email)
-        if user is None:
-            return
+        user, _ = await user_service.get_by_email_or_create(self.session, request.email)
 
         code, email_otp = await self.create(
             identity_id=user.id,


### PR DESCRIPTION
- server/auth: create user if does not exist when requesting email OTP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email OTP request handling to ensure login codes can be requested for all email addresses during the authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->