### PR TITLE
Allow fixed + seat-based prices

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26714,7 +26714,7 @@ export interface components {
       visibility: components['schemas']['ProductVisibility']
       /**
        * ProductPriceCreateList
-       * @description List of available prices for this product. It should contain at most one static price (fixed, custom or free), and any number of metered prices. Metered prices are not supported on one-time purchase products.
+       * @description List of available prices for this product. It may combine at most one fixed price with one seat-based price (billed as `fixed + seat_charge`), or contain a single custom or free price, plus any number of metered prices. A free price cannot be combined with other prices, and a custom price cannot be combined with a fixed or seat-based price. Metered prices are not supported on one-time purchase products.
        */
       prices: (
         | components['schemas']['ProductPriceFixedCreate']
@@ -26785,7 +26785,7 @@ export interface components {
       visibility: components['schemas']['ProductVisibility']
       /**
        * ProductPriceCreateList
-       * @description List of available prices for this product. It should contain at most one static price (fixed, custom or free), and any number of metered prices. Metered prices are not supported on one-time purchase products.
+       * @description List of available prices for this product. It may combine at most one fixed price with one seat-based price (billed as `fixed + seat_charge`), or contain a single custom or free price, plus any number of metered prices. A free price cannot be combined with other prices, and a custom price cannot be combined with a fixed or seat-based price. Metered prices are not supported on one-time purchase products.
        */
       prices: (
         | components['schemas']['ProductPriceFixedCreate']

--- a/server/polar/product/guard.py
+++ b/server/polar/product/guard.py
@@ -23,6 +23,7 @@ type StaticPrice = (
     | LegacyRecurringProductPriceFree
     | ProductPriceCustom
     | LegacyRecurringProductPriceCustom
+    | ProductPriceSeatUnit
 )
 
 type FixedPrice = ProductPriceFixed | LegacyRecurringProductPriceFixed

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -404,8 +404,11 @@ ProductPriceCreateList = Annotated[
             "title": "ProductPriceCreateList",
             "description": (
                 "List of prices for the product. "
-                "At most one static price (fixed, custom or free) is allowed. "
-                "Any number of metered prices can be added."
+                "At most one fixed price and one seat-based price may be combined "
+                "(billed as `fixed + seat_charge`), or a single custom or free "
+                "price may stand alone, plus any number of metered prices. "
+                "A free price cannot be combined with other prices, and a custom "
+                "price cannot be combined with a fixed or seat-based price."
             ),
         }
     ),
@@ -422,8 +425,11 @@ class ProductCreateBase(MetadataInputMixin, Schema):
     prices: ProductPriceCreateList = Field(
         ...,
         description="List of available prices for this product. "
-        "It should contain at most one static price (fixed, custom or free), and "
-        "any number of metered prices. "
+        "It may combine at most one fixed price with one seat-based price "
+        "(billed as `fixed + seat_charge`), or contain a single custom or free "
+        "price, plus any number of metered prices. A free price cannot be "
+        "combined with other prices, and a custom price cannot be combined with "
+        "a fixed or seat-based price. "
         "Metered prices are not supported on one-time purchase products.",
     )
     medias: list[UUID4] | None = Field(

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -44,8 +44,12 @@ from polar.models.webhook_endpoint import WebhookEventType
 from polar.organization.repository import OrganizationRepository
 from polar.organization.resolver import get_payload_organization
 from polar.product.guard import (
+    is_custom_price,
+    is_fixed_price,
+    is_free_price,
     is_legacy_price,
     is_metered_price,
+    is_seat_price,
     is_static_price,
 )
 from polar.product.repository import ProductRepository
@@ -641,19 +645,66 @@ class ProductService:
             )
 
         # Track price structure per currency for cross-currency validation
-        price_structure_per_currency: dict[str, tuple[int, int]] = {}
+        price_structure_per_currency: dict[str, tuple[bool, bool, bool, bool, int]] = {}
 
         for currency, currency_prices in prices_per_currency.items():
-            # Check that only one static price exists per currency
+            # Classify the static prices in this currency. A product may compose
+            # one fixed price with one seat-based price (billed `fixed + seat_charge`),
+            # plus any number of metered prices. Custom and free prices stand alone.
             static_prices = [p for p, _ in currency_prices if is_static_price(p)]
-            if len(static_prices) > 1:
-                # Bypass that rule for legacy recurring products
-                if not all(is_legacy_price(p) for p in static_prices):
+            fixed_prices = [p for p in static_prices if is_fixed_price(p)]
+            free_prices = [p for p in static_prices if is_free_price(p)]
+            custom_prices = [p for p in static_prices if is_custom_price(p)]
+            seat_prices = [p for p in static_prices if is_seat_price(p)]
+
+            # Bypass these rules for legacy recurring products, which predate the
+            # static-composition model and may carry one static price per interval.
+            if not all(is_legacy_price(p) for p in static_prices):
+                if len(fixed_prices) > 1:
                     errors.append(
                         {
                             "type": "value_error",
                             "loc": error_prefix,
-                            "msg": "Only one static price is allowed.",
+                            "msg": "Only one fixed price is allowed.",
+                            "input": prices_schema,
+                        }
+                    )
+                if len(seat_prices) > 1:
+                    errors.append(
+                        {
+                            "type": "value_error",
+                            "loc": error_prefix,
+                            "msg": "Only one seat-based price is allowed.",
+                            "input": prices_schema,
+                        }
+                    )
+                if len(custom_prices) > 1:
+                    errors.append(
+                        {
+                            "type": "value_error",
+                            "loc": error_prefix,
+                            "msg": "Only one custom price is allowed.",
+                            "input": prices_schema,
+                        }
+                    )
+                if free_prices and len(static_prices) > 1:
+                    errors.append(
+                        {
+                            "type": "value_error",
+                            "loc": error_prefix,
+                            "msg": "A free price cannot be combined with other prices.",
+                            "input": prices_schema,
+                        }
+                    )
+                if custom_prices and (fixed_prices or seat_prices):
+                    errors.append(
+                        {
+                            "type": "value_error",
+                            "loc": error_prefix,
+                            "msg": (
+                                "A custom price cannot be combined with "
+                                "a fixed or seat-based price."
+                            ),
                             "input": prices_schema,
                         }
                     )
@@ -687,9 +738,13 @@ class ProductService:
                     }
                 )
 
-            # Record the structure: (static_count, metered_count)
+            # Record the structure:
+            # (has_fixed, has_seat, has_custom, has_free, metered_count)
             price_structure_per_currency[currency] = (
-                len(static_prices),
+                len(fixed_prices) > 0,
+                len(seat_prices) > 0,
+                len(custom_prices) > 0,
+                len(free_prices) > 0,
                 len(currency_meters),
             )
 

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -30,6 +30,7 @@ from polar.models import (
 from polar.models.checkout import CheckoutStatus
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.organization import OrganizationStatus
+from polar.models.product_price import ProductPriceSeatUnit
 from polar.postgres import AsyncSession
 from polar.tax.calculation import TaxCalculationService
 from polar.tax.calculation.base import TaxabilityReason
@@ -41,6 +42,7 @@ from tests.fixtures.random_objects import (
     create_discount,
     create_organization,
     create_product,
+    create_product_fixed_and_seat,
     create_webhook_endpoint,
 )
 
@@ -451,6 +453,44 @@ class TestCreateCheckout:
         assert json["seats"] == 6
         assert json["amount"] == 1500 * 6
         assert json["product_price"]["id"] == str(product.prices[0].id)
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
+    async def test_valid_fixed_and_seat_checkout(
+        self,
+        api_prefix: str,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        organization: Organization,
+    ) -> None:
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            fixed_amount=99900,
+            price_per_seat=2000,
+        )
+        fixed_price, seat_price = product.prices[0], product.prices[1]
+        assert isinstance(seat_price, ProductPriceSeatUnit)
+
+        response = await client.post(
+            f"{api_prefix}/",
+            json={
+                "payment_processor": "stripe",
+                "products": [str(product.id)],
+                "seats": 10,
+            },
+        )
+
+        assert response.status_code == 201
+
+        json = response.json()
+        assert json["seats"] == 10
+        # Combined amount: fixed base + seat charge.
+        assert json["amount"] == 99900 + seat_price.calculate_amount(10)
+        # FK points at the fixed price (the default).
+        assert json["product_price"]["id"] == str(fixed_price.id)
+        # Both static prices are exposed on the product.
+        assert len(json["product"]["prices"]) == 2
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkouts_write}))
     async def test_seat_based_missing_seats_defaults_to_minimum(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -111,6 +111,7 @@ from tests.fixtures.random_objects import (
     create_discount,
     create_order,
     create_product,
+    create_product_fixed_and_seat,
     create_product_price_fixed,
     create_product_price_seat_unit,
     create_subscription,
@@ -382,6 +383,19 @@ async def checkout_seat_based(
     save_fixture: SaveFixture, product_seat_based: Product
 ) -> Checkout:
     return await create_checkout(save_fixture, products=[product_seat_based], seats=5)
+
+
+@pytest_asyncio.fixture
+async def product_fixed_seat(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    """$999 base + $20/seat, billed `fixed + seat_charge`."""
+    return await create_product_fixed_and_seat(
+        save_fixture,
+        organization=organization,
+        fixed_amount=99900,
+        price_per_seat=2000,
+    )
 
 
 @pytest_asyncio.fixture
@@ -1894,6 +1908,115 @@ class TestCreate:
         assert checkout.seats == 10
         assert checkout.amount == price.calculate_amount(10)
         assert checkout.currency == price.price_currency
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_fixed_and_seat_price_combined_amount(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        product_fixed_seat: Product,
+    ) -> None:
+        fixed_price = next(p for p in product_fixed_seat.prices if is_fixed_price(p))
+        seat_price = next(p for p in product_fixed_seat.prices if is_seat_price(p))
+
+        checkout = await checkout_service.create(
+            session,
+            CheckoutProductCreate(
+                product_id=product_fixed_seat.id,
+                seats=10,
+            ),
+            auth_subject,
+        )
+
+        # FK points at the fixed price (the default), but the amount rebuilds
+        # from the full static set: F + S(seats).
+        assert checkout.product_price == fixed_price
+        assert checkout.product == product_fixed_seat
+        assert checkout.seats == 10
+        assert (
+            checkout.amount
+            == fixed_price.price_amount + seat_price.calculate_amount(10)
+        )
+        assert checkout.currency == fixed_price.price_currency
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_fixed_and_seat_price_seat_update_recomputes_amount(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        product_fixed_seat: Product,
+    ) -> None:
+        fixed_price = next(p for p in product_fixed_seat.prices if is_fixed_price(p))
+        seat_price = next(p for p in product_fixed_seat.prices if is_seat_price(p))
+
+        checkout = await checkout_service.create(
+            session,
+            CheckoutProductCreate(product_id=product_fixed_seat.id, seats=5),
+            auth_subject,
+        )
+        assert (
+            checkout.amount == fixed_price.price_amount + seat_price.calculate_amount(5)
+        )
+
+        updated = await checkout_service.update(
+            session,
+            checkout,
+            CheckoutUpdate(seats=12),
+        )
+
+        assert updated.seats == 12
+        assert updated.amount == fixed_price.price_amount + seat_price.calculate_amount(
+            12
+        )
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_fixed_and_seat_price_discount_on_combined_amount(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        organization: Organization,
+        product_fixed_seat: Product,
+    ) -> None:
+        fixed_price = next(p for p in product_fixed_seat.prices if is_fixed_price(p))
+        seat_price = next(p for p in product_fixed_seat.prices if is_seat_price(p))
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=2500,
+            duration=DiscountDuration.forever,
+            organization=organization,
+        )
+
+        checkout = await checkout_service.create(
+            session,
+            CheckoutProductCreate(
+                product_id=product_fixed_seat.id,
+                seats=10,
+                discount_id=discount.id,
+            ),
+            auth_subject,
+        )
+
+        combined = fixed_price.price_amount + seat_price.calculate_amount(10)
+        assert checkout.discount == discount
+        assert checkout.amount == combined
+        # The discount is computed against the combined F + S(seats) amount.
+        assert checkout.net_amount == combined - discount.get_discount_amount(
+            combined, checkout.currency
+        )
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -118,6 +118,7 @@ from polar.models.pledge import Pledge, PledgeState, PledgeType
 from polar.models.product_price import (
     ProductPriceAmountType,
     ProductPriceType,
+    SeatTierType,
 )
 from polar.models.subscription import SubscriptionStatus
 from polar.models.transaction import Processor, TransactionType
@@ -611,24 +612,35 @@ async def create_product_price_seat_unit(
     price_per_seat: int = 1000,
     minimum_seats: int = 1,
     maximum_seats: int | None = None,
+    tiers: list[dict[str, typing.Any]] | None = None,
+    seat_tier_type: SeatTierType = SeatTierType.volume,
     currency: str = "usd",
     tax_behavior: TaxBehavior | None = TaxBehavior.exclusive,
 ) -> ProductPriceSeatUnit:
-    """Create a seat-based price with a single tier.
+    """Create a seat-based price.
+
+    By default a single tier is built from ``price_per_seat`` /
+    ``minimum_seats`` / ``maximum_seats``. Pass ``tiers`` to define a
+    multi-tier price explicitly (e.g. a graduated schedule).
 
     Args:
-        price_per_seat: Price per seat in cents.
+        price_per_seat: Price per seat in cents (single-tier shorthand).
         minimum_seats: Minimum seats allowed (first tier's min_seats).
         maximum_seats: Maximum seats allowed (last tier's max_seats). None for unlimited.
+        tiers: Explicit list of tier dicts (min_seats/max_seats/price_per_seat).
+        seat_tier_type: How tiers are applied (volume or graduated).
     """
-    seat_tiers: dict[str, typing.Any] = {
-        "tiers": [
+    if tiers is None:
+        tiers = [
             {
                 "min_seats": minimum_seats,
                 "max_seats": maximum_seats,
                 "price_per_seat": price_per_seat,
             }
         ]
+    seat_tiers: dict[str, typing.Any] = {
+        "seat_tier_type": seat_tier_type,
+        "tiers": tiers,
     }
 
     price = ProductPriceSeatUnit(
@@ -640,6 +652,43 @@ async def create_product_price_seat_unit(
     assert price.amount_type == ProductPriceAmountType.seat_based
     await save_fixture(price)
     return price
+
+
+async def create_product_fixed_and_seat(
+    save_fixture: SaveFixture,
+    *,
+    organization: Organization,
+    fixed_amount: int = 99900,
+    price_per_seat: int = 1000,
+    tiers: list[dict[str, typing.Any]] | None = None,
+    seat_tier_type: SeatTierType = SeatTierType.volume,
+    currency: str = "usd",
+    recurring_interval: SubscriptionRecurringInterval = (
+        SubscriptionRecurringInterval.month
+    ),
+) -> Product:
+    """Create a recurring product composing one fixed price with one seat price.
+
+    Bills ``fixed_amount + seat_price.calculate_amount(seats)``. Pass ``tiers``
+    (with ``seat_tier_type=graduated``) for a graduated seat schedule.
+    """
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=recurring_interval,
+        prices=[(fixed_amount, currency)],
+    )
+    seat_price = await create_product_price_seat_unit(
+        save_fixture,
+        product=product,
+        price_per_seat=price_per_seat,
+        tiers=tiers,
+        seat_tier_type=seat_tier_type,
+        currency=currency,
+    )
+    product.prices.append(seat_price)
+    product.all_prices.append(seat_price)
+    return product
 
 
 @typing.overload
@@ -1538,7 +1587,21 @@ async def create_checkout(
     if price.price_currency != currency:
         raise ValueError("Price currency does not match checkout currency")
 
-    if isinstance(price, ProductPriceFixed):
+    static_prices = currency_prices.get_static_prices()
+    if len(static_prices) > 1:
+        # Composed static prices (e.g. fixed + seat): sum each component,
+        # mirroring `calculate_upfront_amount`.
+        seat_count = seats if seats is not None else 1
+        composed = 0
+        for static_price in static_prices:
+            if isinstance(static_price, ProductPriceFixed):
+                composed += static_price.price_amount
+            elif isinstance(static_price, ProductPriceCustom):
+                composed += amount if amount is not None else 10_00
+            elif isinstance(static_price, ProductPriceSeatUnit):
+                composed += static_price.calculate_amount(seat_count)
+        amount = composed
+    elif isinstance(price, ProductPriceFixed):
         amount = price.price_amount
     elif isinstance(price, ProductPriceCustom):
         amount = amount or 10_00

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -88,7 +88,7 @@ from polar.order.service import (
     SubscriptionNotTrialing,
 )
 from polar.order.service import order as order_service
-from polar.product.guard import is_fixed_price, is_static_price
+from polar.product.guard import is_fixed_price, is_seat_price, is_static_price
 from polar.product.price_set import PriceSet
 from polar.subscription.service import SubscriptionService
 from polar.tax.calculation import (
@@ -121,6 +121,7 @@ from tests.fixtures.random_objects import (
     create_payment,
     create_payment_method,
     create_product,
+    create_product_fixed_and_seat,
     create_subscription,
     create_trialing_subscription,
     create_wallet,
@@ -872,6 +873,55 @@ class TestCreateFromCheckoutSubscription:
         assert len(order.items) == len(
             [p for p in product_recurring_metered.prices if is_static_price(p)]
         )
+
+    async def test_fixed_and_seat(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            fixed_amount=99900,
+            price_per_seat=2000,
+        )
+        fixed_price = next(p for p in product.prices if is_fixed_price(p))
+        seat_price = next(p for p in product.prices if is_seat_price(p))
+
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            seats=10,
+        )
+        assert checkout.amount == (
+            fixed_price.price_amount + seat_price.calculate_amount(10)
+        )
+
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=customer, seats=10
+        )
+
+        order = await order_service.create_from_checkout_subscription(
+            session,
+            checkout,
+            subscription,
+            OrderBillingReasonInternal.subscription_create,
+        )
+
+        assert order.customer == checkout.customer
+        assert order.product == product
+
+        # Two static line items (fixed + seat), summing to the combined subtotal.
+        assert len(order.items) == 2
+        by_price = {item.product_price_id: item for item in order.items}
+        assert by_price[fixed_price.id].amount == fixed_price.price_amount
+        assert by_price[seat_price.id].amount == seat_price.calculate_amount(10)
+        assert sum(item.amount for item in order.items) == order.subtotal_amount
+        assert order.subtotal_amount == checkout.amount
 
 
 class DiscountFixture(BaseModel):

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -1366,33 +1366,6 @@ class TestCreateFixedSeatComposition:
             )
 
     @pytest.mark.auth
-    async def test_free_and_seat_rejected(
-        self,
-        auth_subject: AuthSubject[User],
-        session: AsyncSession,
-        organization: Organization,
-        user_organization: UserOrganization,
-        seat_based_pricing_enabled: None,
-    ) -> None:
-        with pytest.raises(PolarRequestValidationError):
-            await product_service.create(
-                session,
-                ProductCreateRecurring(
-                    name="Product",
-                    recurring_interval=SubscriptionRecurringInterval.month,
-                    prices=[
-                        ProductPriceFreeCreate(
-                            amount_type=ProductPriceAmountType.free,
-                            price_currency=PresentmentCurrency.usd,
-                        ),
-                        _seat_price_create(),
-                    ],
-                    organization_id=organization.id,
-                ),
-                auth_subject,
-            )
-
-    @pytest.mark.auth
     async def test_cross_currency_structure_mismatch_rejected(
         self,
         auth_subject: AuthSubject[User],

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, call
 
 import pytest
+import pytest_asyncio
 from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
@@ -28,7 +29,12 @@ from polar.models.product_price import (
     ProductPriceFixed,
 )
 from polar.postgres import AsyncSession
-from polar.product.guard import is_metered_price, is_static_price
+from polar.product.guard import (
+    is_fixed_price,
+    is_metered_price,
+    is_seat_price,
+    is_static_price,
+)
 from polar.product.schemas import (
     ExistingProductPrice,
     ProductCreate,
@@ -1125,6 +1131,340 @@ class TestCreate:
         assert all(
             p.tax_behavior == TaxBehaviorOption.inclusive for p in product.prices
         )
+
+
+def _fixed_price_create(
+    *,
+    amount: int = 99900,
+    currency: PresentmentCurrency = PresentmentCurrency.usd,
+    tax_behavior: TaxBehaviorOption | None = None,
+) -> ProductPriceFixedCreate:
+    return ProductPriceFixedCreate(
+        amount_type=ProductPriceAmountType.fixed,
+        price_amount=amount,
+        price_currency=currency,
+        tax_behavior=tax_behavior,
+    )
+
+
+def _seat_price_create(
+    *,
+    price_per_seat: int = 2000,
+    currency: PresentmentCurrency = PresentmentCurrency.usd,
+    tax_behavior: TaxBehaviorOption | None = None,
+) -> ProductPriceSeatBasedCreate:
+    return ProductPriceSeatBasedCreate(
+        amount_type=ProductPriceAmountType.seat_based,
+        price_currency=currency,
+        tax_behavior=tax_behavior,
+        seat_tiers=ProductPriceSeatTiers(
+            tiers=[
+                ProductPriceSeatTier(
+                    min_seats=1, max_seats=None, price_per_seat=price_per_seat
+                )
+            ]
+        ),
+    )
+
+
+@pytest.mark.asyncio
+class TestCreateFixedSeatComposition:
+    """Validation for composing a fixed price with a seat-based price."""
+
+    @pytest_asyncio.fixture
+    async def seat_based_pricing_enabled(
+        self, session: AsyncSession, organization: Organization
+    ) -> None:
+        organization.feature_settings = {"seat_based_pricing_enabled": True}
+        session.add(organization)
+        await session.flush()
+
+    @pytest.mark.auth
+    async def test_fixed_and_seat_allowed(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        product = await product_service.create(
+            session,
+            ProductCreateRecurring(
+                name="Product",
+                recurring_interval=SubscriptionRecurringInterval.month,
+                prices=[_fixed_price_create(), _seat_price_create()],
+                organization_id=organization.id,
+            ),
+            auth_subject,
+        )
+
+        assert len(product.prices) == 2
+        assert len([p for p in product.prices if is_fixed_price(p)]) == 1
+        assert len([p for p in product.prices if is_seat_price(p)]) == 1
+
+    @pytest.mark.auth
+    async def test_fixed_and_seat_and_metered_allowed(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        meter: Meter,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        product = await product_service.create(
+            session,
+            ProductCreateRecurring(
+                name="Product",
+                recurring_interval=SubscriptionRecurringInterval.month,
+                prices=[
+                    _fixed_price_create(),
+                    _seat_price_create(),
+                    ProductPriceMeteredUnitCreate(
+                        amount_type=ProductPriceAmountType.metered_unit,
+                        price_currency=PresentmentCurrency.usd,
+                        unit_amount=Decimal(100),
+                        meter_id=meter.id,
+                    ),
+                ],
+                organization_id=organization.id,
+            ),
+            auth_subject,
+        )
+
+        assert len(product.prices) == 3
+        assert len([p for p in product.prices if is_fixed_price(p)]) == 1
+        assert len([p for p in product.prices if is_seat_price(p)]) == 1
+        assert len([p for p in product.prices if is_metered_price(p)]) == 1
+
+    @pytest.mark.auth
+    async def test_two_fixed_prices_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        _fixed_price_create(amount=99900),
+                        _fixed_price_create(amount=49900),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_two_seat_prices_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        _seat_price_create(price_per_seat=2000),
+                        _seat_price_create(price_per_seat=1500),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_seat_and_custom_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        _seat_price_create(),
+                        ProductPriceCustomCreate(
+                            amount_type=ProductPriceAmountType.custom,
+                            price_currency=PresentmentCurrency.usd,
+                        ),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_fixed_and_custom_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        _fixed_price_create(),
+                        ProductPriceCustomCreate(
+                            amount_type=ProductPriceAmountType.custom,
+                            price_currency=PresentmentCurrency.usd,
+                        ),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_free_and_fixed_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        ProductPriceFreeCreate(
+                            amount_type=ProductPriceAmountType.free,
+                            price_currency=PresentmentCurrency.usd,
+                        ),
+                        _fixed_price_create(),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_free_and_seat_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        ProductPriceFreeCreate(
+                            amount_type=ProductPriceAmountType.free,
+                            price_currency=PresentmentCurrency.usd,
+                        ),
+                        _seat_price_create(),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_cross_currency_structure_mismatch_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        """USD = fixed + seat, EUR = fixed only must be rejected."""
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        _fixed_price_create(currency=PresentmentCurrency.usd),
+                        _seat_price_create(currency=PresentmentCurrency.usd),
+                        _fixed_price_create(
+                            amount=89900, currency=PresentmentCurrency.eur
+                        ),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_tax_behavior_mismatch_across_pair_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        seat_based_pricing_enabled: None,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[
+                        _fixed_price_create(tax_behavior=TaxBehaviorOption.inclusive),
+                        _seat_price_create(tax_behavior=TaxBehaviorOption.exclusive),
+                    ],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_fixed_and_seat_feature_disabled_rejected(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """Without ``seat_based_pricing_enabled`` the seat gate alone rejects the
+        composition — no separate fixed+seat gate is needed."""
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.month,
+                    prices=[_fixed_price_create(), _seat_price_create()],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -70,6 +70,8 @@ from polar.product.guard import (
     is_fixed_price,
     is_free_price,
     is_metered_price,
+    is_seat_price,
+    is_static_price,
 )
 from polar.product.price_set import PriceSet
 from polar.subscription.repository import SubscriptionUpdateRepository
@@ -107,6 +109,7 @@ from tests.fixtures.random_objects import (
     create_meter,
     create_payment_method,
     create_product,
+    create_product_fixed_and_seat,
     create_subscription,
     create_subscription_with_seats,
     create_trialing_subscription,
@@ -6974,3 +6977,89 @@ class TestClearPendingUpdate:
 
         # Then: Pending update is cleared
         assert updated_subscription.pending_update is None
+
+
+@pytest.mark.asyncio
+class TestFixedSeatComposition:
+    """A product composing a fixed price with a seat-based price bills F + S(n)."""
+
+    async def test_subscription_has_two_static_prices_and_combined_amount(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            fixed_amount=99900,
+            price_per_seat=2000,
+        )
+        fixed_price = next(p for p in product.prices if is_fixed_price(p))
+        seat_price = next(p for p in product.prices if is_seat_price(p))
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=10,
+        )
+
+        static_prices = [
+            spp
+            for spp in subscription.subscription_product_prices
+            if is_static_price(spp.product_price)
+        ]
+        assert len(static_prices) == 2
+        assert subscription.amount == (
+            fixed_price.price_amount + seat_price.calculate_amount(10)
+        )
+
+    async def test_cycle_emits_two_static_billing_entries(
+        self,
+        session: AsyncSession,
+        enqueue_job_mock: MagicMock,
+        webhook_service_send_mock: AsyncMock,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            fixed_amount=99900,
+            price_per_seat=2000,
+        )
+        fixed_price = next(p for p in product.prices if is_fixed_price(p))
+        seat_price = next(p for p in product.prices if is_seat_price(p))
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=10,
+            scheduler_locked_at=utc_now(),
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.cycle(session, ctx, subscription)
+
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        billing_entries = await billing_entry_repository.get_pending_by_subscription(
+            subscription.id
+        )
+        assert len(billing_entries) == 2
+        assert all(
+            entry.direction == BillingEntryDirection.debit for entry in billing_entries
+        )
+
+        by_price = {entry.product_price_id: entry for entry in billing_entries}
+        assert by_price[fixed_price.id].amount == fixed_price.price_amount
+        assert by_price[seat_price.id].amount == seat_price.calculate_amount(10)
+        # The two static entries together reconstruct the combined amount F + S(n).
+        assert subscription.amount == (
+            fixed_price.price_amount + seat_price.calculate_amount(10)
+        )

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -49,19 +49,13 @@ from tests.fixtures.random_objects import (
     create_subscription_with_seats,
 )
 
-# Sonar Atlas graduated seat schedule: 1–50 @ $0 (included), 51–100 @ $20,
+# Graduated seat schedule: 1–50 @ $0 (included), 51–100 @ $20,
 # 101–200 @ $17.50, 201+ @ $15.
-SONAR_SEAT_TIERS: list[dict[str, object]] = [
+GRADUATED_SEAT_TIERS: list[dict[str, object]] = [
     {"min_seats": 1, "max_seats": 50, "price_per_seat": 0},
     {"min_seats": 51, "max_seats": 100, "price_per_seat": 2000},
     {"min_seats": 101, "max_seats": 200, "price_per_seat": 1750},
     {"min_seats": 201, "max_seats": None, "price_per_seat": 1500},
-]
-
-# Example B: $200 base, 1–10 @ $0 (included), 11+ @ $20.
-INCLUDED_SEAT_TIERS: list[dict[str, object]] = [
-    {"min_seats": 1, "max_seats": 10, "price_per_seat": 0},
-    {"min_seats": 11, "max_seats": None, "price_per_seat": 2000},
 ]
 
 # This tests Subscription updates with prorations, where the subscription is
@@ -1982,7 +1976,7 @@ class TestFixedSeatProrations:
             save_fixture,
             organization=organization,
             fixed_amount=99900,
-            tiers=SONAR_SEAT_TIERS,
+            tiers=GRADUATED_SEAT_TIERS,
             seat_tier_type=SeatTierType.graduated,
         )
         fixed_price = next(p for p in product.prices if is_fixed_price(p))
@@ -2013,7 +2007,7 @@ class TestFixedSeatProrations:
                 )
             await session.flush()
 
-        # Sonar 143-seat case: $999 + (50×$0 + 50×$20 + 43×$17.50) = $2,751.50
+        # 143-seat case: $999 + (50×$0 + 50×$20 + 43×$17.50) = $2,751.50
         assert updated.seats == 143
         assert updated.amount == 275150
         assert updated.amount == (
@@ -2033,7 +2027,7 @@ class TestFixedSeatProrations:
         assert seat_entries[0].direction == BillingEntryDirection.debit
         assert seat_entries[0].type == BillingEntryType.subscription_seats_increase
 
-    @pytest.mark.parametrize("seats", [1, 10, 11])
+    @pytest.mark.parametrize("seats", [1, 50, 51])
     async def test_included_seats_composition(
         self,
         session: AsyncSession,
@@ -2046,7 +2040,7 @@ class TestFixedSeatProrations:
             save_fixture,
             organization=organization,
             fixed_amount=20000,
-            tiers=INCLUDED_SEAT_TIERS,
+            tiers=GRADUATED_SEAT_TIERS,
             seat_tier_type=SeatTierType.graduated,
         )
         fixed_price = next(p for p in product.prices if is_fixed_price(p))
@@ -2060,7 +2054,7 @@ class TestFixedSeatProrations:
         )
 
         # Seats within the included tier contribute nothing on top of the base.
-        if seats <= 10:
+        if seats <= 50:
             assert seat_price.calculate_amount(seats) == 0
 
         assert subscription.amount == (

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -27,6 +27,7 @@ from polar.models import (
 )
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.discount import DiscountDuration, DiscountType
+from polar.models.product_price import SeatTierType
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.product.guard import (
@@ -42,10 +43,26 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_discount,
     create_product,
+    create_product_fixed_and_seat,
     create_product_price_fixed,
     create_subscription,
     create_subscription_with_seats,
 )
+
+# Sonar Atlas graduated seat schedule: 1–50 @ $0 (included), 51–100 @ $20,
+# 101–200 @ $17.50, 201+ @ $15.
+SONAR_SEAT_TIERS: list[dict[str, object]] = [
+    {"min_seats": 1, "max_seats": 50, "price_per_seat": 0},
+    {"min_seats": 51, "max_seats": 100, "price_per_seat": 2000},
+    {"min_seats": 101, "max_seats": 200, "price_per_seat": 1750},
+    {"min_seats": 201, "max_seats": None, "price_per_seat": 1500},
+]
+
+# Example B: $200 base, 1–10 @ $0 (included), 11+ @ $20.
+INCLUDED_SEAT_TIERS: list[dict[str, object]] = [
+    {"min_seats": 1, "max_seats": 10, "price_per_seat": 0},
+    {"min_seats": 11, "max_seats": None, "price_per_seat": 2000},
+]
 
 # This tests Subscription updates with prorations, where the subscription is
 # not a subscription in Stripe.
@@ -1938,3 +1955,114 @@ class TestComposedStaticPriceDiscountAllocation:
         entry = seat_entries[0]
         assert entry.direction == BillingEntryDirection.debit
         assert entry.amount == 45_00
+
+
+@pytest.mark.asyncio
+class TestFixedSeatProrations:
+    """Fixed base price composed with a seat-based price bills `F + S(n)`."""
+
+    async def test_seat_change_prorates_only_seat_delta(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        enqueue_benefits_grants_mock: MagicMock,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # Customer has no payment method; mock the order-creation call that the
+        # prorate path would otherwise drive on context exit.
+        mocker.patch.object(
+            subscription_service,
+            "_create_subscription_update_order",
+            new=AsyncMock(),
+        )
+
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            fixed_amount=99900,
+            tiers=SONAR_SEAT_TIERS,
+            seat_tier_type=SeatTierType.graduated,
+        )
+        fixed_price = next(p for p in product.prices if is_fixed_price(p))
+        seat_price = next(p for p in product.prices if is_seat_price(p))
+
+        with freezegun.freeze_time(datetime(2024, 1, 1, tzinfo=UTC)) as frozen_time:
+            subscription = await create_subscription_with_seats(
+                save_fixture,
+                product=product,
+                customer=customer,
+                seats=100,
+            )
+            assert subscription.amount == (
+                fixed_price.price_amount + seat_price.calculate_amount(100)
+            )
+
+            frozen_time.move_to(datetime(2024, 1, 16, tzinfo=UTC))
+
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                updated = await subscription_service.update_seats(
+                    session,
+                    ctx,
+                    subscription,
+                    seats=143,
+                    proration_behavior=SubscriptionProrationBehavior.prorate,
+                )
+            await session.flush()
+
+        # Sonar 143-seat case: $999 + (50×$0 + 50×$20 + 43×$17.50) = $2,751.50
+        assert updated.seats == 143
+        assert updated.amount == 275150
+        assert updated.amount == (
+            fixed_price.price_amount + seat_price.calculate_amount(143)
+        )
+
+        # Only the seat delta is prorated; the fixed fee gets no billing entry.
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        entries = await billing_entry_repository.get_pending_by_subscription(
+            subscription.id
+        )
+        assert all(entry.product_price_id != fixed_price.id for entry in entries)
+        seat_entries = [
+            entry for entry in entries if entry.product_price_id == seat_price.id
+        ]
+        assert len(seat_entries) == 1
+        assert seat_entries[0].direction == BillingEntryDirection.debit
+        assert seat_entries[0].type == BillingEntryType.subscription_seats_increase
+
+    @pytest.mark.parametrize("seats", [1, 10, 11])
+    async def test_included_seats_composition(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        seats: int,
+    ) -> None:
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            fixed_amount=20000,
+            tiers=INCLUDED_SEAT_TIERS,
+            seat_tier_type=SeatTierType.graduated,
+        )
+        fixed_price = next(p for p in product.prices if is_fixed_price(p))
+        seat_price = next(p for p in product.prices if is_seat_price(p))
+
+        subscription = await create_subscription_with_seats(
+            save_fixture,
+            product=product,
+            customer=customer,
+            seats=seats,
+        )
+
+        # Seats within the included tier contribute nothing on top of the base.
+        if seats <= 10:
+            assert seat_price.calculate_amount(seats) == 0
+
+        assert subscription.amount == (
+            fixed_price.price_amount + seat_price.calculate_amount(seats)
+        )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allows products to combine one fixed base price with one seat-based price, billed as fixed + seat_charge. Checkout, orders, and subscriptions now compute and display the combined amount.

- **New Features**
  - Composition & validation: at most one fixed + one seat per currency, or a single custom/free; free cannot combine; custom cannot combine with fixed/seat; tax behavior must match across the pair; legacy recurring exempt.
  - Cross-currency & metered: require the same static structure across currencies; allow any number of metered prices; metered not supported on one-time products.
  - Billing & discounts: sum fixed + seat_charge; checkout references the fixed price by default; seat updates recompute totals; discounts apply to the combined amount; prorations affect only the seat delta.
  - Line items: orders and subscription cycles emit separate static items for the fixed and seat components.
  - Seat tiers: support volume and graduated tiers, including “included seats” via zero-cost tiers.
  - Client: updated `v1` price list descriptions to document the new rules.

<sup>Written for commit bb78429ec4e6a9b4a848c8ff8f7d8baa8fdb3e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

