### PR TITLE
docs: clarify payouts are held, not paused, during review

### DIFF
--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -134,6 +134,6 @@ Polar meets all of these criteria and therefore issues 1099-K forms to eligible 
     For individual accounts, yes. For business accounts, you will need a business bank account.
   </Accordion>
   <Accordion title="Why does my payout say 'Held'?">
-    You can always request a payout. We review accounts continuously, so a request made during one shows as "Held" for a few days, then pays out automatically. See [Account Reviews](/merchant-of-record/account-reviews) for details.
+    You can request a payout at any time. [Account Reviews](/merchant-of-record/account-reviews) are a normal part of how we operate, so if your account happens to be under review when you request one, the payout shows as "Held" until you are reviewed, then is paid out automatically.
   </Accordion>
 </AccordionGroup>

--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -133,7 +133,7 @@ Polar meets all of these criteria and therefore issues 1099-K forms to eligible 
   <Accordion title="Can I use my personal bank account to receive payouts?">
     For individual accounts, yes. For business accounts, you will need a business bank account.
   </Accordion>
-  <Accordion title="I'm currently not allowed to withdraw a payout. What should I do?">
-    Payouts are temporarily paused while your account is being reviewed. This is part of our standard risk management process — see [Account Reviews](/merchant-of-record/account-reviews) for details on how reviews work and what to expect. You'll be able to withdraw again as soon as the review is resolved.
+  <Accordion title="Why does my payout say 'Held'?">
+    You can always request a payout. We review accounts continuously, so a request made during one shows as "Held" for a few days, then pays out automatically. See [Account Reviews](/merchant-of-record/account-reviews) for details.
   </Accordion>
 </AccordionGroup>

--- a/docs/merchant-of-record/account-reviews.mdx
+++ b/docs/merchant-of-record/account-reviews.mdx
@@ -20,7 +20,7 @@ Initial reviews can take **up to 14 days** to complete, depending on volume, wee
 
 We continuously monitor all transactions across our platform to proactively prevent fraud, and we run asynchronous reviews of accounts at certain sales thresholds. Most of these reviews don't require any additional information from you.
 
-You can always request a [payout](/features/finance/payouts). A request made during a review shows as "Held" for a few days, then pays out automatically. Your customers are unaffected: new purchases keep going through, and existing subscriptions renew as usual.
+You can always request a [payout](/features/finance/payouts). A request made while your organization is under review shows as "Held" until approval, then is paid out automatically. Your customers are unaffected: new purchases keep going through, and existing subscriptions renew as usual.
 
 In a continuous review, we look at two things: that your use case is still within our [Acceptable Use Policy](/merchant-of-record/acceptable-use) and consistent with what was approved during your first review, and that your account is in good financial health — refunds, chargebacks, and risk scores across recent transactions.
 

--- a/docs/merchant-of-record/account-reviews.mdx
+++ b/docs/merchant-of-record/account-reviews.mdx
@@ -20,7 +20,7 @@ Initial reviews can take **up to 14 days** to complete, depending on volume, wee
 
 We continuously monitor all transactions across our platform to proactively prevent fraud, and we run asynchronous reviews of accounts at certain sales thresholds. Most of these reviews don't require any additional information from you.
 
-While a review is in progress, [payouts](/features/finance/payouts) are temporarily paused — so you may notice that you can't withdraw your balance until the review is resolved. Your customers are unaffected: new purchases keep going through, and existing subscriptions renew as usual.
+You can always request a [payout](/features/finance/payouts). A request made during a review shows as "Held" for a few days, then pays out automatically. Your customers are unaffected: new purchases keep going through, and existing subscriptions renew as usual.
 
 In a continuous review, we look at two things: that your use case is still within our [Acceptable Use Policy](/merchant-of-record/acceptable-use) and consistent with what was approved during your first review, and that your account is in good financial health — refunds, chargebacks, and risk scores across recent transactions.
 


### PR DESCRIPTION
## Summary

Payouts are no longer paused during account review. Merchants can request a payout anytime; one made during a review shows as "Held" for a few days, then pays out automatically. This updates the public docs to match (Phase 5 of the payout-reviews RFC).

## What

- `docs/features/finance/payouts.mdx`: FAQ rewritten around the "Held" status instead of "paused".
- `docs/merchant-of-record/account-reviews.mdx`: continuous-review copy updated.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included