### PR TITLE
feat: show banner when organization is offboarding

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
@@ -1,0 +1,40 @@
+import { schemas } from '@polar-sh/client'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import Button from '@polar-sh/ui/components/atoms/Button'
+import { AlertTriangleIcon } from 'lucide-react'
+import Link from 'next/link'
+
+interface OffboardingBannerProps {
+  organization: schemas['Organization']
+}
+
+export const OffboardingBanner = ({ organization }: OffboardingBannerProps) => {
+  return (
+    <Box
+      display="flex"
+      flexDirection={{ base: 'column', md: 'row' }}
+      justifyContent="between"
+      gap="l"
+      borderRadius="l"
+      backgroundColor="background-card"
+      padding={{ base: 'l', md: 'xl' }}
+    >
+      <Box display="flex" flexDirection="column" rowGap="s">
+        <Box display="flex" alignItems="center" columnGap="s">
+          <AlertTriangleIcon className="h-4 w-4 shrink-0" />
+          <Text as="strong">Your organization is being offboarded</Text>
+        </Box>
+        <Box maxWidth={720}>
+          <Text color="muted">
+            Your organization is in the process of being offboarded from Polar.
+            Some features may be limited. Reach out if you have any questions.
+          </Text>
+        </Box>
+      </Box>
+      <Link href={`/dashboard/${organization.slug}/finance/account`}>
+        <Button>Learn More</Button>
+      </Link>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
@@ -32,7 +32,7 @@ export const OffboardingBanner = ({ organization }: OffboardingBannerProps) => {
         </Box>
       </Box>
       <Link href={`/dashboard/${organization.slug}/finance/account`}>
-        <Button>Learn More</Button>
+        <Button variant="secondary">Learn More</Button>
       </Link>
     </Box>
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
@@ -1,7 +1,6 @@
 import { schemas } from '@polar-sh/client'
-import { Text } from '@polar-sh/orbit'
+import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import Button from '@polar-sh/ui/components/atoms/Button'
 import { AlertTriangleIcon } from 'lucide-react'
 import Link from 'next/link'
 
@@ -25,7 +24,7 @@ export const OffboardingBanner = ({ organization }: OffboardingBannerProps) => {
           <AlertTriangleIcon className="h-4 w-4 shrink-0" />
           <Text as="strong">Your organization is being offboarded</Text>
         </Box>
-        <Box maxWidth={720}>
+        <Box maxWidth="45rem">
           <Text color="muted">
             Your organization is in the process of being offboarded from Polar.
             Some features may be limited. Reach out if you have any questions.

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OrganizationStatusBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OrganizationStatusBanner.tsx
@@ -2,6 +2,7 @@ import { useOrganizationPaymentStatus } from '@/hooks/queries'
 import { CONFIG } from '@/utils/config'
 import { schemas } from '@polar-sh/client'
 import { DeniedBanner } from './DeniedBanner'
+import { OffboardingBanner } from './OffboardingBanner'
 import { TestModeBanner } from './TestModeBanner'
 
 interface OrganizationStatusBannerProps {
@@ -21,6 +22,10 @@ export const OrganizationStatusBanner = ({
 
   if (paymentStatus?.organization_status === 'denied') {
     return <DeniedBanner organization={organization} />
+  }
+
+  if (paymentStatus?.organization_status === 'offboarding') {
+    return <OffboardingBanner organization={organization} />
   }
 
   if (paymentStatus?.organization_status === 'created') {


### PR DESCRIPTION
## Summary

Show a status banner on the dashboard home when an organization's payment status is `offboarding`, matching the existing denied and test-mode ("go live") banners.

## What

- Add `OffboardingBanner`, styled like the existing status banners.
- Render it from `OrganizationStatusBanner` when `organization_status === 'offboarding'`.

## Why

Offboarding organizations previously had no on-dashboard indication of their state. The denied and test-mode states already surface a banner; offboarding was the gap.

## How

The copy is intentionally generic ("some features may be limited") rather than enumerating specific capabilities. Capabilities are a per-organization override on top of the status defaults, so checkout/payouts/refunds availability can't be assumed from the status alone.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (frontend `pnpm lint` + `tsc --noEmit`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Offboarding notification banner that alerts organizations in offboarding, shows a prominent headline, supporting explanatory copy, and a “Learn More” action linking to account finance details.
  * Organization status handling now displays the new Offboarding banner when an account is offboarding while preserving existing flows for other statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->