### PR TITLE
slack: Add feature flag to control benefit availability

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23970,6 +23970,12 @@ export interface components {
        * @default false
        */
       billing_enabled: boolean
+      /**
+       * Slack Benefit Enabled
+       * @description If this organization can create the Slack shared channel benefit
+       * @default false
+       */
+      slack_benefit_enabled: boolean
     }
     /** OrganizationIndividualLegalEntitySchema */
     OrganizationIndividualLegalEntitySchema: {

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -597,6 +597,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
     def is_account_review_v2_enabled(self) -> bool:
         return self.feature_settings.get("account_review_v2_enabled", False)
 
+    @property
+    def is_slack_benefit_enabled(self) -> bool:
+        return self.feature_settings.get("slack_benefit_enabled", False)
+
     #
     # Currency and tax settings
     #

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -162,6 +162,10 @@ class OrganizationFeatureSettings(Schema):
     billing_enabled: bool = Field(
         False, description="If this organization has billing enabled"
     )
+    slack_benefit_enabled: bool = Field(
+        False,
+        description="If this organization can create the Slack shared channel benefit",
+    )
 
     @field_validator("overview_metrics", mode="before")
     @classmethod


### PR DESCRIPTION
So that we can roll this out to Polar initially, before all organizations gets access to the Slack benefit feature


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-organization feature flag to gate the Slack shared channel benefit, defaulting to off. This lets us roll out the benefit to Polar first before enabling it for all orgs.

- **New Features**
  - Added `slack_benefit_enabled` to `OrganizationFeatureSettings` (default: false).
  - Added `is_slack_benefit_enabled` property on the `Organization` model.
  - Exposed `slack_benefit_enabled` in the client `v1` types for organizations.

<sup>Written for commit 67e21cc7abd707b5a2054322c863eeb7460a9130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

