### PR TITLE
Normalize organization_id on subscriptions

### DIFF
--- a/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
+++ b/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
@@ -32,7 +32,7 @@ def upgrade() -> None:
         ondelete="restrict",
     )
     with op.get_context().autocommit_block():
-        op.execute("SET LOCAL lock_timeout = '5s'")
+        op.execute("SET lock_timeout = '5s'")
         op.create_index(
             op.f("ix_subscriptions_organization_id"),
             "subscriptions",

--- a/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
+++ b/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
@@ -19,8 +19,6 @@ depends_on: tuple[str] | None = None
 
 
 def upgrade() -> None:
-    # Ensures we don't break app by applying a deadlock-inducing migration
-    op.execute("SET LOCAL lock_timeout = '5s'")
     op.add_column(
         "subscriptions",
         sa.Column("organization_id", sa.Uuid(), nullable=True),
@@ -34,6 +32,7 @@ def upgrade() -> None:
         ondelete="restrict",
     )
     with op.get_context().autocommit_block():
+        op.execute("SET LOCAL lock_timeout = '5s'")
         op.create_index(
             op.f("ix_subscriptions_organization_id"),
             "subscriptions",

--- a/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
+++ b/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
@@ -19,6 +19,8 @@ depends_on: tuple[str] | None = None
 
 
 def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
     op.add_column(
         "subscriptions",
         sa.Column("organization_id", sa.Uuid(), nullable=True),
@@ -42,6 +44,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
     op.drop_constraint(
         op.f("subscriptions_organization_id_fkey"),
         "subscriptions",

--- a/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
+++ b/server/migrations/versions/2026-06-03-1200_add_organization_id_to_subscriptions.py
@@ -1,0 +1,51 @@
+"""add organization_id to subscriptions
+
+Revision ID: 5263a32cf4dd
+Revises: 4c80966d7217
+Create Date: 2026-06-03 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "5263a32cf4dd"
+down_revision = "4c80966d7217"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subscriptions",
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("subscriptions_organization_id_fkey"),
+        "subscriptions",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_subscriptions_organization_id"),
+            "subscriptions",
+            ["organization_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("subscriptions_organization_id_fkey"),
+        "subscriptions",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_subscriptions_organization_id"), table_name="subscriptions")
+    op.drop_column("subscriptions", "organization_id")

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -195,6 +195,17 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
     def customer(cls) -> Mapped["Customer"]:
         return relationship("Customer", lazy="raise")
 
+    organization_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("organizations.id", ondelete="restrict"),
+        nullable=True,
+        index=True,
+    )
+
+    organization: AssociationProxy["Organization"] = association_proxy(
+        "product", "organization"
+    )
+
     payment_method_id: Mapped[UUID | None] = mapped_column(
         Uuid,
         ForeignKey("payment_methods.id", ondelete="set null"),
@@ -251,10 +262,6 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         cascade="all, delete-orphan",
         # Eager load
         lazy="selectin",
-    )
-
-    organization: AssociationProxy["Organization"] = association_proxy(
-        "product", "organization"
     )
 
     checkout_id: Mapped[UUID | None] = mapped_column(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -474,6 +474,7 @@ class SubscriptionService:
             cancel_at_period_end=False,
             recurring_interval=recurring_interval,
             recurring_interval_count=recurring_interval_count,
+            organization_id=product.organization_id,
             product=product,
             customer=customer,
             subscription_product_prices=subscription_product_prices,
@@ -585,6 +586,7 @@ class SubscriptionService:
         subscription.recurring_interval_count = recurring_interval_count
         subscription.status = status
         subscription.payment_method = payment_method
+        subscription.organization_id = product.organization_id
         subscription.product = product
         subscription.subscription_product_prices = subscription_product_prices
         subscription.currency = currency

--- a/server/scripts/backfill_subscription_organization_id.py
+++ b/server/scripts/backfill_subscription_organization_id.py
@@ -1,0 +1,56 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import select, update
+
+from polar.models import Product, Subscription
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill_subscription_organization_id(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    await run_batched_update(
+        (
+            update(Subscription)
+            .values(
+                organization_id=select(Product.organization_id)
+                .where(Product.id == Subscription.product_id)
+                .correlate(Subscription)
+                .scalar_subquery()
+            )
+            .where(
+                Subscription.id.in_(
+                    select(Subscription.id)
+                    .where(Subscription.organization_id.is_(None))
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1143,6 +1143,7 @@ async def create_subscription(
         started_at=started_at,
         ended_at=ended_at,
         ends_at=ends_at,
+        organization_id=product.organization_id,
         customer=customer,
         product=product,
         payment_method=payment_method,


### PR DESCRIPTION
Same as [#11206](https://github.com/polarsource/polar/issues/11206) but for subscriptions.

Add a denormalized organization_id column to the subscriptions table to improve query performance when listing subscriptions by organization. This is Phase A of a two-phase rollout, mirroring the same change made to orders.

Phase A (this change):
- Migration adds the column as nullable (safe to run before new code deploys), with FK to organizations and a concurrently-created index
- Subscription creation paths (programmatic create + checkout) now set organization_id from the product's organization
- Backfill script (scripts/backfill_subscription_organization_id.py) populates existing rows from products.organization_id
- Existing queries are unchanged - they still resolve the organization via the product association proxy (to be updated in Phase B)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a denormalized `organization_id` column to subscriptions to speed up org-based listing. Phase A: write paths now set the column and a script backfills existing rows; reads remain unchanged.

- **Migration**
  - Adds nullable `organization_id` with FK to organizations and a concurrently built index; sets `lock_timeout` during the concurrent index build to avoid blocking.
  - Sets `organization_id` on subscription creation (programmatic and checkout) from the product’s organization.
  - Includes `scripts/backfill_subscription_organization_id.py` to populate existing rows.
  - No query changes yet; reads still use the product association. Phase B will switch reads to the new column.

<sup>Written for commit 908275bf2f53a30cd7405efa12e20325619fec33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions can be associated with organizations for organization-level tracking and management.

* **Chores**
  * Database schema updated to add organization linkage for subscriptions.
  * Backfill utility added to populate organization associations for existing subscriptions.
  * Subscription creation now ensures new subscriptions inherit the correct organization association.

* **Tests**
  * Test fixtures updated to include organization association when creating subscriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polarsource/polar/pull/12121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->