### PR TITLE
slack: Add slack/benefit model

### DIFF
--- a/server/migrations/versions/2026-06-04-1650_add_slack_apps.py
+++ b/server/migrations/versions/2026-06-04-1650_add_slack_apps.py
@@ -1,0 +1,102 @@
+"""add slack apps
+
+Revision ID: bc2540d6d2c0
+Revises: c9e9440f7d03
+Create Date: 2026-06-04 16:50:37.766909
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "bc2540d6d2c0"
+down_revision = "c9e9440f7d03"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.create_table(
+        "slack_apps",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("modified_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("display_name", sa.String(length=35), nullable=False),
+        sa.Column("slack_app_id", sa.String(length=32), nullable=True),
+        sa.Column("client_id", sa.String(length=255), nullable=True),
+        sa.Column("client_secret", sa.String(length=255), nullable=True),
+        sa.Column("signing_secret", sa.String(length=255), nullable=True),
+        sa.Column("team_id", sa.String(length=32), nullable=True),
+        sa.Column("team_name", sa.String(length=255), nullable=True),
+        sa.Column("bot_user_id", sa.String(length=32), nullable=True),
+        sa.Column("bot_token", sa.String(length=255), nullable=True),
+        sa.Column("authed_user_id", sa.String(length=32), nullable=True),
+        sa.Column("scopes", postgresql.ARRAY(sa.String()), nullable=True),
+        sa.Column("installed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            name=op.f("slack_apps_organization_id_fkey"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("slack_apps_pkey")),
+        sa.UniqueConstraint(
+            "slack_app_id",
+            name=op.f("slack_apps_slack_app_id_key"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_slack_apps_created_at"),
+        "slack_apps",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_slack_apps_deleted_at"),
+        "slack_apps",
+        ["deleted_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_slack_apps_organization_id"),
+        "slack_apps",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_slack_apps_team_id"),
+        "slack_apps",
+        ["team_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_index(
+        op.f("ix_slack_apps_team_id"),
+        table_name="slack_apps",
+    )
+    op.drop_index(
+        op.f("ix_slack_apps_organization_id"),
+        table_name="slack_apps",
+    )
+    op.drop_index(
+        op.f("ix_slack_apps_deleted_at"),
+        table_name="slack_apps",
+    )
+    op.drop_index(
+        op.f("ix_slack_apps_created_at"),
+        table_name="slack_apps",
+    )
+    op.drop_table("slack_apps")

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -79,6 +79,7 @@ from .product_price import (
     ProductPriceSeatUnit,
 )
 from .refund import Refund
+from .slack_app import SlackApp
 from .subscription import Subscription
 from .subscription_meter import SubscriptionMeter
 from .subscription_product_price import SubscriptionProductPrice
@@ -182,6 +183,7 @@ __all__ = [
     "ProductVisibility",
     "Refund",
     "SeatStatus",
+    "SlackApp",
     "Subscription",
     "SubscriptionMeter",
     "SubscriptionProductPrice",

--- a/server/polar/models/slack_app.py
+++ b/server/polar/models/slack_app.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import TIMESTAMP, ForeignKey, String, Uuid
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+
+from polar.kit.db.models.base import RecordModel
+
+from .organization import Organization
+
+
+class SlackApp(RecordModel):
+    __tablename__ = "slack_apps"
+
+    organization_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("organizations.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
+
+    display_name: Mapped[str] = mapped_column(String(35), nullable=False)
+    slack_app_id: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, unique=True, default=None
+    )
+    client_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+    client_secret: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+    signing_secret: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+
+    team_id: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None, index=True
+    )
+    team_name: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+    bot_user_id: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None
+    )
+    bot_token: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+    authed_user_id: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None
+    )
+    scopes: Mapped[list[str] | None] = mapped_column(
+        ARRAY(String), nullable=True, default=None
+    )
+    installed_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, default=None
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, default=None
+    )
+
+    @declared_attr
+    def organization(cls) -> Mapped["Organization"]:
+        return relationship(Organization, lazy="raise")


### PR DESCRIPTION
The idea is that this table will hold the integration details between a Slack app on an organization, and the benefit it links to.

The benefit_id is nullable to allow the slack connection to be created before the benefit is saved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SlackApp` to store Slack app installation details per organization, with a new `slack_apps` table and ORM export for use across the app.

- **New Features**
  - Added `SlackApp` model and `slack_apps` table; exported in `polar.models`.
  - Stores app/team/bot/user IDs, tokens/secrets, scopes, and install/revoke timestamps.
  - Unique on `slack_app_id`; cascade delete via `organization_id`; indexes on `organization_id`, `team_id`, `created_at`, and `deleted_at`.

<sup>Written for commit 6916397c83f57348df6e979bd17c6442e3e8c22c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

