### PR TITLE
tf: Circumvent bootstrap issue for render

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -253,12 +253,19 @@ resource "render_web_service" "api" {
   health_check_path  = "/healthz"
   pre_deploy_command = "uv run task pre_deploy"
 
+  # Deploy from the "latest" tag so newly created services come up on the most
+  # recent main build. CI deploys specific digests out-of-band (deploy_server.sh),
+  # so ignore_changes below keeps Terraform from reverting them.
   runtime_source = {
     image = {
       image_url              = split("@", var.api_service_config.image_url)[0]
       registry_credential_id = var.registry_credential_id
-      digest                 = var.api_service_config.image_digest
+      tag                    = "latest"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [runtime_source.image]
   }
 
   autoscaling = var.environment == "production" ? {
@@ -327,12 +334,19 @@ resource "render_web_service" "worker" {
   start_command     = each.value.start_command
   num_instances     = each.value.num_instances
 
+  # Deploy from the "latest" tag so newly created services come up on the most
+  # recent main build. CI deploys specific digests out-of-band (deploy_server.sh),
+  # so ignore_changes below keeps Terraform from reverting them.
   runtime_source = {
     image = {
       image_url              = split("@", each.value.image_url)[0]
       registry_credential_id = var.registry_credential_id
-      digest                 = each.value.image_digest
+      tag                    = "latest"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [runtime_source.image]
   }
 
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -29,7 +29,6 @@ variable "api_service_config" {
     cors_origins           = string # "[\"https://polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = list(object({ name = string }))
     image_url              = optional(string, "ghcr.io/polarsource/polar")
-    image_digest           = string
     web_concurrency        = optional(string, "2")
     forwarded_allow_ips    = optional(string, "*")
     database_pool_size     = optional(string, "10")
@@ -44,8 +43,7 @@ variable "workers" {
   description = "Map of worker configurations"
   type = map(object({
     start_command      = string
-    image_url          = string
-    image_digest       = string
+    image_url          = optional(string, "ghcr.io/polarsource/polar")
     custom_domains     = optional(list(object({ name = string })), [])
     dramatiq_prom_port = optional(string, "10000")
     plan               = optional(string, "pro")

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -106,42 +106,6 @@ resource "render_redis" "redis" {
 }
 
 # =============================================================================
-# Service image data sources
-#
-# We read the current image digest from Render to avoid stale state in
-# Terraform causing "unable to fetch image" errors on service updates.
-#
-# The service IDs are hardcoded because referencing module outputs would
-# create a cyclic dependency (module -> data source -> module).
-#
-# First-time setup: create the services first without the data sources
-# (use a default tag like "latest"), then add the data sources with the
-# service IDs from `terraform state show`.
-# =============================================================================
-
-locals {
-  production_service_ids = {
-    api                      = "srv-ci4r87h8g3ne0dmvvl60"
-    scheduler                = "srv-d4uto5ili9vc73dd37tg"
-    worker                   = "srv-d4k6otfgi27c73cicnpg"
-    worker-medium-priority   = "srv-d4k62svpm1nc73af5e3g"
-    worker-high-priority     = "srv-d3hrh1j3fgac73a1t4r0"
-    worker-webhook           = "srv-d5l0oekhg0os73clofm0"
-    worker-tinybird          = "srv-d733djuuk2gs73e98h1g"
-    worker-invoices-receipts = "srv-d7us9je7r5hc73be5ieg"
-  }
-}
-
-data "render_web_service" "production_api" {
-  id = local.production_service_ids["api"]
-}
-
-data "render_web_service" "production_worker" {
-  for_each = { for k, v in local.production_service_ids : k => v if k != "api" }
-  id       = each.value
-}
-
-# =============================================================================
 # Production
 # =============================================================================
 
@@ -156,8 +120,6 @@ module "production" {
     allowed_hosts   = "[\"polar.sh\", \"backoffice.polar.sh\"]"
     cors_origins    = "[\"https://polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains  = [{ name = "api.polar.sh" }, { name = "api-alt.polar.sh" }, { name = "buy.polar.sh" }, { name = "backoffice.polar.sh" }]
-    image_url       = data.render_web_service.production_api.runtime_source.image.image_url
-    image_digest    = data.render_web_service.production_api.runtime_source.image.digest
     plan            = "pro_plus"
     web_concurrency = "6"
   }
@@ -182,47 +144,33 @@ module "production" {
     "scheduler" = {
       start_command      = "uv run python -m polar.worker.scheduler"
       plan               = "standard"
-      image_url          = data.render_web_service.production_worker["scheduler"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["scheduler"].runtime_source.image.digest
       dramatiq_prom_port = "10000"
     }
     "worker" = {
       start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority"
-      image_url          = data.render_web_service.production_worker["worker"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker"].runtime_source.image.digest
       custom_domains     = [{ name = "worker.polar.sh" }]
       dramatiq_prom_port = "10000"
     }
     "worker-medium-priority" = {
       start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues medium_priority"
-      image_url          = data.render_web_service.production_worker["worker-medium-priority"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker-medium-priority"].runtime_source.image.digest
       dramatiq_prom_port = "10001"
     }
     "worker-high-priority" = {
       start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority"
-      image_url          = data.render_web_service.production_worker["worker-high-priority"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker-high-priority"].runtime_source.image.digest
       dramatiq_prom_port = "10001"
     }
     "worker-webhook" = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues webhooks"
-      image_url          = data.render_web_service.production_worker["worker-webhook"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker-webhook"].runtime_source.image.digest
       dramatiq_prom_port = "10001"
       database_pool_size = "16"
     }
     "worker-tinybird" = {
       start_command      = "uv run dramatiq polar.worker.run -p 4 -t 32 --queues tinybird"
-      image_url          = data.render_web_service.production_worker["worker-tinybird"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker-tinybird"].runtime_source.image.digest
       dramatiq_prom_port = "10002"
     }
     "worker-invoices-receipts" = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
-      image_url          = data.render_web_service.production_worker["worker-invoices-receipts"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.production_worker["worker-invoices-receipts"].runtime_source.image.digest
       dramatiq_prom_port = "10003"
     }
   }

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -52,43 +52,6 @@ locals {
 # Sandbox
 # =============================================================================
 
-# =============================================================================
-# Service image data sources
-#
-# We read the current image digest from Render to avoid stale state in
-# Terraform causing "unable to fetch image" errors on service updates.
-#
-# The service IDs are hardcoded because referencing module outputs would
-# create a cyclic dependency (module -> data source -> module).
-#
-# First-time setup: create the services first without the data sources
-# (use a default tag like "latest"), then add the data sources with the
-# service IDs from `terraform state show`.
-# =============================================================================
-
-locals {
-  sandbox_service_ids = {
-    api                              = "srv-crkocgbtq21c73ddsdbg"
-    worker-sandbox                   = "srv-d089jj7diees73934kgg"
-    worker-sandbox-webhook           = "srv-d62q7vh4tr6s73fk44ng"
-    worker-sandbox-tinybird          = "srv-d733cp15pdvs73f6vqng"
-    worker-sandbox-invoices-receipts = "srv-d7unnjhj2pic73c2vr60"
-  }
-}
-
-data "render_web_service" "sandbox_api" {
-  id = local.sandbox_service_ids["api"]
-}
-
-data "render_web_service" "sandbox_worker" {
-  for_each = { for k, v in local.sandbox_service_ids : k => v if k != "api" }
-  id       = each.value
-}
-
-# =============================================================================
-# Sandbox
-# =============================================================================
-
 module "sandbox" {
   source = "../modules/render_service"
 
@@ -116,8 +79,6 @@ module "sandbox" {
     allowed_hosts          = "[\"sandbox.polar.sh\"]"
     cors_origins           = "[\"https://sandbox.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "sandbox-api.polar.sh" }]
-    image_url              = data.render_web_service.sandbox_api.runtime_source.image.image_url
-    image_digest           = data.render_web_service.sandbox_api.runtime_source.image.digest
     web_concurrency        = "2"
     forwarded_allow_ips    = "*"
     database_pool_size     = "10"
@@ -130,28 +91,20 @@ module "sandbox" {
   workers = {
     worker-sandbox = {
       start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority"
-      image_url          = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.sandbox_worker["worker-sandbox"].runtime_source.image.digest
       dramatiq_prom_port = "10000"
     }
     worker-sandbox-webhook = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues webhooks"
-      image_url          = data.render_web_service.sandbox_worker["worker-sandbox-webhook"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.sandbox_worker["worker-sandbox-webhook"].runtime_source.image.digest
       dramatiq_prom_port = "10001"
       database_pool_size = "16"
     }
     worker-sandbox-tinybird = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues tinybird"
-      image_url          = data.render_web_service.sandbox_worker["worker-sandbox-tinybird"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.sandbox_worker["worker-sandbox-tinybird"].runtime_source.image.digest
       dramatiq_prom_port = "10002"
     }
     worker-sandbox-invoices-receipts = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
-      image_url          = data.render_web_service.sandbox_worker["worker-sandbox-invoices-receipts"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.sandbox_worker["worker-sandbox-invoices-receipts"].runtime_source.image.digest
       dramatiq_prom_port = "10003"
     }
   }

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -95,37 +95,6 @@ locals {
   redis_port = "6379"
 }
 
-# =============================================================================
-# Service image data sources
-#
-# We read the current image digest from Render to avoid stale state in
-# Terraform causing "unable to fetch image" errors on service updates.
-#
-# The service IDs are hardcoded because referencing module outputs would
-# create a cyclic dependency (module -> data source -> module).
-#
-# First-time setup: create the services first without the data sources
-# (use a default tag like "latest"), then add the data sources with the
-# service IDs from `terraform state show`.
-# =============================================================================
-
-locals {
-  test_service_ids = {
-    api         = "srv-d4nuq6ur433s73eerdeg"
-    worker-test = "srv-d4nvmabe5dus738l4ui0"
-  }
-}
-
-data "render_web_service" "test_api" {
-  count = local.test_enabled ? 1 : 0
-  id    = local.test_service_ids["api"]
-}
-
-data "render_web_service" "test_worker" {
-  for_each = local.test_enabled ? { for k, v in local.test_service_ids : k => v if k != "api" } : {}
-  id       = each.value
-}
-
 module "test" {
   count  = local.test_enabled ? 1 : 0
   source = "../modules/render_service"
@@ -154,8 +123,6 @@ module "test" {
     allowed_hosts          = "[\"test.polar.sh\"]"
     cors_origins           = "[\"https://test.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "test-api.polar.sh" }]
-    image_url              = data.render_web_service.test_api[0].runtime_source.image.image_url
-    image_digest           = data.render_web_service.test_api[0].runtime_source.image.digest
     web_concurrency        = "2"
     forwarded_allow_ips    = "*"
     database_pool_size     = "10"
@@ -168,8 +135,6 @@ module "test" {
   workers = {
     worker-test = {
       start_command      = "uv run dramatiq -p 2 -t 4 -f polar.worker.scheduler:start polar.worker.run"
-      image_url          = data.render_web_service.test_worker["worker-test"].runtime_source.image.image_url
-      image_digest       = data.render_web_service.test_worker["worker-test"].runtime_source.image.digest
       dramatiq_prom_port = "10000"
     }
   }


### PR DESCRIPTION
We've had an issue bootstrapping an environment due to us reading the data source. Since the deploys happen outside of terraform anyway, this attempts to disregard it fully and ignore changes to the image in terraform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service deployment configuration to use latest container images instead of pinned versions for API and worker services across all environments.
  * Simplified image management by removing manual digest tracking from configuration files.
  * Added safeguards to prevent Terraform from reverting image updates made outside of Terraform workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->