### PR TITLE
tf/vercel: Add frontend to test environment

### DIFF
--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -378,3 +378,92 @@ resource "tfe_variable" "polar_scale_product_id_test" {
   description     = "Polar Scale-tier product ID for test"
   variable_set_id = tfe_variable_set.test.id
 }
+
+# Vercel frontend
+resource "tfe_variable" "vercel_stripe_publishable_key_preview_test" {
+  key             = "stripe_publishable_key_preview"
+  category        = "terraform"
+  description     = "Stripe publishable key for Vercel test preview deployments"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_mintlify_assistant_api_key_test" {
+  key             = "mintlify_assistant_api_key"
+  category        = "terraform"
+  description     = "Mintlify assistant API key for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_gram_api_key_test" {
+  key             = "gram_api_key"
+  category        = "terraform"
+  description     = "Gram API key for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_sentry_auth_token_test" {
+  key             = "sentry_auth_token"
+  category        = "terraform"
+  description     = "Sentry auth token for the Vercel test frontend build"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_polar_preview_access_token_test" {
+  key             = "polar_preview_access_token"
+  category        = "terraform"
+  description     = "Polar preview access token for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_mcp_oauth2_client_id_test" {
+  key             = "mcp_oauth2_client_id"
+  category        = "terraform"
+  description     = "MCP OAuth2 client ID for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_mcp_oauth2_client_secret_test" {
+  key             = "mcp_oauth2_client_secret"
+  category        = "terraform"
+  description     = "MCP OAuth2 client secret for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_next_public_sentry_dsn_test" {
+  key             = "next_public_sentry_dsn"
+  category        = "terraform"
+  description     = "Sentry DSN for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_next_public_posthog_token_test" {
+  key             = "next_public_posthog_token"
+  category        = "terraform"
+  description     = "PostHog token for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_next_public_apple_domain_association_test" {
+  key             = "next_public_apple_domain_association"
+  category        = "terraform"
+  description     = "Apple Pay domain association for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_test" {
+  key             = "next_public_stripe_payment_method_configuration"
+  category        = "terraform"
+  description     = "Stripe payment method configuration ID for the Vercel test frontend"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -8,6 +8,9 @@ provider "render" {
 provider "cloudflare" {
 }
 
+provider "vercel" {
+}
+
 module "s3_buckets" {
   count           = local.test_enabled ? 1 : 0
   source          = "../modules/s3_buckets"

--- a/terraform/test/terraform.tf
+++ b/terraform/test/terraform.tf
@@ -26,6 +26,11 @@ terraform {
       source  = "hashicorp/tfe"
       version = "0.71.0"
     }
+
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 5.3"
+    }
   }
 
   required_version = ">= 1.2"

--- a/terraform/test/terraform.tf
+++ b/terraform/test/terraform.tf
@@ -29,7 +29,7 @@ terraform {
 
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 5.3"
+      version = "~> 5.2"
     }
   }
 

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -330,3 +330,70 @@ variable "polar_scale_product_id" {
   description = "Polar Scale-tier product ID"
   type        = string
 }
+
+# Vercel frontend
+variable "stripe_publishable_key_preview" {
+  description = "Stripe publishable key for Vercel preview deployments"
+  type        = string
+  sensitive   = true
+}
+
+variable "mintlify_assistant_api_key" {
+  description = "Mintlify assistant API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "gram_api_key" {
+  description = "Gram API key for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "sentry_auth_token" {
+  description = "Sentry auth token for the Vercel frontend build"
+  type        = string
+  sensitive   = true
+}
+
+variable "polar_preview_access_token" {
+  description = "Polar preview access token for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_oauth2_client_id" {
+  description = "MCP OAuth2 client ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_oauth2_client_secret" {
+  description = "MCP OAuth2 client secret for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_sentry_dsn" {
+  description = "Sentry DSN for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_posthog_token" {
+  description = "PostHog token for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_apple_domain_association" {
+  description = "Apple Pay domain association for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "next_public_stripe_payment_method_configuration" {
+  description = "Stripe payment method configuration ID for the Vercel frontend"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/test/vercel.tf
+++ b/terraform/test/vercel.tf
@@ -1,0 +1,56 @@
+# =============================================================================
+# Vercel — Test frontend (test.polar.sh)
+# =============================================================================
+#
+# Created fresh by Terraform (no import blocks): Terraform owns the project,
+# its domain and every env var declared here from the start.
+
+module "vercel" {
+  source = "../modules/vercel"
+
+  name     = "polar-test"
+  git_repo = "polarsource/polar"
+
+  domains = [
+    { name = "test.polar.sh" },
+  ]
+
+  config = {
+    next_public_api_url                             = "https://test-api.polar.sh"
+    next_public_backoffice_url                      = "https://test-api.polar.sh/backoffice"
+    next_public_sentry_dsn                          = var.next_public_sentry_dsn
+    next_public_posthog_token                       = var.next_public_posthog_token
+    next_public_apple_domain_association            = var.next_public_apple_domain_association
+    next_public_checkout_embed_script_src           = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
+    next_public_stripe_payment_method_configuration = var.next_public_stripe_payment_method_configuration
+    s3_public_images_bucket_protocol                = "https"
+    s3_public_images_bucket_hostname                = "polar-public-files.s3.amazonaws.com"
+    s3_public_images_bucket_port                    = null
+    s3_public_images_bucket_pathname                = "/product_media/**"
+    s3_upload_origins                               = "https://polar-test-files.s3.amazonaws.com https://polar-public-files.s3.amazonaws.com"
+    polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh"
+    polar_openapi_schema_url                        = "https://api.polar.sh/openapi.json"
+    enable_experimental_corepack                    = "1"
+  }
+
+  secrets = {
+    pydantic_ai_gateway_api_key = var.pydantic_ai_gateway_api_key
+    mintlify_assistant_api_key  = var.mintlify_assistant_api_key
+    gram_api_key                = var.gram_api_key
+    sentry_auth_token           = var.sentry_auth_token
+    polar_preview_access_token  = var.polar_preview_access_token
+  }
+
+  # Environment-specific or target-varies-by-env.
+  environment_variables = [
+    { key = "NEXT_PUBLIC_FRONTEND_BASE_URL", value = "https://test.polar.sh" },
+    { key = "NEXT_PUBLIC_ENVIRONMENT", value = "test" },
+    { key = "POLAR_AUTH_COOKIE_KEY", value = "polar_test_session" },
+    { key = "NEXT_PUBLIC_PRODUCT_LINK_BASE_URL", value = "https://test.polar.sh/api/checkout?price=" },
+    { key = "POLAR_PREVIEW_BACKEND_HOST", value = "", target = ["preview"] },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key, target = ["production", "development"] },
+    { key = "NEXT_PUBLIC_STRIPE_KEY", value = var.stripe_publishable_key_preview, target = ["preview"], sensitive = true },
+    { key = "MCP_OAUTH2_CLIENT_ID", value = var.mcp_oauth2_client_id, target = ["production", "preview", "development"] },
+    { key = "MCP_OAUTH2_CLIENT_SECRET", value = var.mcp_oauth2_client_secret, target = ["production", "preview", "development"] },
+  ]
+}

--- a/terraform/test/vercel.tf
+++ b/terraform/test/vercel.tf
@@ -28,7 +28,7 @@ module "vercel" {
     s3_public_images_bucket_port                    = null
     s3_public_images_bucket_pathname                = "/product_media/**"
     s3_upload_origins                               = "https://polar-test-files.s3.amazonaws.com https://polar-public-files.s3.amazonaws.com"
-    polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh"
+    polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
     polar_openapi_schema_url                        = "https://api.polar.sh/openapi.json"
     enable_experimental_corepack                    = "1"
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Provision a Vercel-managed frontend for the test environment at test.polar.sh via Terraform. Adds a `vercel` project, domain, config, env vars, and secrets to run the test frontend end-to-end, and allows the checkout embed on the test domain.

- **New Features**
  - Added terraform/test/vercel.tf to create the `polar-test` project for repo `polarsource/polar` and domain `test.polar.sh`.
  - Configures public settings: API/backoffice URLs, S3, analytics (PostHog), Sentry DSN, Stripe payment method configuration, and checkout embed script source.
  - Sets env vars per target (production/preview/development): Stripe publishable keys, MCP OAuth2 credentials, frontend base URL, auth cookie key, product link URL, and preview backend host.
  - Wires secrets from Terraform vars (Mintlify, Gram, Sentry auth token, Polar preview access token, Pydantic AI Gateway).
  - Adds TFE variables in the test set for the above secrets and public tokens (Sentry DSN, PostHog token, Apple Pay association, Stripe preview key, Stripe payment method configuration).
  - Adds the `vercel/vercel` provider (`~> 5.2`) in the test stack.

- **Bug Fixes**
  - Allow checkout embed on test by adding test.polar.sh to the embed allowed origins.

<sup>Written for commit 65dadc088b129ebbea99c16e4476437e83cbd543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

