### PR TITLE
tf/vercel: Map up frontend DNS into Cloudflare as well

### DIFF
--- a/terraform/modules/vercel/main.tf
+++ b/terraform/modules/vercel/main.tf
@@ -116,3 +116,17 @@ resource "vercel_project_domain" "this" {
   redirect_status_code = each.value.redirect_status_code
   git_branch           = each.value.git_branch
 }
+
+# Cloudflare record pointing the hostname at Vercel, for domains that opt in
+# via `dns`. Apex domains use an A record; subdomains a CNAME to the project's
+# Vercel DNS target.
+resource "cloudflare_dns_record" "this" {
+  for_each = { for domain in var.domains : domain.name => domain if domain.dns != null }
+
+  zone_id = each.value.dns.zone_id
+  name    = each.value.name
+  type    = each.value.dns.type
+  content = each.value.dns.content
+  proxied = each.value.dns.proxied
+  ttl     = each.value.dns.ttl
+}

--- a/terraform/modules/vercel/terraform.tf
+++ b/terraform/modules/vercel/terraform.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "vercel/vercel"
       version = "~> 5.3"
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.13"
+    }
   }
 
   required_version = ">= 1.2"

--- a/terraform/modules/vercel/variables.tf
+++ b/terraform/modules/vercel/variables.tf
@@ -98,6 +98,13 @@ variable "domains" {
     redirect             = optional(string)
     redirect_status_code = optional(number)
     git_branch           = optional(string)
+    dns = optional(object({
+      zone_id = string
+      type    = optional(string, "CNAME")
+      content = string
+      proxied = optional(bool, false)
+      ttl     = optional(number, 1)
+    }))
   }))
   default = []
 }

--- a/terraform/production/vercel.tf
+++ b/terraform/production/vercel.tf
@@ -40,6 +40,28 @@ import {
   id = "prj_9YDPCLXAX2w3RJqbXV7F1c3cZi9F/www.polar.new"
 }
 
+# --- Cloudflare DNS records (adopt existing live records) ---
+
+import {
+  to = module.vercel.cloudflare_dns_record.this["polar.sh"]
+  id = "22bcd1b07ec25452aab472486bc8df94/8b0ceddb75258af3fa49fd7846655535"
+}
+
+import {
+  to = module.vercel.cloudflare_dns_record.this["www.polar.sh"]
+  id = "22bcd1b07ec25452aab472486bc8df94/1ab226a5a0bb731e56a95fb994eeb51f"
+}
+
+import {
+  to = module.vercel.cloudflare_dns_record.this["dashboard.polar.sh"]
+  id = "22bcd1b07ec25452aab472486bc8df94/ff92f83787a1c170bd97c43107ca233f"
+}
+
+import {
+  to = module.vercel.cloudflare_dns_record.this["blog.polar.sh"]
+  id = "22bcd1b07ec25452aab472486bc8df94/68e8b181600e850ab36dfcb9ebf414b0"
+}
+
 module "vercel" {
   source = "../modules/vercel"
 
@@ -52,10 +74,42 @@ module "vercel" {
   }
 
   domains = [
-    { name = "polar.sh" },
-    { name = "www.polar.sh", redirect = "polar.sh", redirect_status_code = 308 },
-    { name = "dashboard.polar.sh" },
-    { name = "blog.polar.sh" },
+    {
+      name = "polar.sh"
+      dns = {
+        zone_id = "22bcd1b07ec25452aab472486bc8df94"
+        type    = "A"
+        content = "216.150.1.1"
+        ttl     = 600
+      }
+    },
+    {
+      name                 = "www.polar.sh"
+      redirect             = "polar.sh"
+      redirect_status_code = 308
+      dns = {
+        zone_id = "22bcd1b07ec25452aab472486bc8df94"
+        content = "582a8a8790ca4ebf.vercel-dns-016.com"
+        ttl     = 600
+      }
+    },
+    {
+      name = "dashboard.polar.sh"
+      dns = {
+        zone_id = "22bcd1b07ec25452aab472486bc8df94"
+        content = "582a8a8790ca4ebf.vercel-dns-016.com"
+        ttl     = 600
+      }
+    },
+    {
+      name = "blog.polar.sh"
+      dns = {
+        zone_id = "22bcd1b07ec25452aab472486bc8df94"
+        content = "582a8a8790ca4ebf.vercel-dns-016.com"
+        ttl     = 600
+      }
+    },
+    # polar.new and www.polar.new live in a separate zone and are managed separately.
     { name = "polar.new" },
     { name = "www.polar.new", redirect = "polar.new", redirect_status_code = 308 },
   ]

--- a/terraform/sandbox/vercel.tf
+++ b/terraform/sandbox/vercel.tf
@@ -12,6 +12,11 @@ import {
   id = "prj_HjPbSesm9rpLRPaK6bLOwVqQzQBD/sandbox.polar.sh"
 }
 
+import {
+  to = module.vercel.cloudflare_dns_record.this["sandbox.polar.sh"]
+  id = "22bcd1b07ec25452aab472486bc8df94/9e0564c9263d6d626b96bf6bed6e216f"
+}
+
 module "vercel" {
   source = "../modules/vercel"
 
@@ -19,7 +24,13 @@ module "vercel" {
   git_repo = "polarsource/polar"
 
   domains = [
-    { name = "sandbox.polar.sh" },
+    {
+      name = "sandbox.polar.sh"
+      dns = {
+        zone_id = "22bcd1b07ec25452aab472486bc8df94"
+        content = "50b537f2e43aa1b6.vercel-dns-016.com"
+      }
+    },
   ]
 
   config = {

--- a/terraform/test/vercel.tf
+++ b/terraform/test/vercel.tf
@@ -12,7 +12,13 @@ module "vercel" {
   git_repo = "polarsource/polar"
 
   domains = [
-    { name = "test.polar.sh" },
+    {
+      name = "test.polar.sh"
+      dns = {
+        zone_id = "22bcd1b07ec25452aab472486bc8df94"
+        content = "cname.vercel-dns.com"
+      }
+    },
   ]
 
   config = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Manage Cloudflare DNS for Vercel frontend domains in Terraform. Adds `cloudflare/cloudflare` and provisions records for `polar.sh` and subdomains, with imports to adopt existing live entries.

- **New Features**
  - Added `cloudflare/cloudflare` provider to the Vercel module.
  - Introduced optional `dns` object on `domains` to create Cloudflare records.
  - Created `cloudflare_dns_record` for opted-in domains (A for apex, CNAME for subdomains).
  - Updated production, sandbox, and test configs with DNS targets and import blocks for current records.

<sup>Written for commit 7f628e37dc847d0f4ddc42464fcfea2d05eadf07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

