### PR TITLE
feat: allow held payouts for organizations under review

### DIFF
--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import UUID4, BeforeValidator, ValidationError
 from pydantic_core import PydanticCustomError
 from sqlalchemy import func, or_, select
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from tagflow import attr, classes, tag, text
 
 from polar.enums import PayoutAccountType
@@ -538,6 +538,9 @@ async def cancel(
             joinedload(Payout.transactions).options(
                 joinedload(Transaction.account),
                 joinedload(Transaction.payout),
+                # Needed so cancel can reverse the per-payout fees when the
+                # payout never ran its Stripe transfer (held / not-yet-transferred).
+                selectinload(Transaction.incurred_transactions),
             ),
         ),
     )

--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -538,8 +538,7 @@ async def cancel(
             joinedload(Payout.transactions).options(
                 joinedload(Transaction.account),
                 joinedload(Transaction.payout),
-                # Needed so cancel can reverse the per-payout fees when the
-                # payout never ran its Stripe transfer (held / not-yet-transferred).
+                # So cancel() can reverse per-payout fees (held/untransferred).
                 selectinload(Transaction.incurred_transactions),
             ),
         ),

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -281,9 +281,8 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
     OrganizationStatus.REVIEW: {
         "checkout_payments": True,
         "subscription_renewals": True,
-        # Payouts are allowed while under review: the request is reserved and
-        # held until the org is approved (see PayoutService.create). `payouts`
-        # now means "the merchant may request a payout", not "paid immediately".
+        # Allowed under review: the request is reserved and held until approval
+        # (see PayoutService.create), so `payouts` now means "may request".
         "payouts": True,
         "refunds": True,
         "api_access": True,
@@ -292,7 +291,6 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
     OrganizationStatus.SNOOZED: {
         "checkout_payments": True,
         "subscription_renewals": True,
-        # See REVIEW: held payouts are allowed while snoozed too.
         "payouts": True,
         "refunds": True,
         "api_access": True,

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -281,7 +281,10 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
     OrganizationStatus.REVIEW: {
         "checkout_payments": True,
         "subscription_renewals": True,
-        "payouts": False,
+        # Payouts are allowed while under review: the request is reserved and
+        # held until the org is approved (see PayoutService.create). `payouts`
+        # now means "the merchant may request a payout", not "paid immediately".
+        "payouts": True,
         "refunds": True,
         "api_access": True,
         "dashboard_access": True,
@@ -289,7 +292,8 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
     OrganizationStatus.SNOOZED: {
         "checkout_payments": True,
         "subscription_renewals": True,
-        "payouts": False,
+        # See REVIEW: held payouts are allowed while snoozed too.
+        "payouts": True,
         "refunds": True,
         "api_access": True,
         "dashboard_access": True,

--- a/server/polar/models/payout.py
+++ b/server/polar/models/payout.py
@@ -43,7 +43,7 @@ class PayoutStatus(StrEnum):
 
     def is_cancelable(self) -> bool:
         """Whether a payout with this status can be canceled."""
-        return self in {PayoutStatus.pending, PayoutStatus.failed}
+        return self in {PayoutStatus.pending, PayoutStatus.failed, PayoutStatus.held}
 
 
 class Payout(RecordModel):

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -800,7 +800,7 @@ class OrganizationService:
         )
         if account_changed and organization.account_id is not None:
             enqueue_job(
-                "organization.cancel_held_payouts",
+                "payout.cancel_held_payouts",
                 account_id=organization.account_id,
             )
 
@@ -1003,7 +1003,7 @@ class OrganizationService:
         review flow to a terminal state (denied, blocked, offboarding)."""
         if organization.account_id is not None:
             enqueue_job(
-                "organization.cancel_pending_payouts",
+                "payout.cancel_account_payouts",
                 account_id=organization.account_id,
             )
 
@@ -1063,7 +1063,7 @@ class OrganizationService:
         # held payouts; a lost race returns None and does nothing.
         if confirmed is not None and confirmed.account_id is not None:
             enqueue_job(
-                "organization.release_held_payouts",
+                "payout.release_held_payouts",
                 account_id=confirmed.account_id,
             )
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -780,9 +780,6 @@ class OrganizationService:
         organization: Organization,
         payout_account: PayoutAccount,
     ) -> Organization:
-        from polar.models.payout import PayoutStatus
-        from polar.payout.service import payout as payout_service
-
         previous_payout_account_id = organization.payout_account_id
 
         organization_repository = OrganizationRepository.from_session(session)
@@ -795,16 +792,16 @@ class OrganizationService:
         # A held payout pins the Connect account it was created against, so a
         # rebind would release to a stale account. Cancel held payouts on swap
         # (they refund their fees, so re-requesting is safe); leave pending ones,
-        # whose transfer may already be in flight.
+        # whose transfer may already be in flight. Emitted as an event to keep
+        # the payout layer out of this service.
         account_changed = (
             previous_payout_account_id is not None
             and previous_payout_account_id != payout_account.id
         )
         if account_changed and organization.account_id is not None:
-            await payout_service.cancel_account_payouts(
-                session,
-                organization.account_id,
-                statuses=(PayoutStatus.held,),
+            enqueue_job(
+                "organization.cancel_held_payouts",
+                account_id=organization.account_id,
             )
 
         # Reusing an already-ready payout account doesn't fire a Stripe

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -789,7 +789,7 @@ class OrganizationService:
             flush=True,
         )
 
-        # A held payout pins the Connect account it was created against, so a
+        # A held payout pins the payout account it was created against, so a
         # rebind would release to a stale account. Cancel held payouts on swap
         # (they refund their fees, so re-requesting is safe); leave pending ones,
         # whose transfer may already be in flight. Scope the cancel to the

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -792,12 +792,10 @@ class OrganizationService:
             flush=True,
         )
 
-        # A held payout pins the Connect account it was created against. If the
-        # merchant rebinds to a different account while a payout is held, the
-        # release would transfer to the stale account — so cancel held payouts
-        # here and let them re-request. Canceled held payouts return their fees
-        # too, so re-requesting doesn't double-charge. Pending payouts are left
-        # alone (their transfer may already be in flight to the old account).
+        # A held payout pins the Connect account it was created against, so a
+        # rebind would release to a stale account. Cancel held payouts on swap
+        # (they refund their fees, so re-requesting is safe); leave pending ones,
+        # whose transfer may already be in flight.
         account_changed = (
             previous_payout_account_id is not None
             and previous_payout_account_id != payout_account.id

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -780,12 +780,35 @@ class OrganizationService:
         organization: Organization,
         payout_account: PayoutAccount,
     ) -> Organization:
+        from polar.models.payout import PayoutStatus
+        from polar.payout.service import payout as payout_service
+
+        previous_payout_account_id = organization.payout_account_id
+
         organization_repository = OrganizationRepository.from_session(session)
         await organization_repository.update(
             organization,
             update_dict={"payout_account_id": payout_account.id},
             flush=True,
         )
+
+        # A held payout pins the Connect account it was created against. If the
+        # merchant rebinds to a different account while a payout is held, the
+        # release would transfer to the stale account — so cancel held payouts
+        # here and let them re-request. Canceled held payouts return their fees
+        # too, so re-requesting doesn't double-charge. Pending payouts are left
+        # alone (their transfer may already be in flight to the old account).
+        account_changed = (
+            previous_payout_account_id is not None
+            and previous_payout_account_id != payout_account.id
+        )
+        if account_changed and organization.account_id is not None:
+            await payout_service.cancel_account_payouts(
+                session,
+                organization.account_id,
+                statuses=(PayoutStatus.held,),
+            )
+
         # Reusing an already-ready payout account doesn't fire a Stripe
         # `account.updated` webhook, so attempt activation here too.
         await self.maybe_activate(session, organization)
@@ -980,6 +1003,15 @@ class OrganizationService:
 
         return organization
 
+    def _enqueue_cancel_pending_payouts(self, organization: Organization) -> None:
+        """Cancel in-flight (held/pending) payouts when an org leaves the
+        review flow to a terminal state (denied, blocked, offboarding)."""
+        if organization.account_id is not None:
+            enqueue_job(
+                "organization.cancel_pending_payouts",
+                account_id=organization.account_id,
+            )
+
     async def block_organization(
         self,
         session: AsyncSession,
@@ -988,6 +1020,7 @@ class OrganizationService:
         """Block an organization by setting status to BLOCKED."""
         organization.set_status(OrganizationStatus.BLOCKED)
         session.add(organization)
+        self._enqueue_cancel_pending_payouts(organization)
         return organization
 
     async def confirm_organization_reviewed(
@@ -1023,13 +1056,23 @@ class OrganizationService:
             )
 
         repository = OrganizationRepository.from_session(session)
-        return await repository.confirm_review_atomic(
+        confirmed = await repository.confirm_review_atomic(
             organization.id,
             next_review_threshold=next_review_threshold,
             min_threshold=_MIN_REVIEW_THRESHOLD,
             active_capabilities={**STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]},
             now=datetime.now(UTC),
         )
+
+        # Only the worker that actually flipped the org to ACTIVE releases its
+        # held payouts; a lost race returns None and does nothing.
+        if confirmed is not None and confirmed.account_id is not None:
+            enqueue_job(
+                "organization.release_held_payouts",
+                account_id=confirmed.account_id,
+            )
+
+        return confirmed
 
     async def _is_activation_ready(
         self, session: AsyncSession, organization: Organization
@@ -1238,6 +1281,8 @@ class OrganizationService:
         organization.set_status(OrganizationStatus.DENIED)
         session.add(organization)
 
+        self._enqueue_cancel_pending_payouts(organization)
+
         # If there's a pending appeal, mark it as rejected
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
@@ -1381,6 +1426,7 @@ class OrganizationService:
             organization, "Organization set to offboarding.", reason=reason
         )
         session.add(organization)
+        self._enqueue_cancel_pending_payouts(organization)
         return organization
 
     def get_payment_status(self, organization: Organization) -> PaymentStatusResponse:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -792,8 +792,10 @@ class OrganizationService:
         # A held payout pins the Connect account it was created against, so a
         # rebind would release to a stale account. Cancel held payouts on swap
         # (they refund their fees, so re-requesting is safe); leave pending ones,
-        # whose transfer may already be in flight. Emitted as an event to keep
-        # the payout layer out of this service.
+        # whose transfer may already be in flight. Scope the cancel to the
+        # previous payout account so a held payout already created against the
+        # new account isn't swept up. Emitted as an event to keep the payout
+        # layer out of this service.
         account_changed = (
             previous_payout_account_id is not None
             and previous_payout_account_id != payout_account.id
@@ -802,6 +804,7 @@ class OrganizationService:
             enqueue_job(
                 "payout.cancel_held_payouts",
                 account_id=organization.account_id,
+                payout_account_id=previous_payout_account_id,
             )
 
         # Reusing an already-ready payout account doesn't fire a Stripe

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -14,8 +14,6 @@ from polar.models.benefit_grant import BenefitGrant
 from polar.models.customer_seat import SeatStatus
 from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
-from polar.models.payout import PayoutStatus
-from polar.payout.service import payout as payout_service
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
 from polar.worker import (
@@ -126,45 +124,6 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
             "organization_review.run_agent",
             organization_id=organization_id,
             auto_approve_eligible=is_auto_approve_eligible,
-        )
-
-
-@actor(actor_name="organization.release_held_payouts", priority=TaskPriority.LOW)
-async def organization_release_held_payouts(account_id: uuid.UUID) -> None:
-    """Release held payouts for an account once its org becomes ACTIVE.
-
-    Enqueued by ``confirm_organization_reviewed`` after a REVIEW/SNOOZED org is
-    approved. Moves held payouts back to ``pending`` and kicks off the Stripe
-    transfer that was held back at request time.
-    """
-    async with AsyncSessionMaker() as session:
-        await payout_service.release_held_payouts(session, account_id)
-
-
-@actor(actor_name="organization.cancel_pending_payouts", priority=TaskPriority.LOW)
-async def organization_cancel_pending_payouts(account_id: uuid.UUID) -> None:
-    """Cancel in-flight payouts for an account leaving the review flow.
-
-    Enqueued when an org is denied, blocked or set to offboarding. Cancels both
-    ``held`` and ``pending`` payouts and returns the reserved funds (gross plus
-    fees) to the available balance.
-    """
-    async with AsyncSessionMaker() as session:
-        await payout_service.cancel_account_payouts(session, account_id)
-
-
-@actor(actor_name="organization.cancel_held_payouts", priority=TaskPriority.LOW)
-async def organization_cancel_held_payouts(account_id: uuid.UUID) -> None:
-    """Cancel only held payouts for an account when its payout account changes.
-
-    Enqueued by ``set_payout_account`` on a swap: a held payout pins the Connect
-    account it was created against, so releasing it later would transfer to the
-    stale account. Pending payouts are left alone (their transfer may already be
-    in flight to the old account).
-    """
-    async with AsyncSessionMaker() as session:
-        await payout_service.cancel_account_payouts(
-            session, account_id, statuses=(PayoutStatus.held,)
         )
 
 

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -14,6 +14,7 @@ from polar.models.benefit_grant import BenefitGrant
 from polar.models.customer_seat import SeatStatus
 from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
+from polar.models.payout import PayoutStatus
 from polar.payout.service import payout as payout_service
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
@@ -150,6 +151,21 @@ async def organization_cancel_pending_payouts(account_id: uuid.UUID) -> None:
     """
     async with AsyncSessionMaker() as session:
         await payout_service.cancel_account_payouts(session, account_id)
+
+
+@actor(actor_name="organization.cancel_held_payouts", priority=TaskPriority.LOW)
+async def organization_cancel_held_payouts(account_id: uuid.UUID) -> None:
+    """Cancel only held payouts for an account when its payout account changes.
+
+    Enqueued by ``set_payout_account`` on a swap: a held payout pins the Connect
+    account it was created against, so releasing it later would transfer to the
+    stale account. Pending payouts are left alone (their transfer may already be
+    in flight to the old account).
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_service.cancel_account_payouts(
+            session, account_id, statuses=(PayoutStatus.held,)
+        )
 
 
 @actor(actor_name="organization.deletion_requested", priority=TaskPriority.HIGH)

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -14,6 +14,7 @@ from polar.models.benefit_grant import BenefitGrant
 from polar.models.customer_seat import SeatStatus
 from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
+from polar.payout.service import payout as payout_service
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
 from polar.worker import (
@@ -125,6 +126,30 @@ async def organization_under_review(organization_id: uuid.UUID) -> None:
             organization_id=organization_id,
             auto_approve_eligible=is_auto_approve_eligible,
         )
+
+
+@actor(actor_name="organization.release_held_payouts", priority=TaskPriority.LOW)
+async def organization_release_held_payouts(account_id: uuid.UUID) -> None:
+    """Release held payouts for an account once its org becomes ACTIVE.
+
+    Enqueued by ``confirm_organization_reviewed`` after a REVIEW/SNOOZED org is
+    approved. Moves held payouts back to ``pending`` and kicks off the Stripe
+    transfer that was held back at request time.
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_service.release_held_payouts(session, account_id)
+
+
+@actor(actor_name="organization.cancel_pending_payouts", priority=TaskPriority.LOW)
+async def organization_cancel_pending_payouts(account_id: uuid.UUID) -> None:
+    """Cancel in-flight payouts for an account leaving the review flow.
+
+    Enqueued when an org is denied, blocked or set to offboarding. Cancels both
+    ``held`` and ``pending`` payouts and returns the reserved funds (gross plus
+    fees) to the available balance.
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_service.cancel_account_payouts(session, account_id)
 
 
 @actor(actor_name="organization.deletion_requested", priority=TaskPriority.HIGH)

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -52,9 +52,8 @@ class PayoutRepository(
             Payout.payout_account_id == payout_account_id,
             Payout.status.in_(
                 {
-                    # `held` reserves funds against the account just like
-                    # `pending`, so it must count here too — otherwise a payout
-                    # account with held funds could be deleted.
+                    # held reserves funds like pending, so it must count here
+                    # too (otherwise the payout account could be deleted).
                     PayoutStatus.held,
                     PayoutStatus.pending,
                     PayoutStatus.in_transit,
@@ -76,9 +75,8 @@ class PayoutRepository(
                 Payout.account_id == account_id,
                 Payout.status.in_(statuses),
             )
-            # Deterministic order so two concurrent cancel jobs lock the rows
-            # (FOR UPDATE in PayoutService.cancel) in the same order and can't
-            # deadlock.
+            # Deterministic order so concurrent cancel jobs lock rows in the
+            # same order (FOR UPDATE in cancel()) and can't deadlock.
             .order_by(Payout.created_at.asc(), Payout.id.asc())
             .options(*options)
         )

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -47,6 +47,23 @@ class PayoutRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_by_id_for_update(
+        self, id: UUID, *, options: Options = ()
+    ) -> Payout | None:
+        """Get a payout by ID with a FOR UPDATE lock on the payout row.
+
+        Locks only the payout row (``OF payouts``) so eager-loading joins don't
+        try to lock the joined rows. Blocks until any concurrent holder (e.g.
+        cancel()) releases, so the transfer serializes against cancellation.
+        """
+        statement = (
+            self.get_base_statement()
+            .where(Payout.id == id)
+            .options(*options)
+            .with_for_update(of=Payout)
+        )
+        return await self.get_one_or_none(statement)
+
     async def count_pending_by_payout_account(self, payout_account_id: UUID) -> int:
         statement = self.get_base_statement().where(
             Payout.payout_account_id == payout_account_id,

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -67,6 +67,7 @@ class PayoutRepository(
         account_id: UUID,
         statuses: Sequence[PayoutStatus],
         *,
+        payout_account_id: UUID | None = None,
         options: Options = (),
     ) -> Sequence[Payout]:
         statement = (
@@ -80,6 +81,8 @@ class PayoutRepository(
             .order_by(Payout.created_at.asc(), Payout.id.asc())
             .options(*options)
         )
+        if payout_account_id is not None:
+            statement = statement.where(Payout.payout_account_id == payout_account_id)
         return await self.get_all(statement)
 
     async def release_held_by_account(self, account_id: UUID) -> Sequence[UUID]:

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from uuid import UUID
 
-from sqlalchemy import Select, exists, select
+from sqlalchemy import Select, exists, select, update
 from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
@@ -52,12 +52,57 @@ class PayoutRepository(
             Payout.payout_account_id == payout_account_id,
             Payout.status.in_(
                 {
+                    # `held` reserves funds against the account just like
+                    # `pending`, so it must count here too — otherwise a payout
+                    # account with held funds could be deleted.
+                    PayoutStatus.held,
                     PayoutStatus.pending,
                     PayoutStatus.in_transit,
                 }
             ),
         )
         return await self.count(statement)
+
+    async def get_by_account_and_statuses(
+        self,
+        account_id: UUID,
+        statuses: Sequence[PayoutStatus],
+        *,
+        options: Options = (),
+    ) -> Sequence[Payout]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Payout.account_id == account_id,
+                Payout.status.in_(statuses),
+            )
+            # Deterministic order so two concurrent cancel jobs lock the rows
+            # (FOR UPDATE in PayoutService.cancel) in the same order and can't
+            # deadlock.
+            .order_by(Payout.created_at.asc(), Payout.id.asc())
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
+    async def release_held_by_account(self, account_id: UUID) -> Sequence[UUID]:
+        """Move every held payout for an account back to `pending`.
+
+        Returns the ids of the released payouts so the caller can enqueue the
+        Stripe transfer that was skipped while they were held. Done as a single
+        UPDATE ... RETURNING so concurrent releases can't double-release a row.
+        """
+        statement = (
+            update(Payout)
+            .where(
+                Payout.account_id == account_id,
+                Payout.status == PayoutStatus.held,
+                Payout.deleted_at.is_(None),
+            )
+            .values(status=PayoutStatus.pending)
+            .returning(Payout.id)
+        )
+        result = await self.session.execute(statement)
+        return [row[0] for row in result.all()]
 
     async def get_all_stripe_pending(
         self, delay: timedelta = settings.ACCOUNT_PAYOUT_DELAY
@@ -71,7 +116,9 @@ class PayoutRepository(
             .where(
                 Payout.processor == PayoutAccountType.stripe,
                 Payout.created_at < utc_now() - delay,
-                Payout.status.not_in([PayoutStatus.canceled, PayoutStatus.succeeded]),
+                # Strictly `pending`: `held` payouts are not yet payable, so
+                # they must not be picked up by the hourly Stripe-transfer cron.
+                Payout.status == PayoutStatus.pending,
                 # Only include payouts that have no attempts yet
                 ~exists(
                     select(PayoutAttempt).where(PayoutAttempt.payout_id == Payout.id)

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -93,10 +93,9 @@ class PayoutError(PolarError): ...
 class OrganizationCannotPayout(PayoutError):
     """Raised when an organization is not allowed to request a payout.
 
-    The message reflects the actual organization status. Note that `REVIEW`
-    and `SNOOZED` orgs *can* request a payout (it is held until approval), so
-    they never raise this — only `CREATED`, `DENIED`, `OFFBOARDING` and
-    `BLOCKED` do.
+    The message reflects the actual organization status. `REVIEW` and `SNOOZED`
+    orgs can request a payout (held until approval) and never raise this; only
+    `CREATED`, `DENIED`, `OFFBOARDING` and `BLOCKED` do.
     """
 
     def __init__(self, organization: Organization) -> None:
@@ -360,13 +359,10 @@ class PayoutService:
             raise PendingPayoutCreation(account)
 
         async with locker.lock(lock_name, timeout=60, blocking_timeout=1):
-            # Lock the organization row before reading its status, so an
-            # in-flight approval can't slip between the read and the payout
-            # insert. If an approval is committing, this waits for it, then
-            # re-reads `ACTIVE` and takes the immediate path; otherwise we see
-            # `REVIEW`/`SNOOZED` and hold the payout. Only `status` and
-            # `capabilities` are refreshed, leaving the eager-loaded `account`
-            # and `payout_account` relationships intact.
+            # Lock the org row so a concurrent approval can't land between the
+            # status read and the payout insert and strand a held payout on an
+            # already-active org. Refresh only status/capabilities to keep the
+            # eager-loaded relationships.
             await session.refresh(
                 organization,
                 attribute_names=["status", "capabilities"],
@@ -376,9 +372,6 @@ class PayoutService:
             if not organization.can_payout:
                 raise OrganizationCannotPayout(organization)
 
-            # REVIEW/SNOOZED orgs reserve the balance exactly like ACTIVE ones,
-            # but the payout is held: no Stripe transfer runs until the org is
-            # approved (see organization.release_held_payouts).
             held = organization.status in (
                 OrganizationStatus.REVIEW,
                 OrganizationStatus.SNOOZED,
@@ -441,10 +434,7 @@ class PayoutService:
                     update_dict={"account_amount": -transaction.account_amount},
                 )
 
-            # `payout.created` is a plain event that fires for held payouts too
-            # (a hook for confirmation emails, etc). The Stripe transfer is a
-            # separate task we only enqueue once the payout is payable — a held
-            # payout's transfer is enqueued later by release_held_payouts.
+            # A held payout's transfer is deferred until release_held_payouts.
             enqueue_job("payout.created", payout_id=payout.id)
             if not held:
                 enqueue_job("payout.transfer", payout_id=payout.id)
@@ -461,16 +451,10 @@ class PayoutService:
 
         This function performs the first step.
         """
-        # Lock the payout row and re-read its status before moving any funds.
-        # `payout.transfer` can race a cancellation: an org denied/blocked/
-        # offboarded (cancel_pending_payouts) or a backoffice cancel may flip the
-        # payout to `canceled` after the job was queued, and a rolled-back release
-        # can leave it `held`. Without the lock, this guard could read a stale
-        # `pending` status, pass, and then transfer to Stripe *after* a concurrent
-        # cancel already reversed the ledger — moving real funds for a payout the
-        # ledger considers canceled. Holding the FOR UPDATE lock through the Stripe
-        # call serializes against PayoutService.cancel (which takes the same lock):
-        # whichever commits first wins, and the loser sees the updated state.
+        # Lock + re-read status before moving funds: a queued transfer can race a
+        # cancel (deny/block/backoffice) and would otherwise pay out a payout the
+        # ledger already reversed. The FOR UPDATE serializes with cancel(), which
+        # holds the same lock.
         await session.refresh(payout, attribute_names=["status"], with_for_update=True)
         if payout.status in (PayoutStatus.canceled, PayoutStatus.held):
             log.warning(
@@ -708,14 +692,9 @@ class PayoutService:
         )
 
     async def cancel(self, session: AsyncSession, payout: Payout) -> Payout:
-        # Lock the row and re-read the status before reversing anything, so two
-        # concurrent cancels can't both pass the check and each write a set of
-        # reversals (which would double-credit the merchant). This races in
-        # practice: a backoffice cancel against organization.cancel_pending_payouts,
-        # or a deny followed by a block, each enqueue a cancel. The loser blocks
-        # here, then re-reads `canceled` and raises before touching the ledger.
-        # Only `status` is refreshed, so the eager-loaded transaction/fee rows
-        # the reversal needs stay intact.
+        # Lock + re-read before reversing: serializes concurrent cancels (e.g. a
+        # backoffice cancel racing cancel_pending_payouts) so they can't each
+        # write a reversal and double-credit the merchant.
         await session.refresh(payout, attribute_names=["status"], with_for_update=True)
         if not payout.status.is_cancelable():
             raise PayoutNotCancelable(payout)
@@ -744,10 +723,8 @@ class PayoutService:
                 update_dict={"transfer_reversal_id": stripe_reversal.id},
             )
         else:
-            # No Stripe transfer ran (a held payout, or a pending one canceled
-            # before its transfer fired), so the per-payout fees were never paid
-            # to Stripe — they were only reserved on the ledger. Return them so
-            # the merchant gets the full reserved amount back, gross plus fees.
+            # No transfer ran, so the per-payout fees were only reserved, never
+            # paid to Stripe. Return them so the merchant is made whole.
             await platform_fee_transaction_service.create_payout_fees_reversal_balances(
                 session, payout=payout
             )

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -748,11 +748,6 @@ class PayoutService:
         payout_ids = await repository.release_held_by_account(account_id)
         for payout_id in payout_ids:
             enqueue_job("payout.transfer", payout_id=payout_id)
-        log.info(
-            "payout.release_held_payouts",
-            account_id=str(account_id),
-            released=len(payout_ids),
-        )
 
     async def cancel_account_payouts(
         self,
@@ -776,21 +771,14 @@ class PayoutService:
         payouts = await repository.get_by_account_and_statuses(
             account_id, statuses, options=repository.get_eager_options()
         )
-        canceled = 0
         for payout in payouts:
             try:
                 await self.cancel(session, payout)
-                canceled += 1
             except PayoutNotCancelable:
                 # A concurrent cancel/transition already finalized this payout
                 # (cancel() locks and re-checks the row). Skip it rather than
                 # failing the whole job.
                 continue
-        log.info(
-            "payout.cancel_account_payouts",
-            account_id=str(account_id),
-            canceled=canceled,
-        )
 
     async def trigger_invoice_generation(
         self,

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -740,8 +740,8 @@ class PayoutService:
         """Release every held payout for an account after its org is approved.
 
         Moves each held payout back to ``pending`` and enqueues the Stripe
-        transfer that was skipped while it was held. Enqueued by
-        ``organization.release_held_payouts`` when a REVIEW/SNOOZED org becomes
+        transfer that was skipped while it was held. Driven by the
+        ``payout.release_held_payouts`` task when a REVIEW/SNOOZED org becomes
         ACTIVE.
         """
         repository = PayoutRepository.from_session(session)

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -26,6 +26,7 @@ from polar.kit.utils import utc_now
 from polar.locker import Locker
 from polar.logging import Logger
 from polar.models import Account, Organization, Payout, PayoutAttempt
+from polar.models.organization import OrganizationStatus
 from polar.models.payout import PayoutStatus
 from polar.models.payout_attempt import PayoutAttemptStatus
 from polar.organization.repository import OrganizationRepository
@@ -89,10 +90,37 @@ def _adjust_payout_amount_for_zero_decimal_currency(
 class PayoutError(PolarError): ...
 
 
-class OrganizationUnderReview(PayoutError):
+class OrganizationCannotPayout(PayoutError):
+    """Raised when an organization is not allowed to request a payout.
+
+    The message reflects the actual organization status. Note that `REVIEW`
+    and `SNOOZED` orgs *can* request a payout (it is held until approval), so
+    they never raise this — only `CREATED`, `DENIED`, `OFFBOARDING` and
+    `BLOCKED` do.
+    """
+
     def __init__(self, organization: Organization) -> None:
         self.organization = organization
-        message = "Your organization is currently under review. Payouts are disabled during this period."
+        match organization.status:
+            case OrganizationStatus.CREATED:
+                message = (
+                    "Your organization isn't active yet. "
+                    "Payouts will be available once it's approved."
+                )
+            case OrganizationStatus.DENIED:
+                message = (
+                    "Your organization's review was denied, "
+                    "so payouts aren't available."
+                )
+            case OrganizationStatus.OFFBOARDING:
+                message = (
+                    "Your organization is being offboarded, "
+                    "so payouts aren't available."
+                )
+            case OrganizationStatus.BLOCKED:
+                message = "Your organization is blocked, so payouts aren't available."
+            case _:
+                message = "Your organization can't request a payout at the moment."
         super().__init__(message, 403)
 
 
@@ -271,7 +299,7 @@ class PayoutService:
         self, session: AsyncSession, organization: Organization
     ) -> PayoutEstimate:
         if not organization.can_payout:
-            raise OrganizationUnderReview(organization)
+            raise OrganizationCannotPayout(organization)
 
         account = organization.account
         payout_account = organization.get_ready_payout_account()
@@ -325,9 +353,6 @@ class PayoutService:
     async def create(
         self, session: AsyncSession, locker: Locker, organization: Organization
     ) -> Payout:
-        if not organization.can_payout:
-            raise OrganizationUnderReview(organization)
-
         account = organization.account
 
         lock_name = f"payout:{account.id}"
@@ -335,6 +360,30 @@ class PayoutService:
             raise PendingPayoutCreation(account)
 
         async with locker.lock(lock_name, timeout=60, blocking_timeout=1):
+            # Lock the organization row before reading its status, so an
+            # in-flight approval can't slip between the read and the payout
+            # insert. If an approval is committing, this waits for it, then
+            # re-reads `ACTIVE` and takes the immediate path; otherwise we see
+            # `REVIEW`/`SNOOZED` and hold the payout. Only `status` and
+            # `capabilities` are refreshed, leaving the eager-loaded `account`
+            # and `payout_account` relationships intact.
+            await session.refresh(
+                organization,
+                attribute_names=["status", "capabilities"],
+                with_for_update=True,
+            )
+
+            if not organization.can_payout:
+                raise OrganizationCannotPayout(organization)
+
+            # REVIEW/SNOOZED orgs reserve the balance exactly like ACTIVE ones,
+            # but the payout is held: no Stripe transfer runs until the org is
+            # approved (see organization.release_held_payouts).
+            held = organization.status in (
+                OrganizationStatus.REVIEW,
+                OrganizationStatus.SNOOZED,
+            )
+
             next_payout_at = await self.get_next_payout_at(session, account)
             if next_payout_at is not None:
                 raise PayoutIntervalLimitReached(account, account.payout_interval)
@@ -368,6 +417,7 @@ class PayoutService:
             payout = await repository.create(
                 Payout(
                     processor=payout_account.type,
+                    status=PayoutStatus.held if held else PayoutStatus.pending,
                     currency="usd",  # FIXME: Main Polar currency
                     amount=balance_amount_after_fees,
                     fees_amount=balance_amount - balance_amount_after_fees,
@@ -391,7 +441,13 @@ class PayoutService:
                     update_dict={"account_amount": -transaction.account_amount},
                 )
 
+            # `payout.created` is a plain event that fires for held payouts too
+            # (a hook for confirmation emails, etc). The Stripe transfer is a
+            # separate task we only enqueue once the payout is payable — a held
+            # payout's transfer is enqueued later by release_held_payouts.
             enqueue_job("payout.created", payout_id=payout.id)
+            if not held:
+                enqueue_job("payout.transfer", payout_id=payout.id)
 
             return payout
 
@@ -405,6 +461,25 @@ class PayoutService:
 
         This function performs the first step.
         """
+        # Lock the payout row and re-read its status before moving any funds.
+        # `payout.transfer` can race a cancellation: an org denied/blocked/
+        # offboarded (cancel_pending_payouts) or a backoffice cancel may flip the
+        # payout to `canceled` after the job was queued, and a rolled-back release
+        # can leave it `held`. Without the lock, this guard could read a stale
+        # `pending` status, pass, and then transfer to Stripe *after* a concurrent
+        # cancel already reversed the ledger — moving real funds for a payout the
+        # ledger considers canceled. Holding the FOR UPDATE lock through the Stripe
+        # call serializes against PayoutService.cancel (which takes the same lock):
+        # whichever commits first wins, and the loser sees the updated state.
+        await session.refresh(payout, attribute_names=["status"], with_for_update=True)
+        if payout.status in (PayoutStatus.canceled, PayoutStatus.held):
+            log.warning(
+                "payout.transfer_stripe.skipped_not_payable",
+                payout_id=str(payout.id),
+                status=payout.status,
+            )
+            return payout
+
         payout_account = payout.payout_account
         assert payout_account.stripe_id is not None
 
@@ -633,6 +708,15 @@ class PayoutService:
         )
 
     async def cancel(self, session: AsyncSession, payout: Payout) -> Payout:
+        # Lock the row and re-read the status before reversing anything, so two
+        # concurrent cancels can't both pass the check and each write a set of
+        # reversals (which would double-credit the merchant). This races in
+        # practice: a backoffice cancel against organization.cancel_pending_payouts,
+        # or a deny followed by a block, each enqueue a cancel. The loser blocks
+        # here, then re-reads `canceled` and raises before touching the ledger.
+        # Only `status` is refreshed, so the eager-loaded transaction/fee rows
+        # the reversal needs stay intact.
+        await session.refresh(payout, attribute_names=["status"], with_for_update=True)
         if not payout.status.is_cancelable():
             raise PayoutNotCancelable(payout)
 
@@ -659,10 +743,76 @@ class PayoutService:
                 payout_reversal_transaction,
                 update_dict={"transfer_reversal_id": stripe_reversal.id},
             )
+        else:
+            # No Stripe transfer ran (a held payout, or a pending one canceled
+            # before its transfer fired), so the per-payout fees were never paid
+            # to Stripe — they were only reserved on the ledger. Return them so
+            # the merchant gets the full reserved amount back, gross plus fees.
+            await platform_fee_transaction_service.create_payout_fees_reversal_balances(
+                session, payout=payout
+            )
 
         repository = PayoutRepository.from_session(session)
         return await repository.update(
             payout, update_dict={"status": PayoutStatus.canceled}
+        )
+
+    async def release_held_payouts(
+        self, session: AsyncSession, account_id: uuid.UUID
+    ) -> None:
+        """Release every held payout for an account after its org is approved.
+
+        Moves each held payout back to ``pending`` and enqueues the Stripe
+        transfer that was skipped while it was held. Enqueued by
+        ``organization.release_held_payouts`` when a REVIEW/SNOOZED org becomes
+        ACTIVE.
+        """
+        repository = PayoutRepository.from_session(session)
+        payout_ids = await repository.release_held_by_account(account_id)
+        for payout_id in payout_ids:
+            enqueue_job("payout.transfer", payout_id=payout_id)
+        log.info(
+            "payout.release_held_payouts",
+            account_id=str(account_id),
+            released=len(payout_ids),
+        )
+
+    async def cancel_account_payouts(
+        self,
+        session: AsyncSession,
+        account_id: uuid.UUID,
+        *,
+        statuses: Sequence[PayoutStatus] = (
+            PayoutStatus.pending,
+            PayoutStatus.held,
+        ),
+    ) -> None:
+        """Cancel every in-flight payout for an account.
+
+        Defaults to cancelling both ``pending`` and ``held`` payouts, used when
+        an org leaves the review flow to a terminal state (denied, blocked,
+        offboarding). Restricted to ``held`` when a payout account is swapped
+        while a payout is still held, so the release can't transfer to a stale
+        account.
+        """
+        repository = PayoutRepository.from_session(session)
+        payouts = await repository.get_by_account_and_statuses(
+            account_id, statuses, options=repository.get_eager_options()
+        )
+        canceled = 0
+        for payout in payouts:
+            try:
+                await self.cancel(session, payout)
+                canceled += 1
+            except PayoutNotCancelable:
+                # A concurrent cancel/transition already finalized this payout
+                # (cancel() locks and re-checks the row). Skip it rather than
+                # failing the whole job.
+                continue
+        log.info(
+            "payout.cancel_account_payouts",
+            account_id=str(account_id),
+            canceled=canceled,
         )
 
     async def trigger_invoice_generation(

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -441,40 +441,33 @@ class PayoutService:
 
             return payout
 
-    async def transfer_stripe(self, session: AsyncSession, payout: Payout) -> Payout:
-        """
-        The Stripe payout is a two-steps process:
+    async def transfer(self, session: AsyncSession, payout: Payout) -> Payout:
+        """Move funds for a payout, whatever its processor.
 
-        1. Make the transfer to the Stripe Connect account
-        2. Trigger a payout on the Stripe Connect account,
-        but later once the balance is actually available.
-
-        This function performs the first step.
+        The caller (the ``payout.transfer`` task) holds a FOR UPDATE lock on the
+        payout row, so this re-checks the payout is still payable, guards against
+        a payout-account swap, and only then dispatches to the processor-specific
+        transfer. Kept processor-agnostic so any future processor inherits the
+        guards.
         """
-        # Lock + re-read status before moving funds: a queued transfer can race a
-        # cancel (deny/block/backoffice) and would otherwise pay out a payout the
-        # ledger already reversed. The FOR UPDATE serializes with cancel(), which
-        # holds the same lock.
-        await session.refresh(payout, attribute_names=["status"], with_for_update=True)
         if payout.status in (PayoutStatus.canceled, PayoutStatus.held):
             log.warning(
-                "payout.transfer_stripe.skipped_not_payable",
+                "payout.transfer.skipped_not_payable",
                 payout_id=str(payout.id),
                 status=payout.status,
             )
             return payout
 
+        # The payout pins the payout account it was created against. If the org
+        # has since swapped its payout account (a release can win the race
+        # against the swap-cancel job), transferring would send funds to the
+        # abandoned account. Before any transfer is made, cancel + refund instead
+        # so the merchant re-requests against the current account.
         payout_transaction_repository = PayoutTransactionRepository.from_session(
             session
         )
         transaction = await payout_transaction_repository.get_by_payout_id(payout.id)
         assert transaction is not None
-
-        # The payout pins the Connect account it was created against. If the org
-        # has since swapped its payout account (a release can win the race
-        # against the swap-cancel job), transferring would send funds to the
-        # abandoned account. Before any transfer is made, cancel + refund
-        # instead so the merchant re-requests against the current account.
         if transaction.transfer_id is None:
             organization_repository = OrganizationRepository.from_session(session)
             organization = await organization_repository.get_by_account(
@@ -486,15 +479,37 @@ class PayoutService:
                 and organization.payout_account_id != payout.payout_account_id
             ):
                 log.warning(
-                    "payout.transfer_stripe.skipped_payout_account_changed",
+                    "payout.transfer.skipped_payout_account_changed",
                     payout_id=str(payout.id),
                     pinned_payout_account_id=str(payout.payout_account_id),
                     current_payout_account_id=str(organization.payout_account_id),
                 )
                 return await self.cancel(session, payout)
 
+        if payout.processor == PayoutAccountType.stripe:
+            return await self.transfer_stripe(session, payout)
+
+        return payout
+
+    async def transfer_stripe(self, session: AsyncSession, payout: Payout) -> Payout:
+        """
+        The Stripe payout is a two-steps process:
+
+        1. Make the transfer to the Stripe Connect account
+        2. Trigger a payout on the Stripe Connect account,
+        but later once the balance is actually available.
+
+        This function performs the first step. Callers must go through
+        ``transfer``, which holds the row lock and runs the payable/swap guards.
+        """
         payout_account = payout.payout_account
         assert payout_account.stripe_id is not None
+
+        payout_transaction_repository = PayoutTransactionRepository.from_session(
+            session
+        )
+        transaction = await payout_transaction_repository.get_by_payout_id(payout.id)
+        assert transaction is not None
 
         stripe_transfer = await stripe_service.transfer(
             payout_account.stripe_id,
@@ -790,7 +805,7 @@ class PayoutService:
         offboarding). Restricted to ``held`` when a payout account is swapped
         while a payout is still held, so the release can't transfer to a stale
         account. ``payout_account_id`` further scopes the cancel to payouts
-        pinned to that Connect account (the swap case passes the previous one).
+        pinned to that payout account (the swap case passes the previous one).
         """
         repository = PayoutRepository.from_session(session)
         payouts = await repository.get_by_account_and_statuses(

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -464,14 +464,37 @@ class PayoutService:
             )
             return payout
 
-        payout_account = payout.payout_account
-        assert payout_account.stripe_id is not None
-
         payout_transaction_repository = PayoutTransactionRepository.from_session(
             session
         )
         transaction = await payout_transaction_repository.get_by_payout_id(payout.id)
         assert transaction is not None
+
+        # The payout pins the Connect account it was created against. If the org
+        # has since swapped its payout account (a release can win the race
+        # against the swap-cancel job), transferring would send funds to the
+        # abandoned account. Before any transfer is made, cancel + refund
+        # instead so the merchant re-requests against the current account.
+        if transaction.transfer_id is None:
+            organization_repository = OrganizationRepository.from_session(session)
+            organization = await organization_repository.get_by_account(
+                payout.account_id
+            )
+            if (
+                organization is not None
+                and organization.payout_account_id is not None
+                and organization.payout_account_id != payout.payout_account_id
+            ):
+                log.warning(
+                    "payout.transfer_stripe.skipped_payout_account_changed",
+                    payout_id=str(payout.id),
+                    pinned_payout_account_id=str(payout.payout_account_id),
+                    current_payout_account_id=str(organization.payout_account_id),
+                )
+                return await self.cancel(session, payout)
+
+        payout_account = payout.payout_account
+        assert payout_account.stripe_id is not None
 
         stripe_transfer = await stripe_service.transfer(
             payout_account.stripe_id,
@@ -758,6 +781,7 @@ class PayoutService:
             PayoutStatus.pending,
             PayoutStatus.held,
         ),
+        payout_account_id: uuid.UUID | None = None,
     ) -> None:
         """Cancel every in-flight payout for an account.
 
@@ -765,11 +789,15 @@ class PayoutService:
         an org leaves the review flow to a terminal state (denied, blocked,
         offboarding). Restricted to ``held`` when a payout account is swapped
         while a payout is still held, so the release can't transfer to a stale
-        account.
+        account. ``payout_account_id`` further scopes the cancel to payouts
+        pinned to that Connect account (the swap case passes the previous one).
         """
         repository = PayoutRepository.from_session(session)
         payouts = await repository.get_by_account_and_statuses(
-            account_id, statuses, options=repository.get_eager_options()
+            account_id,
+            statuses,
+            payout_account_id=payout_account_id,
+            options=repository.get_eager_options(),
         )
         for payout in payouts:
             try:

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -5,6 +5,7 @@ import structlog
 from polar.enums import PayoutAccountType
 from polar.exceptions import PolarTaskError
 from polar.logging import Logger
+from polar.models.payout import PayoutStatus
 from polar.worker import AsyncSessionMaker, CronTrigger, TaskPriority, actor
 
 from .repository import PayoutRepository
@@ -97,3 +98,42 @@ async def order_invoice(payout_id: uuid.UUID) -> None:
             raise PayoutDoesNotExist(payout_id)
 
         await payout_service.generate_invoice(session, payout)
+
+
+@actor(actor_name="payout.release_held_payouts", priority=TaskPriority.LOW)
+async def release_held_payouts(account_id: uuid.UUID) -> None:
+    """Release held payouts for an account once its org becomes ACTIVE.
+
+    Enqueued by ``confirm_organization_reviewed`` after a REVIEW/SNOOZED org is
+    approved. Moves held payouts back to ``pending`` and kicks off the Stripe
+    transfer that was held back at request time.
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_service.release_held_payouts(session, account_id)
+
+
+@actor(actor_name="payout.cancel_account_payouts", priority=TaskPriority.LOW)
+async def cancel_account_payouts(account_id: uuid.UUID) -> None:
+    """Cancel in-flight payouts for an account leaving the review flow.
+
+    Enqueued when an org is denied, blocked or set to offboarding. Cancels both
+    ``held`` and ``pending`` payouts and returns the reserved funds (gross plus
+    fees) to the available balance.
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_service.cancel_account_payouts(session, account_id)
+
+
+@actor(actor_name="payout.cancel_held_payouts", priority=TaskPriority.LOW)
+async def cancel_held_payouts(account_id: uuid.UUID) -> None:
+    """Cancel only held payouts for an account when its payout account changes.
+
+    Enqueued by ``set_payout_account`` on a swap: a held payout pins the Connect
+    account it was created against, so releasing it later would transfer to the
+    stale account. Pending payouts are left alone (their transfer may already be
+    in flight to the old account).
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_service.cancel_account_payouts(
+            session, account_id, statuses=(PayoutStatus.held,)
+        )

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -125,15 +125,21 @@ async def cancel_account_payouts(account_id: uuid.UUID) -> None:
 
 
 @actor(actor_name="payout.cancel_held_payouts", priority=TaskPriority.LOW)
-async def cancel_held_payouts(account_id: uuid.UUID) -> None:
+async def cancel_held_payouts(
+    account_id: uuid.UUID, payout_account_id: uuid.UUID
+) -> None:
     """Cancel only held payouts for an account when its payout account changes.
 
     Enqueued by ``set_payout_account`` on a swap: a held payout pins the Connect
     account it was created against, so releasing it later would transfer to the
-    stale account. Pending payouts are left alone (their transfer may already be
-    in flight to the old account).
+    stale account. Scoped to ``payout_account_id`` (the previous account) so a
+    held payout already created against the new account isn't canceled. Pending
+    payouts are left alone (their transfer may already be in flight).
     """
     async with AsyncSessionMaker() as session:
         await payout_service.cancel_account_payouts(
-            session, account_id, statuses=(PayoutStatus.held,)
+            session,
+            account_id,
+            statuses=(PayoutStatus.held,),
+            payout_account_id=payout_account_id,
         )

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -2,7 +2,6 @@ import uuid
 
 import structlog
 
-from polar.enums import PayoutAccountType
 from polar.exceptions import PolarTaskError
 from polar.logging import Logger
 from polar.models.payout import PayoutStatus
@@ -49,8 +48,12 @@ async def payout_transfer(payout_id: uuid.UUID) -> None:
         if payout is None:
             raise PayoutDoesNotExist(payout_id)
 
-        if payout.processor == PayoutAccountType.stripe:
-            await payout_service.transfer_stripe(session, payout)
+        # Lock + re-read status before handing off: a queued transfer can race a
+        # cancel (deny/block/backoffice) and would otherwise pay out a payout the
+        # ledger already reversed. The FOR UPDATE serializes with cancel(), which
+        # takes the same lock.
+        await session.refresh(payout, attribute_names=["status"], with_for_update=True)
+        await payout_service.transfer(session, payout)
 
 
 @actor(
@@ -130,7 +133,7 @@ async def cancel_held_payouts(
 ) -> None:
     """Cancel only held payouts for an account when its payout account changes.
 
-    Enqueued by ``set_payout_account`` on a swap: a held payout pins the Connect
+    Enqueued by ``set_payout_account`` on a swap: a held payout pins the payout
     account it was created against, so releasing it later would transfer to the
     stale account. Scoped to ``payout_account_id`` (the previous account) so a
     held payout already created against the new account isn't canceled. Pending

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -29,6 +29,22 @@ class PayoutDoesNotExist(PayoutTaskError):
 
 @actor(actor_name="payout.created", priority=TaskPriority.LOW)
 async def payout_created(payout_id: uuid.UUID) -> None:
+    # Plain event marking that a payout was created. It fires for held payouts
+    # too and is the hook for follow-ups like confirmation emails. The Stripe
+    # transfer is handled separately by `payout.transfer`, which is only
+    # enqueued once the payout is actually payable (never while held).
+    async with AsyncSessionMaker() as session:
+        repository = PayoutRepository(session)
+        payout = await repository.get_by_id(payout_id)
+        if payout is None:
+            raise PayoutDoesNotExist(payout_id)
+
+
+@actor(actor_name="payout.transfer", priority=TaskPriority.LOW)
+async def payout_transfer(payout_id: uuid.UUID) -> None:
+    # Step 1 of the Stripe payout: transfer funds from the platform to the
+    # Connect account. Enqueued by PayoutService.create for immediate payouts,
+    # and by organization.release_held_payouts when a held payout is released.
     async with AsyncSessionMaker() as session:
         repository = PayoutRepository(session)
         payout = await repository.get_by_id(

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -42,17 +42,16 @@ async def payout_created(payout_id: uuid.UUID) -> None:
 async def payout_transfer(payout_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = PayoutRepository(session)
-        payout = await repository.get_by_id(
+        # Lock the payout row up front: a queued transfer can race a cancel
+        # (deny/block/backoffice) and would otherwise pay out a payout the ledger
+        # already reversed. FOR UPDATE serializes with cancel(), which locks the
+        # same row.
+        payout = await repository.get_by_id_for_update(
             payout_id, options=repository.get_eager_options()
         )
         if payout is None:
             raise PayoutDoesNotExist(payout_id)
 
-        # Lock + re-read status before handing off: a queued transfer can race a
-        # cancel (deny/block/backoffice) and would otherwise pay out a payout the
-        # ledger already reversed. The FOR UPDATE serializes with cancel(), which
-        # takes the same lock.
-        await session.refresh(payout, attribute_names=["status"], with_for_update=True)
         await payout_service.transfer(session, payout)
 
 

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -29,10 +29,8 @@ class PayoutDoesNotExist(PayoutTaskError):
 
 @actor(actor_name="payout.created", priority=TaskPriority.LOW)
 async def payout_created(payout_id: uuid.UUID) -> None:
-    # Plain event marking that a payout was created. It fires for held payouts
-    # too and is the hook for follow-ups like confirmation emails. The Stripe
-    # transfer is handled separately by `payout.transfer`, which is only
-    # enqueued once the payout is actually payable (never while held).
+    # Event-only hook (fires for held payouts too); the Stripe transfer is the
+    # separate `payout.transfer` task.
     async with AsyncSessionMaker() as session:
         repository = PayoutRepository(session)
         payout = await repository.get_by_id(payout_id)
@@ -42,9 +40,6 @@ async def payout_created(payout_id: uuid.UUID) -> None:
 
 @actor(actor_name="payout.transfer", priority=TaskPriority.LOW)
 async def payout_transfer(payout_id: uuid.UUID) -> None:
-    # Step 1 of the Stripe payout: transfer funds from the platform to the
-    # Connect account. Enqueued by PayoutService.create for immediate payouts,
-    # and by organization.release_held_payouts when a held payout is released.
     async with AsyncSessionMaker() as session:
         repository = PayoutRepository(session)
         payout = await repository.get_by_id(

--- a/server/polar/transaction/service/platform_fee.py
+++ b/server/polar/transaction/service/platform_fee.py
@@ -8,7 +8,7 @@ from polar.account_credit.service import account_credit_service
 from polar.enums import PayoutAccountType
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.logging import Logger
-from polar.models import Account, PayoutAccount, Transaction
+from polar.models import Account, Payout, PayoutAccount, Transaction
 from polar.models.transaction import PlatformFeeType, Processor, TransactionType
 from polar.postgres import AsyncSession
 from polar.transaction.fees.stripe import (
@@ -105,6 +105,36 @@ class PlatformFeeTransactionService(BaseTransactionService):
             payout_fees.append((PlatformFeeType.payout, payout_fee_amount))
 
         return payout_fees
+
+    async def create_payout_fees_reversal_balances(
+        self,
+        session: AsyncSession,
+        *,
+        payout: Payout,
+    ) -> list[tuple[Transaction, Transaction]]:
+        """Return the per-payout platform fees to the merchant's balance.
+
+        Used when canceling a payout that never ran its Stripe transfer (a held
+        payout, or a pending one canceled before the transfer fired). Those fees
+        were only a ledger reservation — no fee was actually paid to Stripe — so
+        we credit the same amount back, tagged with the same fee type so it
+        counts toward the available balance immediately. Mirrors the debits
+        written by ``create_payout_fees_balances``.
+        """
+        account = payout.account
+        reversals: list[tuple[Transaction, Transaction]] = []
+        for fee_transaction in payout.fees_transactions:
+            # `fee_transaction` is the merchant-side debit, with a negative
+            # amount; credit the same magnitude back to the account.
+            reversal = await balance_transaction_service.create_balance(
+                session,
+                source_account=None,
+                destination_account=account,
+                amount=-fee_transaction.amount,
+                platform_fee_type=fee_transaction.platform_fee_type,
+            )
+            reversals.append(reversal)
+        return reversals
 
     async def create_payout_fees_balances(
         self,

--- a/server/polar/transaction/service/platform_fee.py
+++ b/server/polar/transaction/service/platform_fee.py
@@ -114,18 +114,15 @@ class PlatformFeeTransactionService(BaseTransactionService):
     ) -> list[tuple[Transaction, Transaction]]:
         """Return the per-payout platform fees to the merchant's balance.
 
-        Used when canceling a payout that never ran its Stripe transfer (a held
-        payout, or a pending one canceled before the transfer fired). Those fees
-        were only a ledger reservation — no fee was actually paid to Stripe — so
-        we credit the same amount back, tagged with the same fee type so it
-        counts toward the available balance immediately. Mirrors the debits
-        written by ``create_payout_fees_balances``.
+        Used when canceling a payout that never ran its Stripe transfer (held,
+        or pending-before-transfer). Those fees were only reserved, never paid,
+        so we credit them back with the same fee type, which counts toward the
+        available balance immediately. Mirrors ``create_payout_fees_balances``.
         """
         account = payout.account
         reversals: list[tuple[Transaction, Transaction]] = []
         for fee_transaction in payout.fees_transactions:
-            # `fee_transaction` is the merchant-side debit, with a negative
-            # amount; credit the same magnitude back to the account.
+            # fee_transaction is the merchant-side debit (negative); credit it back.
             reversal = await balance_transaction_service.create_balance(
                 session,
                 source_account=None,

--- a/server/scripts/backfill_held_payouts_capability.py
+++ b/server/scripts/backfill_held_payouts_capability.py
@@ -11,7 +11,10 @@ them until their next status change.
 
 This script backfills `capabilities->>'payouts' = true` for every non-deleted
 org currently in REVIEW or SNOOZED whose stored capability is still false. It
-only touches the `payouts` key; every other capability is left untouched.
+only touches the `payouts` key; every other capability is left untouched. Orgs
+whose payouts capability was explicitly disabled by an admin (an intentional
+override, detected via the internal-notes marker) are skipped so the backfill
+never re-enables a deliberate block.
 
 Usage:
     cd server
@@ -55,13 +58,25 @@ HELD_PAYOUT_STATUSES = (
 
 SAMPLE_LIMIT = 50
 
+# Marker left by OrganizationService.set_capability when an admin disables
+# payouts. Since REVIEW/SNOOZED already defaulted to payouts=false before the
+# flip, set_capability could only write this note by deliberately disabling
+# payouts after the default became true — i.e. an intentional override we must
+# not clobber. (At the initial deploy no such note exists, so this is a no-op
+# then; it protects re-runs once admins can disable payouts on review orgs.)
+_PAYOUTS_DISABLED_NOTE = "%Capability 'payouts' disabled%"
+
 
 def _candidate_filter() -> tuple[ColumnElement[bool], ...]:
-    """Orgs under review whose stored `payouts` capability is still false."""
+    """Orgs under review whose stored `payouts` capability is still false,
+    excluding any whose payouts capability was explicitly disabled by an admin.
+    """
     return (
         Organization.deleted_at.is_(None),
         Organization.status.in_(HELD_PAYOUT_STATUSES),
         Organization.capabilities["payouts"].as_boolean().is_not(True),
+        # Skip intentional overrides (coalesce so NULL notes are still included).
+        ~func.coalesce(Organization.internal_notes, "").ilike(_PAYOUTS_DISABLED_NOTE),
     )
 
 

--- a/server/scripts/backfill_held_payouts_capability.py
+++ b/server/scripts/backfill_held_payouts_capability.py
@@ -11,10 +11,12 @@ them until their next status change.
 
 This script backfills `capabilities->>'payouts' = true` for every non-deleted
 org currently in REVIEW or SNOOZED whose stored capability is still false. It
-only touches the `payouts` key; every other capability is left untouched. Orgs
-whose payouts capability was explicitly disabled by an admin (an intentional
-override, detected via the internal-notes marker) are skipped so the backfill
-never re-enables a deliberate block.
+only touches the `payouts` key; every other capability is left untouched.
+
+Run once at deploy. Before the flip, REVIEW/SNOOZED already defaulted to
+`payouts: false`, and set_capability no-ops on a same-value write, so no
+deliberate "payouts disabled" override can exist yet — a plain capability check
+is enough and there are no admin overrides to preserve.
 
 Usage:
     cd server
@@ -58,25 +60,13 @@ HELD_PAYOUT_STATUSES = (
 
 SAMPLE_LIMIT = 50
 
-# Marker left by OrganizationService.set_capability when an admin disables
-# payouts. Since REVIEW/SNOOZED already defaulted to payouts=false before the
-# flip, set_capability could only write this note by deliberately disabling
-# payouts after the default became true — i.e. an intentional override we must
-# not clobber. (At the initial deploy no such note exists, so this is a no-op
-# then; it protects re-runs once admins can disable payouts on review orgs.)
-_PAYOUTS_DISABLED_NOTE = "%Capability 'payouts' disabled%"
-
 
 def _candidate_filter() -> tuple[ColumnElement[bool], ...]:
-    """Orgs under review whose stored `payouts` capability is still false,
-    excluding any whose payouts capability was explicitly disabled by an admin.
-    """
+    """Orgs under review whose stored `payouts` capability is still false."""
     return (
         Organization.deleted_at.is_(None),
         Organization.status.in_(HELD_PAYOUT_STATUSES),
         Organization.capabilities["payouts"].as_boolean().is_not(True),
-        # Skip intentional overrides (coalesce so NULL notes are still included).
-        ~func.coalesce(Organization.internal_notes, "").ilike(_PAYOUTS_DISABLED_NOTE),
     )
 
 

--- a/server/scripts/backfill_held_payouts_capability.py
+++ b/server/scripts/backfill_held_payouts_capability.py
@@ -1,0 +1,194 @@
+"""
+Grant the `payouts` capability to organizations already under review.
+
+The payout-hold flow flips `STATUS_CAPABILITIES` so REVIEW and SNOOZED orgs
+have `payouts: True` (a request is reserved and held until approval, instead
+of being blocked). But `capabilities` is a denormalized JSONB column that is
+only refreshed on a status transition, so orgs that were already in REVIEW or
+SNOOZED at deploy time still have `payouts: false` stored — `can_payout`,
+`estimate()`, and the public `capabilities.payouts` field would all keep
+rejecting them until their next status change.
+
+This script backfills `capabilities->>'payouts' = true` for every non-deleted
+org currently in REVIEW or SNOOZED whose stored capability is still false. It
+only touches the `payouts` key; every other capability is left untouched.
+
+Usage:
+    cd server
+
+    # Dry-run (default) — show counts and a sample of candidates:
+    uv run python -m scripts.backfill_held_payouts_capability
+
+    # Execute the backfill (batched):
+    uv run python -m scripts.backfill_held_payouts_capability --execute
+"""
+
+import structlog
+import typer
+from rich.console import Console
+from rich.table import Table
+from sqlalchemy import ColumnElement, Text, cast, func, select, update
+from sqlalchemy.dialects.postgresql import ARRAY
+
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.models import Organization
+from polar.models.organization import OrganizationStatus
+from polar.postgres import create_async_engine
+from scripts.helper import (
+    configure_script_console_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+console = Console()
+log = structlog.get_logger()
+
+configure_script_console_logging()
+
+
+HELD_PAYOUT_STATUSES = (
+    OrganizationStatus.REVIEW,
+    OrganizationStatus.SNOOZED,
+)
+
+SAMPLE_LIMIT = 50
+
+
+def _candidate_filter() -> tuple[ColumnElement[bool], ...]:
+    """Orgs under review whose stored `payouts` capability is still false."""
+    return (
+        Organization.deleted_at.is_(None),
+        Organization.status.in_(HELD_PAYOUT_STATUSES),
+        Organization.capabilities["payouts"].as_boolean().is_not(True),
+    )
+
+
+async def _count_by_status(
+    session: AsyncSession,
+) -> list[tuple[OrganizationStatus, int]]:
+    result = await session.execute(
+        select(Organization.status, func.count())
+        .where(*_candidate_filter())
+        .group_by(Organization.status)
+        .order_by(Organization.status)
+    )
+    return [(status, total) for status, total in result.all()]
+
+
+async def _sample_candidates(
+    session: AsyncSession, *, limit: int
+) -> list[Organization]:
+    result = await session.execute(
+        select(Organization)
+        .where(*_candidate_filter())
+        .order_by(Organization.created_at.asc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+def _render_summary(counts: list[tuple[OrganizationStatus, int]]) -> int:
+    table = Table(title="Orgs to grant the payouts capability")
+    table.add_column("Status", style="yellow")
+    table.add_column("Count", justify="right", style="cyan")
+    total = 0
+    for status, count in counts:
+        table.add_row(status.value, str(count))
+        total += count
+    console.print(table)
+    return total
+
+
+def _render_sample(organizations: list[Organization]) -> None:
+    if not organizations:
+        return
+    table = Table(title=f"Sample (first {len(organizations)} by created_at)")
+    table.add_column("ID", style="dim")
+    table.add_column("Slug")
+    table.add_column("Status", style="yellow")
+    table.add_column("Created", style="cyan")
+
+    for org in organizations:
+        table.add_row(
+            str(org.id),
+            org.slug,
+            org.status.value,
+            org.created_at.isoformat(),
+        )
+
+    console.print(table)
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    execute: bool = typer.Option(
+        False, help="Actually run the backfill (default: dry-run)"
+    ),
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            counts = await _count_by_status(session)
+            sample = await _sample_candidates(session, limit=SAMPLE_LIMIT)
+
+        total = _render_summary(counts)
+        if total == 0:
+            console.print(
+                "[green]No REVIEW/SNOOZED organizations with payouts disabled."
+            )
+            return
+
+        console.print()
+        _render_sample(sample)
+
+        if not execute:
+            console.print(
+                f"\n[yellow]Dry-run — use --execute to grant the payouts "
+                f"capability to {total} organization(s)."
+            )
+            return
+
+        console.rule("[bold]Executing backfill")
+        subquery = (
+            select(Organization.id)
+            .where(*_candidate_filter())
+            .order_by(Organization.id)
+            .limit(limit_bindparam())
+            .scalar_subquery()
+        )
+        stmt = (
+            update(Organization)
+            .where(Organization.id.in_(subquery))
+            # Only flip the payouts key; leave the rest of the JSON untouched.
+            # The path must be bound as text[] (not a scalar string), otherwise
+            # Postgres can't resolve jsonb_set(jsonb, varchar, jsonb).
+            .values(
+                capabilities=func.jsonb_set(
+                    Organization.capabilities,
+                    cast(["payouts"], ARRAY(Text)),
+                    func.to_jsonb(True),
+                )
+            )
+        )
+        rows_updated = await run_batched_update(
+            stmt, batch_size=batch_size, sleep_seconds=sleep_seconds
+        )
+        log.info("backfill.complete", rowcount=rows_updated)
+        console.print(
+            f"\n[green]Granted the payouts capability to {rows_updated} "
+            "organization(s)."
+        )
+
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/backfill_held_payouts_capability.py
+++ b/server/scripts/backfill_held_payouts_capability.py
@@ -5,9 +5,9 @@ The payout-hold flow flips `STATUS_CAPABILITIES` so REVIEW and SNOOZED orgs
 have `payouts: True` (a request is reserved and held until approval, instead
 of being blocked). But `capabilities` is a denormalized JSONB column that is
 only refreshed on a status transition, so orgs that were already in REVIEW or
-SNOOZED at deploy time still have `payouts: false` stored — `can_payout`,
-`estimate()`, and the public `capabilities.payouts` field would all keep
-rejecting them until their next status change.
+SNOOZED at deploy time still have `payouts: false` stored, so `can_payout`,
+`estimate()`, and the public `capabilities.payouts` field all keep rejecting
+them until their next status change.
 
 This script backfills `capabilities->>'payouts' = true` for every non-deleted
 org currently in REVIEW or SNOOZED whose stored capability is still false. It
@@ -16,7 +16,7 @@ only touches the `payouts` key; every other capability is left untouched.
 Usage:
     cd server
 
-    # Dry-run (default) — show counts and a sample of candidates:
+    # Dry-run (default): show counts and a sample of candidates.
     uv run python -m scripts.backfill_held_payouts_capability
 
     # Execute the backfill (batched):
@@ -150,7 +150,7 @@ async def backfill(
 
         if not execute:
             console.print(
-                f"\n[yellow]Dry-run — use --execute to grant the payouts "
+                f"\n[yellow]Dry-run. Use --execute to grant the payouts "
                 f"capability to {total} organization(s)."
             )
             return

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3824,8 +3824,6 @@ class TestSetPayoutAccount:
         user_organization: UserOrganization,
         user: User,
     ) -> None:
-        from polar.models.payout import PayoutStatus
-
         old_payout_account = await create_payout_account(
             save_fixture, organization, user, type=PayoutAccountType.stripe
         )
@@ -3837,16 +3835,15 @@ class TestSetPayoutAccount:
         organization.payout_account = old_payout_account
         await save_fixture(organization)
 
-        cancel_mock = mocker.patch("polar.payout.service.payout.cancel_account_payouts")
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
         await organization_service.set_payout_account(
             session, organization, new_payout_account
         )
 
-        cancel_mock.assert_called_once_with(
-            session,
-            organization.account_id,
-            statuses=(PayoutStatus.held,),
+        enqueue_job_mock.assert_any_call(
+            "organization.cancel_held_payouts",
+            account_id=organization.account_id,
         )
 
     @pytest.mark.auth
@@ -3865,13 +3862,18 @@ class TestSetPayoutAccount:
         organization.payout_account = payout_account
         await save_fixture(organization)
 
-        cancel_mock = mocker.patch("polar.payout.service.payout.cancel_account_payouts")
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
         await organization_service.set_payout_account(
             session, organization, payout_account
         )
 
-        cancel_mock.assert_not_called()
+        cancel_calls = [
+            c
+            for c in enqueue_job_mock.call_args_list
+            if c.args and c.args[0] == "organization.cancel_held_payouts"
+        ]
+        assert cancel_calls == []
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -968,6 +968,25 @@ class TestConfirmOrganizationReviewed:
                 session, organization, 15000
             )
 
+    async def test_enqueues_release_held_payouts(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.confirm_organization_reviewed(
+            session, organization, 15000
+        )
+
+        assert result is not None
+        enqueue_job_mock.assert_any_call(
+            "organization.release_held_payouts",
+            account_id=organization.account_id,
+        )
+
     async def test_race_lost_returns_none(
         self,
         session: AsyncSession,
@@ -1185,6 +1204,52 @@ class TestDenyOrganization:
 
         # Then
         assert result.status == OrganizationStatus.DENIED
+
+    async def test_enqueues_cancel_pending_payouts(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.deny_organization(session, organization)
+
+        enqueue_job_mock.assert_any_call(
+            "organization.cancel_pending_payouts",
+            account_id=organization.account_id,
+        )
+
+
+@pytest.mark.asyncio
+class TestBlockOrganization:
+    async def test_block_organization(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.ACTIVE
+
+        result = await organization_service.block_organization(session, organization)
+
+        assert result.status == OrganizationStatus.BLOCKED
+
+    async def test_enqueues_cancel_pending_payouts(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.block_organization(session, organization)
+
+        enqueue_job_mock.assert_any_call(
+            "organization.cancel_pending_payouts",
+            account_id=organization.account_id,
+        )
 
 
 @pytest.mark.asyncio
@@ -3431,6 +3496,22 @@ class TestSetOrganizationOffboarding:
         assert result.internal_notes is not None
         assert "Requested by merchant" in result.internal_notes
 
+    async def test_enqueues_cancel_pending_payouts(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.set_organization_offboarding(session, organization)
+
+        enqueue_job_mock.assert_any_call(
+            "organization.cancel_pending_payouts",
+            account_id=organization.account_id,
+        )
+
 
 @pytest.mark.asyncio
 class TestSnoozeOrganization:
@@ -3732,6 +3813,65 @@ class TestSetPayoutAccount:
 
         assert updated_org.payout_account_id == payout_account.id
         assert updated_org.status == OrganizationStatus.ACTIVE
+
+    @pytest.mark.auth
+    async def test_swap_cancels_held_payouts(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        from polar.models.payout import PayoutStatus
+
+        old_payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        new_payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        # create_payout_account links the org to whichever account it just
+        # created, so pin the "previous" account back to the old one.
+        organization.payout_account = old_payout_account
+        await save_fixture(organization)
+
+        cancel_mock = mocker.patch("polar.payout.service.payout.cancel_account_payouts")
+
+        await organization_service.set_payout_account(
+            session, organization, new_payout_account
+        )
+
+        cancel_mock.assert_called_once_with(
+            session,
+            organization.account_id,
+            statuses=(PayoutStatus.held,),
+        )
+
+    @pytest.mark.auth
+    async def test_no_swap_does_not_cancel(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        organization.payout_account = payout_account
+        await save_fixture(organization)
+
+        cancel_mock = mocker.patch("polar.payout.service.payout.cancel_account_payouts")
+
+        await organization_service.set_payout_account(
+            session, organization, payout_account
+        )
+
+        cancel_mock.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3844,6 +3844,7 @@ class TestSetPayoutAccount:
         enqueue_job_mock.assert_any_call(
             "payout.cancel_held_payouts",
             account_id=organization.account_id,
+            payout_account_id=old_payout_account.id,
         )
 
     @pytest.mark.auth

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -983,7 +983,7 @@ class TestConfirmOrganizationReviewed:
 
         assert result is not None
         enqueue_job_mock.assert_any_call(
-            "organization.release_held_payouts",
+            "payout.release_held_payouts",
             account_id=organization.account_id,
         )
 
@@ -1217,7 +1217,7 @@ class TestDenyOrganization:
         await organization_service.deny_organization(session, organization)
 
         enqueue_job_mock.assert_any_call(
-            "organization.cancel_pending_payouts",
+            "payout.cancel_account_payouts",
             account_id=organization.account_id,
         )
 
@@ -1247,7 +1247,7 @@ class TestBlockOrganization:
         await organization_service.block_organization(session, organization)
 
         enqueue_job_mock.assert_any_call(
-            "organization.cancel_pending_payouts",
+            "payout.cancel_account_payouts",
             account_id=organization.account_id,
         )
 
@@ -3508,7 +3508,7 @@ class TestSetOrganizationOffboarding:
         await organization_service.set_organization_offboarding(session, organization)
 
         enqueue_job_mock.assert_any_call(
-            "organization.cancel_pending_payouts",
+            "payout.cancel_account_payouts",
             account_id=organization.account_id,
         )
 
@@ -3842,7 +3842,7 @@ class TestSetPayoutAccount:
         )
 
         enqueue_job_mock.assert_any_call(
-            "organization.cancel_held_payouts",
+            "payout.cancel_held_payouts",
             account_id=organization.account_id,
         )
 
@@ -3871,7 +3871,7 @@ class TestSetPayoutAccount:
         cancel_calls = [
             c
             for c in enqueue_job_mock.call_args_list
-            if c.args and c.args[0] == "organization.cancel_held_payouts"
+            if c.args and c.args[0] == "payout.cancel_held_payouts"
         ]
         assert cancel_calls == []
 

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -669,6 +669,66 @@ class TestTransferStripe:
         assert result.status == PayoutStatus.canceled
         stripe_service_mock.transfer.assert_not_called()
 
+    async def test_cancels_when_payout_account_swapped(
+        self,
+        mocker: MockerFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # A released hold can win the race against the swap-cancel job. Before
+        # any transfer is made, transfer_stripe must notice the org now points
+        # at a different payout account and cancel + refund instead of sending
+        # funds to the abandoned Connect account.
+        fee_reversal_mock = mocker.patch(
+            "polar.payout.service.platform_fee_transaction_service"
+            ".create_payout_fees_reversal_balances"
+        )
+        account = await create_account(save_fixture, user)
+        old_payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        new_payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        # The org's financial account owns the payout, and its current payout
+        # account is the new one (create_payout_account left it pointing there).
+        organization.account = account
+        await save_fixture(organization)
+
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=old_payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+        payout_transaction = Transaction(
+            type=TransactionType.payout,
+            account=account,
+            processor=Processor.stripe,
+            currency=payout.currency,
+            amount=-payout.amount,
+            account_currency=payout.account_currency,
+            account_amount=-payout.account_amount,
+            tax_amount=0,
+            payout=payout,
+            transfer_id=None,
+        )
+        await save_fixture(payout_transaction)
+        payout_transaction_service_mock.reverse.return_value = Transaction()
+
+        assert organization.payout_account_id == new_payout_account.id
+
+        result = await payout_service.transfer_stripe(session, payout)
+
+        assert result.status == PayoutStatus.canceled
+        stripe_service_mock.transfer.assert_not_called()
+        fee_reversal_mock.assert_called_once_with(session, payout=payout)
+
     async def test_valid(
         self,
         stripe_service_mock: MagicMock,
@@ -1242,6 +1302,69 @@ class TestCancelAccountPayouts:
         await payout_service.cancel_account_payouts(session, account.id)
 
         assert set(attempted) == {held_1.id, held_2.id}
+
+    async def test_scopes_to_payout_account(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # On a payout-account swap we cancel only holds pinned to the previous
+        # account; a fresh hold already created against the new account (the
+        # cooldown clears once the old hold is >24h old) must survive.
+        account = await create_account(save_fixture, user)
+        old_payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        new_payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        stale_hold = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=old_payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        fresh_hold = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=new_payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        payout_transaction = Transaction(
+            type=TransactionType.payout,
+            account=account,
+            processor=Processor.stripe,
+            currency=stale_hold.currency,
+            amount=-stale_hold.amount,
+            account_currency=stale_hold.account_currency,
+            account_amount=-stale_hold.account_amount,
+            tax_amount=0,
+            payout=stale_hold,
+            transfer_id=None,
+        )
+        await save_fixture(payout_transaction)
+        payout_transaction_service_mock.reverse.return_value = Transaction()
+
+        await payout_service.cancel_account_payouts(
+            session,
+            account.id,
+            statuses=(PayoutStatus.held,),
+            payout_account_id=old_payout_account.id,
+        )
+
+        repository = PayoutRepository.from_session(session)
+        refreshed_stale = await repository.get_by_id(stale_hold.id)
+        assert refreshed_stale is not None
+        assert refreshed_stale.status == PayoutStatus.canceled
+
+        refreshed_fresh = await repository.get_by_id(fresh_hold.id)
+        assert refreshed_fresh is not None
+        assert refreshed_fresh.status == PayoutStatus.held
 
 
 @pytest.mark.asyncio

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from datetime import timedelta
 from functools import partial
 from types import SimpleNamespace
@@ -14,16 +15,17 @@ from polar.integrations.stripe.service import StripeService
 from polar.kit.address import Address, CountryAlpha2
 from polar.kit.utils import utc_now
 from polar.locker import Locker
-from polar.models import Account, Organization, Transaction, User
+from polar.models import Account, Organization, Payout, Transaction, User
 from polar.models.organization import OrganizationStatus, PayoutAccountNotReady
 from polar.models.payout import PayoutStatus
 from polar.models.transaction import Processor, TransactionType
+from polar.payout.repository import PayoutRepository
 from polar.payout.schemas import PayoutGenerateInvoice
 from polar.payout.service import (
     InsufficientBalance,
     InvoiceAlreadyExists,
     MissingInvoiceBillingDetails,
-    OrganizationUnderReview,
+    OrganizationCannotPayout,
     PayoutIntervalLimitReached,
     PayoutNotCancelable,
     PayoutNotSucceeded,
@@ -144,13 +146,12 @@ class TestCreate:
         "status",
         [
             OrganizationStatus.CREATED,
-            OrganizationStatus.REVIEW,
-            OrganizationStatus.SNOOZED,
             OrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING,
+            OrganizationStatus.BLOCKED,
         ],
     )
-    async def test_organization_under_review(
+    async def test_organization_cannot_payout(
         self,
         status: OrganizationStatus,
         save_fixture: SaveFixture,
@@ -177,8 +178,81 @@ class TestCreate:
             save_fixture, account=account, payment_transaction=payment_transaction_2
         )
 
-        with pytest.raises(OrganizationUnderReview):
+        with pytest.raises(OrganizationCannotPayout):
             await payout_service.create(session, locker, organization)
+
+    @pytest.mark.parametrize(
+        "status",
+        [OrganizationStatus.REVIEW, OrganizationStatus.SNOOZED],
+    )
+    async def test_held_for_organization_under_review(
+        self,
+        status: OrganizationStatus,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # A REVIEW/SNOOZED org can request a payout: it is reserved and held
+        # until the org is approved, instead of being blocked.
+        enqueue_job_mock = mocker.patch("polar.payout.service.enqueue_job")
+
+        organization.status = status
+        organization.set_status(status)
+        await save_fixture(organization)
+
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction_1 = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction_1
+        )
+
+        payout_transaction_service_mock.create.return_value = Transaction()
+
+        payout = await payout_service.create(session, locker, organization)
+
+        assert payout.status == PayoutStatus.held
+        assert payout.amount > 0
+
+        # The created event fires, but the Stripe transfer is held back until
+        # the org is approved.
+        enqueue_job_mock.assert_called_once_with("payout.created", payout_id=payout.id)
+
+    async def test_active_enqueues_created_and_transfer(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # The default organization fixture is ACTIVE: the payout is pending and
+        # both the created event and the Stripe transfer are enqueued.
+        enqueue_job_mock = mocker.patch("polar.payout.service.enqueue_job")
+
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction_1 = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction_1
+        )
+
+        payout_transaction_service_mock.create.return_value = Transaction()
+
+        payout = await payout_service.create(session, locker, organization)
+
+        assert payout.status == PayoutStatus.pending
+        assert enqueue_job_mock.call_count == 2
+        enqueue_job_mock.assert_any_call("payout.created", payout_id=payout.id)
+        enqueue_job_mock.assert_any_call("payout.transfer", payout_id=payout.id)
 
     async def test_valid(
         self,
@@ -484,6 +558,16 @@ class TestTriggerStripePayouts:
             created_at=utc_now() - datetime.timedelta(days=7),
             status=PayoutStatus.succeeded,
         )
+        # A held payout is not yet payable: even though it is the oldest payout
+        # for payout_account_2, it must be skipped so payout_3 is picked instead.
+        payout_held = await create_payout(
+            save_fixture,
+            account=account_2,
+            payout_account=payout_account_2,
+            created_at=utc_now() - datetime.timedelta(days=14),
+            status=PayoutStatus.held,
+            attempts=[],
+        )
 
         await payout_service.trigger_stripe_payouts(session)
 
@@ -498,6 +582,93 @@ class TestTriggerStripePayouts:
 
 @pytest.mark.asyncio
 class TestTransferStripe:
+    @pytest.mark.parametrize(
+        "status",
+        [PayoutStatus.canceled, PayoutStatus.held],
+    )
+    async def test_skips_not_payable(
+        self,
+        status: PayoutStatus,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # A payout.transfer job can race a cancellation (or a rolled-back
+        # release): transfer_stripe must not move funds for a canceled/held
+        # payout.
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=status,
+            attempts=[],
+        )
+
+        result = await payout_service.transfer_stripe(session, payout)
+
+        assert result.status == status
+        stripe_service_mock.transfer.assert_not_called()
+
+    async def test_skips_after_committed_cancel(
+        self,
+        mocker: MockerFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # transfer_stripe locks and re-reads the row, so a cancel that commits
+        # after the payout.transfer job was queued is observed and the Stripe
+        # transfer is skipped — without this the funds would move for a payout
+        # the ledger has already reversed.
+        mocker.patch(
+            "polar.payout.service.platform_fee_transaction_service"
+            ".create_payout_fees_reversal_balances"
+        )
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+        payout_transaction = Transaction(
+            type=TransactionType.payout,
+            account=account,
+            processor=Processor.stripe,
+            currency=payout.currency,
+            amount=-payout.amount,
+            account_currency=payout.account_currency,
+            account_amount=-payout.account_amount,
+            tax_amount=0,
+            payout=payout,
+            transfer_id=None,
+        )
+        await save_fixture(payout_transaction)
+        payout_transaction_service_mock.reverse.return_value = Transaction()
+
+        # Cancel commits first (the racing deny/block/backoffice cancel)...
+        await payout_service.cancel(session, payout)
+        await session.flush()
+
+        # ...then the already-queued transfer runs and must skip.
+        result = await payout_service.transfer_stripe(session, payout)
+
+        assert result.status == PayoutStatus.canceled
+        stripe_service_mock.transfer.assert_not_called()
+
     async def test_valid(
         self,
         stripe_service_mock: MagicMock,
@@ -875,3 +1046,340 @@ class TestTriggerInvoiceGeneration:
 
         # Verify job was enqueued
         enqueue_job_mock.assert_called_once_with("payout.invoice", payout_id=payout.id)
+
+
+@pytest.mark.asyncio
+class TestReleaseHeldPayouts:
+    async def test_valid(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.payout.service.enqueue_job")
+
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+
+        held_1 = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        held_2 = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        pending = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        await payout_service.release_held_payouts(session, account.id)
+
+        repository = PayoutRepository.from_session(session)
+        for payout in (held_1, held_2):
+            refreshed = await repository.get_by_id(payout.id)
+            assert refreshed is not None
+            assert refreshed.status == PayoutStatus.pending
+
+        # Both held payouts get their Stripe transfer enqueued; the
+        # already-pending payout is left untouched.
+        assert enqueue_job_mock.call_count == 2
+        enqueue_job_mock.assert_any_call("payout.transfer", payout_id=held_1.id)
+        enqueue_job_mock.assert_any_call("payout.transfer", payout_id=held_2.id)
+        for call in enqueue_job_mock.call_args_list:
+            assert call.kwargs["payout_id"] != pending.id
+
+    async def test_no_held_payouts(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.payout.service.enqueue_job")
+
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        await payout_service.release_held_payouts(session, account.id)
+
+        enqueue_job_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestCancelAccountPayouts:
+    async def test_cancels_held_and_pending(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+
+        held = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        pending = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+        succeeded = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.succeeded,
+        )
+
+        # Attach a payout transaction (no transfer ran) to each cancelable
+        # payout so PayoutService.cancel can reverse it.
+        for payout in (held, pending):
+            payout_transaction = Transaction(
+                type=TransactionType.payout,
+                account=account,
+                processor=Processor.stripe,
+                currency=payout.currency,
+                amount=-payout.amount,
+                account_currency=payout.account_currency,
+                account_amount=-payout.account_amount,
+                tax_amount=0,
+                payout=payout,
+                transfer_id=None,
+            )
+            await save_fixture(payout_transaction)
+
+        payout_transaction_service_mock.reverse.return_value = Transaction()
+
+        await payout_service.cancel_account_payouts(session, account.id)
+
+        repository = PayoutRepository.from_session(session)
+        for payout in (held, pending):
+            refreshed = await repository.get_by_id(payout.id)
+            assert refreshed is not None
+            assert refreshed.status == PayoutStatus.canceled
+
+        # The succeeded payout is not in-flight and must be left alone.
+        refreshed_succeeded = await repository.get_by_id(succeeded.id)
+        assert refreshed_succeeded is not None
+        assert refreshed_succeeded.status == PayoutStatus.succeeded
+
+    async def test_tolerates_concurrently_canceled_payout(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # If a payout is finalized by a concurrent cancel between the fetch and
+        # our cancel() (which then raises PayoutNotCancelable), the bulk job
+        # must skip it and keep going rather than failing the whole run.
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        held_1 = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        held_2 = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+
+        attempted: list[uuid.UUID] = []
+
+        async def fake_cancel(session: AsyncSession, payout: "Payout") -> "Payout":
+            attempted.append(payout.id)
+            if payout.id == held_1.id:
+                raise PayoutNotCancelable(payout)
+            return payout
+
+        mocker.patch.object(payout_service, "cancel", side_effect=fake_cancel)
+
+        # Must not raise even though held_1's cancel raised.
+        await payout_service.cancel_account_payouts(session, account.id)
+
+        assert set(attempted) == {held_1.id, held_2.id}
+
+
+@pytest.mark.asyncio
+class TestCancelHeldPayout:
+    async def test_held_is_cancelable_and_reverses_fees(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: MagicMock,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        fee_reversal_mock = mocker.patch(
+            "polar.payout.service.platform_fee_transaction_service"
+            ".create_payout_fees_reversal_balances"
+        )
+
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        payout_transaction = Transaction(
+            type=TransactionType.payout,
+            account=account,
+            processor=Processor.stripe,
+            currency=payout.currency,
+            amount=-payout.amount,
+            account_currency=payout.account_currency,
+            account_amount=-payout.account_amount,
+            tax_amount=0,
+            payout=payout,
+            # A held payout never ran its Stripe transfer.
+            transfer_id=None,
+        )
+        await save_fixture(payout_transaction)
+
+        payout_transaction_service_mock.reverse.return_value = Transaction()
+
+        canceled = await payout_service.cancel(session, payout)
+
+        assert canceled.status == PayoutStatus.canceled
+        # No Stripe transfer ran, so we don't reverse a transfer but we do
+        # return the reserved fees.
+        stripe_service_mock.reverse_transfer.assert_not_called()
+        fee_reversal_mock.assert_called_once_with(session, payout=payout)
+
+    async def test_second_cancel_raises_after_lock_recheck(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # cancel() locks and re-reads the row, so a second cancel of an
+        # already-canceled payout (the loser of a concurrent race) raises
+        # instead of writing a duplicate set of reversals.
+        mocker.patch(
+            "polar.payout.service.platform_fee_transaction_service"
+            ".create_payout_fees_reversal_balances"
+        )
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        payout_transaction = Transaction(
+            type=TransactionType.payout,
+            account=account,
+            processor=Processor.stripe,
+            currency=payout.currency,
+            amount=-payout.amount,
+            account_currency=payout.account_currency,
+            account_amount=-payout.account_amount,
+            tax_amount=0,
+            payout=payout,
+            transfer_id=None,
+        )
+        await save_fixture(payout_transaction)
+        payout_transaction_service_mock.reverse.return_value = Transaction()
+
+        await payout_service.cancel(session, payout)
+        # Flush so the canceled status is visible to the next FOR UPDATE read,
+        # modelling the first cancel's transaction having committed (in prod the
+        # two cancels are separate transactions serialized by the row lock).
+        await session.flush()
+
+        with pytest.raises(PayoutNotCancelable):
+            await payout_service.cancel(session, payout)
+
+
+@pytest.mark.asyncio
+class TestCountPendingByPayoutAccount:
+    async def test_includes_held(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+
+        for status in (
+            PayoutStatus.held,
+            PayoutStatus.pending,
+            PayoutStatus.in_transit,
+            PayoutStatus.succeeded,
+            PayoutStatus.canceled,
+        ):
+            await create_payout(
+                save_fixture,
+                account=account,
+                payout_account=payout_account,
+                status=status,
+                attempts=[],
+            )
+
+        repository = PayoutRepository.from_session(session)
+        count = await repository.count_pending_by_payout_account(payout_account.id)
+
+        # held + pending + in_transit reserve funds; succeeded/canceled do not.
+        assert count == 3

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -581,6 +581,46 @@ class TestTriggerStripePayouts:
 
 
 @pytest.mark.asyncio
+class TestGetByIdForUpdate:
+    async def test_locks_and_eager_loads(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # FOR UPDATE OF payouts must lock only the payout row so the eager-load
+        # joins (account, payout_account, transactions) don't trip the
+        # nullable-outer-join lock error. Exercises the real SQL on Postgres.
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture, account=account, payout_account=payout_account
+        )
+        await create_transaction(
+            save_fixture,
+            account=account,
+            type=TransactionType.payout,
+            amount=-payout.amount,
+            account_currency=account.currency,
+            payout=payout,
+        )
+
+        repository = PayoutRepository.from_session(session)
+        locked = await repository.get_by_id_for_update(
+            payout.id, options=repository.get_eager_options()
+        )
+
+        assert locked is not None
+        assert locked.id == payout.id
+        # Relationships resolve without a lazy load, confirming eager loading.
+        assert locked.account.id == account.id
+        assert locked.payout_account.id == payout_account.id
+
+
+@pytest.mark.asyncio
 class TestTransferStripe:
     @pytest.mark.parametrize(
         "status",

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -596,8 +596,7 @@ class TestTransferStripe:
         user: User,
     ) -> None:
         # A payout.transfer job can race a cancellation (or a rolled-back
-        # release): transfer_stripe must not move funds for a canceled/held
-        # payout.
+        # release): transfer must not move funds for a canceled/held payout.
         account = await create_account(save_fixture, user)
         payout_account = await create_payout_account(
             save_fixture, organization, user, type=PayoutAccountType.stripe
@@ -610,7 +609,7 @@ class TestTransferStripe:
             attempts=[],
         )
 
-        result = await payout_service.transfer_stripe(session, payout)
+        result = await payout_service.transfer(session, payout)
 
         assert result.status == status
         stripe_service_mock.transfer.assert_not_called()
@@ -625,10 +624,10 @@ class TestTransferStripe:
         user: User,
         payout_transaction_service_mock: MagicMock,
     ) -> None:
-        # transfer_stripe locks and re-reads the row, so a cancel that commits
-        # after the payout.transfer job was queued is observed and the Stripe
-        # transfer is skipped — without this the funds would move for a payout
-        # the ledger has already reversed.
+        # A cancel that commits after the payout.transfer job was queued leaves
+        # the row canceled; transfer must honor that and skip rather than pay out
+        # a payout the ledger already reversed. (The task's FOR UPDATE re-read is
+        # what surfaces the committed status in production.)
         mocker.patch(
             "polar.payout.service.platform_fee_transaction_service"
             ".create_payout_fees_reversal_balances"
@@ -664,7 +663,7 @@ class TestTransferStripe:
         await session.flush()
 
         # ...then the already-queued transfer runs and must skip.
-        result = await payout_service.transfer_stripe(session, payout)
+        result = await payout_service.transfer(session, payout)
 
         assert result.status == PayoutStatus.canceled
         stripe_service_mock.transfer.assert_not_called()
@@ -680,9 +679,9 @@ class TestTransferStripe:
         payout_transaction_service_mock: MagicMock,
     ) -> None:
         # A released hold can win the race against the swap-cancel job. Before
-        # any transfer is made, transfer_stripe must notice the org now points
-        # at a different payout account and cancel + refund instead of sending
-        # funds to the abandoned Connect account.
+        # any transfer is made, transfer must notice the org now points at a
+        # different payout account and cancel + refund instead of sending funds
+        # to the abandoned account.
         fee_reversal_mock = mocker.patch(
             "polar.payout.service.platform_fee_transaction_service"
             ".create_payout_fees_reversal_balances"
@@ -723,7 +722,7 @@ class TestTransferStripe:
 
         assert organization.payout_account_id == new_payout_account.id
 
-        result = await payout_service.transfer_stripe(session, payout)
+        result = await payout_service.transfer(session, payout)
 
         assert result.status == PayoutStatus.canceled
         stripe_service_mock.transfer.assert_not_called()

--- a/server/tests/payout/test_service_ledger.py
+++ b/server/tests/payout/test_service_ledger.py
@@ -1,0 +1,82 @@
+"""Integration tests for the held-payout ledger mechanics.
+
+Unlike ``test_service.py`` these exercise the *real* transaction and platform
+fee services (no mocks), so they assert the actual available-balance effect of
+holding then canceling a payout — the guarantee from Appendix A of the
+payout-reviews RFC: canceling a held payout returns the full reserved amount
+(gross plus fees) to the merchant.
+"""
+
+from datetime import timedelta
+from functools import partial
+
+import pytest
+
+from polar.kit.utils import utc_now
+from polar.locker import Locker
+from polar.models import Account, Organization, User
+from polar.models.organization import OrganizationStatus
+from polar.models.payout import PayoutStatus
+from polar.payout.service import payout as payout_service
+from polar.postgres import AsyncSession
+from polar.transaction.service.transaction import transaction as transaction_service
+from tests.fixtures import random_objects as ro
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout_account
+
+ten_days_ago = utc_now() - timedelta(days=10)
+create_payment_transaction = partial(
+    ro.create_payment_transaction, amount=10000, created_at=ten_days_ago
+)
+create_balance_transaction = partial(
+    ro.create_balance_transaction, amount=10000, created_at=ten_days_ago
+)
+
+
+@pytest.mark.asyncio
+class TestHeldPayoutLedger:
+    async def test_cancel_held_returns_gross_and_fees(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        organization.set_status(OrganizationStatus.REVIEW)
+        await save_fixture(organization)
+
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction
+        )
+
+        summary_before = await transaction_service.get_summary(session, account)
+        available_before = summary_before.available_balance.amount
+        assert available_before == 10000
+
+        payout = await payout_service.create(session, locker, organization)
+        assert payout.status == PayoutStatus.held
+        # Held reserves the balance exactly like a pending payout: gross plus
+        # fees are deducted from the available balance right away.
+        assert payout.fees_amount > 0
+
+        summary_held = await transaction_service.get_summary(session, account)
+        assert summary_held.available_balance.amount == 0
+
+        canceled = await payout_service.cancel(session, payout)
+        assert canceled.status == PayoutStatus.canceled
+
+        summary_after = await transaction_service.get_summary(session, account)
+        # The full reserved amount (gross plus fees) is returned to the ledger:
+        # the total balance is restored to its original value.
+        assert summary_after.balance.amount == available_before
+        # The fees become available immediately (they carry a payout fee type).
+        # The gross is returned via a payout_reversal row, which re-ages into
+        # the available balance like any other balance row — this matches how
+        # canceling a regular pending payout already behaves.
+        assert summary_after.available_balance.amount == payout.fees_amount


### PR DESCRIPTION
## Summary

Phase 2 of the [payout-reviews](https://handbook.polar.sh/engineering/design-documents/payout-reviews). Organizations under review (`REVIEW` or `SNOOZED`) can now request a payout instead of being blocked. The payout is created as `held`, then released automatically when the org is approved, or canceled and fully refunded if the org is denied, blocked, offboarded, or swaps its payout account.

## What

- Capability flip: `payouts` is now allowed for `REVIEW`/`SNOOZED`.
- Backfill script to change the payouts to enabled.
- `PayoutService.create` branches on org status under. Orgs in `Active` are created on `pending`, orgs in `REVIEW`/`SNOOZED` to `held`, everything else raises `OrganizationCannotPayout`.
- `payout.created` is split into a plain event plus a new `payout.transfer` task that performs the Stripe transfer.
- New `organization.release_held_payouts` and `organization.cancel_pending_payouts` jobs, wired into the org status transitions.
- Cancel now reverses the per-payout fees.
- Concurrency: `cancel` and `transfer_stripe` lock and read the row, so we avoid double credits. 
- Repository: the hourly transfer cron only picks `pending`, and held payouts count against a payout account so it can't be deleted with funds reserved.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Orgs in REVIEW/SNOOZED may request payouts (created as held); held payouts can be released back to pending and processed later. New background tasks support releasing and bulk-canceling by account.

* **Bug Fixes**
  - Held payouts are cancelable and properly reverse reserved fees; transfers skip held/canceled payouts and detect account swaps to cancel instead. Pending/counting and pickup logic clarified to exclude held from Stripe pickup.

* **Tests**
  - Expanded unit/integration coverage for held-payout lifecycle, transfers, bulk cancel/release, and fee reversals.

* **Chores**
  - Deploy-time backfill script to enable payout capability for REVIEW/SNOOZED orgs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->