### PR TITLE
feat(organisation): gate UI settings behind canManage flag

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
@@ -3,6 +3,7 @@
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import OrganizationProfileSettings from '@/components/Settings/OrganizationProfileSettings'
 import { Section, SectionDescription } from '@/components/Settings/Section'
+import { useHasPermission } from '@/hooks/permissions'
 import { schemas } from '@polar-sh/client'
 
 interface Props {
@@ -10,6 +11,11 @@ interface Props {
 }
 
 export const AccountPageDetailsRequired = ({ organization }: Props) => {
+  const canManageOrganization = useHasPermission(
+    organization.id,
+    'organization:manage',
+  )
+
   return (
     <DashboardBody wrapperClassName="max-w-(--breakpoint-sm)!">
       <div className="flex flex-col gap-y-12">
@@ -18,7 +24,11 @@ export const AccountPageDetailsRequired = ({ organization }: Props) => {
             title="Account Review"
             description="Tell us about your organization so we can review your usecase."
           />
-          <OrganizationProfileSettings organization={organization} kyc={true} />
+          <OrganizationProfileSettings
+            organization={organization}
+            kyc={true}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
       </div>
     </DashboardBody>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
@@ -27,7 +27,7 @@ export const AccountPageDetailsRequired = ({ organization }: Props) => {
           <OrganizationProfileSettings
             organization={organization}
             kyc={true}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
       </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
@@ -33,12 +33,18 @@ export default function ClientPage({
       <div className="flex flex-col gap-y-12">
         <Section id="organization">
           <SectionDescription title="Organization" />
-          <OrganizationProfileSettings organization={org} />
+          <OrganizationProfileSettings
+            organization={org}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
 
         <Section id="payments">
           <SectionDescription title="Payments" />
-          <OrganizationPaymentSettings organization={org} />
+          <OrganizationPaymentSettings
+            organization={org}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
 
         <Section id="subscriptions">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
@@ -84,8 +84,8 @@ export default function ClientPage({
 
         <Section id="account-notifications">
           <SectionDescription
-            title="Your notifications"
-            description="Choose which account and product activity emails you receive as a member of this organization."
+            title="Account notifications"
+            description="Emails sent to members of your organization for account and product activity"
           />
           <OrganizationNotificationSettings organization={org} />
         </Section>
@@ -118,7 +118,11 @@ export default function ClientPage({
             title="Danger Zone"
             description="Irreversible actions for this organization"
           />
-          <OrganizationDeleteSettings organization={org} />
+          {canManageOrganization === false ? (
+            <AccessRestricted message="You don't have permission to delete this organization." />
+          ) : (
+            <OrganizationDeleteSettings organization={org} />
+          )}
         </Section>
       </div>
     </DashboardBody>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
@@ -35,7 +35,7 @@ export default function ClientPage({
           <SectionDescription title="Organization" />
           <OrganizationProfileSettings
             organization={org}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
 
@@ -43,7 +43,7 @@ export default function ClientPage({
           <SectionDescription title="Payments" />
           <OrganizationPaymentSettings
             organization={org}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
 
@@ -51,7 +51,7 @@ export default function ClientPage({
           <SectionDescription title="Subscriptions" />
           <OrganizationSubscriptionSettings
             organization={org}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
 
@@ -59,7 +59,7 @@ export default function ClientPage({
           <SectionDescription title="Customer portal" />
           <OrganizationCustomerPortalSettings
             organization={org}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
 
@@ -84,7 +84,7 @@ export default function ClientPage({
           )}
           <OrganizationCustomerEmailSettings
             organization={org}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
 
@@ -103,7 +103,7 @@ export default function ClientPage({
           />
           <FeatureSettings
             organization={org}
-            canManageOrganization={canManageOrganization}
+            readOnly={!canManageOrganization}
           />
         </Section>
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
@@ -43,12 +43,18 @@ export default function ClientPage({
 
         <Section id="subscriptions">
           <SectionDescription title="Subscriptions" />
-          <OrganizationSubscriptionSettings organization={org} />
+          <OrganizationSubscriptionSettings
+            organization={org}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
 
         <Section id="customer_portal">
           <SectionDescription title="Customer portal" />
-          <OrganizationCustomerPortalSettings organization={org} />
+          <OrganizationCustomerPortalSettings
+            organization={org}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
 
         <Section id="customer_emails">
@@ -70,13 +76,16 @@ export default function ClientPage({
               accepted.
             </Alert>
           )}
-          <OrganizationCustomerEmailSettings organization={org} />
+          <OrganizationCustomerEmailSettings
+            organization={org}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
 
         <Section id="account-notifications">
           <SectionDescription
-            title="Account notifications"
-            description="Emails sent to members of your organization for account and product activity"
+            title="Your notifications"
+            description="Choose which account and product activity emails you receive as a member of this organization."
           />
           <OrganizationNotificationSettings organization={org} />
         </Section>
@@ -86,7 +95,10 @@ export default function ClientPage({
             title="Features"
             description="Manage alpha & beta features for your organization"
           />
-          <FeatureSettings organization={org} />
+          <FeatureSettings
+            organization={org}
+            canManageOrganization={canManageOrganization}
+          />
         </Section>
 
         <Section id="developers">

--- a/clients/apps/web/src/components/CurrencySelector.tsx
+++ b/clients/apps/web/src/components/CurrencySelector.tsx
@@ -100,7 +100,8 @@ export const CurrencySelector = ({
       emptyLabel="No currencies found"
       popoverClassName="min-w-[250px]"
       popoverAlign="end"
-      className={disabled ? 'pointer-events-none opacity-50' : className}
+      disabled={disabled}
+      className={className}
     />
   )
 }

--- a/clients/apps/web/src/components/FileUpload/index.ts
+++ b/clients/apps/web/src/components/FileUpload/index.ts
@@ -40,6 +40,7 @@ interface FileUploadProps<T extends FileRead | schemas['FileUpload']> {
   onFilesUpdated: (files: FileObject<T>[]) => void
   onFilesRejected?: (rejections: FileRejection[]) => void
   onFileUploadError?: (fileName: string, error: Error) => void
+  disabled?: boolean
 }
 
 export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
@@ -51,6 +52,7 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
   onFilesRejected,
   onFileUploadError,
   initialFiles = [],
+  disabled = false,
 }: FileUploadProps<T>) => {
   const [files, setFilesState] = useState<FileObject<T>[]>(
     buildFileObjects(initialFiles) as unknown as FileObject<T>[],
@@ -165,6 +167,7 @@ export const useFileUpload = <T extends FileRead | schemas['FileUpload']>({
     maxSize,
     accept,
     onDrop,
+    disabled,
   })
 
   return {

--- a/clients/apps/web/src/components/Settings/BenefitRevocationGracePeriod.tsx
+++ b/clients/apps/web/src/components/Settings/BenefitRevocationGracePeriod.tsx
@@ -18,6 +18,7 @@ const BENEFIT_REVOCATION_GRACE_PERIOD_LABELS: Record<number, string> = {
 export interface BenefitRevocationGracePeriodProps {
   value: number
   onValueChange: (value: string) => void
+  disabled?: boolean
 }
 
 export const BenefitRevocationGracePeriod: React.FC<

--- a/clients/apps/web/src/components/Settings/FeatureSettings.tsx
+++ b/clients/apps/web/src/components/Settings/FeatureSettings.tsx
@@ -14,8 +14,10 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 export default function FeatureSettings({
   organization,
+  canManageOrganization,
 }: {
   organization: schemas['Organization']
+  canManageOrganization: boolean | undefined
 }) {
   const form = useForm<schemas['OrganizationFeatureSettings']>({
     defaultValues: organization.feature_settings || {},
@@ -105,6 +107,7 @@ export default function FeatureSettings({
                 return (
                   <Switch
                     checked={field.value}
+                    disabled={!canManageOrganization}
                     onCheckedChange={(enabled) => field.onChange(enabled)}
                   />
                 )
@@ -128,7 +131,11 @@ export default function FeatureSettings({
                 return (
                   <Switch
                     checked={field.value}
-                    disabled={!memberModelEnabled || seatBasedAlreadyEnabled}
+                    disabled={
+                      !canManageOrganization ||
+                      !memberModelEnabled ||
+                      seatBasedAlreadyEnabled
+                    }
                     onCheckedChange={() => {
                       setShowSeatBasedModal(true)
                     }}

--- a/clients/apps/web/src/components/Settings/FeatureSettings.tsx
+++ b/clients/apps/web/src/components/Settings/FeatureSettings.tsx
@@ -14,10 +14,10 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 export default function FeatureSettings({
   organization,
-  canManageOrganization,
+  readOnly,
 }: {
   organization: schemas['Organization']
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }) {
   const form = useForm<schemas['OrganizationFeatureSettings']>({
     defaultValues: organization.feature_settings || {},
@@ -107,7 +107,7 @@ export default function FeatureSettings({
                 return (
                   <Switch
                     checked={field.value}
-                    disabled={!canManageOrganization}
+                    disabled={readOnly}
                     onCheckedChange={(enabled) => field.onChange(enabled)}
                   />
                 )
@@ -132,9 +132,7 @@ export default function FeatureSettings({
                   <Switch
                     checked={field.value}
                     disabled={
-                      !canManageOrganization ||
-                      !memberModelEnabled ||
-                      seatBasedAlreadyEnabled
+                      readOnly || !memberModelEnabled || seatBasedAlreadyEnabled
                     }
                     onCheckedChange={() => {
                       setShowSeatBasedModal(true)

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -9,7 +9,7 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationCustomerEmailSettingsProps {
   organization: schemas['Organization']
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 const customerEmails: {
@@ -80,7 +80,7 @@ const customerEmails: {
 
 const OrganizationCustomerEmailSettings: React.FC<
   OrganizationCustomerEmailSettingsProps
-> = ({ organization, canManageOrganization }) => {
+> = ({ organization, readOnly }) => {
   const updateOrganization = useUpdateOrganization()
 
   const { value: settings, update } = useOptimisticSave(
@@ -109,7 +109,7 @@ const OrganizationCustomerEmailSettings: React.FC<
         <SettingsGroupItem key={key} title={title} description={description}>
           <Switch
             checked={settings[key]}
-            disabled={!canManageOrganization}
+            disabled={readOnly}
             onCheckedChange={(checked) =>
               update((previous) => ({ ...previous, [key]: checked }))
             }

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -9,6 +9,7 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationCustomerEmailSettingsProps {
   organization: schemas['Organization']
+  canManageOrganization: boolean | undefined
 }
 
 const customerEmails: {
@@ -79,7 +80,7 @@ const customerEmails: {
 
 const OrganizationCustomerEmailSettings: React.FC<
   OrganizationCustomerEmailSettingsProps
-> = ({ organization }) => {
+> = ({ organization, canManageOrganization }) => {
   const updateOrganization = useUpdateOrganization()
 
   const { value: settings, update } = useOptimisticSave(
@@ -108,6 +109,7 @@ const OrganizationCustomerEmailSettings: React.FC<
         <SettingsGroupItem key={key} title={title} description={description}>
           <Switch
             checked={settings[key]}
+            disabled={!canManageOrganization}
             onCheckedChange={(checked) =>
               update((previous) => ({ ...previous, [key]: checked }))
             }

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
@@ -17,11 +17,12 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationCustomerPortalSettingsProps {
   organization: schemas['Organization']
+  canManageOrganization: boolean | undefined
 }
 
 const OrganizationCustomerPortalSettings: React.FC<
   OrganizationCustomerPortalSettingsProps
-> = ({ organization }) => {
+> = ({ organization, canManageOrganization }) => {
   const form = useForm<schemas['OrganizationCustomerPortalSettings']>({
     defaultValues: {
       ...organization.customer_portal_settings,
@@ -89,6 +90,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
+                      disabled={!canManageOrganization}
                     />
                   </FormControl>
                   <FormMessage />
@@ -110,6 +112,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
+                      disabled={!canManageOrganization}
                     />
                   </FormControl>
                   <FormMessage />
@@ -131,6 +134,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
+                      disabled={!canManageOrganization}
                     />
                   </FormControl>
                   <FormMessage />
@@ -152,6 +156,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
+                      disabled={!canManageOrganization}
                     />
                   </FormControl>
                   <FormMessage />

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
@@ -17,12 +17,12 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationCustomerPortalSettingsProps {
   organization: schemas['Organization']
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 const OrganizationCustomerPortalSettings: React.FC<
   OrganizationCustomerPortalSettingsProps
-> = ({ organization, canManageOrganization }) => {
+> = ({ organization, readOnly }) => {
   const form = useForm<schemas['OrganizationCustomerPortalSettings']>({
     defaultValues: {
       ...organization.customer_portal_settings,
@@ -90,7 +90,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                     />
                   </FormControl>
                   <FormMessage />
@@ -112,7 +112,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                     />
                   </FormControl>
                   <FormMessage />
@@ -134,7 +134,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                     />
                   </FormControl>
                   <FormMessage />
@@ -156,7 +156,7 @@ const OrganizationCustomerPortalSettings: React.FC<
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                     />
                   </FormControl>
                   <FormMessage />

--- a/clients/apps/web/src/components/Settings/OrganizationPaymentSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationPaymentSettings.tsx
@@ -25,7 +25,7 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationPaymentSettingsProps {
   organization: schemas['Organization']
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 type FormSchema = Pick<
@@ -44,7 +44,7 @@ const taxBehaviorOptionDisplayNames: Record<
 
 const OrganizationPaymentSettings: React.FC<
   OrganizationPaymentSettingsProps
-> = ({ organization: _organization, canManageOrganization }) => {
+> = ({ organization: _organization, readOnly }) => {
   const organization = _organization as schemas['Organization'] & {
     default_presentment_currency: schemas['PresentmentCurrency']
   }
@@ -104,7 +104,7 @@ const OrganizationPaymentSettings: React.FC<
                 <FormItem>
                   <FormControl>
                     <CurrencySelector
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                       value={field.value as schemas['PresentmentCurrency']}
                       onChange={field.onChange}
                     />
@@ -125,7 +125,7 @@ const OrganizationPaymentSettings: React.FC<
                 <FormItem>
                   <FormControl>
                     <Select
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                       onValueChange={field.onChange}
                       defaultValue={field.value || undefined}
                     >

--- a/clients/apps/web/src/components/Settings/OrganizationPaymentSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationPaymentSettings.tsx
@@ -25,6 +25,7 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationPaymentSettingsProps {
   organization: schemas['Organization']
+  canManageOrganization: boolean | undefined
 }
 
 type FormSchema = Pick<
@@ -43,7 +44,7 @@ const taxBehaviorOptionDisplayNames: Record<
 
 const OrganizationPaymentSettings: React.FC<
   OrganizationPaymentSettingsProps
-> = ({ organization: _organization }) => {
+> = ({ organization: _organization, canManageOrganization }) => {
   const organization = _organization as schemas['Organization'] & {
     default_presentment_currency: schemas['PresentmentCurrency']
   }
@@ -103,6 +104,7 @@ const OrganizationPaymentSettings: React.FC<
                 <FormItem>
                   <FormControl>
                     <CurrencySelector
+                      disabled={!canManageOrganization}
                       value={field.value as schemas['PresentmentCurrency']}
                       onChange={field.onChange}
                     />
@@ -123,6 +125,7 @@ const OrganizationPaymentSettings: React.FC<
                 <FormItem>
                   <FormControl>
                     <Select
+                      disabled={!canManageOrganization}
                       onValueChange={field.onChange}
                       defaultValue={field.value || undefined}
                     >

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -178,18 +178,27 @@ const OrganizationSocialLinks = ({
                   }
                   placeholder="https://"
                   className="flex-1"
+                  disabled={readOnly}
                 />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => {
-                    field.onChange(socials.filter((_, i) => i !== index))
-                  }}
-                  className="dark:text-polar-400 text-gray-400 hover:text-gray-600"
+                <span
+                  className={twMerge(
+                    'inline-flex',
+                    readOnly && 'cursor-not-allowed',
+                  )}
                 >
-                  <CloseOutlined fontSize="small" />
-                </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    disabled={readOnly}
+                    onClick={() => {
+                      field.onChange(socials.filter((_, i) => i !== index))
+                    }}
+                    className="dark:text-polar-400 text-gray-400 hover:text-gray-600"
+                  >
+                    <CloseOutlined fontSize="small" />
+                  </Button>
+                </span>
               </div>
             ))}
             <span

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -60,6 +60,7 @@ import {
 interface OrganizationDetailsFormProps {
   organization: schemas['Organization']
   inKYCMode: boolean
+  canManageOrganization: boolean | undefined
 }
 
 const SwitchingFromOptions = {
@@ -88,10 +89,12 @@ const SOCIAL_PLATFORM_DOMAINS: Record<string, string> = {
 
 interface OrganizationSocialLinksProps {
   required?: boolean
+  canManageOrganization: boolean | undefined
 }
 
 const OrganizationSocialLinks = ({
   required,
+  canManageOrganization,
 }: OrganizationSocialLinksProps) => {
   const { control, formState } = useFormContext<schemas['OrganizationUpdate']>()
 
@@ -191,6 +194,7 @@ const OrganizationSocialLinks = ({
             ))}
             <Button
               type="button"
+              disabled={!canManageOrganization}
               size="sm"
               variant="secondary"
               onClick={() => {
@@ -232,6 +236,7 @@ const CompactTextArea = ({
 const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
   organization,
   inKYCMode,
+  canManageOrganization,
 }) => {
   const { control, setError, setValue } =
     useFormContext<schemas['OrganizationUpdate']>()
@@ -330,6 +335,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                       {...field}
                       value={field.value || ''}
                       placeholder="Acme Inc"
+                      disabled={!canManageOrganization}
                     />
                     <FormMessage />
                   </div>
@@ -353,6 +359,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                   }
                   onChange={field.onChange as (value: string) => void}
                   placeholder="Select country"
+                  disabled={!canManageOrganization}
                 />
                 <FormMessage />
               </div>
@@ -366,6 +373,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
             <FormField
               control={control}
               name="website"
+              disabled={!canManageOrganization}
               rules={{
                 required: 'Website is required',
                 validate: (value) => {
@@ -440,6 +448,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                   <Input
                     type="email"
                     {...field}
+                    disabled={!canManageOrganization}
                     value={field.value || ''}
                     placeholder="support@acme.com"
                   />
@@ -461,7 +470,10 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
               verification. They will never be shown publicly.
             </p>
           </div>
-          <OrganizationSocialLinks required={inKYCMode} />
+          <OrganizationSocialLinks
+            required={inKYCMode}
+            canManageOrganization={canManageOrganization}
+          />
         </div>
       </div>
 
@@ -566,11 +578,17 @@ interface OrganizationProfileSettingsProps {
   organization: schemas['Organization']
   kyc?: boolean
   onSubmitted?: () => void
+  canManageOrganization: boolean | undefined
 }
 
 const OrganizationProfileSettings: React.FC<
   OrganizationProfileSettingsProps
-> = ({ organization: _organization, kyc, onSubmitted }) => {
+> = ({
+  organization: _organization,
+  kyc,
+  onSubmitted,
+  canManageOrganization,
+}) => {
   const organization = _organization as schemas['Organization'] & {
     default_presentment_currency: schemas['PresentmentCurrency']
     country?: schemas['CountryAlpha2Input']
@@ -782,6 +800,7 @@ const OrganizationProfileSettings: React.FC<
             <OrganizationDetailsForm
               organization={organization}
               inKYCMode={inKYCMode}
+              canManageOrganization={canManageOrganization}
             />
           </div>
 

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -60,7 +60,7 @@ import {
 interface OrganizationDetailsFormProps {
   organization: schemas['Organization']
   inKYCMode: boolean
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 const SwitchingFromOptions = {
@@ -89,12 +89,12 @@ const SOCIAL_PLATFORM_DOMAINS: Record<string, string> = {
 
 interface OrganizationSocialLinksProps {
   required?: boolean
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 const OrganizationSocialLinks = ({
   required,
-  canManageOrganization,
+  readOnly,
 }: OrganizationSocialLinksProps) => {
   const { control, formState } = useFormContext<schemas['OrganizationUpdate']>()
 
@@ -194,7 +194,7 @@ const OrganizationSocialLinks = ({
             ))}
             <Button
               type="button"
-              disabled={!canManageOrganization}
+              disabled={readOnly}
               size="sm"
               variant="secondary"
               onClick={() => {
@@ -236,7 +236,7 @@ const CompactTextArea = ({
 const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
   organization,
   inKYCMode,
-  canManageOrganization,
+  readOnly,
 }) => {
   const { control, setError, setValue } =
     useFormContext<schemas['OrganizationUpdate']>()
@@ -335,7 +335,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                       {...field}
                       value={field.value || ''}
                       placeholder="Acme Inc"
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                     />
                     <FormMessage />
                   </div>
@@ -359,7 +359,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                   }
                   onChange={field.onChange as (value: string) => void}
                   placeholder="Select country"
-                  disabled={!canManageOrganization}
+                  disabled={readOnly}
                 />
                 <FormMessage />
               </div>
@@ -373,7 +373,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
             <FormField
               control={control}
               name="website"
-              disabled={!canManageOrganization}
+              disabled={readOnly}
               rules={{
                 required: 'Website is required',
                 validate: (value) => {
@@ -448,7 +448,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                   <Input
                     type="email"
                     {...field}
-                    disabled={!canManageOrganization}
+                    disabled={readOnly}
                     value={field.value || ''}
                     placeholder="support@acme.com"
                   />
@@ -470,10 +470,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
               verification. They will never be shown publicly.
             </p>
           </div>
-          <OrganizationSocialLinks
-            required={inKYCMode}
-            canManageOrganization={canManageOrganization}
-          />
+          <OrganizationSocialLinks required={inKYCMode} readOnly={readOnly} />
         </div>
       </div>
 
@@ -578,17 +575,12 @@ interface OrganizationProfileSettingsProps {
   organization: schemas['Organization']
   kyc?: boolean
   onSubmitted?: () => void
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 const OrganizationProfileSettings: React.FC<
   OrganizationProfileSettingsProps
-> = ({
-  organization: _organization,
-  kyc,
-  onSubmitted,
-  canManageOrganization,
-}) => {
+> = ({ organization: _organization, kyc, onSubmitted, readOnly }) => {
   const organization = _organization as schemas['Organization'] & {
     default_presentment_currency: schemas['PresentmentCurrency']
     country?: schemas['CountryAlpha2Input']
@@ -800,7 +792,7 @@ const OrganizationProfileSettings: React.FC<
             <OrganizationDetailsForm
               organization={organization}
               inKYCMode={inKYCMode}
-              canManageOrganization={canManageOrganization}
+              readOnly={readOnly}
             />
           </div>
 

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -373,7 +373,6 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
             <FormField
               control={control}
               name="website"
-              disabled={readOnly}
               rules={{
                 required: 'Website is required',
                 validate: (value) => {
@@ -395,6 +394,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                     type="url"
                     {...field}
                     value={field.value || ''}
+                    disabled={readOnly}
                     placeholder="https://acme.com"
                     onChange={(e) => {
                       let value = e.target.value

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -192,18 +192,25 @@ const OrganizationSocialLinks = ({
                 </Button>
               </div>
             ))}
-            <Button
-              type="button"
-              disabled={readOnly}
-              size="sm"
-              variant="secondary"
-              onClick={() => {
-                field.onChange([...socials, { platform: 'other', url: '' }])
-              }}
+            <span
+              className={twMerge(
+                'inline-block',
+                readOnly && 'cursor-not-allowed',
+              )}
             >
-              <AddOutlined fontSize="small" className="mr-1" />
-              Add Social
-            </Button>
+              <Button
+                type="button"
+                disabled={readOnly}
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  field.onChange([...socials, { platform: 'other', url: '' }])
+                }}
+              >
+                <AddOutlined fontSize="small" className="mr-1" />
+                Add Social
+              </Button>
+            </span>
             {showError && (
               <p className="text-destructive text-sm font-medium">
                 At least one social media link is required

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -285,6 +285,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
     onFilesUpdated,
     onFilesRejected,
     initialFiles: [],
+    disabled: readOnly,
   })
 
   return (
@@ -302,7 +303,8 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                   <div
                     {...getRootProps()}
                     className={twMerge(
-                      'relative cursor-pointer',
+                      'relative',
+                      readOnly ? 'cursor-not-allowed' : 'cursor-pointer',
                       isDragActive && 'opacity-50',
                     )}
                   >
@@ -310,11 +312,16 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
                     <Avatar
                       avatar_url={avatarURL ?? ''}
                       name={name ?? ''}
-                      className="h-10 w-10 transition-opacity hover:opacity-75"
+                      className={twMerge(
+                        'h-10 w-10 transition-opacity',
+                        !readOnly && 'hover:opacity-75',
+                      )}
                     />
-                    <div className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity hover:opacity-100">
-                      <AddPhotoAlternateOutlined className="dark:text-polar-400 text-gray-600" />
-                    </div>
+                    {!readOnly && (
+                      <div className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity hover:opacity-100">
+                        <AddPhotoAlternateOutlined className="dark:text-polar-400 text-gray-600" />
+                      </div>
+                    )}
                   </div>
                   <FormMessage className="mt-2 text-xs/snug" />
                 </div>

--- a/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
@@ -19,11 +19,12 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationSubscriptionSettingsProps {
   organization: schemas['Organization']
+  canManageOrganization: boolean | undefined
 }
 
 const OrganizationSubscriptionSettings: React.FC<
   OrganizationSubscriptionSettingsProps
-> = ({ organization }) => {
+> = ({ organization, canManageOrganization }) => {
   const form = useForm<schemas['OrganizationSubscriptionSettings']>({
     defaultValues: organization.subscription_settings,
   })
@@ -84,6 +85,7 @@ const OrganizationSubscriptionSettings: React.FC<
                   <FormControl>
                     <Switch
                       checked={field.value}
+                      disabled={!canManageOrganization}
                       onCheckedChange={field.onChange}
                     />
                   </FormControl>
@@ -149,6 +151,7 @@ const OrganizationSubscriptionSettings: React.FC<
                   <FormControl>
                     <Switch
                       checked={field.value}
+                      disabled={!canManageOrganization}
                       onCheckedChange={field.onChange}
                     />
                   </FormControl>

--- a/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
@@ -110,6 +110,7 @@ const OrganizationSubscriptionSettings: React.FC<
                       organization={organization}
                       value={field.value}
                       onValueChange={field.onChange}
+                      disabled={!canManageOrganization}
                     />
                   </FormControl>
                   <FormMessage />
@@ -130,6 +131,7 @@ const OrganizationSubscriptionSettings: React.FC<
                   <FormControl>
                     <BenefitRevocationGracePeriod
                       value={field.value}
+                      disabled={!canManageOrganization}
                       onValueChange={(value) => field.onChange(Number(value))}
                     />
                   </FormControl>

--- a/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
@@ -19,12 +19,12 @@ import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
 
 interface OrganizationSubscriptionSettingsProps {
   organization: schemas['Organization']
-  canManageOrganization: boolean | undefined
+  readOnly: boolean
 }
 
 const OrganizationSubscriptionSettings: React.FC<
   OrganizationSubscriptionSettingsProps
-> = ({ organization, canManageOrganization }) => {
+> = ({ organization, readOnly }) => {
   const form = useForm<schemas['OrganizationSubscriptionSettings']>({
     defaultValues: organization.subscription_settings,
   })
@@ -85,7 +85,7 @@ const OrganizationSubscriptionSettings: React.FC<
                   <FormControl>
                     <Switch
                       checked={field.value}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                       onCheckedChange={field.onChange}
                     />
                   </FormControl>
@@ -110,7 +110,7 @@ const OrganizationSubscriptionSettings: React.FC<
                       organization={organization}
                       value={field.value}
                       onValueChange={field.onChange}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                     />
                   </FormControl>
                   <FormMessage />
@@ -131,7 +131,7 @@ const OrganizationSubscriptionSettings: React.FC<
                   <FormControl>
                     <BenefitRevocationGracePeriod
                       value={field.value}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                       onValueChange={(value) => field.onChange(Number(value))}
                     />
                   </FormControl>
@@ -153,7 +153,7 @@ const OrganizationSubscriptionSettings: React.FC<
                   <FormControl>
                     <Switch
                       checked={field.value}
-                      disabled={!canManageOrganization}
+                      disabled={readOnly}
                       onCheckedChange={field.onChange}
                     />
                   </FormControl>

--- a/clients/apps/web/src/components/Settings/ProrationBehavior.tsx
+++ b/clients/apps/web/src/components/Settings/ProrationBehavior.tsx
@@ -22,6 +22,7 @@ export interface ProrationBehaviorProps {
   organization: schemas['Organization']
   value: schemas['SubscriptionProrationBehavior']
   onValueChange: (value: string) => void
+  disabled?: boolean
 }
 
 export const ProrationBehavior: React.FC<ProrationBehaviorProps> = ({

--- a/clients/packages/ui/src/components/atoms/Combobox.tsx
+++ b/clients/packages/ui/src/components/atoms/Combobox.tsx
@@ -44,6 +44,9 @@ export interface ComboboxProps<T> {
   className?: string
   popoverClassName?: string
   popoverAlign?: 'start' | 'center' | 'end'
+
+  // State
+  disabled?: boolean
 }
 
 export function Combobox<T>({
@@ -62,6 +65,7 @@ export function Combobox<T>({
   className,
   popoverClassName,
   popoverAlign,
+  disabled = false,
 }: ComboboxProps<T>) {
   const [open, setOpen] = React.useState(false)
   const [query, setQuery] = React.useState('')
@@ -89,24 +93,30 @@ export function Combobox<T>({
   }, [value, selectedItem, getItemLabel])
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className={cn(
-            'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex w-full flex-row justify-between gap-x-2 rounded-xl border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:border-gray-300 hover:bg-white',
-            selectedItem
-              ? 'text-foreground hover:text-foreground'
-              : 'text-foreground/50 hover:text-foreground/50 dark:text-polar-400 dark:hover:text-polar-300',
-            className,
-          )}
-        >
-          {selectedLabel ?? placeholder}
-          <ChevronsUpDown className="opacity-50" />
-        </Button>
-      </PopoverTrigger>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => !disabled && setOpen(nextOpen)}
+    >
+      <span className={cn('block w-full', disabled && 'cursor-not-allowed')}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className={cn(
+              'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex w-full flex-row justify-between gap-x-2 rounded-xl border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:border-gray-300 hover:bg-white',
+              selectedItem
+                ? 'text-foreground hover:text-foreground'
+                : 'text-foreground/50 hover:text-foreground/50 dark:text-polar-400 dark:hover:text-polar-300',
+              className,
+            )}
+          >
+            {selectedLabel ?? placeholder}
+            <ChevronsUpDown className="opacity-50" />
+          </Button>
+        </PopoverTrigger>
+      </span>
       <PopoverContent
         align={popoverAlign}
         className={cn(

--- a/clients/packages/ui/src/components/atoms/Combobox.tsx
+++ b/clients/packages/ui/src/components/atoms/Combobox.tsx
@@ -93,10 +93,7 @@ export function Combobox<T>({
   }, [value, selectedItem, getItemLabel])
 
   return (
-    <Popover
-      open={open}
-      onOpenChange={(nextOpen) => !disabled && setOpen(nextOpen)}
-    >
+    <Popover open={open && !disabled} onOpenChange={setOpen}>
       <span className={cn('block w-full', disabled && 'cursor-not-allowed')}>
         <PopoverTrigger asChild>
           <Button


### PR DESCRIPTION
## What

Gate organisation settings behind `canManageOrganization` flag. They are already gated server side (HTTP 403)

## Why

This will make clearer what a `member` can or cannot do since we are moving notification settings to the user level

### CanManage

https://github.com/user-attachments/assets/b36342c4-79c2-4eb4-b769-76ec9a6cb982


### !CanManage

https://github.com/user-attachments/assets/9b6badc8-4b08-4fed-b012-32f5f789e4e4

