### PR TITLE
refactor(app): use polar client for finance hooks

### DIFF
--- a/clients/apps/app/app/(authenticated)/finance/withdraw/index.tsx
+++ b/clients/apps/app/app/(authenticated)/finance/withdraw/index.tsx
@@ -78,7 +78,7 @@ export default function Index() {
             scrollRef.current?.setNativeProps({ isEnabled: true })
           }}
           onSlideComplete={async () => {
-            await withdrawFunds({ accountId: account?.id })
+            await withdrawFunds()
           }}
           onFinish={() => {
             if (shouldShow(hasOrders)) {

--- a/clients/apps/app/hooks/polar/finance.ts
+++ b/clients/apps/app/hooks/polar/finance.ts
@@ -1,155 +1,91 @@
-import { useSession } from '@/providers/SessionProvider'
+import { usePolarClient } from '@/providers/PolarClientProvider'
 import { queryClient } from '@/utils/query'
-import { schemas } from '@polar-sh/client'
+import { schemas, unwrap } from '@polar-sh/client'
 import {
+  skipToken,
   useMutation,
-  UseMutationResult,
   useQuery,
   UseQueryResult,
 } from '@tanstack/react-query'
 
-export const useOrganizationAccount = (
-  organizationId?: string,
-): UseQueryResult<schemas['Account']> => {
-  const { session } = useSession()
+export const useOrganizationAccount = (organizationId?: string) => {
+  const { polar } = usePolarClient()
+
   return useQuery({
     queryKey: ['finance', 'account', organizationId],
-    queryFn: () =>
-      fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/organizations/${organizationId}/account`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          if ('error' in data && 'error_description' in data) {
-            throw new Error(data.error_description as string)
-          }
-
-          return data
-        }),
-    enabled: !!organizationId,
+    queryFn: organizationId
+      ? () =>
+          unwrap(
+            polar.GET('/v1/organizations/{id}/account', {
+              params: { path: { id: organizationId } },
+            }),
+          )
+      : skipToken,
   })
 }
 
-export const usePayoutAccount = (
-  payoutAccountId?: string,
-): UseQueryResult<schemas['PayoutAccount']> => {
-  const { session } = useSession()
+export const usePayoutAccount = (payoutAccountId?: string) => {
+  const { polar } = usePolarClient()
+
   return useQuery({
     queryKey: ['finance', 'payoutAccount', payoutAccountId],
-    queryFn: () =>
-      fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/payout-accounts/${payoutAccountId}`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          if ('error' in data && 'error_description' in data) {
-            throw new Error(data.error_description as string)
-          }
-
-          return data
-        }),
-    enabled: !!payoutAccountId,
+    queryFn: payoutAccountId
+      ? () =>
+          unwrap(
+            polar.GET('/v1/payout-accounts/{id}', {
+              params: { path: { id: payoutAccountId } },
+            }),
+          )
+      : skipToken,
   })
 }
 
-export const useTransactionsSummary = (
-  accountId?: string,
-): UseQueryResult<schemas['TransactionsSummary']> => {
-  const { session } = useSession()
+export const useTransactionsSummary = (accountId?: string) => {
+  const { polar } = usePolarClient()
 
   return useQuery({
     queryKey: ['finance', accountId, 'transactions', 'summary'],
-    queryFn: () =>
-      fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/transactions/summary?account_id=${accountId}`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          if ('error' in data && 'error_description' in data) {
-            throw new Error(data.error_description as string)
-          }
-
-          return data
-        }),
-    enabled: !!accountId,
+    queryFn: accountId
+      ? () =>
+          unwrap(
+            polar.GET('/v1/transactions/summary', {
+              params: { query: { account_id: accountId } },
+            }),
+          )
+      : skipToken,
   })
 }
 
-export const usePayoutEstimate = (
-  organizationId?: string,
-): UseQueryResult<schemas['PayoutEstimate']> => {
-  const { session } = useSession()
+export const usePayoutEstimate = (organizationId?: string) => {
+  const { polar } = usePolarClient()
 
   return useQuery({
     queryKey: ['finance', organizationId, 'payouts', 'estimate'],
-    queryFn: () =>
-      fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/payouts/estimate?organization_id=${organizationId}`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          if ('error' in data && 'error_description' in data) {
-            throw new Error(data.error_description as string)
-          }
-
-          return data
-        }),
-    enabled: !!organizationId,
+    queryFn: organizationId
+      ? () =>
+          unwrap(
+            polar.GET('/v1/payouts/estimate', {
+              params: { query: { organization_id: organizationId } },
+            }),
+          )
+      : skipToken,
   })
 }
 
-export const useCreatePayout = (
-  organizationId?: string,
-): UseMutationResult<schemas['Payout']> => {
-  const { session } = useSession()
+export const useCreatePayout = (organizationId?: string) => {
+  const { polar } = usePolarClient()
 
   return useMutation({
-    mutationFn: () =>
-      fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/payouts/`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            organization_id: organizationId,
-          }),
-        },
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          if ('error' in data && 'error_description' in data) {
-            throw new Error(data.error_description as string)
-          }
-
-          return data
+    mutationFn: () => {
+      if (!organizationId) {
+        throw new Error('organizationId is required to create a payout')
+      }
+      return unwrap(
+        polar.POST('/v1/payouts/', {
+          body: { organization_id: organizationId },
         }),
+      )
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['finance'] })
     },
@@ -163,40 +99,17 @@ export const usePayout = (
     queryKey: ['finance', 'payouts', payoutId],
     queryFn: () =>
       queryClient
-        .getQueryData<{
-          items: schemas['Payout'][]
-          pagination: schemas['Pagination']
-        }>(['finance', 'payouts'])
+        .getQueryData<schemas['ListResource_Payout_']>(['finance', 'payouts'])
         ?.items.find((payout) => payout.id === payoutId),
     enabled: !!payoutId,
   })
 }
 
-export const usePayouts = (): UseQueryResult<{
-  items: schemas['Payout'][]
-  pagination: schemas['Pagination']
-}> => {
-  const { session } = useSession()
+export const usePayouts = () => {
+  const { polar } = usePolarClient()
 
   return useQuery({
     queryKey: ['finance', 'payouts'],
-    queryFn: () =>
-      fetch(
-        `${process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh'}/v1/payouts/`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session}`,
-          },
-        },
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          if ('error' in data && 'error_description' in data) {
-            throw new Error(data.error_description as string)
-          }
-
-          return data
-        }),
+    queryFn: () => unwrap(polar.GET('/v1/payouts/')),
   })
 }


### PR DESCRIPTION
## Summary

Use polar client for finance hooks in the mobile app.

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->
Use polar client instead of fetch for finance (balance, withdrawals) hooks in the mobile app


## Why

<!-- Explain why this change is needed -->
For consistency, as I'm about to add a custom header to track mobile app version.

## How


https://github.com/user-attachments/assets/13fe30aa-c3a1-4473-9f9f-a8b791078c6a



<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored finance hooks to use the shared Polar client (`@polar-sh/client`) instead of manual fetches. This standardizes auth, improves error handling, and simplifies the withdraw flow.

- **Refactors**
  - Replaced fetch calls with `polar.GET`/`POST` and `unwrap`.
  - Used `skipToken` to avoid running queries without required IDs.
  - `useCreatePayout` now requires `organizationId` and invalidates `['finance']` on success.
  - Updated withdraw screen to call `withdrawFunds()` without `accountId`.
  - Reduced code and tightened types via `schemas`.

<sup>Written for commit 4d74c2ff4579705a0fe32b92f15a59a07014435f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

