### PR TITLE
server/auth: don't pre-create user when requesting email OTP

### DIFF
--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -25,7 +25,6 @@ from polar.logging import Logger
 from polar.models import BackupCodesEnrollment, EmailOTP, TOTPEnrollment
 from polar.postgres import AsyncSession, get_db_session
 from polar.user.repository import UserRepository
-from polar.user.service import user as user_service
 
 from .oauth2.apple import AppleFactor, get_apple_factor
 from .oauth2.github import GitHubFactor, get_github_factor
@@ -95,7 +94,10 @@ class EmailOTPFactor(EmailOTPFactorBase):
     async def request(
         self, request: "EmailOTPRequest", authentication_session: AuthenticationSession
     ) -> None:
-        user, _ = await user_service.get_by_email_or_create(self.session, request.email)
+        user_repository = UserRepository.from_session(self.session)
+        user = await user_repository.get_by_email(request.email)
+        if user is None:
+            return
 
         code, email_otp = await self.create(
             identity_id=user.id,

--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -96,11 +96,10 @@ class EmailOTPFactor(EmailOTPFactorBase):
     ) -> None:
         user_repository = UserRepository.from_session(self.session)
         user = await user_repository.get_by_email(request.email)
-        if user is None:
-            return
+        signup = user is None
 
         code, email_otp = await self.create(
-            identity_id=user.id,
+            identity_id=user.id if user else None,
             email=request.email,
             authentication_session_id=authentication_session.id,
         )
@@ -109,7 +108,7 @@ class EmailOTPFactor(EmailOTPFactorBase):
         code_lifetime_minutes = int(ceil(delta / 60))
 
         domain = settings.frontend_hostname
-        subject = "Sign in to Polar"
+        subject = "Sign up to Polar" if signup else "Sign in to Polar"
         enqueue_email_template(
             LoginCodeEmail(
                 props=LoginCodeProps(


### PR DESCRIPTION

In a26edf84a9ffe5f688641512ace24d56db60bbf1, we made an emergency fix to allow new users to sign up with email OTP. Indeed, the `request` method was silently no-op if the user was not already existing. This quick fix made sure to pre-create the user before proceeding.

However, this wasn't the intended implementation. In `/email-otp/verify` endpoint, we had dedicated logic to create the user after a successful OTP verification. This means that the user should only be created after the OTP is verified, and not before.

The current fix is the right one: we send the email in all cases, even if the user is not yet created. The user will only be created after the OTP is verified, which is the expected flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email OTP authentication flow to correctly distinguish between sign-up and sign-in requests, ensuring users receive appropriately labeled confirmation emails for each action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->