### PR TITLE
feat(app): send headers to identify client version

### DIFF
--- a/clients/apps/app/providers/PolarClientProvider.tsx
+++ b/clients/apps/app/providers/PolarClientProvider.tsx
@@ -1,5 +1,7 @@
 import { refreshMiddleware } from '@/auth/refreshMiddleware'
 import { Client, createClient } from '@polar-sh/client'
+import Constants from 'expo-constants'
+import * as Updates from 'expo-updates'
 import {
   createContext,
   useContext,
@@ -8,11 +10,24 @@ import {
 } from 'react'
 import { useSession } from './SessionProvider'
 
+// `version` is the human-readable marketing version, but it relies on a
+// developer manually bumping it. `runtimeVersion` (the fingerprint) and
+// `updateId` update automatically on every build/OTA, so they're the reliable
+// signal for "which exact build is calling this endpoint". `updateId` is null
+// on an embedded launch (fresh install before any OTA, or in dev).
+const CLIENT_VERSION_HEADERS = {
+  'X-Polar-Client-Version': `mobile/${Constants.expoConfig?.version ?? 'unknown'}`,
+  'X-Polar-Client-Runtime': Updates.runtimeVersion ?? 'unknown',
+  'X-Polar-Client-Update': Updates.updateId ?? 'embedded',
+}
+
 const PolarClientContext = createContext<{
   polar: Client
 }>({
   polar: createClient(
     process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh',
+    undefined,
+    CLIENT_VERSION_HEADERS,
   ),
 })
 
@@ -35,6 +50,7 @@ export function PolarClientProvider({ children }: PropsWithChildren) {
     const client = createClient(
       process.env.EXPO_PUBLIC_POLAR_SERVER_URL ?? 'https://api.polar.sh',
       session ?? '',
+      CLIENT_VERSION_HEADERS,
     )
     client.use(refreshMiddleware)
     return client

--- a/clients/apps/web/src/utils/client/index.ts
+++ b/clients/apps/web/src/utils/client/index.ts
@@ -16,8 +16,18 @@ const errorMiddleware: Middleware = {
   },
 }
 
+const CLIENT_VERSION_HEADERS = {
+  'X-Polar-Client-Version': `web/${
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(0, 8) ?? 'dev'
+  }`,
+}
+
 export const createClientSideAPI = (token?: string): Client => {
-  const api = baseCreateClient(process.env.NEXT_PUBLIC_API_URL as string, token)
+  const api = baseCreateClient(
+    process.env.NEXT_PUBLIC_API_URL as string,
+    token,
+    CLIENT_VERSION_HEADERS,
+  )
   api.use(errorMiddleware)
   return api
 }
@@ -25,7 +35,7 @@ export const createClientSideAPI = (token?: string): Client => {
 export const api = createClientSideAPI()
 
 export const getSSRHeaders = (): Record<string, string> => {
-  const headers: Record<string, string> = {}
+  const headers: Record<string, string> = { ...CLIENT_VERSION_HEADERS }
 
   if (process.env.POLAR_PREVIEW_ACCESS_TOKEN) {
     headers['X-Preview-Token'] = process.env.POLAR_PREVIEW_ACCESS_TOKEN
@@ -39,7 +49,7 @@ export const createServerSideAPI = async (
   cookies: ReadonlyRequestCookies,
   token?: string,
 ): Promise<Client> => {
-  let apiHeaders = {}
+  let apiHeaders: Record<string, string> = { ...CLIENT_VERSION_HEADERS }
 
   const xForwardedFor = headers.get('X-Forwarded-For')
 

--- a/server/polar/logging.py
+++ b/server/polar/logging.py
@@ -174,3 +174,25 @@ class CorrelationID:
     @classmethod
     def clear(cls) -> None:
         cls._correlation_id.set(None)
+
+
+class ClientContext:
+    """Mobile client identification headers for the current request,
+    so they can be attached to events emitted outside the logging
+    path — notably PostHog. Empty outside an HTTP request (e.g. workers)."""
+
+    _client_context: typing.ClassVar[contextvars.ContextVar[dict[str, str] | None]] = (
+        contextvars.ContextVar("polar.client_context", default=None)
+    )
+
+    @classmethod
+    def set(cls, context: dict[str, str]) -> None:
+        cls._client_context.set(context)
+
+    @classmethod
+    def get(cls) -> dict[str, str]:
+        return cls._client_context.get() or {}
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._client_context.set(None)

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -50,22 +50,23 @@ class LogCorrelationIdMiddleware:
             )
             if value is not None
         }
-        if client_context:
-            ClientContext.set(client_context)
-            structlog.contextvars.bind_contextvars(**client_context)
-            for key, value in client_context.items():
-                sentry_sdk.set_tag(key, value)
-                if root_span is not None and root_span.is_recording():
-                    root_span.set_attribute(key, value)
+        try:
+            if client_context:
+                ClientContext.set(client_context)
+                structlog.contextvars.bind_contextvars(**client_context)
+                for key, value in client_context.items():
+                    sentry_sdk.set_tag(key, value)
+                    if root_span is not None and root_span.is_recording():
+                        root_span.set_attribute(key, value)
 
-        await self.app(scope, receive, send)
-
-        logfire_stack.close()
-        structlog.contextvars.unbind_contextvars(
-            "correlation_id", "method", "path", *client_context.keys()
-        )
-        CorrelationID.clear()
-        ClientContext.clear()
+            await self.app(scope, receive, send)
+        finally:
+            logfire_stack.close()
+            structlog.contextvars.unbind_contextvars(
+                "correlation_id", "method", "path", *client_context.keys()
+            )
+            CorrelationID.clear()
+            ClientContext.clear()
 
 
 class FlushEnqueuedWorkerJobsMiddleware:

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -9,7 +9,7 @@ import structlog
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from polar.logging import CorrelationID, Logger
+from polar.logging import ClientContext, CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
 from polar.worker import JobQueueManager
 
@@ -51,6 +51,7 @@ class LogCorrelationIdMiddleware:
             if value is not None
         }
         if client_context:
+            ClientContext.set(client_context)
             structlog.contextvars.bind_contextvars(**client_context)
             for key, value in client_context.items():
                 sentry_sdk.set_tag(key, value)
@@ -64,6 +65,7 @@ class LogCorrelationIdMiddleware:
             "correlation_id", "method", "path", *client_context.keys()
         )
         CorrelationID.clear()
+        ClientContext.clear()
 
 
 class FlushEnqueuedWorkerJobsMiddleware:

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -6,7 +6,7 @@ import dramatiq
 import logfire
 import sentry_sdk
 import structlog
-from starlette.datastructures import MutableHeaders
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from polar.logging import CorrelationID, Logger
@@ -37,10 +37,32 @@ class LogCorrelationIdMiddleware:
         if root_span is not None and root_span.is_recording():
             root_span.set_attribute("correlation_id", correlation_id)
 
+        # Capture client identification headers (sent by the mobile app)
+        # so we can correlate API traffic to specific client builds for
+        # retrocompatibility monitoring.
+        headers = Headers(scope=scope)
+        client_context = {
+            key: value
+            for key, value in (
+                ("client_version", headers.get("x-polar-client-version")),
+                ("client_runtime", headers.get("x-polar-client-runtime")),
+                ("client_update", headers.get("x-polar-client-update")),
+            )
+            if value is not None
+        }
+        if client_context:
+            structlog.contextvars.bind_contextvars(**client_context)
+            for key, value in client_context.items():
+                sentry_sdk.set_tag(key, value)
+                if root_span is not None and root_span.is_recording():
+                    root_span.set_attribute(key, value)
+
         await self.app(scope, receive, send)
 
         logfire_stack.close()
-        structlog.contextvars.unbind_contextvars("correlation_id", "method", "path")
+        structlog.contextvars.unbind_contextvars(
+            "correlation_id", "method", "path", *client_context.keys()
+        )
         CorrelationID.clear()
 
 

--- a/server/polar/posthog.py
+++ b/server/polar/posthog.py
@@ -6,6 +6,7 @@ from posthog import Posthog
 
 from polar.auth.models import AuthSubject, Subject, is_organization, is_user
 from polar.config import settings
+from polar.logging import ClientContext
 from polar.models import Organization, User
 
 ORGANIZATION_EVENT_DISTINCT_ID = "organization_event"
@@ -195,6 +196,8 @@ class Service:
     def _get_common_properties(self) -> dict[str, Any]:
         return {
             "_environment": settings.ENV,
+            # Mobile client identification
+            **ClientContext.get(),
         }
 
     def _get_user_properties(self, user: User) -> dict[str, Any]:

--- a/server/polar/posthog.py
+++ b/server/polar/posthog.py
@@ -93,6 +93,8 @@ class Service:
             groups=groups,
             properties={
                 **self._get_common_properties(),
+                # Mobile client identification
+                **ClientContext.get(),
                 **(properties or {}),
             },
         )
@@ -196,8 +198,6 @@ class Service:
     def _get_common_properties(self) -> dict[str, Any]:
         return {
             "_environment": settings.ENV,
-            # Mobile client identification
-            **ClientContext.get(),
         }
 
     def _get_user_properties(self, user: User) -> dict[str, Any]:

--- a/server/tests/observability/test_log_correlation_middleware.py
+++ b/server/tests/observability/test_log_correlation_middleware.py
@@ -7,8 +7,11 @@ context for the duration of a request and cleans them up afterwards.
 import asyncio
 from typing import Any, cast
 
+import pytest
 import structlog
 from starlette.types import Receive, Scope, Send
+
+from polar.logging import ClientContext
 
 
 def _run(scope: Scope) -> dict[str, Any]:
@@ -26,9 +29,7 @@ def _run(scope: Scope) -> dict[str, Any]:
     async def noop_send(message: dict[str, Any]) -> None:
         pass
 
-    asyncio.get_event_loop().run_until_complete(
-        middleware(scope, cast(Receive, None), cast(Send, noop_send))
-    )
+    asyncio.run(middleware(scope, cast(Receive, None), cast(Send, noop_send)))
     return captured
 
 
@@ -75,3 +76,23 @@ class TestClientHeaderCapture:
         _run(_http_scope([(b"x-polar-client-version", b"mobile/1.4.0")]))
         # Context must not leak past the request lifecycle.
         assert "client_version" not in structlog.contextvars.get_contextvars()
+
+    def test_cleans_up_context_when_app_raises(self) -> None:
+        # The cleanup runs in a finally block, so a failing request must not
+        # leak client identification into error-path logging or later requests.
+        from polar.middlewares import LogCorrelationIdMiddleware
+
+        async def failing_app(scope: Scope, receive: Receive, send: Send) -> None:
+            raise RuntimeError("boom")
+
+        middleware = LogCorrelationIdMiddleware(failing_app)
+
+        async def noop_send(message: dict[str, Any]) -> None:
+            pass
+
+        scope = _http_scope([(b"x-polar-client-version", b"mobile/1.4.0")])
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(middleware(scope, cast(Receive, None), cast(Send, noop_send)))
+
+        assert "client_version" not in structlog.contextvars.get_contextvars()
+        assert ClientContext.get() == {}

--- a/server/tests/observability/test_log_correlation_middleware.py
+++ b/server/tests/observability/test_log_correlation_middleware.py
@@ -1,0 +1,77 @@
+"""Tests for LogCorrelationIdMiddleware client-identification capture.
+
+Verifies the middleware binds the mobile client headers to the structlog
+context for the duration of a request and cleans them up afterwards.
+"""
+
+import asyncio
+from typing import Any, cast
+
+import structlog
+from starlette.types import Receive, Scope, Send
+
+
+def _run(scope: Scope) -> dict[str, Any]:
+    """Run the middleware against ``scope`` and return the structlog
+    contextvars as seen from inside the wrapped app."""
+    from polar.middlewares import LogCorrelationIdMiddleware
+
+    captured: dict[str, Any] = {}
+
+    async def mock_app(scope: Scope, receive: Receive, send: Send) -> None:
+        captured.update(structlog.contextvars.get_contextvars())
+
+    middleware = LogCorrelationIdMiddleware(mock_app)
+
+    async def noop_send(message: dict[str, Any]) -> None:
+        pass
+
+    asyncio.get_event_loop().run_until_complete(
+        middleware(scope, cast(Receive, None), cast(Send, noop_send))
+    )
+    return captured
+
+
+def _http_scope(headers: list[tuple[bytes, bytes]]) -> Scope:
+    return cast(
+        Scope,
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v1/test",
+            "headers": headers,
+        },
+    )
+
+
+class TestClientHeaderCapture:
+    def test_binds_all_client_headers_when_present(self) -> None:
+        captured = _run(
+            _http_scope(
+                [
+                    (b"x-polar-client-version", b"mobile/1.4.0"),
+                    (b"x-polar-client-runtime", b"fingerprint-abc"),
+                    (b"x-polar-client-update", b"update-xyz"),
+                ]
+            )
+        )
+        assert captured["client_version"] == "mobile/1.4.0"
+        assert captured["client_runtime"] == "fingerprint-abc"
+        assert captured["client_update"] == "update-xyz"
+
+    def test_binds_only_present_headers(self) -> None:
+        captured = _run(_http_scope([(b"x-polar-client-version", b"mobile/1.4.0")]))
+        assert captured["client_version"] == "mobile/1.4.0"
+        assert "client_runtime" not in captured
+        assert "client_update" not in captured
+
+    def test_no_client_keys_for_non_mobile_request(self) -> None:
+        captured = _run(_http_scope([]))
+        assert "client_version" not in captured
+        assert "client_runtime" not in captured
+        assert "client_update" not in captured
+
+    def test_unbinds_after_request(self) -> None:
+        _run(_http_scope([(b"x-polar-client-version", b"mobile/1.4.0")]))
+        # Context must not leak past the request lifecycle.
+        assert "client_version" not in structlog.contextvars.get_contextvars()

--- a/server/tests/observability/test_posthog_client_context.py
+++ b/server/tests/observability/test_posthog_client_context.py
@@ -1,13 +1,34 @@
-"""Tests that mobile client identification flows through to PostHog event properties.
+"""Tests that mobile/web client identification (polar #12159) is attached to
+PostHog *events*, and crucially NOT to person/profile properties.
 
-Exercises the real path middleware -> ClientContext ->
-PostHog `_get_common_properties`.
+Isolated from the main Polar infrastructure (see conftest.py): no database or
+service connections. Exercises the real path middleware -> ClientContext ->
+PostHog capture, with a mocked PostHog client.
 """
 
 import asyncio
+from collections.abc import Callable, Iterator
 from typing import Any, cast
+from unittest.mock import MagicMock
 
+import pytest
 from starlette.types import Receive, Scope, Send
+
+from polar.logging import ClientContext
+
+
+@pytest.fixture
+def mock_posthog_client() -> Iterator[MagicMock]:
+    from polar.posthog import posthog
+
+    original = posthog.client
+    client = MagicMock()
+    posthog.client = client
+    try:
+        yield client
+    finally:
+        posthog.client = original
+        ClientContext.clear()
 
 
 def _http_scope(headers: list[tuple[bytes, bytes]]) -> Scope:
@@ -22,55 +43,93 @@ def _http_scope(headers: list[tuple[bytes, bytes]]) -> Scope:
     )
 
 
-def _common_properties_during_request(scope: Scope) -> dict[str, Any]:
-    """Run a request through the middleware and return the PostHog common
-    properties as seen from inside the request."""
+def _run_request(scope: Scope, inside_request: Callable[[], None]) -> None:
+    """Drive the middleware; ``inside_request`` runs while ClientContext is
+    populated (i.e. as if a handler emitted a PostHog event mid-request)."""
     from polar.middlewares import LogCorrelationIdMiddleware
-    from polar.posthog import posthog
-
-    captured: dict[str, Any] = {}
 
     async def mock_app(scope: Scope, receive: Receive, send: Send) -> None:
-        captured.update(posthog._get_common_properties())
+        inside_request()
 
     middleware = LogCorrelationIdMiddleware(mock_app)
 
     async def noop_send(message: dict[str, Any]) -> None:
         pass
 
-    asyncio.get_event_loop().run_until_complete(
-        middleware(scope, cast(Receive, None), cast(Send, noop_send))
-    )
-    return captured
+    asyncio.run(middleware(scope, cast(Receive, None), cast(Send, noop_send)))
+
+
+def _captured_event_properties(client: MagicMock) -> dict[str, Any]:
+    return client.capture.call_args.kwargs["properties"]
 
 
 class TestPostHogClientContext:
-    def test_client_properties_forwarded_during_mobile_request(self) -> None:
-        properties = _common_properties_during_request(
+    def test_client_identification_attached_to_events(
+        self, mock_posthog_client: MagicMock
+    ) -> None:
+        from polar.posthog import posthog
+
+        _run_request(
             _http_scope(
                 [
                     (b"x-polar-client-version", b"mobile/1.4.0"),
                     (b"x-polar-client-runtime", b"fingerprint-abc"),
                     (b"x-polar-client-update", b"update-xyz"),
                 ]
-            )
+            ),
+            lambda: posthog.capture("distinct-id", "backend:test:thing:done"),
         )
+
+        properties = _captured_event_properties(mock_posthog_client)
         assert properties["client_version"] == "mobile/1.4.0"
         assert properties["client_runtime"] == "fingerprint-abc"
         assert properties["client_update"] == "update-xyz"
 
-    def test_no_client_properties_for_non_mobile_request(self) -> None:
-        properties = _common_properties_during_request(_http_scope([]))
-        assert "client_version" not in properties
-        assert "client_runtime" not in properties
-        assert "client_update" not in properties
-
-    def test_context_does_not_leak_after_request(self) -> None:
+    def test_client_identification_not_persisted_to_person(
+        self, mock_posthog_client: MagicMock
+    ) -> None:
         from polar.posthog import posthog
 
-        _common_properties_during_request(
-            _http_scope([(b"x-polar-client-version", b"mobile/1.4.0")])
+        user = MagicMock(
+            posthog_distinct_id="user-1",
+            email="a@b.co",
+            email_verified=True,
+            signup_attribution=None,
         )
-        # Events emitted outside the request (e.g. workers) must not inherit
-        # the previous request's client identification.
-        assert "client_version" not in posthog._get_common_properties()
+
+        _run_request(
+            _http_scope([(b"x-polar-client-version", b"mobile/1.4.0")]),
+            lambda: posthog.identify(user),
+        )
+
+        person_properties = mock_posthog_client.set.call_args.kwargs["properties"]
+        assert "client_version" not in person_properties
+        assert "client_runtime" not in person_properties
+        assert "client_update" not in person_properties
+
+    def test_no_client_identification_for_non_mobile_request(
+        self, mock_posthog_client: MagicMock
+    ) -> None:
+        from polar.posthog import posthog
+
+        _run_request(
+            _http_scope([]),
+            lambda: posthog.capture("distinct-id", "backend:test:thing:done"),
+        )
+
+        assert "client_version" not in _captured_event_properties(mock_posthog_client)
+
+    def test_context_does_not_leak_after_request(
+        self, mock_posthog_client: MagicMock
+    ) -> None:
+        from polar.posthog import posthog
+
+        _run_request(
+            _http_scope([(b"x-polar-client-version", b"mobile/1.4.0")]),
+            lambda: None,
+        )
+
+        # An event emitted outside the request (e.g. from a worker) must not
+        # inherit the previous request's client identification.
+        posthog.capture("distinct-id", "backend:test:thing:done")
+        assert "client_version" not in _captured_event_properties(mock_posthog_client)

--- a/server/tests/observability/test_posthog_client_context.py
+++ b/server/tests/observability/test_posthog_client_context.py
@@ -1,0 +1,76 @@
+"""Tests that mobile client identification flows through to PostHog event properties.
+
+Exercises the real path middleware -> ClientContext ->
+PostHog `_get_common_properties`.
+"""
+
+import asyncio
+from typing import Any, cast
+
+from starlette.types import Receive, Scope, Send
+
+
+def _http_scope(headers: list[tuple[bytes, bytes]]) -> Scope:
+    return cast(
+        Scope,
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v1/test",
+            "headers": headers,
+        },
+    )
+
+
+def _common_properties_during_request(scope: Scope) -> dict[str, Any]:
+    """Run a request through the middleware and return the PostHog common
+    properties as seen from inside the request."""
+    from polar.middlewares import LogCorrelationIdMiddleware
+    from polar.posthog import posthog
+
+    captured: dict[str, Any] = {}
+
+    async def mock_app(scope: Scope, receive: Receive, send: Send) -> None:
+        captured.update(posthog._get_common_properties())
+
+    middleware = LogCorrelationIdMiddleware(mock_app)
+
+    async def noop_send(message: dict[str, Any]) -> None:
+        pass
+
+    asyncio.get_event_loop().run_until_complete(
+        middleware(scope, cast(Receive, None), cast(Send, noop_send))
+    )
+    return captured
+
+
+class TestPostHogClientContext:
+    def test_client_properties_forwarded_during_mobile_request(self) -> None:
+        properties = _common_properties_during_request(
+            _http_scope(
+                [
+                    (b"x-polar-client-version", b"mobile/1.4.0"),
+                    (b"x-polar-client-runtime", b"fingerprint-abc"),
+                    (b"x-polar-client-update", b"update-xyz"),
+                ]
+            )
+        )
+        assert properties["client_version"] == "mobile/1.4.0"
+        assert properties["client_runtime"] == "fingerprint-abc"
+        assert properties["client_update"] == "update-xyz"
+
+    def test_no_client_properties_for_non_mobile_request(self) -> None:
+        properties = _common_properties_during_request(_http_scope([]))
+        assert "client_version" not in properties
+        assert "client_runtime" not in properties
+        assert "client_update" not in properties
+
+    def test_context_does_not_leak_after_request(self) -> None:
+        from polar.posthog import posthog
+
+        _common_properties_during_request(
+            _http_scope([(b"x-polar-client-version", b"mobile/1.4.0")])
+        )
+        # Events emitted outside the request (e.g. workers) must not inherit
+        # the previous request's client identification.
+        assert "client_version" not in posthog._get_common_properties()


### PR DESCRIPTION
## Summary

**Related Issue**: #12159

<!-- Brief description of what this PR does -->

## What
Every request from our web and mobile apps now identifies which build it came from, and that signal flows into our logs, traces, and PostHog.
<!-- Describe what changes you've made -->

## Why
We had no visibility into which app versions are still live, so we couldn't safely deprecate or evolve API endpoints without risking breaking old clients. This gives us the data to make those calls with confidence.
<!-- Explain why this change is needed -->

## How
The apps attach a lightweight version tag to each request; the backend reads it and forwards it to our observability and analytics tools, where we can build dashboards of active-version distribution over time.
<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send app build identifiers from mobile and web with every API request and propagate them through the backend for observability. The backend tags logs, Sentry, traces, and PostHog events (not person profiles) with the calling app version.

- New Features
  - Clients: Mobile sends `X-Polar-Client-Version` (`mobile/<expo version>`), `X-Polar-Client-Runtime` (`runtimeVersion`), and `X-Polar-Client-Update` (`updateId`; `embedded` if none). Web sends `X-Polar-Client-Version` (`web/<commit sha>` or `dev`) on client-side, SSR headers, and server-side API. Values from `expo-constants` and `expo-updates`.
  - Server: Middleware parses these headers, binds them to `structlog` context, sets Sentry tags and root span attributes, and cleans up after the request (even on errors). PostHog event properties now include these via a per-request `ClientContext` (not persisted to person properties).
  - Tests: Cover middleware capture/cleanup, error-path cleanup, and PostHog event property propagation without leaking to person properties.

<sup>Written for commit 648f75a688165bc9cd973d1ea819b190325e2b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



