### PR TITLE
meter: Widen custom multiplier

### DIFF
--- a/server/migrations/versions/2026-06-01-1504_widen_meters_custom_multiplier_to_bigint.py
+++ b/server/migrations/versions/2026-06-01-1504_widen_meters_custom_multiplier_to_bigint.py
@@ -1,0 +1,38 @@
+"""Widen meters.custom_multiplier to BIGINT
+
+Revision ID: 64d92ea66fa5
+Revises: 10b4f3608e4f
+Create Date: 2026-06-01 10:56:53.066327
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "64d92ea66fa5"
+down_revision = "10b4f3608e4f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "meters",
+        "custom_multiplier",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "meters",
+        "custom_multiplier",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=True,
+    )

--- a/server/polar/models/meter.py
+++ b/server/polar/models/meter.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import TIMESTAMP, ForeignKey, String, Uuid
+from sqlalchemy import TIMESTAMP, BigInteger, ForeignKey, String, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models.base import RecordModel
@@ -27,7 +27,9 @@ class Meter(RecordModel, MetadataMixin):
     custom_label: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None
     )
-    custom_multiplier: Mapped[int | None] = mapped_column(nullable=True, default=None)
+    custom_multiplier: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     filter: Mapped[Filter] = mapped_column(FilterType, nullable=False)
     aggregation: Mapped[Aggregation] = mapped_column(AggregationType, nullable=False)
     last_billed_event_id: Mapped[UUID | None] = mapped_column(


### PR DESCRIPTION
This allows meter's custom multipliers to be larger. Fixes https://github.com/polarsource/feedback/issues/107.

Given the amount of data in this table, we can just do an alter on the table itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased capacity of meter customization field to support larger numerical values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->