### PR TITLE
Simplify review reason display and preserve formatting

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
@@ -139,14 +139,10 @@ class ReviewsSection:
 
                             # Reason
                             if human_feedback.reason:
-                                with tag.p(classes="text-xs text-base-content/70 mt-1"):
-                                    truncated = (
-                                        human_feedback.reason[:120] + "..."
-                                        if len(human_feedback.reason) > 120
-                                        else human_feedback.reason
-                                    )
-                                    with tag.span(title=human_feedback.reason):
-                                        text(truncated)
+                                with tag.p(
+                                    classes="text-xs text-base-content/70 mt-1 whitespace-pre-wrap"
+                                ):
+                                    text(human_feedback.reason)
                         else:
                             with tag.span(classes="text-sm text-base-content/40"):
                                 text("No human decision")


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Simplifies the review reason display in the organization reviews section by removing truncation logic and preserving whitespace formatting.

## What

- Removed the 120-character truncation logic that was limiting review reason text
- Removed the title attribute tooltip that was showing the full text
- Added `whitespace-pre-wrap` CSS class to preserve line breaks and formatting in the reason text
- Display the full reason text directly without truncation

## Why

The previous implementation truncated long reasons to 120 characters with a tooltip fallback. This approach:
- Hides important context from users at a glance
- Requires hovering to see the full reason
- Doesn't preserve the original formatting of multi-line reasons

Displaying the full reason with preserved formatting provides better UX and allows users to see complete context immediately.

## How

Simplified the HTML structure by:
1. Removing the truncation logic (`reason[:120] + "..."`)
2. Removing the `span` wrapper with title attribute
3. Adding `whitespace-pre-wrap` to the paragraph to preserve formatting
4. Directly rendering the full reason text

## Checklist

- [x] This PR addresses a single concern (one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] No new functionality requiring tests
- [x] No linting or type checking issues introduced
- [x] No unrelated changes included

https://claude.ai/code/session_01X9H57cBXmu6X4JDDcHzLup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Human feedback reasons now display in full instead of being truncated. Text formatting preserves line breaks and spacing for improved readability and complete context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->