### PR TITLE
slack: Add benefit to org schema

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24122,6 +24122,12 @@ export interface components {
        * @default false
        */
       billing_enabled: boolean
+      /**
+       * Slack Benefit Enabled
+       * @description Enables the slack shared channel benefit
+       * @default false
+       */
+      slack_benefit_enabled: boolean
     }
     /** OrganizationIndividualLegalEntitySchema */
     OrganizationIndividualLegalEntitySchema: {

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -162,6 +162,9 @@ class OrganizationFeatureSettings(Schema):
     billing_enabled: bool = Field(
         False, description="If this organization has billing enabled"
     )
+    slack_benefit_enabled: bool = Field(
+        False, description="Enables the slack shared channel benefit"
+    )
 
     @field_validator("overview_metrics", mode="before")
     @classmethod


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `slack_benefit_enabled` to the organization feature settings to enable or disable the Slack shared channel benefit. Updated the server schema and the TS client `components` so the flag is available; default is false.

<sup>Written for commit 6580d2229aec0c538245b8f3e0068bdb98bf105f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

