### PR TITLE
Fix Startup Program discount proration

### DIFF
--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -305,13 +305,32 @@ class PolarSelfService:
             subscription = await client.uncancel_subscription(
                 subscription_id=subscription.id
             )
-        # Discounts are scoped to a specific product and never carry across
-        # a plan change. Clear it before switching the product so the API
-        # doesn't reject the update on incompatible-discount grounds.
-        if subscription.discount_id is not None:
+
+        # Apply the Startup Program's discount BEFORE switching the product, so
+        # the proration computed at product-switch reflects the discounted
+        # amount. The discount is no longer product-scoped, so the API accepts
+        # it on the current product and carries it through the switch. Only the
+        # Scale plan is eligible, so we only attach when switching to Scale.
+        # Mirror ``start_checkout``: without this a Pro/Growth -> Scale switch
+        # via the Change Plan page would skip the Startup Program discount even
+        # when the org is invited.
+        if product_id == settings.POLAR_SCALE_PRODUCT_ID:
+            discount_id = await startup_program_service.resolve_checkout_discount_id(
+                organization_id=organization_id, product_id=product_id
+            )
+            if discount_id is not None:
+                subscription = await client.update_subscription_discount(
+                    subscription_id=subscription.id, discount_id=discount_id
+                )
+        elif subscription.discount_id is not None:
+            # Switching away from Scale to a non-eligible plan: the Startup
+            # Program discount only applies to Scale. Since the discount is no
+            # longer product-scoped, it would otherwise carry onto the new plan,
+            # so clear it before the switch.
             subscription = await client.update_subscription_discount(
                 subscription_id=subscription.id, discount_id=None
             )
+
         target_amount = self._product_fixed_price_amount(target_product)
         proration = (
             SubscriptionProrationBehavior.INVOICE
@@ -323,19 +342,6 @@ class PolarSelfService:
             product_id=product_id,
             proration_behavior=proration,
         )
-
-        # Mirror ``start_checkout``: if the new product has a claimable
-        # discount for this org (e.g. the Startup Program's discount on
-        # Scale), attach it. Without this step a Pro/Growth -> Scale switch
-        # via the Change Plan page would skip the Startup Program discount
-        # even when the org is invited.
-        discount_id = await startup_program_service.resolve_checkout_discount_id(
-            organization_id=organization_id, product_id=product_id
-        )
-        if discount_id is not None:
-            subscription = await client.update_subscription_discount(
-                subscription_id=subscription.id, discount_id=discount_id
-            )
 
         return subscription
 
@@ -415,19 +421,26 @@ class PolarSelfService:
                 subscription_id=subscription.id
             )
 
-        if subscription.product_id != settings.POLAR_SCALE_PRODUCT_ID:
-            # Upgrade-to-Scale always invoices immediately; with a 100%
-            # discount the API computes a $0 prorated charge anyway.
+        needs_switch = subscription.product_id != settings.POLAR_SCALE_PRODUCT_ID
+
+        # Attach the discount BEFORE switching the product so the proration
+        # computed at the switch reflects the 100% discount (a $0 prorated
+        # charge). The discount is no longer product-scoped, so the API accepts
+        # it on the current product and carries it through the switch.
+        subscription = await client.update_subscription_discount(
+            subscription_id=subscription.id,
+            discount_id=discount_id,
+        )
+
+        if needs_switch:
+            # Upgrade-to-Scale always invoices immediately; with the discount
+            # already in place the API computes a $0 prorated charge.
             subscription = await client.update_subscription_product(
                 subscription_id=subscription.id,
                 product_id=settings.POLAR_SCALE_PRODUCT_ID,
                 proration_behavior=SubscriptionProrationBehavior.INVOICE,
             )
 
-        subscription = await client.update_subscription_discount(
-            subscription_id=subscription.id,
-            discount_id=discount_id,
-        )
         return (subscription, None)
 
     async def list_orders(

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -268,14 +268,6 @@ class PolarSelfService:
         existing = await client.get_active_subscription(
             external_customer_id=str(organization_id)
         )
-        # Discounts are scoped to a specific product. When switching the
-        # active subscription's product via a fresh checkout, the previous
-        # discount must be cleared first — otherwise the API rejects the
-        # checkout because the discount no longer applies.
-        if existing is not None and existing.discount_id is not None:
-            existing = await client.update_subscription_discount(
-                subscription_id=existing.id, discount_id=None
-            )
         # Auto-apply the Startup Program discount when an eligible organization
         # checks out the Scale plan.
         discount_id = await startup_program_service.resolve_checkout_discount_id(

--- a/server/polar/startup_program/service.py
+++ b/server/polar/startup_program/service.py
@@ -103,13 +103,22 @@ class StartupProgramService:
         # ``organization_id`` is intentionally omitted: ``POLAR_ACCESS_TOKEN``
         # is an organization-scoped token, and the API rejects any explicit
         # ``organization_id`` on the request when that's the case.
+        #
+        # ``products`` is intentionally omitted (no product constraint). A
+        # product-scoped discount can only be attached to a subscription once
+        # it's already on that product, which forces us to switch the product
+        # first and apply the discount after — so the proration computed at
+        # the switch misses the discount. Leaving the discount unscoped lets
+        # us attach it before the product change so proration is correct.
+        # Redemption is still bounded by ``max_redemptions`` and the discount
+        # is customer-specific via metadata.
         discount = await client.create_percentage_discount(
             name=self._discount_name(organization),
             basis_points=DISCOUNT_BASIS_POINTS,
             duration=DiscountDuration.REPEATING,
             duration_in_months=DISCOUNT_DURATION_IN_MONTHS,
             max_redemptions=DISCOUNT_MAX_REDEMPTIONS,
-            products=[settings.POLAR_SCALE_PRODUCT_ID],
+            products=None,
             metadata={
                 DISCOUNT_TAG_KEY: "true",
                 "customer_id": customer.id,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -1144,15 +1144,16 @@ class TestStartCheckout:
 
         client_mock.create_checkout.assert_not_awaited()
 
-    async def test_clears_existing_discount_before_checkout(
+    async def test_does_not_touch_existing_discount_on_checkout(
         self,
         configured: None,
         client_mock: MagicMock,
         organization_repository_mock: MagicMock,
         read_session_mock: AsyncReadSession,
     ) -> None:
-        """A new checkout that switches an existing subscription's product
-        must not carry the previous discount — clear it first."""
+        """Discounts are no longer product-scoped, so a checkout that switches
+        an existing subscription's product must NOT clear the previous
+        discount — the checkout handles its own discount via ``discount_id``."""
         client_mock.list_recurring_products.return_value = [
             _make_product(id="prod_paid", metadata={"order": 1}),
         ]
@@ -1168,10 +1169,7 @@ class TestStartCheckout:
             product_id="prod_paid",
         )
 
-        client_mock.update_subscription_discount.assert_awaited_once_with(
-            subscription_id="sub_existing",
-            discount_id=None,
-        )
+        client_mock.update_subscription_discount.assert_not_awaited()
         client_mock.create_checkout.assert_awaited_once()
 
     async def test_does_not_clear_when_no_existing_subscription(
@@ -1366,16 +1364,21 @@ class TestChangePlan:
 
         client_mock.update_subscription_product.assert_not_awaited()
 
-    async def test_clears_existing_discount_before_switching(
+    async def test_clears_existing_discount_when_leaving_scale(
         self,
         configured: None,
         client_mock: MagicMock,
         organization_repository_mock: MagicMock,
+        mocker: MockerFixture,
         read_session_mock: AsyncReadSession,
     ) -> None:
-        """Discounts are scoped to a product, so a plan change must clear
-        the existing discount first — otherwise the API rejects the update
-        on incompatible-discount grounds."""
+        """Discounts are no longer product-scoped, so switching away from Scale
+        to a non-eligible plan must clear the discount — otherwise the Startup
+        Program discount would leak onto the new plan."""
+        mocker.patch(
+            "polar.integrations.polar.service.settings.POLAR_SCALE_PRODUCT_ID",
+            "prod_scale",
+        )
         client_mock.list_recurring_products.return_value = [
             _make_product(id="prod_growth", metadata={"order": 2}, price_amount=10000),
         ]
@@ -1433,7 +1436,7 @@ class TestChangePlan:
 
         client_mock.update_subscription_discount.assert_not_awaited()
 
-    async def test_attaches_claimable_discount_after_product_switch(
+    async def test_attaches_claimable_discount_before_product_switch(
         self,
         configured: None,
         client_mock: MagicMock,
@@ -1442,13 +1445,18 @@ class TestChangePlan:
         read_session_mock: AsyncReadSession,
     ) -> None:
         """Pro -> Scale via Change Plan: if the org is invited to the
-        Startup Program, attach the discount after switching products.
+        Startup Program, attach the discount BEFORE switching products so the
+        proration computed at the switch reflects the discounted amount.
         Mirrors what ``start_checkout`` does for Free -> Scale."""
         client_mock.list_recurring_products.return_value = [
             _make_product(id="prod_scale", metadata={"order": 4}, price_amount=40000),
         ]
         client_mock.get_active_subscription.return_value = _make_subscription(
             id="sub_existing", product_id="prod_pro", amount=2000
+        )
+        mocker.patch(
+            "polar.integrations.polar.service.settings.POLAR_SCALE_PRODUCT_ID",
+            "prod_scale",
         )
         mocker.patch(
             "polar.integrations.polar.service.startup_program_service."
@@ -1462,14 +1470,21 @@ class TestChangePlan:
             product_id="prod_scale",
         )
 
-        client_mock.update_subscription_product.assert_awaited_once()
-        # The resolver gates on target product == Scale; the discount is
-        # attached to the post-switch subscription returned by
-        # update_subscription_product (default id "sub_2" from the mock).
+        # The discount is attached to the current subscription ("sub_existing")
+        # before the product switch.
         client_mock.update_subscription_discount.assert_awaited_once_with(
-            subscription_id="sub_2",
+            subscription_id="sub_existing",
             discount_id="disc_startup",
         )
+        client_mock.update_subscription_product.assert_awaited_once()
+        # The discount must be applied before the product update. ``mock_calls``
+        # captures the global call order across all mock attributes.
+        method_call_order = [
+            call[0] for call in client_mock.mock_calls if "()" not in call[0]
+        ]
+        discount_index = method_call_order.index("update_subscription_discount")
+        update_index = method_call_order.index("update_subscription_product")
+        assert discount_index < update_index
 
     async def test_does_not_attach_when_no_claimable_discount(
         self,
@@ -1598,7 +1613,7 @@ class TestClaimStartupProgram:
         client_mock.update_subscription_product.assert_not_awaited()
         client_mock.update_subscription_discount.assert_not_awaited()
 
-    async def test_switches_product_then_applies_discount(
+    async def test_applies_discount_then_switches_product(
         self,
         configured: None,
         client_mock: MagicMock,
@@ -1606,9 +1621,9 @@ class TestClaimStartupProgram:
         mocker: MockerFixture,
         read_session_mock: AsyncReadSession,
     ) -> None:
-        """Org on Growth → switches product to Scale, then applies the
-        Startup Program discount. Both calls happen via PATCH; no
-        ``create_checkout``."""
+        """Org on Growth → applies the Startup Program discount, THEN switches
+        product to Scale so the proration at the switch reflects the discount.
+        Both calls happen via PATCH; no ``create_checkout``."""
         mocker.patch(
             "polar.integrations.polar.service.settings.STARTUP_PROGRAM_ENABLED",
             True,
@@ -1632,15 +1647,23 @@ class TestClaimStartupProgram:
 
         assert subscription is not None
         assert checkout is None
+        # Discount is attached to the current subscription before the switch.
+        client_mock.update_subscription_discount.assert_awaited_once_with(
+            subscription_id="sub_existing",
+            discount_id="disc_startup",
+        )
         client_mock.update_subscription_product.assert_awaited_once_with(
             subscription_id="sub_existing",
             product_id="prod_scale",
             proration_behavior=SubscriptionProrationBehavior.INVOICE,
         )
-        client_mock.update_subscription_discount.assert_awaited_once_with(
-            subscription_id="sub_2",  # default id returned by update_subscription_product mock
-            discount_id="disc_startup",
-        )
+        # The discount must be applied before the product update.
+        method_call_order = [
+            call[0] for call in client_mock.mock_calls if "()" not in call[0]
+        ]
+        discount_index = method_call_order.index("update_subscription_discount")
+        update_index = method_call_order.index("update_subscription_product")
+        assert discount_index < update_index
         client_mock.create_checkout.assert_not_awaited()
 
     async def test_only_applies_discount_when_already_on_scale(

--- a/server/tests/startup_program/test_service.py
+++ b/server/tests/startup_program/test_service.py
@@ -123,7 +123,10 @@ class TestMarkInvited:
         assert create_kwargs["basis_points"] == DISCOUNT_BASIS_POINTS
         assert create_kwargs["duration_in_months"] == DISCOUNT_DURATION_IN_MONTHS
         assert create_kwargs["max_redemptions"] == DISCOUNT_MAX_REDEMPTIONS
-        assert create_kwargs["products"] == [SCALE_PRODUCT_ID]
+        # No product constraint: the discount must be attachable to a
+        # subscription before its product is switched to Scale, so proration
+        # at the switch reflects the discount.
+        assert create_kwargs["products"] is None
         # POLAR_ACCESS_TOKEN is organization-scoped, so the API rejects any
         # explicit organization_id on the request.
         assert "organization_id" not in create_kwargs


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Startup Program discount unscoped and apply it before product switches so prorations are correct. Stop clearing discounts during checkout; clear only when leaving Scale.

- **Bug Fixes**
  - Removed product constraint when creating the Startup Program discount; it can now be attached before a plan change to ensure prorations reflect the discount.
  - Checkout no longer clears existing subscription discounts; the flow uses its own `discount_id`.
  - Change Plan: when switching to Scale, attach the Startup discount before switching products; when switching away from Scale, clear the discount so it doesn’t carry over.
  - Claim Startup Program: attach the discount first, then switch to Scale, yielding a $0 proration on upgrade.
  - Tests updated to assert the new order of operations and discount scoping.

<sup>Written for commit faa561dfb8f3cef972c1d63a6dd22b473ae3b242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

