### PR TITLE
amount v2: Migrate disputes amount to bigint

### DIFF
--- a/server/migrations/versions/2026-06-01-1442_widen_disputes_amounts_to_bigint.py
+++ b/server/migrations/versions/2026-06-01-1442_widen_disputes_amounts_to_bigint.py
@@ -1,0 +1,56 @@
+"""widen disputes amounts to bigint
+
+Revision ID: 10b4f3608e4f
+Revises: 35e9e6992886
+Create Date: 2026-06-01 14:02:31.680817
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "10b4f3608e4f"
+down_revision = "35e9e6992886"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '2s'")
+    op.alter_column(
+        "disputes",
+        "amount",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "disputes",
+        "tax_amount",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '2s'")
+    # WARNING: Rolling back will FAIL if any disputes.amount or tax_amount value
+    # exceeds INTEGER max (2,147,483,647). Check data before downgrading.
+    op.alter_column(
+        "disputes",
+        "tax_amount",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "disputes",
+        "amount",
+        existing_type=sa.BigInteger(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )

--- a/server/polar/models/dispute.py
+++ b/server/polar/models/dispute.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
 from sqlalchemy import (
+    BigInteger,
     ColumnElement,
     ForeignKey,
-    Integer,
     String,
     UniqueConstraint,
     Uuid,
@@ -78,8 +78,8 @@ class Dispute(RecordModel):
     status: Mapped[DisputeStatus] = mapped_column(
         StringEnum(DisputeStatus), nullable=False
     )
-    amount: Mapped[int] = mapped_column(Integer, nullable=False)
-    tax_amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    tax_amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
 
     payment_processor: Mapped[PaymentProcessor | None] = mapped_column(


### PR DESCRIPTION
Since the table is so small, we can do this as an online alter table without having to create a separate column and backfill.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased storage capacity for dispute amounts to support larger values in the database; includes a migration to apply the change safely (note: downgrading may fail if values exceed the previous limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->