### PR TITLE
server/subscription: add an update context to unify side-effects

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -29876,20 +29876,6 @@ export interface components {
        */
       trial_end: string | 'now'
     }
-    /** SubscriptionUpdatedBillingPeriodMetadata */
-    SubscriptionUpdatedBillingPeriodMetadata: {
-      /** Subscription Id */
-      subscription_id: string
-      /** Billing Period End */
-      billing_period_end: string
-    }
-    /** SubscriptionUpdatedDiscountMetadata */
-    SubscriptionUpdatedDiscountMetadata: {
-      /** Subscription Id */
-      subscription_id: string
-      /** Discount Id */
-      discount_id: string | null
-    }
     /**
      * SubscriptionUpdatedEvent
      * @description An event created by Polar when a subscription is updated.
@@ -29963,36 +29949,23 @@ export interface components {
        * @enum {string}
        */
       name: 'subscription.updated'
-      /** Metadata */
-      metadata:
-        | components['schemas']['SubscriptionUpdatedProductMetadata']
-        | components['schemas']['SubscriptionUpdatedDiscountMetadata']
-        | components['schemas']['SubscriptionUpdatedTrialMetadata']
-        | components['schemas']['SubscriptionUpdatedSeatsMetadata']
-        | components['schemas']['SubscriptionUpdatedBillingPeriodMetadata']
+      metadata: components['schemas']['SubscriptionUpdatedMetadata']
     }
-    /** SubscriptionUpdatedProductMetadata */
-    SubscriptionUpdatedProductMetadata: {
-      /** Subscription Id */
-      subscription_id: string
+    /** SubscriptionUpdatedMetadata */
+    SubscriptionUpdatedMetadata: {
       /** Product Id */
-      product_id: string
-      proration_behavior: components['schemas']['SubscriptionProrationBehavior']
-    }
-    /** SubscriptionUpdatedSeatsMetadata */
-    SubscriptionUpdatedSeatsMetadata: {
-      /** Subscription Id */
-      subscription_id: string
-      /** Seats */
-      seats: number
-      proration_behavior: components['schemas']['SubscriptionProrationBehavior']
-    }
-    /** SubscriptionUpdatedTrialMetadata */
-    SubscriptionUpdatedTrialMetadata: {
-      /** Subscription Id */
-      subscription_id: string
+      product_id?: string
+      proration_behavior?: components['schemas']['SubscriptionProrationBehavior']
+      /** Discount Id */
+      discount_id?: string | null
       /** Trial End */
-      trial_end: string
+      trial_end?: string
+      /** Seats */
+      seats?: number
+      /** Billing Period End */
+      billing_period_end?: string
+      /** Subscription Id */
+      subscription_id: string
     }
     /** SubscriptionUser */
     SubscriptionUser: {

--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -17,6 +17,7 @@ from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.subscription import sorting
 from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.subscription.sorting import SubscriptionSortProperty
 
@@ -404,13 +405,17 @@ async def cancel(
         data = await request.form()
         try:
             form = CancelForm.model_validate_form(data)
-            await subscription_service._perform_cancellation(
-                session,
-                subscription,
-                customer_reason=form.customer_cancellation_reason,
-                customer_comment=form.customer_cancellation_comment,
-                immediately=form.revoke,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service._perform_cancellation(
+                    session,
+                    ctx,
+                    subscription,
+                    customer_reason=form.customer_cancellation_reason,
+                    customer_comment=form.customer_cancellation_comment,
+                    immediately=form.revoke,
+                )
             return HXRedirectResponse(
                 request, str(request.url_for("subscriptions:get", id=id)), 303
             )
@@ -451,7 +456,10 @@ async def uncancel(
         return
 
     if request.method == "POST":
-        await subscription_service.uncancel(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.uncancel(session, ctx, subscription)
         return HXRedirectResponse(
             request, str(request.url_for("subscriptions:get", id=id)), 303
         )
@@ -504,11 +512,15 @@ async def update_billing_period_end(
         data = await request.form()
         try:
             form = UpdateBillingPeriodEndForm.model_validate_form(data)
-            await subscription_service.update_currrent_billing_period_end(
-                session,
-                subscription,
-                new_period_end=form.new_period_end,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_currrent_billing_period_end(
+                    session,
+                    ctx,
+                    subscription,
+                    new_period_end=form.new_period_end,
+                )
             return HXRedirectResponse(
                 request, str(request.url_for("subscriptions:get", id=id)), 303
             )

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -20,6 +20,7 @@ from polar.models import (
     SubscriptionMeter,
 )
 from polar.models.subscription import CustomerCancellationReason
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 
 from ..schemas.subscription import (
@@ -163,17 +164,24 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
             if not organization.customer_portal_subscription_update_seats:
                 raise UpdateSubscriptionSeatsNotAllowed()
 
-            return await subscription_service.update_seats(
-                session,
-                subscription,
-                seats=updates.seats,
-                proration_behavior=updates.proration_behavior,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                return await subscription_service.update_seats(
+                    session,
+                    ctx,
+                    subscription,
+                    seats=updates.seats,
+                    proration_behavior=updates.proration_behavior,
+                )
 
         if isinstance(updates, CustomerSubscriptionUpdateClear):
-            return await subscription_service.clear_pending_update(
-                session, subscription
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                return await subscription_service.clear_pending_update(
+                    session, ctx, subscription
+                )
 
         cancel = updates.cancel_at_period_end is True
         uncancel = updates.cancel_at_period_end is False
@@ -197,22 +205,30 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         *,
         product_id: uuid.UUID,
     ) -> Subscription:
-        return await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_id,
-            allowed_visibilities=frozenset({Visibility.public}),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            return await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_id,
+                allowed_visibilities=frozenset({Visibility.public}),
+            )
 
     async def uncancel(
         self,
         session: AsyncSession,
         subscription: Subscription,
     ) -> Subscription:
-        return await subscription_service.uncancel(
-            session,
-            subscription,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            return await subscription_service.uncancel(
+                session,
+                ctx,
+                subscription,
+            )
 
     async def cancel(
         self,
@@ -222,12 +238,16 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         reason: CustomerCancellationReason | None = None,
         comment: str | None = None,
     ) -> Subscription:
-        return await subscription_service.cancel(
-            session,
-            subscription,
-            customer_reason=reason,
-            customer_comment=comment,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            return await subscription_service.cancel(
+                session,
+                ctx,
+                subscription,
+                customer_reason=reason,
+                customer_comment=comment,
+            )
 
     def _get_readable_subscription_statement(
         self, auth_subject: AuthSubject[Customer | Member]

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -23,6 +23,7 @@ from polar.postgres import AsyncReadSession, AsyncSession
 from polar.product.repository import ProductRepository
 from polar.refund.service import refund as refund_service
 from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.transaction.service.dispute import (
     dispute_transaction as dispute_transaction_service,
@@ -257,7 +258,10 @@ class DisputeService:
             )
             assert subscription is not None
             if subscription.can_cancel(immediately=True):
-                await subscription_service.revoke(session, subscription)
+                async with SubscriptionUpdateContext(
+                    session, subscription, subscription_service
+                ) as ctx:
+                    await subscription_service.revoke(session, ctx, subscription)
         # Revoke the order benefits
         elif dispute.order.product_id is not None:
             product_repository = ProductRepository.from_session(session)

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -208,40 +208,17 @@ class SubscriptionCreatedEvent(Event):
         user_metadata: Mapped[SubscriptionCreatedMetadata]  # type: ignore[assignment]
 
 
-class SubscriptionUpdatedProductMetadata(TypedDict):
-    subscription_id: str
+class SubscriptionUpdatedMetadataFields(TypedDict, total=False):
     product_id: str
     proration_behavior: SubscriptionProrationBehavior
-
-
-class SubscriptionUpdatedDiscountMetadata(TypedDict):
-    subscription_id: str
     discount_id: str | None
-
-
-class SubscriptionUpdatedTrialMetadata(TypedDict):
-    subscription_id: str
     trial_end: str
-
-
-class SubscriptionUpdatedSeatsMetadata(TypedDict):
-    subscription_id: str
     seats: int
-    proration_behavior: SubscriptionProrationBehavior
-
-
-class SubscriptionUpdatedBillingPeriodMetadata(TypedDict):
-    subscription_id: str
     billing_period_end: str
 
 
-SubscriptionUpdatedMetadata = (
-    SubscriptionUpdatedProductMetadata
-    | SubscriptionUpdatedDiscountMetadata
-    | SubscriptionUpdatedTrialMetadata
-    | SubscriptionUpdatedSeatsMetadata
-    | SubscriptionUpdatedBillingPeriodMetadata
-)
+class SubscriptionUpdatedMetadata(SubscriptionUpdatedMetadataFields):
+    subscription_id: str
 
 
 class SubscriptionUpdatedEvent(Event):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -110,6 +110,7 @@ from polar.product.price_set import (
 )
 from polar.product.repository import ProductRepository
 from polar.receipt.service import receipt as receipt_service
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import (
     CalculationExpiredError,
@@ -2900,7 +2901,10 @@ class OrderService:
             )
 
             if subscription is not None and subscription.can_cancel(immediately=True):
-                await subscription_service.revoke(session, subscription)
+                async with SubscriptionUpdateContext(
+                    session, subscription, subscription_service
+                ) as ctx:
+                    await subscription_service.revoke(session, ctx, subscription)
 
             return order
 

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -38,6 +38,7 @@ from .schemas import (
 from .service import (
     AlreadyCanceledSubscription,
     SubscriptionLocked,
+    SubscriptionUpdateContext,
 )
 from .service import subscription as subscription_service
 
@@ -323,9 +324,12 @@ async def update(
         customer_id=auth_subject.subject.id,
         updates=subscription_update,
     )
-    return await subscription_service.update(
-        session, subscription, update=subscription_update
-    )
+    async with SubscriptionUpdateContext(
+        session, subscription, subscription_service
+    ) as ctx:
+        return await subscription_service.update(
+            session, ctx, subscription, update=subscription_update
+        )
 
 
 @router.delete(
@@ -367,4 +371,7 @@ async def revoke(
     log.info(
         "subscription.revoke", id=id, admin_id=auth_subject.subject.id, immediate=True
     )
-    return await subscription_service.revoke(session, subscription)
+    async with SubscriptionUpdateContext(
+        session, subscription, subscription_service
+    ) as ctx:
+        return await subscription_service.revoke(session, ctx, subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -267,7 +267,7 @@ class SubscriptionUpdateContext:
 
         match self._billing_effect:
             case "cycle":
-                await self.service.cycle(self.session, self.subscription)
+                await self.service.cycle(self.session, self, self.subscription)
             case "invoice":
                 await self.service._create_subscription_update_order(
                     self.session, self.subscription
@@ -733,6 +733,7 @@ class SubscriptionService:
     async def cycle(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         update_cycle_dates: bool = True,
     ) -> Subscription:
@@ -866,17 +867,11 @@ class SubscriptionService:
             billing_reason = OrderBillingReasonInternal.subscription_cycle_after_trial
         else:
             billing_reason = OrderBillingReasonInternal.subscription_cycle
+
         enqueue_job(
             "order.create_subscription_order",
             subscription.id,
             billing_reason,
-        )
-
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_canceled,
         )
 
         return subscription

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2,7 +2,8 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import Any, Literal, cast, overload
+from types import TracebackType
+from typing import Any, Literal, Unpack, cast, overload
 from urllib.parse import urlencode
 
 import structlog
@@ -42,6 +43,7 @@ from polar.event.system import (
     SubscriptionReactivatedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionUncanceledMetadata,
+    SubscriptionUpdatedMetadataFields,
     SystemEvent,
     build_system_event,
 )
@@ -224,6 +226,84 @@ def _from_timestamp(t: int | None) -> datetime | None:
     if t is None:
         return None
     return datetime.fromtimestamp(t, UTC)
+
+
+class SubscriptionUpdateContext:
+    """Async context manager for batching subscription update side effects.
+
+    Centralizes the execution of side effects (webhooks, events, billing actions)
+    to ensure they are triggered exactly once, even when multiple update operations
+    are performed together.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        service: "SubscriptionService",
+    ) -> None:
+        self.session = session
+        self.service = service
+
+        self.subscription = subscription
+        self._previous_status = subscription.status
+        self._previous_is_canceled = subscription.canceled
+
+        self._billing_effect: Literal["invoice", "cycle"] | None = None
+        self._event_metadata: SubscriptionUpdatedMetadataFields = {}
+
+    async def __aenter__(self) -> "SubscriptionUpdateContext":
+        return self
+
+    async def __aexit__(
+        self,
+        type_: type[BaseException] | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        # Don't trigger side effects if an exception was raised within the context
+        if value is not None:
+            return
+
+        match self._billing_effect:
+            case "cycle":
+                await self.service.cycle(self.session, self.subscription)
+            case "invoice":
+                await self.service._create_subscription_update_order(
+                    self.session, self.subscription
+                )
+
+        if self._event_metadata:
+            await event_service.create_event(
+                self.session,
+                build_system_event(
+                    SystemEvent.subscription_updated,
+                    customer=self.subscription.customer,
+                    organization=self.subscription.organization,
+                    metadata={
+                        "subscription_id": str(self.subscription.id),
+                        **self._event_metadata,
+                    },
+                ),
+            )
+
+        await self.service._after_subscription_updated(
+            self.session,
+            self.subscription,
+            previous_status=self._previous_status,
+            previous_is_canceled=self._previous_is_canceled,
+        )
+
+    def set_billing_effect(self, effect: Literal["invoice", "cycle"]) -> None:
+        if effect == "cycle":
+            self._billing_effect = "cycle"
+        elif effect == "invoice" and self._billing_effect != "cycle":
+            self._billing_effect = "invoice"
+
+    def add_event_metadata(
+        self, **metadata: Unpack[SubscriptionUpdatedMetadataFields]
+    ) -> None:
+        self._event_metadata.update(metadata)
 
 
 class SubscriptionService:
@@ -890,6 +970,7 @@ class SubscriptionService:
     async def update(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         update: SubscriptionUpdate,
@@ -915,6 +996,7 @@ class SubscriptionService:
         if isinstance(update, SubscriptionUpdateProduct):
             return await self.update_product(
                 session,
+                ctx,
                 subscription,
                 product_id=update.product_id,
                 proration_behavior=update.proration_behavior,
@@ -923,18 +1005,20 @@ class SubscriptionService:
         if isinstance(update, SubscriptionUpdateDiscount):
             return await self.update_discount(
                 session,
+                ctx,
                 subscription,
                 discount_id=update.discount_id,
             )
 
         if isinstance(update, SubscriptionUpdateTrial):
             return await self.update_trial(
-                session, subscription, trial_end=update.trial_end
+                session, ctx, subscription, trial_end=update.trial_end
             )
 
         if isinstance(update, SubscriptionUpdateSeats):
             return await self.update_seats(
                 session,
+                ctx,
                 subscription,
                 seats=update.seats,
                 proration_behavior=update.proration_behavior,
@@ -943,6 +1027,7 @@ class SubscriptionService:
         if isinstance(update, SubscriptionUpdateBillingPeriod):
             return await self.update_currrent_billing_period_end(
                 session,
+                ctx,
                 subscription,
                 new_period_end=update.current_billing_period_end,
             )
@@ -951,10 +1036,11 @@ class SubscriptionService:
             uncancel = update.cancel_at_period_end is False
 
             if uncancel:
-                return await self.uncancel(session, subscription)
+                return await self.uncancel(session, ctx, subscription)
 
             return await self.cancel(
                 session,
+                ctx,
                 subscription,
                 customer_reason=update.customer_cancellation_reason,
                 customer_comment=update.customer_cancellation_comment,
@@ -963,6 +1049,7 @@ class SubscriptionService:
         if isinstance(update, SubscriptionRevoke):
             return await self._perform_cancellation(
                 session,
+                ctx,
                 subscription,
                 customer_reason=update.customer_cancellation_reason,
                 customer_comment=update.customer_cancellation_comment,
@@ -970,11 +1057,12 @@ class SubscriptionService:
             )
 
         if isinstance(update, SubscriptionUpdateClear):
-            return await self.clear_pending_update(session, subscription)
+            return await self.clear_pending_update(session, ctx, subscription)
 
     async def update_product(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         product_id: uuid.UUID,
@@ -1206,14 +1294,13 @@ class SubscriptionService:
             await session.flush()
 
             if was_trialing and ends_trial:
-                subscription = await self.cycle(session, subscription)
+                ctx.set_billing_effect("cycle")
             elif (
                 (proration_behavior.is_immediate() or interval_changed)
                 and not was_trialing
                 and billing_entries
             ):
-                # Invoice and attempt to pay immediately
-                await self._create_subscription_update_order(session, subscription)
+                ctx.set_billing_effect("invoice")
 
             # When transitioning from non-seat to seat-based pricing, promote
             # the billing customer to a 'team' customer and claim a seat for
@@ -1244,26 +1331,9 @@ class SubscriptionService:
                 session, subscription, product, proration_behavior
             )
 
-        await event_service.create_event(
-            session,
-            build_system_event(
-                SystemEvent.subscription_updated,
-                customer=subscription.customer,
-                organization=subscription.organization,
-                metadata={
-                    "subscription_id": str(subscription.id),
-                    "product_id": str(product.id),
-                    "proration_behavior": proration_behavior,
-                },
-            ),
-        )
-
-        # Trigger subscription updated events and re-evaluate benefits
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
+        ctx.add_event_metadata(
+            product_id=str(product.id),
+            proration_behavior=proration_behavior,
         )
 
         return subscription
@@ -1271,6 +1341,7 @@ class SubscriptionService:
     async def clear_pending_update(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
     ) -> Subscription:
         """Clear the pending update for a subscription."""
@@ -1309,18 +1380,12 @@ class SubscriptionService:
             ),
         )
 
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=subscription.status,
-            previous_is_canceled=False,
-        )
-
         return subscription
 
     async def update_discount(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         discount_id: uuid.UUID | None = None,
@@ -1367,26 +1432,11 @@ class SubscriptionService:
             discount: Discount | None,
         ) -> Subscription:
             repository = SubscriptionRepository.from_session(session)
-            await event_service.create_event(
-                session,
-                build_system_event(
-                    SystemEvent.subscription_updated,
-                    customer=subscription.customer,
-                    organization=subscription.organization,
-                    metadata={
-                        "subscription_id": str(subscription.id),
-                        "discount_id": str(discount.id) if discount else None,
-                    },
-                ),
+            ctx.add_event_metadata(
+                discount_id=str(discount.id) if discount else None,
             )
             subscription = await repository.update(
                 subscription, update_dict={"discount": discount}, flush=True
-            )
-            await self._after_subscription_updated(
-                session,
-                subscription,
-                previous_status=subscription.status,
-                previous_is_canceled=subscription.canceled,
             )
             return subscription
 
@@ -1402,6 +1452,7 @@ class SubscriptionService:
     async def update_trial(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         trial_end: datetime | Literal["now"],
@@ -1409,16 +1460,13 @@ class SubscriptionService:
         if not subscription.active:
             raise InactiveSubscription(subscription)
 
-        previous_status = subscription.status
-        previous_is_canceled = subscription.canceled
-
         # Already trialing
         if subscription.trialing:
             # End trial immediately
             if trial_end == "now":
                 subscription.trial_end = subscription.current_period_end = utc_now()
                 # Make sure to cycle the subscription immediately to update status and trigger order
-                subscription = await self.cycle(session, subscription)
+                ctx.set_billing_effect("cycle")
             # Set new trial end date
             else:
                 subscription.trial_end = subscription.current_period_end = trial_end
@@ -1457,24 +1505,8 @@ class SubscriptionService:
         subscription = await repository.update(subscription)
 
         assert subscription.trial_end is not None
-        await event_service.create_event(
-            session,
-            build_system_event(
-                SystemEvent.subscription_updated,
-                customer=subscription.customer,
-                organization=subscription.organization,
-                metadata={
-                    "subscription_id": str(subscription.id),
-                    "trial_end": subscription.trial_end.isoformat(),
-                },
-            ),
-        )
-
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
+        ctx.add_event_metadata(
+            trial_end=subscription.trial_end.isoformat(),
         )
 
         return subscription
@@ -1482,6 +1514,7 @@ class SubscriptionService:
     async def update_seats(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         seats: int,
@@ -1616,28 +1649,11 @@ class SubscriptionService:
                 and billing_entries
             ):
                 # Invoice and attempt to pay immediately
-                await self._create_subscription_update_order(session, subscription)
+                ctx.set_billing_effect("invoice")
 
-        await event_service.create_event(
-            session,
-            build_system_event(
-                SystemEvent.subscription_updated,
-                customer=subscription.customer,
-                organization=subscription.organization,
-                metadata={
-                    "subscription_id": str(subscription.id),
-                    "seats": seats,
-                    "proration_behavior": proration_behavior,
-                },
-            ),
-        )
-
-        # Send webhooks and notifications
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
+        ctx.add_event_metadata(
+            seats=seats,
+            proration_behavior=proration_behavior,
         )
 
         return subscription
@@ -1645,6 +1661,7 @@ class SubscriptionService:
     async def update_currrent_billing_period_end(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         new_period_end: datetime,
@@ -1682,30 +1699,17 @@ class SubscriptionService:
         repository = SubscriptionRepository.from_session(session)
         subscription = await repository.update(subscription)
 
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
-        )
-
-        await event_service.create_event(
-            session,
-            build_system_event(
-                SystemEvent.subscription_updated,
-                customer=subscription.customer,
-                organization=subscription.organization,
-                metadata={
-                    "subscription_id": str(subscription.id),
-                    "billing_period_end": new_period_end.isoformat(),
-                },
-            ),
+        ctx.add_event_metadata(
+            billing_period_end=subscription.current_period_end.isoformat()
         )
 
         return subscription
 
     async def uncancel(
-        self, session: AsyncSession, subscription: Subscription
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
     ) -> Subscription:
         if subscription.ended_at:
             raise ResourceUnavailable()
@@ -1716,27 +1720,18 @@ class SubscriptionService:
         ):
             raise BadRequest()
 
-        previous_status = subscription.status
-        previous_is_canceled = subscription.canceled
-
         subscription.cancel_at_period_end = False
         subscription.ends_at = None
         subscription.canceled_at = None
         subscription.customer_cancellation_reason = None
         subscription.customer_cancellation_comment = None
         session.add(subscription)
-
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
-        )
         return subscription
 
     async def revoke(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         customer_reason: CustomerCancellationReason | None = None,
@@ -1744,6 +1739,7 @@ class SubscriptionService:
     ) -> Subscription:
         return await self._perform_cancellation(
             session,
+            ctx,
             subscription,
             customer_reason=customer_reason,
             customer_comment=customer_comment,
@@ -1753,6 +1749,7 @@ class SubscriptionService:
     async def cancel(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         customer_reason: CustomerCancellationReason | None = None,
@@ -1760,6 +1757,7 @@ class SubscriptionService:
     ) -> Subscription:
         return await self._perform_cancellation(
             session,
+            ctx,
             subscription,
             customer_reason=customer_reason,
             customer_comment=customer_comment,
@@ -1773,17 +1771,20 @@ class SubscriptionService:
             customer_id
         )
         for subscription in subscriptions:
-            await self._perform_cancellation(
-                session,
-                subscription,
-                immediately=True,
-                # Benefits are revoked through `benefit.revoke_customer`
-                revoke_benefits=False,
-            )
+            async with SubscriptionUpdateContext(session, subscription, self) as ctx:
+                await self._perform_cancellation(
+                    session,
+                    ctx,
+                    subscription,
+                    immediately=True,
+                    # Benefits are revoked through `benefit.revoke_customer`
+                    revoke_benefits=False,
+                )
 
     async def _perform_cancellation(
         self,
         session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
         customer_reason: CustomerCancellationReason | None = None,
@@ -1793,9 +1794,6 @@ class SubscriptionService:
     ) -> Subscription:
         if not subscription.can_cancel(immediately):
             raise AlreadyCanceledSubscription(subscription)
-
-        previous_status = subscription.status
-        previous_is_canceled = subscription.canceled
 
         now = utc_now()
         subscription.canceled_at = now
@@ -1826,13 +1824,6 @@ class SubscriptionService:
             reason=customer_reason,
         )
         session.add(subscription)
-
-        await self._after_subscription_updated(
-            session,
-            subscription,
-            previous_status=previous_status,
-            previous_is_canceled=previous_is_canceled,
-        )
         return subscription
 
     async def update_meters(

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -20,6 +20,7 @@ from polar.worker import (
     enqueue_job,
 )
 
+from .service import SubscriptionUpdateContext
 from .service import subscription as subscription_service
 
 log: Logger = structlog.get_logger()
@@ -80,7 +81,10 @@ async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) ->
                 )
                 return
 
-            await subscription_service.cycle(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.cycle(session, ctx, subscription)
 
 
 @actor(

--- a/server/scripts/batch_subscriptions_cancel.py
+++ b/server/scripts/batch_subscriptions_cancel.py
@@ -17,6 +17,7 @@ from polar.organization.repository import OrganizationRepository
 from polar.postgres import create_async_engine
 from polar.redis import create_redis
 from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.worker import JobQueueManager
 
@@ -96,11 +97,15 @@ async def batch_subscriptions_cancel(
                         *subscription_repository.get_eager_options()
                     )
                 ):
-                    await subscription_service._perform_cancellation(
-                        session,
-                        subscription,
-                        immediately=True,
-                    )
+                    async with SubscriptionUpdateContext(
+                        session, subscription, subscription_service
+                    ) as ctx:
+                        await subscription_service._perform_cancellation(
+                            session,
+                            ctx,
+                            subscription,
+                            immediately=True,
+                        )
                     subscription_ids.add(subscription.id)
                     progress.advance(task)
 

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -44,6 +44,7 @@ from polar.models.order import OrderStatus
 from polar.models.subscription import CustomerCancellationReason
 from polar.order.service import order as order_service
 from polar.postgres import AsyncSession
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -2040,12 +2041,16 @@ class TestSystemEvents:
             customer=customer,
         )
 
-        await subscription_service.cancel(
-            session,
-            subscription,
-            customer_reason=CustomerCancellationReason.too_expensive,
-            customer_comment="Too pricey for me",
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.cancel(
+                session,
+                ctx,
+                subscription,
+                customer_reason=CustomerCancellationReason.too_expensive,
+                customer_comment="Too pricey for me",
+            )
 
         event_repository = EventRepository.from_session(session)
         events = await event_repository.get_all_by_name(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -3026,7 +3026,7 @@ class TestHandlePaymentFailure:
 
         # Then
         assert result_order.next_payment_attempt_at is None
-        mock_revoke.assert_called_once_with(session, subscription)
+        mock_revoke.assert_called_once_with(session, ANY, subscription)
         mock_mark_past_due.assert_not_called()
 
     @freeze_time("2024-01-01 12:00:00")
@@ -3412,7 +3412,7 @@ class TestHandlePaymentFailure:
 
         # Then — subscription revoked, no further retries
         assert result_order.next_payment_attempt_at is None
-        mock_revoke.assert_called_once_with(session, subscription)
+        mock_revoke.assert_called_once_with(session, ANY, subscription)
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import ANY, AsyncMock, MagicMock, call
 
 import freezegun
 import pytest
@@ -131,6 +131,32 @@ def assert_hooks_called_once(subscription_hooks: Hooks, called: set[str]) -> Non
 def reset_hooks(subscription_hooks: Hooks) -> None:
     for hook in HookNames:
         getattr(subscription_hooks, hook).reset_mock()
+
+
+async def assert_order_exists(
+    session: AsyncSession, subscription: Subscription
+) -> None:
+    order_repository = OrderRepository.from_session(session)
+    orders = await order_repository.get_all_by_subscription(subscription.id)
+    assert len(orders) > 0, (
+        "Expected at least one order to be created for the subscription"
+    )
+
+
+def assert_webhook_sent_once(
+    send_mock: MagicMock,
+    event_type: WebhookEventType,
+    organization: Organization,
+    subscription: Subscription,
+) -> None:
+    send_mock.assert_any_call(ANY, organization, event_type, subscription)
+    event_occurences = 0
+    for mock_calls in send_mock.call_args_list:
+        if mock_calls.args[1] == organization and mock_calls.args[2] == event_type:
+            event_occurences += 1
+    assert event_occurences == 1, (
+        f"Expected webhook {event_type} to be sent once, but was sent {event_occurences} times"
+    )
 
 
 def build_stripe_payment_intent(
@@ -921,16 +947,21 @@ class TestCycle:
         )
 
         with pytest.raises(InactiveSubscription):
-            await subscription_service.cycle(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.cycle(session, ctx, subscription)
 
     async def test_fixed_price(
         self,
         session: AsyncSession,
         enqueue_job_mock: MagicMock,
         enqueue_email_mock: MagicMock,
+        webhook_service_send_mock: AsyncMock,
         save_fixture: SaveFixture,
         product: Product,
         customer: Customer,
+        organization: Organization,
     ) -> None:
         subscription = await create_active_subscription(
             save_fixture,
@@ -941,7 +972,12 @@ class TestCycle:
 
         previous_current_period_end = subscription.current_period_end
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.ended_at is None
         assert updated_subscription.current_period_start == previous_current_period_end
@@ -993,6 +1029,13 @@ class TestCycle:
             OrderBillingReasonInternal.subscription_cycle,
         )
 
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated_subscription,
+        )
+
         enqueue_email_mock.assert_not_called()
 
     async def test_free_price(
@@ -1009,7 +1052,10 @@ class TestCycle:
             scheduler_locked_at=utc_now(),
         )
 
-        await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.cycle(session, ctx, subscription)
 
         price = product_recurring_free_price.prices[0]
         assert is_free_price(price)
@@ -1047,19 +1093,28 @@ class TestCycle:
             scheduler_locked_at=utc_now(),
         )
 
-        second_month_subscription = await subscription_service.cycle(
-            session, subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            second_month_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
         assert second_month_subscription.discount == discount
 
-        third_month_subscription = await subscription_service.cycle(
-            session, second_month_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, second_month_subscription, subscription_service
+        ) as ctx:
+            third_month_subscription = await subscription_service.cycle(
+                session, ctx, second_month_subscription
+            )
         assert third_month_subscription.discount == discount
 
-        fourth_month_subscription = await subscription_service.cycle(
-            session, third_month_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, third_month_subscription, subscription_service
+        ) as ctx:
+            fourth_month_subscription = await subscription_service.cycle(
+                session, ctx, third_month_subscription
+            )
         assert fourth_month_subscription.discount is None
 
         billing_entry_repository = BillingEntryRepository.from_session(session)
@@ -1099,18 +1154,24 @@ class TestCycle:
         assert first_period_end is not None
         assert first_period_end == first_period_start.replace(month=3)
 
-        second_cycle_subscription = await subscription_service.cycle(
-            session, subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            second_cycle_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
         second_period_start = second_cycle_subscription.current_period_start
         second_period_end = second_cycle_subscription.current_period_end
         assert second_period_start == first_period_end
         assert second_period_end is not None
         assert second_period_end == first_period_end.replace(month=5)
 
-        third_cycle_subscription = await subscription_service.cycle(
-            session, second_cycle_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, second_cycle_subscription, subscription_service
+        ) as ctx:
+            third_cycle_subscription = await subscription_service.cycle(
+                session, ctx, second_cycle_subscription
+            )
         assert third_cycle_subscription.current_period_start == second_period_end
         assert third_cycle_subscription.current_period_end is not None
         assert third_cycle_subscription.current_period_end == second_period_end.replace(
@@ -1155,9 +1216,12 @@ class TestCycle:
         assert subscription.current_period_start.month == 1
         assert subscription.current_period_end.month == 2
 
-        second_cycle_subscription = await subscription_service.cycle(
-            session, subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            second_cycle_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
         second_period_start = second_cycle_subscription.current_period_start
         assert second_period_start.month == 2
         assert second_period_start.day == 29
@@ -1165,9 +1229,12 @@ class TestCycle:
         assert second_period_end.month == 3
         assert second_period_end.day == 31
 
-        third_cycle_subscription = await subscription_service.cycle(
-            session, second_cycle_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, second_cycle_subscription, subscription_service
+        ) as ctx:
+            third_cycle_subscription = await subscription_service.cycle(
+                session, ctx, second_cycle_subscription
+            )
         third_period_start = third_cycle_subscription.current_period_start
         assert third_period_start.month == 3
         assert third_period_start.day == 31
@@ -1195,7 +1262,12 @@ class TestCycle:
         previous_current_period_start = subscription.current_period_start
         previous_current_period_end = subscription.current_period_end
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.status == SubscriptionStatus.canceled
         # ended_at should be set to the current time, not to ends_at
@@ -1282,7 +1354,12 @@ class TestCycle:
         assert subscription.ends_at == subscription.current_period_end
         assert subscription.ends_at > cycle_time
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         # ended_at should be set to the current time when the cycle ran, not to ends_at
         assert updated_subscription.status == SubscriptionStatus.canceled
@@ -1307,7 +1384,12 @@ class TestCycle:
         previous_trial_end = subscription.trial_end
         previous_current_period_end = subscription.current_period_end
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.ended_at is None
         assert updated_subscription.current_period_start == previous_current_period_end
@@ -1350,7 +1432,12 @@ class TestCycle:
         assert subscription.trial_end == datetime(2024, 5, 5, 12, 0, 0, tzinfo=UTC)
         assert subscription.current_period_end == subscription.trial_end
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.status == SubscriptionStatus.active
         assert updated_subscription.anchor_day == 5
@@ -1393,7 +1480,12 @@ class TestCycle:
         assert subscription.status == SubscriptionStatus.trialing
 
         # Cycle the subscription (trial ends, first billing cycle)
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         # Verify discount is STILL applied after trial ends
         # This is the first actual billing cycle, so "once" discount should apply
@@ -1415,9 +1507,12 @@ class TestCycle:
         assert cycle_entries[0].discount_amount > 0
 
         # Now cycle again (second billing period)
-        second_cycle_subscription = await subscription_service.cycle(
-            session, updated_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, updated_subscription, subscription_service
+        ) as ctx:
+            second_cycle_subscription = await subscription_service.cycle(
+                session, ctx, updated_subscription
+            )
 
         # Verify discount is NOW removed (used up after first billing cycle)
         assert second_cycle_subscription.discount is None
@@ -1460,9 +1555,12 @@ class TestCycle:
         assert subscription.status == SubscriptionStatus.trialing
 
         # Cycle 1: Trial ends, first billing cycle
-        first_billing_subscription = await subscription_service.cycle(
-            session, subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            first_billing_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         # Verify discount_applied_at is now set to the first billing period start
         assert first_billing_subscription.discount == discount
@@ -1474,21 +1572,30 @@ class TestCycle:
         assert first_billing_subscription.status == SubscriptionStatus.active
 
         # Cycle 2: Second billing cycle (2nd month of discount)
-        second_billing_subscription = await subscription_service.cycle(
-            session, first_billing_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, first_billing_subscription, subscription_service
+        ) as ctx:
+            second_billing_subscription = await subscription_service.cycle(
+                session, ctx, first_billing_subscription
+            )
         assert second_billing_subscription.discount == discount
 
         # Cycle 3: Third billing cycle (3rd month of discount)
-        third_billing_subscription = await subscription_service.cycle(
-            session, second_billing_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, second_billing_subscription, subscription_service
+        ) as ctx:
+            third_billing_subscription = await subscription_service.cycle(
+                session, ctx, second_billing_subscription
+            )
         assert third_billing_subscription.discount == discount
 
         # Cycle 4: Fourth billing cycle - discount should now be expired
-        fourth_billing_subscription = await subscription_service.cycle(
-            session, third_billing_subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, third_billing_subscription, subscription_service
+        ) as ctx:
+            fourth_billing_subscription = await subscription_service.cycle(
+                session, ctx, third_billing_subscription
+            )
         assert fourth_billing_subscription.discount is None
 
         # Verify billing entries - 3 should have discount, 1 should not
@@ -1535,7 +1642,12 @@ class TestCycle:
 
         previous_current_period_end = subscription.current_period_end
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.ended_at is None
         assert updated_subscription.current_period_start == previous_current_period_end
@@ -1606,7 +1718,12 @@ class TestCycle:
 
         previous_current_period_end = subscription.current_period_end
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.ended_at is None
         assert updated_subscription.current_period_start == previous_current_period_end
@@ -1660,7 +1777,12 @@ class TestCycle:
         old_period_end = subscription.current_period_end
         assert old_period_end is not None
 
-        updated_subscription = await subscription_service.cycle(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
 
         # The new period should start exactly at the old period end
         assert updated_subscription.current_period_start == old_period_end
@@ -2421,16 +2543,6 @@ class TestList:
         assert subscription_2 in results
 
 
-async def assert_order_exists(
-    session: AsyncSession, subscription: Subscription
-) -> None:
-    order_repository = OrderRepository.from_session(session)
-    orders = await order_repository.get_all_by_subscription(subscription.id)
-    assert len(orders) > 0, (
-        "Expected at least one order to be created for the subscription"
-    )
-
-
 @pytest.mark.asyncio
 class TestUpdate:
     async def test_product_update_prorate(
@@ -2466,8 +2578,11 @@ class TestUpdate:
 
         assert updated.product == new_product
 
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
     async def test_product_update_invoice(
@@ -2506,8 +2621,11 @@ class TestUpdate:
 
         assert updated.product == new_product
         await assert_order_exists(session, subscription)
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
     async def test_discount_update(
@@ -2538,9 +2656,11 @@ class TestUpdate:
             )
 
         assert updated.discount == discount_percentage_50
-
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
     async def test_trial_update_extends(
@@ -2576,9 +2696,11 @@ class TestUpdate:
 
         assert updated.status == SubscriptionStatus.trialing
         assert updated.trial_end == initial_trial_end + timedelta(days=7)
-
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
     async def test_trial_update_ends(
@@ -2616,8 +2738,11 @@ class TestUpdate:
         assert updated.trial_end == updated.current_period_start
         assert updated.trial_end < initial_trial_end
 
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
         enqueue_job_mock.assert_any_call(
             "order.create_subscription_order",
@@ -2653,8 +2778,11 @@ class TestUpdate:
 
         assert updated.seats == 10
 
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
     async def test_seats_update_invoice(
@@ -2698,8 +2826,11 @@ class TestUpdate:
         await assert_order_exists(session, subscription)
         trigger_payment_mock.assert_awaited_once()
 
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
     async def test_billing_period_end_update(
@@ -2733,8 +2864,11 @@ class TestUpdate:
 
         assert updated.current_period_end == initial_period_end + timedelta(days=7)
 
-        webhook_service_send_mock.assert_any_call(
-            session, organization, WebhookEventType.subscription_updated, updated
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
         )
 
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -91,6 +91,7 @@ from polar.subscription.service import (
     NotARecurringProduct,
     NotASeatBasedSubscription,
     SeatsAlreadyAssigned,
+    SubscriptionUpdateContext,
 )
 from polar.subscription.service import subscription as subscription_service
 from polar.subscription.update import generate_subscription_update
@@ -1702,7 +1703,10 @@ class TestRevoke:
         )
 
         with pytest.raises(AlreadyCanceledSubscription):
-            await subscription_service.revoke(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.revoke(session, ctx, subscription)
 
     async def test_valid(
         self,
@@ -1720,7 +1724,12 @@ class TestRevoke:
             customer=customer,
         )
 
-        updated_subscription = await subscription_service.revoke(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.revoke(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.status == SubscriptionStatus.canceled
         assert updated_subscription.canceled_at == frozen_time
@@ -1756,7 +1765,10 @@ class TestRevoke:
         assert subscription.cancel_at_period_end is True
         reset_hooks(subscription_hooks)
 
-        await subscription_service.revoke(session, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.revoke(session, ctx, subscription)
 
         subscription_hooks.canceled.assert_called_once()
         subscription_hooks.revoked.assert_called_once()
@@ -1781,7 +1793,10 @@ class TestCancel:
         assert subscription.cancel_at_period_end is True
 
         with pytest.raises(AlreadyCanceledSubscription):
-            await subscription_service.cancel(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.cancel(session, ctx, subscription)
 
 
 @pytest.mark.asyncio
@@ -1800,7 +1815,10 @@ class TestUncancel:
         )
 
         with pytest.raises(BadRequest):
-            await subscription_service.uncancel(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.uncancel(session, ctx, subscription)
 
     async def test_valid(
         self,
@@ -1818,9 +1836,12 @@ class TestUncancel:
             cancel_at_period_end=True,
         )
 
-        updated_subscription = await subscription_service.uncancel(
-            session, subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.uncancel(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.status == SubscriptionStatus.active
         assert updated_subscription.cancel_at_period_end is False
@@ -1844,7 +1865,10 @@ class TestUncancel:
         assert subscription.cancel_at_period_end is False
 
         with pytest.raises(BadRequest):
-            await subscription_service.uncancel(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.uncancel(session, ctx, subscription)
 
     async def test_uncancel_already_revoked(
         self,
@@ -1867,7 +1891,10 @@ class TestUncancel:
         assert subscription.canceled_at
 
         with pytest.raises(ResourceUnavailable):
-            await subscription_service.uncancel(session, subscription)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.uncancel(session, ctx, subscription)
 
     async def test_uncancel_past_due(
         self,
@@ -1886,9 +1913,12 @@ class TestUncancel:
             cancel_at_period_end=True,
         )
 
-        updated_subscription = await subscription_service.uncancel(
-            session, subscription
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.uncancel(
+                session, ctx, subscription
+            )
 
         assert updated_subscription.status == SubscriptionStatus.past_due
         assert updated_subscription.cancel_at_period_end is False
@@ -2424,11 +2454,15 @@ class TestUpdate:
             recurring_interval=SubscriptionRecurringInterval.month,
         )
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateProduct(product_id=new_product.id),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateProduct(product_id=new_product.id),
+            )
 
         assert updated.product == new_product
 
@@ -2457,14 +2491,18 @@ class TestUpdate:
             recurring_interval=SubscriptionRecurringInterval.month,
         )
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateProduct(
-                product_id=new_product.id,
-                proration_behavior=SubscriptionProrationBehavior.invoice,
-            ),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateProduct(
+                    product_id=new_product.id,
+                    proration_behavior=SubscriptionProrationBehavior.invoice,
+                ),
+            )
 
         assert updated.product == new_product
         await assert_order_exists(session, subscription)
@@ -2487,11 +2525,17 @@ class TestUpdate:
             product=product,
             customer=customer,
         )
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateDiscount(discount_id=discount_percentage_50.id),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateDiscount(
+                    discount_id=discount_percentage_50.id
+                ),
+            )
 
         assert updated.discount == discount_percentage_50
 
@@ -2518,13 +2562,17 @@ class TestUpdate:
         initial_trial_end = subscription.trial_end
         assert initial_trial_end is not None
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateTrial(
-                trial_end=initial_trial_end + timedelta(days=7),
-            ),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateTrial(
+                    trial_end=initial_trial_end + timedelta(days=7),
+                ),
+            )
 
         assert updated.status == SubscriptionStatus.trialing
         assert updated.trial_end == initial_trial_end + timedelta(days=7)
@@ -2553,11 +2601,15 @@ class TestUpdate:
         initial_trial_end = subscription.trial_end
         assert initial_trial_end is not None
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateTrial(trial_end="now"),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateTrial(trial_end="now"),
+            )
 
         assert updated.status == SubscriptionStatus.active
         assert updated.trial_end is not None
@@ -2589,11 +2641,15 @@ class TestUpdate:
             seats=5,
         )
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateSeats(seats=10),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateSeats(seats=10),
+            )
 
         assert updated.seats == 10
 
@@ -2626,13 +2682,17 @@ class TestUpdate:
             payment_method=payment_method,
         )
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateSeats(
-                seats=10, proration_behavior=SubscriptionProrationBehavior.invoice
-            ),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateSeats(
+                    seats=10, proration_behavior=SubscriptionProrationBehavior.invoice
+                ),
+            )
 
         assert updated.seats == 10
         await assert_order_exists(session, subscription)
@@ -2659,13 +2719,17 @@ class TestUpdate:
         initial_period_end = subscription.current_period_end
         assert initial_period_end is not None
 
-        updated = await subscription_service.update(
-            session,
-            subscription,
-            update=SubscriptionUpdateBillingPeriod(
-                current_billing_period_end=initial_period_end + timedelta(days=7)
-            ),
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update(
+                session,
+                ctx,
+                subscription,
+                update=SubscriptionUpdateBillingPeriod(
+                    current_billing_period_end=initial_period_end + timedelta(days=7)
+                ),
+            )
 
         assert updated.current_period_end == initial_period_end + timedelta(days=7)
 
@@ -2701,9 +2765,12 @@ class TestUpdateProduct:
             trial_interval_count=1,
         )
 
-        updated = await subscription_service.update_product(
-            session, subscription, product_id=new_product.id
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session, ctx, subscription, product_id=new_product.id
+            )
 
         assert updated.product == new_product
         assert updated.status == SubscriptionStatus.trialing
@@ -2736,9 +2803,12 @@ class TestUpdateProduct:
             trial_interval_count=14,
         )
 
-        updated = await subscription_service.update_product(
-            session, subscription, product_id=new_product.id
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session, ctx, subscription, product_id=new_product.id
+            )
 
         expected_trial_end = TrialInterval.day.get_end(trial_start, 14)
         assert updated.product == new_product
@@ -2775,9 +2845,12 @@ class TestUpdateProduct:
         )
 
         with freezegun.freeze_time(trial_creation_time + timedelta(days=1)):
-            updated = await subscription_service.update_product(
-                session, subscription, product_id=new_product.id
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated = await subscription_service.update_product(
+                    session, ctx, subscription, product_id=new_product.id
+                )
 
         expected_trial_end = TrialInterval.day.get_end(trial_start, 7)
         assert updated.product == new_product
@@ -2814,9 +2887,12 @@ class TestUpdateProduct:
 
         change_time = trial_creation_time + timedelta(days=10)
         with freezegun.freeze_time(change_time):
-            updated = await subscription_service.update_product(
-                session, subscription, product_id=new_product.id
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated = await subscription_service.update_product(
+                    session, ctx, subscription, product_id=new_product.id
+                )
 
         assert updated.product == new_product
         assert updated.status == SubscriptionStatus.active
@@ -2850,9 +2926,12 @@ class TestUpdateProduct:
             recurring_interval=SubscriptionRecurringInterval.month,
         )
 
-        updated = await subscription_service.update_product(
-            session, subscription, product_id=new_product.id
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session, ctx, subscription, product_id=new_product.id
+            )
 
         assert updated.product == new_product
         assert updated.status == SubscriptionStatus.active
@@ -2891,12 +2970,16 @@ class TestUpdateProduct:
             trial_interval_count=2,
         )
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=new_product.id,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
 
         create_subscription_update_order_mock.assert_not_called()
 
@@ -2937,12 +3020,16 @@ class TestUpdateProduct:
             prices=[(3000, "usd"), (meter, Decimal(50), None, "usd")],
         )
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=new_product.id,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         assert updated_subscription.product == new_product
@@ -2974,12 +3061,16 @@ class TestUpdateProduct:
             prices=[(meter, Decimal(100), None, "usd")],
         )
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=metered_only_product.id,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=metered_only_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
 
         assert updated_subscription.product == metered_only_product
 
@@ -3016,12 +3107,16 @@ class TestUpdateProduct:
             seats=3,
         )
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=new_seat_product.id,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
 
         assert updated_subscription.product == new_seat_product
         create_subscription_update_order_mock.assert_called_once()
@@ -3079,12 +3174,16 @@ class TestUpdateProduct:
 
         enqueue_job_mock = mocker.patch("polar.customer_seat.service.enqueue_job")
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=new_seat_product.id,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
 
         benefit_grant_calls = [
             c
@@ -3106,6 +3205,7 @@ class TestUpdateProduct:
         product_recurring_multiple_currencies: Product,
         customer: Customer,
         organization: Organization,
+        webhook_service_send_mock: MagicMock,
     ) -> None:
         subscription = await create_active_subscription(
             save_fixture,
@@ -3116,12 +3216,18 @@ class TestUpdateProduct:
         assert len(subscription.prices) == 1
 
         with pytest.raises(PolarRequestValidationError):
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=product.id,
-                proration_behavior=SubscriptionProrationBehavior.prorate,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=product.id,
+                    proration_behavior=SubscriptionProrationBehavior.prorate,
+                )
+
+        webhook_service_send_mock.assert_not_called()
 
     async def test_available_currency(
         self,
@@ -3140,12 +3246,16 @@ class TestUpdateProduct:
         )
         assert len(subscription.prices) == 1
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product.id,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
 
         assert updated_subscription.product == product
         assert len(updated_subscription.prices) == 1
@@ -3195,11 +3305,15 @@ class TestUpdateProduct:
         )
 
         with pytest.raises(PolarRequestValidationError):
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=fixed_product.id,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=fixed_product.id,
+                )
 
     async def test_upgrade_from_legacy_recurring_product_to_new_recurring_product(
         self,
@@ -3243,12 +3357,16 @@ class TestUpdateProduct:
             customer=customer,
         )
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=new_product.id,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
 
         assert updated_subscription.product == new_product
 
@@ -3269,12 +3387,16 @@ class TestUpdateProduct:
         )
         assert len(subscription.prices) == 1
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
 
         assert updated_subscription.product == product_recurring_multiple_currencies
 
@@ -3329,12 +3451,16 @@ class TestUpdateProduct:
         )
         await save_fixture(subscription_update)
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_second.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_second.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
 
         assert updated_subscription.product == product_recurring_multiple_currencies
 
@@ -3390,12 +3516,16 @@ class TestUpdateProduct:
         )
         await save_fixture(subscription_update)
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_second.id,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_second.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
 
         assert updated_subscription.product == product_second
 
@@ -3431,12 +3561,16 @@ class TestUpdateProduct:
         )
         assert len(subscription.prices) == 1
 
-        updated_subscription = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
 
         assert updated_subscription.product == product_recurring_multiple_currencies
 
@@ -3495,18 +3629,26 @@ class TestUpdateProduct:
             save_fixture, product=product_a, customer=customer, seats=5
         )
 
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=8,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_b.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=8,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_b.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         repo = SubscriptionUpdateRepository.from_session(session)
@@ -3556,12 +3698,16 @@ class TestUpdateProduct:
         seat_product.prices.append(seat_price)
         await save_fixture(seat_product)
 
-        updated = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=seat_product.id,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
 
         assert updated.product == seat_product
         assert updated.seats == 1
@@ -3604,12 +3750,16 @@ class TestUpdateProduct:
             prices=[("seat", 1500, "usd")],
         )
 
-        updated = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=seat_product.id,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
 
         await session.refresh(updated.customer)
         assert updated.customer.type == CustomerType.team
@@ -3643,12 +3793,16 @@ class TestUpdateProduct:
             prices=[("seat", 2000, "usd")],
         )
 
-        updated = await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=seat_product.id,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
 
         billing_entry_repository = BillingEntryRepository.from_session(session)
         entries = await billing_entry_repository.get_pending_by_subscription(updated.id)
@@ -3694,12 +3848,16 @@ class TestUpdateProduct:
         )
 
         with pytest.raises(PolarRequestValidationError) as exc_info:
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=seat_product.id,
-                proration_behavior=SubscriptionProrationBehavior.next_period,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=seat_product.id,
+                    proration_behavior=SubscriptionProrationBehavior.next_period,
+                )
 
         errors = exc_info.value.errors()
         assert any(
@@ -3728,9 +3886,12 @@ class TestUpdateDiscount:
         )
 
         with pytest.raises(PolarRequestValidationError):
-            await subscription_service.update_discount(
-                session, subscription, discount_id=uuid.uuid4()
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_discount(
+                    session, ctx, subscription, discount_id=uuid.uuid4()
+                )
 
     async def test_same_discount(
         self,
@@ -3749,9 +3910,12 @@ class TestUpdateDiscount:
         )
 
         with pytest.raises(PolarRequestValidationError):
-            await subscription_service.update_discount(
-                session, subscription, discount_id=discount_percentage_50.id
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_discount(
+                    session, ctx, subscription, discount_id=discount_percentage_50.id
+                )
 
     async def test_valid_removed(
         self,
@@ -3768,9 +3932,12 @@ class TestUpdateDiscount:
             discount=discount_percentage_50,
         )
 
-        subscription = await subscription_service.update_discount(
-            session, subscription, discount_id=None
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            subscription = await subscription_service.update_discount(
+                session, ctx, subscription, discount_id=None
+            )
 
         assert subscription.discount is None
 
@@ -3797,9 +3964,12 @@ class TestUpdateDiscount:
             save_fixture, product=product, customer=customer
         )
 
-        subscription = await subscription_service.update_discount(
-            session, subscription, discount_id=discount_percentage_50.id
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            subscription = await subscription_service.update_discount(
+                session, ctx, subscription, discount_id=discount_percentage_50.id
+            )
 
         assert subscription.discount == discount_percentage_50
 
@@ -3830,9 +4000,12 @@ class TestUpdateDiscount:
             discount=discount_percentage_50,
         )
 
-        subscription = await subscription_service.update_discount(
-            session, subscription, discount_id=discount_percentage_100.id
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            subscription = await subscription_service.update_discount(
+                session, ctx, subscription, discount_id=discount_percentage_100.id
+            )
 
         assert subscription.discount == discount_percentage_100
 
@@ -3864,9 +4037,12 @@ class TestUpdateTrial:
         assert subscription.trial_end is not None
         original_trial_end = subscription.trial_end
 
-        updated_subscription = await subscription_service.update_trial(
-            session, subscription, trial_end="now"
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_trial(
+                session, ctx, subscription, trial_end="now"
+            )
 
         assert updated_subscription.status == SubscriptionStatus.active
         assert updated_subscription.trial_end is not None
@@ -3893,9 +4069,12 @@ class TestUpdateTrial:
         new_trial_end = original_trial_end + timedelta(days=30)
 
         reset_hooks(subscription_hooks)
-        updated_subscription = await subscription_service.update_trial(
-            session, subscription, trial_end=new_trial_end
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_trial(
+                session, ctx, subscription, trial_end=new_trial_end
+            )
 
         assert updated_subscription.status == SubscriptionStatus.trialing
         assert updated_subscription.current_period_end == new_trial_end
@@ -3931,9 +4110,12 @@ class TestUpdateTrial:
         )
 
         with pytest.raises(PolarRequestValidationError) as exc_info:
-            await subscription_service.update_trial(
-                session, subscription, trial_end="now"
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_trial(
+                    session, ctx, subscription, trial_end="now"
+                )
 
         errors = exc_info.value.errors()
         assert len(errors) == 1
@@ -3958,9 +4140,12 @@ class TestUpdateTrial:
 
         trial_end = subscription.current_period_end + timedelta(days=14)
 
-        updated_subscription = await subscription_service.update_trial(
-            session, subscription, trial_end=trial_end
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_trial(
+                session, ctx, subscription, trial_end=trial_end
+            )
 
         assert updated_subscription.status == SubscriptionStatus.trialing
         assert updated_subscription.trial_end == trial_end
@@ -3995,9 +4180,12 @@ class TestUpdateTrial:
         trial_end_before_period = subscription.current_period_end - timedelta(days=1)
 
         with pytest.raises(PolarRequestValidationError) as exc_info:
-            await subscription_service.update_trial(
-                session, subscription, trial_end=trial_end_before_period
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_trial(
+                    session, ctx, subscription, trial_end=trial_end_before_period
+                )
 
         errors = exc_info.value.errors()
         assert len(errors) == 1
@@ -4034,9 +4222,12 @@ class TestUpdateTrial:
         new_trial_end = original_trial_end + timedelta(days=30)
 
         # When: Extend trial
-        updated_subscription = await subscription_service.update_trial(
-            session, subscription, trial_end=new_trial_end
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.update_trial(
+                session, ctx, subscription, trial_end=new_trial_end
+            )
 
         # Then: Trial extended, seats preserved
         assert updated_subscription.status == SubscriptionStatus.trialing
@@ -4224,12 +4415,16 @@ class TestUpdateSeats:
         assert subscription.amount == 5000
 
         # When: Increase to 10 seats
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Seats and amount updated
@@ -4289,12 +4484,16 @@ class TestUpdateSeats:
         assert subscription.amount == 5000
 
         # When: Increase to 15 seats (crosses to tier 2)
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=15,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=15,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Amount = 15 * $8 = $120 (tier 2 pricing)
@@ -4344,7 +4543,12 @@ class TestUpdateSeats:
         # When: Try to decrease to 5 seats
         # Then: Raises error
         with pytest.raises(SeatsAlreadyAssigned) as exc_info:
-            await subscription_service.update_seats(session, subscription, seats=5)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session, ctx, subscription, seats=5
+                )
 
         assert exc_info.value.assigned_count == 7
         assert exc_info.value.requested_seats == 5
@@ -4385,12 +4589,16 @@ class TestUpdateSeats:
             )
 
         # When: Decrease to 5 seats (above assigned count)
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=5,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=5,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Successfully updated
@@ -4433,7 +4641,12 @@ class TestUpdateSeats:
         # When: Try to set seats=0
         # Then: Raises error
         with pytest.raises(BelowMinimumSeats) as exc_info:
-            await subscription_service.update_seats(session, subscription, seats=0)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session, ctx, subscription, seats=0
+                )
 
         assert exc_info.value.minimum_seats == 1
         assert exc_info.value.requested_seats == 0
@@ -4474,7 +4687,12 @@ class TestUpdateSeats:
 
         # When: Try to set seats below custom minimum
         with pytest.raises(BelowMinimumSeats) as exc_info:
-            await subscription_service.update_seats(session, subscription, seats=2)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session, ctx, subscription, seats=2
+                )
 
         assert exc_info.value.minimum_seats == 3
         assert exc_info.value.requested_seats == 2
@@ -4515,7 +4733,12 @@ class TestUpdateSeats:
 
         # When: Try to set seats above maximum
         with pytest.raises(AboveMaximumSeats) as exc_info:
-            await subscription_service.update_seats(session, subscription, seats=15)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session, ctx, subscription, seats=15
+                )
 
         assert exc_info.value.maximum_seats == 10
         assert exc_info.value.requested_seats == 15
@@ -4555,9 +4778,12 @@ class TestUpdateSeats:
         )
 
         # When: Update seats within limits
-        updated = await subscription_service.update_seats(
-            session, subscription, seats=15
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session, ctx, subscription, seats=15
+            )
         await session.flush()
 
         # Then: Successfully updated
@@ -4581,7 +4807,12 @@ class TestUpdateSeats:
         # When: Try to update seats
         # Then: Raises error
         with pytest.raises(NotASeatBasedSubscription):
-            await subscription_service.update_seats(session, subscription, seats=10)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session, ctx, subscription, seats=10
+                )
 
     @pytest.mark.parametrize(
         "proration_behavior",
@@ -4607,9 +4838,16 @@ class TestUpdateSeats:
         )
 
         # When: Update with same seat count
-        updated = await subscription_service.update_seats(
-            session, subscription, seats=10, proration_behavior=proration_behavior
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=proration_behavior,
+            )
         await session.flush()
 
         # Then: Successfully updated (no-op)
@@ -4665,9 +4903,16 @@ class TestUpdateSeats:
         )
 
         # When: Update seats during trial
-        updated = await subscription_service.update_seats(
-            session, subscription, seats=10, proration_behavior=proration_behavior
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=proration_behavior,
+            )
         await session.flush()
 
         # Then: Successfully updated
@@ -4706,7 +4951,12 @@ class TestUpdateSeats:
         # When: Try to update seats
         # Then: Raises error
         with pytest.raises(AlreadyCanceledSubscription):
-            await subscription_service.update_seats(session, subscription, seats=10)
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session, ctx, subscription, seats=10
+                )
 
     @pytest.mark.parametrize(
         ("initial", "new"),
@@ -4746,12 +4996,16 @@ class TestUpdateSeats:
         )
 
         # When: Update with invoice behavior
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=new,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=new,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
         await session.flush()
 
         # Then: Order created and paid immediately
@@ -4793,12 +5047,16 @@ class TestUpdateSeats:
 
         # When: Update with invoice behavior
         with pytest.raises(PaymentFailed):
-            await subscription_service.update_seats(
-                session,
-                subscription,
-                seats=10,
-                proration_behavior=SubscriptionProrationBehavior.invoice,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_seats(
+                    session,
+                    ctx,
+                    subscription,
+                    seats=10,
+                    proration_behavior=SubscriptionProrationBehavior.invoice,
+                )
 
         # Then: subscription is untouched
         await nested.rollback()
@@ -4853,12 +5111,16 @@ class TestUpdateSeats:
                 update_time, new_anchor_day, subscription.recurring_interval_count
             )
 
-            updated_subscription = await subscription_service.update_seats(
-                session,
-                subscription,
-                seats=new,
-                proration_behavior=SubscriptionProrationBehavior.reset,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_seats(
+                    session,
+                    ctx,
+                    subscription,
+                    seats=new,
+                    proration_behavior=SubscriptionProrationBehavior.reset,
+                )
             await session.flush()
 
             # Then: Order created and paid immediately
@@ -4907,12 +5169,16 @@ class TestUpdateSeats:
         )
 
         # When: Update with prorate behavior
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Order creation job NOT enqueued for immediate invoice
@@ -4963,12 +5229,16 @@ class TestUpdateSeats:
         )
 
         # When: Update with invoice behavior
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
         await session.flush()
 
         # Then: subscription.updated event emitted with invoice proration behavior
@@ -5012,12 +5282,16 @@ class TestUpdateSeats:
         await save_fixture(subscription)
 
         # When: Update seats
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Seats updated but no billing entry created
@@ -5060,12 +5334,16 @@ class TestUpdateSeats:
         await save_fixture(subscription)
 
         # When: Update seats
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         # Then: seats not updated
@@ -5112,12 +5390,16 @@ class TestUpdateSeats:
         await save_fixture(subscription_update)
 
         # When: Update seats with next_period behavior
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         # Then: seats not updated
@@ -5164,12 +5446,16 @@ class TestUpdateSeats:
         await save_fixture(subscription_update)
 
         # When: Update seats with a proration behavior
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: seats are updated
@@ -5212,18 +5498,26 @@ class TestUpdateSeats:
             save_fixture, product=product_a, customer=customer, seats=5
         )
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_b.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=8,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_b.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=8,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         repo = SubscriptionUpdateRepository.from_session(session)
@@ -5264,19 +5558,27 @@ class TestUpdateSeats:
             save_fixture, product=product_a, customer=customer, seats=5
         )
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_b.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_b.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
 
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=8,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=8,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Subscription stays on A with seats applied immediately.
@@ -5333,18 +5635,26 @@ class TestUpdateSeats:
             save_fixture, product=product_a, customer=customer, seats=5
         )
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_b.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=8,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_b.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=8,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         repo = SubscriptionUpdateRepository.from_session(session)
@@ -5353,12 +5663,16 @@ class TestUpdateSeats:
         merged_pending_id = pending.id
         assert pending.seats == 8
 
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         assert updated.seats == 10
@@ -5402,20 +5716,28 @@ class TestUpdateSeats:
             save_fixture, product=product_a, customer=customer, seats=5
         )
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_b.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_b.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=5,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=5,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         repo = SubscriptionUpdateRepository.from_session(session)
@@ -5449,18 +5771,26 @@ class TestUpdateSeats:
             save_fixture, product=product_a, customer=customer, seats=5
         )
 
-        await subscription_service.update_product(
-            session,
-            subscription,
-            product_id=product_b.id,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=8,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=product_b.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=8,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         repo = SubscriptionUpdateRepository.from_session(session)
@@ -5470,12 +5800,16 @@ class TestUpdateSeats:
         assert pending.product_id == product_b.id
         assert pending.seats == 8
 
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=5,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=5,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         pending = await repo.get_unapplied_by_subscription_id(subscription.id)
@@ -5513,12 +5847,16 @@ class TestUpdateSeats:
             session
         )
 
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=1,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=1,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
         pending = await subscription_update_repository.get_unapplied_by_subscription_id(
             subscription.id
@@ -5526,12 +5864,16 @@ class TestUpdateSeats:
         assert pending is not None
         assert pending.seats == 1
 
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=2,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=2,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
         pending = await subscription_update_repository.get_unapplied_by_subscription_id(
             subscription.id
@@ -5540,12 +5882,16 @@ class TestUpdateSeats:
         assert pending.seats == 2
 
         # Reverting to current seat count must clear the pending update
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=3,
-            proration_behavior=SubscriptionProrationBehavior.next_period,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=3,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
         await session.flush()
 
         assert updated.seats == 3
@@ -5597,12 +5943,16 @@ class TestUpdateSeats:
         assert subscription.amount == 4000
 
         # When: Increase to 10 seats (delta = $50)
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Fixed discount does not change between old and new effective
@@ -5662,12 +6012,16 @@ class TestUpdateSeats:
         )
 
         # When: Increase to 10 seats (delta = $50, 20% discount = $10 off)
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Percentage discount applied
@@ -5727,12 +6081,16 @@ class TestUpdateSeats:
         )
 
         # When: Decrease to 5 seats (credit delta = -$50)
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=5,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=5,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Fixed discount applies equally to old ($100 → $90) and new
@@ -5775,12 +6133,16 @@ class TestUpdateSeats:
         assert subscription.discount is None
 
         # When: Increase seats
-        await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=10,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: No discount in billing entry
@@ -5834,12 +6196,16 @@ class TestUpdateSeats:
         assert subscription.seats == 1
 
         # When: Increase to 2 seats with invoice proration behavior
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=2,
-            proration_behavior=SubscriptionProrationBehavior.invoice,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=2,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
         await session.flush()
 
         # Then: Seats updated successfully, no billing entries created
@@ -5891,12 +6257,16 @@ class TestUpdateSeats:
         assert subscription.seats == 1
 
         # When: Increase to 2 seats with prorate behavior
-        updated = await subscription_service.update_seats(
-            session,
-            subscription,
-            seats=2,
-            proration_behavior=SubscriptionProrationBehavior.prorate,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=2,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
         await session.flush()
 
         # Then: Seats updated successfully, no billing entries created
@@ -6056,13 +6426,17 @@ class TestUpdateBillingPeriod:
         assert subscription.current_period_end is not None
         new_period_end = subscription.current_period_end + timedelta(days=7)
 
-        updated_subscription = (
-            await subscription_service.update_currrent_billing_period_end(
-                session,
-                subscription,
-                new_period_end=new_period_end,
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = (
+                await subscription_service.update_currrent_billing_period_end(
+                    session,
+                    ctx,
+                    subscription,
+                    new_period_end=new_period_end,
+                )
             )
-        )
 
         assert updated_subscription.current_period_end == new_period_end
         assert updated_subscription.anchor_day == new_period_end.day
@@ -6094,11 +6468,15 @@ class TestUpdateBillingPeriod:
         new_period_end = utc_now() + timedelta(days=30)
 
         with pytest.raises(AlreadyCanceledSubscription):
-            await subscription_service.update_currrent_billing_period_end(
-                session,
-                subscription,
-                new_period_end=new_period_end,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_currrent_billing_period_end(
+                    session,
+                    ctx,
+                    subscription,
+                    new_period_end=new_period_end,
+                )
 
 
 @pytest.mark.asyncio
@@ -6172,10 +6550,14 @@ class TestClearPendingUpdate:
         await save_fixture(subscription)
 
         # When: Clear the pending update
-        updated_subscription = await subscription_service.clear_pending_update(
-            session,
-            subscription,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.clear_pending_update(
+                session,
+                ctx,
+                subscription,
+            )
         await save_fixture(updated_subscription)
 
         # Then: Pending update is cleared
@@ -6197,10 +6579,14 @@ class TestClearPendingUpdate:
 
         # When/Then: Should raise validation error
         with pytest.raises(PolarRequestValidationError) as exc_info:
-            await subscription_service.clear_pending_update(
-                session,
-                subscription,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.clear_pending_update(
+                    session,
+                    ctx,
+                    subscription,
+                )
 
         errors = exc_info.value.errors()
         assert len(errors) == 1
@@ -6238,10 +6624,14 @@ class TestClearPendingUpdate:
         await save_fixture(subscription)
 
         # When: Clear the pending update
-        updated_subscription = await subscription_service.clear_pending_update(
-            session,
-            subscription,
-        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.clear_pending_update(
+                session,
+                ctx,
+                subscription,
+            )
         await save_fixture(updated_subscription)
 
         # Then: Pending update is cleared

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -1399,7 +1399,10 @@ class TestImmediateSeatChangeWithPendingProductChange:
             # 3. Force cycle past current_period_end so it applies the
             # pending product change.
             frozen_time.move_to(previous_period_end + timedelta(seconds=1))
-            cycled = await subscription_service.cycle(session, updated)
+            async with SubscriptionUpdateContext(
+                session, updated, subscription_service
+            ) as ctx:
+                cycled = await subscription_service.cycle(session, ctx, updated)
             await session.flush()
 
             assert cycled.product_id == product_b.id

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -27,6 +27,7 @@ from polar.product.guard import (
     is_seat_price,
 )
 from polar.subscription.repository import SubscriptionUpdateRepository
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -338,11 +339,15 @@ class TestUpdateProductProrations:
             frozen_time.move_to(time_of_update)
 
             # Actually update subscription
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=new_product.id,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=new_product.id,
+                )
 
             assert updated_subscription.ended_at is None
             if old_product.recurring_interval == new_product.recurring_interval:
@@ -463,11 +468,15 @@ class TestUpdateProductProrations:
 
         update_time = datetime(2025, 6, 16, tzinfo=UTC)
         with freezegun.freeze_time(update_time):
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=new_product.id,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=new_product.id,
+                )
 
             old_price = old_product.prices[0]
             new_price = new_product.prices[0]
@@ -521,11 +530,15 @@ class TestUpdateProductProrations:
 
         update_time = datetime(2025, 6, 16, tzinfo=UTC)
         with freezegun.freeze_time(update_time):
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=new_product.id,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=new_product.id,
+                )
 
             old_price = old_product.prices[0]
             new_price = new_product.prices[0]
@@ -581,11 +594,15 @@ class TestUpdateProductProrations:
 
         update_time = datetime(2025, 6, 16, tzinfo=UTC)
         with freezegun.freeze_time(update_time):
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=product.id,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=product.id,
+                )
 
             new_price = product.prices[0]
             assert not new_price.is_archived
@@ -661,12 +678,16 @@ class TestUpdateProductProrations:
                 update_time, new_anchor_day, subscription.recurring_interval_count
             )
 
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=new_product.id,
-                proration_behavior=SubscriptionProrationBehavior.reset,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=new_product.id,
+                    proration_behavior=SubscriptionProrationBehavior.reset,
+                )
 
             create_subscription_update_order_mock.assert_awaited_once_with(
                 session, subscription
@@ -765,12 +786,16 @@ class TestUpdateProductProrations:
             frozen_time.move_to(time_of_update)
 
             # Actually update subscription
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=new_product.id,
-                proration_behavior=call_proration,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=new_product.id,
+                    proration_behavior=call_proration,
+                )
 
             if expected_proration == SubscriptionProrationBehavior.invoice:
                 create_subscription_update_order_mock.assert_awaited_once_with(
@@ -822,12 +847,16 @@ class TestUpdateProductProrations:
 
             #  Update subscription no. 2 on June 17th
             frozen_time.move_to(time_of_update)
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscriptions[1],
-                product_id=products[3].id,
-                proration_behavior=SubscriptionProrationBehavior.invoice,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscriptions[1], subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscriptions[1],
+                    product_id=products[3].id,
+                    proration_behavior=SubscriptionProrationBehavior.invoice,
+                )
 
             assert updated_subscription.current_period_start == datetime(
                 2025, 6, 2, tzinfo=UTC
@@ -947,12 +976,16 @@ class TestUpdateProductProrations:
             ############
             # Update 1 #
             ############
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=products[1].id,
-                proration_behavior=proration_behavior,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=products[1].id,
+                    proration_behavior=proration_behavior,
+                )
 
             # fmt: off
             assert updated_subscription.ended_at is None
@@ -976,13 +1009,17 @@ class TestUpdateProductProrations:
             ############
             # Update 2 #
             ############
-            frozen_time.move_to(time_of_update_2)
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=products[2].id,
-                proration_behavior=proration_behavior,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                frozen_time.move_to(time_of_update_2)
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=products[2].id,
+                    proration_behavior=proration_behavior,
+                )
 
             # fmt: off
             assert updated_subscription.ended_at is None
@@ -1009,12 +1046,16 @@ class TestUpdateProductProrations:
             # Update 3 #
             ############
             frozen_time.move_to(time_of_update_3)
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=products[3].id,
-                proration_behavior=proration_behavior,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=products[3].id,
+                    proration_behavior=proration_behavior,
+                )
 
             # fmt: off
             assert updated_subscription.ended_at is None
@@ -1082,12 +1123,16 @@ class TestUpdateProductProrations:
 
             frozen_time.move_to(time_of_update)
 
-            updated_subscription = await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=new_product.id,
-                proration_behavior=SubscriptionProrationBehavior.prorate,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated_subscription = await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=new_product.id,
+                    proration_behavior=SubscriptionProrationBehavior.prorate,
+                )
 
             assert updated_subscription.product == new_product
             assert len(updated_subscription.meters) == 1
@@ -1277,12 +1322,16 @@ class TestImmediateSeatChangeWithPendingProductChange:
             frozen_time.move_to(time_of_update)
 
             # 1. Schedule A -> B at next_period.
-            await subscription_service.update_product(
-                session,
-                subscription,
-                product_id=product_b.id,
-                proration_behavior=SubscriptionProrationBehavior.next_period,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_product(
+                    session,
+                    ctx,
+                    subscription,
+                    product_id=product_b.id,
+                    proration_behavior=SubscriptionProrationBehavior.next_period,
+                )
             await session.flush()
 
             sub_update_repo = SubscriptionUpdateRepository.from_session(session)
@@ -1294,12 +1343,16 @@ class TestImmediateSeatChangeWithPendingProductChange:
             assert pending.seats is None
 
             # 2. Bump seats with `prorate` — immediate proration entry.
-            updated = await subscription_service.update_seats(
-                session,
-                subscription,
-                seats=new_seats,
-                proration_behavior=SubscriptionProrationBehavior.prorate,
-            )
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated = await subscription_service.update_seats(
+                    session,
+                    ctx,
+                    subscription,
+                    seats=new_seats,
+                    proration_behavior=SubscriptionProrationBehavior.prorate,
+                )
             await session.flush()
 
             # Subscription stays on A with seats applied immediately.


### PR DESCRIPTION

Preparatory work for #12094

## Problem

In the current implementation, we have several ways to update a subscription: update product, update trial, cancel, revoke, etc. Each one is responsible to trigger the side effects, like the updated webhook or cycle the subscription.

We also have a global `update` method that simply routes to the specific update method, but it doesn't trigger any side effect.

However, in #12094, we'll need to "bundle" several updates into one (like product + trial + discount). In that case, we don't want to trigger the side effects for each update, but only once at the end of the process.

The challenge is then the following: we want to trigger the side effects once when calling `update`, but we also want to trigger them when calling the specific update methods directly.

Here is a schema of all the update methods and how they're called:

```mermaid
flowchart LR
    subgraph Update
        Product
        Discount
        Trial
        Seats
        BillingPeriod
        Cancel
        Uncancel
        Revoke
        ClearPendingUpdate
    end
    API
    CPAPI[Customer Portal API]
    Dispute
    OD[Order Dunning]
    Backoffice
    API --> Update
    API --> Revoke
    CPAPI --> Uncancel
    CPAPI --> ClearPendingUpdate
    CPAPI --> Seats
    CPAPI --> Revoke
    Backoffice --> Uncancel
    Backoffice --> BillingPeriod
    Dispute --> Revoke
    OD --> Revoke
```

## Proposed solution

In this PR, we implement a context manager that's responsible to keep track of the updates happening inside, and trigger the side effects when exiting:

1. Track the billing side effect: immediate invoice or cycle. Cycle will always take precedence over immediate invoice.
2. Track the updated metadata to build the subscription updated system event.
3. Trigger the `_after_subscription_updated` callback at the end of the context.

With this approach, we can be totally flexible in the number of individual updates we want to perform, and make sure we trigger the right side effects at the end of the process.

> [!NOTE]
> This PR doesn't change any behavior, but simply refactors the code to use the new context manager. The next PR will be the one that actually implements the product + trial + discount update, and will show the real benefits of this new approach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an async SubscriptionUpdateContext to batch subscription update/cycle side effects and run them once at the end. No behavior changes; prepares bundled updates for #12094.

- **Refactors**
  - Introduced SubscriptionUpdateContext to collect billing actions (cycle > invoice-now), aggregate SubscriptionUpdatedMetadataFields, and trigger _after_subscription_updated once.
  - Updated service methods to accept a ctx and register effects: update, update_product, update_trial, update_seats, cancel, revoke, cycle.
  - Wrapped entry points with the context: public API, Customer Portal, Backoffice, dispute and dunning revocations, batch cancel script, and the subscription_cycle task; updated tests.
  - Simplified subscription.updated event metadata to a single shape and regenerated the OpenAPI client in `clients/packages/client`.

- **Migration**
  - When calling update/cancel/revoke/cycle directly, create an async SubscriptionUpdateContext and pass ctx; side effects run once on context exit.

<sup>Written for commit f94620b7f416fb8c43c638c63828260e09aff101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

