### PR TITLE
tf/test: Import updated DNS record from Cloudflare

### DIFF
--- a/terraform/test/vercel.tf
+++ b/terraform/test/vercel.tf
@@ -1,9 +1,11 @@
 # =============================================================================
 # Vercel — Test frontend (test.polar.sh)
 # =============================================================================
-#
-# Created fresh by Terraform (no import blocks): Terraform owns the project,
-# its domain and every env var declared here from the start.
+
+import {
+  to = module.vercel.cloudflare_dns_record.this["test.polar.sh"]
+  id = "22bcd1b07ec25452aab472486bc8df94/7eee3c07157a8904f30fc3fd27b7ba27"
+}
 
 module "vercel" {
   source = "../modules/vercel"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Imported the existing Cloudflare DNS record for test.polar.sh into Terraform so the test frontend domain is managed without recreation or drift.

Added an import block in terraform/test/vercel.tf pointing to module.vercel.cloudflare_dns_record.this["test.polar.sh"] with the Cloudflare record ID.

<sup>Written for commit d32bc4584ae2ea48aa328fba2ba4576d40b64b59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

