### PR TITLE
server/subscription: add tests on SubscriptionService.update

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -69,6 +69,22 @@ class OrderRepository(
             statement = statement.where(Order.status == status)
         return await self.get_all(statement)
 
+    async def get_all_by_subscription(
+        self,
+        subscription_id: UUID,
+        *,
+        status: OrderStatus | None = None,
+        options: Options = (),
+    ) -> Sequence[Order]:
+        statement = (
+            self.get_base_statement()
+            .where(Order.subscription_id == subscription_id)
+            .options(*options)
+        )
+        if status is not None:
+            statement = statement.where(Order.status == status)
+        return await self.get_all(statement)
+
     async def get_by_stripe_invoice_id(
         self, stripe_invoice_id: str, *, options: Options = ()
     ) -> Order | None:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1390,9 +1390,16 @@ class SubscriptionService:
                     },
                 ),
             )
-            return await repository.update(
+            subscription = await repository.update(
                 subscription, update_dict={"discount": discount}, flush=True
             )
+            await self._after_subscription_updated(
+                session,
+                subscription,
+                previous_status=subscription.status,
+                previous_is_canceled=subscription.canceled,
+            )
+            return subscription
 
         if discount is None:
             return await _update_discount(session, subscription, None)

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1392,6 +1392,18 @@ async def product_recurring_free_seat_based(
 
 
 @pytest_asyncio.fixture
+async def product_recurring_seat_based(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    return await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=SubscriptionRecurringInterval.month,
+        prices=[("seat", 1000, "usd")],
+    )
+
+
+@pytest_asyncio.fixture
 async def product_recurring_metered(
     save_fixture: SaveFixture, organization: Organization, meter: Meter
 ) -> Product:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -60,7 +60,10 @@ from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.order import OrderBillingReasonInternal
 from polar.models.product_price import ProductPriceAmountType, ProductPriceSeatUnit
 from polar.models.subscription import SubscriptionStatus
+from polar.models.webhook_endpoint import WebhookEventType
+from polar.order.repository import OrderRepository
 from polar.order.service import PaymentFailed, PaymentFailedReason
+from polar.order.service import order as order_service
 from polar.postgres import AsyncSession
 from polar.product.guard import (
     MeteredPrice,
@@ -73,6 +76,11 @@ from polar.subscription.repository import SubscriptionUpdateRepository
 from polar.subscription.schemas import (
     SubscriptionCreateCustomer,
     SubscriptionCreateExternalCustomer,
+    SubscriptionUpdateBillingPeriod,
+    SubscriptionUpdateDiscount,
+    SubscriptionUpdateProduct,
+    SubscriptionUpdateSeats,
+    SubscriptionUpdateTrial,
 )
 from polar.subscription.service import (
     AboveMaximumSeats,
@@ -98,6 +106,7 @@ from tests.fixtures.random_objects import (
     create_event,
     create_legacy_recurring_product_price,
     create_meter,
+    create_payment_method,
     create_product,
     create_subscription,
     create_subscription_with_seats,
@@ -178,6 +187,11 @@ def enqueue_job_mock(mocker: MockerFixture) -> MagicMock:
 @pytest.fixture
 def enqueue_email_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("polar.subscription.service.enqueue_email_template")
+
+
+@pytest.fixture
+def webhook_service_send_mock(mocker: MockerFixture) -> AsyncMock:
+    return mocker.patch("polar.subscription.service.webhook_service.send")
 
 
 @pytest.fixture
@@ -2375,6 +2389,305 @@ class TestList:
 
         assert subscription_1 in results
         assert subscription_2 in results
+
+
+async def assert_order_exists(
+    session: AsyncSession, subscription: Subscription
+) -> None:
+    order_repository = OrderRepository.from_session(session)
+    orders = await order_repository.get_all_by_subscription(subscription.id)
+    assert len(orders) > 0, (
+        "Expected at least one order to be created for the subscription"
+    )
+
+
+@pytest.mark.asyncio
+class TestUpdate:
+    async def test_product_update_prorate(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateProduct(product_id=new_product.id),
+        )
+
+        assert updated.product == new_product
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+
+    async def test_product_update_invoice(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateProduct(
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            ),
+        )
+
+        assert updated.product == new_product
+        await assert_order_exists(session, subscription)
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+
+    async def test_discount_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        discount_percentage_50: Discount,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateDiscount(discount_id=discount_percentage_50.id),
+        )
+
+        assert updated.discount == discount_percentage_50
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+
+    async def test_trial_update_extends(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=7,
+        )
+        initial_trial_end = subscription.trial_end
+        assert initial_trial_end is not None
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateTrial(
+                trial_end=initial_trial_end + timedelta(days=7),
+            ),
+        )
+
+        assert updated.status == SubscriptionStatus.trialing
+        assert updated.trial_end == initial_trial_end + timedelta(days=7)
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+
+    async def test_trial_update_ends(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
+    ) -> None:
+        subscription = await create_trialing_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            trial_interval=TrialInterval.day,
+            trial_interval_count=7,
+        )
+        initial_trial_end = subscription.trial_end
+        assert initial_trial_end is not None
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateTrial(trial_end="now"),
+        )
+
+        assert updated.status == SubscriptionStatus.active
+        assert updated.trial_end is not None
+        assert updated.trial_end == updated.current_period_start
+        assert updated.trial_end < initial_trial_end
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+        enqueue_job_mock.assert_any_call(
+            "order.create_subscription_order",
+            updated.id,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+        )
+
+    async def test_seats_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product_recurring_seat_based: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product_recurring_seat_based,
+            customer=customer,
+            seats=5,
+        )
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateSeats(seats=10),
+        )
+
+        assert updated.seats == 10
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+
+    async def test_seats_update_invoice(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product_recurring_seat_based: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        trigger_payment_mock = mocker.patch.object(
+            order_service,
+            "trigger_payment",
+            new_callable=AsyncMock,
+        )
+
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product_recurring_seat_based,
+            customer=customer,
+            seats=5,
+            payment_method=payment_method,
+        )
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateSeats(
+                seats=10, proration_behavior=SubscriptionProrationBehavior.invoice
+            ),
+        )
+
+        assert updated.seats == 10
+        await assert_order_exists(session, subscription)
+        trigger_payment_mock.assert_awaited_once()
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
+
+    async def test_billing_period_end_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        locker: Locker,
+        webhook_service_send_mock: MagicMock,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        initial_period_end = subscription.current_period_end
+        assert initial_period_end is not None
+
+        updated = await subscription_service.update(
+            session,
+            locker,
+            subscription,
+            update=SubscriptionUpdateBillingPeriod(
+                current_billing_period_end=initial_period_end + timedelta(days=7)
+            ),
+        )
+
+        assert updated.current_period_end == initial_period_end + timedelta(days=7)
+
+        webhook_service_send_mock.assert_any_call(
+            session, organization, WebhookEventType.subscription_updated, updated
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

Preparatory work for #12094: add more high level tests on the `update` method to make sure we have all the right side-effects no matter the underneath update path.

Found a bug while doing it: we never triggered the update webhook on discount update. Now fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subscription discount update flow to properly complete post-update operations.

* **Tests**
  * Added comprehensive test coverage for subscription updates, including product changes, trial modifications, seat count adjustments, and billing period updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->