### PR TITLE
tf/vercel: Map up Vercel frontends in terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ clients/apps/web/src/app/(main)/onboarding/validate-description/acceptable-use-p
 server/polar/organization_review/acceptable-use-policy.mdx
 
 .worktrees/
+.vercel

--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -450,3 +450,116 @@ resource "tfe_variable" "firecrawl_api_key_production" {
   sensitive       = true
   variable_set_id = tfe_variable_set.production.id
 }
+
+# Vercel frontend
+resource "tfe_variable" "vercel_stripe_publishable_key_production" {
+  key             = "stripe_publishable_key"
+  category        = "terraform"
+  description     = "Stripe publishable key for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_pydantic_ai_gateway_api_key_production" {
+  key             = "pydantic_ai_gateway_api_key"
+  category        = "terraform"
+  description     = "Pydantic AI Gateway API key for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_gram_api_key_production" {
+  key             = "gram_api_key"
+  category        = "terraform"
+  description     = "Gram API key for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_mintlify_assistant_api_key_production" {
+  key             = "mintlify_assistant_api_key"
+  category        = "terraform"
+  description     = "Mintlify assistant API key for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_attio_api_key_production" {
+  key             = "attio_api_key"
+  category        = "terraform"
+  description     = "Attio API key for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_attio_startup_list_id_production" {
+  key             = "attio_startup_list_id"
+  category        = "terraform"
+  description     = "Attio startup list ID for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_mcp_oauth2_client_id_production" {
+  key             = "mcp_oauth2_client_id"
+  category        = "terraform"
+  description     = "MCP OAuth2 client ID for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_mcp_oauth2_client_secret_production" {
+  key             = "mcp_oauth2_client_secret"
+  category        = "terraform"
+  description     = "MCP OAuth2 client secret for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_sentry_auth_token_production" {
+  key             = "sentry_auth_token"
+  category        = "terraform"
+  description     = "Sentry auth token for the Vercel production frontend build"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_polar_preview_access_token_production" {
+  key             = "polar_preview_access_token"
+  category        = "terraform"
+  description     = "Polar preview access token for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_next_public_sentry_dsn_production" {
+  key             = "next_public_sentry_dsn"
+  category        = "terraform"
+  description     = "Sentry DSN for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_next_public_posthog_token_production" {
+  key             = "next_public_posthog_token"
+  category        = "terraform"
+  description     = "PostHog token for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_next_public_apple_domain_association_production" {
+  key             = "next_public_apple_domain_association"
+  category        = "terraform"
+  description     = "Apple Pay domain association for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_production" {
+  key             = "next_public_stripe_payment_method_configuration"
+  category        = "terraform"
+  description     = "Stripe payment method configuration ID for the Vercel production frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -376,3 +376,108 @@ resource "tfe_variable" "firecrawl_api_key_sandbox" {
   sensitive       = true
   variable_set_id = tfe_variable_set.sandbox.id
 }
+
+# Vercel frontend
+resource "tfe_variable" "vercel_stripe_publishable_key_sandbox" {
+  key             = "stripe_publishable_key"
+  category        = "terraform"
+  description     = "Stripe publishable key for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_stripe_publishable_key_preview_sandbox" {
+  key             = "stripe_publishable_key_preview"
+  category        = "terraform"
+  description     = "Stripe publishable key for Vercel sandbox preview deployments"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_pydantic_ai_gateway_api_key_sandbox" {
+  key             = "pydantic_ai_gateway_api_key"
+  category        = "terraform"
+  description     = "Pydantic AI Gateway API key for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_gram_api_key_sandbox" {
+  key             = "gram_api_key"
+  category        = "terraform"
+  description     = "Gram API key for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_mintlify_assistant_api_key_sandbox" {
+  key             = "mintlify_assistant_api_key"
+  category        = "terraform"
+  description     = "Mintlify assistant API key for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_mcp_oauth2_client_id_sandbox" {
+  key             = "mcp_oauth2_client_id"
+  category        = "terraform"
+  description     = "MCP OAuth2 client ID for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_mcp_oauth2_client_secret_sandbox" {
+  key             = "mcp_oauth2_client_secret"
+  category        = "terraform"
+  description     = "MCP OAuth2 client secret for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_sentry_auth_token_sandbox" {
+  key             = "sentry_auth_token"
+  category        = "terraform"
+  description     = "Sentry auth token for the Vercel sandbox frontend build"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_polar_preview_access_token_sandbox" {
+  key             = "polar_preview_access_token"
+  category        = "terraform"
+  description     = "Polar preview access token for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_next_public_sentry_dsn_sandbox" {
+  key             = "next_public_sentry_dsn"
+  category        = "terraform"
+  description     = "Sentry DSN for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_next_public_posthog_token_sandbox" {
+  key             = "next_public_posthog_token"
+  category        = "terraform"
+  description     = "PostHog token for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_next_public_apple_domain_association_sandbox" {
+  key             = "next_public_apple_domain_association"
+  category        = "terraform"
+  description     = "Apple Pay domain association for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_sandbox" {
+  key             = "next_public_stripe_payment_method_configuration"
+  category        = "terraform"
+  description     = "Stripe payment method configuration ID for the Vercel sandbox frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}

--- a/terraform/modules/vercel/main.tf
+++ b/terraform/modules/vercel/main.tf
@@ -1,0 +1,105 @@
+# Polar Vercel project setup
+#
+# One Vercel project per environment (production, sandbox), its custom domains
+# and its environment variables. Env vars are managed via the dedicated
+# vercel_project_environment_variables resource, so the project's inline
+# `environment` is intentionally left unmanaged (see lifecycle below).
+
+resource "vercel_project" "this" {
+  name      = var.name
+  framework = var.framework
+
+  root_directory  = var.root_directory
+  build_command   = var.build_command
+  install_command = var.install_command
+  ignore_command  = var.ignore_command
+
+  git_repository = {
+    type              = "github"
+    repo              = var.git_repo
+    production_branch = var.production_branch
+  }
+
+  lifecycle {
+    # Environment variables are owned by vercel_project_environment_variables.
+    ignore_changes = [environment]
+  }
+}
+
+locals {
+  # Identical across all environments (same key, value and target everywhere).
+  shared_environment_variables = [
+    { key = "SENTRY_ORG", value = "polar-sh", target = ["production", "preview"] },
+    { key = "SENTRY_PROJECT", value = "dashboard", target = ["production", "preview"] },
+  ]
+
+  # Non-secret config present in every environment, applied to all targets.
+  config_environment_variables = [
+    { key = "NEXT_PUBLIC_API_URL", value = var.config.next_public_api_url },
+    { key = "NEXT_PUBLIC_BACKOFFICE_URL", value = var.config.next_public_backoffice_url },
+    { key = "NEXT_PUBLIC_SENTRY_DSN", value = var.config.next_public_sentry_dsn },
+    { key = "NEXT_PUBLIC_POSTHOG_TOKEN", value = var.config.next_public_posthog_token },
+    { key = "NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION", value = var.config.next_public_apple_domain_association },
+    { key = "NEXT_PUBLIC_CHECKOUT_EMBED_SCRIPT_SRC", value = var.config.next_public_checkout_embed_script_src },
+    { key = "NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CONFIGURATION", value = var.config.next_public_stripe_payment_method_configuration },
+    { key = "S3_PUBLIC_IMAGES_BUCKET_PROTOCOL", value = var.config.s3_public_images_bucket_protocol },
+    { key = "S3_PUBLIC_IMAGES_BUCKET_HOSTNAME", value = var.config.s3_public_images_bucket_hostname },
+    { key = "S3_PUBLIC_IMAGES_BUCKET_PORT", value = var.config.s3_public_images_bucket_port },
+    { key = "S3_PUBLIC_IMAGES_BUCKET_PATHNAME", value = var.config.s3_public_images_bucket_pathname },
+    { key = "S3_UPLOAD_ORIGINS", value = var.config.s3_upload_origins },
+    { key = "POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS", value = var.config.polar_checkout_embed_script_allowed_origins },
+    { key = "POLAR_OPENAPI_SCHEMA_URL", value = var.config.polar_openapi_schema_url },
+    { key = "ENABLE_EXPERIMENTAL_COREPACK", value = var.config.enable_experimental_corepack },
+  ]
+
+  # Secrets present in every environment; targets baked per key.
+  secret_environment_variables = [
+    { key = "PYDANTIC_AI_GATEWAY_API_KEY", value = var.secrets.pydantic_ai_gateway_api_key, target = ["production", "preview"] },
+    { key = "MINTLIFY_ASSISTANT_API_KEY", value = var.secrets.mintlify_assistant_api_key, target = ["production", "preview"] },
+    { key = "GRAM_API_KEY", value = var.secrets.gram_api_key, target = ["production", "preview"] },
+    { key = "SENTRY_AUTH_TOKEN", value = var.secrets.sentry_auth_token, target = ["production", "preview"] },
+    { key = "POLAR_PREVIEW_ACCESS_TOKEN", value = var.secrets.polar_preview_access_token, target = ["preview"] },
+  ]
+
+  environment_variables = concat(
+    [for env in local.shared_environment_variables : {
+      key       = env.key
+      value     = env.value
+      target    = toset(env.target)
+      sensitive = false
+    }],
+    [for env in local.config_environment_variables : {
+      key       = env.key
+      value     = env.value
+      target    = toset(["production", "preview", "development"])
+      sensitive = false
+    }],
+    [for env in local.secret_environment_variables : {
+      key       = env.key
+      value     = env.value
+      target    = toset(env.target)
+      sensitive = true
+    }],
+    [for env in var.environment_variables : {
+      key       = env.key
+      value     = env.value
+      target    = env.target
+      sensitive = env.sensitive
+    }],
+  )
+}
+
+resource "vercel_project_environment_variables" "this" {
+  project_id = vercel_project.this.id
+  variables  = local.environment_variables
+}
+
+resource "vercel_project_domain" "this" {
+  for_each = { for domain in var.domains : domain.name => domain }
+
+  project_id           = vercel_project.this.id
+  domain               = each.value.name
+  redirect             = each.value.redirect
+  redirect_status_code = each.value.redirect_status_code
+  git_branch           = each.value.git_branch
+}

--- a/terraform/modules/vercel/outputs.tf
+++ b/terraform/modules/vercel/outputs.tf
@@ -1,0 +1,14 @@
+output "project_id" {
+  description = "The ID of the Vercel project"
+  value       = vercel_project.this.id
+}
+
+output "project_name" {
+  description = "The name of the Vercel project"
+  value       = vercel_project.this.name
+}
+
+output "domains" {
+  description = "Custom domains attached to the project"
+  value       = [for domain in vercel_project_domain.this : domain.domain]
+}

--- a/terraform/modules/vercel/terraform.tf
+++ b/terraform/modules/vercel/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 5.3"
+    }
+  }
+
+  required_version = ">= 1.2"
+}

--- a/terraform/modules/vercel/variables.tf
+++ b/terraform/modules/vercel/variables.tf
@@ -1,0 +1,105 @@
+variable "name" {
+  description = "The Vercel project name"
+  type        = string
+}
+
+# Git / build configuration
+variable "git_repo" {
+  description = "Connected Git repository, e.g. \"polarsource/polar\""
+  type        = string
+}
+
+variable "production_branch" {
+  description = "Branch deployed to the project's production environment"
+  type        = string
+  default     = "main"
+}
+
+variable "framework" {
+  description = "Vercel framework preset"
+  type        = string
+  default     = "nextjs"
+}
+
+variable "root_directory" {
+  description = "Directory within the repo that Vercel builds from"
+  type        = string
+  default     = "clients/apps/web"
+}
+
+variable "build_command" {
+  description = "Override build command. Leave null to use the repo's vercel.json / autodetection."
+  type        = string
+  default     = null
+}
+
+variable "install_command" {
+  description = "Override install command. Leave null to use autodetection."
+  type        = string
+  default     = null
+}
+
+variable "ignore_command" {
+  description = "Command that decides whether to skip a build. Leave null to always build."
+  type        = string
+  default     = null
+}
+
+# Custom domains attached to the project
+variable "domains" {
+  description = "Custom domains served by the project"
+  type = list(object({
+    name                 = string
+    redirect             = optional(string)
+    redirect_status_code = optional(number)
+    git_branch           = optional(string)
+  }))
+  default = []
+}
+
+# Non-sensitive env vars present in every environment, applied to all targets.
+variable "config" {
+  description = "Non-sensitive env vars common to every environment"
+  type = object({
+    next_public_api_url                             = string
+    next_public_backoffice_url                      = string
+    next_public_sentry_dsn                          = string
+    next_public_posthog_token                       = string
+    next_public_apple_domain_association            = string
+    next_public_checkout_embed_script_src           = string
+    next_public_stripe_payment_method_configuration = string
+    s3_public_images_bucket_protocol                = string
+    s3_public_images_bucket_hostname                = string
+    s3_public_images_bucket_port                    = string
+    s3_public_images_bucket_pathname                = string
+    s3_upload_origins                               = string
+    polar_checkout_embed_script_allowed_origins     = string
+    polar_openapi_schema_url                        = string
+    enable_experimental_corepack                    = string
+  })
+}
+
+# Sensitive env vars present in every environment. Targets are baked in the module.
+variable "secrets" {
+  description = "Sensitive env vars common to every environment"
+  type = object({
+    pydantic_ai_gateway_api_key = string
+    mintlify_assistant_api_key  = string
+    gram_api_key                = string
+    sentry_auth_token           = string
+    polar_preview_access_token  = string
+  })
+  sensitive = true
+}
+
+# Env vars that are environment-specific or whose target varies by environment.
+variable "environment_variables" {
+  description = "Environment-specific Vercel environment variables"
+  type = list(object({
+    key       = string
+    value     = string
+    target    = optional(set(string), ["production", "preview", "development"])
+    sensitive = optional(bool, false)
+  }))
+  default = []
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -17,3 +17,6 @@ provider "aws" {
 
 provider "render" {
 }
+
+provider "vercel" {
+}

--- a/terraform/production/terraform.tf
+++ b/terraform/production/terraform.tf
@@ -21,6 +21,11 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5.13"
     }
+
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 5.3"
+    }
   }
 
   required_version = ">= 1.2"

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -414,3 +414,91 @@ variable "firecrawl_api_key" {
   type        = string
   sensitive   = true
 }
+
+# Vercel frontend secrets
+variable "stripe_publishable_key" {
+  description = "Stripe publishable key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+
+variable "pydantic_ai_gateway_api_key" {
+  description = "Pydantic AI Gateway API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+
+
+variable "gram_api_key" {
+  description = "Gram API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mintlify_assistant_api_key" {
+  description = "Mintlify assistant API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "attio_api_key" {
+  description = "Attio API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "attio_startup_list_id" {
+  description = "Attio startup list ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_oauth2_client_id" {
+  description = "MCP OAuth2 client ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_oauth2_client_secret" {
+  description = "MCP OAuth2 client secret for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "sentry_auth_token" {
+  description = "Sentry auth token for the Vercel frontend build"
+  type        = string
+  sensitive   = true
+}
+
+variable "polar_preview_access_token" {
+  description = "Polar preview access token for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_sentry_dsn" {
+  description = "Sentry DSN for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_posthog_token" {
+  description = "PostHog token for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_apple_domain_association" {
+  description = "Apple Pay domain association for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_stripe_payment_method_configuration" {
+  description = "Stripe payment method configuration ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/production/vercel.tf
+++ b/terraform/production/vercel.tf
@@ -1,0 +1,99 @@
+# =============================================================================
+# Vercel — Production frontend (polar.sh)
+# =============================================================================
+#
+# vercel_project_environment_variables manages only the keys declared below;
+# other env vars on the live project are left untouched.
+
+import {
+  to = module.vercel.vercel_project.this
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["polar.sh"]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/polar.sh"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["dashboard.polar.sh"]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/dashboard.polar.sh"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["blog.polar.sh"]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/blog.polar.sh"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["www.polar.sh"]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/www.polar.sh"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["polar.new"]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/polar.new"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["www.polar.new"]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/www.polar.new"
+}
+
+module "vercel" {
+  source = "../modules/vercel"
+
+  name     = "polar"
+  git_repo = "polarsource/polar"
+
+  domains = [
+    { name = "polar.sh" },
+    { name = "www.polar.sh", redirect = "polar.sh", redirect_status_code = 308 },
+    { name = "dashboard.polar.sh" },
+    { name = "blog.polar.sh" },
+    { name = "polar.new" },
+    { name = "www.polar.new", redirect = "polar.new", redirect_status_code = 308 },
+  ]
+
+  config = {
+    next_public_api_url                             = "https://api.polar.sh"
+    next_public_backoffice_url                      = "https://backoffice.polar.sh"
+    next_public_sentry_dsn                          = var.next_public_sentry_dsn
+    next_public_posthog_token                       = var.next_public_posthog_token
+    next_public_apple_domain_association            = var.next_public_apple_domain_association
+    next_public_checkout_embed_script_src           = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
+    next_public_stripe_payment_method_configuration = var.next_public_stripe_payment_method_configuration
+    s3_public_images_bucket_protocol                = "https"
+    s3_public_images_bucket_hostname                = "polar-public-files.s3.amazonaws.com"
+    s3_public_images_bucket_port                    = null
+    s3_public_images_bucket_pathname                = "/product_media/**"
+    s3_upload_origins                               = "https://polar-production-files.s3.amazonaws.com https://polar-public-files.s3.amazonaws.com"
+    polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh"
+    polar_openapi_schema_url                        = "https://api.polar.sh/openapi.json"
+    enable_experimental_corepack                    = "1"
+  }
+
+  secrets = {
+    pydantic_ai_gateway_api_key = var.pydantic_ai_gateway_api_key
+    mintlify_assistant_api_key  = var.mintlify_assistant_api_key
+    gram_api_key                = var.gram_api_key
+    sentry_auth_token           = var.sentry_auth_token
+    polar_preview_access_token  = var.polar_preview_access_token
+  }
+
+  # Environment-specific or target-varies-by-env.
+  environment_variables = [
+    { key = "NEXT_PUBLIC_FRONTEND_BASE_URL", value = "https://polar.sh", target = ["production"] },
+    { key = "NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL", value = "https://sandbox.polar.sh" },
+    { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "", target = ["production"] },
+    { key = "NEXT_PUBLIC_POSTHOG_HOST", value = "https://polar.sh/ingest" },
+    { key = "NEXT_PUBLIC_SENTRY_ENABLED", value = "true" },
+    { key = "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID", value = "G-MBYW1QZFHE" },
+    { key = "NEXT_PUBLIC_GITHUB_INSTALLATION_URL", value = "https://github.com/apps/polar-sh/installations/new" },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview"], sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview"], sensitive = true },
+    { key = "ATTIO_API_KEY", value = var.attio_api_key, target = ["production", "preview"], sensitive = true },
+    { key = "ATTIO_STARTUP_LIST_ID", value = var.attio_startup_list_id, target = ["production", "preview"], sensitive = true },
+  ]
+}

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -10,6 +10,9 @@ provider "aws" {
 provider "render" {
 }
 
+provider "vercel" {
+}
+
 module "s3_buckets" {
   source                   = "../modules/s3_buckets"
   environment              = "sandbox"

--- a/terraform/sandbox/terraform.tf
+++ b/terraform/sandbox/terraform.tf
@@ -26,6 +26,11 @@ terraform {
       source  = "hashicorp/tfe"
       version = "0.71.0"
     }
+
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 5.3"
+    }
   }
 
   required_version = ">= 1.2"

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -331,3 +331,85 @@ variable "firecrawl_api_key" {
   type        = string
   sensitive   = true
 }
+
+# Vercel frontend secrets
+variable "stripe_publishable_key" {
+  description = "Stripe publishable key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "stripe_publishable_key_preview" {
+  description = "Stripe publishable key for Vercel preview deployments"
+  type        = string
+  sensitive   = true
+}
+
+
+variable "pydantic_ai_gateway_api_key" {
+  description = "Pydantic AI Gateway API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+
+
+variable "gram_api_key" {
+  description = "Gram API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mintlify_assistant_api_key" {
+  description = "Mintlify assistant API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_oauth2_client_id" {
+  description = "MCP OAuth2 client ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_oauth2_client_secret" {
+  description = "MCP OAuth2 client secret for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "sentry_auth_token" {
+  description = "Sentry auth token for the Vercel frontend build"
+  type        = string
+  sensitive   = true
+}
+
+variable "polar_preview_access_token" {
+  description = "Polar preview access token for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_sentry_dsn" {
+  description = "Sentry DSN for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_posthog_token" {
+  description = "PostHog token for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_apple_domain_association" {
+  description = "Apple Pay domain association for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_stripe_payment_method_configuration" {
+  description = "Stripe payment method configuration ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/sandbox/vercel.tf
+++ b/terraform/sandbox/vercel.tf
@@ -1,0 +1,63 @@
+# =============================================================================
+# Vercel — Sandbox frontend (sandbox.polar.sh)
+# =============================================================================
+
+import {
+  to = module.vercel.vercel_project.this
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD"
+}
+
+import {
+  to = module.vercel.vercel_project_domain.this["sandbox.polar.sh"]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/sandbox.polar.sh"
+}
+
+module "vercel" {
+  source = "../modules/vercel"
+
+  name     = "polar-sandbox"
+  git_repo = "polarsource/polar"
+
+  domains = [
+    { name = "sandbox.polar.sh" },
+  ]
+
+  config = {
+    next_public_api_url                             = "https://sandbox-api.polar.sh"
+    next_public_backoffice_url                      = "https://sandbox-api.polar.sh/backoffice"
+    next_public_sentry_dsn                          = var.next_public_sentry_dsn
+    next_public_posthog_token                       = var.next_public_posthog_token
+    next_public_apple_domain_association            = var.next_public_apple_domain_association
+    next_public_checkout_embed_script_src           = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
+    next_public_stripe_payment_method_configuration = var.next_public_stripe_payment_method_configuration
+    s3_public_images_bucket_protocol                = "https"
+    s3_public_images_bucket_hostname                = "polar-public-sandbox-files.s3.amazonaws.com"
+    s3_public_images_bucket_port                    = null
+    s3_public_images_bucket_pathname                = "/product_media/**"
+    s3_upload_origins                               = "https://polar-sandbox-files.s3.amazonaws.com https://polar-public-sandbox-files.s3.amazonaws.com"
+    polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh"
+    polar_openapi_schema_url                        = "https://api.polar.sh/openapi.json"
+    enable_experimental_corepack                    = "1"
+  }
+
+  secrets = {
+    pydantic_ai_gateway_api_key = var.pydantic_ai_gateway_api_key
+    mintlify_assistant_api_key  = var.mintlify_assistant_api_key
+    gram_api_key                = var.gram_api_key
+    sentry_auth_token           = var.sentry_auth_token
+    polar_preview_access_token  = var.polar_preview_access_token
+  }
+
+  # Environment-specific or target-varies-by-env.
+  environment_variables = [
+    { key = "NEXT_PUBLIC_FRONTEND_BASE_URL", value = "https://sandbox.polar.sh" },
+    { key = "NEXT_PUBLIC_ENVIRONMENT", value = "sandbox" },
+    { key = "POLAR_AUTH_COOKIE_KEY", value = "polar_sandbox_session" },
+    { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "https://sandbox.polar.sh/api/checkout?price=" },
+    { key = "POLAR_PREVIEW_BACKEND_HOST", value = "", target = ["preview"] },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, target = ["production", "development"], sensitive = true },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key_preview, target = ["preview"], sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, sensitive = true },
+  ]
+}


### PR DESCRIPTION
This makes it easier to make changes in Vercel the same way we make changes in other parts of our infrastructure.

As well as spinning up/down the test environment


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terraform now manages our Vercel frontends for production and sandbox, including projects, domains, and environment variables. This makes Vercel changes consistent with our infra and simplifies spinning test environments up/down.

- **New Features**
  - Added a reusable `modules/vercel` to define projects, domains, and env vars; mapped existing projects via import blocks.
  - Codified domains for `polar.sh` (incl. `www`, `dashboard`, `blog`, `polar.new`) and `sandbox.polar.sh`.
  - Centralized secrets in Terraform Cloud variable sets and wired env-specific vars (Stripe, Sentry, PostHog, MCP, Attio).

- **Dependencies**
  - Added `vercel/vercel` provider (~> 5.3).
  - Ignored local `.vercel` directory in `.gitignore`.

<sup>Written for commit cca816b2fb8d1fd82d3b58f2f3ad92915ecc9fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Vercel deployment infrastructure for frontend applications with support for custom domains and environment-specific configurations.
  * Integrated essential third-party service credentials (Stripe, Sentry, PostHog, MCP OAuth, and others) for production and sandbox deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->