### PR TITLE
feat: surface held payouts in the backoffice review queue

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -86,6 +86,7 @@ from polar.organization_review.schemas import (
     ReviewContext,
     ReviewVerdict,
 )
+from polar.payout.repository import PayoutRepository
 from polar.payout_account.service import payout_account as payout_account_service
 from polar.postgres import AsyncSession, get_db_session
 from polar.startup_program.service import (
@@ -265,6 +266,11 @@ async def _build_review_signals(
         ar.organization_id: ar for ar in result.scalars()
     }
 
+    payout_repository = PayoutRepository.from_session(session)
+    held_counts = await payout_repository.get_held_counts_by_accounts(
+        [o.account_id for o in orgs]
+    )
+
     signals: dict[uuid.UUID, Signals] = {}
     for org in orgs:
         metrics = None
@@ -282,7 +288,10 @@ async def _build_review_signals(
                 metrics = report.data_snapshot.metrics
                 risk_score = report.report.overall_risk_score
         signals[org.id] = review_priority.compute(
-            org, metrics=metrics, risk_score=risk_score
+            org,
+            metrics=metrics,
+            risk_score=risk_score,
+            held_payout_count=held_counts.get(org.account_id, 0),
         )
     return signals
 
@@ -1736,7 +1745,11 @@ async def under_review_dialog(
                     with tag.li():
                         text("Change the organization status to Ongoing Review")
                     with tag.li():
-                        text("Block payouts while the organization is under review")
+                        text(
+                            "Hold any payout requests for review instead of paying "
+                            "them out immediately. Held payouts are released "
+                            "automatically once the organization is approved."
+                        )
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
                 with tag.form(method="dialog"):

--- a/server/polar/backoffice/organizations_v2/priority.py
+++ b/server/polar/backoffice/organizations_v2/priority.py
@@ -1,12 +1,8 @@
 """Composite priority score for the Review queue.
 
-Sum of four components. Risk, payment health, and fast-mover are each
-capped at 25 — they're "tie-breaker" signals on top of the queue's main
-sort, which is age in status. Aging is uncapped at 25 (50pts max) so
-orgs sitting in the queue past ~10 days naturally outrank fresh orgs
-that lack other signals — but a fresh dispute-heavy merchant can still
-surface if its other signals stack up. ``compute`` is pure over
-primitives — fetching and JSONB parsing live in the caller.
+Additive signals layered on the queue's main sort (age in status); each
+constant below documents its own component. ``compute`` is pure over
+primitives, so fetching and JSONB parsing stay in the caller.
 """
 
 from __future__ import annotations
@@ -24,7 +20,7 @@ from polar.organization_review.schemas import PaymentMetrics
 AGING_DAILY_PTS = 2.5
 AGING_MAX_PTS = 50.0
 
-# Other components share this cap; the sum stays meaningful at [0, 125].
+# Per-component cap shared by the risk, payment, and fast-mover signals.
 SIGNAL_CAP = 25.0
 
 # Risk: AI overall_risk_score is 0..100 (LOW=15, MEDIUM=50, HIGH=85).
@@ -43,6 +39,10 @@ NEW_ORG_DAYS = 30
 FAST_MOVER_MIN_REVENUE_CENTS = 100_000  # $1,000
 FAST_MOVER_MIN_PAYMENTS = 25
 
+# A held payout means a merchant is waiting on their money, so bump the org up.
+# A flat boost for having any held payout, regardless of how many.
+HELD_PAYOUT_PTS = 25.0
+
 
 @dataclass
 class Signals:
@@ -50,10 +50,17 @@ class Signals:
     risk_pts: float = 0.0
     payment_pts: float = 0.0
     fast_mover_pts: float = 0.0
+    held_payout_pts: float = 0.0
 
     @property
     def priority(self) -> float:
-        return self.aging_pts + self.risk_pts + self.payment_pts + self.fast_mover_pts
+        return (
+            self.aging_pts
+            + self.risk_pts
+            + self.payment_pts
+            + self.fast_mover_pts
+            + self.held_payout_pts
+        )
 
 
 def _days_between(later: datetime, earlier: datetime) -> float:
@@ -119,11 +126,17 @@ def _fast_mover_component(
     return min(ramp, 1.0) * SIGNAL_CAP
 
 
+def _held_payout_component(held_payout_count: int) -> float:
+    # Flat boost for having any held payout, not scaled by how many.
+    return HELD_PAYOUT_PTS if held_payout_count > 0 else 0.0
+
+
 def compute(
     org: Organization,
     *,
     metrics: PaymentMetrics | None = None,
     risk_score: float | None = None,
+    held_payout_count: int = 0,
     now: datetime | None = None,
 ) -> Signals:
     """Compute the priority breakdown for an org in the Review queue."""
@@ -135,4 +148,5 @@ def compute(
         risk_pts=_risk_component(risk_score),
         payment_pts=_payment_component(metrics),
         fast_mover_pts=_fast_mover_component(org, metrics, now),
+        held_payout_pts=_held_payout_component(held_payout_count),
     )

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -256,7 +256,8 @@ class OrganizationListView:
                     f"Aging {signals.aging_pts:.0f} + "
                     f"Risk {signals.risk_pts:.0f} + "
                     f"Payments {signals.payment_pts:.0f} + "
-                    f"Fast Mover {signals.fast_mover_pts:.0f}"
+                    f"Fast Mover {signals.fast_mover_pts:.0f} + "
+                    f"Held Payouts {signals.held_payout_pts:.0f}"
                 )
                 with tag.td(classes="text-sm font-bold text-center"):
                     with tag.span(title=tooltip):

--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -52,6 +52,8 @@ def payout_status_badge(status: PayoutStatus) -> Generator[None]:
                 classes("badge-neutral")
             case PayoutStatus.canceled:
                 classes("badge-neutral")
+            case PayoutStatus.held:
+                classes("badge-info")
         text(status.value.replace("_", " ").title())
     yield
 

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from uuid import UUID
 
-from sqlalchemy import Select, exists, select, update
+from sqlalchemy import Select, exists, func, select, update
 from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
@@ -34,6 +34,28 @@ class PayoutRepository(
     async def count_by_account(self, account: UUID) -> int:
         statement = self.get_base_statement().where(Payout.account_id == account)
         return await self.count(statement)
+
+    async def get_held_counts_by_accounts(
+        self, account_ids: Sequence[UUID]
+    ) -> dict[UUID, int]:
+        """Count held payouts per account, for the Review-queue priority boost.
+
+        Accounts with no held payout are absent from the result (caller defaults
+        the count to 0).
+        """
+        if not account_ids:
+            return {}
+        statement = (
+            self.get_base_statement()
+            .with_only_columns(Payout.account_id, func.count(Payout.id))
+            .where(
+                Payout.account_id.in_(account_ids),
+                Payout.status == PayoutStatus.held,
+            )
+            .group_by(Payout.account_id)
+        )
+        result = await self.session.execute(statement)
+        return {account_id: count for account_id, count in result.all()}
 
     async def get_latest_by_account(self, account: UUID) -> Payout | None:
         statement = (

--- a/server/tests/backoffice/organizations_v2/test_priority.py
+++ b/server/tests/backoffice/organizations_v2/test_priority.py
@@ -16,6 +16,7 @@ import pytest
 from polar.backoffice.organizations_v2.priority import (
     AGING_DAILY_PTS,
     AGING_MAX_PTS,
+    HELD_PAYOUT_PTS,
     compute,
 )
 from polar.organization_review.schemas import PaymentMetrics
@@ -217,6 +218,28 @@ class TestFastMoverComponent:
         assert s.fast_mover_pts == pytest.approx(0.0, abs=0.5)
 
 
+class TestHeldPayoutComponent:
+    def test_no_held_payouts_no_points(self) -> None:
+        s = compute(_org(), now=NOW)
+        assert s.held_payout_pts == 0.0
+
+    def test_single_held_payout(self) -> None:
+        s = compute(_org(), held_payout_count=1, now=NOW)
+        assert s.held_payout_pts == pytest.approx(HELD_PAYOUT_PTS)
+
+    def test_multiple_held_payouts_still_flat(self) -> None:
+        # Flat boost for having any held payout — three still only adds 25.
+        s = compute(_org(), held_payout_count=3, now=NOW)
+        assert s.held_payout_pts == pytest.approx(HELD_PAYOUT_PTS)
+
+    def test_held_payout_boosts_over_org_without_one(self) -> None:
+        # A fresh org with a held payout should outrank an equally-fresh org
+        # carrying no other signals.
+        held = compute(_org(days_in_status=2), held_payout_count=1, now=NOW)
+        plain = compute(_org(days_in_status=2), now=NOW)
+        assert held.priority > plain.priority
+
+
 class TestPriorityComposite:
     def test_zero_signals(self) -> None:
         s = compute(_org(days_in_status=0, created_days_ago=200), now=NOW)
@@ -232,6 +255,21 @@ class TestPriorityComposite:
         # aging 14d * 2.5 (35) + risk 85% (21.25) + payment auth (10) + no fast
         assert s.priority == pytest.approx(66.25, abs=0.1)
 
+    def test_priority_includes_held_payout_boost(self) -> None:
+        # Same as the sum-of-components case, plus a held payout (+25). Pins that
+        # held_payout_pts is actually summed into `priority`, not just held on
+        # the field.
+        s = compute(
+            _org(days_in_status=14, created_days_ago=200),
+            metrics=_metrics(total_payments=10, succeeded_payments=5),  # 50% auth
+            risk_score=85.0,
+            held_payout_count=2,
+            now=NOW,
+        )
+        # aging 35 + risk 21.25 + payment 10 + held flat (25) = 91.25
+        assert s.held_payout_pts == pytest.approx(25.0)
+        assert s.priority == pytest.approx(91.25, abs=0.1)
+
     def test_max_priority_bounded(self) -> None:
         s = compute(
             _org(days_in_status=30, created_days_ago=10),
@@ -245,5 +283,7 @@ class TestPriorityComposite:
             risk_score=100.0,
             now=NOW,
         )
-        # aging max (50) + risk (25) + payment cap (25) + fast cap (25) = 125
+        # The four capped components are bounded: aging max (50) + risk (25) +
+        # payment cap (25) + fast cap (25) = 125. The held-payout boost adds at
+        # most another 25 (overall max 150); this case has no held payout.
         assert s.priority <= 125.0

--- a/server/tests/payout/test_repository.py
+++ b/server/tests/payout/test_repository.py
@@ -1,0 +1,114 @@
+import pytest
+
+from polar.enums import PayoutAccountType
+from polar.kit.utils import utc_now
+from polar.models import Organization, User
+from polar.models.payout import PayoutStatus
+from polar.payout.repository import PayoutRepository
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_account,
+    create_payout,
+    create_payout_account,
+)
+
+
+@pytest.mark.asyncio
+class TestGetHeldCountsByAccounts:
+    async def test_empty_input(self, session: AsyncSession) -> None:
+        repository = PayoutRepository.from_session(session)
+        assert await repository.get_held_counts_by_accounts([]) == {}
+
+    async def test_counts_only_held_per_account(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        organization_second: Organization,
+        user_second: User,
+    ) -> None:
+        account_1 = await create_account(save_fixture, user)
+        payout_account_1 = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        account_2 = await create_account(save_fixture, user_second)
+        payout_account_2 = await create_payout_account(
+            save_fixture,
+            organization_second,
+            user_second,
+            type=PayoutAccountType.stripe,
+        )
+
+        # account_1: two held + one pending (pending is excluded).
+        await create_payout(
+            save_fixture,
+            account=account_1,
+            payout_account=payout_account_1,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        await create_payout(
+            save_fixture,
+            account=account_1,
+            payout_account=payout_account_1,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        await create_payout(
+            save_fixture,
+            account=account_1,
+            payout_account=payout_account_1,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+        # account_2: no held payout, only a succeeded one.
+        await create_payout(
+            save_fixture,
+            account=account_2,
+            payout_account=payout_account_2,
+            status=PayoutStatus.succeeded,
+        )
+
+        repository = PayoutRepository.from_session(session)
+        counts = await repository.get_held_counts_by_accounts(
+            [account_1.id, account_2.id]
+        )
+
+        # account_2 has no held payout, so it's absent from the mapping.
+        assert counts == {account_1.id: 2}
+
+    async def test_soft_deleted_held_not_counted(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        soft_deleted = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+        soft_deleted.deleted_at = utc_now()
+        await save_fixture(soft_deleted)
+
+        repository = PayoutRepository.from_session(session)
+        counts = await repository.get_held_counts_by_accounts([account.id])
+
+        # Only the live held payout counts; the soft-deleted one is excluded.
+        assert counts == {account.id: 1}


### PR DESCRIPTION
## Summary

Now, orgs with a held payout rank higher in the backoffice review queue.


## What

- Add a distinct **"Held"** status badge on the backoffice payouts list and detail.
- Boost an org's Review-queue **priority by +25 per held payout**
- Reword the **"Set Under Review"** dialog bullet to say payouts are held for review, not blocked.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface held payouts in Backoffice and add a flat +25 review-queue boost when an org has any held payout, so accounts with money on hold rise in the queue and get cleared faster.

- **New Features**
  - Show a distinct "Held" status badge on payouts (uses `badge-info`).
  - Add a flat +25 Held Payouts boost to review-queue priority (if any held payout), and include it in the priority tooltip.
  - Detect held payouts per account via a batched `get_held_counts_by_accounts` repository query to feed priority signals.
  - Update the "Set Under Review" dialog to say payouts are held and auto-released on approval.

<sup>Written for commit bfd609cc7dd5eb2b82304291bedf1a33f54d1b75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



