### PR TITLE
Make subscriptions.organization_id non-nullable

### DIFF
--- a/server/migrations/versions/2026-06-04-1000_make_subscriptions_organization_id_non_nullable.py
+++ b/server/migrations/versions/2026-06-04-1000_make_subscriptions_organization_id_non_nullable.py
@@ -1,0 +1,84 @@
+"""Make subscriptions.organization_id non nullable
+
+Revision ID: c9e9440f7d03
+Revises: 5263a32cf4dd
+Create Date: 2026-06-04 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c9e9440f7d03"
+down_revision = "5263a32cf4dd"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    # Production is expected to have been backfilled via
+    # scripts/backfill_subscription_organization_id.py before this migration
+    # runs; this UPDATE is a safety net for local environments where the script
+    # may not have been executed.
+    op.execute(
+        """
+        UPDATE subscriptions
+           SET organization_id = products.organization_id
+          FROM products
+         WHERE subscriptions.product_id = products.id
+           AND subscriptions.organization_id IS NULL
+        """
+    )
+
+    # Use the NOT VALID / VALIDATE pattern to avoid a full-table ACCESS EXCLUSIVE
+    # lock when setting NOT NULL.
+    #
+    # Step 1: add the check constraint as NOT VALID — takes only SHARE UPDATE
+    #         EXCLUSIVE, so concurrent reads and writes are unblocked.
+    op.execute(
+        """
+        ALTER TABLE subscriptions
+            ADD CONSTRAINT subscriptions_organization_id_not_null
+            CHECK (organization_id IS NOT NULL) NOT VALID
+        """
+    )
+
+    # Step 2: validate the constraint — also SHARE UPDATE EXCLUSIVE.  Postgres
+    #         scans the table for violations here, but concurrent DML is still
+    #         allowed (it must simply not introduce new NULLs).
+    op.execute(
+        """
+        ALTER TABLE subscriptions
+            VALIDATE CONSTRAINT subscriptions_organization_id_not_null
+        """
+    )
+
+    # Step 3: set NOT NULL — because a validated check constraint already proves
+    #         no NULLs exist, Postgres 12+ skips the full table scan and holds
+    #         ACCESS EXCLUSIVE for only a very short time.
+    op.alter_column(
+        "subscriptions", "organization_id", existing_type=sa.UUID(), nullable=False
+    )
+
+    # Step 4: the check constraint is now redundant — the NOT NULL column
+    #         constraint takes over.
+    op.execute(
+        """
+        ALTER TABLE subscriptions
+            DROP CONSTRAINT subscriptions_organization_id_not_null
+        """
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.alter_column(
+        "subscriptions", "organization_id", existing_type=sa.UUID(), nullable=True
+    )

--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -389,7 +389,9 @@ async def cancel(
     session: AsyncSession = Depends(get_db_session),
 ) -> Any:
     subscription_repository = SubscriptionRepository.from_session(session)
-    subscription = await subscription_repository.get_by_id(id)
+    subscription = await subscription_repository.get_by_id(
+        id, options=subscription_repository.get_eager_options()
+    )
 
     if subscription is None:
         raise HTTPException(status_code=404)
@@ -441,7 +443,9 @@ async def uncancel(
     session: AsyncSession = Depends(get_db_session),
 ) -> Any:
     subscription_repository = SubscriptionRepository.from_session(session)
-    subscription = await subscription_repository.get_by_id(id)
+    subscription = await subscription_repository.get_by_id(
+        id, options=subscription_repository.get_eager_options()
+    )
 
     if subscription is None:
         raise HTTPException(status_code=404)

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -205,6 +205,7 @@ async def list_claimed_subscriptions(
         auth_subject
     ).options(
         joinedload(Subscription.customer),
+        joinedload(Subscription.organization),
         joinedload(Subscription.product).options(
             selectinload(Product.product_medias),
             joinedload(Product.organization),

--- a/server/polar/customer_portal/endpoints/customer_seat.py
+++ b/server/polar/customer_portal/endpoints/customer_seat.py
@@ -205,7 +205,6 @@ async def list_claimed_subscriptions(
         auth_subject
     ).options(
         joinedload(Subscription.customer),
-        joinedload(Subscription.organization),
         joinedload(Subscription.product).options(
             selectinload(Product.product_medias),
             joinedload(Product.organization),

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -75,6 +75,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
             .join(Organization, onclause=Product.organization_id == Organization.id)
             .options(
                 joinedload(Subscription.customer).joinedload(Customer.organization),
+                joinedload(Subscription.organization),
                 contains_eager(Subscription.product).options(
                     selectinload(Product.product_medias),
                     contains_eager(Product.organization),
@@ -126,6 +127,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
             .where(Subscription.id == id)
             .options(
                 joinedload(Subscription.customer),
+                joinedload(Subscription.organization),
                 joinedload(Subscription.product).options(
                     selectinload(Product.product_medias),
                     joinedload(Product.organization),

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -75,7 +75,6 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
             .join(Organization, onclause=Product.organization_id == Organization.id)
             .options(
                 joinedload(Subscription.customer).joinedload(Customer.organization),
-                joinedload(Subscription.organization),
                 contains_eager(Subscription.product).options(
                     selectinload(Product.product_medias),
                     contains_eager(Product.organization),

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -195,16 +195,16 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
     def customer(cls) -> Mapped["Customer"]:
         return relationship("Customer", lazy="raise")
 
-    organization_id: Mapped[UUID | None] = mapped_column(
+    organization_id: Mapped[UUID] = mapped_column(
         Uuid,
         ForeignKey("organizations.id", ondelete="restrict"),
-        nullable=True,
+        nullable=False,
         index=True,
     )
 
-    organization: AssociationProxy["Organization"] = association_proxy(
-        "product", "organization"
-    )
+    @declared_attr
+    def organization(cls) -> Mapped["Organization"]:
+        return relationship("Organization", lazy="raise")
 
     payment_method_id: Mapped[UUID | None] = mapped_column(
         Uuid,

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -119,12 +119,11 @@ class SubscriptionRepository(
     ) -> Subscription | None:
         statement = (
             self.get_base_statement()
-            .join(Product)
             .where(
                 Subscription.id == id,
-                Product.organization_id == organization_id,
+                Subscription.organization_id == organization_id,
             )
-            .options(contains_eager(Subscription.product), *options)
+            .options(joinedload(Subscription.product), *options)
         )
         return await self.get_one_or_none(statement)
 
@@ -174,6 +173,7 @@ class SubscriptionRepository(
             product_load = joinedload(Subscription.product)
         return (
             joinedload(Subscription.customer).joinedload(Customer.organization),
+            joinedload(Subscription.organization),
             product_load.options(
                 joinedload(Product.organization),
                 selectinload(Product.product_medias),
@@ -186,11 +186,11 @@ class SubscriptionRepository(
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization | Customer | Member]
     ) -> Select[tuple[Subscription]]:
-        statement = self.get_base_statement().join(Product)
+        statement = self.get_base_statement()
 
         if is_user(auth_subject):
             statement = statement.where(
-                Product.organization_id.in_(
+                Subscription.organization_id.in_(
                     select_user_org_ids(
                         auth_subject.subject.id,
                         permission=OrganizationPermission.sales_read,
@@ -199,7 +199,7 @@ class SubscriptionRepository(
             )
         elif is_organization(auth_subject):
             statement = statement.where(
-                Product.organization_id == auth_subject.subject.id,
+                Subscription.organization_id == auth_subject.subject.id,
             )
         elif is_customer(auth_subject):
             customer = auth_subject.subject

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -589,7 +589,7 @@ class SubscriptionService:
         subscription.recurring_interval_count = recurring_interval_count
         subscription.status = status
         subscription.payment_method = payment_method
-        subscription.organization = product.organization
+        subscription.organization = checkout.organization
         subscription.product = product
         subscription.subscription_product_prices = subscription_product_prices
         subscription.currency = currency

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -477,7 +477,7 @@ class SubscriptionService:
             cancel_at_period_end=False,
             recurring_interval=recurring_interval,
             recurring_interval_count=recurring_interval_count,
-            organization_id=product.organization_id,
+            organization=product.organization,
             product=product,
             customer=customer,
             subscription_product_prices=subscription_product_prices,
@@ -589,7 +589,7 @@ class SubscriptionService:
         subscription.recurring_interval_count = recurring_interval_count
         subscription.status = status
         subscription.payment_method = payment_method
-        subscription.organization_id = product.organization_id
+        subscription.organization = product.organization
         subscription.product = product
         subscription.subscription_product_prices = subscription_product_prices
         subscription.currency = currency
@@ -1771,7 +1771,7 @@ class SubscriptionService:
     ) -> None:
         subscription_repository = SubscriptionRepository.from_session(session)
         subscriptions = await subscription_repository.list_active_by_customer(
-            customer_id
+            customer_id, options=subscription_repository.get_eager_options()
         )
         for subscription in subscriptions:
             await self._perform_cancellation(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -253,15 +253,18 @@ class SubscriptionService:
         statement = (
             repository.get_readable_statement(auth_subject)
             .where(Subscription.started_at.is_not(None))
+            .join(Subscription.product)
             .join(Subscription.customer)
             .join(Subscription.discount, isouter=True)
         )
 
         if organization_id is not None:
-            statement = statement.where(Product.organization_id.in_(organization_id))
+            statement = statement.where(
+                Subscription.organization_id.in_(organization_id)
+            )
 
         if product_id is not None:
-            statement = statement.where(Product.id.in_(product_id))
+            statement = statement.where(Subscription.product_id.in_(product_id))
 
         if customer_id is not None:
             statement = statement.where(Subscription.customer_id.in_(customer_id))
@@ -331,11 +334,7 @@ class SubscriptionService:
                 Subscription.id == id,
                 Subscription.started_at.is_not(None),
             )
-            .options(
-                *repository.get_eager_options(
-                    product_load=contains_eager(Subscription.product)
-                )
-            )
+            .options(*repository.get_eager_options())
         )
 
         if for_update:

--- a/server/scripts/create_subscription.py
+++ b/server/scripts/create_subscription.py
@@ -206,7 +206,7 @@ async def create_subscription(
                 cancel_at_period_end=False,
                 recurring_interval=recurring_interval,
                 recurring_interval_count=recurring_interval_count,
-                organization_id=product.organization_id,
+                organization=product.organization,
                 product=product,
                 customer=customer,
                 subscription_product_prices=subscription_product_prices,

--- a/server/scripts/create_subscription.py
+++ b/server/scripts/create_subscription.py
@@ -206,6 +206,7 @@ async def create_subscription(
                 cancel_at_period_end=False,
                 recurring_interval=recurring_interval,
                 recurring_interval_count=recurring_interval_count,
+                organization_id=product.organization_id,
                 product=product,
                 customer=customer,
                 subscription_product_prices=subscription_product_prices,

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -1973,6 +1973,7 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
                         cancel_at_period_end=False,
                         started_at=now,
                         customer_id=sub_customer.id,
+                        organization_id=product.organization_id,
                         product_id=product.id,
                         anchor_day=now.day,
                     )
@@ -2025,6 +2026,7 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
                     cancel_at_period_end=False,
                     started_at=utc_now(),
                     customer_id=seat_customer.id,
+                    organization_id=seat_based_product.organization_id,
                     product_id=seat_based_product.id,
                     seats=seats_purchased,
                     anchor_day=utc_now().day,

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1143,7 +1143,7 @@ async def create_subscription(
         started_at=started_at,
         ended_at=ended_at,
         ends_at=ends_at,
-        organization_id=product.organization_id,
+        organization=product.organization,
         customer=customer,
         product=product,
         payment_method=payment_method,


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number if available -->

Denormalizes `organization_id` directly onto the `Subscription` model as a non-nullable column, eliminating the need to traverse through the product relationship to determine subscription ownership.

## What

- Added database migration to make `subscriptions.organization_id` non-nullable using PostgreSQL's NOT VALID/VALIDATE pattern to minimize locking
- Updated `Subscription` model to make `organization_id` a required UUID column with a direct relationship to `Organization`
- Refactored all subscription queries to filter by `Subscription.organization_id` instead of `Product.organization_id`
- Updated subscription creation and update logic to set `organization` relationship instead of `organization_id`
- Added eager loading of `Subscription.organization` throughout the codebase to prevent N+1 queries

## Why

This change improves query efficiency and data consistency:
- Eliminates unnecessary joins to the `Product` table when filtering subscriptions by organization
- Provides direct access to organization information without traversing relationships
- Simplifies authorization checks by making organization ownership explicit on the subscription
- Reduces query complexity and improves performance for subscription list operations

## How

1. **Database Migration**: Uses PostgreSQL's constraint validation pattern to safely add NOT NULL constraint without full table locks:
   - Backfills any remaining NULL values from product organization
   - Adds NOT VALID check constraint (SHARE UPDATE EXCLUSIVE lock)
   - Validates constraint (SHARE UPDATE EXCLUSIVE lock)
   - Sets column NOT NULL (brief ACCESS EXCLUSIVE lock)
   - Drops redundant check constraint

2. **Model Changes**: 
   - Changed `organization_id` from nullable to non-nullable
   - Replaced `AssociationProxy` with direct `relationship` to `Organization`

3. **Query Refactoring**:
   - Updated `SubscriptionRepository` methods to filter by `Subscription.organization_id`
   - Removed unnecessary `Product` joins in authorization checks
   - Added `joinedload(Subscription.organization)` to eager loading options

4. **Data Updates**:
   - Updated seed data and test fixtures to provide `organization_id` or `organization` relationship
   - Updated subscription creation endpoints to set organization relationship

## Checklist

- [x] This PR addresses a single concern (denormalizing organization_id for query efficiency)
- [x] The diff is reasonably sized and focused on the denormalization
- [x] Existing tests pass with the schema changes
- [x] Migration uses safe PostgreSQL patterns to avoid locking issues
- [x] No unrelated changes included

https://claude.ai/code/session_01KbVZWRgkFKk6HF7pdKH8gt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `subscriptions.organization_id` required and add a direct `Subscription.organization` relationship. This removes `Product` joins from auth and listing paths, trims redundant eager-loads in read-only lists, and speeds up subscription queries.

- **Migration**
  - Backfills NULLs from `products.organization_id` as a safety net.
  - Uses NOT VALID → VALIDATE → SET NOT NULL to minimize locks; then drops the check.
  - Sets `lock_timeout` to 5s to avoid long waits.

- **Refactors**
  - Model: `organization_id` is non-nullable; replace association proxy with a direct `organization` relationship (`lazy="raise"`).
  - Repositories: filter by `Subscription.organization_id`; remove `Product` joins; eager-load `Subscription.organization`.
  - Services/endpoints: list/get filter on subscription columns; explicitly join `Subscription.product` where needed; backoffice cancel/uncancel and customer portal get-by-id eagerly load `Subscription.organization`; drop redundant eager-loads in read-only customer portal and claimed-seat lists.
  - Creation paths: assign the `organization` relationship on create; in checkout flows set from `Checkout.organization` (not `Product.organization`) to avoid `lazy="raise"` errors.
  - Seeds/scripts/tests: seeding sets `organization_id`; dev script and test fixture assign the `organization` relationship.

<sup>Written for commit 4b8e811e3597871ca6218713d55380dbb3183400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

