### PR TITLE
chore: disable CodeRabbit automatic PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,8 @@ reviews:
   abort_on_close: true
 
   auto_review:
-    enabled: true
+    # Disabled: CodeRabbit no longer reviews PRs automatically.
+    enabled: false
     drafts: false
     auto_incremental_review: true
     base_branches:


### PR DESCRIPTION
## Summary

Disables CodeRabbit's automatic PR reviews.

## Scope / caveat

This stops **automatic** reviews only. But
- manual `@coderabbitai review` comments still trigger a review
- `chat.auto_reply: true` means it still answers comments

We will keep or remove it after 1 week

🤖 Generated with [Claude Code](https://claude.com/claude-code)