### PR TITLE
fix: bill first graduated seat tier from seat 1

### DIFF
--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -406,19 +406,26 @@ class ProductPriceSeatUnit(NewProductPrice, ProductPrice):
     def _calculate_graduated(self, seats: int) -> int:
         total = 0
         remaining = seats
+        # Tier capacity is measured from the previous tier's upper bound, not the
+        # tier's own min_seats. The first tier's min_seats doubles as the minimum
+        # order quantity (see get_minimum_seats), so it may be > 1; the first tier
+        # must still bill from seat 1, otherwise seats below it spill into cheaper
+        # tiers (T-28449).
+        previous_max = 0
         for tier in sorted(
             self.seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
         ):
             if remaining <= 0:
                 break
-            min_seats = tier["min_seats"]
             max_seats = tier.get("max_seats")
             tier_capacity = (
-                (max_seats - min_seats + 1) if max_seats is not None else remaining
+                (max_seats - previous_max) if max_seats is not None else remaining
             )
             seats_in_tier = min(remaining, tier_capacity)
             total += seats_in_tier * tier["price_per_seat"]
             remaining -= seats_in_tier
+            if max_seats is not None:
+                previous_max = max_seats
         return total
 
     def get_minimum_seats(self) -> int:

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -197,3 +197,20 @@ class TestGraduatedPricing:
         assert price.calculate_amount(5) == 0
         assert price.calculate_amount(8) == 3 * 1000
         assert price.calculate_amount(15) == 10 * 1000
+
+    def test_first_tier_min_seats_above_one(self) -> None:
+        # Regression for T-28449: a merchant enforcing a 10-seat minimum sets the
+        # first tier's min_seats to 10. The first 10 seats should all be priced at
+        # the first tier's rate ($200/seat = $2000), then cheaper after.
+        # Reproduces the exact sandbox config of product 231d03ca.
+        price = _make_seat_price(
+            [
+                {"min_seats": 10, "max_seats": 10, "price_per_seat": 20000},
+                {"min_seats": 11, "max_seats": None, "price_per_seat": 6000},
+            ],
+            SeatTierType.graduated,
+        )
+        # All 10 seats fall in the first tier.
+        assert price.calculate_amount(10) == 10 * 20000
+        # 10 at first tier + 5 at second tier.
+        assert price.calculate_amount(15) == 10 * 20000 + 5 * 6000


### PR DESCRIPTION
## Summary

Fixes a cost-calculation bug in graduated seat-based pricing when the first tier starts above 1 seat. Reported via support https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01KSPT730YAN9Y1DCYEPSAEKE2/

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced graduated seat pricing logic to correctly calculate tier capacity using previous tier bounds, preventing seats from being incorrectly allocated to cheaper tiers.

* **Tests**
  * Added regression test for graduated pricing with non-standard tier configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->