### PR TITLE
feat: surface held payout status in the dashboard

### DIFF
--- a/clients/apps/web/src/components/Organization/AIValidationResult.tsx
+++ b/clients/apps/web/src/components/Organization/AIValidationResult.tsx
@@ -82,7 +82,7 @@ const AIValidationResult = ({
           type: 'pass',
           title: 'Approved!',
           message:
-            'Your organization details have been automatically validated. You can accept payments immediately, but a manual review will still occur before your first payout.',
+            'Your organization details have been automatically validated. You can accept payments immediately. A manual review will still take place, and any payout you request in the meantime will be paid out automatically once the review is complete.',
           icon: (
             <CheckCircleIcon className="dark:text-polar-400 -mt-0.5 h-4 w-4 text-gray-500" />
           ),

--- a/clients/apps/web/src/components/Payouts/PayoutStatus.tsx
+++ b/clients/apps/web/src/components/Payouts/PayoutStatus.tsx
@@ -5,14 +5,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@polar-sh/ui/components/ui/tooltip'
-import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 const PayoutStatusDisplayTitle: Record<schemas['PayoutStatus'], string> = {
   succeeded: 'Succeeded',
   pending: 'Pending',
-  // `held` is an internal state; merchants see it as a regular pending payout.
-  held: 'Pending',
+  held: 'Held',
   failed: 'Failed',
   in_transit: 'In Transit',
   canceled: 'Canceled',
@@ -27,33 +25,37 @@ const PayoutStatusDisplayColor: Record<schemas['PayoutStatus'], string> = {
   canceled: 'bg-gray-100 text-gray-600 dark:bg-polar-700 dark:text-polar-400',
 }
 
+const PayoutStatusTooltip: Partial<Record<schemas['PayoutStatus'], string>> = {
+  held: 'This payout is on hold while your account is under review. It will be paid out automatically once the review is complete.',
+}
+
 export const PayoutStatus = ({
   payout: { status, attempts },
 }: {
   payout: schemas['Payout']
 }) => {
-  const lastAttempt = useMemo(() => attempts[attempts.length - 1], [attempts])
+  const tooltipMessage =
+    status === 'failed'
+      ? attempts.at(-1)?.failed_reason
+      : PayoutStatusTooltip[status]
 
-  if (status === 'failed') {
-    return (
-      <Tooltip>
-        <TooltipTrigger className="cursor-help">
-          <Status
-            className={twMerge(PayoutStatusDisplayColor[status], 'w-fit')}
-            status={PayoutStatusDisplayTitle[status]}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="right" className="max-w-64">
-          <p className="text-justify text-sm">{lastAttempt.failed_reason}</p>
-        </TooltipContent>
-      </Tooltip>
-    )
-  }
-
-  return (
+  const badge = (
     <Status
       className={twMerge(PayoutStatusDisplayColor[status], 'w-fit')}
       status={PayoutStatusDisplayTitle[status]}
     />
+  )
+
+  if (!tooltipMessage) {
+    return badge
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger className="cursor-help">{badge}</TooltipTrigger>
+      <TooltipContent side="right" className="max-w-64">
+        <p className="text-justify text-sm">{tooltipMessage}</p>
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/clients/apps/web/src/components/Payouts/WithdrawModal.tsx
+++ b/clients/apps/web/src/components/Payouts/WithdrawModal.tsx
@@ -141,9 +141,8 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
           {!canWithdraw && (
             <div className="flex flex-col gap-6">
               <p>
-                Your organization is currently under review, as part of our
-                compliance process. Withdrawals are disabled until the review is
-                complete.
+                Withdrawals are currently unavailable for your organization. If
+                you have any questions, please reach out to our support team.
               </p>
               <p>
                 <Link


### PR DESCRIPTION
## Summary

Show payouts that are held during an organization review in the merchant dashboard.

## What

- **`PayoutStatus`**: render the `held` payout status as a distinct "Held" badge (same color as pending) with a hover tooltip explaining the payout is on hold while the account is under review and will be paid out automatically once it completes.
- **`WithdrawModal`**: generalize the blocker copy so it no longer says "under review" for every blocked state; it now applies generically to orgs that can't currently request payouts.
- **`AIValidationResult`**: update the PASS message so it no longer implies payouts are blocked until review; a payout requested in the meantime is paid out automatically once the review completes.

## Why

Merchants under review can now request payouts, which are held until approval. The dashboard needs to show that state clearly, and the previous copy described payouts as paused/blocked during review, which is no longer accurate.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`pnpm lint` and `pnpm typecheck` for the web app)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show payouts requested during organization review as a distinct "Held" status with a tooltip explaining the hold and automatic release after review. Update dashboard copy to clarify payouts are not paused during review and that withdrawals may be unavailable for other reasons.

- **New Features**
  - Display `held` payouts with a "Held" badge and tooltip in Payouts.
  - Generalize WithdrawModal blocker copy to avoid implying review in all cases.
  - Update AI validation PASS message to note payouts can be requested during review and will be paid automatically once it completes.

<sup>Written for commit a643336c6dd475d5cac4eb7c1ba4f9c02ac95efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

