### PR TITLE
docs: add customer payment methods API reference pages

### DIFF
--- a/docs/api-reference/customers/list-payment-methods-external.mdx
+++ b/docs/api-reference/customers/list-payment-methods-external.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/customers/external/{external_id}/payment-methods
+---

--- a/docs/api-reference/customers/list-payment-methods.mdx
+++ b/docs/api-reference/customers/list-payment-methods.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/customers/{id}/payment-methods
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -264,7 +264,9 @@
                   "api-reference/customers/delete",
                   "api-reference/customers/get-external",
                   "api-reference/customers/update-external",
-                  "api-reference/customers/delete-external"
+                  "api-reference/customers/delete-external",
+                  "api-reference/customers/list-payment-methods",
+                  "api-reference/customers/list-payment-methods-external"
                 ]
               },
               {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added API reference pages for listing a customer's payment methods by customer id and by external_id.
Documents GET /v1/customers/{id}/payment-methods and GET /v1/customers/external/{external_id}/payment-methods, and updates docs navigation to include both pages.

<sup>Written for commit afc9b55d71c9828481c1a5311defa1a45e544803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

