### PR TITLE
clients/web: add TOTP and backup codes setup in user settings

### DIFF
--- a/clients/apps/web/package.json
+++ b/clients/apps/web/package.json
@@ -81,6 +81,7 @@
     "nuqs": "^2.8.9",
     "posthog-js": "^1.369.1",
     "posthog-node": "^5.29.2",
+    "react-qr-code": "^2.0.11",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-dropzone": "^14.4.1",

--- a/clients/apps/web/src/app/(main)/dashboard/account/preferences/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/account/preferences/page.tsx
@@ -4,6 +4,7 @@ import IdentityVerificationSettings from '@/components/Settings/IdentityVerifica
 import { NotificationRecipientsSettings } from '@/components/Settings/NotificationRecipientsSettings'
 import PersonalInformationSettings from '@/components/Settings/PersonalInformationSettings'
 import { Section, SectionDescription } from '@/components/Settings/Section'
+import TwoFactorSettings from '@/components/Settings/TwoFactorSettings'
 import UserDeleteSettings from '@/components/Settings/UserDeleteSettings'
 import { Metadata } from 'next'
 
@@ -33,6 +34,10 @@ export default function Page() {
       <Section>
         <SectionDescription title="Authentication Methods" />
         <AuthenticationSettings />
+      </Section>
+      <Section>
+        <SectionDescription title="Two-Factor Authentication" />
+        <TwoFactorSettings />
       </Section>
       <Section>
         <SectionDescription

--- a/clients/apps/web/src/components/Settings/BackupCodesModal.tsx
+++ b/clients/apps/web/src/components/Settings/BackupCodesModal.tsx
@@ -2,6 +2,7 @@
 
 import { Modal } from '@/components/Modal'
 import Button from '@polar-sh/ui/components/atoms/Button'
+import { useEffect, useRef, useState } from 'react'
 
 interface BackupCodesModalProps {
   isShown: boolean
@@ -16,16 +17,30 @@ export default function BackupCodesModal({
 }: BackupCodesModalProps) {
   const codesText = codes.join('\n')
 
+  const [isCopied, setIsCopied] = useState(false)
+  const copyResetTimeout = useRef<number | null>(null)
+
   const handleCopy = () => {
     navigator.clipboard.writeText(codesText)
+    setIsCopied(true)
+    copyResetTimeout.current = window.setTimeout(() => setIsCopied(false), 2000)
   }
+
+  // Clear timeout if the component unmounts while the "Copied!" state is active
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeout.current) {
+        clearTimeout(copyResetTimeout.current)
+      }
+    }
+  }, [])
 
   const modalContent = (
     <div className="p-8">
-      <p className="dark:text-polar-400 mb-4 text-sm text-gray-600">
-        These backup codes will only be shown once. Store them securely. Each
-        code can be used once to access your account if you lose your
-        authenticator device.
+      <p className="dark:text-polar-400 mb-4 max-w-md text-sm text-gray-600">
+        You&rsquo;ll only see these backup codes once, so save them somewhere
+        secure. Each code lets you sign in one time if you lose access to your
+        authenticator app.
       </p>
 
       <div className="relative">
@@ -38,7 +53,7 @@ export default function BackupCodesModal({
           className="absolute top-2 right-2"
           onClick={handleCopy}
         >
-          Copy All
+          {isCopied ? 'Copied!' : 'Copy All'}
         </Button>
       </div>
 
@@ -53,7 +68,7 @@ export default function BackupCodesModal({
       title="Your Backup Codes"
       isShown={isShown}
       hide={hide}
-      className="max-w-lg"
+      className="lg:max-w-lg"
       modalContent={modalContent}
     />
   )

--- a/clients/apps/web/src/components/Settings/BackupCodesModal.tsx
+++ b/clients/apps/web/src/components/Settings/BackupCodesModal.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { Modal } from '@/components/Modal'
+import Button from '@polar-sh/ui/components/atoms/Button'
+
+interface BackupCodesModalProps {
+  isShown: boolean
+  hide: () => void
+  codes: string[]
+}
+
+export default function BackupCodesModal({
+  isShown,
+  hide,
+  codes,
+}: BackupCodesModalProps) {
+  const codesText = codes.join('\n')
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(codesText)
+  }
+
+  const modalContent = (
+    <div className="p-8">
+      <p className="dark:text-polar-400 mb-4 text-sm text-gray-600">
+        These backup codes will only be shown once. Store them securely. Each
+        code can be used once to access your account if you lose your
+        authenticator device.
+      </p>
+
+      <div className="relative">
+        <pre className="dark:bg-polar-800 rounded-lg bg-gray-100 p-4 font-mono text-sm break-all whitespace-pre-wrap">
+          {codesText}
+        </pre>
+        <Button
+          variant="secondary"
+          size="sm"
+          className="absolute top-2 right-2"
+          onClick={handleCopy}
+        >
+          Copy All
+        </Button>
+      </div>
+
+      <div className="mt-4 text-center">
+        <Button onClick={hide}>I&apos;ve saved my codes</Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <Modal
+      title="Your Backup Codes"
+      isShown={isShown}
+      hide={hide}
+      className="max-w-lg"
+      modalContent={modalContent}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Settings/BackupCodesRegenerateModal.tsx
+++ b/clients/apps/web/src/components/Settings/BackupCodesRegenerateModal.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { ConfirmModal } from '@/components/Modal/ConfirmModal'
+
+interface BackupCodesRegenerateModalProps {
+  isShown: boolean
+  hide: () => void
+  onRegenerate: () => Promise<{ codes: string[] } | null>
+}
+
+export default function BackupCodesRegenerateModal({
+  isShown,
+  hide,
+  onRegenerate,
+}: BackupCodesRegenerateModalProps) {
+  const handleConfirm = async () => {
+    await onRegenerate()
+    hide()
+  }
+
+  return (
+    <ConfirmModal
+      isShown={isShown}
+      hide={hide}
+      title="Regenerate Backup Codes"
+      description="Are you sure you want to regenerate your backup codes? This will invalidate all existing backup codes and generate new ones."
+      destructive
+      destructiveText="Regenerate"
+      onConfirm={handleConfirm}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Settings/BackupCodesRegenerateModal.tsx
+++ b/clients/apps/web/src/components/Settings/BackupCodesRegenerateModal.tsx
@@ -22,8 +22,8 @@ export default function BackupCodesRegenerateModal({
     <ConfirmModal
       isShown={isShown}
       hide={hide}
-      title="Regenerate Backup Codes"
-      description="Are you sure you want to regenerate your backup codes? This will invalidate all existing backup codes and generate new ones."
+      title="Regenerate backup codes?"
+      description="Your current backup codes will stop working immediately and be replaced with new backup codes."
       destructive
       destructiveText="Regenerate"
       onConfirm={handleConfirm}

--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -1,88 +1,44 @@
 'use client'
 
 import { Modal } from '@/components/Modal'
-import {
-  useBackupCodesEnroll,
-  useTOTPEnroll,
-  useTOTPEnable,
-  useTOTPStatus,
-} from '@/hooks/auth'
+import { useTOTPEnroll, useTOTPEnable } from '@/hooks/auth'
 import { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
-import Input from '@polar-sh/ui/components/atoms/Input'
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from '@polar-sh/ui/components/atoms/InputOTP'
 import QRCode from 'react-qr-code'
 import { useState } from 'react'
-import Spinner from '@/components/Shared/Spinner'
-import BackupCodesModal from './BackupCodesModal'
-import { useModal } from '@/components/Modal/useModal'
+import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
+import { toast } from '../Toast/use-toast'
 
 export interface TOTPSetupModalProps {
   isShown: boolean
   hide: () => void
+  onEnabled: () => void
 }
 
-const TOTPSetupContent = () => {
+const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
   const [code, setCode] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [enrollment, setEnrollment] = useState<
     schemas['TOTPEnrollment'] | null
   >(null)
-  const [showSuccess, setShowSuccess] = useState(false)
-  const [generatedBackupCodes, setGeneratedBackupCodes] = useState<
-    string[] | null
-  >(null)
 
-  const totpStatus = useTOTPStatus()
+  const [manualEntryMode, setManualEntryMode] = useState(false)
+
   const totpEnroll = useTOTPEnroll()
   const totpEnable = useTOTPEnable()
-  const backupCodesEnroll = useBackupCodesEnroll()
-
-  const {
-    isShown: isBackupCodesModalShown,
-    show: showBackupCodesModal,
-    hide: hideBackupCodesModal,
-  } = useModal()
 
   const renderContent = () => {
-    if (showSuccess) {
-      return (
-        <div className="flex flex-col items-center justify-center gap-4 p-8 py-12">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/20">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-8 w-8 text-green-600 dark:text-green-400"
-            >
-              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-              <polyline points="22 4 12 14.01 9 11.01" />
-            </svg>
-          </div>
-          <h2 className="text-lg font-semibold text-green-600 dark:text-green-400">
-            TOTP Enabled!
-          </h2>
-          <p className="dark:text-polar-400 text-center text-gray-600">
-            Two-factor authentication is now active on your account.
-          </p>
-          {backupCodesEnroll.isPending && (
-            <p className="dark:text-polar-500 text-sm text-gray-500">
-              Generating backup codes...
-            </p>
-          )}
-        </div>
-      )
-    }
-
     if (!enrollment) {
       return (
         <div className="flex flex-col gap-6 p-8">
           <p className="dark:text-polar-400 text-sm text-gray-600">
-            Add an extra layer of security to your account. You&apos;ll need an
-            authenticator app such as Google Authenticator or Authy.
+            To set this up, you&rsquo;ll need an authenticator app like Google
+            Authenticator or Authy.
           </p>
           {error && (
             <p className="text-sm text-red-500 dark:text-red-400">{error}</p>
@@ -97,74 +53,70 @@ const TOTPSetupContent = () => {
     return (
       <div className="flex flex-col gap-6 p-8">
         <p className="dark:text-polar-400 text-sm text-gray-600">
-          Scan this QR code with your authenticator app (Google Authenticator,
-          Authy, etc.) to get a 6-digit code.
+          Scan this QR code with your authenticator app, then enter the 6-digit
+          code it generates.
         </p>
 
-        <div className="dark:bg-polar-800 flex justify-center rounded-lg bg-white p-4">
-          <QRCode value={enrollment.provisioning_uri} size={200} />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <label className="dark:text-polar-300 text-sm font-medium text-gray-700">
-            Can&apos;t scan? Enter this code manually:
-          </label>
-          <div className="flex gap-2">
-            <Input
-              readOnly
-              value={enrollment.provisioning_uri}
-              className="flex-1 font-mono text-xs"
-            />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() =>
-                navigator.clipboard.writeText(enrollment.provisioning_uri)
-              }
-            >
-              Copy
-            </Button>
+        <div className="flex flex-col items-center gap-0">
+          <div className="dark:bg-polar-800 flex justify-center rounded-lg bg-white p-4">
+            <QRCode value={enrollment.provisioning_uri} size={200} />
           </div>
-        </div>
 
-        <div className="flex flex-col gap-2">
-          <label className="dark:text-polar-300 text-sm font-medium text-gray-700">
-            Enter the 6-digit code from your app:
-          </label>
-          <div className="flex gap-2">
-            <Input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              value={code}
-              onChange={handleCodeChange}
-              placeholder="123456"
-              className="flex-1"
-            />
-            <Button
-              onClick={handleVerify}
-              loading={totpEnable.isPending}
-              className="min-w-[100px]"
-            >
-              Verify
-            </Button>
-          </div>
-          {error && (
-            <p className="text-sm text-red-500 dark:text-red-400">{error}</p>
+          <button
+            className="dark:text-polar-500 dark:hover:text-polar-400 mx-auto cursor-pointer appearance-none p-2 text-center text-xs text-gray-500 hover:text-gray-700"
+            onClick={() => setManualEntryMode(!manualEntryMode)}
+          >
+            Can&rsquo;t scan?{' '}
+            {manualEntryMode
+              ? 'Enter this code manually:'
+              : 'Get a code to enter manually.'}
+          </button>
+
+          {manualEntryMode && (
+            <div className="w-full pt-2">
+              <CopyToClipboardInput
+                value={enrollment.provisioning_uri}
+                buttonLabel="Copy"
+              />
+            </div>
           )}
         </div>
 
-        {totpEnable.isPending && (
-          <div className="flex items-center justify-center gap-2">
-            <div className="h-5 w-5 animate-spin">
-              <Spinner />
-            </div>
-            <p className="dark:text-polar-500 text-sm text-gray-500">
-              Verifying...
-            </p>
+        <div className="flex flex-col gap-2">
+          <label className="dark:text-polar-300 text-center text-sm font-medium text-gray-700">
+            Enter the 6-digit code from your app
+          </label>
+          <div className="flex flex-col items-center gap-4">
+            <InputOTP
+              maxLength={6}
+              minLength={6}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              autoFocus={true}
+              value={code}
+              onChange={handleCodeChange}
+              onComplete={handleVerify}
+            >
+              <InputOTPGroup>
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <InputOTPSlot
+                    key={index}
+                    index={index}
+                    className="dark:border-polar-600 h-12 w-12 border-gray-300 text-xl"
+                  />
+                ))}
+              </InputOTPGroup>
+            </InputOTP>
+            <Button onClick={handleVerify} loading={totpEnable.isPending}>
+              {totpEnable.isPending ? 'Verifying…' : 'Verify'}
+            </Button>
           </div>
-        )}
+          {error && (
+            <p className="text-center text-sm text-red-500 dark:text-red-400">
+              {error}
+            </p>
+          )}
+        </div>
       </div>
     )
   }
@@ -190,51 +142,33 @@ const TOTPSetupContent = () => {
     }
     setError(null)
     totpEnable.mutate(code, {
-      onSuccess: async () => {
-        setShowSuccess(true)
-        totpStatus.refetch()
-        // Generate backup codes after TOTP is enabled
-        try {
-          const result = await backupCodesEnroll.mutateAsync()
-          if (result.data?.codes) {
-            setGeneratedBackupCodes(result.data.codes)
-            showBackupCodesModal()
-          }
-        } catch {
-          // Backup codes generation failed, but TOTP is still enabled
-          // Don't block the success flow
-        }
+      onSuccess: () => {
+        toast({ title: 'Two-factor authentication enabled' })
+        onEnabled()
       },
       onError: (err) =>
         setError(err.message || 'Invalid code. Please try again.'),
     })
   }
 
-  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCode(e.target.value)
+  const handleCodeChange = (value: string) => {
+    setCode(value)
     if (error) setError(null)
   }
 
-  return (
-    <>
-      {renderContent()}
-      <BackupCodesModal
-        isShown={isBackupCodesModalShown}
-        hide={hideBackupCodesModal}
-        codes={generatedBackupCodes || []}
-      />
-    </>
-  )
+  return renderContent()
 }
 
-const TOTPSetupModal = ({ isShown, hide }: TOTPSetupModalProps) => {
+const TOTPSetupModal = ({ isShown, hide, onEnabled }: TOTPSetupModalProps) => {
   return (
     <Modal
       title="Set Up Two-Factor Authentication"
       isShown={isShown}
       hide={hide}
-      className="md:min-w-[400px] lg:max-w-[540px]"
-      modalContent={<TOTPSetupContent key={String(isShown)} />}
+      className="md:min-w-100 lg:max-w-135"
+      modalContent={
+        <TOTPSetupContent key={String(isShown)} onEnabled={onEnabled} />
+      }
     />
   )
 }

--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { Modal } from '@/components/Modal'
+import {
+  useBackupCodesEnroll,
+  useTOTPEnroll,
+  useTOTPEnable,
+  useTOTPStatus,
+} from '@/hooks/auth'
+import { schemas } from '@polar-sh/client'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import Input from '@polar-sh/ui/components/atoms/Input'
+import QRCode from 'react-qr-code'
+import { useState } from 'react'
+import Spinner from '@/components/Shared/Spinner'
+import BackupCodesModal from './BackupCodesModal'
+import { useModal } from '@/components/Modal/useModal'
+
+export interface TOTPSetupModalProps {
+  isShown: boolean
+  hide: () => void
+}
+
+const TOTPSetupContent = () => {
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [enrollment, setEnrollment] = useState<
+    schemas['TOTPEnrollment'] | null
+  >(null)
+  const [showSuccess, setShowSuccess] = useState(false)
+  const [generatedBackupCodes, setGeneratedBackupCodes] = useState<
+    string[] | null
+  >(null)
+
+  const totpStatus = useTOTPStatus()
+  const totpEnroll = useTOTPEnroll()
+  const totpEnable = useTOTPEnable()
+  const backupCodesEnroll = useBackupCodesEnroll()
+
+  const {
+    isShown: isBackupCodesModalShown,
+    show: showBackupCodesModal,
+    hide: hideBackupCodesModal,
+  } = useModal()
+
+  const renderContent = () => {
+    if (showSuccess) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-4 p-8 py-12">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/20">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-8 w-8 text-green-600 dark:text-green-400"
+            >
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+              <polyline points="22 4 12 14.01 9 11.01" />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-green-600 dark:text-green-400">
+            TOTP Enabled!
+          </h2>
+          <p className="dark:text-polar-400 text-center text-gray-600">
+            Two-factor authentication is now active on your account.
+          </p>
+          {backupCodesEnroll.isPending && (
+            <p className="dark:text-polar-500 text-sm text-gray-500">
+              Generating backup codes...
+            </p>
+          )}
+        </div>
+      )
+    }
+
+    if (!enrollment) {
+      return (
+        <div className="flex flex-col gap-6 p-8">
+          <p className="dark:text-polar-400 text-sm text-gray-600">
+            Add an extra layer of security to your account. You&apos;ll need an
+            authenticator app such as Google Authenticator or Authy.
+          </p>
+          {error && (
+            <p className="text-sm text-red-500 dark:text-red-400">{error}</p>
+          )}
+          <Button onClick={handleEnroll} loading={totpEnroll.isPending}>
+            Get Started
+          </Button>
+        </div>
+      )
+    }
+
+    return (
+      <div className="flex flex-col gap-6 p-8">
+        <p className="dark:text-polar-400 text-sm text-gray-600">
+          Scan this QR code with your authenticator app (Google Authenticator,
+          Authy, etc.) to get a 6-digit code.
+        </p>
+
+        <div className="dark:bg-polar-800 flex justify-center rounded-lg bg-white p-4">
+          <QRCode value={enrollment.provisioning_uri} size={200} />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="dark:text-polar-300 text-sm font-medium text-gray-700">
+            Can&apos;t scan? Enter this code manually:
+          </label>
+          <div className="flex gap-2">
+            <Input
+              readOnly
+              value={enrollment.provisioning_uri}
+              className="flex-1 font-mono text-xs"
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() =>
+                navigator.clipboard.writeText(enrollment.provisioning_uri)
+              }
+            >
+              Copy
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="dark:text-polar-300 text-sm font-medium text-gray-700">
+            Enter the 6-digit code from your app:
+          </label>
+          <div className="flex gap-2">
+            <Input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              maxLength={6}
+              value={code}
+              onChange={handleCodeChange}
+              placeholder="123456"
+              className="flex-1"
+            />
+            <Button
+              onClick={handleVerify}
+              loading={totpEnable.isPending}
+              className="min-w-[100px]"
+            >
+              Verify
+            </Button>
+          </div>
+          {error && (
+            <p className="text-sm text-red-500 dark:text-red-400">{error}</p>
+          )}
+        </div>
+
+        {totpEnable.isPending && (
+          <div className="flex items-center justify-center gap-2">
+            <div className="h-5 w-5 animate-spin">
+              <Spinner />
+            </div>
+            <p className="dark:text-polar-500 text-sm text-gray-500">
+              Verifying...
+            </p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const handleEnroll = () => {
+    setError(null)
+    totpEnroll.mutate(undefined, {
+      onSuccess: (response) => {
+        if (response.data) {
+          setEnrollment(response.data)
+        } else {
+          setError('Failed to start TOTP setup. Please try again.')
+        }
+      },
+      onError: (err) => setError(err.message || 'Failed to start TOTP setup'),
+    })
+  }
+
+  const handleVerify = () => {
+    if (!code || code.length !== 6) {
+      setError('Please enter a 6-digit code')
+      return
+    }
+    setError(null)
+    totpEnable.mutate(code, {
+      onSuccess: async () => {
+        setShowSuccess(true)
+        totpStatus.refetch()
+        // Generate backup codes after TOTP is enabled
+        try {
+          const result = await backupCodesEnroll.mutateAsync()
+          if (result.data?.codes) {
+            setGeneratedBackupCodes(result.data.codes)
+            showBackupCodesModal()
+          }
+        } catch {
+          // Backup codes generation failed, but TOTP is still enabled
+          // Don't block the success flow
+        }
+      },
+      onError: (err) =>
+        setError(err.message || 'Invalid code. Please try again.'),
+    })
+  }
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCode(e.target.value)
+    if (error) setError(null)
+  }
+
+  return (
+    <>
+      {renderContent()}
+      <BackupCodesModal
+        isShown={isBackupCodesModalShown}
+        hide={hideBackupCodesModal}
+        codes={generatedBackupCodes || []}
+      />
+    </>
+  )
+}
+
+const TOTPSetupModal = ({ isShown, hide }: TOTPSetupModalProps) => {
+  return (
+    <Modal
+      title="Set Up Two-Factor Authentication"
+      isShown={isShown}
+      hide={hide}
+      className="md:min-w-[400px] lg:max-w-[540px]"
+      modalContent={<TOTPSetupContent key={String(isShown)} />}
+    />
+  )
+}
+
+export default TOTPSetupModal

--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -135,20 +135,19 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
     })
   }
 
-  const handleVerify = () => {
+  const handleVerify = async () => {
     if (!code || code.length !== 6) {
       setError('Please enter a 6-digit code')
       return
     }
     setError(null)
-    totpEnable.mutate(code, {
-      onSuccess: () => {
-        toast({ title: 'Two-factor authentication enabled' })
-        onEnabled()
-      },
-      onError: (err) =>
-        setError(err.message || 'Invalid code. Please try again.'),
-    })
+    const { error } = await totpEnable.mutateAsync(code)
+    if (error) {
+      setError('Invalid code. Please try again.')
+      return
+    }
+    toast({ title: 'Two-factor authentication enabled' })
+    onEnabled()
   }
 
   const handleCodeChange = (value: string) => {

--- a/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
+++ b/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
@@ -6,8 +6,6 @@ import {
   useTOTPStatus,
   useTOTPDelete,
 } from '@/hooks'
-import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined'
-import KeyOutlined from '@mui/icons-material/KeyOutlined'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import ListGroup from '@polar-sh/ui/components/atoms/ListGroup'
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
@@ -16,6 +14,7 @@ import { useState } from 'react'
 import TOTPSetupModal from './TOTPSetupModal'
 import BackupCodesModal from './BackupCodesModal'
 import BackupCodesRegenerateModal from './BackupCodesRegenerateModal'
+import { KeyRoundIcon, ShieldCheckIcon } from 'lucide-react'
 
 const AuthenticationMethod = ({
   icon,
@@ -87,12 +86,12 @@ const TwoFactorSettings = () => {
       <ListGroup>
         <ListGroup.Item>
           <AuthenticationMethod
-            icon={<VerifiedUserOutlined />}
+            icon={<ShieldCheckIcon />}
             title="Authenticator App"
             subtitle={
               totpStatus.data?.enabled
-                ? 'Use an authenticator app to sign in.'
-                : 'Add an extra layer of security to your account.'
+                ? "You're using an authenticator app to sign in securely."
+                : 'Add an extra layer of security when you sign in.'
             }
             action={
               totpStatus.data?.enabled ? (
@@ -110,52 +109,67 @@ const TwoFactorSettings = () => {
           />
         </ListGroup.Item>
 
-        <ListGroup.Item>
-          <AuthenticationMethod
-            icon={<KeyOutlined />}
-            title="Backup Codes"
-            subtitle={
-              backupCodesStatus.data
-                ? `${backupCodesStatus.data.codes - backupCodesStatus.data.used_codes} remaining`
-                : 'Generate backup codes for emergency access.'
-            }
-            action={
-              backupCodesStatus.data?.codes &&
-              backupCodesStatus.data.codes > 0 ? (
-                <Button
-                  variant="secondary"
-                  onClick={showBackupCodesRegenerateModal}
-                  loading={backupCodesEnroll.isPending}
-                >
-                  Regenerate
-                </Button>
-              ) : totpStatus.data?.enabled ? (
-                <Button
-                  onClick={async () => {
-                    const result = await backupCodesEnroll.mutateAsync()
-                    if (result.data?.codes) {
-                      setNewBackupCodes(result.data.codes)
-                      await backupCodesStatus.refetch()
-                      showBackupCodesModal()
-                    }
-                  }}
-                  loading={backupCodesEnroll.isPending}
-                >
-                  Generate
-                </Button>
-              ) : null
-            }
-          />
-        </ListGroup.Item>
+        {totpStatus.data?.enabled && (
+          <ListGroup.Item>
+            <AuthenticationMethod
+              icon={<KeyRoundIcon />}
+              title="Backup Codes"
+              subtitle={
+                backupCodesStatus.data
+                  ? `${backupCodesStatus.data.codes - backupCodesStatus.data.used_codes} remaining`
+                  : 'Generate backup codes for emergency access.'
+              }
+              action={
+                backupCodesStatus.data?.codes &&
+                backupCodesStatus.data.codes > 0 ? (
+                  <Button
+                    variant="secondary"
+                    onClick={showBackupCodesRegenerateModal}
+                    loading={backupCodesEnroll.isPending}
+                  >
+                    Regenerate
+                  </Button>
+                ) : (
+                  <Button
+                    onClick={async () => {
+                      const result = await backupCodesEnroll.mutateAsync()
+                      if (result.data?.codes) {
+                        setNewBackupCodes(result.data.codes)
+                        await backupCodesStatus.refetch()
+                        showBackupCodesModal()
+                      }
+                    }}
+                    loading={backupCodesEnroll.isPending}
+                  >
+                    Generate
+                  </Button>
+                )
+              }
+            />
+          </ListGroup.Item>
+        )}
       </ListGroup>
 
-      <TOTPSetupModal isShown={isTOTPModalShown} hide={hideTOTPModal} />
+      <TOTPSetupModal
+        isShown={isTOTPModalShown}
+        hide={hideTOTPModal}
+        onEnabled={async () => {
+          hideTOTPModal()
+          await totpStatus.refetch()
+          const result = await backupCodesEnroll.mutateAsync()
+          if (result.data?.codes) {
+            setNewBackupCodes(result.data.codes)
+            await backupCodesStatus.refetch()
+            showBackupCodesModal()
+          }
+        }}
+      />
 
       <ConfirmModal
         isShown={isDeleteConfirmShown}
         hide={hideDeleteConfirmModal}
-        title="Disable Authenticator App"
-        description="Are you sure you want to disable your authenticator app? Your account will be less secure without two-factor authentication."
+        title="Disable Authenticator App?"
+        description="You'll no longer be asked for a code when you sign in, and your backup codes will stop working. You can turn it back on anytime."
         destructive
         destructiveText="Disable"
         onConfirm={handleDeleteTOTP}

--- a/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
+++ b/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import {
+  useBackupCodesEnroll,
+  useBackupCodesStatus,
+  useTOTPStatus,
+  useTOTPDelete,
+} from '@/hooks'
+import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined'
+import KeyOutlined from '@mui/icons-material/KeyOutlined'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import ListGroup from '@polar-sh/ui/components/atoms/ListGroup'
+import { ConfirmModal } from '@/components/Modal/ConfirmModal'
+import { useModal } from '@/components/Modal/useModal'
+import { useState } from 'react'
+import TOTPSetupModal from './TOTPSetupModal'
+import BackupCodesModal from './BackupCodesModal'
+import BackupCodesRegenerateModal from './BackupCodesRegenerateModal'
+
+const AuthenticationMethod = ({
+  icon,
+  title,
+  subtitle,
+  action,
+}: {
+  icon: React.ReactNode
+  title: React.ReactNode
+  subtitle: React.ReactNode
+  action: React.ReactNode
+}) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-center">
+        <div className="self-start">{icon}</div>
+        <div className="grow">
+          <div className="font-medium">{title}</div>
+          <div className="dark:text-polar-500 text-sm text-gray-500">
+            {subtitle}
+          </div>
+        </div>
+        <div className="flex-0">{action}</div>
+      </div>
+    </div>
+  )
+}
+
+const TwoFactorSettings = () => {
+  const totpStatus = useTOTPStatus()
+  const totpDelete = useTOTPDelete()
+  const backupCodesStatus = useBackupCodesStatus()
+  const backupCodesEnroll = useBackupCodesEnroll()
+
+  const {
+    isShown: isTOTPModalShown,
+    show: showTOTPModal,
+    hide: hideTOTPModal,
+  } = useModal()
+
+  const {
+    isShown: isDeleteConfirmShown,
+    show: showDeleteConfirmModal,
+    hide: hideDeleteConfirmModal,
+  } = useModal()
+
+  const {
+    isShown: isBackupCodesModalShown,
+    show: showBackupCodesModal,
+    hide: hideBackupCodesModal,
+  } = useModal()
+
+  const {
+    isShown: isBackupCodesRegenerateModalShown,
+    show: showBackupCodesRegenerateModal,
+    hide: hideBackupCodesRegenerateModal,
+  } = useModal()
+
+  const [newBackupCodes, setNewBackupCodes] = useState<string[] | null>(null)
+
+  const handleDeleteTOTP = async () => {
+    await totpDelete.mutateAsync()
+    await totpStatus.refetch()
+    hideDeleteConfirmModal()
+  }
+
+  return (
+    <div>
+      <ListGroup>
+        <ListGroup.Item>
+          <AuthenticationMethod
+            icon={<VerifiedUserOutlined />}
+            title="Authenticator App"
+            subtitle={
+              totpStatus.data?.enabled
+                ? 'Use an authenticator app to sign in.'
+                : 'Add an extra layer of security to your account.'
+            }
+            action={
+              totpStatus.data?.enabled ? (
+                <Button
+                  variant="secondary"
+                  onClick={showDeleteConfirmModal}
+                  loading={totpDelete.isPending}
+                >
+                  Disable
+                </Button>
+              ) : (
+                <Button onClick={showTOTPModal}>Set Up</Button>
+              )
+            }
+          />
+        </ListGroup.Item>
+
+        <ListGroup.Item>
+          <AuthenticationMethod
+            icon={<KeyOutlined />}
+            title="Backup Codes"
+            subtitle={
+              backupCodesStatus.data
+                ? `${backupCodesStatus.data.codes - backupCodesStatus.data.used_codes} remaining`
+                : 'Generate backup codes for emergency access.'
+            }
+            action={
+              backupCodesStatus.data?.codes &&
+              backupCodesStatus.data.codes > 0 ? (
+                <Button
+                  variant="secondary"
+                  onClick={showBackupCodesRegenerateModal}
+                  loading={backupCodesEnroll.isPending}
+                >
+                  Regenerate
+                </Button>
+              ) : totpStatus.data?.enabled ? (
+                <Button
+                  onClick={async () => {
+                    const result = await backupCodesEnroll.mutateAsync()
+                    if (result.data?.codes) {
+                      setNewBackupCodes(result.data.codes)
+                      await backupCodesStatus.refetch()
+                      showBackupCodesModal()
+                    }
+                  }}
+                  loading={backupCodesEnroll.isPending}
+                >
+                  Generate
+                </Button>
+              ) : null
+            }
+          />
+        </ListGroup.Item>
+      </ListGroup>
+
+      <TOTPSetupModal isShown={isTOTPModalShown} hide={hideTOTPModal} />
+
+      <ConfirmModal
+        isShown={isDeleteConfirmShown}
+        hide={hideDeleteConfirmModal}
+        title="Disable Authenticator App"
+        description="Are you sure you want to disable your authenticator app? Your account will be less secure without two-factor authentication."
+        destructive
+        destructiveText="Disable"
+        onConfirm={handleDeleteTOTP}
+      />
+
+      <BackupCodesRegenerateModal
+        isShown={isBackupCodesRegenerateModalShown}
+        hide={hideBackupCodesRegenerateModal}
+        onRegenerate={async () => {
+          const result = await backupCodesEnroll.mutateAsync()
+          if (result.data?.codes) {
+            setNewBackupCodes(result.data.codes)
+            await backupCodesStatus.refetch()
+            showBackupCodesModal()
+            return result.data
+          }
+          return null
+        }}
+      />
+
+      <BackupCodesModal
+        isShown={isBackupCodesModalShown}
+        hide={hideBackupCodesModal}
+        codes={newBackupCodes || []}
+      />
+    </div>
+  )
+}
+
+export default TwoFactorSettings

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -87,3 +87,48 @@ export const useBackupCodesVerify = () =>
     mutationFn: (body: { code: string }) =>
       api.POST('/v1/auth/backup-codes/verify', { body }),
   })
+
+export const useTOTPStatus = () =>
+  useQuery({
+    queryKey: ['totp', 'status'],
+    queryFn: async () => {
+      const { data, response } = await api.GET('/v1/auth/totp')
+      if (response.status === 404) return { enabled: false }
+      if (!response.ok) throw new Error('Failed to fetch TOTP status')
+      return data ?? { enabled: false }
+    },
+    retry: false,
+  })
+
+export const useTOTPEnroll = () =>
+  useMutation({
+    mutationFn: () => api.POST('/v1/auth/totp', {}),
+  })
+
+export const useTOTPEnable = () =>
+  useMutation({
+    mutationFn: (code: string) =>
+      api.POST('/v1/auth/totp/enable', { body: { code } }),
+  })
+
+export const useTOTPDelete = () =>
+  useMutation({
+    mutationFn: () => api.DELETE('/v1/auth/totp'),
+  })
+
+export const useBackupCodesStatus = () =>
+  useQuery({
+    queryKey: ['backup-codes', 'status'],
+    queryFn: async () => {
+      const { data, response } = await api.GET('/v1/auth/backup-codes')
+      if (response.status === 404) return null
+      if (!response.ok) throw new Error('Failed to fetch backup codes status')
+      return data
+    },
+    retry: false,
+  })
+
+export const useBackupCodesEnroll = () =>
+  useMutation({
+    mutationFn: () => api.POST('/v1/auth/backup-codes', {}),
+  })

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -460,6 +460,9 @@ importers:
       react-hook-form:
         specifier: ~7.72.1
         version: 7.72.1(react@19.2.5)
+      react-qr-code:
+        specifier: ^2.0.11
+        version: 2.0.21(react@19.2.5)
       react-timeago:
         specifier: ^8.3.0
         version: 8.3.0(react@19.2.5)
@@ -10041,6 +10044,9 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qr.js@0.0.0:
+    resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
+
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
@@ -10240,6 +10246,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-qr-code@2.0.21:
+    resolution: {integrity: sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==}
+    peerDependencies:
+      react: '*'
 
   react-reconciler@0.31.0:
     resolution: {integrity: sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==}
@@ -23362,6 +23373,8 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  qr.js@0.0.0: {}
+
   qrcode-terminal@0.11.0: {}
 
   qs@6.15.0:
@@ -23628,6 +23641,12 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-qr-code@2.0.21(react@19.2.5):
+    dependencies:
+      prop-types: 15.8.1
+      qr.js: 0.0.0
+      react: 19.2.5
 
   react-reconciler@0.31.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
- clients/web: add TOTP and backup codes setup in user settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-factor authentication (TOTP) via authenticator apps with QR code and manual URI copy
  * Full TOTP enrollment, verification, enable/disable flows in account preferences
  * Dedicated TOTP setup modal with OTP entry, error handling, and success callback
  * Backup code generation and display modal with newline-delimited codes and “I’ve saved my codes” action
  * “Copy All” for backup codes with temporary “Copied!” feedback
  * Backup-code regeneration flow with confirmation modal
<!-- end of auto-generated comment: release notes by coderabbit.ai -->