### PR TITLE
tf/render: Bump API service memory

### DIFF
--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -129,7 +129,7 @@ module "test" {
     postgres_database      = local.db_name
     postgres_read_database = local.db_name
     redis_db               = "0"
-    plan                   = "standard"
+    plan                   = "pro"
   }
 
   workers = {


### PR DESCRIPTION
Since we're above the standard plan, we need to bump it in test as well


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the Render plan for the test API service from standard to pro to match current usage and avoid memory limits. Updates terraform/test/render.tf so test mirrors production capacity.

<sup>Written for commit 547eea8af783adcca9e97f57d23c5798aa9d84c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

