### PR TITLE
tf: Add Resend DNS records to terraform

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -504,3 +504,11 @@ resource "render_env_group_link" "memory_profile" {
   env_group_id = render_env_group.memory_profile[0].id
   service_ids  = concat([render_web_service.api.id], local.worker_ids)
 }
+
+resource "cloudflare_dns_record" "resend_dkim" {
+  zone_id = var.resend_dkim.zone_id
+  name    = "resend._domainkey.${var.backend_config.email_from_domain}"
+  type    = "TXT"
+  content = var.resend_dkim.public_key
+  ttl     = 1
+}

--- a/terraform/modules/render_service/terraform.tf
+++ b/terraform/modules/render_service/terraform.tf
@@ -9,6 +9,11 @@ terraform {
       source  = "render-oss/render"
       version = ">= 1.8.0"
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 5.13"
+    }
   }
 
   required_version = ">= 1.2"

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -289,6 +289,14 @@ variable "cron_jobs" {
   default = {}
 }
 
+variable "resend_dkim" {
+  description = "Resend DKIM TXT record. The record name is derived from backend_config.email_from_domain."
+  type = object({
+    zone_id    = string
+    public_key = string
+  })
+}
+
 variable "tinybird_config" {
   description = "Tinybird configuration (optional)"
   type = object({

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -109,6 +109,11 @@ resource "render_redis" "redis" {
 # Production
 # =============================================================================
 
+import {
+  to = module.production.cloudflare_dns_record.resend_dkim
+  id = "22bcd1b07ec25452aab472486bc8df94/85d90083fadec2175e748e87bdb6a8c1"
+}
+
 module "production" {
   source = "../modules/render_service"
 
@@ -138,6 +143,11 @@ module "production" {
   redis_config = {
     host = local.redis_host
     port = local.redis_port
+  }
+
+  resend_dkim = {
+    zone_id    = "22bcd1b07ec25452aab472486bc8df94"
+    public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqT9xW1l4M3o9tgdDcKBrQ3s+WFLwrVkGppzoq1GP36o+TPHFVXMJvMRa+RSokTXRAlxu2hR00WHj7vKVJUhDaqbtZDm0wUhgYleuiXB6pxa13g+/dMyrI9L/bM1BLDa3TOJBwxbB7JTNAyyJ6Q+FcHsGA1b/5B+HPQE+TCpDZUwIDAQAB"
   }
 
   workers = {

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -52,6 +52,11 @@ locals {
 # Sandbox
 # =============================================================================
 
+import {
+  to = module.sandbox.cloudflare_dns_record.resend_dkim
+  id = "22bcd1b07ec25452aab472486bc8df94/18ef1ec6c3bae11c97624278b1dc0436"
+}
+
 module "sandbox" {
   source = "../modules/render_service"
 
@@ -73,6 +78,11 @@ module "sandbox" {
   redis_config = {
     host = local.redis_host
     port = local.redis_port
+  }
+
+  resend_dkim = {
+    zone_id    = "22bcd1b07ec25452aab472486bc8df94"
+    public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCx8TPulpiuGKqifNLwJchDkpDbZK0R25boNFoztUf8nNT+4h3jzZL6pE3sJ2oSbqOZ4Jfr+4R7E9uXsmSQf5WJcXJOLjVhd8HJOQIdjn9WtJGxzplXs5f1iWFBBsTK7jOkDPVnWOovYBDa2fRypKGdHsSvi0kDZ5sV89/y/1QZlQIDAQAB"
   }
 
   api_service_config = {

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -119,6 +119,11 @@ module "test" {
     port = local.redis_port
   }
 
+  resend_dkim = {
+    zone_id    = "22bcd1b07ec25452aab472486bc8df94"
+    public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCsvUiyJlml2c1COR9sPotdXJ9PS+IFyBaJurKwkPQzJwECB3reBiTr7L1TeDuz0FuFfs3fRrdXZwZumF1lmwbAp6Kx+5uua4Px3nRheoHJPtX2KXoY80TIRQhDTXHB/C1K/03m1HgvtlxWq37uUcJHSACSuUw+m+MBQEONqO12qQIDAQAB"
+  }
+
   api_service_config = {
     allowed_hosts          = "[\"test.polar.sh\"]"
     cors_origins           = "[\"https://test.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds DKIM DNS records for Resend via Cloudflare, enabling authenticated email sending. Adds a `resend_dkim` input to the module and configures production, sandbox, and test; existing prod/sandbox records are imported so Terraform manages them.

- **Dependencies**
  - Adds Terraform provider `cloudflare/cloudflare` (>= 5.13).

- **Migration**
  - Ensure Cloudflare provider credentials are set for applies.
  - For any new module consumers, pass `resend_dkim = { zone_id, public_key }`.
  - Record is created at `resend._domainkey.<backend_config.email_from_domain>` with TTL 1.

<sup>Written for commit 352994d8355877a86cd790ca3ccfe3ece863d8aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

