### PR TITLE
server/migrations: add lock_timeout by default

### DIFF
--- a/server/migrations/script.py.mako
+++ b/server/migrations/script.py.mako
@@ -19,8 +19,12 @@ depends_on: tuple[str] | None = ${repr(depends_on)}
 
 
 def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
     ${upgrades if upgrades else "pass"}
 
 
 def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
     ${downgrades if downgrades else "pass"}


### PR DESCRIPTION

To prevent the app from going down when running a migration, set a lock timeout by default. This will cause the migration to fail if it cannot acquire a lock within the specified time, rather than hanging indefinitely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database migration configuration with automatic lock timeout settings to improve deployment stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->