### PR TITLE
remove detail tooltip

### DIFF
--- a/clients/apps/web/src/components/Shared/DetailRow.tsx
+++ b/clients/apps/web/src/components/Shared/DetailRow.tsx
@@ -21,30 +21,25 @@ export const DetailRow = ({
   action,
 }: DetailRowProps) => {
   return (
-    <Tooltip>
-      <div className="flex flex-col text-sm md:flex-row md:items-baseline md:justify-between md:gap-4">
-        <TooltipTrigger asChild>
-          <h3
-            className={twMerge(
-              'dark:text-polar-500 flex-1 text-gray-500 truncate',
-              labelClassName,
-            )}
-          >
-            {label}
-          </h3>
-        </TooltipTrigger>
-        <TooltipContent>{label}</TooltipContent>
-        <span
-          className={twMerge(
-            'dark:md:hover:bg-polar-800 group flex flex-1 flex-row flex-nowrap items-center justify-between gap-x-2 rounded-md transition-colors duration-75 md:px-2.5 md:py-1 hover:md:bg-gray-100',
-            value ? '' : 'dark:text-polar-500 text-gray-500',
-            valueClassName,
-          )}
-        >
-          {value ?? '—'}
-          <span className="opacity-0 group-hover:opacity-100">{action}</span>
-        </span>
-      </div>
-    </Tooltip>
+    <div className="flex flex-col text-sm md:flex-row md:items-baseline md:justify-between md:gap-4">
+      <h3
+        className={twMerge(
+          'dark:text-polar-500 flex-1 text-gray-500 truncate',
+          labelClassName,
+        )}
+      >
+        {label}
+      </h3>
+      <span
+        className={twMerge(
+          'dark:md:hover:bg-polar-800 group flex flex-1 flex-row flex-nowrap items-center justify-between gap-x-2 rounded-md transition-colors duration-75 md:px-2.5 md:py-1 hover:md:bg-gray-100',
+          value ? '' : 'dark:text-polar-500 text-gray-500',
+          valueClassName,
+        )}
+      >
+        {value ?? '—'}
+        <span className="opacity-0 group-hover:opacity-100">{action}</span>
+      </span>
+    </div>
   )
 }

--- a/clients/apps/web/src/components/Shared/DetailRow.tsx
+++ b/clients/apps/web/src/components/Shared/DetailRow.tsx
@@ -1,8 +1,3 @@
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@polar-sh/ui/components/ui/tooltip'
 import { twMerge } from 'tailwind-merge'
 
 export interface DetailRowProps {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the tooltip from the `DetailRow` component to simplify the UI and remove redundant hover overlays. Label and value now render directly with hover only revealing the optional action; removed unused `@polar-sh/ui/components/ui/tooltip` imports.

<sup>Written for commit fb01ef176d6d636e28145fbdae6054885648269d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

