### PR TITLE
Include failed checkout in customer-filtered payments

### DIFF
--- a/server/polar/payment/service.py
+++ b/server/polar/payment/service.py
@@ -2,6 +2,7 @@ import uuid
 from collections.abc import Sequence
 
 import stripe as stripe_lib
+from sqlalchemy import func, or_
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
@@ -76,9 +77,17 @@ class PaymentService:
             statement = statement.where(Payment.order_id.in_(order_id))
 
         if customer_id is not None:
-            statement = statement.join(Order, Payment.order_id == Order.id).where(
-                Order.is_deleted.is_(False),
-                Order.customer_id.in_(customer_id),
+            statement = statement.outerjoin(Order, Payment.order_id == Order.id)
+            statement = statement.outerjoin(
+                Checkout, Payment.checkout_id == Checkout.id
+            )
+            effective_customer_id = func.coalesce(
+                Order.customer_id, Checkout.customer_id
+            )
+
+            statement = statement.where(
+                effective_customer_id.in_(customer_id),
+                or_(Order.is_deleted.is_(False), Order.id.is_(None)),
             )
 
         if status is not None:

--- a/server/tests/payment/test_endpoints.py
+++ b/server/tests/payment/test_endpoints.py
@@ -4,9 +4,9 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
-from polar.models import Customer, Organization, Payment, UserOrganization
+from polar.models import Customer, Organization, Payment, Product, UserOrganization
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_order, create_payment
+from tests.fixtures.random_objects import create_checkout, create_order, create_payment
 
 
 @pytest_asyncio.fixture
@@ -59,6 +59,32 @@ class TestListPayments:
         json = response.json()
         assert json["pagination"]["total_count"] == 1
         assert json["items"][0]["id"] == str(payment.id)
+
+    @pytest.mark.auth
+    async def test_filter_by_customer_id_includes_checkout_payments_without_order(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        failed_checkout_payment = await create_payment(
+            save_fixture, organization, checkout=checkout, order=None
+        )
+
+        response = await client.get(
+            "/v1/payments/", params={"customer_id": str(customer.id)}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 1
+        assert json["items"][0]["id"] == str(failed_checkout_payment.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #12056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment filtering by customer ID to now include payments from checkouts without associated orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->