### PR TITLE
feat(customer): expose customer payment methods on the merchant API

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3073,6 +3073,50 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/customers/{id}/payment-methods': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Customer Payment Methods
+     * @description Get saved payment methods of a customer.
+     *
+     *     **Scopes**: `customers:read` `customers:write`
+     */
+    get: operations['customers:list_payment_methods']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/customers/external/{external_id}/payment-methods': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Customer Payment Methods by External ID
+     * @description Get saved payment methods of a customer by external ID.
+     *
+     *     **Scopes**: `customers:read` `customers:write`
+     */
+    get: operations['customers:list_payment_methods_external']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/members/': {
     parameters: {
       query?: never
@@ -14731,6 +14775,11 @@ export interface components {
        */
       organization_id: string
       /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
+      /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
        */
@@ -15433,6 +15482,44 @@ export interface components {
     CustomerPaymentMethod:
       | components['schemas']['PaymentMethodCard']
       | components['schemas']['PaymentMethodGeneric']
+    /** CustomerPaymentMethodCard */
+    CustomerPaymentMethodCard: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      processor: components['schemas']['PaymentProcessor']
+      /**
+       * Customer Id
+       * Format: uuid4
+       */
+      customer_id: string
+      /**
+       * Type
+       * @constant
+       */
+      type: 'card'
+      method_metadata: components['schemas']['PaymentMethodCardMetadata']
+      /**
+       * Is Default
+       * @description Whether this payment method is the customer's default payment method.
+       * @example true
+       */
+      is_default: boolean
+    }
     /** CustomerPaymentMethodConfirm */
     CustomerPaymentMethodConfirm: {
       /** Setup Intent Id */
@@ -15472,6 +15559,43 @@ export interface components {
       /** CustomerPaymentMethod */
       payment_method: components['schemas']['CustomerPaymentMethod']
     }
+    /** CustomerPaymentMethodGeneric */
+    CustomerPaymentMethodGeneric: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      processor: components['schemas']['PaymentProcessor']
+      /**
+       * Customer Id
+       * Format: uuid4
+       */
+      customer_id: string
+      /** Type */
+      type: string
+      /**
+       * Is Default
+       * @description Whether this payment method is the customer's default payment method.
+       * @example false
+       */
+      is_default: boolean
+    }
+    CustomerPaymentMethodWithDefault:
+      | components['schemas']['CustomerPaymentMethodCard']
+      | components['schemas']['CustomerPaymentMethodGeneric']
     /** CustomerPortalCustomer */
     CustomerPortalCustomer: {
       /**
@@ -16203,6 +16327,11 @@ export interface components {
        */
       organization_id: string
       /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
+      /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
        */
@@ -16514,6 +16643,11 @@ export interface components {
        * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
        */
       organization_id: string
+      /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
       /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
@@ -16977,6 +17111,11 @@ export interface components {
        * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
        */
       organization_id: string
+      /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
       /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
@@ -19698,6 +19837,11 @@ export interface components {
        */
       organization_id: string
       /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
+      /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
        */
@@ -19982,6 +20126,12 @@ export interface components {
     ListResource_CustomerOrder_: {
       /** Items */
       items: components['schemas']['CustomerOrder'][]
+      pagination: components['schemas']['Pagination']
+    }
+    /** ListResource[CustomerPaymentMethodWithDefault] */
+    ListResource_CustomerPaymentMethodWithDefault_: {
+      /** Items */
+      items: components['schemas']['CustomerPaymentMethodWithDefault'][]
       pagination: components['schemas']['Pagination']
     }
     /** ListResource[CustomerPaymentMethod] */
@@ -22054,6 +22204,11 @@ export interface components {
        * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
        */
       organization_id: string
+      /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
       /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
@@ -28939,6 +29094,11 @@ export interface components {
        * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
        */
       organization_id: string
+      /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
       /**
        * Deleted At
        * @description Timestamp for when the customer was soft deleted.
@@ -40597,6 +40757,98 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['CustomerState']
+        }
+      }
+      /** @description Customer not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:list_payment_methods': {
+    parameters: {
+      query?: {
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path: {
+        /** @description The customer ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_CustomerPaymentMethodWithDefault_']
+        }
+      }
+      /** @description Customer not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:list_payment_methods_external': {
+    parameters: {
+      query?: {
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path: {
+        /** @description The customer external ID. */
+        external_id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_CustomerPaymentMethodWithDefault_']
         }
       }
       /** @description Customer not found. */

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -15,9 +15,10 @@ from polar.kit.csv import IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
-from polar.models import Customer
+from polar.models import Customer, PaymentMethod
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
+from polar.payment_method.schemas import PaymentMethodTypeAdapter
 from polar.postgres import (
     AsyncReadSession,
     AsyncSession,
@@ -32,6 +33,8 @@ from .repository import CustomerRepository
 from .schemas.customer import (
     CustomerCreate,
     CustomerID,
+    CustomerPaymentMethod,
+    CustomerPaymentMethodTypeAdapter,
     CustomerUpdate,
     CustomerUpdateExternalID,
     ExternalCustomerID,
@@ -278,6 +281,78 @@ async def get_state_external(
         raise ResourceNotFound()
 
     return await customer_service.get_state(session, redis, customer)
+
+
+def _serialize_payment_method(
+    customer: Customer, payment_method: PaymentMethod
+) -> CustomerPaymentMethod:
+    base = PaymentMethodTypeAdapter.validate_python(
+        payment_method, from_attributes=True
+    )
+    return CustomerPaymentMethodTypeAdapter.validate_python(
+        {
+            **dict(base),
+            "is_default": customer.default_payment_method_id == payment_method.id,
+        }
+    )
+
+
+@router.get(
+    "/{id}/payment-methods",
+    summary="List Customer Payment Methods",
+    response_model=ListResource[CustomerPaymentMethod],
+    responses={404: CustomerNotFound},
+)
+async def list_payment_methods(
+    id: CustomerID,
+    auth_subject: auth.CustomerRead,
+    pagination: PaginationParamsQuery,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> ListResource[CustomerPaymentMethod]:
+    """Get saved payment methods of a customer."""
+    customer = await customer_service.get(session, auth_subject, id)
+
+    if customer is None:
+        raise ResourceNotFound()
+
+    results, count = await customer_service.list_payment_methods(
+        session, customer, pagination=pagination
+    )
+
+    return ListResource.from_paginated_results(
+        [_serialize_payment_method(customer, result) for result in results],
+        count,
+        pagination,
+    )
+
+
+@router.get(
+    "/external/{external_id}/payment-methods",
+    summary="List Customer Payment Methods by External ID",
+    response_model=ListResource[CustomerPaymentMethod],
+    responses={404: CustomerNotFound},
+)
+async def list_payment_methods_external(
+    external_id: ExternalCustomerID,
+    auth_subject: auth.CustomerRead,
+    pagination: PaginationParamsQuery,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> ListResource[CustomerPaymentMethod]:
+    """Get saved payment methods of a customer by external ID."""
+    customer = await customer_service.get_external(session, auth_subject, external_id)
+
+    if customer is None:
+        raise ResourceNotFound()
+
+    results, count = await customer_service.list_payment_methods(
+        session, customer, pagination=pagination
+    )
+
+    return ListResource.from_paginated_results(
+        [_serialize_payment_method(customer, result) for result in results],
+        count,
+        pagination,
+    )
 
 
 @router.post(

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -4,7 +4,15 @@ from typing import Annotated, Literal
 
 from annotated_types import MaxLen
 from fastapi import Path
-from pydantic import UUID4, Discriminator, Field, Tag, computed_field, model_validator
+from pydantic import (
+    UUID4,
+    Discriminator,
+    Field,
+    Tag,
+    TypeAdapter,
+    computed_field,
+    model_validator,
+)
 from pydantic.aliases import AliasChoices
 
 from polar.config import settings
@@ -21,6 +29,7 @@ from polar.kit.schemas import (
     ClassName,
     EmptyStrToNoneValidator,
     IDSchema,
+    MergeJSONSchema,
     Schema,
     SetSchemaReference,
     TimestampedSchema,
@@ -28,6 +37,7 @@ from polar.kit.schemas import (
 from polar.member import MemberOwnerCreate
 from polar.models.customer import CustomerType
 from polar.organization.schemas import OrganizationID
+from polar.payment_method.schemas import PaymentMethodCard, PaymentMethodGeneric
 from polar.tax.tax_id import TaxID
 
 CustomerID = Annotated[UUID4, Path(description="The customer ID.")]
@@ -216,6 +226,13 @@ class CustomerBase(MetadataOutputMixin, TimestampedSchema, IDSchema):
         description="The ID of the organization owning the customer.",
         examples=[ORGANIZATION_ID_EXAMPLE],
     )
+    default_payment_method_id: UUID4 | None = Field(
+        default=None,
+        description=(
+            "The ID of the customer's default payment method, if any. "
+            "Use the payment methods endpoint to retrieve its details."
+        ),
+    )
 
     deleted_at: datetime | None = Field(
         description="Timestamp for when the customer was soft deleted."
@@ -256,3 +273,27 @@ CustomerResponse = Annotated[
     SetSchemaReference("Customer"),
     ClassName("Customer"),
 ]
+
+
+_is_default_description = (
+    "Whether this payment method is the customer's default payment method."
+)
+
+
+class CustomerPaymentMethodCard(PaymentMethodCard):
+    is_default: bool = Field(description=_is_default_description, examples=[True])
+
+
+class CustomerPaymentMethodGeneric(PaymentMethodGeneric):
+    is_default: bool = Field(description=_is_default_description, examples=[False])
+
+
+CustomerPaymentMethod = Annotated[
+    CustomerPaymentMethodCard | CustomerPaymentMethodGeneric,
+    SetSchemaReference("CustomerPaymentMethodWithDefault"),
+    MergeJSONSchema({"title": "CustomerPaymentMethodWithDefault"}),
+    ClassName("CustomerPaymentMethodWithDefault"),
+]
+CustomerPaymentMethodTypeAdapter: TypeAdapter[CustomerPaymentMethod] = TypeAdapter(
+    CustomerPaymentMethod
+)

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -34,7 +34,15 @@ from polar.kit.utils import utc_now
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
 from polar.member_session.service import member_session as member_session_service
-from polar.models import BenefitGrant, Customer, Order, Organization, Subscription, User
+from polar.models import (
+    BenefitGrant,
+    Customer,
+    Order,
+    Organization,
+    PaymentMethod,
+    Subscription,
+    User,
+)
 from polar.models.customer import CustomerType
 from polar.models.member import MemberRole
 from polar.models.webhook_endpoint import CustomerWebhookEventType, WebhookEventType
@@ -721,6 +729,21 @@ class CustomerService:
             return None
         token, _ = await member_session_service.create_member_session(session, member)
         return token
+
+    async def list_payment_methods(
+        self,
+        session: AsyncReadSession,
+        customer: Customer,
+        *,
+        pagination: PaginationParams,
+    ) -> tuple[Sequence[PaymentMethod], int]:
+        repository = PaymentMethodRepository.from_session(session)
+        statement = repository.get_by_customer_statement(customer.id).order_by(
+            PaymentMethod.created_at.desc()
+        )
+        return await repository.paginate(
+            statement, limit=pagination.limit, page=pagination.page
+        )
 
     async def get_export(
         self,

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from sqlalchemy import update
+from sqlalchemy import Select, update
 from sqlalchemy.orm import joinedload
 
 from polar.enums import PaymentProcessor
@@ -56,6 +56,11 @@ class PaymentMethodRepository(
             .options(*options)
         )
         return await self.get_one_or_none(statement)
+
+    def get_by_customer_statement(
+        self, customer_id: UUID
+    ) -> Select[tuple[PaymentMethod]]:
+        return self.get_base_statement().where(PaymentMethod.customer_id == customer_id)
 
     async def list_by_customer(
         self,

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -20,6 +20,7 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_benefit_grant,
     create_customer,
+    create_payment_method,
     create_subscription,
 )
 
@@ -247,6 +248,28 @@ class TestGetExternal:
 
         json = response.json()
         assert json["id"] == str(customer_external_id.id)
+        assert json["default_payment_method_id"] is None
+
+    @pytest.mark.auth
+    async def test_valid_default_payment_method(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        customer_external_id: Customer,
+    ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer_external_id)
+        customer_external_id.default_payment_method_id = payment_method.id
+        await save_fixture(customer_external_id)
+
+        response = await client.get(
+            f"/v1/customers/external/{customer_external_id.external_id}"
+        )
+
+        assert response.status_code == 200
+
+        json = response.json()
+        assert json["default_payment_method_id"] == str(payment_method.id)
 
 
 @pytest.mark.asyncio
@@ -318,6 +341,109 @@ class TestGetState:
             json["granted_benefits"][0]["benefit_metadata"]
             == benefit_organization.user_metadata
         )
+
+
+@pytest.mark.asyncio
+class TestListPaymentMethods:
+    async def test_anonymous(self, client: AsyncClient, customer: Customer) -> None:
+        response = await client.get(f"/v1/customers/{customer.id}/payment-methods")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
+    async def test_missing_scope(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        customer: Customer,
+    ) -> None:
+        response = await client.get(f"/v1/customers/{customer.id}/payment-methods")
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_not_existing(
+        self, client: AsyncClient, user_organization: UserOrganization
+    ) -> None:
+        response = await client.get(f"/v1/customers/{uuid.uuid4()}/payment-methods")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_not_accessible(
+        self, client: AsyncClient, customer: Customer
+    ) -> None:
+        response = await client.get(f"/v1/customers/{customer.id}/payment-methods")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        customer: Customer,
+    ) -> None:
+        default_payment_method = await create_payment_method(
+            save_fixture,
+            customer,
+            type="card",
+            method_metadata={
+                "brand": "visa",
+                "last4": "4242",
+                "exp_month": 12,
+                "exp_year": 2030,
+            },
+        )
+        other_payment_method = await create_payment_method(save_fixture, customer)
+
+        customer.default_payment_method_id = default_payment_method.id
+        await save_fixture(customer)
+
+        response = await client.get(f"/v1/customers/{customer.id}/payment-methods")
+
+        assert response.status_code == 200
+
+        json = response.json()
+
+        assert json["pagination"]["total_count"] == 2
+
+        items_by_id = {item["id"]: item for item in json["items"]}
+
+        default_item = items_by_id[str(default_payment_method.id)]
+        assert default_item["type"] == "card"
+        assert default_item["method_metadata"]["brand"] == "visa"
+        assert default_item["is_default"] is True
+
+        other_item = items_by_id[str(other_payment_method.id)]
+        assert other_item["is_default"] is False
+
+    @pytest.mark.auth
+    async def test_valid_external_id(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="external-123",
+        )
+        payment_method = await create_payment_method(save_fixture, customer)
+
+        response = await client.get(
+            f"/v1/customers/external/{customer.external_id}/payment-methods"
+        )
+
+        assert response.status_code == 200
+
+        json = response.json()
+
+        assert json["pagination"]["total_count"] == 1
+        assert json["items"][0]["id"] == str(payment_method.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

Adds merchant-facing API endpoints to retrieve a customer's saved payment methods, and surfaces the customer's default payment method on the merchant `Customer` schema.

## What

- New endpoints (public API, `customers` tag):
  - `GET /v1/customers/{id}/payment-methods`
  - `GET /v1/customers/external/{external_id}/payment-methods`
- Each listed payment method now includes an `is_default` flag.
- `default_payment_method_id` is now exposed on the merchant `Customer` schema (flows through Get / Get by External ID / List Customers / Customer State).
- Regenerated the TypeScript client SDK (`clients/packages/client/src/v1.ts`).

## Why

Previously the only way to read a customer's payment methods was the **customer portal** API (`/v1/customer-portal/customers/me/payment-methods`), which is authenticated as the customer themselves. Merchants/organizations had no way via the API to:

- list a given customer's saved payment methods, or
- tell whether a customer has a default payment method configured.

## How

- `PaymentMethodRepository.get_by_customer_statement(...)` builds the paginatable query; `CustomerService.list_payment_methods(...)` orders by `created_at` desc and paginates.
- The endpoints resolve the customer (by ID / external ID) via the existing auth-aware `customer_service.get` / `get_external`, returning `404` when not found or not accessible.
- `is_default` is computed per item against `customer.default_payment_method_id`.
- A dedicated merchant schema `CustomerPaymentMethodWithDefault` (card/generic variants with `is_default`) is used for the response. A distinct OpenAPI ref name was required: the customer portal already registers a `CustomerPaymentMethod` component, and reusing the name caused a silent OpenAPI schema collision (verified against the generated `openapi.json`).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds merchant API endpoints to list a customer’s saved payment methods and surfaces the default payment method on the `Customer` resource. Merchants can now fetch methods by customer ID or external ID and see which one is default.

- **New Features**
  - Endpoints: `GET /v1/customers/{id}/payment-methods` and `GET /v1/customers/external/{external_id}/payment-methods` (paginated).
  - Each item includes `is_default`.
  - `default_payment_method_id` added to merchant `Customer` schema (get, list, state).
  - Requires `customers:read` or `customers:write` scope.
  - Regenerated TypeScript client (`clients/packages/client/src/v1.ts`).

<sup>Written for commit 6c6bd685da80b6cc71845fcbffd84e7bf74a385b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

