### PR TITLE
feat: Allow custom amount and description on off-session draft orders

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -21973,7 +21973,7 @@ export interface components {
       /**
        * Product Id
        * Format: uuid4
-       * @description The ID of the one-time, fixed-price product to charge for. Must belong to the order's organization. Subscription, seat-based, and pay-what-you-want products are not supported.
+       * @description The ID of the one-time product to charge for. Must belong to the order's organization. Only fixed-price and free products are supported.
        */
       product_id: string
       /**
@@ -21981,6 +21981,16 @@ export interface components {
        * @description The currency to charge in (ISO 4217, lowercase, e.g. `usd`). Defaults to the organization's default currency; specify it to force a different one, or when the product isn't priced in the organization's default currency.
        */
       currency?: string | null
+      /**
+       * Amount
+       * @description A custom amount to charge, in the smallest currency unit. Overrides the product's price; defaults to the product's configured price (0 for free products). A positive amount must be at least the currency's minimum.
+       */
+      amount?: number | null
+      /**
+       * Description
+       * @description A custom description for the order's line item, shown on the invoice and receipt (e.g. `5,000 tokens`). Defaults to the product name.
+       */
+      description?: string | null
     }
     /** OrderCustomer */
     OrderCustomer: {

--- a/server/polar/models/order_item.py
+++ b/server/polar/models/order_item.py
@@ -67,6 +67,7 @@ class OrderItem(RecordModel):
         tax_amount: int,
         amount: int | None = None,
         seats: int | None = None,
+        label: str | None = None,
     ) -> Self:
         if isinstance(price, ProductPriceFixed | LegacyRecurringProductPriceFixed):
             amount = price.price_amount
@@ -78,7 +79,7 @@ class OrderItem(RecordModel):
             assert seats is not None, "seats must be provided for seat-based prices"
             amount = price.calculate_amount(seats)
         return cls(
-            label=price.product.name,
+            label=label if label is not None else price.product.name,
             amount=amount,
             tax_amount=tax_amount,
             net_amount=amount,

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -5,10 +5,10 @@ from pydantic import (
     UUID4,
     AliasChoices,
     AliasPath,
+    BeforeValidator,
     Field,
     computed_field,
     field_serializer,
-    field_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
 
@@ -22,7 +22,13 @@ from polar.exceptions import ResourceNotFound
 from polar.kit.address import Address, AddressInput
 from polar.kit.currency import format_currency
 from polar.kit.metadata import MetadataInputMixin, MetadataOutputMixin
-from polar.kit.schemas import IDSchema, MergeJSONSchema, Schema, TimestampedSchema
+from polar.kit.schemas import (
+    IDSchema,
+    MergeJSONSchema,
+    Schema,
+    TimestampedSchema,
+    empty_str_to_none,
+)
 from polar.models.order import (
     OrderBillingReason,
     OrderBillingReasonInternal,
@@ -319,7 +325,10 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
             "currency's minimum."
         ),
     )
-    description: str | None = Field(
+    # `BeforeValidator` runs the strip/empty→None normalization *before* the
+    # `max_length` constraint, so a long whitespace-only value is treated as
+    # empty instead of rejected; non-strings fall through to type validation.
+    description: Annotated[str | None, BeforeValidator(empty_str_to_none)] = Field(
         None,
         max_length=500,
         description=(
@@ -328,18 +337,6 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
             "product name."
         ),
     )
-
-    @field_validator("description", mode="before")
-    @classmethod
-    def strip_description(cls, value: object) -> object:
-        # Run in `before` mode so blank input is normalized to None *before*
-        # the `max_length` constraint is checked — otherwise a long
-        # whitespace-only string is rejected instead of treated as empty.
-        # Non-strings fall through to Pydantic's normal type validation.
-        if isinstance(value, str):
-            value = value.strip()
-            return value or None
-        return value
 
 
 class OrderUpdateBase(Schema):

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -8,6 +8,7 @@ from pydantic import (
     Field,
     computed_field,
     field_serializer,
+    field_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
 
@@ -295,10 +296,9 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
         "Must belong to the order's organization."
     )
     product_id: UUID4 = Field(
-        description="The ID of the one-time, fixed-price product to charge for. "
+        description="The ID of the one-time product to charge for. "
         "Must belong to the order's organization. "
-        "Subscription, seat-based, and pay-what-you-want products are not "
-        "supported."
+        "Only fixed-price and free products are supported."
     )
     currency: str | None = Field(
         None,
@@ -309,6 +309,33 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
             "organization's default currency."
         ),
     )
+    amount: int | None = Field(
+        None,
+        ge=0,
+        description=(
+            "A custom amount to charge, in the smallest currency unit. Overrides "
+            "the product's price; defaults to the product's configured price "
+            "(0 for free products). A positive amount must be at least the "
+            "currency's minimum."
+        ),
+    )
+    description: str | None = Field(
+        None,
+        max_length=500,
+        description=(
+            "A custom description for the order's line item, shown on the "
+            "invoice and receipt (e.g. `5,000 tokens`). Defaults to the "
+            "product name."
+        ),
+    )
+
+    @field_validator("description")
+    @classmethod
+    def strip_description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        return value or None
 
 
 class OrderUpdateBase(Schema):

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -329,13 +329,17 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
         ),
     )
 
-    @field_validator("description")
+    @field_validator("description", mode="before")
     @classmethod
-    def strip_description(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-        value = value.strip()
-        return value or None
+    def strip_description(cls, value: object) -> object:
+        # Run in `before` mode so blank input is normalized to None *before*
+        # the `max_length` constraint is checked — otherwise a long
+        # whitespace-only string is rejected instead of treated as empty.
+        # Non-strings fall through to Pydantic's normal type validation.
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
 
 
 class OrderUpdateBase(Schema):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -53,7 +53,7 @@ from polar.integrations.stripe.service import (
     stripe as stripe_service,
 )
 from polar.invoice.service import invoice as invoice_service
-from polar.kit.currency import get_minimum_currency_amount
+from polar.kit.currency import format_currency, get_minimum_currency_amount
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
@@ -96,6 +96,7 @@ from polar.payment_method.service import payment_method as payment_method_servic
 from polar.product.guard import (
     is_custom_price,
     is_fixed_price,
+    is_free_price,
     is_seat_price,
     is_static_price,
 )
@@ -679,6 +680,66 @@ class OrderService:
                 items.append(OrderItem.from_price(price, 0, seats=seats))
         return items
 
+    def _build_draft_order_items(
+        self,
+        prices: Iterable[ProductPrice],
+        *,
+        amount: int | None,
+        label: str | None,
+    ) -> Sequence[OrderItem]:
+        """
+        Build line items for an off-session draft order over a product's
+        fixed/free static prices.
+
+        `amount`, when provided, overrides the charge (the merchant sets a custom
+        price for this order); otherwise the price's own amount is used — the
+        configured amount for fixed prices, 0 for free prices. `label` overrides
+        the line item's description, defaulting to the product name.
+        """
+        items: list[OrderItem] = []
+        for price in prices:
+            if not is_static_price(price):
+                continue
+            if amount is not None:
+                items.append(
+                    OrderItem(
+                        label=label if label is not None else price.product.name,
+                        amount=amount,
+                        tax_amount=0,
+                        net_amount=amount,
+                        proration=False,
+                        product_price=price,
+                    )
+                )
+            else:
+                items.append(OrderItem.from_price(price, 0, label=label))
+        return items
+
+    def _validate_purchase_amount(self, payload: OrderCreate, currency: str) -> None:
+        """
+        When the merchant provides a custom `amount`, ensure a positive amount
+        clears the currency's processor minimum — otherwise the charge would be
+        rejected at finalize. A 0 amount is allowed (e.g. a free product).
+        """
+        if payload.amount is None or payload.amount == 0:
+            return
+        currency_minimum = get_minimum_currency_amount(currency)
+        if payload.amount < currency_minimum:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "greater_than_equal",
+                        "loc": ("body", "amount"),
+                        "msg": (
+                            "Amount must be at least "
+                            f"{format_currency(currency_minimum, currency)}."
+                        ),
+                        "input": payload.amount,
+                        "ctx": {"ge": currency_minimum},
+                    }
+                ]
+            )
+
     async def _create_order_from_checkout(
         self,
         session: AsyncSession,
@@ -844,9 +905,10 @@ class OrderService:
                 ]
             )
 
-        # Off-session charges currently support fixed-price products only — the
-        # amount must be fully determined by the product. Custom
-        # (pay-what-you-want) and free prices are rejected.
+        # Off-session charges only support fixed-price and free products — the
+        # amount is predetermined by the product, or set by the merchant via
+        # `amount`, never chosen by the customer. Pay-what-you-want (custom)
+        # prices are rejected.
         static_prices = [price for price in product.prices if is_static_price(price)]
         if not static_prices:
             raise PolarRequestValidationError(
@@ -859,13 +921,19 @@ class OrderService:
                     }
                 ]
             )
-        if any(not is_fixed_price(price) for price in static_prices):
+        if any(
+            not (is_fixed_price(price) or is_free_price(price))
+            for price in static_prices
+        ):
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "product_id"),
-                        "msg": "Off-session charges only support fixed-price products.",
+                        "msg": (
+                            "Off-session charges only support fixed-price and "
+                            "free products."
+                        ),
                         "input": payload.product_id,
                     }
                 ]
@@ -917,8 +985,13 @@ class OrderService:
                 ]
             ) from e
 
+        self._validate_purchase_amount(payload, currency)
         items = list(
-            self._build_static_order_items(currency_prices, amount=None, seats=None)
+            self._build_draft_order_items(
+                currency_prices,
+                amount=payload.amount,
+                label=payload.description,
+            )
         )
 
         # Validate custom field values against the product's attached fields,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -53,7 +53,11 @@ from polar.integrations.stripe.service import (
     stripe as stripe_service,
 )
 from polar.invoice.service import invoice as invoice_service
-from polar.kit.currency import format_currency, get_minimum_currency_amount
+from polar.kit.currency import (
+    format_currency,
+    get_maximum_currency_amount,
+    get_minimum_currency_amount,
+)
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
@@ -718,8 +722,9 @@ class OrderService:
     def _validate_purchase_amount(self, payload: OrderCreate, currency: str) -> None:
         """
         When the merchant provides a custom `amount`, ensure a positive amount
-        clears the currency's processor minimum — otherwise the charge would be
-        rejected at finalize. A 0 amount is allowed (e.g. a free product).
+        falls within the currency's processor bounds — otherwise the charge
+        would be rejected at finalize. A 0 amount is allowed (e.g. a free
+        product).
         """
         if payload.amount is None or payload.amount == 0:
             return
@@ -736,6 +741,22 @@ class OrderService:
                         ),
                         "input": payload.amount,
                         "ctx": {"ge": currency_minimum},
+                    }
+                ]
+            )
+        currency_maximum = get_maximum_currency_amount(currency)
+        if payload.amount > currency_maximum:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "less_than_equal",
+                        "loc": ("body", "amount"),
+                        "msg": (
+                            "Amount must be at most "
+                            f"{format_currency(currency_maximum, currency)}."
+                        ),
+                        "input": payload.amount,
+                        "ctx": {"le": currency_maximum},
                     }
                 ]
             )

--- a/server/tests/order/test_schemas.py
+++ b/server/tests/order/test_schemas.py
@@ -1,6 +1,9 @@
 """Test for order schema serialization."""
 
+import uuid
+
 import pytest
+from pydantic import ValidationError
 
 from polar.models.customer import Customer
 from polar.models.order import (
@@ -8,7 +11,7 @@ from polar.models.order import (
     OrderBillingReasonInternal,
 )
 from polar.models.product import Product
-from polar.order.schemas import Order
+from polar.order.schemas import Order, OrderCreate
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_order
 
@@ -57,3 +60,30 @@ class TestOrderBillingReasonSerializer:
         order_schema = Order.model_validate(order)
         serialized = order_schema.model_dump(mode="json")
         assert serialized["billing_reason"] == expected_output
+
+
+class TestOrderCreateDescription:
+    """Test OrderCreate.description normalization."""
+
+    def _create(self, description: object) -> OrderCreate:
+        return OrderCreate(
+            customer_id=uuid.uuid4(),
+            product_id=uuid.uuid4(),
+            description=description,  # type: ignore[arg-type]
+        )
+
+    def test_surrounding_whitespace_trimmed(self) -> None:
+        assert self._create("  5,000 tokens  ").description == "5,000 tokens"
+
+    def test_blank_normalized_to_none(self) -> None:
+        assert self._create("   ").description is None
+
+    def test_long_blank_normalized_to_none(self) -> None:
+        # Whitespace-only input is trimmed to None *before* `max_length` is
+        # enforced, so an over-length blank string is accepted, not rejected.
+        assert self._create(" " * 501).description is None
+
+    def test_genuine_over_length_rejected(self) -> None:
+        # A real (non-blank) description over the limit is still rejected.
+        with pytest.raises(ValidationError):
+            self._create("a" * 501)

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -37,6 +37,7 @@ from polar.kit.address import (
     CountryAlpha2,
     CountryAlpha2Input,
 )
+from polar.kit.currency import get_maximum_currency_amount
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.math import polar_round
 from polar.kit.pagination import PaginationParams
@@ -5420,6 +5421,25 @@ class TestCreateDraftOrder:
             customer_id=customer.id,
             product_id=product_one_time.id,
             amount=10,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_amount_above_currency_maximum_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        # An amount above the currency's maximum would be rejected at finalize,
+        # so reject it up front.
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+            amount=get_maximum_currency_amount("usd") + 1,
         )
         with pytest.raises(PolarRequestValidationError):
             await order_service.create_draft_order(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5313,8 +5313,8 @@ class TestCreateDraftOrder:
         product_one_time_custom_price: Product,
         customer: Customer,
     ) -> None:
-        # Only fixed-price products are supported off-session; a pay-what-you-want
-        # (custom) product is rejected.
+        # Only fixed-price and free products are supported off-session; a
+        # pay-what-you-want (custom) product is rejected.
         payload = OrderCreate(
             customer_id=customer.id,
             product_id=product_one_time_custom_price.id,
@@ -5324,7 +5324,49 @@ class TestCreateDraftOrder:
                 session, off_session_organization, payload
             )
 
-    async def test_free_product_rejected(
+    async def test_free_product_allowed(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # Free products are chargeable off-session; without an amount the order
+        # is a $0 draft.
+        product = await create_product(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+            prices=[(None, "usd")],
+        )
+        payload = OrderCreate(customer_id=customer.id, product_id=product.id)
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.status == OrderStatus.draft
+        assert order.subtotal_amount == 0
+
+    async def test_amount_overrides_fixed_price(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        # `product_one_time` is priced at 1000 usd; the merchant charges 2500.
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+            amount=2500,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.status == OrderStatus.draft
+        assert order.subtotal_amount == 2500
+        assert order.items[0].amount == 2500
+
+    async def test_amount_on_free_product(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -5337,7 +5379,48 @@ class TestCreateDraftOrder:
             recurring_interval=None,
             prices=[(None, "usd")],
         )
-        payload = OrderCreate(customer_id=customer.id, product_id=product.id)
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            amount=1500,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.subtotal_amount == 1500
+        assert order.items[0].amount == 1500
+
+    async def test_custom_description_overrides_label(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+            description="5,000 tokens",
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.items[0].label == "5,000 tokens"
+
+    async def test_positive_amount_below_currency_minimum_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        # usd's minimum is 50; a positive amount below it would be rejected at
+        # finalize, so reject it up front.
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+            amount=10,
+        )
         with pytest.raises(PolarRequestValidationError):
             await order_service.create_draft_order(
                 session, off_session_organization, payload


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#127

Allow a merchant to provide a **custom amount and line-item description** when creating an off-session draft order for a one-time **fixed-price or free** product.

> Supersedes the earlier "Set on order" price-type approach: instead of a new `merchant_priced` price type (model column, migration, product/checkout guards, dashboard option), the amount is supplied per charge in the create call. The base PR #12089 is merged, so this now targets `main`.

## What

- `OrderCreate` gains optional `amount` and `description` fields
- `create_draft_order` accepts **fixed-price and free** products (pay-what-you-want/custom still rejected; recurring and seat-based still rejected)
- `amount` overrides the charge — defaults to the product's configured fixed price, or `0` for free products; a *positive* amount must clear the currency minimum
- `description` overrides the order line-item label (rendered on the invoice, receipt, and orders API); defaults to the product name
- `OrderItem.from_price` gains an optional `label` override

## Why

For off-session "top up"-style charges (credits, token balances, …) the amount often isn't known at product-config time — it's decided per charge. Rather than introduce a dedicated price type, the merchant supplies the amount (and an optional human-readable description) directly in the create call, reusing ordinary fixed/free products.

## How

The override is isolated to the off-session path: a dedicated `_build_draft_order_items` applies the amount/label override, leaving the shared `_build_static_order_items` (used by the checkout→order flow) and its semantics untouched. The custom amount/description flow into the standard order line items, so they surface consistently through the orders API, webhooks, and the invoice/receipt PDFs. A positive amount below the currency minimum is rejected up front, since it would otherwise fail at finalize.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft orders accept an optional amount to override product pricing
  * Free products are allowed in off-session draft orders
  * Optional custom labels can be applied to order items (description can override item label)

* **Improvements**
  * Order descriptions are normalized (trimmed; blank/whitespace-only → none) and limited to 500 chars
  * Draft amount is validated against currency min/max; custom pay-what-you-want pricing is rejected for drafts

* **Tests**
  * Added tests for description normalization, amount overrides, free-product drafts, label override, and validation rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->