### PR TITLE
fix: avoid Docker dev instance port collisions with shared infra

### DIFF
--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -19,7 +19,15 @@ from typing import Annotated
 import typer
 from rich.table import Table
 
-from shared import ROOT_DIR, SECRETS_FILE, SERVER_DIR, console, run_command
+from shared import (
+    DEFAULT_API_PORT,
+    DEFAULT_WEB_PORT,
+    ROOT_DIR,
+    SECRETS_FILE,
+    SERVER_DIR,
+    console,
+    run_command,
+)
 
 DOCKER_DIR = ROOT_DIR / "dev" / "docker"
 COMPOSE_FILE = DOCKER_DIR / "docker-compose.dev.yml"
@@ -65,6 +73,61 @@ def s3_bucket(instance: int) -> str:
 
 def s3_public_bucket(instance: int) -> str:
     return f"polar-s3-public-{instance}"
+
+
+# Host ports for the per-instance app stack. Only api and web publish host
+# ports; shared infra is reached by container name with no host ports.
+#
+# These must avoid every host port published by the legacy single-instance
+# stack (server/docker-compose.yml) and the non-Docker dev defaults — most
+# importantly minio on 9000/9001.
+#
+# The previous scheme (8000 + instance*100 / 3000 + instance*100) swept the
+# whole 8100..17900 / 3100..12900 range across 99 instances and so landed on
+# reserved ports: instance 10 → api 9000 (minio), instance 60 → web 9000
+# (minio), instance 50 → web 8000 (default api). Instead we pack each port
+# into a tight dedicated band that is clear of every reserved port, keeping
+# the trailing two digits equal to the instance number for readability.
+# Instance 0 keeps the legacy defaults ("0 = default ports, no offset").
+API_PORT_BASE = 8100  # instance 1..99 → 8101..8199
+WEB_PORT_BASE = 3100  # instance 1..99 → 3101..3199
+
+# Host ports published by the legacy/shared infra stack and the non-Docker
+# dev tooling. The per-instance app ports must never collide with these.
+RESERVED_HOST_PORTS = frozenset(
+    {
+        DEFAULT_API_PORT,  # 8000 — non-Docker / legacy api
+        DEFAULT_WEB_PORT,  # 3000 — non-Docker / legacy web
+        3001,  # grafana
+        5432,  # postgres
+        6379,  # redis
+        7181,  # tinybird
+        7182,  # tinybird admin
+        9000,  # minio api
+        9001,  # minio console
+        9090,  # prometheus
+    }
+)
+
+
+def api_port(instance: int) -> int:
+    return DEFAULT_API_PORT if instance == 0 else API_PORT_BASE + instance
+
+
+def web_port(instance: int) -> int:
+    return DEFAULT_WEB_PORT if instance == 0 else WEB_PORT_BASE + instance
+
+
+def _assert_ports_free(instance: int) -> None:
+    """Guard against any future port-scheme change re-introducing collisions."""
+    for label, port in (("API", api_port(instance)), ("web", web_port(instance))):
+        if instance != 0 and port in RESERVED_HOST_PORTS:
+            console.print(
+                f"[red]Instance {instance} maps {label} to reserved infra port "
+                f"{port}. This is a bug in the port scheme (dev/cli/commands/"
+                f"docker.py); please report it.[/red]"
+            )
+            raise typer.Exit(1)
 
 
 APP_SERVICES = frozenset(("api", "worker", "web"))
@@ -460,11 +523,11 @@ def _build_compose_env(instance: int) -> dict[str, str]:
     the host browser). Infra services live in the shared stack and are
     reached by container name on the polar-shared network — no host ports.
     """
-    offset = instance * 100
+    _assert_ports_free(instance)
     return {
         "POLAR_DOCKER_INSTANCE": str(instance),
-        "API_PORT": str(8000 + offset),
-        "WEB_PORT": str(3000 + offset),
+        "API_PORT": str(api_port(instance)),
+        "WEB_PORT": str(web_port(instance)),
         "POLAR_POSTGRES_DATABASE": db_name(instance),
         "POLAR_REDIS_DB": str(redis_db(instance)),
         "POLAR_S3_FILES_BUCKET_NAME": s3_bucket(instance),
@@ -498,7 +561,6 @@ def _instance_was_explicit(ctx: typer.Context) -> bool:
 
 
 def _print_access_info(ctx: typer.Context, instance: int) -> None:
-    offset = instance * 100
     i_flag = f" -i {instance}" if _instance_was_explicit(ctx) else ""
     console.print()
     console.print("[bold]Polar Docker Development Environment[/bold]")
@@ -509,8 +571,8 @@ def _print_access_info(ctx: typer.Context, instance: int) -> None:
     )
     console.print()
     console.print("[bold]App services:[/bold]")
-    console.print(f"  API:           http://localhost:{8000 + offset}")
-    console.print(f"  Web:           http://localhost:{3000 + offset}")
+    console.print(f"  API:           http://localhost:{api_port(instance)}")
+    console.print(f"  Web:           http://localhost:{web_port(instance)}")
     console.print()
     console.print(
         "[bold]Shared infra:[/bold] (no host ports — reach via `dev docker exec <service>`)"
@@ -916,10 +978,10 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
                 raise typer.Exit(1)
             _upsert_registry(str(ROOT_DIR), instance)
         _write_stored_instance(instance)
-        offset = instance * 100
         console.print(f"[green]Stored instance {instance} in .env.docker[/green]")
         console.print(
-            f"[dim]Ports: API={8000 + offset}, Web={3000 + offset}, DB=5432 (shared)[/dim]"
+            f"[dim]Ports: API={api_port(instance)}, Web={web_port(instance)}, "
+            f"DB=5432 (shared)[/dim]"
         )
         console.print(
             f"[dim]Database: {db_name(instance)}, Redis DB: {redis_db(instance)}, "

--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -76,24 +76,15 @@ def s3_public_bucket(instance: int) -> str:
 
 
 # Host ports for the per-instance app stack. Only api and web publish host
-# ports; shared infra is reached by container name with no host ports.
-#
-# These must avoid every host port published by the legacy single-instance
-# stack (server/docker-compose.yml) and the non-Docker dev defaults — most
-# importantly minio on 9000/9001.
-#
-# The previous scheme (8000 + instance*100 / 3000 + instance*100) swept the
-# whole 8100..17900 / 3100..12900 range across 99 instances and so landed on
-# reserved ports: instance 10 → api 9000 (minio), instance 60 → web 9000
-# (minio), instance 50 → web 8000 (default api). Instead we pack each port
-# into a tight dedicated band that is clear of every reserved port, keeping
-# the trailing two digits equal to the instance number for readability.
-# Instance 0 keeps the legacy defaults ("0 = default ports, no offset").
+# ports (shared infra is reached by container name). Each instance gets one
+# port per service from a tight band whose trailing two digits are the
+# instance number; both bands stay clear of every RESERVED_HOST_PORT.
+# Instance 0 uses the legacy defaults.
 API_PORT_BASE = 8100  # instance 1..99 → 8101..8199
 WEB_PORT_BASE = 3100  # instance 1..99 → 3101..3199
 
-# Host ports published by the legacy/shared infra stack and the non-Docker
-# dev tooling. The per-instance app ports must never collide with these.
+# Host ports published by the shared infra and the non-Docker dev tooling.
+# Per-instance app ports must never collide with these.
 RESERVED_HOST_PORTS = frozenset(
     {
         DEFAULT_API_PORT,  # 8000 — non-Docker / legacy api
@@ -119,9 +110,9 @@ def web_port(instance: int) -> int:
 
 
 def _assert_ports_free(instance: int) -> None:
-    """Guard against any future port-scheme change re-introducing collisions."""
+    """Fail fast if an instance's api or web port falls on a reserved infra port."""
     if instance == 0:
-        return  # instance 0 intentionally maps to the reserved legacy defaults
+        return  # instance 0 uses the reserved legacy defaults by design
     for label, port in (("API", api_port(instance)), ("web", web_port(instance))):
         if port in RESERVED_HOST_PORTS:
             console.print(

--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -120,8 +120,10 @@ def web_port(instance: int) -> int:
 
 def _assert_ports_free(instance: int) -> None:
     """Guard against any future port-scheme change re-introducing collisions."""
+    if instance == 0:
+        return  # instance 0 intentionally maps to the reserved legacy defaults
     for label, port in (("API", api_port(instance)), ("web", web_port(instance))):
-        if instance != 0 and port in RESERVED_HOST_PORTS:
+        if port in RESERVED_HOST_PORTS:
             console.print(
                 f"[red]Instance {instance} maps {label} to reserved infra port "
                 f"{port}. This is a bug in the port scheme (dev/cli/commands/"


### PR DESCRIPTION
## Summary

`dev docker -i 10 up` failed because previous port computation (`8000/3000 + instance*100`) collided with shared infra. When the instance was 10, backend collided with Minio.

Now each port comes from their port band (API `8101..8199`, web `3101..3199`) that is clear of all reserved ports, so every instance `1..99` is unique and collision-free.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`ruff check` on the dev CLI)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Docker development environment port isolation to prevent conflicts with reserved system ports
  * Added validation to detect unavailable ports early during environment setup
  * Updated port information displayed to users for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->