### PR TITLE
Refactor checkout away from deprecated `product_price`

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -17,6 +17,7 @@ import {
   CheckoutSeatSelector,
 } from '@polar-sh/checkout/components'
 import {
+  getSeatPrice,
   hasProductCheckout,
   type ProductCheckoutPublic,
 } from '@polar-sh/checkout/guards'
@@ -275,7 +276,7 @@ const Checkout = ({
           beforeSubmit={
             hasProductCheckout(checkout) && !checkout.is_free_product_price ? (
               <div className="flex flex-col gap-4">
-                {checkout.product_price.amount_type === 'seat_based' && (
+                {!!getSeatPrice(checkout) && (
                   <CheckoutSeatSelector
                     checkout={checkout}
                     update={update}
@@ -411,7 +412,7 @@ const Checkout = ({
                 )}
                 {!checkout.is_free_product_price && (
                   <div className="flex flex-col gap-4 text-sm">
-                    {checkout.product_price.amount_type === 'seat_based' && (
+                    {!!getSeatPrice(checkout) && (
                       <CheckoutSeatSelector
                         checkout={checkout}
                         update={update}

--- a/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutSeatInvitations.tsx
@@ -2,7 +2,7 @@
 
 import { useAssignSeatFromCheckout } from '@/hooks/queries'
 import { validateEmail } from '@/utils/validation'
-import { hasProductCheckout } from '@polar-sh/checkout/guards'
+import { getSeatPrice } from '@polar-sh/checkout/guards'
 import type { schemas } from '@polar-sh/client'
 import Button from '@polar-sh/ui/components/atoms/Button'
 import Input from '@polar-sh/ui/components/atoms/Input'
@@ -26,9 +26,7 @@ const CheckoutSeatInvitations = ({
   checkout,
   customerSessionToken,
 }: CheckoutSeatInvitationsProps) => {
-  const isSeatBased =
-    hasProductCheckout(checkout) &&
-    checkout.product_price.amount_type === 'seat_based'
+  const isSeatBased = getSeatPrice(checkout) !== null
 
   if (!isSeatBased || !checkout.seats || !customerSessionToken) {
     return null

--- a/clients/packages/checkout/src/components/CheckoutSeatSelector.tsx
+++ b/clients/packages/checkout/src/components/CheckoutSeatSelector.tsx
@@ -10,7 +10,7 @@ import {
 import Button from '@polar-sh/ui/components/atoms/Button'
 import Input from '@polar-sh/ui/components/atoms/Input'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { ProductCheckoutPublic } from '../guards'
+import { getSeatPrice, type ProductCheckoutPublic } from '../guards'
 import { ErrorResponse } from '../providers/CheckoutProvider'
 import MeteredPricesDisplay from './MeteredPricesDisplay'
 
@@ -48,12 +48,12 @@ const CheckoutSeatSelector = ({
   )
 
   // Check if the product has seat-based pricing
-  const productPrice = checkout.product_price
-  const isSeatBased = productPrice.amount_type === 'seat_based'
+  const seatPrice = getSeatPrice(checkout)
+  const isSeatBased = seatPrice !== null
 
   // Get seat limits from the tiers
   // The minimum comes from the first tier's min_seats, maximum from the last tier's max_seats
-  const seatTiers = isSeatBased ? productPrice.seat_tiers : null
+  const seatTiers = seatPrice?.seat_tiers ?? null
   const tiers = seatTiers?.tiers ?? []
   const sortedTiers = [...tiers].sort((a, b) => a.min_seats - b.min_seats)
   const tierMinimumSeats = sortedTiers[0]?.min_seats ?? 1

--- a/clients/packages/checkout/src/guards.ts
+++ b/clients/packages/checkout/src/guards.ts
@@ -22,3 +22,24 @@ export const isLegacyRecurringProductPrice = (
 ): price is schemas['LegacyRecurringProductPrice'] => {
   return (price as schemas['LegacyRecurringProductPrice']).type === 'recurring'
 }
+
+export const getSeatPrice = (
+  checkout: schemas['CheckoutPublic'],
+): schemas['ProductPriceSeatBased'] | null => {
+  if (!checkout.product || !checkout.prices) {
+    return null
+  }
+
+  const prices = checkout.prices[checkout.product.id]
+
+  if (!prices) {
+    return null
+  }
+
+  return (
+    prices.find(
+      (price): price is schemas['ProductPriceSeatBased'] =>
+        price.amount_type === 'seat_based',
+    ) ?? null
+  )
+}

--- a/clients/packages/checkout/src/test-utils/makeCheckout.ts
+++ b/clients/packages/checkout/src/test-utils/makeCheckout.ts
@@ -171,14 +171,22 @@ const defaults: ProductCheckoutPublic = {
 /**
  * Create a ProductCheckoutPublic for testing.
  * Only override the fields relevant to your test case.
+ *
+ * Unless `prices` is set explicitly, it's derived from the selected
+ * `product_price` so `prices[product_id]` contains it — mirroring the backend,
+ * where the product's price list always includes the selected price.
  */
 export function createCheckout(
   overrides: Partial<ProductCheckoutPublic> = {},
 ): ProductCheckoutPublic {
-  return {
+  const checkout = {
     ...defaults,
     ...overrides,
   } satisfies ProductCheckoutPublic
+  if (!('prices' in overrides)) {
+    checkout.prices = { [checkout.product_id]: [checkout.product_price] }
+  }
+  return checkout
 }
 
 /**

--- a/clients/packages/checkout/src/utils/seats.ts
+++ b/clients/packages/checkout/src/utils/seats.ts
@@ -1,4 +1,5 @@
 import type { schemas } from '@polar-sh/client'
+import { getSeatPrice } from '../guards'
 
 export interface SeatRow {
   seats: number
@@ -8,9 +9,8 @@ export interface SeatRow {
 export function getSeatRows(
   checkout: schemas['CheckoutPublic'],
 ): SeatRow[] | null {
-  if (!checkout.product || !checkout.product_price) return null
-  const price = checkout.product_price
-  if (price.amount_type !== 'seat_based') return null
+  const price = getSeatPrice(checkout)
+  if (!price) return null
   const seats = checkout.seats
   if (!seats) return null
 


### PR DESCRIPTION
Decouples the frontend checkout's seat-based pricing from the deprecated `checkout.product_price`, reading it instead from `checkout.prices`. There's no behavioral change today: with a single price per product, the seat price `getSeatPrice` returns is the same object `product_price` is pointed at.

This is groundwork for allowing fixed + seat prices in a single product.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors checkout to stop using deprecated `checkout.product_price` and read seat-based prices from `checkout.prices` via `getSeatPrice`. No behavior change today; this prepares for products with both fixed and seat prices.

- **Refactors**
  - Adds `getSeatPrice` in `@polar-sh/checkout/guards` to pick the seat-based price from `checkout.prices`.
  - Updates `Checkout`, `CheckoutSeatSelector`, `CheckoutSeatInvitations`, and seat utils to use `getSeatPrice` instead of `product_price`.
  - Test helper `createCheckout` now derives `prices[product_id]` from `product_price` by default.

<sup>Written for commit 69d0d2fb73121e8730aa7940679aa3ad75baab51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

