### PR TITLE
fix(order): notify on off-session draft order creation and finalization

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1180,17 +1180,27 @@ class OrderService:
             if settled is not None and settled.status == OrderStatus.pending:
                 await self._revert_to_draft(session, order)
                 raise PaymentFailed(PaymentFailedReason.missing_payment_method)
-            return await self._assign_invoice_number(session, order)
+            order = await self._assign_invoice_number(session, order)
+        else:
+            # Apply the charge.succeeded path inline so the finalize HTTP
+            # response carries the paid order. The webhook arrives shortly after
+            # and no-ops via the idempotency guards in
+            # upsert_from_stripe_charge / handle_payment.
+            charge = self._get_intent_charge(payment_intent)
+            order = await self._assign_invoice_number(session, order)
+            payment = await payment_service.upsert_from_stripe_charge(
+                session, charge, organization, None, None, order
+            )
+            order = await self.handle_payment(session, order, payment)
 
-        # Apply the charge.succeeded path inline so the finalize HTTP response
-        # carries the paid order. The webhook arrives shortly after and no-ops
-        # via the idempotency guards in upsert_from_stripe_charge / handle_payment.
-        charge = self._get_intent_charge(payment_intent)
-        order = await self._assign_invoice_number(session, order)
-        payment = await payment_service.upsert_from_stripe_charge(
-            session, charge, organization, None, None, order
-        )
-        return await self.handle_payment(session, order, payment)
+        # Unlike the checkout flow, the off-session draft flow skips the
+        # confirmation email at draft creation (nothing is charged yet). Now that
+        # finalize has settled the order as paid, send it so the customer gets
+        # their confirmation.
+        if order.paid:
+            enqueue_job("order.confirmation_email", order.id)
+
+        return order
 
     def _get_intent_charge(
         self, payment_intent: stripe_lib.PaymentIntent

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1104,6 +1104,13 @@ class OrderService:
             flush=True,
         )
 
+        # Fire the `order.created` webhook so merchants are notified about the
+        # draft. We deliberately don't route through `_on_order_created`: a draft
+        # isn't charged yet, so the customer-facing confirmation email it
+        # enqueues would be premature. The `order.paid`/`order.updated` events
+        # are emitted later by finalize_order once the charge settles.
+        await self.send_webhook(session, order, WebhookEventType.order_created)
+
         return order
 
     async def finalize_order(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -67,6 +67,7 @@ from polar.models.product import ProductBillingType
 from polar.models.subscription import SubscriptionStatus
 from polar.models.transaction import PlatformFeeType, TransactionType
 from polar.models.wallet import WalletType
+from polar.models.webhook_endpoint import WebhookEventType
 from polar.order.schemas import OrderCreate, OrderUpdate
 from polar.order.service import (
     ManualRetryLimitExceeded,
@@ -5238,6 +5239,28 @@ class TestCreateDraftOrder:
         assert order.checkout_id is None
         assert order.subtotal_amount > 0
         assert len(order.items) >= 1
+
+    async def test_fires_order_created_webhook(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        send_webhook_mock = mocker.patch.object(order_service, "send_webhook")
+
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+
+        send_webhook_mock.assert_awaited_once_with(
+            session, order, WebhookEventType.order_created
+        )
 
     async def test_multi_currency_falls_back_to_org_default(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5844,3 +5844,94 @@ class TestFinalizeOrder:
         assert isinstance(charge_arg, stripe_lib.Charge)
         assert charge_arg.id == "ch_finalize_success"
         handle_payment_mock.assert_awaited_once()
+
+    async def test_sends_confirmation_email_once_settled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        product: Product,
+        customer: Customer,
+        stripe_service_mock: MagicMock,
+        mocker: MockerFixture,
+        enqueue_job_mock: MagicMock,
+    ) -> None:
+        # The draft flow skips the confirmation email at creation, so finalize
+        # must enqueue it once the order settles as paid.
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.draft,
+            invoice_number=None,
+        )
+
+        payment_intent = stripe_lib.PaymentIntent.construct_from(
+            {
+                "id": "pi_finalize_success",
+                "status": "succeeded",
+                "latest_charge": {"object": "charge", "id": "ch_finalize_success"},
+            },
+            None,
+        )
+        stripe_service_mock.create_payment_intent.return_value = payment_intent
+
+        def _settle(_session: AsyncSession, settled: Order, _payment: object) -> Order:
+            settled.status = OrderStatus.paid
+            return settled
+
+        mocker.patch(
+            "polar.order.service.payment_service.upsert_from_stripe_charge",
+            new=AsyncMock(return_value=MagicMock()),
+        )
+        mocker.patch.object(
+            order_service, "handle_payment", new=AsyncMock(side_effect=_settle)
+        )
+
+        result = await order_service.finalize_order(
+            session, order, payment_method_id=payment_method.id
+        )
+
+        assert result.status == OrderStatus.paid
+        assert (
+            call("order.confirmation_email", order.id)
+            in enqueue_job_mock.call_args_list
+        )
+
+    async def test_sends_confirmation_email_for_free_product(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        off_session_organization: Organization,
+        customer: Customer,
+        enqueue_job_mock: MagicMock,
+    ) -> None:
+        # A $0 (free) draft settles via the under-minimum branch of
+        # trigger_payment (no Stripe charge), which still reaches the paid state.
+        # The confirmation email must be enqueued on that path too.
+        product = await create_product(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+            prices=[(None, "usd")],
+        )
+        order = await order_service.create_draft_order(
+            session,
+            off_session_organization,
+            OrderCreate(customer_id=customer.id, product_id=product.id),
+        )
+        assert order.status == OrderStatus.draft
+        assert order.due_amount == 0
+
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+
+        result = await order_service.finalize_order(
+            session, order, payment_method_id=payment_method.id
+        )
+
+        assert result.status == OrderStatus.paid
+        assert (
+            call("order.confirmation_email", order.id)
+            in enqueue_job_mock.call_args_list
+        )


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

Draft orders (off-session charges) didn't emit an `order.created` webhook when created, and a finalized draft never sent the customer a confirmation email. This PR fixes both gaps in the off-session draft order lifecycle.

## What

- Fire the `order.created` webhook from `create_draft_order`, so merchants are notified when a draft order is created. The payload's `status` field conveys the draft state (`"draft"`, `paid: false`).
- Enqueue `order.confirmation_email` from `finalize_order` once the order settles as paid, so the customer receives their confirmation.

## Why

- **No `order.created` webhook for drafts**: draft orders were persisted and returned without firing any "created" notification, so webhook subscribers never learned about them.
- **No confirmation email for finalized drafts**: the draft flow intentionally skips the confirmation email at creation (nothing is charged yet), but the paid path (`_on_order_paid`) never sent one either — so a finalized draft order resulted in no customer confirmation at all.

## How

- `create_draft_order` calls `send_webhook(..., WebhookEventType.order_created)` before returning. It deliberately does **not** route through `_on_order_created`, because that helper also enqueues `order.confirmation_email`, which would email the customer about an unpaid draft.
- `finalize_order` was refactored so both success paths converge on a single return; once the order is `paid`, it enqueues `order.confirmation_email`. This is placed in the finalize flow (not the shared `_on_order_paid` hook) so regular orders — which already email at creation — don't get a duplicate.

Resulting off-session draft lifecycle:
- Draft created → `order.created` webhook (`status: draft`, `paid: false`); no customer email.
- Draft finalized & paid → `order.updated` + `order.paid` webhooks, and the customer receives the confirmation email.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit the `order.created` webhook for draft (off-session) orders and send the confirmation email when a draft is finalized and paid. This restores merchant notifications and ensures customers get confirmations.

- **Bug Fixes**
  - `create_draft_order`: send `order.created` for drafts; skip `_on_order_created` to avoid a premature confirmation email.
  - `finalize_order`: apply the charge-succeeded path inline so the response returns the paid order; when the order settles as `paid` (including $0 drafts), enqueue `order.confirmation_email` to avoid duplicate emails.

<sup>Written for commit 50eb8872e0bd20ef418581d94f0b282053ed4ba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

