### PR TITLE
refactor(customer): rename CustomerPaymentMethodWithDefault schema to PaymentMethod

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15593,9 +15593,6 @@ export interface components {
        */
       is_default: boolean
     }
-    CustomerPaymentMethodWithDefault:
-      | components['schemas']['CustomerPaymentMethodCard']
-      | components['schemas']['CustomerPaymentMethodGeneric']
     /** CustomerPortalCustomer */
     CustomerPortalCustomer: {
       /**
@@ -20128,12 +20125,6 @@ export interface components {
       items: components['schemas']['CustomerOrder'][]
       pagination: components['schemas']['Pagination']
     }
-    /** ListResource[CustomerPaymentMethodWithDefault] */
-    ListResource_CustomerPaymentMethodWithDefault_: {
-      /** Items */
-      items: components['schemas']['CustomerPaymentMethodWithDefault'][]
-      pagination: components['schemas']['Pagination']
-    }
     /** ListResource[CustomerPaymentMethod] */
     ListResource_CustomerPaymentMethod_: {
       /** Items */
@@ -20268,6 +20259,12 @@ export interface components {
     ListResource_Organization_: {
       /** Items */
       items: components['schemas']['Organization'][]
+      pagination: components['schemas']['Pagination']
+    }
+    /** ListResource[PaymentMethod] */
+    ListResource_PaymentMethod_: {
+      /** Items */
+      items: components['schemas']['PaymentMethod'][]
       pagination: components['schemas']['Pagination']
     }
     /** ListResource[Payment] */
@@ -25691,6 +25688,9 @@ export interface components {
       /** Detail */
       detail: string
     }
+    PaymentMethod:
+      | components['schemas']['CustomerPaymentMethodCard']
+      | components['schemas']['CustomerPaymentMethodGeneric']
     /** PaymentMethodCard */
     PaymentMethodCard: {
       /**
@@ -40802,7 +40802,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['ListResource_CustomerPaymentMethodWithDefault_']
+          'application/json': components['schemas']['ListResource_PaymentMethod_']
         }
       }
       /** @description Customer not found. */
@@ -40848,7 +40848,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['ListResource_CustomerPaymentMethodWithDefault_']
+          'application/json': components['schemas']['ListResource_PaymentMethod_']
         }
       }
       /** @description Customer not found. */

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -290,9 +290,9 @@ class CustomerPaymentMethodGeneric(PaymentMethodGeneric):
 
 CustomerPaymentMethod = Annotated[
     CustomerPaymentMethodCard | CustomerPaymentMethodGeneric,
-    SetSchemaReference("CustomerPaymentMethodWithDefault"),
-    MergeJSONSchema({"title": "CustomerPaymentMethodWithDefault"}),
-    ClassName("CustomerPaymentMethodWithDefault"),
+    SetSchemaReference("PaymentMethod"),
+    MergeJSONSchema({"title": "PaymentMethod"}),
+    ClassName("PaymentMethod"),
 ]
 CustomerPaymentMethodTypeAdapter: TypeAdapter[CustomerPaymentMethod] = TypeAdapter(
     CustomerPaymentMethod


### PR DESCRIPTION
Unfortunately can't also rename `CustomerPaymentMethodCard` and `CustomerPaymentMethodGeneric` because of name conflict with customer portal counterparts.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the `CustomerPaymentMethodWithDefault` schema to `PaymentMethod` in the OpenAPI spec and regenerated the TS client. No response shape changes—only type names.

- **Refactors**
  - Server: updated schema reference/title/class name to `PaymentMethod`.
  - Client: replaced `CustomerPaymentMethodWithDefault` with `PaymentMethod`; updated responses to use `ListResource_PaymentMethod_`.

- **Migration**
  - Replace `CustomerPaymentMethodWithDefault` with `PaymentMethod` in type imports/usages.
  - Replace `ListResource_CustomerPaymentMethodWithDefault_` with `ListResource_PaymentMethod_`.

<sup>Written for commit 719bff8a30e7b884d5bdea16f2b68d20ea085d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

