### PR TITLE
Make order finalize request body optional

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -36738,7 +36738,7 @@ export interface operations {
       }
       cookie?: never
     }
-    requestBody: {
+    requestBody?: {
       content: {
         'application/json': components['schemas']['OrderFinalize']
       }

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -280,8 +280,8 @@ async def update(
     },
 )
 async def finalize(
-    finalize_payload: OrderFinalize,
     authorized: auth.OrderSalesManage,
+    finalize_payload: OrderFinalize = OrderFinalize(),
     session: AsyncSession = Depends(get_db_session),
 ) -> Order:
     """

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -587,6 +587,16 @@ class TestFinalizeOrderEndpoint:
         assert response.status_code == 404
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_empty_body_allowed(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        # The payload is optional: sending no body at all must not 422.
+        response = await client.post(f"/v1/orders/{uuid.uuid4()}/finalize")
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
     async def test_412_when_not_draft(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

`POST /v1/orders/{id}/finalize` rejected requests with no body, requiring callers to send at least an empty object `{}`. Since every field on the `OrderFinalize` payload is optional, an entirely empty body should be accepted (and is the expected common case). This PR makes the body optional.

## What

- `server/polar/order/endpoints.py`: give the `finalize_payload` parameter a default (`OrderFinalize()`) and move it after the no-default `authorized` dependency to satisfy Python argument ordering. FastAPI now marks the request body as not required.
- `server/tests/order/test_endpoints.py`: add `test_empty_body_allowed`, which `POST`s with no body and asserts it does not 422.

## Why

The mandatory body was a needless friction point: finalize only ever needs an optional `payment_method_id`, which falls back to the customer's default payment method when unset. Requiring `{}` to invoke a no-argument-by-default operation is surprising for API consumers.

## How

A Pydantic body parameter becomes optional in FastAPI as soon as it has a default value. The default instance is only ever read (never mutated), so sharing a single `OrderFinalize()` across requests is safe. Requests with no body, an empty body, or `{}` now all succeed, and `payment_method_id` still works when provided.

This only relaxes the contract (a previously-required body becomes optional), so it is backward compatible — existing callers sending `{}` keep working.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `POST /v1/orders/{id}/finalize` accept requests with no body, and update the generated TypeScript client to reflect the optional body. This keeps `payment_method_id` working when provided and remains backward compatible.

- **Bug Fixes**
  - Defaulted `finalize_payload: OrderFinalize = OrderFinalize()` and moved it after `authorized` so `FastAPI` marks the body optional.
  - Regenerated `clients/packages/client` OpenAPI client: `requestBody` for finalize is optional in `v1.ts`.
  - Added a test to confirm an empty body doesn’t 422 (unknown IDs still return 404).

<sup>Written for commit b9e87a69846e7358fccc8e547e5913ccb8cf5300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

