### PR TITLE
feat: add Firecrawl Cloud scraper behind a toggle for organization review

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -241,6 +241,16 @@ class Settings(BaseSettings):
     PYDANTIC_AI_GATEWAY_API_KEY: str = "DummyKey"
     PYDANTIC_AI_GATEWAY_MODEL: str = "openai:gpt-5.5"
 
+    # Organization review website scraping
+    FIRECRAWL_API_KEY: str | None = None
+    # Which scraper backs the JS-render path of the organization-review website
+    # collector. "playwright" uses the in-house headless browser, "firecrawl"
+    # uses Firecrawl Cloud, and "shadow" runs Firecrawl alongside Playwright to
+    # log a comparison while still using Playwright's result for the live verdict.
+    ORGANIZATION_REVIEW_SCRAPER: Literal["playwright", "firecrawl", "shadow"] = (
+        "playwright"
+    )
+
     # Stripe
     STRIPE_SECRET_KEY: str = ""
     STRIPE_PUBLISHABLE_KEY: str = ""

--- a/server/polar/organization_review/collectors/firecrawl_client.py
+++ b/server/polar/organization_review/collectors/firecrawl_client.py
@@ -1,0 +1,90 @@
+"""Thin wrapper around the Firecrawl Cloud `/scrape` endpoint.
+
+Firecrawl renders JavaScript, evades bot/Cloudflare blocks, and uses proxies
+server-side, so it replaces the in-house headless Chromium (Playwright) used by
+the organization-review website collector. The browser egress is now Firecrawl's
+network rather than ours.
+"""
+
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import structlog
+
+from polar.config import settings
+
+if TYPE_CHECKING:
+    from firecrawl import AsyncFirecrawl
+
+log = structlog.get_logger(__name__)
+
+# Firecrawl expresses both of these in milliseconds. `wait_for` gives JS-heavy
+# SPAs a moment to hydrate; `timeout` caps a single scrape. Kept well under the
+# website collector's 90s OVERALL_TIMEOUT_S budget.
+_SCRAPE_WAIT_FOR_MS = 2_000
+_SCRAPE_TIMEOUT_MS = 30_000
+
+
+@dataclass
+class ScrapeResult:
+    """Normalized result of a Firecrawl scrape."""
+
+    markdown: str
+    url: str
+    """Final URL after any HTTP/JS/meta-refresh redirects."""
+    status_code: int | None
+    title: str | None
+
+
+@functools.cache
+def _get_client() -> AsyncFirecrawl:
+    """Lazily build a singleton Firecrawl client.
+
+    Imported lazily (and cached) so that importing this module — or running the
+    collector with the Playwright scraper selected — never requires the
+    Firecrawl SDK to be configured. Mirrors the `_get_website_agent` pattern.
+    """
+    from firecrawl import AsyncFirecrawl
+
+    api_key = settings.FIRECRAWL_API_KEY
+    if not api_key:
+        raise RuntimeError("FIRECRAWL_API_KEY is not configured")
+    return AsyncFirecrawl(api_key=api_key)
+
+
+async def scrape_markdown(url: str) -> ScrapeResult:
+    """Scrape a URL via Firecrawl Cloud and return its main-content markdown.
+
+    Renders JavaScript and follows redirects server-side. Raises on transport
+    or API errors — callers map those onto their own error contracts.
+    """
+    client = _get_client()
+    doc = await client.scrape(
+        url,
+        formats=["markdown"],
+        only_main_content=True,
+        wait_for=_SCRAPE_WAIT_FOR_MS,
+        timeout=_SCRAPE_TIMEOUT_MS,
+    )
+
+    # The SDK snake_cases the camelCase API. `metadata.url` is the post-redirect
+    # final URL; `metadata.source_url` is the URL we requested. Fall through both
+    # to the requested URL so callers always get a usable value.
+    metadata = doc.metadata
+    final_url = url
+    status_code: int | None = None
+    title: str | None = None
+    if metadata is not None:
+        final_url = metadata.url or metadata.source_url or url
+        status_code = metadata.status_code
+        title = metadata.title
+
+    return ScrapeResult(
+        markdown=doc.markdown or "",
+        url=final_url,
+        status_code=status_code,
+        title=title,
+    )

--- a/server/polar/organization_review/collectors/firecrawl_client.py
+++ b/server/polar/organization_review/collectors/firecrawl_client.py
@@ -70,15 +70,14 @@ async def scrape_markdown(url: str) -> ScrapeResult:
         timeout=_SCRAPE_TIMEOUT_MS,
     )
 
-    # The SDK snake_cases the camelCase API. `metadata.url` is the post-redirect
-    # final URL; `metadata.source_url` is the URL we requested. Fall through both
-    # to the requested URL so callers always get a usable value.
+    # `metadata.url` is the final URL after any redirects; fall back to the
+    # requested URL when Firecrawl doesn't report one.
     metadata = doc.metadata
     final_url = url
     status_code: int | None = None
     title: str | None = None
     if metadata is not None:
-        final_url = metadata.url or metadata.source_url or url
+        final_url = metadata.url or url
         status_code = metadata.status_code
         title = metadata.title
 

--- a/server/polar/organization_review/collectors/setup.py
+++ b/server/polar/organization_review/collectors/setup.py
@@ -5,6 +5,7 @@ import httpx
 import structlog
 from playwright.async_api import async_playwright
 
+from polar.config import settings
 from polar.kit.http import SSRFBlockedError, resolve_and_validate_ip
 from polar.models.checkout_link import CheckoutLink
 from polar.models.webhook_endpoint import WebhookEndpoint
@@ -20,6 +21,7 @@ from ..schemas import (
     UrlRedirectInfo,
     WebhookEndpointData,
 )
+from .firecrawl_client import scrape_markdown
 
 log = structlog.get_logger(__name__)
 
@@ -155,6 +157,21 @@ def _pick_one_per_hostname(urls: list[str]) -> list[str]:
 
 
 async def _resolve_redirect_with_browser(url: str) -> UrlRedirectInfo:
+    """Detect client-side redirects (meta refresh, JS) for a single URL.
+
+    Dispatches to the configured scraper: the in-house Playwright browser,
+    Firecrawl Cloud, or (in shadow mode) both — logging a comparison while
+    returning Playwright's result for the live verdict.
+    """
+    scraper = settings.ORGANIZATION_REVIEW_SCRAPER
+    if scraper == "firecrawl":
+        return await _resolve_redirect_firecrawl(url)
+    if scraper == "shadow":
+        return await _resolve_redirect_shadow(url)
+    return await _resolve_redirect_playwright(url)
+
+
+async def _resolve_redirect_playwright(url: str) -> UrlRedirectInfo:
     """Use a headless browser to detect client-side redirects (meta refresh, JS).
 
     Launches a fresh Playwright browser, navigates to the URL, waits for
@@ -235,6 +252,61 @@ async def _resolve_redirect_with_browser(url: str) -> UrlRedirectInfo:
                 await pw.stop()
             except Exception:
                 pass
+
+
+async def _resolve_redirect_firecrawl(url: str) -> UrlRedirectInfo:
+    """Use Firecrawl Cloud to detect client-side redirects (meta refresh, JS).
+
+    Firecrawl follows HTTP/JS/meta-refresh redirects server-side and reports the
+    final URL; we compare its domain against the original. Egress is Firecrawl's
+    network, so the per-hop SSRF interceptor is dropped — the scheme/host
+    pre-flight remains.
+    """
+    try:
+        _validate_url_scheme(url)
+        await _validate_url_host(url)
+    except (ValueError, SSRFBlockedError):
+        return UrlRedirectInfo(original_url=url, error="blocked")
+
+    try:
+        result = await scrape_markdown(url)
+    except Exception:
+        log.warning("setup_collector.firecrawl_redirect_error", url=url, exc_info=True)
+        return UrlRedirectInfo(original_url=url, error="browser_error")
+
+    final_url = result.url
+    final_domain = _extract_domain(final_url)
+    original_domain = _extract_domain(url)
+    redirected = _is_cross_domain(original_domain, final_domain)
+    return UrlRedirectInfo(
+        original_url=url,
+        final_url=final_url,
+        final_domain=final_domain,
+        redirected=redirected,
+    )
+
+
+async def _resolve_redirect_shadow(url: str) -> UrlRedirectInfo:
+    """Run Firecrawl alongside Playwright, log a comparison, return Playwright's.
+
+    The two resolvers run concurrently so the observational Firecrawl scrape
+    doesn't add its latency on top of Playwright's for every URL.
+    """
+    firecrawl_result, playwright_result = await asyncio.gather(
+        _resolve_redirect_firecrawl(url),
+        _resolve_redirect_playwright(url),
+    )
+    log.info(
+        "setup_collector.shadow_compare",
+        url=url,
+        playwright_redirected=playwright_result.redirected,
+        playwright_final_url=playwright_result.final_url,
+        playwright_error=playwright_result.error,
+        firecrawl_redirected=firecrawl_result.redirected,
+        firecrawl_final_url=firecrawl_result.final_url,
+        firecrawl_error=firecrawl_result.error,
+    )
+    return playwright_result
 
 
 async def resolve_url_redirects(urls: list[str]) -> list[UrlRedirectInfo]:

--- a/server/polar/organization_review/collectors/website.py
+++ b/server/polar/organization_review/collectors/website.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import functools
 import re
+import time
 from dataclasses import dataclass, field
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -17,6 +19,7 @@ from polar.kit.http import SSRFBlockedError, resolve_and_validate_ip
 from polar.observability.baggage import organization_baggage
 
 from ..schemas import UsageInfo, WebsiteData, WebsitePage
+from .firecrawl_client import scrape_markdown
 
 log = structlog.get_logger(__name__)
 
@@ -393,6 +396,16 @@ Slower but handles SPAs and JS-heavy sites. Use when fetch_page returns empty co
     if not _is_allowed_origin(url, deps.allowed_domain):
         return f"Error: URL is off-origin (only {deps.allowed_domain} is allowed)"
 
+    scraper = settings.ORGANIZATION_REVIEW_SCRAPER
+    if scraper == "firecrawl":
+        return await _browse_page_firecrawl(deps, url)
+    if scraper == "shadow":
+        return await _browse_page_shadow(deps, url)
+    return await _browse_page_playwright(deps, url)
+
+
+async def _browse_page_playwright(deps: WebsiteDeps, url: str) -> str:
+    """Render a page with the in-house headless browser (Playwright)."""
     # SSRF pre-check (defense-in-depth — interceptor also blocks)
     initial_host = urlparse(url).hostname
     if initial_host:
@@ -465,6 +478,115 @@ Slower but handles SPAs and JS-heavy sites. Use when fetch_page returns empty co
         truncated=truncated,
         links=links,
     )
+
+
+async def _browse_page_firecrawl(deps: WebsiteDeps, url: str) -> str:
+    """Render a page via Firecrawl Cloud.
+
+    Firecrawl's browser egress is external, so the per-hop SSRF interceptor is
+    dropped — the cheap origin pre-flight (already done by the caller) plus the
+    origin-lock on the returned final URL remain.
+    """
+    deps.pages_navigated += 1
+
+    try:
+        result = await scrape_markdown(url)
+    except Exception as e:
+        return f"Error navigating to {url}: {str(e)[:100]}"
+
+    if result.status_code is not None and result.status_code >= 400:
+        return f"Error: HTTP {result.status_code} for {url}"
+
+    # Post-navigation origin check — catch JS-driven redirects
+    current_url = result.url
+    if not _is_allowed_origin(current_url, deps.allowed_domain):
+        return (
+            f"Error: page redirected to off-origin URL {current_url} "
+            f"(only {deps.allowed_domain} is allowed)"
+        )
+
+    content = result.markdown
+    title = result.title or None
+
+    truncated = len(content) > MAX_CHARS_PER_PAGE
+    if truncated:
+        content = content[:MAX_CHARS_PER_PAGE]
+
+    deps.pages_visited.append(
+        WebsitePage(
+            url=current_url,
+            title=title,
+            content=content,
+            content_truncated=truncated,
+            method="browser",
+        )
+    )
+
+    return _build_tool_response(
+        title=title,
+        current_url=current_url,
+        pages_navigated=deps.pages_navigated,
+        content=content,
+        truncated=truncated,
+        links=[],
+    )
+
+
+async def _browse_page_shadow(deps: WebsiteDeps, url: str) -> str:
+    """Run Firecrawl alongside Playwright, log a comparison, return Playwright's.
+
+    Observational: the Firecrawl scrape never raises and never touches
+    `pages_navigated` / `pages_visited` — only Playwright's result is used. The
+    two run concurrently so the shadow scrape never adds to the live verdict's
+    latency (which is bounded by `OVERALL_TIMEOUT_S`).
+    """
+    pages_before = len(deps.pages_visited)
+    observation, response = await asyncio.gather(
+        _firecrawl_observe(url),
+        _browse_page_playwright(deps, url),
+    )
+
+    # Only attribute a page to this call if Playwright actually appended one;
+    # otherwise pages_visited[-1] would be a stale page from an earlier call.
+    playwright_page = (
+        deps.pages_visited[-1] if len(deps.pages_visited) > pages_before else None
+    )
+    log.info(
+        "website_collector.shadow_compare",
+        url=url,
+        playwright_markdown_length=(
+            len(playwright_page.content) if playwright_page else 0
+        ),
+        playwright_final_url=playwright_page.url if playwright_page else None,
+        **observation,
+    )
+    return response
+
+
+async def _firecrawl_observe(url: str) -> dict[str, Any]:
+    """Scrape via Firecrawl for shadow comparison. Never raises; returns log fields.
+
+    Success and failure return the same set of keys so the `shadow_compare` log
+    event has a stable schema for downstream comparison queries.
+    """
+    start = time.monotonic()
+    try:
+        result = await scrape_markdown(url)
+    except Exception as e:
+        return {
+            "firecrawl_markdown_length": 0,
+            "firecrawl_final_url": None,
+            "firecrawl_status_code": None,
+            "firecrawl_latency_ms": int((time.monotonic() - start) * 1000),
+            "firecrawl_error": str(e)[:200],
+        }
+    return {
+        "firecrawl_markdown_length": len(result.markdown),
+        "firecrawl_final_url": result.url,
+        "firecrawl_status_code": result.status_code,
+        "firecrawl_latency_ms": int((time.monotonic() - start) * 1000),
+        "firecrawl_error": None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "clickhouse-connect[async]>=1.0.1",
   "playwright>=1.60.0",
   "trafilatura>=2.0.0",
+  "firecrawl-py>=4.28.0",
   "polar-sdk==0.31.5",
   "anyio>=4.13.0",
   "markdown-it-py>=4.2.0",

--- a/server/tests/organization_review/collectors/test_firecrawl_client.py
+++ b/server/tests/organization_review/collectors/test_firecrawl_client.py
@@ -16,16 +16,13 @@ def _doc(
     *,
     markdown: str | None = None,
     url: str | None = None,
-    source_url: str | None = None,
     status_code: int | None = None,
     title: str | None = None,
     with_metadata: bool = True,
 ) -> SimpleNamespace:
     """Build a stand-in for firecrawl.v2.types.Document."""
     metadata = (
-        SimpleNamespace(
-            url=url, source_url=source_url, status_code=status_code, title=title
-        )
+        SimpleNamespace(url=url, status_code=status_code, title=title)
         if with_metadata
         else None
     )
@@ -40,12 +37,11 @@ def _patch_client(doc: SimpleNamespace) -> Any:
 
 class TestScrapeMarkdown:
     @pytest.mark.asyncio
-    async def test_prefers_metadata_url_as_final_url(self) -> None:
-        """metadata.url is the post-redirect final URL and wins over source_url."""
+    async def test_uses_metadata_url_as_final_url(self) -> None:
+        """metadata.url is the post-redirect final URL, used in preference to the request."""
         doc = _doc(
             markdown="# Hi",
             url="https://final.example.com/",
-            source_url="https://requested.example.com/",
             status_code=200,
             title="Title",
         )
@@ -68,17 +64,12 @@ class TestScrapeMarkdown:
         assert "timeout" in kwargs
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_source_url_when_url_missing(self) -> None:
-        doc = _doc(
-            markdown="x",
-            url=None,
-            source_url="https://source.example.com/",
-            status_code=200,
-        )
+    async def test_falls_back_to_requested_url_when_metadata_url_missing(self) -> None:
+        doc = _doc(markdown="x", url=None, status_code=200)
         with _patch_client(doc):
             result = await scrape_markdown("https://requested.example.com/")
 
-        assert result.url == "https://source.example.com/"
+        assert result.url == "https://requested.example.com/"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_requested_url_when_metadata_missing(self) -> None:

--- a/server/tests/organization_review/collectors/test_firecrawl_client.py
+++ b/server/tests/organization_review/collectors/test_firecrawl_client.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from polar.config import settings
+from polar.organization_review.collectors import firecrawl_client
+from polar.organization_review.collectors.firecrawl_client import (
+    ScrapeResult,
+    scrape_markdown,
+)
+
+
+def _doc(
+    *,
+    markdown: str | None = None,
+    url: str | None = None,
+    source_url: str | None = None,
+    status_code: int | None = None,
+    title: str | None = None,
+    with_metadata: bool = True,
+) -> SimpleNamespace:
+    """Build a stand-in for firecrawl.v2.types.Document."""
+    metadata = (
+        SimpleNamespace(
+            url=url, source_url=source_url, status_code=status_code, title=title
+        )
+        if with_metadata
+        else None
+    )
+    return SimpleNamespace(markdown=markdown, metadata=metadata)
+
+
+def _patch_client(doc: SimpleNamespace) -> Any:
+    client = AsyncMock()
+    client.scrape = AsyncMock(return_value=doc)
+    return patch.object(firecrawl_client, "_get_client", return_value=client)
+
+
+class TestScrapeMarkdown:
+    @pytest.mark.asyncio
+    async def test_prefers_metadata_url_as_final_url(self) -> None:
+        """metadata.url is the post-redirect final URL and wins over source_url."""
+        doc = _doc(
+            markdown="# Hi",
+            url="https://final.example.com/",
+            source_url="https://requested.example.com/",
+            status_code=200,
+            title="Title",
+        )
+        with _patch_client(doc) as get_client:
+            result = await scrape_markdown("https://requested.example.com/")
+
+        assert isinstance(result, ScrapeResult)
+        assert result.url == "https://final.example.com/"
+        assert result.markdown == "# Hi"
+        assert result.status_code == 200
+        assert result.title == "Title"
+
+        client = get_client.return_value
+        client.scrape.assert_awaited_once()
+        args, kwargs = client.scrape.call_args
+        assert args[0] == "https://requested.example.com/"
+        assert kwargs["formats"] == ["markdown"]
+        assert kwargs["only_main_content"] is True
+        assert "wait_for" in kwargs
+        assert "timeout" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_source_url_when_url_missing(self) -> None:
+        doc = _doc(
+            markdown="x",
+            url=None,
+            source_url="https://source.example.com/",
+            status_code=200,
+        )
+        with _patch_client(doc):
+            result = await scrape_markdown("https://requested.example.com/")
+
+        assert result.url == "https://source.example.com/"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_requested_url_when_metadata_missing(self) -> None:
+        doc = _doc(markdown="x", with_metadata=False)
+        with _patch_client(doc):
+            result = await scrape_markdown("https://requested.example.com/")
+
+        assert result.url == "https://requested.example.com/"
+        assert result.status_code is None
+        assert result.title is None
+
+    @pytest.mark.asyncio
+    async def test_none_markdown_becomes_empty_string(self) -> None:
+        doc = _doc(markdown=None, url="https://example.com/", status_code=200)
+        with _patch_client(doc):
+            result = await scrape_markdown("https://example.com/")
+
+        assert result.markdown == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_get_client raises a clear error when the key isn't configured."""
+        firecrawl_client._get_client.cache_clear()
+        monkeypatch.setattr(settings, "FIRECRAWL_API_KEY", None)
+        try:
+            with pytest.raises(RuntimeError, match="FIRECRAWL_API_KEY"):
+                await scrape_markdown("https://example.com/")
+        finally:
+            firecrawl_client._get_client.cache_clear()

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -1,11 +1,14 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.config import settings
+from polar.organization_review.collectors.firecrawl_client import ScrapeResult
 from polar.organization_review.collectors.setup import (
     _extract_domain,
     _normalize_domain,
+    _resolve_redirect_with_browser,
     collect_setup_data,
     resolve_url_redirects,
 )
@@ -574,3 +577,182 @@ class TestResolveUrlRedirects:
         assert len(results) == 1
         assert results[0].error == "browser_error"
         assert results[0].redirected is False
+
+
+class TestResolveRedirectWithBrowserDispatch:
+    """The redirect resolver dispatches to the configured scraper."""
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_playwright(self, mocker: MockerFixture) -> None:
+        playwright = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
+            new_callable=AsyncMock,
+            return_value=UrlRedirectInfo(original_url="https://example.com/"),
+        )
+        firecrawl = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
+            new_callable=AsyncMock,
+        )
+
+        await _resolve_redirect_with_browser("https://example.com/")
+
+        playwright.assert_called_once_with("https://example.com/")
+        firecrawl.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_toggle_uses_firecrawl(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "firecrawl")
+        playwright = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
+            new_callable=AsyncMock,
+        )
+        firecrawl = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
+            new_callable=AsyncMock,
+            return_value=UrlRedirectInfo(original_url="https://example.com/"),
+        )
+
+        await _resolve_redirect_with_browser("https://example.com/")
+
+        firecrawl.assert_called_once_with("https://example.com/")
+        playwright.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shadow_returns_playwright_runs_both(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "shadow")
+        playwright_result = UrlRedirectInfo(
+            original_url="https://example.com/",
+            final_url="https://example.com/",
+            final_domain="example.com",
+            redirected=False,
+        )
+        firecrawl_result = UrlRedirectInfo(
+            original_url="https://example.com/",
+            final_url="https://scam.com/",
+            final_domain="scam.com",
+            redirected=True,
+        )
+        playwright = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
+            new_callable=AsyncMock,
+            return_value=playwright_result,
+        )
+        firecrawl = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
+            new_callable=AsyncMock,
+            return_value=firecrawl_result,
+        )
+
+        result = await _resolve_redirect_with_browser("https://example.com/")
+
+        assert result is playwright_result
+        playwright.assert_called_once()
+        firecrawl.assert_called_once()
+
+
+class TestResolveRedirectFirecrawl:
+    """The Firecrawl redirect path compares the post-redirect final domain."""
+
+    @pytest.fixture(autouse=True)
+    def _use_firecrawl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "firecrawl")
+
+    @pytest.mark.asyncio
+    async def test_cross_domain_redirect(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "polar.organization_review.collectors.setup._validate_url_host",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.organization_review.collectors.setup.scrape_markdown",
+            new_callable=AsyncMock,
+            return_value=ScrapeResult(
+                markdown="x",
+                url="https://scam-site.com/landing",
+                status_code=200,
+                title=None,
+            ),
+        )
+
+        result = await _resolve_redirect_with_browser("https://legit-api.com/success")
+
+        assert result.redirected is True
+        assert result.final_domain == "scam-site.com"
+        assert result.final_url == "https://scam-site.com/landing"
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_same_domain_not_flagged(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "polar.organization_review.collectors.setup._validate_url_host",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.organization_review.collectors.setup.scrape_markdown",
+            new_callable=AsyncMock,
+            return_value=ScrapeResult(
+                markdown="x",
+                url="https://example.com/new",
+                status_code=200,
+                title=None,
+            ),
+        )
+
+        result = await _resolve_redirect_with_browser("https://example.com/old")
+
+        assert result.redirected is False
+        assert result.final_domain == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_www_variant_not_flagged(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "polar.organization_review.collectors.setup._validate_url_host",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.organization_review.collectors.setup.scrape_markdown",
+            new_callable=AsyncMock,
+            return_value=ScrapeResult(
+                markdown="x",
+                url="https://www.example.com/thanks",
+                status_code=200,
+                title=None,
+            ),
+        )
+
+        result = await _resolve_redirect_with_browser("https://example.com/thanks")
+
+        assert result.redirected is False
+
+    @pytest.mark.asyncio
+    async def test_blocked_scheme(self, mocker: MockerFixture) -> None:
+        scrape = mocker.patch(
+            "polar.organization_review.collectors.setup.scrape_markdown",
+            new_callable=AsyncMock,
+        )
+
+        result = await _resolve_redirect_with_browser("ftp://example.com/file")
+
+        assert result.error == "blocked"
+        scrape.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_scrape_error_reported(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "polar.organization_review.collectors.setup._validate_url_host",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.organization_review.collectors.setup.scrape_markdown",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("firecrawl down"),
+        )
+
+        result = await _resolve_redirect_with_browser("https://flaky.com/page")
+
+        assert result.error == "browser_error"
+        assert result.redirected is False

--- a/server/tests/organization_review/collectors/test_website.py
+++ b/server/tests/organization_review/collectors/test_website.py
@@ -890,7 +890,7 @@ class TestBrowsePageFirecrawl:
             response = await browse_page(ctx, "https://example.com/")
 
         assert "off-origin" in response
-        assert "evil.com" in response
+        assert "https://evil.com/landing" in response
         assert deps.pages_visited == []
 
     @pytest.mark.asyncio

--- a/server/tests/organization_review/collectors/test_website.py
+++ b/server/tests/organization_review/collectors/test_website.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from polar.config import settings
 from polar.kit.http import SSRFBlockedError
+from polar.organization_review.collectors.firecrawl_client import ScrapeResult
 from polar.organization_review.collectors.website import (
     MAX_CHARS_PER_PAGE,
     MAX_PAGES,
@@ -784,3 +786,246 @@ class TestPlaywrightRouteInterceptor:
             await handler["handler"](route)
 
         route.abort.assert_called_once_with("blockedbyclient")
+
+
+# ---------------------------------------------------------------------------
+# browse_page — Firecrawl branch
+# ---------------------------------------------------------------------------
+
+
+def _patch_scrape_markdown(result: ScrapeResult | Exception) -> Any:
+    """Patch scrape_markdown to return a ScrapeResult or raise an exception."""
+    if isinstance(result, Exception):
+        return patch(
+            "polar.organization_review.collectors.website.scrape_markdown",
+            new_callable=AsyncMock,
+            side_effect=result,
+        )
+    return patch(
+        "polar.organization_review.collectors.website.scrape_markdown",
+        new_callable=AsyncMock,
+        return_value=result,
+    )
+
+
+class TestBrowsePageFirecrawl:
+    @pytest.fixture(autouse=True)
+    def _use_firecrawl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "firecrawl")
+
+    @pytest.mark.asyncio
+    async def test_successful_scrape(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        result = ScrapeResult(
+            markdown="# Welcome\n\nThis is a real business.",
+            url="https://example.com/",
+            status_code=200,
+            title="My Site",
+        )
+        with _patch_scrape_markdown(result):
+            response = await browse_page(ctx, "https://example.com/")
+
+        assert deps.pages_navigated == 1
+        assert len(deps.pages_visited) == 1
+        page = deps.pages_visited[0]
+        assert page.url == "https://example.com/"
+        assert page.title == "My Site"
+        assert page.method == "browser"
+        assert "real business" in page.content
+        assert "Page: My Site" in response
+
+    @pytest.mark.asyncio
+    async def test_rejects_off_origin_url(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        with _patch_scrape_markdown(
+            ScrapeResult(
+                markdown="x", url="https://evil.com/", status_code=200, title=None
+            )
+        ) as mock_scrape:
+            response = await browse_page(ctx, "https://evil.com/steal")
+
+        assert "off-origin" in response
+        assert deps.pages_navigated == 0
+        mock_scrape.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_respects_page_limit(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(
+            client=client, allowed_domain="example.com", pages_navigated=MAX_PAGES
+        )
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        with _patch_scrape_markdown(
+            ScrapeResult(
+                markdown="x", url="https://example.com/", status_code=200, title=None
+            )
+        ) as mock_scrape:
+            response = await browse_page(ctx, "https://example.com/page")
+
+        assert "Page limit reached" in response
+        mock_scrape.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_off_origin_final_url_blocked(self) -> None:
+        """A JS/HTTP redirect that lands off-origin is rejected via the final URL."""
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        result = ScrapeResult(
+            markdown="phish", url="https://evil.com/landing", status_code=200, title="X"
+        )
+        with _patch_scrape_markdown(result):
+            response = await browse_page(ctx, "https://example.com/")
+
+        assert "off-origin" in response
+        assert "evil.com" in response
+        assert deps.pages_visited == []
+
+    @pytest.mark.asyncio
+    async def test_http_error(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        result = ScrapeResult(
+            markdown="", url="https://example.com/missing", status_code=404, title=None
+        )
+        with _patch_scrape_markdown(result):
+            response = await browse_page(ctx, "https://example.com/missing")
+
+        assert "Error: HTTP 404" in response
+        assert deps.pages_visited == []
+
+    @pytest.mark.asyncio
+    async def test_scrape_exception(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        with _patch_scrape_markdown(RuntimeError("firecrawl down")):
+            response = await browse_page(ctx, "https://example.com/")
+
+        assert "Error navigating" in response
+        assert deps.pages_visited == []
+
+    @pytest.mark.asyncio
+    async def test_content_truncation(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        long_markdown = "x" * (MAX_CHARS_PER_PAGE + 5_000)
+        result = ScrapeResult(
+            markdown=long_markdown,
+            url="https://example.com/",
+            status_code=200,
+            title="Big",
+        )
+        with _patch_scrape_markdown(result):
+            response = await browse_page(ctx, "https://example.com/")
+
+        assert deps.pages_visited[0].content_truncated is True
+        assert len(deps.pages_visited[0].content) <= MAX_CHARS_PER_PAGE
+        assert "(content truncated)" in response
+
+
+# ---------------------------------------------------------------------------
+# browse_page — shadow mode
+# ---------------------------------------------------------------------------
+
+
+class TestBrowsePageShadow:
+    @pytest.mark.asyncio
+    async def test_uses_playwright_result_and_runs_firecrawl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shadow mode returns Playwright's result but still invokes Firecrawl."""
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "shadow")
+
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock(return_value=MagicMock(status=200))
+        mock_page.wait_for_load_state = AsyncMock()
+        mock_page.wait_for_timeout = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.content = AsyncMock(
+            return_value=(
+                "<html><head><title>PW Title</title></head>"
+                "<body><p>Playwright content here</p></body></html>"
+            )
+        )
+        mock_page.title = AsyncMock(return_value="PW Title")
+        mock_page.evaluate = AsyncMock(return_value=[])
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        deps._browser_page = mock_page
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        firecrawl_result = ScrapeResult(
+            markdown="firecrawl content",
+            url="https://example.com/",
+            status_code=200,
+            title="FC Title",
+        )
+        with (
+            _patch_scrape_markdown(firecrawl_result) as mock_scrape,
+            _PATCH_SSRF,
+        ):
+            response = await browse_page(ctx, "https://example.com/")
+
+        # Playwright's result is the live one
+        assert "Page: PW Title" in response
+        assert deps.pages_navigated == 1
+        assert len(deps.pages_visited) == 1
+        assert deps.pages_visited[0].title == "PW Title"
+        # Firecrawl was still run for comparison
+        mock_scrape.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_failure_does_not_break_playwright(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A Firecrawl error in shadow mode must not affect the Playwright result."""
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "shadow")
+
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock(return_value=MagicMock(status=200))
+        mock_page.wait_for_load_state = AsyncMock()
+        mock_page.wait_for_timeout = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.content = AsyncMock(
+            return_value="<html><head><title>PW</title></head><body><p>ok</p></body></html>"
+        )
+        mock_page.title = AsyncMock(return_value="PW")
+        mock_page.evaluate = AsyncMock(return_value=[])
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        deps = WebsiteDeps(client=client, allowed_domain="example.com")
+        deps._browser_page = mock_page
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        with (
+            _patch_scrape_markdown(RuntimeError("firecrawl exploded")),
+            _PATCH_SSRF,
+        ):
+            response = await browse_page(ctx, "https://example.com/")
+
+        assert "Page: PW" in response
+        assert deps.pages_navigated == 1

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-22T12:27:39.872887Z"
+exclude-newer = "2026-05-25T12:40:42.054704Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -934,6 +934,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "firecrawl-py"
+version = "4.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "httpx" },
+    { name = "nest-asyncio" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/d5/22cf938c920da8ccc04afc910239a2d4de008a0645d48af90759315cc6c8/firecrawl_py-4.28.0.tar.gz", hash = "sha256:c5fa2b1ce21f01627f197d357741edaf60183260fa34ba4e5f979e3b16b64e0b", size = 191466, upload-time = "2026-05-23T23:03:42.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5b/52f6ad949d412cf342e882c3f08808a226ad462864489afc451661e5268c/firecrawl_py-4.28.0-py3-none-any.whl", hash = "sha256:0745c13cc8a13c874c86094a3fea98ea2aa2289d58cef8b7fa64877b270d809f", size = 238547, upload-time = "2026-05-23T23:03:40.47Z" },
 ]
 
 [[package]]
@@ -1974,6 +1992,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2313,6 +2340,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "exponent-server-sdk" },
     { name = "fastapi" },
+    { name = "firecrawl-py" },
     { name = "fpdf2" },
     { name = "genai-prices" },
     { name = "githubkit" },
@@ -2408,6 +2436,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.1.0.post1" },
     { name = "exponent-server-sdk", specifier = ">=2.1.0" },
     { name = "fastapi", specifier = ">=0.136.1" },
+    { name = "firecrawl-py", specifier = ">=4.28.0" },
     { name = "fpdf2", specifier = ">=2.8.3" },
     { name = "genai-prices", specifier = ">=0.0.61" },
     { name = "githubkit", specifier = "==0.15.5" },

--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -442,3 +442,11 @@ resource "tfe_variable" "plain_default_tier_external_id_production" {
   sensitive       = false
   variable_set_id = tfe_variable_set.production.id
 }
+
+resource "tfe_variable" "firecrawl_api_key_production" {
+  key             = "firecrawl_api_key"
+  category        = "terraform"
+  description     = "Firecrawl Cloud API key for production"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -368,3 +368,11 @@ resource "tfe_variable" "plain_default_tier_external_id_sandbox" {
   sensitive       = false
   variable_set_id = tfe_variable_set.sandbox.id
 }
+
+resource "tfe_variable" "firecrawl_api_key_sandbox" {
+  key             = "firecrawl_api_key"
+  category        = "terraform"
+  description     = "Firecrawl Cloud API key for sandbox"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -304,3 +304,11 @@ resource "tfe_variable" "plain_default_tier_external_id_test" {
   sensitive       = false
   variable_set_id = tfe_variable_set.test.id
 }
+
+resource "tfe_variable" "firecrawl_api_key_test" {
+  key             = "firecrawl_api_key"
+  category        = "terraform"
+  description     = "Firecrawl Cloud API key for test"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -62,6 +62,7 @@ resource "render_env_group" "backend" {
       POLAR_DISCORD_PROXY_URL                    = { value = var.backend_secrets.discord_proxy_url }
       POLAR_RESEND_API_KEY                       = { value = var.backend_secrets.resend_api_key }
       POLAR_RESEND_WEBHOOK_SECRET                = { value = var.backend_secrets.resend_webhook_secret }
+      POLAR_FIRECRAWL_API_KEY                    = { value = var.backend_secrets.firecrawl_api_key }
       POLAR_LOGO_DEV_PUBLISHABLE_KEY             = { value = var.backend_secrets.logo_dev_publishable_key }
       POLAR_SECRET                               = { value = var.backend_secrets.secret }
       POLAR_SENTRY_DSN                           = { value = var.backend_secrets.sentry_dsn }

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -160,6 +160,7 @@ variable "backend_secrets" {
     app_review_otp_code            = optional(string, "")
     chargeback_stop_webhook_secret = optional(string, "")
     numeral_api_key                = optional(string, "")
+    firecrawl_api_key              = optional(string, "")
   })
   sensitive = true
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -325,6 +325,7 @@ module "production" {
     posthog_project_api_key        = var.backend_posthog_project_api_key_production
     resend_api_key                 = var.backend_resend_api_key_production
     resend_webhook_secret          = var.backend_resend_webhook_secret
+    firecrawl_api_key              = var.firecrawl_api_key
     logo_dev_publishable_key       = var.backend_logo_dev_publishable_key_production
     secret                         = var.backend_secret_production
     sentry_dsn                     = var.backend_sentry_dsn_production

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -408,3 +408,9 @@ variable "plain_default_tier_external_id" {
   description = "Default Plain tier external ID used as a fallback for the polar-self support benefit"
   type        = string
 }
+
+variable "firecrawl_api_key" {
+  description = "Firecrawl Cloud API key"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -201,6 +201,7 @@ module "sandbox" {
     discord_proxy_url        = var.backend_discord_proxy_url
     resend_api_key           = var.backend_resend_api_key_sandbox
     resend_webhook_secret    = var.backend_resend_webhook_secret
+    firecrawl_api_key        = var.firecrawl_api_key
     logo_dev_publishable_key = var.backend_logo_dev_publishable_key_sandbox
     secret                   = var.backend_secret_sandbox
     sentry_dsn               = var.backend_sentry_dsn_sandbox

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -325,3 +325,9 @@ variable "plain_default_tier_external_id" {
   description = "Default Plain tier external ID used as a fallback for the polar-self support benefit"
   type        = string
 }
+
+variable "firecrawl_api_key" {
+  description = "Firecrawl Cloud API key"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -217,6 +217,7 @@ module "test" {
     discord_client_secret    = var.backend_discord_client_secret
     resend_api_key           = var.backend_resend_api_key
     resend_webhook_secret    = var.backend_resend_webhook_secret
+    firecrawl_api_key        = var.firecrawl_api_key
     logo_dev_publishable_key = var.backend_logo_dev_publishable_key
     secret                   = var.backend_secret
     sentry_dsn               = var.backend_sentry_dsn

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -285,3 +285,9 @@ variable "plain_default_tier_external_id" {
   description = "Default Plain tier external ID used as a fallback for the polar-self support benefit"
   type        = string
 }
+
+variable "firecrawl_api_key" {
+  description = "Firecrawl Cloud API key"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

Replace the organization-review playwright with Firecrawl Cloud. This is behing a new setting toggle and it's disabled for now.

## What

- New `firecrawl_client.py`
- New settings: `ORGANIZATION_REVIEW_SCRAPER` (`playwright` | `firecrawl` | `shadow`) and `FIRECRAWL_API_KEY`.
- `shadow` runs both scrapers, logs a comparison, and keeps Playwright's result as the live verdict.
- Terraform: declare and wire `FIRECRAWL_API_KEY` across production/sandbox/test.
## Why

Different reasons for this change:
- Sometimes we get access denied for our playwright browser
- We need to build 2 images for this
- Security concerns


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Firecrawl Cloud integration as an alternative web scraping backend for organization reviews.
  * Introduced configurable scraper selection with three options: Playwright, Firecrawl, or shadow mode (concurrent comparison).
  * Enhanced organization review content extraction and redirect detection capabilities.

* **Infrastructure**
  * Added Firecrawl API key configuration across production, sandbox, and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->