### PR TITLE
Cache Turborepo packages across Vercel builds

### DIFF
--- a/clients/apps/web/turbo.json
+++ b/clients/apps/web/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://v2-9-4.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", ".env", ".env.*"],
+      "env": ["VERCEL_GIT_PULL_REQUEST_ID", "VERCEL_GIT_COMMIT_SHA"]
+    }
+  }
+}

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://v2-9-4.turborepo.dev/schema.json",
-  "globalDependencies": ["**/.env.*local"],
   "globalEnv": [
     "POLAR_API_URL",
     "EXPO_PUBLIC_POLAR_SERVER_URL",
@@ -16,8 +15,6 @@
     "POLAR_PREVIEW_BUILD",
     "POLAR_PREVIEW_BACKEND_HOST",
     "VERCEL_ENV",
-    "VERCEL_GIT_PULL_REQUEST_ID",
-    "VERCEL_URL",
     "NEXT_PUBLIC_VERCEL_ENV",
     "NEXT_PUBLIC_LOGIN_PATH",
     "NEXT_PUBLIC_GITHUB_APP_NAMESPACE",
@@ -27,7 +24,6 @@
     "NEXT_PUBLIC_STRIPE_COUNTRIES_WHITELIST",
     "NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION",
     "SENTRY_AUTH_TOKEN",
-    "VERCEL_GIT_COMMIT_SHA",
     "NEXT_PUBLIC_SENTRY_DSN",
     "SENTRY_PROJECT",
     "SENTRY_ORG",


### PR DESCRIPTION
This PR stops hashing Vercel's per build env (which changes every commit) into the package cache key, so packages now reuse their cache instead of rebuilding every deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to optimize dependency handling and environment variable management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->