### PR TITLE
ci: Add deployment to test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,9 @@ jobs:
       backend-production: ${{ steps.filter-backend-production.outputs.backend }}
       migrations-production: ${{ steps.filter-backend-production.outputs.migrations }}
       frontend-production: ${{ steps.filter-frontend-production.outputs.frontend }}
+      # Whether the test environment is enabled in Terraform. The deploy-test
+      # job is skipped entirely when this is false.
+      test-enabled: ${{ steps.test-enabled.outputs.enabled }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -114,6 +117,19 @@ jobs:
             echo "backend-production=$(resolve deployed/backend-production)"
             echo "frontend-production=$(resolve deployed/frontend-production)"
           } >> "$GITHUB_OUTPUT"
+
+      # Parse local.test_enabled from the Terraform test config so the
+      # deploy-test job only runs when the test environment is actually
+      # provisioned. Defaults to false if the local is missing or unparseable.
+      - name: Resolve test environment enabled flag
+        id: test-enabled
+        run: |
+          set -euo pipefail
+          enabled="$(grep -oE '^[[:space:]]*test_enabled[[:space:]]*=[[:space:]]*(true|false)' terraform/test/render.tf \
+            | grep -oE '(true|false)$' \
+            | head -1 || true)"
+          echo "enabled=${enabled:-false}" >> "$GITHUB_OUTPUT"
+          echo "test_enabled=${enabled:-false}"
 
       # Four paths-filter invocations: one per component per env. We can't
       # combine them because dorny/paths-filter@v4 uses a single base for
@@ -275,6 +291,31 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+
+  deploy-test:
+    name: "Deploy to Test 🧰"
+    # Parallel to sandbox/production: depends only on changes + build, never on
+    # the other deploy jobs, so it can't slow the sandbox→production path.
+    # Reuses the sandbox change outputs for skip logic and only runs when the
+    # test environment is enabled in Terraform.
+    needs: [changes, build]
+    if: always() && !failure() && !cancelled() && needs.changes.outputs.test-enabled == 'true' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.frontend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      environment: test
+      docker-digest: ${{ needs.build.outputs.digest }}
+      render-api-service-id: "srv-d8ffbc42m8qs73e7lv30"
+      render-worker-service-ids: "srv-d8ffbbvavr4c73a79u00"
+      has-migrations: ${{ needs.changes.outputs.migrations-sandbox == 'true' || github.event_name == 'workflow_dispatch' }}
+      skip-backend: ${{ needs.changes.outputs.backend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
+      skip-frontend: ${{ needs.changes.outputs.frontend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
+    secrets:
+      RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_TEST }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
 


### PR DESCRIPTION
If test environment is enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `deploy-test` job to CI that deploys to the Test environment only when Terraform `test_enabled` is true. Runs in parallel with other environments and stays out of the sandbox→production path.

- **New Features**
  - Gate Test deploys by reading `local.test_enabled` from `terraform/test/render.tf` (defaults to false if missing or unparseable).
  - New `deploy-test` job uses `deploy-environment.yml`, existing sandbox change filters, and build outputs; supports manual `workflow_dispatch`.
  - Test deploy uses `VERCEL_PROJECT_ID_TEST`, includes Render service IDs, and applies per-component skip logic and migrations.

<sup>Written for commit 5a410c1123cfe1ae6902b0bd83c17b2853f693f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

