### PR TITLE
Add optimistic updates for customer/account notifications

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -1,17 +1,9 @@
 import { useUpdateOrganization } from '@/hooks/queries'
-import { useAutoSave } from '@/hooks/useAutoSave'
-import { extractApiErrorMessage, setValidationErrors } from '@/utils/api/errors'
-import { isValidationError, schemas } from '@polar-sh/client'
+import { useOptimisticSave } from '@/hooks/useOptimisticSave'
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import { schemas } from '@polar-sh/client'
 import Switch from '@polar-sh/ui/components/atoms/Switch'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from '@polar-sh/ui/components/ui/form'
 import React from 'react'
-import { useForm } from 'react-hook-form'
 import { toast } from '../Toast/use-toast'
 import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
@@ -88,81 +80,41 @@ const customerEmails: {
 const OrganizationCustomerEmailSettings: React.FC<
   OrganizationCustomerEmailSettingsProps
 > = ({ organization }) => {
-  const form = useForm<schemas['OrganizationCustomerEmailSettings']>({
-    defaultValues: organization.customer_email_settings,
-  })
-  const { control, setError, reset } = form
-
   const updateOrganization = useUpdateOrganization()
-  const onSave = async (
-    customer_email_settings: schemas['OrganizationCustomerEmailSettings'],
-  ) => {
-    const { data, error } = await updateOrganization.mutateAsync({
-      id: organization.id,
-      body: {
-        customer_email_settings,
-      },
-    })
 
-    if (error) {
-      if (isValidationError(error.detail)) {
-        setValidationErrors(error.detail, setError)
-      } else {
-        setError('root', { message: error.detail })
-      }
-
-      toast({
-        title: 'Customer Email Settings Update Failed',
-        description: `Error updating customer email settings: ${extractApiErrorMessage(error)}`,
+  const { value: settings, update } = useOptimisticSave(
+    organization.customer_email_settings,
+    async (customer_email_settings) => {
+      const { error } = await updateOrganization.mutateAsync({
+        id: organization.id,
+        body: { customer_email_settings },
       })
 
-      return
-    }
+      if (error) {
+        toast({
+          title: 'Customer Email Settings Update Failed',
+          description: `Error updating customer email settings: ${extractApiErrorMessage(error)}`,
+        })
+        return false
+      }
 
-    reset(data.customer_email_settings)
-  }
-
-  useAutoSave({
-    form,
-    onSave,
-    delay: 200,
-  })
+      return true
+    },
+  )
 
   return (
-    <Form {...form}>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-        }}
-      >
-        <SettingsGroup>
-          {customerEmails.map(({ key, title, description }) => (
-            <SettingsGroupItem
-              key={key}
-              title={title}
-              description={description}
-            >
-              <FormField
-                control={control}
-                name={key}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </SettingsGroupItem>
-          ))}
-        </SettingsGroup>
-      </form>
-    </Form>
+    <SettingsGroup>
+      {customerEmails.map(({ key, title, description }) => (
+        <SettingsGroupItem key={key} title={title} description={description}>
+          <Switch
+            checked={settings[key]}
+            onCheckedChange={(checked) =>
+              update((previous) => ({ ...previous, [key]: checked }))
+            }
+          />
+        </SettingsGroupItem>
+      ))}
+    </SettingsGroup>
   )
 }
 

--- a/clients/apps/web/src/components/Settings/OrganizationNotificationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationNotificationSettings.tsx
@@ -1,17 +1,9 @@
 import { useUpdateOrganization } from '@/hooks/queries'
-import { useAutoSave } from '@/hooks/useAutoSave'
-import { extractApiErrorMessage, setValidationErrors } from '@/utils/api/errors'
-import { isValidationError, schemas } from '@polar-sh/client'
+import { useOptimisticSave } from '@/hooks/useOptimisticSave'
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import { schemas } from '@polar-sh/client'
 import Switch from '@polar-sh/ui/components/atoms/Switch'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from '@polar-sh/ui/components/ui/form'
 import React from 'react'
-import { useForm } from 'react-hook-form'
 import { toast } from '../Toast/use-toast'
 import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
@@ -22,102 +14,54 @@ interface OrganizationNotificationSettingsProps {
 const OrganizationNotificationSettings: React.FC<
   OrganizationNotificationSettingsProps
 > = ({ organization }) => {
-  const form = useForm<schemas['OrganizationNotificationSettings']>({
-    defaultValues: organization.notification_settings,
-  })
-  const { control, setError, reset } = form
-
   const updateOrganization = useUpdateOrganization()
-  const onSave = async (
-    notification_settings: schemas['OrganizationNotificationSettings'],
-  ) => {
-    const { data, error } = await updateOrganization.mutateAsync({
-      id: organization.id,
-      body: {
-        notification_settings: {
-          ...organization.notification_settings,
-          ...notification_settings,
-        },
-      },
-    })
 
-    if (error) {
-      if (isValidationError(error.detail)) {
-        setValidationErrors(error.detail, setError)
-      } else {
-        setError('root', { message: error.detail })
-      }
-
-      toast({
-        title: 'Notification Settings Update Failed',
-        description: `Error updating notification settings: ${extractApiErrorMessage(error)}`,
+  const { value: settings, update } = useOptimisticSave(
+    organization.notification_settings,
+    async (notification_settings) => {
+      const { error } = await updateOrganization.mutateAsync({
+        id: organization.id,
+        body: { notification_settings },
       })
 
-      return
-    }
+      if (error) {
+        toast({
+          title: 'Notification Settings Update Failed',
+          description: `Error updating notification settings: ${extractApiErrorMessage(error)}`,
+        })
+        return false
+      }
 
-    reset(data.notification_settings)
-  }
-
-  useAutoSave({
-    form,
-    onSave,
-    delay: 200,
-  })
+      return true
+    },
+  )
 
   return (
-    <Form {...form}>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-        }}
+    <SettingsGroup>
+      <SettingsGroupItem
+        title="New Orders"
+        description="Send a notification when new orders are created"
       >
-        <SettingsGroup>
-          <SettingsGroupItem
-            title="New Orders"
-            description="Send a notification when new orders are created"
-          >
-            <FormField
-              control={control}
-              name="new_order"
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
+        <Switch
+          checked={settings.new_order}
+          onCheckedChange={(checked) =>
+            update((previous) => ({ ...previous, new_order: checked }))
+          }
+        />
+      </SettingsGroupItem>
 
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </SettingsGroupItem>
-
-          <SettingsGroupItem
-            title="New Subscriptions"
-            description="Send a notification when new subscriptions are created"
-          >
-            <FormField
-              control={control}
-              name="new_subscription"
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </SettingsGroupItem>
-        </SettingsGroup>
-      </form>
-    </Form>
+      <SettingsGroupItem
+        title="New Subscriptions"
+        description="Send a notification when new subscriptions are created"
+      >
+        <Switch
+          checked={settings.new_subscription}
+          onCheckedChange={(checked) =>
+            update((previous) => ({ ...previous, new_subscription: checked }))
+          }
+        />
+      </SettingsGroupItem>
+    </SettingsGroup>
   )
 }
 

--- a/clients/apps/web/src/hooks/useOptimisticSave.test.ts
+++ b/clients/apps/web/src/hooks/useOptimisticSave.test.ts
@@ -1,0 +1,196 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useOptimisticSave } from './useOptimisticSave'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+function defer<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function tick(work?: () => void) {
+  await act(async () => {
+    work?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function setup<T>(initial: T) {
+  const calls: { value: T; deferred: Deferred<boolean> }[] = []
+  const save = vi.fn((value: T) => {
+    const deferred = defer<boolean>()
+    calls.push({ value, deferred })
+    return deferred.promise
+  })
+  const { result } = renderHook(() => useOptimisticSave(initial, save))
+  return { calls, save, result }
+}
+
+describe('useOptimisticSave', () => {
+  it('starts at the initial value and saves nothing on mount', () => {
+    const { calls, result } = setup({ enabled: false })
+
+    expect(result.current.value).toEqual({ enabled: false })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('flips the value synchronously and fires the save before it resolves', () => {
+    const { calls, result } = setup({ enabled: false })
+
+    act(() => result.current.update({ enabled: true }))
+
+    expect(result.current.value).toEqual({ enabled: true })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].value).toEqual({ enabled: true })
+  })
+
+  it('persists the value and advances the confirmed baseline on success', async () => {
+    const { calls, result } = setup({ enabled: false })
+
+    act(() => result.current.update({ enabled: true }))
+    await tick(() => calls[0].deferred.resolve(true))
+    expect(result.current.value).toEqual({ enabled: true })
+
+    act(() => result.current.update({ enabled: false }))
+    expect(calls).toHaveLength(2)
+    expect(calls[1].value).toEqual({ enabled: false })
+
+    await tick(() => calls[1].deferred.resolve(true))
+    expect(result.current.value).toEqual({ enabled: false })
+  })
+
+  it('serializes saves — an update mid-flight waits for the in-flight save', async () => {
+    const { calls, result } = setup({ step: 0 })
+
+    act(() => result.current.update({ step: 1 }))
+    expect(calls).toHaveLength(1)
+
+    act(() => result.current.update({ step: 2 }))
+    expect(result.current.value).toEqual({ step: 2 })
+
+    expect(calls).toHaveLength(1)
+
+    await tick(() => calls[0].deferred.resolve(true))
+    expect(calls).toHaveLength(2)
+    expect(calls[1].value).toEqual({ step: 2 })
+
+    await tick(() => calls[1].deferred.resolve(true))
+    expect(result.current.value).toEqual({ step: 2 })
+  })
+
+  it('coalesces multiple mid-flight updates into one trailing save with the latest value', async () => {
+    const { calls, result } = setup({ step: 0 })
+
+    act(() => {
+      result.current.update({ step: 1 })
+      result.current.update({ step: 2 })
+      result.current.update({ step: 3 })
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].value).toEqual({ step: 1 })
+    expect(result.current.value).toEqual({ step: 3 })
+
+    await tick(() => calls[0].deferred.resolve(true))
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1].value).toEqual({ step: 3 })
+
+    await tick(() => calls[1].deferred.resolve(true))
+    expect(result.current.value).toEqual({ step: 3 })
+    expect(calls).toHaveLength(2)
+  })
+
+  it('rolls back to the last confirmed value when a save fails', async () => {
+    const { calls, result } = setup({ enabled: false })
+
+    act(() => result.current.update({ enabled: true }))
+    expect(result.current.value).toEqual({ enabled: true })
+
+    await tick(() => calls[0].deferred.resolve(false))
+    expect(result.current.value).toEqual({ enabled: false })
+
+    act(() => result.current.update({ enabled: true }))
+    expect(calls).toHaveLength(2)
+    await tick(() => calls[1].deferred.resolve(true))
+    expect(result.current.value).toEqual({ enabled: true })
+  })
+
+  it('rolls back when the save throws (e.g. a transport error that rejects)', async () => {
+    const { calls, result } = setup({ enabled: false })
+
+    act(() => result.current.update({ enabled: true }))
+    expect(result.current.value).toEqual({ enabled: true })
+
+    await tick(() => calls[0].deferred.reject(new Error('Failed to fetch')))
+    expect(result.current.value).toEqual({ enabled: false })
+
+    act(() => result.current.update({ enabled: true }))
+    expect(calls).toHaveLength(2)
+    await tick(() => calls[1].deferred.resolve(true))
+    expect(result.current.value).toEqual({ enabled: true })
+  })
+
+  it('reverts to the last confirmed value (not the initial) and drops pending intent on failure', async () => {
+    const { calls, result } = setup({ step: 0 })
+
+    act(() => result.current.update({ step: 1 }))
+    await tick(() => calls[0].deferred.resolve(true))
+    expect(result.current.value).toEqual({ step: 1 })
+
+    act(() => result.current.update({ step: 2 }))
+    act(() => result.current.update({ step: 3 }))
+    expect(calls).toHaveLength(2)
+    expect(result.current.value).toEqual({ step: 3 })
+
+    await tick(() => calls[1].deferred.resolve(false))
+    expect(result.current.value).toEqual({ step: 1 })
+    expect(calls).toHaveLength(2)
+  })
+
+  it('passes the latest intent to the updater, compounding synchronous updates', async () => {
+    const { calls, result } = setup({ count: 0 })
+
+    act(() => {
+      result.current.update((prev) => ({ count: prev.count + 1 }))
+      result.current.update((prev) => ({ count: prev.count + 1 }))
+    })
+
+    expect(result.current.value).toEqual({ count: 2 })
+    expect(calls[0].value).toEqual({ count: 1 })
+
+    await tick(() => calls[0].deferred.resolve(true))
+    expect(calls).toHaveLength(2)
+    expect(calls[1].value).toEqual({ count: 2 })
+  })
+
+  it('always calls the latest save callback', () => {
+    const initial = { enabled: false }
+    const save1 = vi.fn(() => new Promise<boolean>(() => {}))
+    const save2 = vi.fn(() => new Promise<boolean>(() => {}))
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: (value: typeof initial) => Promise<boolean> }) =>
+        useOptimisticSave(initial, s),
+      { initialProps: { s: save1 } },
+    )
+
+    rerender({ s: save2 })
+    act(() => result.current.update({ enabled: true }))
+
+    expect(save1).not.toHaveBeenCalled()
+    expect(save2).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/apps/web/src/hooks/useOptimisticSave.ts
+++ b/clients/apps/web/src/hooks/useOptimisticSave.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type ValueOrUpdater<Value> = Value | ((previous: Value) => Value)
+
+export function useOptimisticSave<Value>(
+  initial: Value,
+  save: (value: Value) => Promise<boolean>,
+) {
+  const [value, setValue] = useState<Value>(initial)
+
+  const saveRef = useRef(save)
+  useEffect(() => {
+    saveRef.current = save
+  }, [save])
+
+  const lastSavedValueRef = useRef<Value>(initial)
+  const desiredValueRef = useRef<Value>(initial)
+  const isSavingRef = useRef(false)
+
+  const flush = useCallback(async () => {
+    if (isSavingRef.current) return
+    isSavingRef.current = true
+    try {
+      while (!Object.is(desiredValueRef.current, lastSavedValueRef.current)) {
+        const valueToSave = desiredValueRef.current
+        let succeeded: boolean
+        try {
+          succeeded = await saveRef.current(valueToSave)
+        } catch {
+          succeeded = false
+        }
+        if (succeeded) {
+          lastSavedValueRef.current = valueToSave
+        } else {
+          desiredValueRef.current = lastSavedValueRef.current
+          setValue(lastSavedValueRef.current)
+          break
+        }
+      }
+    } finally {
+      isSavingRef.current = false
+    }
+  }, [])
+
+  const update = useCallback(
+    (valueOrUpdater: ValueOrUpdater<Value>) => {
+      const nextValue =
+        typeof valueOrUpdater === 'function'
+          ? (valueOrUpdater as (previous: Value) => Value)(
+              desiredValueRef.current,
+            )
+          : valueOrUpdater
+      desiredValueRef.current = nextValue
+      setValue(nextValue)
+      void flush()
+    },
+    [flush],
+  )
+
+  return { value, update }
+}


### PR DESCRIPTION
Our notification settings in the dashboard can be toggled very quickly, which means that we can get into the following state:

1. I **toggle on** notification A, then B, then C
2. We fire a request for notification A
3. Request comes back and sets A as on, however this request also sets B and C as off
4. UI gets in a bad state

This PR solves that with an optimistic update approach instead. Meaning the following now happens:

1. I **toggle on** A, then B, then C. Each switch flips instantly in the UI
2. A request is sent for the first change (toggle A on). While we wait for the response, toggling B and C does not fire new requests it just updates the local state
3. When we get the response back, another request is sent with the latest state (A+B+C on).
4. Because only one request is sent at a time, responses can't arrive out of order and overwrite each other
5. The UI is in a good state

If a request fails, the switches roll back to the last successfully saved state and an error toast is shown.

### Before

https://github.com/user-attachments/assets/618acb2c-0e03-479a-a8a3-9cfd9566f5b3


### After


https://github.com/user-attachments/assets/29b40fdf-dcf3-463a-a8b1-6783649b0871




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification and customer email settings now update instantly with optimistic saves, providing immediate visual feedback.

* **Refactor**
  * Streamlined settings interfaces by removing unnecessary form validation steps.

* **Tests**
  * Added comprehensive test coverage for optimistic update behavior, including concurrent updates and error recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->