### PR TITLE
chore(docs): update development.md to match stripe dashboard

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,7 +121,7 @@ If you want to work with payments and subscriptions, you'll need to set up a Str
     - Click "Add destination"
     - Select "Your account"
     - Set API version to the latest (not the preview)
-    - Set enabled events to only the one listed in `DIRECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`)
+    - Set enabled events to only the events listed in `DIRECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`)
     - Click continue, Select Webhook endpoint
     - Set the endpoint URL to: `https://your-domain.ngrok-free.app/v1/integrations/stripe/webhook`
     - Copy the webhook signing secret and add it to your `server/.env` file:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,25 +107,35 @@ If you want to work with payments and subscriptions, you'll need to set up a Str
 
 1. **Create a Stripe account** at [https://dashboard.stripe.com/register](https://dashboard.stripe.com/register)
 
-2. **Enable billing** in your Stripe account by visiting [Stripe Billing Starter Guide](https://dashboard.stripe.com/billing/starter-guide)
-
-3. **Copy your API keys** from the [Stripe API Keys page](https://dashboard.stripe.com/test/apikeys) and add them to your `server/.env` file:
+2. **Copy your API keys** from the [Stripe API Keys page](https://dashboard.stripe.com/test/apikeys) and add them to your `server/.env` file:
 
     ```
-    STRIPE_SECRET_KEY=sk_test_...
-    STRIPE_PUBLISHABLE_KEY=pk_test_...
+    POLAR_STRIPE_SECRET_KEY=sk_test_...
+    POLAR_STRIPE_PUBLISHABLE_KEY=pk_test_...
     ```
 
-4. **Create a webhook endpoint** to handle Stripe events:
+3. **Enable tax calculation** by visiting [https://dashboard.stripe.com/test/tax](https://dashboard.stripe.com/test/tax)
+
+4. **Create webhook endpoints** to handle Stripe events:
     - Go to [Stripe Webhooks](https://dashboard.stripe.com/test/webhooks)
-    - Click "Add endpoint"
+    - Click "Add destination"
+    - Select "Your account"
+    - Set API version to the latest (not the preview)
+    - Set enabled events to only the one listed in `DIRECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`)
+    - Click continue, Select Webhook endpoint
     - Set the endpoint URL to: `https://your-domain.ngrok-free.app/v1/integrations/stripe/webhook`
-    - Set enabled events to: `*` (all events)
-    - Set API version to: `2025-02-24.acacia`
     - Copy the webhook signing secret and add it to your `server/.env` file:
         ```
-        STRIPE_WEBHOOK_SECRET=whsec_...
+        POLAR_STRIPE_WEBHOOK_SECRET=whsec_...
         ```
+    - Restart the same operation with:
+        - events listed in `CONNECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`)
+        - Set the endpoint URL to: `https://your-domain.ngrok-free.app/v1/integrations/stripe/webhook-connect`
+        - Copy the webhook signing secret and add it to your `server/.env` file:
+            ```
+            POLAR_STRIPE_CONNECT_WEBHOOK_SECRET=whsec_...
+            ```
+
 
 ### Setup backend
 


### PR DESCRIPTION
Came across some inconsistencies in the setup flow. 

This should better reflect what one has to do to setup the stack locally. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Stripe setup in DEVELOPMENT.md to match the current Stripe Dashboard flow and Polar env vars. Adds Tax setup and clarifies creating Account and Connect webhooks with event allowlists.

- **Migration**
  - In `server/.env`, rename `STRIPE_*` to `POLAR_STRIPE_SECRET_KEY`, `POLAR_STRIPE_PUBLISHABLE_KEY`, `POLAR_STRIPE_WEBHOOK_SECRET`, and add `POLAR_STRIPE_CONNECT_WEBHOOK_SECRET`.
  - Create two webhooks: account → `/v1/integrations/stripe/webhook` using `DIRECT_IMPLEMENTED_WEBHOOKS`; Connect → `/v1/integrations/stripe/webhook-connect` using `CONNECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`).
  - In Stripe Dashboard, use “Add destination” → “Your account”, select the latest non-preview API version, and enable Tax at `/test/tax`.

<sup>Written for commit 468cf5754f45080b8db2052cf1a1744926b792ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

