### PR TITLE
amount v2: Increase max amount for specific currencies

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26769,12 +26769,29 @@ export interface components {
        *     - YER: 200
        *     - ZAR: 9
        *     - ZMW: 10
+       *     - Other currencies: 0.5
        * @default 50
        */
       minimum_amount: number
       /**
        * Maximum Amount
-       * @description The maximum amount the customer can pay.
+       * @description The maximum amount the customer can pay. Maximum per currency:
+       *     - USD: 999,999.99
+       *     - EUR: 999,999.99
+       *     - GBP: 999,999.99
+       *     - ARS: 1,400,000
+       *     - CDF: 2,800,000
+       *     - COP: 4,000,000
+       *     - IDR: 16,000,000
+       *     - KHR: 4,000,000
+       *     - LAK: 21,000,000
+       *     - MNT: 3,500,000
+       *     - MWK: 1,750,000
+       *     - NGN: 1,550,000
+       *     - TZS: 2,500,000
+       *     - UGX: 3,700,000
+       *     - UZS: 12,500,000
+       *     - Other currencies: 999,999.99
        */
       maximum_amount?: number | null
       /**
@@ -26906,6 +26923,7 @@ export interface components {
        *     - YER: 200
        *     - ZAR: 9
        *     - ZMW: 10
+       *     - Other currencies: 0.5
        */
       preset_amount?: number | null
     }
@@ -27109,6 +27127,7 @@ export interface components {
        *     - YER: 200
        *     - ZAR: 9
        *     - ZMW: 10
+       *     - Other currencies: 0.5
        */
       price_amount: number
     }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26769,7 +26769,7 @@ export interface components {
        *     - YER: 200
        *     - ZAR: 9
        *     - ZMW: 10
-       *     - Other currencies: 0.5
+       *     - Other currencies: 50 minor units
        * @default 50
        */
       minimum_amount: number
@@ -26791,7 +26791,7 @@ export interface components {
        *     - TZS: 2,500,000
        *     - UGX: 3,700,000
        *     - UZS: 12,500,000
-       *     - Other currencies: 999,999.99
+       *     - Other currencies: 99,999,999 minor units
        */
       maximum_amount?: number | null
       /**
@@ -26923,7 +26923,7 @@ export interface components {
        *     - YER: 200
        *     - ZAR: 9
        *     - ZMW: 10
-       *     - Other currencies: 0.5
+       *     - Other currencies: 50 minor units
        */
       preset_amount?: number | null
     }
@@ -27127,7 +27127,7 @@ export interface components {
        *     - YER: 200
        *     - ZAR: 9
        *     - ZMW: 10
-       *     - Other currencies: 0.5
+       *     - Other currencies: 50 minor units
        */
       price_amount: number
     }

--- a/server/polar/kit/currency.py
+++ b/server/polar/kit/currency.py
@@ -355,7 +355,7 @@ MINIMUM_PRICE_PER_CURRENCY_DOCSTRING = "\n".join(
             f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
             for currency, amount in MINIMUM_PRICE_PER_CURRENCY.items()
         ),
-        f"- Other currencies: {format_decimal(MINIMUM_PRICE_PER_CURRENCY_DEFAULT / 100, locale='en_US', decimal_quantization=False)}",
+        f"- Other currencies: {format_decimal(MINIMUM_PRICE_PER_CURRENCY_DEFAULT, locale='en_US', decimal_quantization=False)} minor units",
     ]
 )
 
@@ -386,7 +386,7 @@ MAXIMUM_PRICE_PER_CURRENCY_DOCSTRING = "\n".join(
             f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
             for currency, amount in MAXIMUM_PRICE_PER_CURRENCY.items()
         ),
-        f"- Other currencies: {format_decimal(MAXIMUM_PRICE_PER_CURRENCY_DEFAULT / 100, locale='en_US', decimal_quantization=False)}",
+        f"- Other currencies: {format_decimal(MAXIMUM_PRICE_PER_CURRENCY_DEFAULT, locale='en_US', decimal_quantization=False)} minor units",
     ]
 )
 

--- a/server/polar/kit/currency.py
+++ b/server/polar/kit/currency.py
@@ -219,6 +219,7 @@ def format_currency(
 # of the target currency.
 # Comment added for the cases where our minimum differs from Stripe's.
 # Ref: https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts
+MINIMUM_PRICE_PER_CURRENCY_DEFAULT = 50
 MINIMUM_PRICE_PER_CURRENCY: dict[str, int] = {
     "usd": 50,
     "aed": 200,
@@ -349,8 +350,44 @@ MINIMUM_PRICE_PER_CURRENCY: dict[str, int] = {
 }
 
 MINIMUM_PRICE_PER_CURRENCY_DOCSTRING = "\n".join(
-    f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
-    for currency, amount in MINIMUM_PRICE_PER_CURRENCY.items()
+    [
+        *(
+            f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
+            for currency, amount in MINIMUM_PRICE_PER_CURRENCY.items()
+        ),
+        f"- Other currencies: {format_decimal(MINIMUM_PRICE_PER_CURRENCY_DEFAULT / 100, locale='en_US', decimal_quantization=False)}",
+    ]
+)
+
+# Maximums for currencies whose weak per-USD rate makes the default ceiling too low.
+# Everything else falls back to the default.
+MAXIMUM_PRICE_PER_CURRENCY_DEFAULT = 999_999_99
+MAXIMUM_PRICE_PER_CURRENCY: dict[str, int] = {
+    "usd": MAXIMUM_PRICE_PER_CURRENCY_DEFAULT,
+    "eur": MAXIMUM_PRICE_PER_CURRENCY_DEFAULT,
+    "gbp": MAXIMUM_PRICE_PER_CURRENCY_DEFAULT,
+    "ars": 1_400_000_00,  # 1,400,000.00 ARS ≈ $1,000
+    "cdf": 2_800_000_00,  # 2,800,000.00 CDF ≈ $1,000
+    "cop": 4_000_000_00,  # 4,000,000.00 COP ≈ $1,000
+    "idr": 16_000_000_00,  # 16,000,000.00 IDR ≈ $1,000
+    "khr": 4_000_000_00,  # 4,000,000.00 KHR ≈ $1,000
+    "lak": 21_000_000_00,  # 21,000,000.00 LAK ≈ $1,000
+    "mnt": 3_500_000_00,  # 3,500,000.00 MNT ≈ $1,000
+    "mwk": 1_750_000_00,  # 1,750,000.00 MWK ≈ $1,000
+    "ngn": 1_550_000_00,  # 1,550,000.00 NGN ≈ $1,000
+    "tzs": 2_500_000_00,  # 2,500,000.00 TZS ≈ $1,000
+    "ugx": 3_700_000_00,  # 3,700,000.00 UGX ≈ $1,000
+    "uzs": 12_500_000_00,  # 12,500,000.00 UZS ≈ $1,000
+}
+
+MAXIMUM_PRICE_PER_CURRENCY_DOCSTRING = "\n".join(
+    [
+        *(
+            f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
+            for currency, amount in MAXIMUM_PRICE_PER_CURRENCY.items()
+        ),
+        f"- Other currencies: {format_decimal(MAXIMUM_PRICE_PER_CURRENCY_DEFAULT / 100, locale='en_US', decimal_quantization=False)}",
+    ]
 )
 
 
@@ -363,7 +400,9 @@ def get_minimum_currency_amount(currency: PresentmentCurrency | str) -> int:
     Returns:
         The minimum price amount in the smallest currency unit.
     """
-    return MINIMUM_PRICE_PER_CURRENCY.get(currency.lower(), 50)
+    return MINIMUM_PRICE_PER_CURRENCY.get(
+        currency.lower(), MINIMUM_PRICE_PER_CURRENCY_DEFAULT
+    )
 
 
 def get_maximum_currency_amount(currency: PresentmentCurrency | str) -> int:
@@ -375,4 +414,6 @@ def get_maximum_currency_amount(currency: PresentmentCurrency | str) -> int:
     Returns:
         The maximum price amount in the smallest currency unit.
     """
-    return 99999999  # TODO: Define maximum price amounts per currency
+    return MAXIMUM_PRICE_PER_CURRENCY.get(
+        currency.lower(), MAXIMUM_PRICE_PER_CURRENCY_DEFAULT
+    )

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -23,6 +23,7 @@ from polar.custom_field.schemas import (
 from polar.enums import SubscriptionRecurringInterval, TaxBehaviorOption
 from polar.file.schemas import ProductMediaFileRead
 from polar.kit.currency import (
+    MAXIMUM_PRICE_PER_CURRENCY_DOCSTRING,
     MINIMUM_PRICE_PER_CURRENCY_DOCSTRING,
     PresentmentCurrency,
     format_currency,
@@ -195,7 +196,10 @@ class ProductPriceCustomCreate(ProductPriceCreateBase):
     )
     maximum_amount: PriceAmount | None = Field(
         default=None,
-        description="The maximum amount the customer can pay.",
+        description=(
+            "The maximum amount the customer can pay. "
+            f"Maximum per currency:\n{MAXIMUM_PRICE_PER_CURRENCY_DOCSTRING}"
+        ),
     )
     preset_amount: PriceAmount | None = Field(
         default=None,


### PR DESCRIPTION
Now that all of the amounts have been migrated to bigint, we can increase the max amount for specific currencies.

This commit sets it to k for the ones that are specified. To be updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-currency maximum price configuration with a sensible default fallback and case-insensitive currency handling.
  * Minimum price now uses a configurable default fallback (case-insensitive) instead of a single hardcoded value.

* **Documentation**
  * Product pricing descriptions updated to show per-currency maximums and clarify maximum/minimum amount behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->