### PR TITLE
tf/vercel: Omit null values

### DIFF
--- a/terraform/modules/vercel/main.tf
+++ b/terraform/modules/vercel/main.tf
@@ -61,7 +61,7 @@ locals {
     { key = "POLAR_PREVIEW_ACCESS_TOKEN", value = var.secrets.polar_preview_access_token, target = ["preview"] },
   ]
 
-  environment_variables = concat(
+  managed_environment_variables = concat(
     [for env in local.shared_environment_variables : {
       key       = env.key
       value     = env.value
@@ -87,6 +87,9 @@ locals {
       sensitive = env.sensitive
     }],
   )
+
+  # A null value omits the env var (a typed config key can be left unset).
+  environment_variables = [for env in local.managed_environment_variables : env if env.value != null]
 }
 
 resource "vercel_project_environment_variables" "this" {

--- a/terraform/modules/vercel/main.tf
+++ b/terraform/modules/vercel/main.tf
@@ -2,7 +2,7 @@
 #
 # One Vercel project per environment (production, sandbox), its custom domains
 # and its environment variables. Env vars are managed via the dedicated
-# vercel_project_environment_variables resource, so the project's inline
+# vercel_project_environment_variable resources, so the project's inline
 # `environment` is intentionally left unmanaged (see lifecycle below).
 
 resource "vercel_project" "this" {
@@ -27,7 +27,7 @@ resource "vercel_project" "this" {
   }
 
   lifecycle {
-    # Environment variables are owned by vercel_project_environment_variables.
+    # Environment variables are owned by vercel_project_environment_variable resources.
     ignore_changes = [environment]
   }
 }
@@ -58,13 +58,13 @@ locals {
     { key = "ENABLE_EXPERIMENTAL_COREPACK", value = var.config.enable_experimental_corepack },
   ]
 
-  # Secrets present in every environment; targets baked per key.
+  # Secrets present in every environment.
   secret_environment_variables = [
-    { key = "PYDANTIC_AI_GATEWAY_API_KEY", value = var.secrets.pydantic_ai_gateway_api_key, target = ["production", "preview"] },
-    { key = "MINTLIFY_ASSISTANT_API_KEY", value = var.secrets.mintlify_assistant_api_key, target = ["production", "preview"] },
-    { key = "GRAM_API_KEY", value = var.secrets.gram_api_key, target = ["production", "preview"] },
-    { key = "SENTRY_AUTH_TOKEN", value = var.secrets.sentry_auth_token, target = ["production", "preview"] },
-    { key = "POLAR_PREVIEW_ACCESS_TOKEN", value = var.secrets.polar_preview_access_token, target = ["preview"] },
+    { key = "PYDANTIC_AI_GATEWAY_API_KEY", value = var.secrets.pydantic_ai_gateway_api_key, target = ["production", "preview"], sensitive = true },
+    { key = "MINTLIFY_ASSISTANT_API_KEY", value = var.secrets.mintlify_assistant_api_key, target = ["production", "preview"], sensitive = true },
+    { key = "GRAM_API_KEY", value = var.secrets.gram_api_key, target = ["production", "preview"], sensitive = false },
+    { key = "SENTRY_AUTH_TOKEN", value = var.secrets.sentry_auth_token, target = ["production", "preview"], sensitive = false },
+    { key = "POLAR_PREVIEW_ACCESS_TOKEN", value = var.secrets.polar_preview_access_token, target = ["preview"], sensitive = true },
   ]
 
   managed_environment_variables = concat(
@@ -84,7 +84,7 @@ locals {
       key       = env.key
       value     = env.value
       target    = toset(env.target)
-      sensitive = true
+      sensitive = env.sensitive
     }],
     [for env in var.environment_variables : {
       key       = env.key
@@ -94,13 +94,17 @@ locals {
     }],
   )
 
-  # A null value omits the env var (a typed config key can be left unset).
   environment_variables = [for env in local.managed_environment_variables : env if env.value != null]
 }
 
-resource "vercel_project_environment_variables" "this" {
+resource "vercel_project_environment_variable" "this" {
+  count = length(local.environment_variables)
+
   project_id = vercel_project.this.id
-  variables  = local.environment_variables
+  key        = local.environment_variables[count.index].key
+  value      = local.environment_variables[count.index].value
+  target     = local.environment_variables[count.index].target
+  sensitive  = local.environment_variables[count.index].sensitive
 }
 
 resource "vercel_project_domain" "this" {

--- a/terraform/modules/vercel/main.tf
+++ b/terraform/modules/vercel/main.tf
@@ -14,6 +14,12 @@ resource "vercel_project" "this" {
   install_command = var.install_command
   ignore_command  = var.ignore_command
 
+  build_machine_type         = var.build_machine_type
+  resource_config            = var.resource_config
+  enable_preview_feedback    = var.enable_preview_feedback
+  enable_production_feedback = var.enable_production_feedback
+  git_provider_options       = var.git_provider_options
+
   git_repository = {
     type              = "github"
     repo              = var.git_repo

--- a/terraform/modules/vercel/outputs.tf
+++ b/terraform/modules/vercel/outputs.tf
@@ -12,3 +12,6 @@ output "domains" {
   description = "Custom domains attached to the project"
   value       = [for domain in vercel_project_domain.this : domain.domain]
 }
+
+
+

--- a/terraform/modules/vercel/variables.tf
+++ b/terraform/modules/vercel/variables.tf
@@ -40,9 +40,9 @@ variable "install_command" {
 }
 
 variable "ignore_command" {
-  description = "Command that decides whether to skip a build. Leave null to always build."
+  description = "Command that decides whether to skip a build (empty = always build)."
   type        = string
-  default     = null
+  default     = ""
 }
 
 # Project settings (defaults track the live values; override per env if they differ)

--- a/terraform/modules/vercel/variables.tf
+++ b/terraform/modules/vercel/variables.tf
@@ -45,6 +45,51 @@ variable "ignore_command" {
   default     = null
 }
 
+# Project settings (defaults track the live values; override per env if they differ)
+variable "build_machine_type" {
+  description = "Vercel build machine type"
+  type        = string
+  default     = "elastic"
+}
+
+variable "resource_config" {
+  description = "Vercel project resource configuration"
+  type = object({
+    fluid                     = optional(bool, true)
+    function_default_cpu_type = optional(string)
+    function_default_regions  = optional(set(string), ["iad1"])
+    function_default_timeout  = optional(number)
+  })
+  default = {}
+}
+
+variable "enable_preview_feedback" {
+  description = "Enable the Vercel Toolbar on preview deployments"
+  type        = bool
+  default     = null
+}
+
+variable "enable_production_feedback" {
+  description = "Enable the Vercel Toolbar on production deployments"
+  type        = bool
+  default     = null
+}
+
+variable "git_provider_options" {
+  description = "Vercel project Git provider options"
+  type = object({
+    create_deployments         = optional(bool)
+    git_commit_status          = optional(bool)
+    repository_dispatch_events = optional(bool)
+    require_verified_commits   = optional(bool)
+    consolidated_git_commit_status = optional(object({
+      enabled            = optional(bool)
+      propagate_failures = optional(bool)
+    }))
+  })
+  default = null
+}
+
 # Custom domains attached to the project
 variable "domains" {
   description = "Custom domains served by the project"

--- a/terraform/production/vercel.tf
+++ b/terraform/production/vercel.tf
@@ -46,6 +46,11 @@ module "vercel" {
   name     = "polar"
   git_repo = "polarsource/polar"
 
+  # Production runs functions in cle1 (sandbox uses the module default, iad1).
+  resource_config = {
+    function_default_regions = ["cle1"]
+  }
+
   domains = [
     { name = "polar.sh" },
     { name = "www.polar.sh", redirect = "polar.sh", redirect_status_code = 308 },

--- a/terraform/production/vercel.tf
+++ b/terraform/production/vercel.tf
@@ -90,7 +90,7 @@ module "vercel" {
     { key = "NEXT_PUBLIC_SENTRY_ENABLED", value = "true" },
     { key = "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID", value = "G-MBYW1QZFHE" },
     { key = "NEXT_PUBLIC_GITHUB_INSTALLATION_URL", value = "https://github.com/apps/polar-sh/installations/new" },
-    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, sensitive = true },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key },
     { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview"], sensitive = true },
     { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview"], sensitive = true },
     { key = "ATTIO_API_KEY", value = var.attio_api_key, target = ["production", "preview"], sensitive = true },

--- a/terraform/production/vercel.tf
+++ b/terraform/production/vercel.tf
@@ -2,7 +2,7 @@
 # Vercel — Production frontend (polar.sh)
 # =============================================================================
 #
-# vercel_project_environment_variables manages only the keys declared below;
+# Terraform manages only the env vars declared below;
 # other env vars on the live project are left untouched.
 
 import {
@@ -90,15 +90,182 @@ module "vercel" {
   environment_variables = [
     { key = "NEXT_PUBLIC_FRONTEND_BASE_URL", value = "https://polar.sh", target = ["production"] },
     { key = "NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL", value = "https://sandbox.polar.sh" },
-    { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "", target = ["production"] },
+    { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "https://buy.polar.sh/", target = ["production"] },
     { key = "NEXT_PUBLIC_POSTHOG_HOST", value = "https://polar.sh/ingest" },
     { key = "NEXT_PUBLIC_SENTRY_ENABLED", value = "true" },
     { key = "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID", value = "G-MBYW1QZFHE" },
     { key = "NEXT_PUBLIC_GITHUB_INSTALLATION_URL", value = "https://github.com/apps/polar-sh/installations/new" },
     { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key },
-    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview"], sensitive = true },
-    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview"], sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview"] },
+    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview"] },
     { key = "ATTIO_API_KEY", value = var.attio_api_key, target = ["production", "preview"], sensitive = true },
     { key = "ATTIO_STARTUP_LIST_ID", value = var.attio_startup_list_id, target = ["production", "preview"], sensitive = true },
   ]
+}
+
+# --- Environment variable imports (adopt existing live vars) ---
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[0]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/4fa4BxjEIMLAzdAB"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[1]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/RAkt1FIv0NmFl3tV"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[2]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/C6AC2gG7GQeVlEBK"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[3]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/rSctw1DqAONjbFcp"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[4]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/Q8qmYYtiDxZ0XeFu"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[5]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/fMQsWonzffWywYou"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[6]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/9aMlLbvnxFONTZjQ"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[7]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/Fi0d7hBf3MgqV5f5"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[8]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/T78XUk6k1RxsVAgp"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[9]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/XdIaiZQuQITJfMvm"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[10]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/VdgyFQpcfsJ11VyO"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[11]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/gdG9LSJCBNIoAJQL"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[12]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/fDeTkyRntb0qTDlr"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[13]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/xrtpOhmYjci2Yywf"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[14]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/hHa1TNpephFGUWdk"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[15]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/3aJkKDlgmlIBvc2u"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[16]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/zKj3hvAneqD0QWJ3"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[17]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/vlRUnZhfuUitZdqX"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[18]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/U7awREzqtaL0WXP4"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[19]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/LVoLuF0txPBChAfT"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[20]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/6EwGF0i9P2PV4Fgv"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[21]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/zDrfJwGSuOqLSIxW"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[22]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/CpBwceFCfbsOZb0g"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[23]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/S77KmCrcYXOBecOA"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[24]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/X77SHKqLaZgGeHYe"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[25]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/UisYIh5lqPYpbxou"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[26]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/SOQHMFDvQttmegNI"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[27]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/r5lc9GtOAiiZyKMP"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[28]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/vpC4Vhp3JYeIermm"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[29]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/LzwwhyHXXTYcPN9w"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[30]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/5xVCEd1JYmQeyVCA"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[31]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/6E07M1Zs6ZallJFb"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[32]
+  id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/cOVlRr8hf2lAd94n"
 }

--- a/terraform/sandbox/vercel.tf
+++ b/terraform/sandbox/vercel.tf
@@ -56,8 +56,160 @@ module "vercel" {
     { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "https://sandbox.polar.sh/api/checkout?price=" },
     { key = "POLAR_PREVIEW_BACKEND_HOST", value = "", target = ["preview"] },
     { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, target = ["production", "development"] },
-    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key_preview, target = ["preview"] },
-    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview"], sensitive = true },
-    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview"], sensitive = true },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key_preview, target = ["preview"], sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview", "development"] },
+    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview", "development"] },
   ]
+}
+
+# --- Environment variable imports (adopt existing live vars) ---
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[0]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/w1NY4uqMF9RRJEQ4"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[1]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/28dvcKhgCADC0p13"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[2]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/4dyzp0AbpAz6c9K3"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[3]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/IdczbgDwiRTC2v6f"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[4]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/5mCAPYOHrZNEsXty"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[5]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/FySW8EWdhQzpyzKA"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[6]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/QAYtBfaZlKB4pTin"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[7]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/L4qbynrJFIyufUiH"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[8]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/bytc5jFrDw9ssXxt"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[9]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/VobDmxSUtP7adFLt"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[10]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/X3X8orv1KleBBo0r"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[11]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/vJhzDLNxPKJsd2Wp"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[12]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/iTAa5iIkwA9YODNZ"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[13]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/dbGdko2sXT89XX5Z"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[14]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/OBCQHn3zEiJO3IAs"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[15]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/EgQjfzlTK2qIKGHB"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[16]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/97nfHHz8Yp3jyhDP"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[17]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/lXOEP3o9Ba2vywVe"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[18]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/226bArwHf6cBkwQL"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[19]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/G8Hea1UtAUeyc7Op"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[20]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/GGmDCMw1PtlON5aO"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[21]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/AsZo1f5xvFesGTii"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[22]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/Y1MhbDdlM5AGmqQA"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[23]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/EC3UsI3H59QtadgB"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[24]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/TNVIdwsxp2x4uY0y"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[25]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/H3gjIuSxXosjhMAM"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[26]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/5EOd7Pn9ATsN2xg0"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[27]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/YxzqIpIRgF8vwtd2"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[28]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/2zLQorUoqHKTSpF9"
+}
+
+import {
+  to = module.vercel.vercel_project_environment_variable.this[29]
+  id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/pKASdBbGCc9aMPFW"
 }

--- a/terraform/sandbox/vercel.tf
+++ b/terraform/sandbox/vercel.tf
@@ -55,9 +55,9 @@ module "vercel" {
     { key = "POLAR_AUTH_COOKIE_KEY", value = "polar_sandbox_session" },
     { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "https://sandbox.polar.sh/api/checkout?price=" },
     { key = "POLAR_PREVIEW_BACKEND_HOST", value = "", target = ["preview"] },
-    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, target = ["production", "development"], sensitive = true },
-    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key_preview, target = ["preview"], sensitive = true },
-    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, sensitive = true },
-    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, sensitive = true },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, target = ["production", "development"] },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key_preview, target = ["preview"] },
+    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview"], sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview"], sensitive = true },
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch Terraform Vercel env vars to one `vercel_project_environment_variable` per key, import the live prod/sandbox vars so apply is a no‑op, and drop null values (empty `ignore_command` = always build).
Map project settings and align env var sensitivity/targets to live: build machine, resource config (prod functions `cle1`, sandbox `iad1`), preview/production feedback, Git options; make `NEXT_PUBLIC_STRIPE_KEY` non‑sensitive in prod/dev (preview sensitive), `GRAM_API_KEY`/`SENTRY_AUTH_TOKEN` non‑sensitive, and set prod `NEXT_PUBLIC_PRODUCT_LINK_BASE_URL` to `https://buy.polar.sh/`.

<sup>Written for commit 8f74867b1f94ff7445ada301051ce8d19a876ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

