### PR TITLE
Send questions straight to Plain

### DIFF
--- a/server/polar/feedback/service.py
+++ b/server/polar/feedback/service.py
@@ -2,9 +2,11 @@ from polar.auth.models import AuthSubject
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Feedback, User
+from polar.models.feedback import FeedbackType
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
+from polar.worker import enqueue_job
 
 from .repository import FeedbackRepository
 from .schemas import FeedbackCreate
@@ -38,7 +40,7 @@ class FeedbackService:
             )
 
         repository = FeedbackRepository.from_session(session)
-        return await repository.create(
+        feedback = await repository.create(
             Feedback(
                 type=create_schema.type,
                 message=create_schema.message,
@@ -48,6 +50,13 @@ class FeedbackService:
             ),
             flush=True,
         )
+
+        # Questions automatically open a Plain support thread, impersonating the
+        # customer with their message and attaching the conversation transcript.
+        if feedback.type == FeedbackType.question:
+            enqueue_job("feedback.reply_in_plain", feedback_id=feedback.id)
+
+        return feedback
 
 
 feedback = FeedbackService()

--- a/server/polar/feedback/tasks.py
+++ b/server/polar/feedback/tasks.py
@@ -1,0 +1,45 @@
+from uuid import UUID
+
+from sqlalchemy.orm import joinedload
+
+from polar.integrations.plain.service import plain as plain_service
+from polar.models import Feedback
+from polar.models.feedback import FeedbackStatus
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+from .repository import FeedbackRepository
+
+
+@actor(actor_name="feedback.reply_in_plain", priority=TaskPriority.LOW)
+async def feedback_reply_in_plain(feedback_id: UUID) -> None:
+    """
+    Automatically open a Plain support thread for a freshly submitted question.
+
+    Mirrors the manual "Reply in Plain" backoffice action: it impersonates the
+    customer with the message they wrote and attaches the full conversation
+    transcript as an internal note.
+    """
+    if not plain_service.enabled:
+        return
+
+    async with AsyncSessionMaker() as session:
+        repository = FeedbackRepository.from_session(session)
+        feedback = await repository.get_by_id(
+            feedback_id, options=(joinedload(Feedback.user),)
+        )
+        if feedback is None:
+            return
+        # A thread may already exist if backoffice created one manually first.
+        if feedback.support_thread_url is not None:
+            return
+
+        thread_url = await plain_service.create_feedback_thread(feedback)
+        # The thread was created successfully, so the question is now being
+        # handled in Plain: mark it as triaged in the backoffice.
+        await repository.update(
+            feedback,
+            update_dict={
+                "support_thread_url": thread_url,
+                "status": FeedbackStatus.triaged,
+            },
+        )

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -1,7 +1,6 @@
 # pyright: reportCallIssue=false
 import asyncio
 import contextlib
-import json
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 
@@ -49,10 +48,7 @@ from plain_client import (
     UpsertCustomerUpsertCustomer,
     UpsertTenantInput,
 )
-from plain_client.exceptions import (
-    GraphQLClientGraphQLMultiError,
-    GraphQLClientHttpError,
-)
+from plain_client.exceptions import GraphQLClientGraphQLMultiError
 from pydantic_ai import Agent
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
@@ -155,38 +151,6 @@ Rules:
 - No surrounding quotes, no "Subject:" prefix, no trailing punctuation.
 - Output only the subject line, nothing else.
 """
-
-
-def _format_plain_http_error(e: GraphQLClientHttpError) -> str:
-    """
-    Build a diagnostic message from a Plain HTTP error: which GraphQL operation
-    failed, Plain's own response body (which names the missing permission), and
-    a fingerprint of the token actually sent — so a 403 points at the real cause
-    instead of a generic permissions checklist.
-    """
-    operation = ""
-    try:
-        payload = json.loads(e.response.request.content)
-        operation = payload.get("operationName") or ""
-    except Exception:
-        pass
-
-    body = ""
-    try:
-        body = e.response.text[:600]
-    except Exception:
-        pass
-
-    token = settings.PLAIN_TOKEN or ""
-    fingerprint = f"…{token[-4:]} (len {len(token)})" if token else "<unset>"
-
-    parts = [f"Plain API HTTP {e.status_code}"]
-    if operation:
-        parts.append(f"on `{operation}`")
-    parts.append(f"using token {fingerprint}")
-    if body:
-        parts.append(f"— response: {body}")
-    return " ".join(parts)
 
 
 async def _generate_thread_subject(content: str, fallback: str) -> str:
@@ -1460,90 +1424,78 @@ class PlainService:
 
         async with self._get_plain_client() as plain:
             try:
-                try:
-                    customer_id = await self._upsert_customer_id_for_user(
-                        plain, feedback.user
-                    )
-                except PlainCustomerError as e:
-                    raise FeedbackThreadCreationError(feedback.id, e.message) from e
-
-                thread_result = await plain.create_thread(
-                    CreateThreadInput(
-                        customer_identifier=CustomerIdentifierInput(
-                            customer_id=customer_id
-                        ),
-                        title=title,
-                    )
+                customer_id = await self._upsert_customer_id_for_user(
+                    plain, feedback.user
                 )
-                if thread_result.error is not None:
-                    raise FeedbackThreadCreationError(
-                        feedback.id, thread_result.error.message
-                    )
-                if thread_result.thread is None:
-                    raise FeedbackThreadCreationError(
-                        feedback.id, "No thread returned by create_thread"
-                    )
-                thread_id = thread_result.thread.id
+            except PlainCustomerError as e:
+                raise FeedbackThreadCreationError(feedback.id, e.message) from e
 
-                if transcript is not None:
-                    # Chat escalation: post the customer's message as if it came
-                    # from them, falling back to their original question when no
-                    # extra note was added.
-                    customer_message = note or _first_user_message(transcript)
-                    if customer_message:
-                        reply_result = await plain.reply_to_thread(
-                            ReplyToThreadInput(
-                                thread_id=thread_id,
-                                text_content=customer_message,
-                                impersonation=ImpersonationInput(
-                                    as_customer=CustomerImpersonationInput(
-                                        customer_identifier=CustomerIdentifierInput(
-                                            customer_id=customer_id
-                                        )
-                                    )
-                                ),
-                            )
-                        )
-                        if reply_result.error is not None:
-                            raise FeedbackThreadCreationError(
-                                feedback.id, reply_result.error.message
-                            )
-                    note_text = transcript
-                else:
-                    # Direct submission (e.g. manual backoffice reply for a bug
-                    # or feedback report): keep the message itself as the note.
-                    note_text = feedback.message
-
-                # Link back to the backoffice feedback record so whoever picks
-                # up the thread can jump straight to it.
-                backoffice_url = settings.generate_backoffice_url(
-                    f"/feedbacks/{feedback.id}"
+            thread_result = await plain.create_thread(
+                CreateThreadInput(
+                    customer_identifier=CustomerIdentifierInput(
+                        customer_id=customer_id
+                    ),
+                    title=title,
                 )
-                note_result = await plain.create_note(
-                    CreateNoteInput(
-                        customer_id=customer_id,
-                        thread_id=thread_id,
-                        text=f"{note_text}\n\nView in backoffice: {backoffice_url}",
-                        markdown=(
-                            f"{note_text}\n\n[View in backoffice]({backoffice_url})"
-                        ),
-                    )
-                )
-                if note_result.error is not None:
-                    raise FeedbackThreadCreationError(
-                        feedback.id, note_result.error.message
-                    )
-
-                return plain_thread_url(thread_id)
-            except GraphQLClientHttpError as e:
-                # HTTP-level failures (e.g. 403 when the token lacks a required
-                # permission, or 5xx) aren't surfaced as GraphQL `.error`
-                # fields — wrap them with the failing operation, Plain's
-                # response body, and the token fingerprint so the real cause is
-                # visible instead of a generic guess.
+            )
+            if thread_result.error is not None:
                 raise FeedbackThreadCreationError(
-                    feedback.id, _format_plain_http_error(e)
-                ) from e
+                    feedback.id, thread_result.error.message
+                )
+            if thread_result.thread is None:
+                raise FeedbackThreadCreationError(
+                    feedback.id, "No thread returned by create_thread"
+                )
+            thread_id = thread_result.thread.id
+
+            if transcript is not None:
+                # Chat escalation: post the customer's message as if it came
+                # from them, falling back to their original question when no
+                # extra note was added.
+                customer_message = note or _first_user_message(transcript)
+                if customer_message:
+                    reply_result = await plain.reply_to_thread(
+                        ReplyToThreadInput(
+                            thread_id=thread_id,
+                            text_content=customer_message,
+                            impersonation=ImpersonationInput(
+                                as_customer=CustomerImpersonationInput(
+                                    customer_identifier=CustomerIdentifierInput(
+                                        customer_id=customer_id
+                                    )
+                                )
+                            ),
+                        )
+                    )
+                    if reply_result.error is not None:
+                        raise FeedbackThreadCreationError(
+                            feedback.id, reply_result.error.message
+                        )
+                note_text = transcript
+            else:
+                # Direct submission (e.g. manual backoffice reply for a bug
+                # or feedback report): keep the message itself as the note.
+                note_text = feedback.message
+
+            # Link back to the backoffice feedback record so whoever picks
+            # up the thread can jump straight to it.
+            backoffice_url = settings.generate_backoffice_url(
+                f"/feedbacks/{feedback.id}"
+            )
+            note_result = await plain.create_note(
+                CreateNoteInput(
+                    customer_id=customer_id,
+                    thread_id=thread_id,
+                    text=f"{note_text}\n\nView in backoffice: {backoffice_url}",
+                    markdown=(f"{note_text}\n\n[View in backoffice]({backoffice_url})"),
+                )
+            )
+            if note_result.error is not None:
+                raise FeedbackThreadCreationError(
+                    feedback.id, note_result.error.message
+                )
+
+            return plain_thread_url(thread_id)
 
     async def check_thread_exists(
         self, customer_email: str, thread_title: str, fuzzy: bool = False

--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -1,6 +1,7 @@
 # pyright: reportCallIssue=false
 import asyncio
 import contextlib
+import json
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 
@@ -27,10 +28,13 @@ from plain_client import (
     CreateNoteInput,
     CreateThreadInput,
     CustomerIdentifierInput,
+    CustomerImpersonationInput,
     EmailAddressInput,
+    ImpersonationInput,
     OptionalStringInput,
     Plain,
     RemoveCustomerFromTenantsInput,
+    ReplyToThreadInput,
     TenantIdentifierInput,
     ThreadsFilter,
     ThreadStatus,
@@ -45,7 +49,11 @@ from plain_client import (
     UpsertCustomerUpsertCustomer,
     UpsertTenantInput,
 )
-from plain_client.exceptions import GraphQLClientGraphQLMultiError
+from plain_client.exceptions import (
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+)
+from pydantic_ai import Agent
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
 
@@ -82,6 +90,132 @@ PLAIN_WORKSPACE_ID = "w_01JE9TRRX9KT61D8P2CH77XDQM"
 
 def plain_thread_url(thread_id: str) -> str:
     return f"https://app.plain.com/workspace/{PLAIN_WORKSPACE_ID}/thread/{thread_id}"
+
+
+# Markers used by the question chat flow when it builds the feedback message
+# (see `clients/apps/web/src/components/Feedback/QuestionFlow.tsx`). The frontend
+# submits either:
+#   "<note>\n\n---\n\n## Transcript\n\n<transcript>"   (an extra note was added)
+#   "## Transcript\n\n<transcript>"                     (no extra note)
+_TRANSCRIPT_SEPARATOR = "\n\n---\n\n## Transcript\n\n"
+_TRANSCRIPT_PREFIX = "## Transcript\n\n"
+_TRANSCRIPT_USER_HEADING = "**User**"
+_TRANSCRIPT_ASSISTANT_HEADING = "**Assistant**"
+
+
+def _split_feedback_message(message: str) -> tuple[str, str | None]:
+    """
+    Split a feedback message produced by the question chat flow into the user's
+    free-text note and the conversation transcript.
+
+    Returns `(note, transcript)`. `transcript` is `None` when the message does
+    not come from the chat flow (e.g. a direct bug/feedback submission), in
+    which case the whole message is treated as the note.
+    """
+    if _TRANSCRIPT_SEPARATOR in message:
+        note, transcript = message.split(_TRANSCRIPT_SEPARATOR, 1)
+        return note.strip(), transcript.strip()
+    if message.startswith(_TRANSCRIPT_PREFIX):
+        return "", message[len(_TRANSCRIPT_PREFIX) :].strip()
+    return message.strip(), None
+
+
+def _first_user_message(transcript: str) -> str | None:
+    """
+    Extract the customer's original question (the first `**User**` turn) from a
+    chat transcript, used as the impersonated message when no extra note was
+    added.
+    """
+    heading = f"{_TRANSCRIPT_USER_HEADING}\n\n"
+    if not transcript.startswith(heading):
+        return None
+    body = transcript[len(heading) :]
+    # The first user turn runs until the next speaker heading.
+    cut = len(body)
+    for next_heading in (
+        f"\n\n{_TRANSCRIPT_ASSISTANT_HEADING}\n\n",
+        f"\n\n{_TRANSCRIPT_USER_HEADING}\n\n",
+    ):
+        index = body.find(next_heading)
+        if index != -1:
+            cut = min(cut, index)
+    return body[:cut].strip() or None
+
+
+_SUBJECT_SYSTEM_PROMPT = """\
+You write the subject line for a customer support email.
+
+You are given a customer's support message, which may include a chat transcript \
+of an earlier conversation with an assistant. Write a single subject line that \
+captures what the customer needs help with, as if they wrote it themselves.
+
+Rules:
+- At most 60 characters.
+- Be specific about the topic; never generic like "Support request" or "Question".
+- No surrounding quotes, no "Subject:" prefix, no trailing punctuation.
+- Output only the subject line, nothing else.
+"""
+
+
+def _format_plain_http_error(e: GraphQLClientHttpError) -> str:
+    """
+    Build a diagnostic message from a Plain HTTP error: which GraphQL operation
+    failed, Plain's own response body (which names the missing permission), and
+    a fingerprint of the token actually sent — so a 403 points at the real cause
+    instead of a generic permissions checklist.
+    """
+    operation = ""
+    try:
+        payload = json.loads(e.response.request.content)
+        operation = payload.get("operationName") or ""
+    except Exception:
+        pass
+
+    body = ""
+    try:
+        body = e.response.text[:600]
+    except Exception:
+        pass
+
+    token = settings.PLAIN_TOKEN or ""
+    fingerprint = f"…{token[-4:]} (len {len(token)})" if token else "<unset>"
+
+    parts = [f"Plain API HTTP {e.status_code}"]
+    if operation:
+        parts.append(f"on `{operation}`")
+    parts.append(f"using token {fingerprint}")
+    if body:
+        parts.append(f"— response: {body}")
+    return " ".join(parts)
+
+
+async def _generate_thread_subject(content: str, fallback: str) -> str:
+    """
+    Write a concise, specific subject line from the feedback content using the
+    configured gateway model. Falls back to `fallback` when the content is empty
+    or the model call fails for any reason, so thread creation never depends on
+    the LLM.
+    """
+    if not content.strip():
+        return fallback
+    try:
+        # Use the gateway's default model so we don't depend on a provider
+        # extra that may not be installed (e.g. anthropic).
+        model_instance, _, model_name = settings.get_pydantic_gateway_model()
+        agent = Agent(
+            model_instance,
+            output_type=str,
+            system_prompt=_SUBJECT_SYSTEM_PROMPT,
+            # gpt-5.5+ reasoning models reject any non-default temperature.
+            model_settings=(
+                {} if model_name.startswith("gpt-5.5") else {"temperature": 0}
+            ),
+        )
+        result = await asyncio.wait_for(agent.run(content[:4000]), timeout=10)
+        subject = result.output.strip().strip('"').strip()
+        return subject or fallback
+    except Exception:
+        return fallback
 
 
 class PlainServiceError(PolarError): ...
@@ -1298,9 +1432,14 @@ class PlainService:
 
     async def create_feedback_thread(self, feedback: Feedback) -> str:
         """
-        Open a Plain thread for a feedback record and attach the original
-        feedback message as an internal note. Returns the URL of the new
+        Open a Plain thread for a feedback record. Returns the URL of the new
         thread.
+
+        For feedback that came out of the question chat flow, the customer's
+        message is posted into the thread impersonated as the customer (so it
+        reads as an email sent *from* them), and the full conversation
+        transcript is attached as an internal note. For direct submissions the
+        message is attached as an internal note as before.
 
         Requires `feedback.user` to be loaded (e.g. via `joinedload`).
         """
@@ -1314,46 +1453,97 @@ class PlainService:
             FeedbackType.feedback: "feedback",
             FeedbackType.question: "question",
         }
-        title = f"Re: your recent {noun_by_type[feedback.type]}"
+        fallback_title = f"Re: your recent {noun_by_type[feedback.type]}"
+        title = await _generate_thread_subject(feedback.message, fallback_title)
+
+        note, transcript = _split_feedback_message(feedback.message)
 
         async with self._get_plain_client() as plain:
             try:
-                customer_id = await self._upsert_customer_id_for_user(
-                    plain, feedback.user
-                )
-            except PlainCustomerError as e:
-                raise FeedbackThreadCreationError(feedback.id, e.message) from e
+                try:
+                    customer_id = await self._upsert_customer_id_for_user(
+                        plain, feedback.user
+                    )
+                except PlainCustomerError as e:
+                    raise FeedbackThreadCreationError(feedback.id, e.message) from e
 
-            thread_result = await plain.create_thread(
-                CreateThreadInput(
-                    customer_identifier=CustomerIdentifierInput(
-                        customer_id=customer_id
-                    ),
-                    title=title,
+                thread_result = await plain.create_thread(
+                    CreateThreadInput(
+                        customer_identifier=CustomerIdentifierInput(
+                            customer_id=customer_id
+                        ),
+                        title=title,
+                    )
                 )
-            )
-            if thread_result.error is not None:
-                raise FeedbackThreadCreationError(
-                    feedback.id, thread_result.error.message
-                )
-            if thread_result.thread is None:
-                raise FeedbackThreadCreationError(
-                    feedback.id, "No thread returned by create_thread"
-                )
+                if thread_result.error is not None:
+                    raise FeedbackThreadCreationError(
+                        feedback.id, thread_result.error.message
+                    )
+                if thread_result.thread is None:
+                    raise FeedbackThreadCreationError(
+                        feedback.id, "No thread returned by create_thread"
+                    )
+                thread_id = thread_result.thread.id
 
-            note_result = await plain.create_note(
-                CreateNoteInput(
-                    customer_id=customer_id,
-                    thread_id=thread_result.thread.id,
-                    text=feedback.message,
-                )
-            )
-            if note_result.error is not None:
-                raise FeedbackThreadCreationError(
-                    feedback.id, note_result.error.message
-                )
+                if transcript is not None:
+                    # Chat escalation: post the customer's message as if it came
+                    # from them, falling back to their original question when no
+                    # extra note was added.
+                    customer_message = note or _first_user_message(transcript)
+                    if customer_message:
+                        reply_result = await plain.reply_to_thread(
+                            ReplyToThreadInput(
+                                thread_id=thread_id,
+                                text_content=customer_message,
+                                impersonation=ImpersonationInput(
+                                    as_customer=CustomerImpersonationInput(
+                                        customer_identifier=CustomerIdentifierInput(
+                                            customer_id=customer_id
+                                        )
+                                    )
+                                ),
+                            )
+                        )
+                        if reply_result.error is not None:
+                            raise FeedbackThreadCreationError(
+                                feedback.id, reply_result.error.message
+                            )
+                    note_text = transcript
+                else:
+                    # Direct submission (e.g. manual backoffice reply for a bug
+                    # or feedback report): keep the message itself as the note.
+                    note_text = feedback.message
 
-            return plain_thread_url(thread_result.thread.id)
+                # Link back to the backoffice feedback record so whoever picks
+                # up the thread can jump straight to it.
+                backoffice_url = settings.generate_backoffice_url(
+                    f"/feedbacks/{feedback.id}"
+                )
+                note_result = await plain.create_note(
+                    CreateNoteInput(
+                        customer_id=customer_id,
+                        thread_id=thread_id,
+                        text=f"{note_text}\n\nView in backoffice: {backoffice_url}",
+                        markdown=(
+                            f"{note_text}\n\n[View in backoffice]({backoffice_url})"
+                        ),
+                    )
+                )
+                if note_result.error is not None:
+                    raise FeedbackThreadCreationError(
+                        feedback.id, note_result.error.message
+                    )
+
+                return plain_thread_url(thread_id)
+            except GraphQLClientHttpError as e:
+                # HTTP-level failures (e.g. 403 when the token lacks a required
+                # permission, or 5xx) aren't surfaced as GraphQL `.error`
+                # fields — wrap them with the failing operation, Plain's
+                # response body, and the token fingerprint so the real cause is
+                # visible instead of a generic guess.
+                raise FeedbackThreadCreationError(
+                    feedback.id, _format_plain_http_error(e)
+                ) from e
 
     async def check_thread_exists(
         self, customer_email: str, thread_title: str, fuzzy: bool = False

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -12,6 +12,7 @@ from polar.email_update import tasks as email_update
 from polar.event import tasks as event
 from polar.eventstream import tasks as eventstream
 from polar.external_event import tasks as external_event
+from polar.feedback import tasks as feedback
 from polar.integrations.chargeback_stop import tasks as chargeback_stop
 from polar.integrations.polar import tasks as polar_self
 from polar.integrations.stripe import tasks as stripe
@@ -48,6 +49,7 @@ __all__ = [
     "event",
     "eventstream",
     "external_event",
+    "feedback",
     "meter",
     "notifications",
     "order",

--- a/server/tests/feedback/test_service.py
+++ b/server/tests/feedback/test_service.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
 from polar.exceptions import PolarRequestValidationError
@@ -43,6 +44,48 @@ class TestSubmit:
         assert feedback.organization_id == organization.id
         assert feedback.type == FeedbackType.bug
         assert feedback.client_context == {"url": "https://polar.sh/dashboard"}
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user"))
+    async def test_question_enqueues_plain_reply(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        auth_subject: AuthSubject[User],
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.feedback.service.enqueue_job")
+
+        feedback = await feedback_service.submit(
+            session,
+            auth_subject,
+            _build_payload(
+                organization,
+                type=FeedbackType.question,
+                message="How do I configure custom domains?",
+            ),
+        )
+
+        enqueue_job_mock.assert_called_once_with(
+            "feedback.reply_in_plain", feedback_id=feedback.id
+        )
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user"))
+    async def test_non_question_does_not_enqueue_plain_reply(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        auth_subject: AuthSubject[User],
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.feedback.service.enqueue_job")
+
+        await feedback_service.submit(
+            session, auth_subject, _build_payload(organization, type=FeedbackType.bug)
+        )
+
+        enqueue_job_mock.assert_not_called()
 
     @pytest.mark.auth(AuthSubjectFixture(subject="user"))
     async def test_non_member_is_rejected(

--- a/server/tests/feedback/test_tasks.py
+++ b/server/tests/feedback/test_tasks.py
@@ -1,0 +1,82 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.feedback.repository import FeedbackRepository
+from polar.feedback.tasks import feedback_reply_in_plain
+from polar.models import Feedback, Organization, User
+from polar.models.feedback import FeedbackStatus, FeedbackType
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+async def _create_question(
+    save_fixture: SaveFixture,
+    user: User,
+    organization: Organization,
+) -> Feedback:
+    feedback = Feedback(
+        type=FeedbackType.question,
+        message="## Transcript\n\n**User**\n\nHow do I cancel?",
+        client_context={},
+        user=user,
+        organization=organization,
+    )
+    await save_fixture(feedback)
+    return feedback
+
+
+@pytest.mark.asyncio
+class TestFeedbackReplyInPlain:
+    async def test_marks_as_triaged_on_success(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+        organization: Organization,
+    ) -> None:
+        feedback = await _create_question(save_fixture, user, organization)
+        mocker.patch("polar.feedback.tasks.plain_service.enabled", new=True)
+        create_thread_mock = mocker.patch(
+            "polar.feedback.tasks.plain_service.create_feedback_thread",
+            return_value="https://app.plain.com/workspace/w/thread/th_123",
+        )
+
+        await feedback_reply_in_plain(feedback.id)
+
+        create_thread_mock.assert_called_once()
+
+        repository = FeedbackRepository.from_session(session)
+        updated = await repository.get_by_id(feedback.id)
+        assert updated is not None
+        assert updated.status == FeedbackStatus.triaged
+        assert (
+            updated.support_thread_url
+            == "https://app.plain.com/workspace/w/thread/th_123"
+        )
+
+    async def test_skips_when_thread_already_exists(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+        organization: Organization,
+    ) -> None:
+        feedback = await _create_question(save_fixture, user, organization)
+        feedback.support_thread_url = "https://app.plain.com/workspace/w/thread/th_old"
+        await save_fixture(feedback)
+
+        mocker.patch("polar.feedback.tasks.plain_service.enabled", new=True)
+        create_thread_mock = mocker.patch(
+            "polar.feedback.tasks.plain_service.create_feedback_thread",
+        )
+
+        await feedback_reply_in_plain(feedback.id)
+
+        create_thread_mock.assert_not_called()
+
+        repository = FeedbackRepository.from_session(session)
+        updated = await repository.get_by_id(feedback.id)
+        assert updated is not None
+        assert updated.status == FeedbackStatus.new

--- a/server/tests/integrations/plain/test_service.py
+++ b/server/tests/integrations/plain/test_service.py
@@ -8,11 +8,9 @@ from plain_client import (
     CustomerByEmailCustomerByEmail,
     UpsertCustomerUpsertCustomer,
 )
-from plain_client.exceptions import GraphQLClientHttpError
 from pytest_mock import MockerFixture
 
 from polar.integrations.plain.service import (
-    FeedbackThreadCreationError,
     PlainCustomerError,
     PlainService,
 )
@@ -184,37 +182,6 @@ class TestCreateFeedbackThread:
         note_input = feedback_thread_client.create_note.call_args.args[0]
         assert note_input.text.startswith("The dashboard is broken.")
         assert f"/feedbacks/{_FEEDBACK_ID}" in note_input.markdown
-
-    async def test_wraps_plain_http_error(
-        self,
-        mocker: MockerFixture,
-        plain_service: PlainService,
-        feedback_thread_client: MagicMock,
-    ) -> None:
-        mocker.patch.object(
-            type(plain_service), "enabled", True
-        )  # keep PLAIN_TOKEN fingerprint logic happy
-        mocker.patch(
-            "polar.integrations.plain.service.settings.PLAIN_TOKEN",
-            "plainApiKey_secret_D9J0",
-        )
-        # Plain returns 403 with a body naming the missing permission.
-        response = MagicMock()
-        response.text = '{"error":{"message":"Forbidden: missing thread:reply"}}'
-        response.request.content = b'{"operationName":"replyToThread"}'
-        feedback_thread_client.customer_by_email.side_effect = GraphQLClientHttpError(
-            status_code=403, response=response
-        )
-        feedback = _feedback(message="The dashboard is broken.", type=FeedbackType.bug)
-
-        with pytest.raises(FeedbackThreadCreationError) as excinfo:
-            await plain_service.create_feedback_thread(feedback)
-
-        message = str(excinfo.value)
-        assert "HTTP 403" in message
-        assert "replyToThread" in message  # which operation failed
-        assert "thread:reply" in message  # Plain's actual reason
-        assert "D9J0" in message  # token fingerprint actually used
 
 
 @pytest.mark.asyncio

--- a/server/tests/integrations/plain/test_service.py
+++ b/server/tests/integrations/plain/test_service.py
@@ -8,9 +8,16 @@ from plain_client import (
     CustomerByEmailCustomerByEmail,
     UpsertCustomerUpsertCustomer,
 )
+from plain_client.exceptions import GraphQLClientHttpError
 from pytest_mock import MockerFixture
 
-from polar.integrations.plain.service import PlainCustomerError, PlainService
+from polar.integrations.plain.service import (
+    FeedbackThreadCreationError,
+    PlainCustomerError,
+    PlainService,
+)
+from polar.models import Feedback, User
+from polar.models.feedback import FeedbackType
 
 
 @contextlib.asynccontextmanager
@@ -81,6 +88,180 @@ def plain_client(mocker: MockerFixture) -> MagicMock:
         return_value=_mock_client(client),
     )
     return client
+
+
+_FEEDBACK_ID = uuid.UUID("9627a2e3-b7e3-4c6a-9f00-13ed415849fd")
+
+
+def _feedback(*, message: str, type: FeedbackType = FeedbackType.question) -> Feedback:
+    user = User(email="user@example.com", email_verified=False)
+    return Feedback(id=_FEEDBACK_ID, type=type, message=message, user=user)
+
+
+def _ok_result() -> MagicMock:
+    result = MagicMock()
+    result.error = None
+    return result
+
+
+@pytest.fixture
+def feedback_thread_client(mocker: MockerFixture, plain_client: MagicMock) -> MagicMock:
+    # Don't hit the LLM gateway from thread-creation tests.
+    mocker.patch(
+        "polar.integrations.plain.service._generate_thread_subject",
+        AsyncMock(return_value="Generated subject"),
+    )
+    plain_client.customer_by_email.return_value = _customer_by_email_payload(
+        external_id=str(uuid.uuid4())
+    )
+    thread_result = _ok_result()
+    thread_result.thread.id = "t_123"
+    plain_client.create_thread = AsyncMock(return_value=thread_result)
+    plain_client.create_note = AsyncMock(return_value=_ok_result())
+    plain_client.reply_to_thread = AsyncMock(return_value=_ok_result())
+    return plain_client
+
+
+@pytest.mark.asyncio
+class TestCreateFeedbackThread:
+    async def test_impersonates_with_note_and_notes_transcript(
+        self,
+        plain_service: PlainService,
+        feedback_thread_client: MagicMock,
+    ) -> None:
+        transcript = "**User**\n\nHow do I do X?\n\n**Assistant**\n\nTry Y."
+        feedback = _feedback(
+            message=f"I still need help\n\n---\n\n## Transcript\n\n{transcript}"
+        )
+
+        url = await plain_service.create_feedback_thread(feedback)
+
+        assert url == (
+            "https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/t_123"
+        )
+        thread_input = feedback_thread_client.create_thread.call_args.args[0]
+        assert thread_input.title == "Generated subject"
+        feedback_thread_client.reply_to_thread.assert_awaited_once()
+        reply_input = feedback_thread_client.reply_to_thread.call_args.args[0]
+        assert reply_input.thread_id == "t_123"
+        assert reply_input.text_content == "I still need help"
+        assert (
+            reply_input.impersonation.as_customer.customer_identifier.customer_id
+            == "c_123"
+        )
+        note_input = feedback_thread_client.create_note.call_args.args[0]
+        assert note_input.text.startswith(transcript)
+        # The note links back to the backoffice feedback record.
+        assert f"/feedbacks/{_FEEDBACK_ID}" in note_input.markdown
+        assert "[View in backoffice]" in note_input.markdown
+
+    async def test_impersonates_with_original_question_when_no_note(
+        self,
+        plain_service: PlainService,
+        feedback_thread_client: MagicMock,
+    ) -> None:
+        transcript = "**User**\n\nHow do I do X?\n\n**Assistant**\n\nTry Y."
+        feedback = _feedback(message=f"## Transcript\n\n{transcript}")
+
+        await plain_service.create_feedback_thread(feedback)
+
+        reply_input = feedback_thread_client.reply_to_thread.call_args.args[0]
+        assert reply_input.text_content == "How do I do X?"
+        note_input = feedback_thread_client.create_note.call_args.args[0]
+        assert note_input.text.startswith(transcript)
+        assert f"/feedbacks/{_FEEDBACK_ID}" in note_input.markdown
+
+    async def test_direct_submission_keeps_message_as_note(
+        self,
+        plain_service: PlainService,
+        feedback_thread_client: MagicMock,
+    ) -> None:
+        feedback = _feedback(message="The dashboard is broken.", type=FeedbackType.bug)
+
+        await plain_service.create_feedback_thread(feedback)
+
+        feedback_thread_client.reply_to_thread.assert_not_awaited()
+        note_input = feedback_thread_client.create_note.call_args.args[0]
+        assert note_input.text.startswith("The dashboard is broken.")
+        assert f"/feedbacks/{_FEEDBACK_ID}" in note_input.markdown
+
+    async def test_wraps_plain_http_error(
+        self,
+        mocker: MockerFixture,
+        plain_service: PlainService,
+        feedback_thread_client: MagicMock,
+    ) -> None:
+        mocker.patch.object(
+            type(plain_service), "enabled", True
+        )  # keep PLAIN_TOKEN fingerprint logic happy
+        mocker.patch(
+            "polar.integrations.plain.service.settings.PLAIN_TOKEN",
+            "plainApiKey_secret_D9J0",
+        )
+        # Plain returns 403 with a body naming the missing permission.
+        response = MagicMock()
+        response.text = '{"error":{"message":"Forbidden: missing thread:reply"}}'
+        response.request.content = b'{"operationName":"replyToThread"}'
+        feedback_thread_client.customer_by_email.side_effect = GraphQLClientHttpError(
+            status_code=403, response=response
+        )
+        feedback = _feedback(message="The dashboard is broken.", type=FeedbackType.bug)
+
+        with pytest.raises(FeedbackThreadCreationError) as excinfo:
+            await plain_service.create_feedback_thread(feedback)
+
+        message = str(excinfo.value)
+        assert "HTTP 403" in message
+        assert "replyToThread" in message  # which operation failed
+        assert "thread:reply" in message  # Plain's actual reason
+        assert "D9J0" in message  # token fingerprint actually used
+
+
+@pytest.mark.asyncio
+class TestGenerateThreadSubject:
+    async def test_returns_model_output(self, mocker: MockerFixture) -> None:
+        from polar.integrations.plain.service import _generate_thread_subject
+
+        get_model = mocker.patch(
+            "polar.integrations.plain.service.settings.get_pydantic_gateway_model",
+            return_value=(MagicMock(), "openai", "gpt-5.5"),
+        )
+        agent = MagicMock()
+        agent.run = AsyncMock(
+            return_value=MagicMock(output='  "Custom domain setup"  ')
+        )
+        agent_cls = mocker.patch(
+            "polar.integrations.plain.service.Agent", return_value=agent
+        )
+
+        subject = await _generate_thread_subject(
+            "How do I set up a domain?", "Fallback"
+        )
+
+        assert subject == "Custom domain setup"
+        # Uses the configured default model (no hardcoded provider).
+        get_model.assert_called_once_with()
+        # gpt-5.5 rejects a non-default temperature.
+        assert agent_cls.call_args.kwargs["model_settings"] == {}
+
+    async def test_falls_back_on_error(self, mocker: MockerFixture) -> None:
+        from polar.integrations.plain.service import _generate_thread_subject
+
+        mocker.patch(
+            "polar.integrations.plain.service.settings.get_pydantic_gateway_model",
+            side_effect=RuntimeError("gateway down"),
+        )
+
+        subject = await _generate_thread_subject("Anything", "Re: your recent question")
+
+        assert subject == "Re: your recent question"
+
+    async def test_falls_back_on_empty_content(self) -> None:
+        from polar.integrations.plain.service import _generate_thread_subject
+
+        subject = await _generate_thread_subject("   ", "Re: your recent question")
+
+        assert subject == "Re: your recent question"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Question-type feedback submissions now enqueue background processing to automatically create Plain support threads.
  * Thread subjects are generated via an AI-driven helper with robust fallback handling.
  * When present, transcripts are posted as customer messages and preserved; otherwise original messages become internal notes.
  * Feedback records are updated to persist support thread URLs and mark triaged status after thread creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->