### PR TITLE
Work with PriceSet throughout `checkout/service.py`

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -733,7 +733,9 @@ class CheckoutService:
 
         amount = calculate_upfront_amount(
             currency_prices.get_static_prices(),
-            custom_amount=custom_amount or None,
+            # A validated `0` prefill is honored (PWYW prices that allow 0);
+            # `None` falls back to the preset/minimum.
+            custom_amount=custom_amount,
             seats=seats,
         )
 

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -90,14 +90,15 @@ from polar.postgres import AsyncReadSession, AsyncSession
 from polar.posthog import posthog
 from polar.product.custom_price import validate_custom_price_amount
 from polar.product.guard import (
+    CustomPrice,
+    SeatPrice,
     is_custom_price,
     is_discount_applicable,
-    is_fixed_price,
-    is_seat_price,
 )
 from polar.product.price_set import (
     NoPricesForCurrencies,
     PriceSet,
+    calculate_upfront_amount,
 )
 from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.schemas import ProductPriceCreateList
@@ -328,11 +329,11 @@ class CheckoutService:
 
         ad_hoc_prices: dict[Product, Sequence[ProductPrice]] = {}
         if isinstance(checkout_create, CheckoutPriceCreate):
-            products, product, price, currency = await self._get_validated_price(
+            products, product, price_set, currency = await self._get_validated_price(
                 session, auth_subject, checkout_create.product_price_id
             )
         elif isinstance(checkout_create, CheckoutProductCreate):
-            products, product, price, currency = await self._get_validated_product(
+            products, product, price_set, currency = await self._get_validated_product(
                 session,
                 auth_subject,
                 checkout_create.product_id,
@@ -364,7 +365,6 @@ class CheckoutService:
 
             try:
                 price_set = PriceSet.from_prices(prices, *currencies)
-                price = price_set.get_default_price()
                 currency = price_set.currency
             except NoPricesForCurrencies as e:
                 raise PolarRequestValidationError(
@@ -377,6 +377,8 @@ class CheckoutService:
                         }
                     ]
                 ) from e
+
+        price = price_set.get_default_price()
 
         if not product.organization.can_authenticate:
             raise NotPermitted()
@@ -432,15 +434,18 @@ class CheckoutService:
         # Validate seats for seat-based pricing
         min_seats = checkout_create.min_seats
         max_seats = checkout_create.max_seats
-        self._validate_checkout_seat_constraints(price, min_seats, max_seats)
+        seat_price = price_set.get_seat_price()
+        self._validate_checkout_seat_constraints(seat_price, min_seats, max_seats)
 
-        if is_seat_price(price):
+        if seat_price is not None:
             if checkout_create.seats is None:
                 checkout_create.seats = (
-                    min_seats if min_seats is not None else price.get_minimum_seats()
+                    min_seats
+                    if min_seats is not None
+                    else seat_price.get_minimum_seats()
                 )
             self._validate_seat_limits(
-                price,
+                seat_price,
                 checkout_create.seats,
                 checkout_min_seats=min_seats,
                 checkout_max_seats=max_seats,
@@ -488,19 +493,11 @@ class CheckoutService:
                 checkout_create.external_customer_id, product.organization_id
             )
 
-        amount = checkout_create.amount
-        if is_fixed_price(price):
-            amount = price.price_amount
-        elif is_custom_price(price):
-            if amount is None:
-                amount = price.preset_amount or price.minimum_amount
-        elif is_seat_price(price):
-            # Calculate amount based on seat count
-            # seats is guaranteed to be set above when is_seat_price(price) is True
-            assert checkout_create.seats is not None
-            amount = price.calculate_amount(checkout_create.seats)
-        else:
-            amount = 0
+        amount = calculate_upfront_amount(
+            price_set.get_static_prices(),
+            custom_amount=checkout_create.amount,
+            seats=checkout_create.seats,
+        )
 
         custom_field_data = validate_custom_field_data(
             product.attached_custom_fields,
@@ -713,28 +710,32 @@ class CheckoutService:
         price = currency_prices.get_default_price()
         currency = currency_prices.currency
 
-        amount = 0
+        seat_price = currency_prices.get_seat_price()
         seats = None
-        if is_fixed_price(price):
-            amount = price.price_amount
-        elif is_custom_price(price):
+        if seat_price is not None:
+            seats = seat_price.get_minimum_seats()
+
+        custom_price = currency_prices.get_custom_price()
+        custom_amount: int | None = None
+        if custom_price is not None:
             query_amount_str = query_prefill.get("amount") if query_prefill else None
 
             # Try to parse and validate query amount
-            valid_query_amount = None
             if query_amount_str is not None and isinstance(query_amount_str, str):
                 try:
                     query_amount_int = int(float(query_amount_str))
-                    validate_custom_price_amount(price, query_amount_int, currency)
-                    valid_query_amount = query_amount_int
+                    validate_custom_price_amount(
+                        custom_price, query_amount_int, currency
+                    )
+                    custom_amount = query_amount_int
                 except (ValueError, TypeError, PolarRequestValidationError):
                     pass
 
-            amount = valid_query_amount or price.preset_amount or price.minimum_amount
-        elif is_seat_price(price):
-            # Default to minimum seats for checkout links with seat-based pricing
-            seats = price.get_minimum_seats()
-            amount = price.calculate_amount(seats)
+        amount = calculate_upfront_amount(
+            currency_prices.get_static_prices(),
+            custom_amount=custom_amount or None,
+            seats=seats,
+        )
 
         discount: Discount | None = None
         if checkout_link.discount_id is not None:
@@ -1425,7 +1426,7 @@ class CheckoutService:
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         product_price_id: uuid.UUID,
-    ) -> tuple[Sequence[Product], Product, ProductPrice, str]:
+    ) -> tuple[Sequence[Product], Product, PriceSet, str]:
         product_price_repository = ProductPriceRepository.from_session(session)
         org_ids = await get_accessible_org_ids(session, auth_subject)
         price = await product_price_repository.get_readable_by_id(
@@ -1478,7 +1479,12 @@ class CheckoutService:
 
         currency = price.price_currency
 
-        return [product], product, price, currency
+        # Legacy explicit-price checkout: the caller picked one price by ID, so
+        # the set is exactly that price. Keeps the amount/seat math identical to
+        # selecting it directly (e.g. a metered price still contributes nothing).
+        price_set = PriceSet.from_prices([price], currency)
+
+        return [product], product, price_set, currency
 
     async def _get_validated_product(
         self,
@@ -1487,7 +1493,7 @@ class CheckoutService:
         product_id: uuid.UUID,
         currency: str | None,
         ip_country: str | None,
-    ) -> tuple[Sequence[Product], Product, ProductPrice, str]:
+    ) -> tuple[Sequence[Product], Product, PriceSet, str]:
         product = await product_service.get(session, auth_subject, product_id)
 
         if product is None:
@@ -1543,10 +1549,9 @@ class CheckoutService:
                 ]
             ) from e
 
-        price = currency_prices.get_default_price()
         currency = currency_prices.currency
 
-        return [product], product, price, currency
+        return [product], product, currency_prices, currency
 
     async def _get_validated_products(
         self,
@@ -1849,8 +1854,9 @@ class CheckoutService:
                         }
                     ]
                 ) from e
-            price = currency_prices.get_default_price()
-            checkout = await self._update_price(checkout, checkout_update, price)
+            checkout = await self._update_price(
+                checkout, checkout_update, currency_prices
+            )
         # Product is updated
         elif checkout_update.product_id is not None:
             product_repository = ProductRepository.from_session(session)
@@ -1904,6 +1910,8 @@ class CheckoutService:
                             }
                         ]
                     ) from e
+                # Explicit price selection: the set is exactly that price.
+                currency_prices = PriceSet.from_prices([price], checkout.currency)
             else:
                 # Product and currency are both updated, make sure the product supports it
                 if updated_currency is not None:
@@ -1933,9 +1941,9 @@ class CheckoutService:
                     )
                     checkout.currency = currency_prices.currency
 
-                price = currency_prices.get_default_price()
-
-            checkout = await self._update_price(checkout, checkout_update, price)
+            checkout = await self._update_price(
+                checkout, checkout_update, currency_prices
+            )
 
         # When changing product, remove the discount if it's not applicable
         if (
@@ -1945,31 +1953,38 @@ class CheckoutService:
         ):
             checkout.discount = None
 
-        if (
-            has_product_checkout(checkout)
-            and checkout_update.amount is not None
-            and is_custom_price(checkout.product_price)
-        ):
+        # Resolve the checkout's current price set once, then drive the amount /
+        # seat logic off it rather than the single `product_price` FK.
+        seat_price: SeatPrice | None = None
+        custom_price: CustomPrice | None = None
+        static_prices: list[ProductPrice] = []
+        if has_product_checkout(checkout):
+            price_set = PriceSet.from_prices(
+                checkout.prices[checkout.product.id], checkout.currency
+            )
+            seat_price = price_set.get_seat_price()
+            custom_price = price_set.get_custom_price()
+            static_prices = price_set.get_static_prices()
+
+        if custom_price is not None and checkout_update.amount is not None:
             validate_custom_price_amount(
-                checkout.product_price, checkout_update.amount, checkout.currency
+                custom_price, checkout_update.amount, checkout.currency
             )
             checkout.amount = checkout_update.amount
 
         # Handle seat updates for seat-based pricing
-        if (
-            has_product_checkout(checkout)
-            and checkout_update.seats is not None
-            and is_seat_price(checkout.product_price)
-        ):
+        if seat_price is not None and checkout_update.seats is not None:
             self._validate_seat_limits(
-                checkout.product_price,
+                seat_price,
                 checkout_update.seats,
                 checkout_min_seats=checkout.min_seats,
                 checkout_max_seats=checkout.max_seats,
             )
             checkout.seats = checkout_update.seats
-            checkout.amount = checkout.product_price.calculate_amount(
-                checkout_update.seats
+            checkout.amount = calculate_upfront_amount(
+                static_prices,
+                custom_amount=None,
+                seats=checkout_update.seats,
             )
         elif checkout_update.seats is not None:
             # Seats provided for non-seat-based pricing
@@ -2119,23 +2134,19 @@ class CheckoutService:
         self,
         checkout: Checkout,
         checkout_update: CheckoutUpdate | CheckoutUpdatePublic | CheckoutConfirmStripe,
-        price: ProductPrice,
+        price_set: PriceSet,
     ) -> Checkout:
-        checkout.product_price = price
-        checkout.amount = 0
+        checkout.product_price = price_set.get_default_price()
         checkout.seats = None
-        if is_fixed_price(price):
-            checkout.amount = price.price_amount
-        elif is_custom_price(price):
-            checkout.amount = price.preset_amount or price.minimum_amount
-        elif is_seat_price(price):
-            # Use minimum_seats as default if no seats are set
-            minimum_seats = price.get_minimum_seats()
-            seats = checkout.seats or checkout_update.seats or minimum_seats
-            # Validate seat limits for the new price
-            self._validate_seat_limits(price, seats)
+        seat_price = price_set.get_seat_price()
+        seats: int | None = None
+        if seat_price is not None:
+            seats = checkout_update.seats or seat_price.get_minimum_seats()
+            self._validate_seat_limits(seat_price, seats)
             checkout.seats = seats
-            checkout.amount = price.calculate_amount(seats)
+        checkout.amount = calculate_upfront_amount(
+            price_set.get_static_prices(), custom_amount=None, seats=seats
+        )
 
         return checkout
 
@@ -2321,7 +2332,7 @@ class CheckoutService:
 
     def _validate_seat_limits(
         self,
-        price: ProductPrice,
+        price: SeatPrice | None,
         seats: int,
         loc: tuple[str, ...] = ("body", "seats"),
         *,
@@ -2329,7 +2340,7 @@ class CheckoutService:
         checkout_max_seats: int | None = None,
     ) -> None:
         """Validate that a seat count is within the min/max bounds for a seat-based price."""
-        if not is_seat_price(price):
+        if price is None:
             return
 
         minimum_seats = price.get_minimum_seats()
@@ -2372,7 +2383,7 @@ class CheckoutService:
 
     def _validate_checkout_seat_constraints(
         self,
-        price: ProductPrice,
+        price: SeatPrice | None,
         min_seats: int | None,
         max_seats: int | None,
     ) -> None:
@@ -2380,7 +2391,7 @@ class CheckoutService:
         if min_seats is None and max_seats is None:
             return
 
-        if not is_seat_price(price):
+        if price is None:
             fields: list[ValidationError] = []
             if min_seats is not None:
                 fields.append(

--- a/server/polar/product/price_set.py
+++ b/server/polar/product/price_set.py
@@ -140,8 +140,12 @@ def calculate_upfront_amount(
         elif is_custom_price(price):
             if custom_amount is not None:
                 amount += custom_amount
+            elif price.preset_amount is not None:
+                # A configured preset of 0 ("show $0 default") is honored; only a
+                # missing preset falls back to the minimum.
+                amount += price.preset_amount
             else:
-                amount += price.preset_amount or price.minimum_amount
+                amount += price.minimum_amount
         elif is_seat_price(price):
             if seats is None:
                 raise ValueError("seats must be provided to price a seat-based price")

--- a/server/polar/product/price_set.py
+++ b/server/polar/product/price_set.py
@@ -4,7 +4,14 @@ from typing import Self
 from polar.exceptions import PolarError
 from polar.models import Product, ProductPrice
 
-from .guard import is_static_price
+from .guard import (
+    CustomPrice,
+    SeatPrice,
+    is_custom_price,
+    is_fixed_price,
+    is_seat_price,
+    is_static_price,
+)
 
 
 class PriceSetError(PolarError): ...
@@ -92,9 +99,59 @@ class PriceSet:
                 return price
         return self.prices[0]
 
+    def get_static_prices(self) -> list[ProductPrice]:
+        """Return every static price in the set (fixed, custom, free, seat)."""
+        return [price for price in self.prices if is_static_price(price)]
+
+    def get_seat_price(self) -> SeatPrice | None:
+        """Return the lone seat-based price in the set, if any."""
+        for price in self.prices:
+            if is_seat_price(price):
+                return price
+        return None
+
+    def get_custom_price(self) -> CustomPrice | None:
+        """Return the lone custom (pay-what-you-want) price in the set, if any."""
+        for price in self.prices:
+            if is_custom_price(price):
+                return price
+        return None
+
+
+def calculate_upfront_amount(
+    prices: Sequence[ProductPrice],
+    *,
+    custom_amount: int | None,
+    seats: int | None,
+) -> int:
+    """Sum the upfront amount charged for a checkout across a set of prices.
+
+    Each price contributes according to its type:
+    - fixed: its configured amount
+    - custom: the buyer-provided ``custom_amount`` (``0`` is honored), falling
+      back to the price's preset or minimum when ``None``
+    - seat: the amount for ``seats`` seats
+    - free / metered: nothing upfront
+    """
+    amount = 0
+    for price in prices:
+        if is_fixed_price(price):
+            amount += price.price_amount
+        elif is_custom_price(price):
+            if custom_amount is not None:
+                amount += custom_amount
+            else:
+                amount += price.preset_amount or price.minimum_amount
+        elif is_seat_price(price):
+            if seats is None:
+                raise ValueError("seats must be provided to price a seat-based price")
+            amount += price.calculate_amount(seats)
+    return amount
+
 
 __all__ = [
     "NoPricesForCurrencies",
     "PriceSet",
     "PriceSetError",
+    "calculate_upfront_amount",
 ]

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2367,6 +2367,23 @@ class TestCheckoutLinkCreate:
         assert checkout.success_url == "https://example.com/success"
         assert checkout.user_metadata == {"key": "value"}
 
+    async def test_valid_seat_based_defaults_to_minimum_seats(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based: Product,
+    ) -> None:
+        price = product_seat_based.prices[0]
+        assert isinstance(price, ProductPriceSeatUnit)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based]
+        )
+
+        checkout = await checkout_service.checkout_link_create(session, checkout_link)
+
+        assert checkout.seats == price.get_minimum_seats()
+        assert checkout.amount == price.calculate_amount(price.get_minimum_seats())
+
     async def test_valid_with_discount(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2367,6 +2367,28 @@ class TestCheckoutLinkCreate:
         assert checkout.success_url == "https://example.com/success"
         assert checkout.user_metadata == {"key": "value"}
 
+    async def test_valid_custom_price_honors_zero_prefill(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # PWYW price that allows 0 with a non-zero preset: a validated `?amount=0`
+        # prefill must be honored, not fall back to the preset.
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[(0, None, 700, "usd")],
+        )
+        checkout_link = await create_checkout_link(save_fixture, products=[product])
+
+        checkout = await checkout_service.checkout_link_create(
+            session, checkout_link, query_prefill={"amount": "0"}
+        )
+
+        assert checkout.amount == 0
+
     async def test_valid_seat_based_defaults_to_minimum_seats(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/product/test_price_set.py
+++ b/server/tests/product/test_price_set.py
@@ -1,0 +1,145 @@
+from decimal import Decimal
+
+import pytest
+
+from polar.models import (
+    ProductPriceCustom,
+    ProductPriceFixed,
+    ProductPriceFree,
+    ProductPriceMeteredUnit,
+    ProductPriceSeatUnit,
+)
+from polar.product.price_set import PriceSet, calculate_upfront_amount
+
+
+def _fixed(amount: int = 1000) -> ProductPriceFixed:
+    return ProductPriceFixed(price_currency="usd", price_amount=amount)
+
+
+def _custom(
+    *, minimum_amount: int = 500, preset_amount: int | None = None
+) -> ProductPriceCustom:
+    return ProductPriceCustom(
+        price_currency="usd",
+        minimum_amount=minimum_amount,
+        maximum_amount=None,
+        preset_amount=preset_amount,
+    )
+
+
+def _free() -> ProductPriceFree:
+    return ProductPriceFree(price_currency="usd")
+
+
+def _metered() -> ProductPriceMeteredUnit:
+    return ProductPriceMeteredUnit(
+        price_currency="usd", unit_amount=Decimal("0.5"), cap_amount=None
+    )
+
+
+def _seat(*, price_per_seat: int = 1000, minimum_seats: int = 1) -> ProductPriceSeatUnit:
+    return ProductPriceSeatUnit(
+        price_currency="usd",
+        seat_tiers={
+            "tiers": [
+                {
+                    "min_seats": minimum_seats,
+                    "max_seats": None,
+                    "price_per_seat": price_per_seat,
+                }
+            ]
+        },
+    )
+
+
+class TestGetStaticPrices:
+    def test_excludes_metered(self) -> None:
+        fixed = _fixed()
+        price_set = PriceSet("usd", [fixed, _metered()])
+        assert price_set.get_static_prices() == [fixed]
+
+    def test_includes_seat(self) -> None:
+        seat = _seat()
+        price_set = PriceSet("usd", [seat])
+        assert price_set.get_static_prices() == [seat]
+
+
+class TestGetSeatPrice:
+    def test_present(self) -> None:
+        seat = _seat()
+        price_set = PriceSet("usd", [_fixed(), seat])
+        assert price_set.get_seat_price() is seat
+
+    def test_absent(self) -> None:
+        price_set = PriceSet("usd", [_fixed()])
+        assert price_set.get_seat_price() is None
+
+
+class TestGetCustomPrice:
+    def test_present(self) -> None:
+        custom = _custom()
+        price_set = PriceSet("usd", [custom])
+        assert price_set.get_custom_price() is custom
+
+    def test_absent(self) -> None:
+        price_set = PriceSet("usd", [_fixed()])
+        assert price_set.get_custom_price() is None
+
+
+class TestCalculateUpfrontAmount:
+    def test_fixed(self) -> None:
+        amount = calculate_upfront_amount(
+            [_fixed(1500)], custom_amount=None, seats=None
+        )
+        assert amount == 1500
+
+    def test_custom_with_amount(self) -> None:
+        amount = calculate_upfront_amount(
+            [_custom()], custom_amount=2000, seats=None
+        )
+        assert amount == 2000
+
+    def test_custom_falls_back_to_preset(self) -> None:
+        amount = calculate_upfront_amount(
+            [_custom(preset_amount=700)], custom_amount=None, seats=None
+        )
+        assert amount == 700
+
+    def test_custom_falls_back_to_minimum(self) -> None:
+        amount = calculate_upfront_amount(
+            [_custom(minimum_amount=500)], custom_amount=None, seats=None
+        )
+        assert amount == 500
+
+    def test_custom_zero_is_honored(self) -> None:
+        # Pay-what-you-want 0 must NOT fall through to preset/minimum.
+        amount = calculate_upfront_amount(
+            [_custom(minimum_amount=0, preset_amount=700)],
+            custom_amount=0,
+            seats=None,
+        )
+        assert amount == 0
+
+    def test_seat(self) -> None:
+        seat = _seat(price_per_seat=1000)
+        amount = calculate_upfront_amount([seat], custom_amount=None, seats=5)
+        assert amount == seat.calculate_amount(5) == 5000
+
+    def test_free_contributes_nothing(self) -> None:
+        amount = calculate_upfront_amount([_free()], custom_amount=None, seats=None)
+        assert amount == 0
+
+    def test_metered_contributes_nothing(self) -> None:
+        amount = calculate_upfront_amount([_metered()], custom_amount=None, seats=None)
+        assert amount == 0
+
+    def test_seat_price_without_seats_raises(self) -> None:
+        with pytest.raises(ValueError):
+            calculate_upfront_amount([_seat()], custom_amount=None, seats=None)
+
+    def test_sums_fixed_and_seat(self) -> None:
+        # Forward-looking: a base fee combined with seat-based pricing sums both.
+        fixed = _fixed(2000)
+        seat = _seat(price_per_seat=1000)
+        amount = calculate_upfront_amount([fixed, seat], custom_amount=None, seats=3)
+        assert amount == 2000 + seat.calculate_amount(3) == 5000

--- a/server/tests/product/test_price_set.py
+++ b/server/tests/product/test_price_set.py
@@ -120,6 +120,16 @@ class TestCalculateUpfrontAmount:
         )
         assert amount == 0
 
+    def test_custom_preset_zero_is_honored(self) -> None:
+        # A configured preset of 0 ("show $0 default") must NOT fall back to the
+        # minimum; only a missing preset does.
+        amount = calculate_upfront_amount(
+            [_custom(minimum_amount=500, preset_amount=0)],
+            custom_amount=None,
+            seats=None,
+        )
+        assert amount == 0
+
     def test_seat(self) -> None:
         seat = _seat(price_per_seat=1000)
         amount = calculate_upfront_amount([seat], custom_amount=None, seats=5)

--- a/server/tests/product/test_price_set.py
+++ b/server/tests/product/test_price_set.py
@@ -37,7 +37,9 @@ def _metered() -> ProductPriceMeteredUnit:
     )
 
 
-def _seat(*, price_per_seat: int = 1000, minimum_seats: int = 1) -> ProductPriceSeatUnit:
+def _seat(
+    *, price_per_seat: int = 1000, minimum_seats: int = 1
+) -> ProductPriceSeatUnit:
     return ProductPriceSeatUnit(
         price_currency="usd",
         seat_tiers={
@@ -94,9 +96,7 @@ class TestCalculateUpfrontAmount:
         assert amount == 1500
 
     def test_custom_with_amount(self) -> None:
-        amount = calculate_upfront_amount(
-            [_custom()], custom_amount=2000, seats=None
-        )
+        amount = calculate_upfront_amount([_custom()], custom_amount=2000, seats=None)
         assert amount == 2000
 
     def test_custom_falls_back_to_preset(self) -> None:
@@ -134,7 +134,7 @@ class TestCalculateUpfrontAmount:
         assert amount == 0
 
     def test_seat_price_without_seats_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="seats must be provided"):
             calculate_upfront_amount([_seat()], custom_amount=None, seats=None)
 
     def test_sums_fixed_and_seat(self) -> None:


### PR DESCRIPTION
 Refactors checkout so seat handling no longer leans on the single `product_price` foreign key. Use the `PriceSet` directly and run all amount math through one pure helper `calculate_upfront_amount`.

This is a pure refactor with no behavior change. For seat-only products the FK is the seat price today, so looking it up from the set returns the same object and the sums collapse to today's single-price math. The existing seat tests pass without any changes.

Rationale: it's the groundwork for combining seat-based prices with a fixed base fee. Once that exists, `calculate_upfront_amount` can just sum both instead of having to pick one.

As a QOL improvement, also changed some custom-price checks to pull the type-check on `product_price` completely out of the `update` logic to streamline things.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor checkout to use `PriceSet` end-to-end and compute upfront totals with `calculate_upfront_amount`. Fix PWYW handling to honor `0` presets and `?amount=0` link prefills; behavior is otherwise unchanged and this prepares combining seat prices with a base fee.

- **Refactors**
  - Use `PriceSet` across create, update, and checkout‑link; explicit price selection becomes a single‑price set.
  - Compute upfront totals via `calculate_upfront_amount` from the set’s static prices, plus optional `seats` and custom amount.
  - Resolve seat/custom prices with `PriceSet` helpers; validate limits; default seats to the minimum where needed.

- **Tests**
  - Add unit tests for `PriceSet` helpers and `calculate_upfront_amount`, including honoring `preset_amount=0` and summing fixed + seat prices.
  - Add checkout‑link regression test for `?amount=0` PWYW prefills and a test for minimum‑seat defaults on seat‑based pricing.

<sup>Written for commit d6d4ce42354b70c57915fbaa66c5bb0307a6ed4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

