### PR TITLE
tf: Add missing Resend SPF records

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -506,9 +506,26 @@ resource "render_env_group_link" "memory_profile" {
 }
 
 resource "cloudflare_dns_record" "resend_dkim" {
-  zone_id = var.resend_dkim.zone_id
+  zone_id = var.resend_domain.zone_id
   name    = "resend._domainkey.${var.backend_config.email_from_domain}"
   type    = "TXT"
-  content = var.resend_dkim.public_key
+  content = var.resend_domain.dkim_public_key
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "resend_spf_mx" {
+  zone_id  = var.resend_domain.zone_id
+  name     = "send.${var.backend_config.email_from_domain}"
+  type     = "MX"
+  content  = "feedback-smtp.us-east-1.amazonses.com"
+  priority = 10
+  ttl      = 1
+}
+
+resource "cloudflare_dns_record" "resend_spf_txt" {
+  zone_id = var.resend_domain.zone_id
+  name    = "send.${var.backend_config.email_from_domain}"
+  type    = "TXT"
+  content = var.resend_domain.spf_policy
   ttl     = 1
 }

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -289,11 +289,12 @@ variable "cron_jobs" {
   default = {}
 }
 
-variable "resend_dkim" {
-  description = "Resend DKIM TXT record. The record name is derived from backend_config.email_from_domain."
+variable "resend_domain" {
+  description = "Resend domain DNS records (DKIM + SPF). Record names are derived from backend_config.email_from_domain."
   type = object({
-    zone_id    = string
-    public_key = string
+    zone_id         = string
+    dkim_public_key = string
+    spf_policy      = string
   })
 }
 

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -114,6 +114,16 @@ import {
   id = "22bcd1b07ec25452aab472486bc8df94/85d90083fadec2175e748e87bdb6a8c1"
 }
 
+import {
+  to = module.production.cloudflare_dns_record.resend_spf_mx
+  id = "22bcd1b07ec25452aab472486bc8df94/a5c3c3ada2aa12ce91543ab2b2da619e"
+}
+
+import {
+  to = module.production.cloudflare_dns_record.resend_spf_txt
+  id = "22bcd1b07ec25452aab472486bc8df94/00c7b9e60ec890ff5b6f55dff6fa57cb"
+}
+
 module "production" {
   source = "../modules/render_service"
 
@@ -145,9 +155,10 @@ module "production" {
     port = local.redis_port
   }
 
-  resend_dkim = {
-    zone_id    = "22bcd1b07ec25452aab472486bc8df94"
-    public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqT9xW1l4M3o9tgdDcKBrQ3s+WFLwrVkGppzoq1GP36o+TPHFVXMJvMRa+RSokTXRAlxu2hR00WHj7vKVJUhDaqbtZDm0wUhgYleuiXB6pxa13g+/dMyrI9L/bM1BLDa3TOJBwxbB7JTNAyyJ6Q+FcHsGA1b/5B+HPQE+TCpDZUwIDAQAB"
+  resend_domain = {
+    zone_id         = "22bcd1b07ec25452aab472486bc8df94"
+    dkim_public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqT9xW1l4M3o9tgdDcKBrQ3s+WFLwrVkGppzoq1GP36o+TPHFVXMJvMRa+RSokTXRAlxu2hR00WHj7vKVJUhDaqbtZDm0wUhgYleuiXB6pxa13g+/dMyrI9L/bM1BLDa3TOJBwxbB7JTNAyyJ6Q+FcHsGA1b/5B+HPQE+TCpDZUwIDAQAB"
+    spf_policy      = "\"v=spf1 include:amazonses.com -all\""
   }
 
   workers = {

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -57,6 +57,16 @@ import {
   id = "22bcd1b07ec25452aab472486bc8df94/18ef1ec6c3bae11c97624278b1dc0436"
 }
 
+import {
+  to = module.sandbox.cloudflare_dns_record.resend_spf_mx
+  id = "22bcd1b07ec25452aab472486bc8df94/d63d2cb0fe67c06b91baec8ed9f9546b"
+}
+
+import {
+  to = module.sandbox.cloudflare_dns_record.resend_spf_txt
+  id = "22bcd1b07ec25452aab472486bc8df94/eb6326cb55c1a417eacc2f984c9ecf88"
+}
+
 module "sandbox" {
   source = "../modules/render_service"
 
@@ -80,9 +90,10 @@ module "sandbox" {
     port = local.redis_port
   }
 
-  resend_dkim = {
-    zone_id    = "22bcd1b07ec25452aab472486bc8df94"
-    public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCx8TPulpiuGKqifNLwJchDkpDbZK0R25boNFoztUf8nNT+4h3jzZL6pE3sJ2oSbqOZ4Jfr+4R7E9uXsmSQf5WJcXJOLjVhd8HJOQIdjn9WtJGxzplXs5f1iWFBBsTK7jOkDPVnWOovYBDa2fRypKGdHsSvi0kDZ5sV89/y/1QZlQIDAQAB"
+  resend_domain = {
+    zone_id         = "22bcd1b07ec25452aab472486bc8df94"
+    dkim_public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCx8TPulpiuGKqifNLwJchDkpDbZK0R25boNFoztUf8nNT+4h3jzZL6pE3sJ2oSbqOZ4Jfr+4R7E9uXsmSQf5WJcXJOLjVhd8HJOQIdjn9WtJGxzplXs5f1iWFBBsTK7jOkDPVnWOovYBDa2fRypKGdHsSvi0kDZ5sV89/y/1QZlQIDAQAB"
+    spf_policy      = "\"v=spf1 include:amazonses.com -all\""
   }
 
   api_service_config = {

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -119,9 +119,10 @@ module "test" {
     port = local.redis_port
   }
 
-  resend_dkim = {
-    zone_id    = "22bcd1b07ec25452aab472486bc8df94"
-    public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCsvUiyJlml2c1COR9sPotdXJ9PS+IFyBaJurKwkPQzJwECB3reBiTr7L1TeDuz0FuFfs3fRrdXZwZumF1lmwbAp6Kx+5uua4Px3nRheoHJPtX2KXoY80TIRQhDTXHB/C1K/03m1HgvtlxWq37uUcJHSACSuUw+m+MBQEONqO12qQIDAQAB"
+  resend_domain = {
+    zone_id         = "22bcd1b07ec25452aab472486bc8df94"
+    dkim_public_key = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCsvUiyJlml2c1COR9sPotdXJ9PS+IFyBaJurKwkPQzJwECB3reBiTr7L1TeDuz0FuFfs3fRrdXZwZumF1lmwbAp6Kx+5uua4Px3nRheoHJPtX2KXoY80TIRQhDTXHB/C1K/03m1HgvtlxWq37uUcJHSACSuUw+m+MBQEONqO12qQIDAQAB"
+    spf_policy      = "\"v=spf1 include:amazonses.com ~all\""
   }
 
   api_service_config = {


### PR DESCRIPTION
Follow up from https://github.com/polarsource/polar/pull/12192

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing Resend SPF records and consolidate email DNS config. This ensures proper sending for Resend and simplifies Terraform inputs.

- **New Features**
  - Add Cloudflare DNS records for Resend: DKIM TXT at resend._domainkey, MX at send.<email_from_domain> to feedback-smtp.us-east-1.amazonses.com (priority 10), and SPF TXT from policy (prod/sandbox: -all, test: ~all); all with TTL 1.
  - Import existing MX/TXT records in production and sandbox to avoid recreation.

- **Migration**
  - Replace `resend_dkim` with `resend_domain` object: `zone_id`, `dkim_public_key`, `spf_policy`.
  - If these DNS records already exist outside Terraform, import them before apply.

<sup>Written for commit b941519e94ab1f54de016884d7eeb478331d3a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

