### PR TITLE
server/subscription: use FOR UPDATE lock instead of Redis lock

### DIFF
--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -8,7 +8,6 @@ from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.kit.sorting import Sorting, SortingGetter
-from polar.locker import Locker, get_locker
 from polar.models import Subscription
 from polar.openapi import APITag
 from polar.order.service import PaymentFailed
@@ -160,11 +159,10 @@ async def update(
     subscription_update: CustomerSubscriptionUpdate,
     auth_subject: auth.CustomerPortalUnionBillingWrite,
     session: AsyncSession = Depends(get_db_session),
-    locker: Locker = Depends(get_locker),
 ) -> Subscription:
     """Update a subscription of the authenticated customer."""
     subscription = await customer_subscription_service.get_by_id(
-        session, auth_subject, id
+        session, auth_subject, id, for_update=True
     )
 
     if subscription is None:
@@ -176,10 +174,9 @@ async def update(
         updates=subscription_update.model_dump(exclude_unset=True),
         **get_audit_context(auth_subject),
     )
-    async with subscription_service.lock(locker, subscription):
-        return await customer_subscription_service.update(
-            session, subscription, updates=subscription_update
-        )
+    return await customer_subscription_service.update(
+        session, subscription, updates=subscription_update
+    )
 
 
 @router.delete(
@@ -203,11 +200,10 @@ async def cancel(
     id: SubscriptionID,
     auth_subject: auth.CustomerPortalUnionBillingWrite,
     session: AsyncSession = Depends(get_db_session),
-    locker: Locker = Depends(get_locker),
 ) -> Subscription:
     """Cancel a subscription of the authenticated customer."""
     subscription = await customer_subscription_service.get_by_id(
-        session, auth_subject, id
+        session, auth_subject, id, for_update=True
     )
 
     if subscription is None:
@@ -218,5 +214,4 @@ async def cancel(
         subscription_id=id,
         **get_audit_context(auth_subject),
     )
-    async with subscription_service.lock(locker, subscription):
-        return await customer_subscription_service.cancel(session, subscription)
+    return await customer_subscription_service.cancel(session, subscription)

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -118,6 +118,8 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         session: AsyncSession,
         auth_subject: AuthSubject[Customer | Member],
         id: uuid.UUID,
+        *,
+        for_update: bool = False,
     ) -> Subscription | None:
         statement = (
             self._get_readable_subscription_statement(auth_subject)
@@ -132,6 +134,9 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 joinedload(Subscription.pending_update),
             )
         )
+
+        if for_update:
+            statement = statement.with_for_update(of=Subscription)
 
         result = await session.execute(statement)
         return result.scalar_one_or_none()

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -13,7 +13,6 @@ from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParams, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
-from polar.locker import Locker, get_locker
 from polar.models import Subscription
 from polar.models.subscription import CustomerCancellationReason
 from polar.openapi import APITag
@@ -303,10 +302,11 @@ async def update(
     subscription_update: SubscriptionUpdate,
     auth_subject: auth.SubscriptionsWrite,
     session: AsyncSession = Depends(get_db_session),
-    locker: Locker = Depends(get_locker),
 ) -> Subscription:
     """Update a subscription."""
-    subscription = await subscription_service.get(session, auth_subject, id)
+    subscription = await subscription_service.get(
+        session, auth_subject, id, for_update=True
+    )
     if subscription is None:
         raise ResourceNotFound()
 
@@ -323,10 +323,9 @@ async def update(
         customer_id=auth_subject.subject.id,
         updates=subscription_update,
     )
-    async with subscription_service.lock(locker, subscription):
-        return await subscription_service.update(
-            session, locker, subscription, update=subscription_update
-        )
+    return await subscription_service.update(
+        session, subscription, update=subscription_update
+    )
 
 
 @router.delete(
@@ -350,10 +349,11 @@ async def revoke(
     id: SubscriptionID,
     auth_subject: auth.SubscriptionsWrite,
     session: AsyncSession = Depends(get_db_session),
-    locker: Locker = Depends(get_locker),
 ) -> Subscription:
     """Revoke a subscription, i.e cancel immediately."""
-    subscription = await subscription_service.get(session, auth_subject, id)
+    subscription = await subscription_service.get(
+        session, auth_subject, id, for_update=True
+    )
     if subscription is None:
         raise ResourceNotFound()
 
@@ -367,5 +367,4 @@ async def revoke(
     log.info(
         "subscription.revoke", id=id, admin_id=auth_subject.subject.id, immediate=True
     )
-    async with subscription_service.lock(locker, subscription):
-        return await subscription_service.revoke(session, subscription)
+    return await subscription_service.revoke(session, subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1,6 +1,5 @@
-import contextlib
 import uuid
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, Literal, cast, overload
@@ -59,7 +58,6 @@ from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
 from polar.kit.visibility import Visibility
-from polar.locker import Locker
 from polar.logging import Logger
 from polar.models import (
     Benefit,
@@ -323,6 +321,8 @@ class SubscriptionService:
         session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         id: uuid.UUID,
+        *,
+        for_update: bool = False,
     ) -> Subscription | None:
         repository = SubscriptionRepository.from_session(session)
         statement = (
@@ -337,6 +337,10 @@ class SubscriptionService:
                 )
             )
         )
+
+        if for_update:
+            statement = statement.with_for_update(of=Subscription)
+
         return await repository.get_one_or_none(statement)
 
     async def create(
@@ -883,24 +887,9 @@ class SubscriptionService:
 
         enqueue_job("customer.state_changed", subscription.customer_id)
 
-    @contextlib.asynccontextmanager
-    async def lock(
-        self, locker: Locker, subscription: Subscription
-    ) -> AsyncGenerator[Subscription]:
-        lock_name = f"subscription:{subscription.id}"
-        if await locker.is_locked(lock_name):
-            raise SubscriptionLocked(subscription)
-        async with locker.lock(
-            lock_name,
-            timeout=10.0,  # Quite long, but we've experienced slow responses from Stripe in test mode
-            blocking_timeout=1,
-        ):
-            yield subscription
-
     async def update(
         self,
         session: AsyncSession,
-        locker: Locker,
         subscription: Subscription,
         *,
         update: SubscriptionUpdate,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2410,7 +2410,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_active_subscription(
@@ -2427,7 +2426,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateProduct(product_id=new_product.id),
         )
@@ -2445,7 +2443,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_active_subscription(
@@ -2462,7 +2459,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateProduct(
                 product_id=new_product.id,
@@ -2484,7 +2480,6 @@ class TestUpdate:
         organization: Organization,
         product: Product,
         discount_percentage_50: Discount,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_active_subscription(
@@ -2494,7 +2489,6 @@ class TestUpdate:
         )
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateDiscount(discount_id=discount_percentage_50.id),
         )
@@ -2512,7 +2506,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_trialing_subscription(
@@ -2527,7 +2520,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateTrial(
                 trial_end=initial_trial_end + timedelta(days=7),
@@ -2548,7 +2540,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
         enqueue_job_mock: MagicMock,
     ) -> None:
@@ -2564,7 +2555,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateTrial(trial_end="now"),
         )
@@ -2590,7 +2580,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product_recurring_seat_based: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_subscription_with_seats(
@@ -2602,7 +2591,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateSeats(seats=10),
         )
@@ -2621,7 +2609,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product_recurring_seat_based: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         trigger_payment_mock = mocker.patch.object(
@@ -2641,7 +2628,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateSeats(
                 seats=10, proration_behavior=SubscriptionProrationBehavior.invoice
@@ -2663,7 +2649,6 @@ class TestUpdate:
         customer: Customer,
         organization: Organization,
         product: Product,
-        locker: Locker,
         webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_active_subscription(
@@ -2676,7 +2661,6 @@ class TestUpdate:
 
         updated = await subscription_service.update(
             session,
-            locker,
             subscription,
             update=SubscriptionUpdateBillingPeriod(
                 current_billing_period_end=initial_period_end + timedelta(days=7)


### PR DESCRIPTION
- server/subscription: use FOR UPDATE lock instead of Redis lock

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Redis-based subscription locking with database row-level locks using FOR UPDATE. This simplifies the code and ensures transactional consistency without relying on Redis.

- **Refactors**
  - Added `for_update` option to `customer_subscription_service.get_by_id` and `subscription_service.get` to apply `FOR UPDATE`.
  - Removed `Locker`/`get_locker` and the `SubscriptionService.lock` helper.
  - Updated update/cancel/revoke endpoints to fetch with `for_update=True` and call service methods directly.
  - Dropped locker parameter from `subscription_service.update` and cleaned up related tests.

<sup>Written for commit 8b26ef36ae35e6a7b4983c6e81ececc4a21cd89a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

