### PR TITLE
fix(transactions): gate /transactions/summary behind finance:read

### DIFF
--- a/server/polar/account/service.py
+++ b/server/polar/account/service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm.strategy_options import joinedload
 
 from polar.account.repository import AccountRepository
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.config import settings
 from polar.exceptions import PolarError
@@ -25,8 +26,12 @@ class AccountService:
         session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         id: uuid.UUID,
+        *,
+        permission: OrganizationPermission | None = None,
     ) -> Account | None:
-        org_ids = await get_accessible_org_ids(session, auth_subject)
+        org_ids = await get_accessible_org_ids(
+            session, auth_subject, permission=permission
+        )
         repository = AccountRepository.from_session(session)
         statement = (
             repository.get_statement_by_org_ids(org_ids)

--- a/server/polar/transaction/endpoints.py
+++ b/server/polar/transaction/endpoints.py
@@ -4,6 +4,7 @@ from fastapi import Depends, Query
 from pydantic import UUID4
 
 from polar.account.service import account as account_service
+from polar.auth.permission import OrganizationPermission
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.sorting import Sorting, SortingGetter
@@ -67,7 +68,12 @@ async def get_summary(
     account_id: UUID4,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> TransactionsSummary:
-    account = await account_service.get(session, auth_subject, account_id)
+    account = await account_service.get(
+        session,
+        auth_subject,
+        account_id,
+        permission=OrganizationPermission.finance_read,
+    )
     if account is None:
         raise ResourceNotFound()
 

--- a/server/tests/transaction/test_endpoints.py
+++ b/server/tests/transaction/test_endpoints.py
@@ -4,6 +4,9 @@ import pytest
 from httpx import AsyncClient
 
 from polar.models import Account, Transaction, UserOrganization
+from polar.models.user_organization import OrganizationRole
+from tests.fixtures.auth import AuthSubjectFixture
+from tests.fixtures.database import SaveFixture
 
 
 @pytest.mark.asyncio
@@ -43,6 +46,26 @@ class TestGetSummary:
     async def test_not_existing_account(self, client: AsyncClient) -> None:
         response = await client.get(
             "/v1/transactions/summary", params={"account_id": str(uuid.uuid4())}
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
+    async def test_member_without_finance_read(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        account: Account,
+        user_organization_second: UserOrganization,
+        account_transactions: list[Transaction],
+    ) -> None:
+        # A regular member (no `finance:read` permission) must not be able to
+        # access the financial summary of the org's account.
+        user_organization_second.role = OrganizationRole.member
+        await save_fixture(user_organization_second)
+
+        response = await client.get(
+            "/v1/transactions/summary", params={"account_id": str(account.id)}
         )
 
         assert response.status_code == 404


### PR DESCRIPTION
## Summary

**Related Issue**: #12028

Fixes an authorization flaw where a regular organization member could access an org's aggregate financial summary (balance, available balance, payouts) via `/v1/transactions/summary`, bypassing the `finance:read` permission that gates every other finance endpoint.

## What

- `polar/account/service.py` — `AccountService.get` gains an optional keyword-only `permission: OrganizationPermission | None = None`, forwarded to `get_accessible_org_ids`. Default `None` preserves existing behavior.
- `polar/transaction/endpoints.py` — `get_summary` now passes `permission=OrganizationPermission.finance_read` when resolving the account.
- `tests/transaction/test_endpoints.py` — added `test_member_without_finance_read` regression test.

## Why

`/transactions/summary` resolved the account through `account_service.get(...)`, which only checked org **membership** (no permission filter). The `transactions:read` OAuth scope is not a meaningful gate for web dashboard sessions (legacy sessions are upgraded to all scopes), so any member — including the `member` role — received `200 OK` with sensitive balance/payout data. This endpoint was the outlier among finance endpoints, which enforce `finance:read` (e.g. `/accounts/{id}`).

This was introduced when the endpoint was migrated to the repository approach, which dropped the original explicit authorization check. A later commit (`32aa91a81`) wired `finance:read` into the transaction and payout modules but missed `/transactions/summary` because it follows a different code path.

## How

Rather than adding new machinery, the fix reuses the permission filter that `get_accessible_org_ids` already supports (the same mechanism `32aa91a81` used for the payout module): thread an optional permission kwarg through `AccountService.get` and have the summary endpoint request `finance_read`.

A member without `finance:read` now receives **404** (the account is filtered out of their accessible set), consistent with how `/transactions/search` filters members down to zero results rather than returning 403. This also avoids leaking the account's existence.

Verified: the new test fails without the fix (returns 200 — the vulnerability) and passes with it; all 6 tests in the file pass; `mypy` and `ruff` are clean.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `/v1/transactions/summary` behind `finance:read` so regular org members can’t view account balances or payout aggregates. Aligns authorization with other finance endpoints. Fixes #12028.

- **Bug Fixes**
  - Added optional `permission` to `AccountService.get(..., *, permission=None)` and passed it to `get_accessible_org_ids`.
  - `GET /v1/transactions/summary` now requests `OrganizationPermission.finance_read` when resolving the account.
  - Members without `finance:read` now get 404 (no account leakage), matching `/transactions/search`.
  - Added regression test `test_member_without_finance_read`.

<sup>Written for commit 2a933934332b28c2971ed8477fc593386393c12a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

