### PR TITLE
Off-session draft-order charges

### DIFF
--- a/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/orders/[id]/index.tsx
@@ -14,6 +14,7 @@ import { Stack, useLocalSearchParams } from 'expo-router'
 import { RefreshControl, ScrollView } from 'react-native'
 
 const statusColors = {
+  draft: 'gray',
   pending: 'yellow',
   paid: 'green',
   refunded: 'blue',

--- a/clients/apps/app/components/Shared/Pill.tsx
+++ b/clients/apps/app/components/Shared/Pill.tsx
@@ -3,7 +3,7 @@ import { Text } from '@/components/Shared/Text'
 import { useTheme } from '@/design-system/useTheme'
 import { StyleProp, TextStyle, ViewStyle } from 'react-native'
 
-type PillColor = 'green' | 'yellow' | 'red' | 'blue'
+type PillColor = 'green' | 'yellow' | 'red' | 'blue' | 'gray'
 
 const getColorTokens = (color: PillColor) => {
   switch (color) {
@@ -15,6 +15,8 @@ const getColorTokens = (color: PillColor) => {
       return { text: 'statusRed', bg: 'statusRedBg' } as const
     case 'blue':
       return { text: 'statusBlue', bg: 'statusBlueBg' } as const
+    case 'gray':
+      return { text: 'statusGray', bg: 'statusGrayBg' } as const
   }
 }
 

--- a/clients/apps/app/design-system/theme.ts
+++ b/clients/apps/app/design-system/theme.ts
@@ -65,6 +65,8 @@ export const colors = {
   statusRedBg: palette.redDark,
   statusBlue: palette.indigo,
   statusBlueBg: palette.indigoDark,
+  statusGray: palette.gray100,
+  statusGrayBg: palette.gray600,
 } as const
 
 export const dimension = {

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
@@ -15,6 +15,7 @@ import { OrderPaymentRetryModal } from './OrderPaymentRetryModal'
 import { SeatManagementTable } from './SeatManagementTable'
 
 const OrderStatusDisplayTitle: Record<schemas['Order']['status'], string> = {
+  draft: 'Draft',
   paid: 'Paid',
   pending: 'Pending',
   refunded: 'Refunded',
@@ -23,6 +24,7 @@ const OrderStatusDisplayTitle: Record<schemas['Order']['status'], string> = {
 }
 
 const OrderStatusDisplayColor: Record<schemas['Order']['status'], string> = {
+  draft: 'bg-gray-100 text-gray-500 dark:bg-gray-900 dark:text-gray-400',
   paid: 'bg-emerald-100 text-emerald-500 dark:bg-emerald-950 dark:text-emerald-500',
   pending:
     'bg-yellow-100 text-yellow-500 dark:bg-yellow-950 dark:text-yellow-500',

--- a/clients/apps/web/src/components/Orders/OrderStatus.tsx
+++ b/clients/apps/web/src/components/Orders/OrderStatus.tsx
@@ -3,6 +3,7 @@ import { Status } from '@polar-sh/ui/components/atoms/Status'
 import { twMerge } from 'tailwind-merge'
 
 const OrderStatusDisplayTitle: Record<schemas['Order']['status'], string> = {
+  draft: 'Draft',
   paid: 'Paid',
   pending: 'Pending',
   refunded: 'Refunded',
@@ -11,6 +12,7 @@ const OrderStatusDisplayTitle: Record<schemas['Order']['status'], string> = {
 }
 
 const OrderStatusDisplayColor: Record<schemas['Order']['status'], string> = {
+  draft: 'bg-gray-100 text-gray-500 dark:bg-gray-900 dark:text-gray-400',
   paid: 'bg-emerald-100 text-emerald-500 dark:bg-emerald-950 dark:text-emerald-500',
   pending:
     'bg-yellow-100 text-yellow-500 dark:bg-yellow-950 dark:text-yellow-500',

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -21978,7 +21978,7 @@ export interface components {
       product_id: string
       /**
        * Currency
-       * @description The currency to charge in (ISO 4217, lowercase, e.g. `usd`). **Required when the product has prices in more than one currency**; otherwise the product's single currency is used.
+       * @description The currency to charge in (ISO 4217, lowercase, e.g. `usd`). Defaults to the organization's default currency; specify it to force a different one, or when the product isn't priced in the organization's default currency.
        */
       currency?: string | null
     }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -21976,6 +21976,11 @@ export interface components {
        * @description The ID of the one-time, fixed-price product to charge for. Must belong to the order's organization. Subscription, seat-based, and pay-what-you-want products are not supported.
        */
       product_id: string
+      /**
+       * Currency
+       * @description The currency to charge in (ISO 4217, lowercase, e.g. `usd`). **Required when the product has prices in more than one currency**; otherwise the product's single currency is used.
+       */
+      currency?: string | null
     }
     /** OrderCustomer */
     OrderCustomer: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -21973,14 +21973,9 @@ export interface components {
       /**
        * Product Id
        * Format: uuid4
-       * @description The ID of the one-time product to charge for. Must belong to the order's organization. Subscription products and seat-based products are not supported.
+       * @description The ID of the one-time, fixed-price product to charge for. Must belong to the order's organization. Subscription, seat-based, and pay-what-you-want products are not supported.
        */
       product_id: string
-      /**
-       * Amount
-       * @description Amount in the smallest currency unit. Required for pay-what-you-want / custom-priced products; ignored otherwise. Must respect the price's configured minimum and maximum.
-       */
-      amount?: number | null
     }
     /** OrderCustomer */
     OrderCustomer: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -2010,7 +2010,17 @@ export interface paths {
      */
     get: operations['orders:list']
     put?: never
-    post?: never
+    /**
+     * Create Order
+     * @description Create a draft order for an off-session charge against a saved payment
+     *     method. The order is created with `status=draft` and no invoice number;
+     *     call `POST /v1/orders/{id}/finalize` to attempt the charge.
+     *
+     *     The organization must have the `off_session_charges_enabled` feature flag.
+     *
+     *     **Scopes**: `orders:write`
+     */
+    post: operations['orders:create']
     delete?: never
     options?: never
     head?: never
@@ -2065,6 +2075,34 @@ export interface paths {
      *     **Scopes**: `orders:write`
      */
     patch: operations['orders:update']
+    trace?: never
+  }
+  '/v1/orders/{id}/finalize': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Finalize Order
+     * @description Finalize a draft order and synchronously attempt an off-session charge.
+     *
+     *     On success, the order transitions to `paid` and benefit grants fire
+     *     before the response returns. On failure (decline, missing payment method,
+     *     SCA challenge), the order stays in `draft` and a 4xx error is returned.
+     *
+     *     The request fails with 412 if the order is not in `draft` status.
+     *
+     *     **Scopes**: `orders:write`
+     */
+    post: operations['orders:finalize']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
     trace?: never
   }
   '/v1/orders/{id}/invoice': {
@@ -14949,9 +14987,9 @@ export interface components {
       billing_address: components['schemas']['Address'] | null
       /**
        * Invoice Number
-       * @description The invoice number associated with this order.
+       * @description The invoice number associated with this order. `null` while the order is in `draft` status; assigned at finalize.
        */
-      invoice_number: string
+      invoice_number: string | null
       /**
        * Is Invoice Generated
        * @description Whether an invoice has been generated for this order.
@@ -21678,6 +21716,17 @@ export interface components {
      * @enum {string}
      */
     OAuthPlatform: 'github' | 'github_repository_benefit' | 'google' | 'apple'
+    /** OffSessionChargesNotEnabled */
+    OffSessionChargesNotEnabled: {
+      /**
+       * Error
+       * @example OffSessionChargesNotEnabled
+       * @constant
+       */
+      error: 'OffSessionChargesNotEnabled'
+      /** Detail */
+      detail: string
+    }
     /** Order */
     Order: {
       /**
@@ -21773,9 +21822,9 @@ export interface components {
       billing_address: components['schemas']['Address'] | null
       /**
        * Invoice Number
-       * @description The invoice number associated with this order.
+       * @description The invoice number associated with this order. `null` while the order is in `draft` status; assigned at finalize.
        */
-      invoice_number: string
+      invoice_number: string | null
       /**
        * Is Invoice Generated
        * @description Whether an invoice has been generated for this order.
@@ -21881,6 +21930,58 @@ export interface components {
       | 'subscription_cycle_after_trial'
       | 'subscription_cancel'
       | 'subscription_update'
+    /**
+     * OrderCreate
+     * @description Schema to create a draft order for an off-session charge.
+     */
+    OrderCreate: {
+      /**
+       * Custom Field Data
+       * @description Key-value object storing custom field values.
+       */
+      custom_field_data?: {
+        [key: string]: string | number | boolean | null
+      }
+      /**
+       * Metadata
+       * @description Key-value object allowing you to store additional information.
+       *
+       *     The key must be a string with a maximum length of **40 characters**.
+       *     The value must be either:
+       *
+       *     * A string with a maximum length of **500 characters**
+       *     * An integer
+       *     * A floating-point number
+       *     * A boolean
+       *
+       *     You can store up to **50 key-value pairs**.
+       */
+      metadata?: {
+        [key: string]: string | number | boolean
+      }
+      /**
+       * Organization Id
+       * @description The ID of the organization the order belongs to. **Required unless you use an organization token.** The customer and product must belong to this organization.
+       */
+      organization_id?: string | null
+      /**
+       * Customer Id
+       * Format: uuid4
+       * @description The ID of the customer the order is for. Must belong to the order's organization.
+       */
+      customer_id: string
+      /**
+       * Product Id
+       * Format: uuid4
+       * @description The ID of the one-time product to charge for. Must belong to the order's organization. Subscription products and seat-based products are not supported.
+       */
+      product_id: string
+      /**
+       * Amount
+       * @description Amount in the smallest currency unit. Required for pay-what-you-want / custom-priced products; ignored otherwise. Must respect the price's configured minimum and maximum.
+       */
+      amount?: number | null
+    }
     /** OrderCustomer */
     OrderCustomer: {
       /**
@@ -21955,6 +22056,17 @@ export interface components {
       readonly avatar_url: string
     }
     /**
+     * OrderFinalize
+     * @description Schema to finalize a draft order and trigger an off-session charge.
+     */
+    OrderFinalize: {
+      /**
+       * Payment Method Id
+       * @description ID of the payment method to charge. Must belong to the order's customer. Falls back to the customer's default payment method when unset.
+       */
+      payment_method_id?: string | null
+    }
+    /**
      * OrderInvoice
      * @description Order's invoice data.
      */
@@ -22016,6 +22128,17 @@ export interface components {
        * @description Associated price ID, if any.
        */
       product_price_id: string | null
+    }
+    /** OrderNotDraft */
+    OrderNotDraft: {
+      /**
+       * Error
+       * @example OrderNotDraft
+       * @constant
+       */
+      error: 'OrderNotDraft'
+      /** Detail */
+      detail: string
     }
     /** OrderNotEligibleForRetry */
     OrderNotEligibleForRetry: {
@@ -22321,7 +22444,13 @@ export interface components {
      * OrderStatus
      * @enum {string}
      */
-    OrderStatus: 'pending' | 'paid' | 'refunded' | 'partially_refunded' | 'void'
+    OrderStatus:
+      | 'draft'
+      | 'pending'
+      | 'paid'
+      | 'refunded'
+      | 'partially_refunded'
+      | 'void'
     /** OrderSubscription */
     OrderSubscription: {
       metadata: components['schemas']['MetadataOutputType']
@@ -23668,6 +23797,12 @@ export interface components {
        */
       reset_proration_behavior_enabled: boolean
       /**
+       * Off Session Charges Enabled
+       * @description If this organization can create and finalize draft orders via the API (off-session charges against a saved payment method).
+       * @default false
+       */
+      off_session_charges_enabled: boolean
+      /**
        * Billing Enabled
        * @description If this organization has billing enabled
        * @default false
@@ -24074,6 +24209,17 @@ export interface components {
        * @enum {string}
        */
       role: 'admin' | 'member'
+    }
+    /** OrganizationNotReadyForPayments */
+    OrganizationNotReadyForPayments: {
+      /**
+       * Error
+       * @example OrganizationNotReadyForPayments
+       * @constant
+       */
+      error: 'OrganizationNotReadyForPayments'
+      /** Detail */
+      detail: string
     }
     /** OrganizationNotificationSettings */
     OrganizationNotificationSettings: {
@@ -25325,6 +25471,17 @@ export interface components {
     Payment:
       | components['schemas']['CardPayment']
       | components['schemas']['GenericPayment']
+    /** PaymentActionRequired */
+    PaymentActionRequired: {
+      /**
+       * Error
+       * @example PaymentActionRequired
+       * @constant
+       */
+      error: 'PaymentActionRequired'
+      /** Detail */
+      detail: string
+    }
     /** PaymentAlreadyInProgress */
     PaymentAlreadyInProgress: {
       /**
@@ -36417,6 +36574,39 @@ export interface operations {
       }
     }
   }
+  'orders:create': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['OrderCreate']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Order']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'orders:export': {
     parameters: {
       query?: {
@@ -36525,6 +36715,82 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'orders:finalize': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The order ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['OrderFinalize']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Order']
+        }
+      }
+      /** @description The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['PaymentFailed']
+            | components['schemas']['PaymentActionRequired']
+        }
+      }
+      /** @description Off-session charges are not enabled for this organization, or its account can't currently accept payments. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['OffSessionChargesNotEnabled']
+            | components['schemas']['OrganizationNotReadyForPayments']
+        }
+      }
+      /** @description Order not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description The order is not in `draft` status. */
+      412: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrderNotDraft']
         }
       }
       /** @description Validation Error */
@@ -55098,7 +55364,7 @@ export const orderSortPropertyValues: ReadonlyArray<
 ]
 export const orderStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrderStatus']
-> = ['pending', 'paid', 'refunded', 'partially_refunded', 'void']
+> = ['draft', 'pending', 'paid', 'refunded', 'partially_refunded', 'void']
 export const orderVoidedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrderVoidedEvent']['name']
 > = ['order.voided']

--- a/server/migrations/versions/2026-05-27-1705_make_order_invoice_number_nullable_for_.py
+++ b/server/migrations/versions/2026-05-27-1705_make_order_invoice_number_nullable_for_.py
@@ -1,0 +1,30 @@
+"""Make order.invoice_number nullable for draft orders
+
+Revision ID: d2a49dc19a62
+Revises: b7b69a5d5731
+Create Date: 2026-05-27 17:05:07.479671
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "d2a49dc19a62"
+down_revision = "b7b69a5d5731"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "orders", "invoice_number", existing_type=sa.VARCHAR(), nullable=True
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "orders", "invoice_number", existing_type=sa.VARCHAR(), nullable=False
+    )

--- a/server/polar/backoffice/orders/components.py
+++ b/server/polar/backoffice/orders/components.py
@@ -28,7 +28,9 @@ class StatusColumn(datatable.DatatableSortingColumn[Order, OrderSortProperty]):
 @contextlib.contextmanager
 def order_status_badge(status: OrderStatus) -> Generator[None]:
     with tag.div(classes="badge"):
-        if status == OrderStatus.paid:
+        if status == OrderStatus.draft:
+            classes("badge-ghost")
+        elif status == OrderStatus.paid:
             classes("badge-success")
         elif status == OrderStatus.pending:
             classes("badge-warning")

--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -1,4 +1,3 @@
-import contextlib
 import uuid
 from collections.abc import Generator
 from typing import Annotated, Any
@@ -9,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import UUID4, BeforeValidator, ValidationError
 from sqlalchemy import or_
 from sqlalchemy.orm import contains_eager, joinedload
-from tagflow import attr, classes, tag, text
+from tagflow import attr, tag, text
 
 from polar.invoice.service import invoice as invoice_service
 from polar.kit.currency import format_currency
@@ -33,7 +32,7 @@ from ..components import button, datatable, description_list, input, modal
 from ..layout import layout
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
-from .components import orders_datatable, payments_datatable
+from .components import order_status_badge, orders_datatable, payments_datatable
 from .forms import RefundForm
 
 router = APIRouter()
@@ -109,24 +108,6 @@ class ReceiptPDFItem(description_list.DescriptionListItem[Order]):
                 with tag.span(classes="text-gray-500"):
                     text("Not generated")
         return None
-
-
-# Table Columns
-@contextlib.contextmanager
-def order_status_badge(status: OrderStatus) -> Generator[None]:
-    with tag.div(classes="badge"):
-        if status == OrderStatus.paid:
-            classes("badge-success")
-        elif status == OrderStatus.pending:
-            classes("badge-warning")
-        elif status == OrderStatus.refunded:
-            classes("badge-error")
-        elif status == OrderStatus.partially_refunded:
-            classes("badge-info")
-        elif status == OrderStatus.void:
-            classes("badge-error")
-        text(status.replace("_", " ").title())
-    yield
 
 
 @router.get("/", name="orders:list")
@@ -226,6 +207,7 @@ async def list(
                 with input.select(
                     [
                         ("All Statuses", ""),
+                        ("Draft", OrderStatus.draft.value),
                         ("Pending", OrderStatus.pending.value),
                         ("Paid", OrderStatus.paid.value),
                         ("Refunded", OrderStatus.refunded.value),
@@ -324,7 +306,7 @@ async def get(
             with tag.div(classes="flex justify-between items-center"):
                 with tag.div(classes="flex items-center gap-2"):
                     with tag.h1(classes="text-4xl"):
-                        text(f"Order {order.invoice_number}")
+                        text(f"Order {order.invoice_number or order.id}")
                     if order.refunds_blocked:
                         with tag.div(classes="badge badge-warning"):
                             text("Refunds Blocked")

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -51,9 +51,6 @@ from polar.integrations.stripe.utils import get_fingerprint
 from polar.kit.address import AddressInput
 from polar.kit.crypto import generate_token
 from polar.kit.currency import (
-    format_currency,
-    get_maximum_currency_amount,
-    get_minimum_currency_amount,
     get_presentment_currency,
 )
 from polar.kit.db.locking import is_lock_not_available_error
@@ -97,7 +94,11 @@ from polar.product.guard import (
     is_fixed_price,
     is_seat_price,
 )
-from polar.product.price_set import NoPricesForCurrencies, PriceSet
+from polar.product.price_set import (
+    NoPricesForCurrencies,
+    PriceSet,
+    validate_custom_price_amount,
+)
 from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.schemas import ProductPriceCreateList
 from polar.product.service import product as product_service
@@ -385,7 +386,7 @@ class CheckoutService:
         )
 
         if checkout_create.amount is not None and is_custom_price(price):
-            self._validate_custom_price_amount(price, checkout_create.amount, currency)
+            validate_custom_price_amount(price, checkout_create.amount, currency)
 
         discount: Discount | None = None
         if checkout_create.discount_id is not None:
@@ -724,9 +725,7 @@ class CheckoutService:
             if query_amount_str is not None and isinstance(query_amount_str, str):
                 try:
                     query_amount_int = int(float(query_amount_str))
-                    self._validate_custom_price_amount(
-                        price, query_amount_int, currency
-                    )
+                    validate_custom_price_amount(price, query_amount_int, currency)
                     valid_query_amount = query_amount_int
                 except (ValueError, TypeError, PolarRequestValidationError):
                     pass
@@ -1951,7 +1950,7 @@ class CheckoutService:
             and checkout_update.amount is not None
             and is_custom_price(checkout.product_price)
         ):
-            self._validate_custom_price_amount(
+            validate_custom_price_amount(
                 checkout.product_price, checkout_update.amount, checkout.currency
             )
             checkout.amount = checkout_update.amount
@@ -2319,75 +2318,6 @@ class CheckoutService:
 
         if len(existing_subscriptions) > 0:
             raise AlreadyActiveSubscriptionError()
-
-    def _validate_custom_price_amount(
-        self,
-        price: ProductPrice,
-        amount: int,
-        currency: str,
-        loc: tuple[str, ...] = ("body", "amount"),
-    ) -> None:
-        """Validate that an amount is within the min/max bounds for a custom price."""
-        if not is_custom_price(price):
-            return
-
-        if price.minimum_amount == 0:
-            # Free is allowed: accept $0 or any amount >= currency minimum
-            if amount == 0:
-                return
-
-            currency_minimum = get_minimum_currency_amount(currency)
-            if 0 < amount < currency_minimum:
-                raise PolarRequestValidationError(
-                    [
-                        {
-                            "type": "invalid_amount",
-                            "loc": loc,
-                            "msg": f"Amount must be 0 or at least {format_currency(currency_minimum, currency)}.",  # pyright: ignore
-                            "input": amount,
-                            "ctx": {"allowed": [0], "ge": currency_minimum},
-                        }
-                    ]
-                )
-        elif amount < price.minimum_amount:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "greater_than_equal",
-                        "loc": loc,
-                        "msg": "Amount is below minimum.",
-                        "input": amount,
-                        "ctx": {"ge": price.minimum_amount},
-                    }
-                ]
-            )
-
-        if price.maximum_amount is not None and amount > price.maximum_amount:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "less_than_equal",
-                        "loc": loc,
-                        "msg": "Amount is above maximum.",
-                        "input": amount,
-                        "ctx": {"le": price.maximum_amount},
-                    }
-                ]
-            )
-
-        currency_maximum = get_maximum_currency_amount(currency)
-        if amount > currency_maximum:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "less_than_equal",
-                        "loc": loc,
-                        "msg": f"Amount must be at most {format_currency(currency_maximum, currency)}.",  # pyright: ignore
-                        "input": amount,
-                        "ctx": {"le": currency_maximum},
-                    }
-                ]
-            )
 
     def _validate_seat_limits(
         self,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -88,6 +88,7 @@ from polar.observability.checkout_metrics import (
 from polar.order.service import order as order_service
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.posthog import posthog
+from polar.product.custom_price import validate_custom_price_amount
 from polar.product.guard import (
     is_custom_price,
     is_discount_applicable,
@@ -97,7 +98,6 @@ from polar.product.guard import (
 from polar.product.price_set import (
     NoPricesForCurrencies,
     PriceSet,
-    validate_custom_price_amount,
 )
 from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.schemas import ProductPriceCreateList

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -67,6 +67,7 @@ class OrderBillingReason(StrEnum):
 
 
 class OrderStatus(StrEnum):
+    draft = "draft"
     pending = "pending"
     paid = "paid"
     refunded = "refunded"
@@ -165,7 +166,9 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
         String, nullable=True, default=None
     )
 
-    invoice_number: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    invoice_number: Mapped[str | None] = mapped_column(
+        String, nullable=True, unique=True, default=None
+    )
     invoice_path: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None
     )

--- a/server/polar/order/auth.py
+++ b/server/polar/order/auth.py
@@ -1,10 +1,20 @@
-from typing import Annotated
+from dataclasses import dataclass
+from typing import Annotated, Any
 
 from fastapi import Depends
+from sqlalchemy.orm import joinedload
 
 from polar.auth.dependencies import Authenticator
 from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.permission import OrganizationPermission
 from polar.auth.scope import Scope
+from polar.authz.service import assert_resource_permission
+from polar.exceptions import ResourceNotFound
+from polar.models import Order
+from polar.postgres import AsyncSession, get_db_session
+
+from .repository import OrderRepository
+from .schemas import OrderID
 
 _OrdersRead = Authenticator(
     required_scopes={Scope.orders_read},
@@ -19,3 +29,53 @@ _OrdersWrite = Authenticator(
     allowed_subjects={User, Organization},
 )
 OrdersWrite = Annotated[AuthSubject[User | Organization], Depends(_OrdersWrite)]
+
+
+@dataclass(frozen=True)
+class AuthorizedOrder:
+    """Result of an OrderPolicyGuard dependency: the resolved order plus the
+    authenticated subject."""
+
+    order: Order
+    auth_subject: AuthSubject[User | Organization]
+
+
+def OrderPolicyGuard(permission: OrganizationPermission) -> Any:
+    """FastAPI dependency: authenticate (orders:write), resolve the order from
+    the ``{id}`` path parameter scoped to the subject's organizations, and
+    assert ``permission`` on its organization.
+
+    Raises:
+        Unauthorized (401): No valid credentials / disallowed subject type.
+        InsufficientScopeError (403): The token lacks ``orders:write``.
+        ResourceNotFound (404): The order doesn't exist or isn't accessible to
+            the subject (gated before the permission check so we don't leak the
+            existence of orders in other organizations).
+        NotPermitted (403): The subject is a member but lacks ``permission``.
+    """
+
+    async def dependency(
+        id: OrderID,
+        auth_subject: OrdersWrite,
+        session: AsyncSession = Depends(get_db_session),
+    ) -> AuthorizedOrder:
+        repository = OrderRepository.from_session(session)
+        order = await repository.get_readable_by_id(
+            auth_subject,
+            id,
+            options=repository.get_eager_options(
+                product_load=joinedload(Order.product),
+            ),
+        )
+        if order is None:
+            raise ResourceNotFound()
+        await assert_resource_permission(session, auth_subject, order, permission)
+        return AuthorizedOrder(order=order, auth_subject=auth_subject)
+
+    return dependency
+
+
+OrderSalesManage = Annotated[
+    AuthorizedOrder,
+    Depends(OrderPolicyGuard(OrganizationPermission.sales_manage)),
+]

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -5,7 +5,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import UUID4
 
 from polar.auth.permission import OrganizationPermission
-from polar.authz.service import assert_resource_permission
+from polar.authz.service import (
+    assert_organization_permission,
+    assert_resource_permission,
+)
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
 from polar.exceptions import ResourceNotFound
 from polar.kit.csv import IterableCSVWriter
@@ -15,6 +18,7 @@ from polar.kit.schemas import MultipleQueryFilter
 from polar.models import Order
 from polar.models.product import ProductBillingType
 from polar.openapi import APITag
+from polar.organization.resolver import get_payload_organization
 from polar.organization.schemas import OrganizationID
 from polar.postgres import (
     AsyncReadSession,
@@ -28,8 +32,24 @@ from polar.subscription.schemas import SubscriptionID
 
 from . import auth, sorting
 from .schemas import Order as OrderSchema
-from .schemas import OrderID, OrderInvoice, OrderNotFound, OrderReceipt, OrderUpdate
-from .service import MissingInvoiceBillingDetails, NotPaidOrder
+from .schemas import (
+    OrderCreate,
+    OrderFinalize,
+    OrderID,
+    OrderInvoice,
+    OrderNotFound,
+    OrderReceipt,
+    OrderUpdate,
+)
+from .service import (
+    MissingInvoiceBillingDetails,
+    NotPaidOrder,
+    OffSessionChargesNotEnabled,
+    OrderNotDraft,
+    OrganizationNotReadyForPayments,
+    PaymentActionRequired,
+    PaymentFailed,
+)
 from .service import order as order_service
 
 router = APIRouter(prefix="/orders", tags=["orders", APITag.public, APITag.mcp])
@@ -190,6 +210,33 @@ async def get(
     return order
 
 
+@router.post(
+    "/",
+    status_code=201,
+    summary="Create Order",
+    response_model=OrderSchema,
+)
+async def create(
+    order_create: OrderCreate,
+    auth_subject: auth.OrdersWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> Order:
+    """
+    Create a draft order for an off-session charge against a saved payment
+    method. The order is created with `status=draft` and no invoice number;
+    call `POST /v1/orders/{id}/finalize` to attempt the charge.
+
+    The organization must have the `off_session_charges_enabled` feature flag.
+    """
+    organization = await get_payload_organization(session, auth_subject, order_create)
+
+    await assert_organization_permission(
+        session, auth_subject, organization.id, OrganizationPermission.sales_manage
+    )
+
+    return await order_service.create_draft_order(session, organization, order_create)
+
+
 @router.patch(
     "/{id}",
     summary="Update Order",
@@ -197,22 +244,60 @@ async def get(
     responses={404: OrderNotFound},
 )
 async def update(
-    id: OrderID,
     order_update: OrderUpdate,
-    auth_subject: auth.OrdersWrite,
+    authorized: auth.OrderSalesManage,
     session: AsyncSession = Depends(get_db_session),
 ) -> Order:
     """Update an order."""
-    order = await order_service.get(session, auth_subject, id)
+    return await order_service.update(session, authorized.order, order_update)
 
-    if order is None:
-        raise ResourceNotFound()
 
-    await assert_resource_permission(
-        session, auth_subject, order, OrganizationPermission.sales_manage
+@router.post(
+    "/{id}/finalize",
+    summary="Finalize Order",
+    response_model=OrderSchema,
+    responses={
+        402: {
+            "description": (
+                "The charge failed, or requires customer authentication "
+                "(e.g. a 3DS challenge) that can't be completed off-session."
+            ),
+            "model": PaymentFailed.schema() | PaymentActionRequired.schema(),
+        },
+        403: {
+            "description": (
+                "Off-session charges are not enabled for this organization, "
+                "or its account can't currently accept payments."
+            ),
+            "model": OffSessionChargesNotEnabled.schema()
+            | OrganizationNotReadyForPayments.schema(),
+        },
+        404: OrderNotFound,
+        412: {
+            "description": "The order is not in `draft` status.",
+            "model": OrderNotDraft.schema(),
+        },
+    },
+)
+async def finalize(
+    finalize_payload: OrderFinalize,
+    authorized: auth.OrderSalesManage,
+    session: AsyncSession = Depends(get_db_session),
+) -> Order:
+    """
+    Finalize a draft order and synchronously attempt an off-session charge.
+
+    On success, the order transitions to `paid` and benefit grants fire
+    before the response returns. On failure (decline, missing payment method,
+    SCA challenge), the order stays in `draft` and a 4xx error is returned.
+
+    The request fails with 412 if the order is not in `draft` status.
+    """
+    return await order_service.finalize_order(
+        session,
+        authorized.order,
+        payment_method_id=finalize_payload.payment_method_id,
     )
-
-    return await order_service.update(session, order, order_update)
 
 
 @router.post(

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -236,6 +236,26 @@ class OrderRepository(
             order, update_dict={"payment_lock_acquired_at": None}, flush=flush
         )
 
+    async def start_finalization(self, order_id: UUID) -> bool:
+        """
+        Atomically transition a draft order to `pending` so it can be charged.
+
+        Used to claim a draft order for finalization: only one concurrent
+        request wins the transition, so two finalize calls can't both proceed
+        (and consume two invoice numbers / race the order status).
+
+        Returns:
+            True if this call transitioned the order from draft to pending,
+            False if it was no longer a draft (already claimed / non-draft).
+        """
+        statement = (
+            update(Order)
+            .where(Order.id == order_id, Order.status == OrderStatus.draft)
+            .values(status=OrderStatus.pending)
+        )
+        result = cast(CursorResult[Order], await self.session.execute(statement))
+        return result.rowcount > 0
+
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]
     ) -> Select[tuple[Order]]:

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -295,18 +295,10 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
         "Must belong to the order's organization."
     )
     product_id: UUID4 = Field(
-        description="The ID of the one-time product to charge for. "
+        description="The ID of the one-time, fixed-price product to charge for. "
         "Must belong to the order's organization. "
-        "Subscription products and seat-based products are not supported."
-    )
-    amount: int | None = Field(
-        None,
-        ge=0,
-        description=(
-            "Amount in the smallest currency unit. Required for "
-            "pay-what-you-want / custom-priced products; ignored otherwise. "
-            "Must respect the price's configured minimum and maximum."
-        ),
+        "Subscription, seat-based, and pay-what-you-want products are not "
+        "supported."
     )
 
 

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -304,8 +304,9 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
         None,
         description=(
             "The currency to charge in (ISO 4217, lowercase, e.g. `usd`). "
-            "**Required when the product has prices in more than one currency**; "
-            "otherwise the product's single currency is used."
+            "Defaults to the organization's default currency; specify it to "
+            "force a different one, or when the product isn't priced in the "
+            "organization's default currency."
         ),
     )
 

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -300,6 +300,14 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
         "Subscription, seat-based, and pay-what-you-want products are not "
         "supported."
     )
+    currency: str | None = Field(
+        None,
+        description=(
+            "The currency to charge in (ISO 4217, lowercase, e.g. `usd`). "
+            "**Required when the product has prices in more than one currency**; "
+            "otherwise the product's single currency is used."
+        ),
+    )
 
 
 class OrderUpdateBase(Schema):

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -11,19 +11,23 @@ from pydantic import (
 )
 from pydantic.json_schema import SkipJsonSchema
 
-from polar.custom_field.data import CustomFieldDataOutputMixin
+from polar.custom_field.data import (
+    CustomFieldDataInputMixin,
+    CustomFieldDataOutputMixin,
+)
 from polar.customer.schemas.customer import CustomerBase
 from polar.discount.schemas import DiscountMinimal
 from polar.exceptions import ResourceNotFound
 from polar.kit.address import Address, AddressInput
 from polar.kit.currency import format_currency
-from polar.kit.metadata import MetadataOutputMixin
+from polar.kit.metadata import MetadataInputMixin, MetadataOutputMixin
 from polar.kit.schemas import IDSchema, MergeJSONSchema, Schema, TimestampedSchema
 from polar.models.order import (
     OrderBillingReason,
     OrderBillingReasonInternal,
     OrderStatus,
 )
+from polar.organization.schemas import OrganizationID
 from polar.product.schemas import ProductBase, ProductPrice
 from polar.subscription.schemas import SubscriptionBase
 
@@ -90,8 +94,11 @@ class OrderBase(TimestampedSchema, IDSchema):
             return OrderBillingReason.subscription_cycle
         return OrderBillingReason(value)
 
-    invoice_number: str = Field(
-        description="The invoice number associated with this order."
+    invoice_number: str | None = Field(
+        description=(
+            "The invoice number associated with this order. "
+            "`null` while the order is in `draft` status; assigned at finalize."
+        )
     )
     is_invoice_generated: bool = Field(
         description="Whether an invoice has been generated for this order."
@@ -272,6 +279,37 @@ class Order(CustomFieldDataOutputMixin, MetadataOutputMixin, OrderBase):
     )
 
 
+class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
+    """Schema to create a draft order for an off-session charge."""
+
+    organization_id: OrganizationID | None = Field(
+        default=None,
+        description=(
+            "The ID of the organization the order belongs to. "
+            "**Required unless you use an organization token.** "
+            "The customer and product must belong to this organization."
+        ),
+    )
+    customer_id: UUID4 = Field(
+        description="The ID of the customer the order is for. "
+        "Must belong to the order's organization."
+    )
+    product_id: UUID4 = Field(
+        description="The ID of the one-time product to charge for. "
+        "Must belong to the order's organization. "
+        "Subscription products and seat-based products are not supported."
+    )
+    amount: int | None = Field(
+        None,
+        ge=0,
+        description=(
+            "Amount in the smallest currency unit. Required for "
+            "pay-what-you-want / custom-priced products; ignored otherwise. "
+            "Must respect the price's configured minimum and maximum."
+        ),
+    )
+
+
 class OrderUpdateBase(Schema):
     billing_name: str | None = Field(
         None, description="The name of the customer that should appear on the invoice."
@@ -287,6 +325,19 @@ class OrderUpdateBase(Schema):
 
 class OrderUpdate(OrderUpdateBase):
     """Schema to update an order."""
+
+
+class OrderFinalize(Schema):
+    """Schema to finalize a draft order and trigger an off-session charge."""
+
+    payment_method_id: UUID4 | None = Field(
+        None,
+        description=(
+            "ID of the payment method to charge. Must belong to the order's "
+            "customer. Falls back to the customer's default payment method "
+            "when unset."
+        ),
+    )
 
 
 class OrderInvoice(Schema):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -100,7 +100,6 @@ from polar.product.guard import (
     is_static_price,
 )
 from polar.product.price_set import (
-    NoPricesForCurrencies,
     PriceSet,
 )
 from polar.product.repository import ProductRepository
@@ -844,14 +843,22 @@ class OrderService:
                 ]
             )
 
-        # Off-session charges currently support fixed-price products only: the
-        # amount must be fully determined by the product. Custom (pay-what-you-want)
-        # and free prices are rejected.
-        if any(
-            not is_fixed_price(price)
-            for price in product.prices
-            if is_static_price(price)
-        ):
+        # Off-session charges currently support fixed-price products only — the
+        # amount must be fully determined by the product. Custom
+        # (pay-what-you-want) and free prices are rejected.
+        static_prices = [price for price in product.prices if is_static_price(price)]
+        if not static_prices:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": "Product has no chargeable static prices.",
+                        "input": payload.product_id,
+                    }
+                ]
+            )
+        if any(not is_fixed_price(price) for price in static_prices):
             raise PolarRequestValidationError(
                 [
                     {
@@ -879,38 +886,48 @@ class OrderService:
                 ]
             )
 
-        currency = organization.default_presentment_currency
-        try:
-            currency_prices = PriceSet.from_product(product, currency)
-        except NoPricesForCurrencies as e:
+        # Resolve the charge currency. When the product is priced in more than
+        # one currency, the merchant must say which one to use.
+        available_currencies = sorted({price.price_currency for price in static_prices})
+        if payload.currency is not None:
+            requested_currency = payload.currency.lower()
+            if requested_currency not in available_currencies:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "currency"),
+                            "msg": (
+                                "Product has no price in currency "
+                                f"'{requested_currency}'."
+                            ),
+                            "input": payload.currency,
+                        }
+                    ]
+                )
+            currency = requested_currency
+        elif len(available_currencies) > 1:
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
-                        "loc": ("body", "product_id"),
+                        "loc": ("body", "currency"),
                         "msg": (
-                            "Product has no chargeable prices in the "
-                            f"organization currency ({currency})."
+                            "This product is priced in multiple currencies; "
+                            "specify the currency to charge in."
                         ),
-                        "input": payload.product_id,
+                        "input": None,
                     }
                 ]
-            ) from e
+            )
+        else:
+            currency = available_currencies[0]
+
+        currency_prices = PriceSet.from_product(product, currency)
 
         items = list(
             self._build_static_order_items(currency_prices, amount=None, seats=None)
         )
-        if not items:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "product_id"),
-                        "msg": "Product has no chargeable static prices.",
-                        "input": payload.product_id,
-                    }
-                ]
-            )
 
         # Validate custom field values against the product's attached fields,
         # same as the checkout path. Unknown keys are dropped and values are

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -95,13 +95,13 @@ from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.product.guard import (
     is_custom_price,
+    is_fixed_price,
     is_seat_price,
     is_static_price,
 )
 from polar.product.price_set import (
     NoPricesForCurrencies,
     PriceSet,
-    validate_custom_price_amount,
 )
 from polar.product.repository import ProductRepository
 from polar.receipt.service import receipt as receipt_service
@@ -679,33 +679,6 @@ class OrderService:
                 items.append(OrderItem.from_price(price, 0, seats=seats))
         return items
 
-    def _validate_purchase_pricing(
-        self, prices: Iterable[ProductPrice], payload: OrderCreate, currency: str
-    ) -> None:
-        """
-        Validate that the off-session purchase payload provides the values the
-        product's static prices require — and that a custom amount respects the
-        price's configured bounds — returning friendly 4xx errors before
-        `_build_static_order_items` would otherwise hit an assertion.
-        """
-        for price in prices:
-            if is_custom_price(price):
-                if payload.amount is None:
-                    raise PolarRequestValidationError(
-                        [
-                            {
-                                "type": "value_error",
-                                "loc": ("body", "amount"),
-                                "msg": (
-                                    "Amount is required for "
-                                    "pay-what-you-want / custom-priced products."
-                                ),
-                                "input": None,
-                            }
-                        ]
-                    )
-                validate_custom_price_amount(price, payload.amount, currency)
-
     async def _create_order_from_checkout(
         self,
         session: AsyncSession,
@@ -871,6 +844,25 @@ class OrderService:
                 ]
             )
 
+        # Off-session charges currently support fixed-price products only: the
+        # amount must be fully determined by the product. Custom (pay-what-you-want)
+        # and free prices are rejected.
+        if any(
+            not is_fixed_price(price)
+            for price in product.prices
+            if is_static_price(price)
+        ):
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": "Off-session charges only support fixed-price products.",
+                        "input": payload.product_id,
+                    }
+                ]
+            )
+
         customer_repository = CustomerRepository.from_session(session)
         customer = await customer_repository.get_by_id_and_organization(
             payload.customer_id, organization.id
@@ -905,11 +897,8 @@ class OrderService:
                 ]
             ) from e
 
-        self._validate_purchase_pricing(currency_prices, payload, currency)
         items = list(
-            self._build_static_order_items(
-                currency_prices, amount=payload.amount, seats=None
-            )
+            self._build_static_order_items(currency_prices, amount=None, seats=None)
         )
         if not items:
             raise PolarRequestValidationError(

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -100,6 +100,7 @@ from polar.product.guard import (
     is_static_price,
 )
 from polar.product.price_set import (
+    NoPricesForCurrencies,
     PriceSet,
 )
 from polar.product.repository import ProductRepository
@@ -886,44 +887,35 @@ class OrderService:
                 ]
             )
 
-        # Resolve the charge currency. When the product is priced in more than
-        # one currency, the merchant must say which one to use.
-        available_currencies = sorted({price.price_currency for price in static_prices})
+        # Resolve the charge currency: use the one the merchant requested, else
+        # fall back to the organization's default presentment currency (matching
+        # the checkout flow). So `currency` only needs to be passed when the
+        # product isn't priced in the organization's default currency.
         if payload.currency is not None:
-            requested_currency = payload.currency.lower()
-            if requested_currency not in available_currencies:
-                raise PolarRequestValidationError(
-                    [
-                        {
-                            "type": "value_error",
-                            "loc": ("body", "currency"),
-                            "msg": (
-                                "Product has no price in currency "
-                                f"'{requested_currency}'."
-                            ),
-                            "input": payload.currency,
-                        }
-                    ]
-                )
-            currency = requested_currency
-        elif len(available_currencies) > 1:
+            currency = payload.currency.lower()
+        else:
+            currency = organization.default_presentment_currency
+        try:
+            currency_prices = PriceSet.from_product(product, currency)
+        except NoPricesForCurrencies as e:
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "currency"),
                         "msg": (
-                            "This product is priced in multiple currencies; "
-                            "specify the currency to charge in."
+                            f"Product has no price in currency '{currency}'."
+                            if payload.currency is not None
+                            else (
+                                "Product is not priced in the organization's "
+                                f"default currency ('{currency}'); specify a "
+                                "currency to charge in."
+                            )
                         ),
-                        "input": None,
+                        "input": payload.currency,
                     }
                 ]
-            )
-        else:
-            currency = available_currencies[0]
-
-        currency_prices = PriceSet.from_product(product, currency)
+            ) from e
 
         items = list(
             self._build_static_order_items(currency_prices, amount=None, seats=None)

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -274,8 +274,8 @@ class OffSessionChargesNotEnabled(OrderError):
     def __init__(self, organization_id: uuid.UUID) -> None:
         self.organization_id = organization_id
         super().__init__(
-            "Off-session charges are not enabled for this organization. "
-            "Contact Polar support to opt in.",
+            "Off-session charges are not enabled for this organization "
+            f"({organization_id}). Contact Polar support to opt in.",
             403,
         )
 
@@ -287,8 +287,8 @@ class OrganizationNotReadyForPayments(OrderError):
     def __init__(self, organization_id: uuid.UUID) -> None:
         self.organization_id = organization_id
         super().__init__(
-            "This organization can't accept payments yet. Its account may be "
-            "pending onboarding or under review.",
+            f"This organization ({organization_id}) can't accept payments yet. "
+            "Its account may be pending onboarding or under review.",
             403,
         )
 
@@ -936,21 +936,42 @@ class OrderService:
         discount_amount = 0
 
         order_id = uuid.uuid4()
-        (
-            tax_processor,
-            tax_behavior,
-            tax_calculation_processor_id,
-            tax_amount,
-            tax_breakdown,
-        ) = await self._calculate_tax(
-            reference=str(order_id),
-            taxable_amount=subtotal_amount - discount_amount,
-            tax_behavior_option=organization.default_tax_behavior,
-            currency=currency,
-            customer=customer,
-            product=product,
-            tax_exempted=False,
-        )
+        # Unlike the subscription flow, a draft order persists its tax and never
+        # recomputes it at finalize — so a tax we can't compute now (e.g. the
+        # customer's billing address is missing or invalid) must be rejected
+        # rather than silently charged tax-free.
+        try:
+            (
+                tax_processor,
+                tax_behavior,
+                tax_calculation_processor_id,
+                tax_amount,
+                tax_breakdown,
+            ) = await self._calculate_tax(
+                reference=str(order_id),
+                taxable_amount=subtotal_amount - discount_amount,
+                tax_behavior_option=organization.default_tax_behavior,
+                currency=currency,
+                customer=customer,
+                product=product,
+                tax_exempted=False,
+                allow_silent_failure=False,
+            )
+        except TaxCalculationLogicalError as e:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "customer_id"),
+                        "msg": (
+                            "Tax could not be calculated for this order. The "
+                            "customer needs a complete, valid billing address "
+                            "before an off-session charge can be created."
+                        ),
+                        "input": payload.customer_id,
+                    }
+                ]
+            ) from e
 
         net_amount = (
             subtotal_amount
@@ -1559,6 +1580,12 @@ class OrderService:
             order = await repository.update(
                 order, update_dict={"status": OrderStatus.paid}
             )
+
+            # Allocate the invoice number before emitting events/hooks so the
+            # `order.paid` webhook never observes a paid order without one
+            # (off-session drafts only get their number here). Idempotent, so
+            # orders that already have one — e.g. subscription renewals — no-op.
+            order = await self._assign_invoice_number(session, order)
 
             # Add to the customer's balance
             await wallet_service.create_balance_transaction(
@@ -2810,6 +2837,7 @@ class OrderService:
         customer: Customer,
         product: Product,
         tax_exempted: bool,
+        allow_silent_failure: bool = True,
     ) -> tuple[
         TaxProcessor | None,
         TaxBehavior | None,
@@ -2848,6 +2876,12 @@ class OrderService:
                     tax_exempted,
                 )
             except TaxCalculationLogicalError:
+                # The subscription flow tolerates an uncomputable tax (the
+                # address is fixed up over the lifecycle). Off-session draft
+                # orders persist this result and never recompute it, so a silent
+                # zero would charge tax-free — the caller must surface it instead.
+                if not allow_silent_failure:
+                    raise
                 log.warning(
                     "Failed to calculate tax for subscription order due to invalid or incomplete address",
                     reference=reference,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1,5 +1,5 @@
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Iterable, Sequence
 from contextlib import asynccontextmanager
 from enum import StrEnum
 from typing import Any, Literal
@@ -18,6 +18,7 @@ from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.checkout.eventstream import CheckoutEvent, publish_checkout_event
 from polar.checkout.guard import has_product_checkout
 from polar.config import settings
+from polar.custom_field.data import validate_custom_field_data
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
 from polar.customer_portal.schemas.order import (
@@ -68,6 +69,7 @@ from polar.models import (
     Payment,
     PaymentMethod,
     Product,
+    ProductPrice,
     Subscription,
     Transaction,
     User,
@@ -88,6 +90,7 @@ from polar.notifications.service import notifications as notifications_service
 from polar.organization.repository import OrganizationRepository
 from polar.organization.service import organization as organization_service
 from polar.payment.repository import PaymentRepository
+from polar.payment.service import payment as payment_service
 from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.product.guard import (
@@ -95,7 +98,11 @@ from polar.product.guard import (
     is_seat_price,
     is_static_price,
 )
-from polar.product.price_set import PriceSet
+from polar.product.price_set import (
+    NoPricesForCurrencies,
+    PriceSet,
+    validate_custom_price_amount,
+)
 from polar.product.repository import ProductRepository
 from polar.receipt.service import receipt as receipt_service
 from polar.subscription.service import subscription as subscription_service
@@ -120,7 +127,7 @@ from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
 from .repository import OrderRepository
-from .schemas import OrderInvoice, OrderReceipt, OrderUpdate
+from .schemas import OrderCreate, OrderInvoice, OrderReceipt, OrderUpdate
 from .sorting import OrderSortProperty
 
 log: Logger = structlog.get_logger()
@@ -242,6 +249,60 @@ class PaymentFailed(OrderError):
         self.reason = reason
         message = f"Payment failed with reason: {reason}."
         super().__init__(message, 402)
+
+
+class PaymentActionRequired(OrderError):
+    """
+    Off-session charge needs customer interaction (typically 3DS / SCA).
+    The merchant should redirect the customer to the portal to reauthenticate
+    the card.
+    """
+
+    def __init__(self, order: Order, payment_intent_id: str) -> None:
+        self.order = order
+        self.payment_intent_id = payment_intent_id
+        message = (
+            f"Order {order.id} payment requires customer authentication "
+            "(e.g. 3DS challenge); off-session charge cannot complete."
+        )
+        super().__init__(message, 402)
+
+
+class OffSessionChargesNotEnabled(OrderError):
+    """The organization is not allowed to use the off-session charges API."""
+
+    def __init__(self, organization_id: uuid.UUID) -> None:
+        self.organization_id = organization_id
+        super().__init__(
+            "Off-session charges are not enabled for this organization. "
+            "Contact Polar support to opt in.",
+            403,
+        )
+
+
+class OrganizationNotReadyForPayments(OrderError):
+    """The organization's account can't currently accept payments (e.g. not yet
+    onboarded or under review), so an off-session charge can't be attempted."""
+
+    def __init__(self, organization_id: uuid.UUID) -> None:
+        self.organization_id = organization_id
+        super().__init__(
+            "This organization can't accept payments yet. Its account may be "
+            "pending onboarding or under review.",
+            403,
+        )
+
+
+class OrderNotDraft(OrderError):
+    """Operation only valid on orders in `draft` status."""
+
+    def __init__(self, order: Order) -> None:
+        self.order = order
+        super().__init__(
+            f"Order {order.id} is not in draft status (current: {order.status}). "
+            "Only draft orders can be modified or finalized.",
+            412,
+        )
 
 
 class PaymentRetryValidationError(OrderError):
@@ -389,16 +450,13 @@ class OrderService:
         id: uuid.UUID,
     ) -> Order | None:
         repository = OrderRepository.from_session(session)
-        statement = (
-            repository.get_readable_statement(auth_subject)
-            .options(
-                *repository.get_eager_options(
-                    product_load=joinedload(Order.product),
-                )
-            )
-            .where(Order.id == id)
+        return await repository.get_readable_by_id(
+            auth_subject,
+            id,
+            options=repository.get_eager_options(
+                product_load=joinedload(Order.product),
+            ),
         )
-        return await repository.get_one_or_none(statement)
 
     async def update(
         self,
@@ -596,6 +654,58 @@ class OrderService:
             session, checkout, billing_reason, payment, subscription
         )
 
+    def _build_static_order_items(
+        self,
+        prices: Iterable[ProductPrice],
+        *,
+        amount: int | None,
+        seats: int | None,
+    ) -> Sequence[OrderItem]:
+        """
+        Build order line items for the static prices of a product.
+
+        Metered prices are skipped (they're billed through usage). Custom
+        (pay-what-you-want) prices use `amount`; seat-based prices use `seats`.
+        Callers are responsible for validating that `amount` / `seats` are
+        present when the product requires them.
+        """
+        items: list[OrderItem] = []
+        for price in prices:
+            if not is_static_price(price):
+                continue
+            if is_custom_price(price):
+                items.append(OrderItem.from_price(price, 0, amount))
+            else:
+                items.append(OrderItem.from_price(price, 0, seats=seats))
+        return items
+
+    def _validate_purchase_pricing(
+        self, prices: Iterable[ProductPrice], payload: OrderCreate, currency: str
+    ) -> None:
+        """
+        Validate that the off-session purchase payload provides the values the
+        product's static prices require — and that a custom amount respects the
+        price's configured bounds — returning friendly 4xx errors before
+        `_build_static_order_items` would otherwise hit an assertion.
+        """
+        for price in prices:
+            if is_custom_price(price):
+                if payload.amount is None:
+                    raise PolarRequestValidationError(
+                        [
+                            {
+                                "type": "value_error",
+                                "loc": ("body", "amount"),
+                                "msg": (
+                                    "Amount is required for "
+                                    "pay-what-you-want / custom-priced products."
+                                ),
+                                "input": None,
+                            }
+                        ]
+                    )
+                validate_custom_price_amount(price, payload.amount, currency)
+
     async def _create_order_from_checkout(
         self,
         session: AsyncSession,
@@ -613,15 +723,11 @@ class OrderService:
             currency_prices = PriceSet.from_prices(
                 checkout.prices[checkout.product_id], checkout.currency
             )
-            for price in currency_prices:
-                # Don't create an item for metered prices
-                if not is_static_price(price):
-                    continue
-                if is_custom_price(price):
-                    item = OrderItem.from_price(price, 0, checkout.amount)
-                else:
-                    item = OrderItem.from_price(price, 0, seats=checkout.seats)
-                items.append(item)
+            items = list(
+                self._build_static_order_items(
+                    currency_prices, amount=checkout.amount, seats=checkout.seats
+                )
+            )
 
         discount_amount = checkout.discount_amount
 
@@ -700,6 +806,346 @@ class OrderService:
 
         return order
 
+    async def create_draft_order(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        payload: OrderCreate,
+    ) -> Order:
+        """
+        Create a draft order for an off-session charge in `organization`. The
+        order is persisted with `status=draft` and no invoice number; the
+        merchant must call finalize_order() to charge the customer's saved
+        payment method.
+
+        The caller (endpoint) is responsible for having resolved `organization`
+        and asserted `sales_manage` permission on it. The product and customer
+        are looked up scoped to that organization.
+        """
+        if not organization.feature_settings.get("off_session_charges_enabled"):
+            raise OffSessionChargesNotEnabled(organization.id)
+
+        product_repository = ProductRepository.from_session(session)
+        product = await product_repository.get_by_id_and_organization(
+            payload.product_id,
+            organization.id,
+            options=product_repository.get_eager_options(),
+        )
+        if product is None:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": "Product does not exist.",
+                        "input": payload.product_id,
+                    }
+                ]
+            )
+        if product.is_recurring:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": (
+                            "Subscription products are not supported by the "
+                            "off-session charge API. Use a one-time product."
+                        ),
+                        "input": payload.product_id,
+                    }
+                ]
+            )
+        if product.has_seat_based_price:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": (
+                            "Seat-based products are not supported by the "
+                            "off-session charge API."
+                        ),
+                        "input": payload.product_id,
+                    }
+                ]
+            )
+
+        customer_repository = CustomerRepository.from_session(session)
+        customer = await customer_repository.get_by_id_and_organization(
+            payload.customer_id, organization.id
+        )
+        if customer is None:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "customer_id"),
+                        "msg": "Customer does not exist.",
+                        "input": payload.customer_id,
+                    }
+                ]
+            )
+
+        currency = organization.default_presentment_currency
+        try:
+            currency_prices = PriceSet.from_product(product, currency)
+        except NoPricesForCurrencies as e:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": (
+                            "Product has no chargeable prices in the "
+                            f"organization currency ({currency})."
+                        ),
+                        "input": payload.product_id,
+                    }
+                ]
+            ) from e
+
+        self._validate_purchase_pricing(currency_prices, payload, currency)
+        items = list(
+            self._build_static_order_items(
+                currency_prices, amount=payload.amount, seats=None
+            )
+        )
+        if not items:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "product_id"),
+                        "msg": "Product has no chargeable static prices.",
+                        "input": payload.product_id,
+                    }
+                ]
+            )
+
+        # Validate custom field values against the product's attached fields,
+        # same as the checkout path. Unknown keys are dropped and values are
+        # type-checked; required fields aren't enforced at draft creation.
+        custom_field_data = validate_custom_field_data(
+            product.attached_custom_fields,
+            payload.custom_field_data,
+            validate_required=False,
+        )
+
+        subtotal_amount = sum(item.amount for item in items)
+        discount_amount = 0
+
+        order_id = uuid.uuid4()
+        (
+            tax_processor,
+            tax_behavior,
+            tax_calculation_processor_id,
+            tax_amount,
+            tax_breakdown,
+        ) = await self._calculate_tax(
+            reference=str(order_id),
+            taxable_amount=subtotal_amount - discount_amount,
+            tax_behavior_option=organization.default_tax_behavior,
+            currency=currency,
+            customer=customer,
+            product=product,
+            tax_exempted=False,
+        )
+
+        net_amount = (
+            subtotal_amount
+            - discount_amount
+            - (tax_amount if tax_behavior == TaxBehavior.inclusive else 0)
+        )
+
+        repository = OrderRepository.from_session(session)
+        order = await repository.create(
+            Order(
+                id=order_id,
+                status=OrderStatus.draft,
+                subtotal_amount=subtotal_amount,
+                discount_amount=discount_amount,
+                tax_amount=tax_amount,
+                net_amount=net_amount,
+                currency=currency,
+                billing_reason=OrderBillingReasonInternal.purchase,
+                billing_name=customer.billing_name,
+                billing_address=customer.billing_address,
+                tax_id=customer.tax_id,
+                tax_behavior=tax_behavior,
+                tax_breakdown=tax_breakdown or None,
+                tax_processor=tax_processor,
+                tax_calculation_processor_id=tax_calculation_processor_id,
+                invoice_number=None,
+                organization=organization,
+                customer=customer,
+                product=product,
+                discount=None,
+                subscription=None,
+                checkout=None,
+                user_metadata=payload.metadata,
+                custom_field_data=custom_field_data,
+                items=items,
+                seats=None,
+            ),
+            flush=True,
+        )
+
+        return order
+
+    async def finalize_order(
+        self,
+        session: AsyncSession,
+        order: Order,
+        *,
+        payment_method_id: uuid.UUID | None = None,
+    ) -> Order:
+        """
+        Finalize a draft order: resolve the payment method, atomically claim the
+        draft, and synchronously attempt an off-session charge. On success the
+        order transitions to paid, gets an invoice number, and benefit grants
+        fire before this method returns. On any failure the order is reverted to
+        draft so the merchant can fix the situation and retry against the same
+        order ID. The invoice number is assigned only on success, so failed
+        attempts don't burn invoice numbers.
+        """
+        if order.status != OrderStatus.draft:
+            raise OrderNotDraft(order)
+
+        organization = order.organization
+        if not organization.feature_settings.get("off_session_charges_enabled"):
+            raise OffSessionChargesNotEnabled(organization.id)
+
+        # Surface the real reason up front: trigger_payment would otherwise
+        # short-circuit on this same capability and leave the order pending,
+        # which the None-handling below can only report as a generic failure.
+        if not organization.can_accept_payments:
+            raise OrganizationNotReadyForPayments(organization.id)
+
+        customer = order.customer
+        payment_method = await self._resolve_payment_method(
+            session, customer, payment_method_id
+        )
+
+        # Atomically claim the draft (draft -> pending). If another request
+        # already claimed it, this returns False and we bail out so two
+        # finalizes can't both charge / race the order status.
+        repository = OrderRepository.from_session(session)
+        if not await repository.start_finalization(order.id):
+            raise OrderNotDraft(order)
+        # Sync the in-memory status with the atomic transition (deterministic on
+        # a successful claim) so trigger_payment, which requires `pending`, sees
+        # it — without a refresh round-trip or expiring loaded relationships.
+        order.status = OrderStatus.pending
+
+        # Any failure from trigger_payment happens before a charge completes
+        # (declines raise, SCA returns requires_action, a concurrent lock raises
+        # PaymentAlreadyInProgress), so reverting to draft is always safe here.
+        try:
+            payment_intent = await self.trigger_payment(
+                session, order, payment_method, payment_mode=PaymentMode.sync
+            )
+        except Exception:
+            await self._revert_to_draft(session, order)
+            raise
+
+        if payment_intent is None:
+            # trigger_payment short-circuited without a charge. The expected
+            # case is under-currency-minimum, which already marked the order
+            # paid (org capability was checked above), so re-read for a clean
+            # status: paid -> assign the invoice number and return. A still
+            # `pending` order here means no Stripe charge could be attempted
+            # (e.g. a non-Stripe payment method), so revert and report failure.
+            settled = await repository.get_by_id(order.id)
+            if settled is not None and settled.status == OrderStatus.pending:
+                await self._revert_to_draft(session, order)
+                raise PaymentFailed(PaymentFailedReason.missing_payment_method)
+            return await self._assign_invoice_number(session, order)
+
+        # Apply the charge.succeeded path inline so the finalize HTTP response
+        # carries the paid order. The webhook arrives shortly after and no-ops
+        # via the idempotency guards in upsert_from_stripe_charge / handle_payment.
+        charge = self._get_intent_charge(payment_intent)
+        order = await self._assign_invoice_number(session, order)
+        payment = await payment_service.upsert_from_stripe_charge(
+            session, charge, organization, None, None, order
+        )
+        return await self.handle_payment(session, order, payment)
+
+    def _get_intent_charge(
+        self, payment_intent: stripe_lib.PaymentIntent
+    ) -> stripe_lib.Charge:
+        """Return the Charge from a confirmed PaymentIntent.
+
+        trigger_payment creates the intent with ``expand=["latest_charge"]``,
+        so this is a full Charge object. We raise (rather than assert) if it
+        isn't, since asserts are stripped under ``-O`` and this runs after the
+        customer has been charged.
+        """
+        charge = payment_intent.latest_charge
+        if not isinstance(charge, stripe_lib.Charge):
+            raise OrderError(
+                f"PaymentIntent {payment_intent.id} is missing its expanded "
+                "latest_charge; cannot settle the order synchronously."
+            )
+        return charge
+
+    async def _assign_invoice_number(
+        self, session: AsyncSession, order: Order
+    ) -> Order:
+        """Assign the next invoice number to an order that doesn't have one."""
+        if order.invoice_number is not None:
+            return order
+        invoice_number = await organization_service.get_next_invoice_number(
+            session, order.organization, order.customer
+        )
+        repository = OrderRepository.from_session(session)
+        return await repository.update(
+            order, update_dict={"invoice_number": invoice_number}
+        )
+
+    async def _resolve_payment_method(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        payment_method_id: uuid.UUID | None,
+    ) -> PaymentMethod:
+        """
+        Resolve the payment method to charge for an off-session order: the
+        explicitly requested one (which must belong to the customer), else the
+        customer's default. Raises PaymentFailed if none is usable.
+        """
+        repository = PaymentMethodRepository.from_session(session)
+        if payment_method_id is not None:
+            payment_method = await repository.get_by_id(
+                payment_method_id, options=repository.get_eager_options()
+            )
+            if payment_method is None or payment_method.customer_id != customer.id:
+                raise PaymentFailed(PaymentFailedReason.missing_payment_method)
+            return payment_method
+
+        payment_method = await payment_method_service.get_customer_payment_method(
+            session, customer
+        )
+        if payment_method is None:
+            raise PaymentFailed(PaymentFailedReason.missing_payment_method)
+        return payment_method
+
+    async def _revert_to_draft(self, session: AsyncSession, order: Order) -> Order:
+        """
+        Roll a failed finalize back to draft so the merchant can fix the
+        situation and retry against the same order ID. flush=True so the revert
+        is persisted even as the request bubbles up the failure exception. The
+        invoice number is only assigned on success, so there's nothing to
+        release here (cleared defensively).
+        """
+        repository = OrderRepository.from_session(session)
+        return await repository.update(
+            order,
+            update_dict={"status": OrderStatus.draft, "invoice_number": None},
+            flush=True,
+        )
+
     async def create_subscription_order(
         self,
         session: AsyncSession,
@@ -765,7 +1211,7 @@ class OrderService:
                 tax_calculation_processor_id,
                 tax_amount,
                 tax_breakdown,
-            ) = await self._calculate_subscription_order_tax(
+            ) = await self._calculate_tax(
                 reference=str(order_id),
                 taxable_amount=subtotal_amount - discount_amount,
                 tax_behavior_option=tax_behavior_option,
@@ -1065,7 +1511,15 @@ class OrderService:
         *,
         payment_mode: PaymentMode = PaymentMode.background,
         payment_trigger: PaymentTrigger | None = None,
-    ) -> None:
+    ) -> stripe_lib.PaymentIntent | None:
+        """
+        Attempt an off-session charge for the order.
+
+        Returns the Stripe PaymentIntent on Stripe-card paths so callers in
+        synchronous mode can apply the success path inline without waiting for
+        the webhook. Returns None for the under-minimum / non-Stripe / disabled
+        branches that don't create a PaymentIntent.
+        """
         if order.status != OrderStatus.pending:
             raise OrderNotPending(order)
 
@@ -1089,7 +1543,7 @@ class OrderService:
                     else "checkout_payments"
                 ),
             )
-            return
+            return None
 
         if order.payment_lock_acquired_at is not None:
             log.warn("Payment already in progress", order_id=order.id)
@@ -1119,7 +1573,7 @@ class OrderService:
                 session, order, order.organization
             )
             await self._on_order_updated(session, order, previous_status)
-            return
+            return None
 
         async with self.acquire_payment_lock(session, order):
             if payment_method.processor == PaymentProcessor.stripe:
@@ -1139,17 +1593,33 @@ class OrderService:
                 stripe_customer_id = order.customer.stripe_customer_id
                 assert stripe_customer_id is not None
 
+                # Off-session finalize is retried by the merchant against the
+                # same order (which reverts to draft on failure), so the charge
+                # must be idempotent: if it succeeds but the response/commit is
+                # lost, a retry returns the cached PaymentIntent instead of
+                # double-charging. Scoping the key to the payment method keeps a
+                # retry with a *different* card a genuinely fresh attempt. Only
+                # the sync path sets this — background dunning relies on Stripe
+                # attempting a brand-new charge on each retry.
+                idempotency_key: str | None = None
+                if payment_mode == PaymentMode.sync:
+                    idempotency_key = (
+                        f"order_finalize:{order.id}:{payment_method.processor_id}"
+                    )
+
                 try:
-                    await stripe_service.create_payment_intent(
+                    payment_intent = await stripe_service.create_payment_intent(
                         amount=order.due_amount,
                         currency=order.currency,
                         payment_method=payment_method.processor_id,
                         customer=stripe_customer_id,
                         confirm=True,
                         off_session=True,
+                        expand=["latest_charge"],
                         statement_descriptor_suffix=order.statement_descriptor_suffix,
                         description=f"{order.organization.name} — {order.description}",
                         metadata=metadata,
+                        idempotency_key=idempotency_key,
                     )
                 except stripe_lib.CardError as e:
                     # Card errors (declines, expired cards, etc.) should not be retried
@@ -1192,6 +1662,31 @@ class OrderService:
                             raise PaymentFailed(PaymentFailedReason.card_error) from e
 
                     raise
+
+                # Off-session SCA / 3DS challenges return a non-raising intent
+                # in one of the `requires_*` statuses. Only sync callers
+                # (draft-order finalize) surface a typed error so the merchant
+                # can re-authenticate the customer; background callers (checkout
+                # / dunning) must keep waiting for the webhook to drive dunning,
+                # exactly as before this path existed — raising here would break
+                # those flows.
+                if payment_mode == PaymentMode.sync and payment_intent.status in (
+                    "requires_action",
+                    "requires_confirmation",
+                    "requires_payment_method",
+                    "requires_source_action",
+                ):
+                    log.info(
+                        "Off-session payment requires customer action",
+                        order_id=order.id,
+                        payment_intent_id=payment_intent.id,
+                        payment_intent_status=payment_intent.status,
+                    )
+                    raise PaymentActionRequired(order, payment_intent.id)
+
+                return payment_intent
+
+        return None
 
     async def _mark_intent_as_failed_sync(self, error: stripe_lib.StripeError) -> None:
         payment_intent = getattr(error.error, "payment_intent", None)
@@ -1416,6 +1911,12 @@ class OrderService:
     async def handle_payment(
         self, session: AsyncSession, order: Order, payment: Payment | None
     ) -> Order:
+        # Idempotency: a charge.succeeded webhook can arrive after the
+        # finalize-order endpoint already applied the success path inline.
+        # In that case, the order is already paid and there's nothing to do.
+        if order.stripe_invoice_id is None and order.status == OrderStatus.paid:
+            return order
+
         # Stripe invoices may already have been marked as paid, so ignore the check
         if order.stripe_invoice_id is None and order.status != OrderStatus.pending:
             raise OrderNotPending(order)
@@ -1487,7 +1988,7 @@ class OrderService:
                     tax_calculation_processor_id,
                     tax_amount,
                     tax_breakdown,
-                ) = await self._calculate_subscription_order_tax(
+                ) = await self._calculate_tax(
                     reference=str(order.id),
                     taxable_amount=order.net_amount,
                     currency=order.currency,
@@ -2299,7 +2800,7 @@ class OrderService:
 
         return order
 
-    async def _calculate_subscription_order_tax(
+    async def _calculate_tax(
         self,
         *,
         reference: str,

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -152,6 +152,13 @@ class OrganizationFeatureSettings(Schema):
         False,
         description="If this organization has access to reset proration behavior.",
     )
+    off_session_charges_enabled: bool = Field(
+        False,
+        description=(
+            "If this organization can create and finalize draft orders via the API "
+            "(off-session charges against a saved payment method)."
+        ),
+    )
     billing_enabled: bool = Field(
         False, description="If this organization has billing enabled"
     )

--- a/server/polar/product/custom_price.py
+++ b/server/polar/product/custom_price.py
@@ -4,13 +4,12 @@ from polar.kit.currency import (
     get_maximum_currency_amount,
     get_minimum_currency_amount,
 )
-from polar.models import ProductPrice
 
-from .guard import is_custom_price
+from .guard import CustomPrice
 
 
 def validate_custom_price_amount(
-    price: ProductPrice,
+    price: CustomPrice,
     amount: int,
     currency: str,
     loc: tuple[str, ...] = ("body", "amount"),
@@ -18,12 +17,10 @@ def validate_custom_price_amount(
     """Validate a custom (pay-what-you-want) amount against the price's
     configured minimum/maximum and the currency's minimum/maximum.
 
-    No-op for non-custom prices. Shared by the checkout and off-session order
-    flows so both enforce identical bounds.
+    Takes a `CustomPrice` so `minimum_amount`/`maximum_amount` are statically
+    typed (never `None`); callers narrow with `is_custom_price` first. Shared by
+    the checkout and off-session order flows so both enforce identical bounds.
     """
-    if not is_custom_price(price):
-        return
-
     if amount < 0:
         raise PolarRequestValidationError(
             [

--- a/server/polar/product/custom_price.py
+++ b/server/polar/product/custom_price.py
@@ -1,0 +1,107 @@
+from polar.exceptions import PolarRequestValidationError
+from polar.kit.currency import (
+    format_currency,
+    get_maximum_currency_amount,
+    get_minimum_currency_amount,
+)
+from polar.models import ProductPrice
+
+from .guard import is_custom_price
+
+
+def validate_custom_price_amount(
+    price: ProductPrice,
+    amount: int,
+    currency: str,
+    loc: tuple[str, ...] = ("body", "amount"),
+) -> None:
+    """Validate a custom (pay-what-you-want) amount against the price's
+    configured minimum/maximum and the currency's minimum/maximum.
+
+    No-op for non-custom prices. Shared by the checkout and off-session order
+    flows so both enforce identical bounds.
+    """
+    if not is_custom_price(price):
+        return
+
+    if amount < 0:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "greater_than_equal",
+                    "loc": loc,
+                    "msg": "Amount must be at least 0.",
+                    "input": amount,
+                    "ctx": {"ge": 0},
+                }
+            ]
+        )
+
+    # Enforce the price's configured minimum (0 means free / pay-what-you-want
+    # is allowed, so a 0 amount passes here).
+    if amount < price.minimum_amount:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "greater_than_equal",
+                    "loc": loc,
+                    "msg": "Amount is below minimum.",
+                    "input": amount,
+                    "ctx": {"ge": price.minimum_amount},
+                }
+            ]
+        )
+
+    # A positive amount must always clear the processor floor for the currency,
+    # regardless of the configured minimum — otherwise it would pass here but
+    # fail when we try to charge it. (Mirrors the currency-maximum check below.)
+    if amount > 0:
+        currency_minimum = get_minimum_currency_amount(currency)
+        if amount < currency_minimum:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "invalid_amount",
+                        "loc": loc,
+                        "msg": (
+                            "Amount must be 0 or at least "
+                            f"{format_currency(currency_minimum, currency)}."
+                        ),
+                        "input": amount,
+                        "ctx": {"allowed": [0], "ge": currency_minimum},
+                    }
+                ]
+            )
+
+    if price.maximum_amount is not None and amount > price.maximum_amount:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "less_than_equal",
+                    "loc": loc,
+                    "msg": "Amount is above maximum.",
+                    "input": amount,
+                    "ctx": {"le": price.maximum_amount},
+                }
+            ]
+        )
+
+    currency_maximum = get_maximum_currency_amount(currency)
+    if amount > currency_maximum:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "less_than_equal",
+                    "loc": loc,
+                    "msg": (
+                        "Amount must be at most "
+                        f"{format_currency(currency_maximum, currency)}."
+                    ),
+                    "input": amount,
+                    "ctx": {"le": currency_maximum},
+                }
+            ]
+        )
+
+
+__all__ = ["validate_custom_price_amount"]

--- a/server/polar/product/price_set.py
+++ b/server/polar/product/price_set.py
@@ -1,10 +1,15 @@
 from collections.abc import Sequence
 from typing import Self
 
-from polar.exceptions import PolarError
+from polar.exceptions import PolarError, PolarRequestValidationError
+from polar.kit.currency import (
+    format_currency,
+    get_maximum_currency_amount,
+    get_minimum_currency_amount,
+)
 from polar.models import Product, ProductPrice
 
-from .guard import is_static_price
+from .guard import is_custom_price, is_static_price
 
 
 class PriceSetError(PolarError): ...
@@ -93,8 +98,101 @@ class PriceSet:
         return self.prices[0]
 
 
+def validate_custom_price_amount(
+    price: ProductPrice,
+    amount: int,
+    currency: str,
+    loc: tuple[str, ...] = ("body", "amount"),
+) -> None:
+    """Validate a custom (pay-what-you-want) amount against the price's
+    configured minimum/maximum and the currency's minimum/maximum.
+
+    No-op for non-custom prices. Shared by the checkout and off-session order
+    flows so both enforce identical bounds.
+    """
+    if not is_custom_price(price):
+        return
+
+    if amount < 0:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "greater_than_equal",
+                    "loc": loc,
+                    "msg": "Amount must be at least 0.",
+                    "input": amount,
+                    "ctx": {"ge": 0},
+                }
+            ]
+        )
+
+    if price.minimum_amount == 0:
+        # Free is allowed: accept 0, or any amount >= the currency minimum.
+        if amount == 0:
+            return
+        currency_minimum = get_minimum_currency_amount(currency)
+        if 0 < amount < currency_minimum:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "invalid_amount",
+                        "loc": loc,
+                        "msg": (
+                            "Amount must be 0 or at least "
+                            f"{format_currency(currency_minimum, currency)}."
+                        ),
+                        "input": amount,
+                        "ctx": {"allowed": [0], "ge": currency_minimum},
+                    }
+                ]
+            )
+    elif amount < price.minimum_amount:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "greater_than_equal",
+                    "loc": loc,
+                    "msg": "Amount is below minimum.",
+                    "input": amount,
+                    "ctx": {"ge": price.minimum_amount},
+                }
+            ]
+        )
+
+    if price.maximum_amount is not None and amount > price.maximum_amount:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "less_than_equal",
+                    "loc": loc,
+                    "msg": "Amount is above maximum.",
+                    "input": amount,
+                    "ctx": {"le": price.maximum_amount},
+                }
+            ]
+        )
+
+    currency_maximum = get_maximum_currency_amount(currency)
+    if amount > currency_maximum:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "less_than_equal",
+                    "loc": loc,
+                    "msg": (
+                        "Amount must be at most "
+                        f"{format_currency(currency_maximum, currency)}."
+                    ),
+                    "input": amount,
+                    "ctx": {"le": currency_maximum},
+                }
+            ]
+        )
+
+
 __all__ = [
     "NoPricesForCurrencies",
     "PriceSet",
     "PriceSetError",
+    "validate_custom_price_amount",
 ]

--- a/server/polar/product/price_set.py
+++ b/server/polar/product/price_set.py
@@ -126,12 +126,27 @@ def validate_custom_price_amount(
             ]
         )
 
-    if price.minimum_amount == 0:
-        # Free is allowed: accept 0, or any amount >= the currency minimum.
-        if amount == 0:
-            return
+    # Enforce the price's configured minimum (0 means free / pay-what-you-want
+    # is allowed, so a 0 amount passes here).
+    if amount < price.minimum_amount:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "greater_than_equal",
+                    "loc": loc,
+                    "msg": "Amount is below minimum.",
+                    "input": amount,
+                    "ctx": {"ge": price.minimum_amount},
+                }
+            ]
+        )
+
+    # A positive amount must always clear the processor floor for the currency,
+    # regardless of the configured minimum — otherwise it would pass here but
+    # fail when we try to charge it. (Mirrors the currency-maximum check below.)
+    if amount > 0:
         currency_minimum = get_minimum_currency_amount(currency)
-        if 0 < amount < currency_minimum:
+        if amount < currency_minimum:
             raise PolarRequestValidationError(
                 [
                     {
@@ -146,18 +161,6 @@ def validate_custom_price_amount(
                     }
                 ]
             )
-    elif amount < price.minimum_amount:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "greater_than_equal",
-                    "loc": loc,
-                    "msg": "Amount is below minimum.",
-                    "input": amount,
-                    "ctx": {"ge": price.minimum_amount},
-                }
-            ]
-        )
 
     if price.maximum_amount is not None and amount > price.maximum_amount:
         raise PolarRequestValidationError(

--- a/server/polar/product/price_set.py
+++ b/server/polar/product/price_set.py
@@ -1,15 +1,10 @@
 from collections.abc import Sequence
 from typing import Self
 
-from polar.exceptions import PolarError, PolarRequestValidationError
-from polar.kit.currency import (
-    format_currency,
-    get_maximum_currency_amount,
-    get_minimum_currency_amount,
-)
+from polar.exceptions import PolarError
 from polar.models import Product, ProductPrice
 
-from .guard import is_custom_price, is_static_price
+from .guard import is_static_price
 
 
 class PriceSetError(PolarError): ...
@@ -98,104 +93,8 @@ class PriceSet:
         return self.prices[0]
 
 
-def validate_custom_price_amount(
-    price: ProductPrice,
-    amount: int,
-    currency: str,
-    loc: tuple[str, ...] = ("body", "amount"),
-) -> None:
-    """Validate a custom (pay-what-you-want) amount against the price's
-    configured minimum/maximum and the currency's minimum/maximum.
-
-    No-op for non-custom prices. Shared by the checkout and off-session order
-    flows so both enforce identical bounds.
-    """
-    if not is_custom_price(price):
-        return
-
-    if amount < 0:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "greater_than_equal",
-                    "loc": loc,
-                    "msg": "Amount must be at least 0.",
-                    "input": amount,
-                    "ctx": {"ge": 0},
-                }
-            ]
-        )
-
-    # Enforce the price's configured minimum (0 means free / pay-what-you-want
-    # is allowed, so a 0 amount passes here).
-    if amount < price.minimum_amount:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "greater_than_equal",
-                    "loc": loc,
-                    "msg": "Amount is below minimum.",
-                    "input": amount,
-                    "ctx": {"ge": price.minimum_amount},
-                }
-            ]
-        )
-
-    # A positive amount must always clear the processor floor for the currency,
-    # regardless of the configured minimum — otherwise it would pass here but
-    # fail when we try to charge it. (Mirrors the currency-maximum check below.)
-    if amount > 0:
-        currency_minimum = get_minimum_currency_amount(currency)
-        if amount < currency_minimum:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "invalid_amount",
-                        "loc": loc,
-                        "msg": (
-                            "Amount must be 0 or at least "
-                            f"{format_currency(currency_minimum, currency)}."
-                        ),
-                        "input": amount,
-                        "ctx": {"allowed": [0], "ge": currency_minimum},
-                    }
-                ]
-            )
-
-    if price.maximum_amount is not None and amount > price.maximum_amount:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "less_than_equal",
-                    "loc": loc,
-                    "msg": "Amount is above maximum.",
-                    "input": amount,
-                    "ctx": {"le": price.maximum_amount},
-                }
-            ]
-        )
-
-    currency_maximum = get_maximum_currency_amount(currency)
-    if amount > currency_maximum:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "less_than_equal",
-                    "loc": loc,
-                    "msg": (
-                        "Amount must be at most "
-                        f"{format_currency(currency_maximum, currency)}."
-                    ),
-                    "input": amount,
-                    "ctx": {"le": currency_maximum},
-                }
-            ]
-        )
-
-
 __all__ = [
     "NoPricesForCurrencies",
     "PriceSet",
     "PriceSetError",
-    "validate_custom_price_amount",
 ]

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -9,6 +10,7 @@ from pytest_mock import MockerFixture
 from polar.auth.scope import Scope
 from polar.models import Customer, Order, Organization, Product, UserOrganization
 from polar.models.order import OrderStatus
+from polar.order.service import PaymentFailed, PaymentFailedReason
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_order
@@ -595,3 +597,48 @@ class TestFinalizeOrderEndpoint:
         # The default `orders` fixture creates orders with status=paid.
         response = await client.post(f"/v1/orders/{orders[0].id}/finalize", json={})
         assert response.status_code == 412
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_403_when_off_session_disabled(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # No `off_session_organization` fixture here, so the flag is disabled:
+        # finalizing a draft raises OffSessionChargesNotEnabled -> 403.
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+        )
+        response = await client.post(f"/v1/orders/{order.id}/finalize", json={})
+        assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_402_when_payment_fails(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+        )
+        # A PaymentFailed from the service must map to 402.
+        mocker.patch(
+            "polar.order.endpoints.order_service.finalize_order",
+            new=AsyncMock(side_effect=PaymentFailed(PaymentFailedReason.card_error)),
+        )
+        response = await client.post(f"/v1/orders/{order.id}/finalize", json={})
+        assert response.status_code == 402

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -7,7 +7,8 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
-from polar.models import Customer, Order, Product, UserOrganization
+from polar.models import Customer, Order, Organization, Product, UserOrganization
+from polar.models.order import OrderStatus
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_order
@@ -287,6 +288,8 @@ class TestExportOrders:
         assert len(csv_lines) == 2  # Header + 1 order
 
         # Verify only the filtered order is in the export by checking invoice numbers
+        assert order1.invoice_number is not None
+        assert order2.invoice_number is not None
         assert order1.invoice_number in csv_lines[1]
         assert order2.invoice_number not in response.text
 
@@ -463,3 +466,132 @@ class TestGetOrderReceipt:
 
         assert response.status_code == 200
         assert response.json() == {"url": "https://example.com/signed-url"}
+
+
+@pytest_asyncio.fixture
+async def off_session_organization(
+    save_fixture: SaveFixture, organization: Organization
+) -> Organization:
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "off_session_charges_enabled": True,
+    }
+    await save_fixture(organization)
+    return organization
+
+
+@pytest.mark.asyncio
+class TestCreateOrder:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/orders/", json={})
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_user_not_organization_member(
+        self,
+        client: AsyncClient,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        # The authenticated user is not a member of the target organization
+        # (no user_organization fixture), so it isn't resolvable.
+        response = await client.post(
+            "/v1/orders/",
+            json={
+                "organization_id": str(off_session_organization.id),
+                "customer_id": str(customer.id),
+                "product_id": str(product_one_time.id),
+            },
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_feature_flag_disabled(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        response = await client.post(
+            "/v1/orders/",
+            json={
+                "organization_id": str(organization.id),
+                "customer_id": str(customer.id),
+                "product_id": str(product_one_time.id),
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        response = await client.post(
+            "/v1/orders/",
+            json={
+                "organization_id": str(off_session_organization.id),
+                "customer_id": str(customer.id),
+                "product_id": str(product_one_time.id),
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["status"] == OrderStatus.draft
+        assert body["invoice_number"] is None
+        assert body["customer_id"] == str(customer.id)
+        assert body["product_id"] == str(product_one_time.id)
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_missing_organization_id(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        # User tokens must specify which organization the order belongs to.
+        response = await client.post(
+            "/v1/orders/",
+            json={
+                "customer_id": str(customer.id),
+                "product_id": str(product_one_time.id),
+            },
+        )
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestFinalizeOrderEndpoint:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(f"/v1/orders/{uuid.uuid4()}/finalize", json={})
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_not_found(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(f"/v1/orders/{uuid.uuid4()}/finalize", json={})
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_412_when_not_draft(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        off_session_organization: Organization,
+        orders: list[Order],
+    ) -> None:
+        # The default `orders` fixture creates orders with status=paid.
+        response = await client.post(f"/v1/orders/{orders[0].id}/finalize", json={})
+        assert response.status_code == 412

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5238,41 +5238,42 @@ class TestCreateDraftOrder:
         assert order.subtotal_amount > 0
         assert len(order.items) >= 1
 
-    async def test_custom_price_below_minimum_rejected(
+    async def test_custom_price_product_rejected(
         self,
         session: AsyncSession,
         off_session_organization: Organization,
         product_one_time_custom_price: Product,
         customer: Customer,
     ) -> None:
-        # The custom-price fixture has a minimum_amount of 50.
+        # Only fixed-price products are supported off-session; a pay-what-you-want
+        # (custom) product is rejected.
         payload = OrderCreate(
             customer_id=customer.id,
             product_id=product_one_time_custom_price.id,
-            amount=10,
         )
         with pytest.raises(PolarRequestValidationError):
             await order_service.create_draft_order(
                 session, off_session_organization, payload
             )
 
-    async def test_custom_price_within_bounds(
+    async def test_free_product_rejected(
         self,
+        save_fixture: SaveFixture,
         session: AsyncSession,
         off_session_organization: Organization,
-        product_one_time_custom_price: Product,
         customer: Customer,
     ) -> None:
-        payload = OrderCreate(
-            customer_id=customer.id,
-            product_id=product_one_time_custom_price.id,
-            amount=100,
+        product = await create_product(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+            prices=[(None, "usd")],
         )
-        order = await order_service.create_draft_order(
-            session, off_session_organization, payload
-        )
-        assert order.status == OrderStatus.draft
-        assert order.subtotal_amount == 100
+        payload = OrderCreate(customer_id=customer.id, product_id=product.id)
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
 
     async def test_custom_field_data_validated_against_product(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5238,21 +5238,26 @@ class TestCreateDraftOrder:
         assert order.subtotal_amount > 0
         assert len(order.items) >= 1
 
-    async def test_multi_currency_requires_currency(
+    async def test_multi_currency_falls_back_to_org_default(
         self,
         session: AsyncSession,
         off_session_organization: Organization,
         product_one_time_multiple_currencies: Product,
         customer: Customer,
     ) -> None:
+        # When no currency is given, fall back to the organization's default
+        # presentment currency (matching the checkout flow), even though the
+        # product is priced in several currencies.
+        assert off_session_organization.default_presentment_currency == "usd"
         payload = OrderCreate(
             customer_id=customer.id,
             product_id=product_one_time_multiple_currencies.id,
         )
-        with pytest.raises(PolarRequestValidationError):
-            await order_service.create_draft_order(
-                session, off_session_organization, payload
-            )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.status == OrderStatus.draft
+        assert order.currency == "usd"
 
     async def test_multi_currency_with_currency(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5,6 +5,7 @@ from typing import cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call
 
 import pytest
+import pytest_asyncio
 import stripe as stripe_lib
 from freezegun import freeze_time
 from pydantic import BaseModel
@@ -45,6 +46,7 @@ from polar.models import (
     BillingEntry,
     Customer,
     Discount,
+    Order,
     PaymentMethod,
     Product,
     ProductPriceFixed,
@@ -55,6 +57,7 @@ from polar.models import (
 )
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.checkout import CheckoutStatus
+from polar.models.custom_field import CustomFieldType
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.order import OrderBillingReasonInternal, OrderStatus
 from polar.models.organization import Organization, OrganizationStatus
@@ -63,7 +66,7 @@ from polar.models.product import ProductBillingType
 from polar.models.subscription import SubscriptionStatus
 from polar.models.transaction import PlatformFeeType, TransactionType
 from polar.models.wallet import WalletType
-from polar.order.schemas import OrderUpdate
+from polar.order.schemas import OrderCreate, OrderUpdate
 from polar.order.service import (
     ManualRetryLimitExceeded,
     MissingCheckoutCustomer,
@@ -71,8 +74,12 @@ from polar.order.service import (
     NoPendingBillingEntries,
     NotPaidOrder,
     NotRecurringProduct,
+    OffSessionChargesNotEnabled,
+    OrderNotDraft,
     OrderNotEligibleForRetry,
     OrderNotPending,
+    OrganizationNotReadyForPayments,
+    PaymentActionRequired,
     PaymentAlreadyInProgress,
     PaymentFailed,
     RecurringProduct,
@@ -103,6 +110,7 @@ from tests.fixtures.random_objects import (
     create_billing_entry,
     create_canceled_subscription,
     create_checkout,
+    create_custom_field,
     create_customer,
     create_discount,
     create_event,
@@ -2546,19 +2554,38 @@ class TestGenerateInvoice:
 
 @pytest.mark.asyncio
 class TestHandlePayment:
-    async def test_order_not_pending(
+    async def test_already_paid_is_idempotent(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
         product: Product,
         customer: Customer,
     ) -> None:
-        # Create an order that is already paid
+        # An already-paid order is a no-op: the success path may run inline
+        # (from finalize_order) and then again from charge.succeeded.
         order = await create_order(
             save_fixture,
             product=product,
             customer=customer,
             status=OrderStatus.paid,
+        )
+
+        result = await order_service.handle_payment(session, order, None)
+        assert result is order
+        assert result.status == OrderStatus.paid
+
+    async def test_order_not_pending_raises_for_non_paid(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.refunded,
         )
 
         with pytest.raises(OrderNotPending):
@@ -2621,7 +2648,7 @@ class TestHandlePayment:
         product: Product,
         organization: Organization,
     ) -> None:
-        # Create a customer with a billing address so that _calculate_subscription_order_tax
+        # Create a customer with a billing address so that _calculate_tax
         # will actually invoke tax_calculation_service.calculate and produce a non-zero amount.
         # The mocked calculate returns polar_round(amount * 0.20), so for net_amount=1000 → 200.
         customer_with_address = await create_customer(
@@ -5086,3 +5113,475 @@ class TestVoidPendingOrdersForSubscription:
             assert order.status == OrderStatus.void
             assert order.next_payment_attempt_at is None
             assert order.subscription_id == subscription.id
+
+
+@pytest_asyncio.fixture
+async def off_session_organization(
+    save_fixture: SaveFixture, organization: Organization
+) -> Organization:
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "off_session_charges_enabled": True,
+    }
+    await save_fixture(organization)
+    return organization
+
+
+@pytest.mark.asyncio
+class TestCreateDraftOrder:
+    async def test_feature_flag_disabled(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        # `organization` does not have the off_session_charges flag set.
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+        )
+        with pytest.raises(OffSessionChargesNotEnabled):
+            await order_service.create_draft_order(session, organization, payload)
+
+    async def test_unknown_product_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=uuid.uuid4(),
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_recurring_product_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # The default `product` fixture is recurring monthly.
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_seat_based_product_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+            prices=[("seat", 1000, "usd")],
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_unknown_customer_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=uuid.uuid4(),
+            product_id=product_one_time.id,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_happy_path(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+
+        assert order.status == OrderStatus.draft
+        assert order.invoice_number is None
+        assert order.customer_id == customer.id
+        assert order.product_id == product_one_time.id
+        assert order.subscription_id is None
+        assert order.checkout_id is None
+        assert order.subtotal_amount > 0
+        assert len(order.items) >= 1
+
+    async def test_custom_price_below_minimum_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time_custom_price: Product,
+        customer: Customer,
+    ) -> None:
+        # The custom-price fixture has a minimum_amount of 50.
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time_custom_price.id,
+            amount=10,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_custom_price_within_bounds(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time_custom_price: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time_custom_price.id,
+            amount=100,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.status == OrderStatus.draft
+        assert order.subtotal_amount == 100
+
+    async def test_custom_field_data_validated_against_product(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        text_field = await create_custom_field(
+            save_fixture,
+            type=CustomFieldType.text,
+            slug="note",
+            organization=off_session_organization,
+        )
+        product = await create_product(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+            attached_custom_fields=[(text_field, False)],
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            custom_field_data={"note": "hello", "unknown": "dropme"},
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        # Unknown keys are dropped; the product's field is kept.
+        assert order.custom_field_data == {"note": "hello"}
+
+    async def test_custom_field_wrong_type_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        number_field = await create_custom_field(
+            save_fixture,
+            type=CustomFieldType.number,
+            slug="level",
+            organization=off_session_organization,
+        )
+        product = await create_product(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+            attached_custom_fields=[(number_field, False)],
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            custom_field_data={"level": "not-a-number"},
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+
+@pytest.mark.asyncio
+class TestFinalizeOrder:
+    async def test_order_not_draft(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.paid,
+        )
+        with pytest.raises(OrderNotDraft):
+            await order_service.finalize_order(session, order)
+
+    async def test_feature_flag_revoked_between_create_and_finalize(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        # Org has no flag set; calling finalize on a draft should refuse.
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+        with pytest.raises(OffSessionChargesNotEnabled):
+            await order_service.finalize_order(session, order)
+
+    async def test_organization_cannot_accept_payments(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # Flag is enabled, but the org's account can't accept payments yet
+        # (e.g. pending onboarding / under review).
+        off_session_organization.capabilities = {
+            **off_session_organization.capabilities,
+            "checkout_payments": False,
+        }
+        await save_fixture(off_session_organization)
+
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+        with pytest.raises(OrganizationNotReadyForPayments):
+            await order_service.finalize_order(session, order)
+
+        await session.refresh(order)
+        # Rejected before any state change — the order stays a draft.
+        assert order.status == OrderStatus.draft
+
+    async def test_missing_payment_method(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+        with pytest.raises(PaymentFailed):
+            await order_service.finalize_order(session, order)
+
+        await session.refresh(order)
+        # Missing payment method is caught before any state mutation —
+        # nothing changes on the order.
+        assert order.status == OrderStatus.draft
+
+    async def test_card_error_reverts_to_draft(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+        stripe_service_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+
+        stripe_service_mock.create_payment_intent.side_effect = stripe_lib.CardError(
+            message="Your card was declined.",
+            param="card",
+            code="card_declined",
+        )
+
+        with pytest.raises(PaymentFailed):
+            await order_service.finalize_order(
+                session, order, payment_method_id=payment_method.id
+            )
+
+        await session.refresh(order)
+        assert order.status == OrderStatus.draft
+        assert order.invoice_number is None
+        assert order.payment_lock_acquired_at is None
+
+    async def test_requires_action_reverts_to_draft(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+        stripe_service_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+
+        stripe_service_mock.create_payment_intent.return_value = (
+            build_stripe_payment_intent(status="requires_action")
+        )
+
+        with pytest.raises(PaymentActionRequired):
+            await order_service.finalize_order(
+                session, order, payment_method_id=payment_method.id
+            )
+
+        await session.refresh(order)
+        assert order.status == OrderStatus.draft
+        assert order.invoice_number is None
+
+    async def test_explicit_payment_method_must_belong_to_customer(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+        customer_second: Customer,
+    ) -> None:
+        other_payment_method = await create_payment_method(
+            save_fixture, customer=customer_second
+        )
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+
+        with pytest.raises(PaymentFailed):
+            await order_service.finalize_order(
+                session, order, payment_method_id=other_payment_method.id
+            )
+
+        await session.refresh(order)
+        assert order.status == OrderStatus.draft
+
+    async def test_happy_path_charges_and_settles_inline(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+        stripe_service_mock: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+
+        # A succeeded off-session charge with an expanded Charge, as
+        # trigger_payment requests via expand=["latest_charge"].
+        payment_intent = stripe_lib.PaymentIntent.construct_from(
+            {
+                "id": "pi_finalize_success",
+                "status": "succeeded",
+                "latest_charge": {"object": "charge", "id": "ch_finalize_success"},
+            },
+            None,
+        )
+        stripe_service_mock.create_payment_intent.return_value = payment_intent
+
+        # The charge -> payment -> benefit-grant pipeline has its own coverage;
+        # here we only assert finalize's orchestration drives it with a paid
+        # order, rather than leaving settlement to the webhook.
+        def _settle(_session: AsyncSession, settled: Order, _payment: object) -> Order:
+            settled.status = OrderStatus.paid
+            return settled
+
+        upsert_mock = mocker.patch(
+            "polar.order.service.payment_service.upsert_from_stripe_charge",
+            new=AsyncMock(return_value=MagicMock()),
+        )
+        handle_payment_mock = mocker.patch.object(
+            order_service, "handle_payment", new=AsyncMock(side_effect=_settle)
+        )
+
+        result = await order_service.finalize_order(
+            session, order, payment_method_id=payment_method.id
+        )
+
+        assert result.status == OrderStatus.paid
+        # The invoice number is assigned inline, and only on success.
+        assert result.invoice_number is not None
+
+        # The charge is keyed for idempotency (sync/finalize path only) so a
+        # retry after a lost response can't double-charge.
+        call_kwargs = stripe_service_mock.create_payment_intent.call_args[1]
+        assert (
+            call_kwargs["idempotency_key"]
+            == f"order_finalize:{order.id}:{payment_method.processor_id}"
+        )
+
+        # The success path is applied inline: the expanded charge is extracted
+        # and handed to the payment + settlement pipeline.
+        upsert_mock.assert_awaited_once()
+        charge_arg = upsert_mock.call_args.args[1]
+        assert isinstance(charge_arg, stripe_lib.Charge)
+        assert charge_arg.id == "ch_finalize_success"
+        handle_payment_mock.assert_awaited_once()

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -93,6 +93,7 @@ from polar.tax.calculation import (
     CalculationExpiredError,
     TaxabilityReason,
     TaxCalculation,
+    TaxCalculationLogicalError,
     TaxCalculationService,
     get_tax_behavior_from_option,
 )
@@ -5332,6 +5333,34 @@ class TestCreateDraftOrder:
                 session, off_session_organization, payload
             )
 
+    async def test_uncomputable_tax_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        tax_service_mock: MagicMock,
+    ) -> None:
+        # The customer has a billing address (so tax is attempted), but the
+        # processor can't compute tax for it. The draft must be rejected rather
+        # than persisted tax-free — finalize never recomputes it.
+        tax_service_mock.calculate.side_effect = TaxCalculationLogicalError(
+            "Invalid address"
+        )
+        customer = await create_customer(
+            save_fixture,
+            organization=off_session_organization,
+            billing_address=Address(country=CountryAlpha2("US")),
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
 
 @pytest.mark.asyncio
 class TestFinalizeOrder:
@@ -5350,6 +5379,41 @@ class TestFinalizeOrder:
         )
         with pytest.raises(OrderNotDraft):
             await order_service.finalize_order(session, order)
+
+    async def test_lost_draft_claim_raises(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # Another request already claimed the draft, so the atomic
+        # start_finalization() guard returns False. Finalize must refuse and
+        # leave the order untouched.
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+        )
+        original_invoice_number = order.invoice_number
+        mocker.patch(
+            "polar.order.repository.OrderRepository.start_finalization",
+            new=AsyncMock(return_value=False),
+        )
+
+        with pytest.raises(OrderNotDraft):
+            await order_service.finalize_order(
+                session, order, payment_method_id=payment_method.id
+            )
+
+        await session.refresh(order)
+        assert order.status == OrderStatus.draft
+        assert order.invoice_number == original_invoice_number
+        assert order.payment_lock_acquired_at is None
 
     async def test_feature_flag_revoked_between_create_and_finalize(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5238,6 +5238,57 @@ class TestCreateDraftOrder:
         assert order.subtotal_amount > 0
         assert len(order.items) >= 1
 
+    async def test_multi_currency_requires_currency(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time_multiple_currencies: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time_multiple_currencies.id,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_multi_currency_with_currency(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time_multiple_currencies: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time_multiple_currencies.id,
+            currency="eur",
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.status == OrderStatus.draft
+        assert order.currency == "eur"
+
+    async def test_unknown_currency_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+            currency="gbp",
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
     async def test_custom_price_product_rejected(
         self,
         session: AsyncSession,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5258,6 +5258,12 @@ class TestCreateDraftOrder:
         )
         assert order.status == OrderStatus.draft
         assert order.currency == "usd"
+        # The usd price set was selected (1000), not eur (900) or gbp (800).
+        usd_prices = PriceSet.from_product(product_one_time_multiple_currencies, "usd")
+        assert len(order.items) == len(usd_prices.prices)
+        assert order.subtotal_amount == sum(
+            cast(ProductPriceFixed, price).price_amount for price in usd_prices.prices
+        )
 
     async def test_multi_currency_with_currency(
         self,
@@ -5276,6 +5282,12 @@ class TestCreateDraftOrder:
         )
         assert order.status == OrderStatus.draft
         assert order.currency == "eur"
+        # The eur price set was selected (900), not usd (1000) or gbp (800).
+        eur_prices = PriceSet.from_product(product_one_time_multiple_currencies, "eur")
+        assert len(order.items) == len(eur_prices.prices)
+        assert order.subtotal_amount == sum(
+            cast(ProductPriceFixed, price).price_amount for price in eur_prices.prices
+        )
 
     async def test_unknown_currency_rejected(
         self,

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import pytest
 import stripe as stripe_lib
@@ -455,7 +456,7 @@ class TestTriggerPayment:
         # Mock the Stripe service instead of the order service
         mock_create_payment_intent = mocker.patch(
             "polar.order.service.stripe_service.create_payment_intent",
-            return_value=None,
+            return_value=MagicMock(status="succeeded", id="pi_test_success"),
         )
 
         # When
@@ -603,7 +604,7 @@ class TestTriggerPayment:
 
         mock_create_payment_intent = mocker.patch(
             "polar.order.service.stripe_service.create_payment_intent",
-            return_value=None,
+            return_value=MagicMock(status="succeeded", id="pi_test_success"),
         )
 
         # When
@@ -636,7 +637,7 @@ class TestTriggerPayment:
 
         mock_create_payment_intent = mocker.patch(
             "polar.order.service.stripe_service.create_payment_intent",
-            return_value=None,
+            return_value=MagicMock(status="succeeded", id="pi_test_success"),
         )
 
         # When — called without payment_trigger (default None)

--- a/server/tests/product/test_custom_price.py
+++ b/server/tests/product/test_custom_price.py
@@ -2,7 +2,7 @@ import pytest
 
 from polar.exceptions import PolarRequestValidationError
 from polar.models import ProductPriceCustom
-from polar.product.price_set import validate_custom_price_amount
+from polar.product.custom_price import validate_custom_price_amount
 
 
 def _custom_price(

--- a/server/tests/product/test_price_set.py
+++ b/server/tests/product/test_price_set.py
@@ -1,0 +1,50 @@
+import pytest
+
+from polar.exceptions import PolarRequestValidationError
+from polar.models import ProductPriceCustom
+from polar.product.price_set import validate_custom_price_amount
+
+
+def _custom_price(
+    *, minimum_amount: int = 0, maximum_amount: int | None = None
+) -> ProductPriceCustom:
+    return ProductPriceCustom(
+        price_currency="usd",
+        minimum_amount=minimum_amount,
+        maximum_amount=maximum_amount,
+        preset_amount=None,
+    )
+
+
+class TestValidateCustomPriceAmount:
+    def test_negative_rejected_when_minimum_zero(self) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            validate_custom_price_amount(_custom_price(minimum_amount=0), -100, "usd")
+
+    def test_negative_rejected_when_minimum_positive(self) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            validate_custom_price_amount(_custom_price(minimum_amount=500), -1, "usd")
+
+    def test_zero_allowed_when_minimum_zero(self) -> None:
+        validate_custom_price_amount(_custom_price(minimum_amount=0), 0, "usd")
+
+    def test_positive_below_currency_minimum_rejected(self) -> None:
+        # minimum_amount == 0 allows 0, but a positive amount below the
+        # currency minimum (50 for USD) is rejected.
+        with pytest.raises(PolarRequestValidationError):
+            validate_custom_price_amount(_custom_price(minimum_amount=0), 1, "usd")
+
+    def test_below_price_minimum_rejected(self) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            validate_custom_price_amount(_custom_price(minimum_amount=500), 100, "usd")
+
+    def test_above_maximum_rejected(self) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            validate_custom_price_amount(
+                _custom_price(minimum_amount=100, maximum_amount=1000), 2000, "usd"
+            )
+
+    def test_valid_amount_passes(self) -> None:
+        validate_custom_price_amount(
+            _custom_price(minimum_amount=100, maximum_amount=10000), 5000, "usd"
+        )

--- a/server/tests/product/test_price_set.py
+++ b/server/tests/product/test_price_set.py
@@ -38,6 +38,18 @@ class TestValidateCustomPriceAmount:
         with pytest.raises(PolarRequestValidationError):
             validate_custom_price_amount(_custom_price(minimum_amount=500), 100, "usd")
 
+    def test_positive_below_currency_minimum_rejected_with_low_configured_minimum(
+        self,
+    ) -> None:
+        # Even when the configured minimum is below the currency floor (50 for
+        # USD), a positive amount under the floor must be rejected — it would
+        # otherwise pass validation but fail when charged.
+        with pytest.raises(PolarRequestValidationError):
+            validate_custom_price_amount(_custom_price(minimum_amount=10), 30, "usd")
+
+    def test_at_currency_minimum_passes_with_low_configured_minimum(self) -> None:
+        validate_custom_price_amount(_custom_price(minimum_amount=10), 50, "usd")
+
     def test_above_maximum_rejected(self) -> None:
         with pytest.raises(PolarRequestValidationError):
             validate_custom_price_amount(


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#127

Adds the **off-session charge API** — charge a customer's saved payment method off-session by creating a draft order and finalizing it. Scoped to **one-time, fixed-price products**. This is **part 1 of 2** and the base branch for the stacked "Set on order" PR (#12090).

## What

- Draft order status + nullable `invoice_number` (assigned at finalize) — with migration
- `off_session_charges_enabled` organization feature flag
- `POST /v1/orders` (create draft) and finalize endpoints + service, authorized via an `OrderPolicyGuard` dependency
- Only **fixed-price** one-time products are chargeable; subscription, seat-based, and pay-what-you-want products are rejected. `OrderCreate` takes no `amount` — it's fully determined by the product's price
- Client SDK regen, mobile-app draft-order status handling, and a backoffice draft-order badge

## Why

Merchants need to charge customers off-session against a saved payment method (e.g. manual/overage charges), outside the interactive checkout flow.

## How

Draft orders are persisted with `status=draft` and no invoice number. Finalize resolves the payment method, attempts an off-session charge synchronously, and on success transitions the order to paid, assigns an invoice number, and grants benefits; on failure it reverts to draft for retry. Authorization is centralized in an `OrderPolicyGuard`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft order creation and finalize flow for off‑session charges with saved payment methods; new API endpoints to create and finalize draft orders.

* **Improvements**
  * Global "Draft" order status with gray badge/styling and list filter.
  * Order header shows ID when invoice number is missing.
  * Feature‑flag gating for off‑session charges and clearer finalize error responses.

* **Tests**
  * Expanded tests covering draft/create/finalize flows, payment edge cases, and custom‑price validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->