### PR TITLE
Prevent CodeRabbit from posting review status comments even when autoreview disabled

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,13 +9,11 @@ reviews:
   # Keep reviews advisory; CodeRabbit comments but does not block merges.
   request_changes_workflow: false
   high_level_summary: true
-  review_status: true
+  review_status: false
   collapse_walkthrough: true
   poem: false
   # Stop spending review cycles on PRs that get closed mid-review.
   abort_on_close: true
-
-  review_status: false
 
   auto_review:
     # Disabled: CodeRabbit no longer reviews PRs automatically.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,6 +15,8 @@ reviews:
   # Stop spending review cycles on PRs that get closed mid-review.
   abort_on_close: true
 
+  review_status: false
+
   auto_review:
     # Disabled: CodeRabbit no longer reviews PRs automatically.
     enabled: false


### PR DESCRIPTION
As per docs: https://docs.coderabbit.ai/reference/configuration#param-review-status


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable CodeRabbit review status comments when auto-review is off by setting `reviews.review_status: false` in `.coderabbit.yaml`, and fix a duplicate key in the config. This suppresses noisy status updates and ensures the config parses correctly.

<sup>Written for commit 1b94d6895b649025624d9109c12055c0fb1ebe4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



