### PR TITLE
server/auth: handle hard-coded app review login in email OTP flow

### DIFF
--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -5,6 +5,7 @@ from math import ceil
 import structlog
 from fastapi import Depends
 from reauth.authentication_session import AuthenticationSession
+from reauth.crypto import get_token_hash
 from reauth.factors import FactorBase
 from reauth.factors.backup_codes import (
     BackupCodesEnrollment as BackupCodesEnrollmentDataclass,
@@ -64,6 +65,21 @@ class EmailOTPFactor(EmailOTPFactorBase):
         await self.session.flush()
         return email_otp_orm.id
 
+    async def update(self, email_otp: EmailOTPDataclass) -> None:
+        statement = (
+            update(EmailOTP)
+            .where(EmailOTP.id == email_otp.id)
+            .values(
+                code_hash=email_otp.code_hash,
+                expires_at=email_otp.expires_at,
+                email=email_otp.email,
+                identity_id=email_otp.identity_id,
+                authentication_session_id=email_otp.authentication_session_id,
+            )
+        )
+        await self.session.execute(statement)
+        await self.session.flush()
+
     async def get_by_code_hash_and_authentication_session_id(
         self, code_hash: str, authentication_session_id: uuid.UUID
     ) -> EmailOTPDataclass | None:
@@ -103,6 +119,15 @@ class EmailOTPFactor(EmailOTPFactorBase):
             email=request.email,
             authentication_session_id=authentication_session.id,
         )
+
+        if (
+            email_otp.email == settings.APP_REVIEW_EMAIL
+            and settings.APP_REVIEW_OTP_CODE is not None
+        ):
+            log.info("App review login, hard-coding OTP code")
+            code = settings.APP_REVIEW_OTP_CODE
+            email_otp.code_hash = get_token_hash(code, secret=self.hash_secret)
+            await self.update(email_otp)
 
         delta = email_otp.expires_at - int(utc_now().timestamp())
         code_lifetime_minutes = int(ceil(delta / 60))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the email OTP flow so OTPs are now reliably persisted and verified during the app-review path.

* **Improvements**
  * More reliable email OTP handling to improve authentication stability and user identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->