### PR TITLE
tf/vercel: Expose system env vars

### DIFF
--- a/terraform/modules/vercel/main.tf
+++ b/terraform/modules/vercel/main.tf
@@ -20,6 +20,8 @@ resource "vercel_project" "this" {
   enable_production_feedback = var.enable_production_feedback
   git_provider_options       = var.git_provider_options
 
+  automatically_expose_system_environment_variables = true
+
   git_repository = {
     type              = "github"
     repo              = var.git_repo


### PR DESCRIPTION
Otherwise we wont cache bust, and the AUP wont copy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Vercel system env vars so builds and deployments receive them and cache bust correctly. Set `automatically_expose_system_environment_variables = true` in the `vercel_project` resource.

<sup>Written for commit a1508a53e9a116b65cddd2484d4dfc98e4f6e966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

