### PR TITLE
Align auth settings icon

### DIFF
--- a/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
@@ -19,6 +19,7 @@ import ListGroup from '@polar-sh/ui/components/atoms/ListGroup'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import EmailUpdateForm from '../Form/EmailUpdateForm'
+import { twMerge } from 'tailwind-merge'
 
 const AuthenticationMethod = ({
   icon,
@@ -38,7 +39,11 @@ const AuthenticationMethod = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-center">
-        <div className="self-start">{icon}</div>
+        <div
+          className={twMerge('self-start', !hideTitle && 'relative top-[3px]')}
+        >
+          {icon}
+        </div>
         {!hideTitle && (
           <div className="grow">
             <div className="font-medium">{title}</div>


### PR DESCRIPTION
The line height of the title makes the icon placement slightly too high, and that makes me sad. This PR makes me happy.

<img width="4131" height="2247" alt="Frame 30we" src="https://github.com/user-attachments/assets/1b29143f-9957-4c5c-815a-01c487a6fa3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced conditional styling for authentication method icons to improve visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->