### PR TITLE
feat(tax_id): relax ecuador RUC validation

### DIFF
--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Sequence
 from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, Protocol
@@ -6,6 +7,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Protocol
 import stdnum.ca.bn
 import stdnum.cl.rut
 import stdnum.co.nit
+import stdnum.ec.ruc
 import stdnum.exceptions
 import stdnum.il.idnr
 import stdnum.in_.gstin
@@ -268,6 +270,40 @@ class CONITValidator(ValidatorProtocol):
             raise InvalidTaxID(number, country) from e
 
 
+# Juridical/company RUC (third digit "9") that the SRI issues without a usable
+# módulo-11 check digit: province (2) + "9" + 7-digit identifier + "001" matriz.
+# Only consulted after stdnum raises InvalidChecksum, i.e. once length, digits
+# and a valid province code are already guaranteed.
+# Upstream: https://github.com/arthurdejong/python-stdnum/issues/497
+_EC_RUC_NO_CHECKSUM = re.compile(r"[0-9]{2}9[0-9]{7}001")
+
+
+class ECRUCValidator(ValidatorProtocol):
+    """Validate Ecuadorian RUC.
+
+    Some valid juridical RUCs (third digit "9") carry no recomputable check
+    digit: the SRI issues them without applying the módulo-11 algorithm, so
+    stdnum rejects them with InvalidChecksum even though they are active,
+    registered companies.
+
+    We keep stdnum's full validation (length, province, entity type,
+    establishment number) but forgive the checksum, and only for this
+    juridical/company class. Natural-person (third digit 0-5) and public (6)
+    RUCs keep their full checksum, so personal numbers stay strictly validated.
+    """
+
+    def validate(self, number: str, country: str) -> str:
+        number = stdnum.ec.ruc.compact(number)
+        try:
+            return stdnum.ec.ruc.validate(number)
+        except stdnum.exceptions.InvalidChecksum as e:
+            if _EC_RUC_NO_CHECKSUM.fullmatch(number):
+                return number
+            raise InvalidTaxID(number, country) from e
+        except stdnum.exceptions.ValidationError as e:
+            raise InvalidTaxID(number, country) from e
+
+
 class TRTINValidator(ValidatorProtocol):
     def validate(self, number: str, country: str) -> str:
         number = stdnum.tr.vkn.compact(number)
@@ -343,6 +379,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return CLTINValidator()
         case TaxIDFormat.co_nit:
             return CONITValidator()
+        case TaxIDFormat.ec_ruc:
+            return ECRUCValidator()
         case TaxIDFormat.ge_vat:
             return GEVATValidator()
         case TaxIDFormat.il_vat:

--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -270,12 +270,12 @@ class CONITValidator(ValidatorProtocol):
             raise InvalidTaxID(number, country) from e
 
 
-# Juridical/company RUC (third digit "9") that the SRI issues without a usable
-# módulo-11 check digit: province (2) + "9" + 7-digit identifier + "001" matriz.
-# Only consulted after stdnum raises InvalidChecksum, i.e. once length, digits
-# and a valid province code are already guaranteed.
+# Structural fallback for company RUCs the SRI issues without a usable módulo-11
+# check digit (see ECRUCValidator for the full breakdown). Self-contained so the
+# recovery path validates the structure itself rather than trusting stdnum,
+# whose checksum we already know to be unreliable for these numbers.
 # Upstream: https://github.com/arthurdejong/python-stdnum/issues/497
-_EC_RUC_NO_CHECKSUM = re.compile(r"[0-9]{2}9[0-9]{7}001")
+_EC_RUC_NO_CHECKSUM = re.compile(r"(0[1-9]|1[0-9]|2[0-4]|30)9[0-d]{7}001")
 
 
 class ECRUCValidator(ValidatorProtocol):
@@ -284,12 +284,21 @@ class ECRUCValidator(ValidatorProtocol):
     Some valid juridical RUCs (third digit "9") carry no recomputable check
     digit: the SRI issues them without applying the módulo-11 algorithm, so
     stdnum rejects them with InvalidChecksum even though they are active,
-    registered companies.
+    registered companies (e.g. 1793213150001 -> CARNADA S.A.S.).
 
-    We keep stdnum's full validation (length, province, entity type,
-    establishment number) but forgive the checksum, and only for this
-    juridical/company class. Natural-person (third digit 0-5) and public (6)
-    RUCs keep their full checksum, so personal numbers stay strictly validated.
+    When stdnum reports a bad checksum we fall back to validating the structure
+    ourselves against _EC_RUC_NO_CHECKSUM, which matches, in order:
+
+    - ``(0[1-9]|1[0-9]|2[0-4]|30)`` -- province code: 01-24 (the 24 provinces)
+      or 30 (registered abroad); 25-29 are reserved,
+    - ``9`` -- third digit: company/juridical taxpayer,
+    - ``[0-d]{7}`` -- 7-digit identifier (the sequential plus the unused check
+      digit slot),
+    - ``001`` -- establishment: the head office (matriz).
+
+    The pattern only matches companies, so the checksum is forgiven solely for
+    them: a natural-person (third digit 0-5, i.e. sole proprietor) or public (6)
+    RUC that reaches this fallback fails to match and is rejected.
     """
 
     def validate(self, number: str, country: str) -> str:

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -25,6 +25,23 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("234567899", "CA", ("234567899", TaxIDFormat.ca_bn)),
         ("12.531.909-2", "CL", ("125319092", TaxIDFormat.cl_tin)),
         ("12531909-2", "CL", ("125319092", TaxIDFormat.cl_tin)),
+        # EC RUC: normal juridical / public numbers (pass stdnum checksum)
+        ("1792060346001", "EC", ("1792060346001", TaxIDFormat.ec_ruc)),
+        ("1792060346-001", "EC", ("1792060346001", TaxIDFormat.ec_ruc)),
+        ("1793221293001", "EC", ("1793221293001", TaxIDFormat.ec_ruc)),
+        # EC RUC: valid company numbers the SRI issues without a check digit
+        # (stdnum raises InvalidChecksum, relaxed for third digit "9").
+        # See https://github.com/arthurdejong/python-stdnum/issues/497
+        (
+            "1793213150001",
+            "EC",
+            ("1793213150001", TaxIDFormat.ec_ruc),
+        ),  # CARNADA S.A.S.
+        (
+            "0993370026001",
+            "EC",
+            ("0993370026001", TaxIDFormat.ec_ruc),
+        ),  # PONTEDORA S.A.S.
         ("213.123.432-1", "CO", ("2131234321", TaxIDFormat.co_nit)),
         ("213-123-432-1", "CO", ("2131234321", TaxIDFormat.co_nit)),
         ("213 123 432 1", "CO", ("2131234321", TaxIDFormat.co_nit)),
@@ -72,6 +89,11 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("123456789", "IL"),
         ("516179150", "IL"),
         ("2131234325", "CO"),  # Wrong check digit
+        ("1714307104001", "EC"),  # natural-person RUC (3rd digit 1), bad checksum
+        ("1763154690001", "EC"),  # public RUC (3rd digit 6), bad checksum
+        ("1793213150002", "EC"),  # 3rd digit 9 but branch establishment (not 001)
+        ("179321315001", "EC"),  # too short
+        ("2593213150001", "EC"),  # invalid province code (25)
         ("4030000375890", "MK"),  # Wrong check digit
         ("12345678", "GE"),  # Too short
         ("1234567890", "GE"),  # Between supported lengths (10)


### PR DESCRIPTION
## Summary

**Related Issue**: #12168

<!-- Brief description of what this PR does -->

## What
 Add ECRUCValidator for Ecuador RUC — keeps stdnum's full validation, but when it raises InvalidChecksum, falls back to a structural match ^[0-9]{2}9[0-9]{7}001$ (province + 9 + identifier + 001). Registered for ec_ruc.


<!-- Describe what changes you've made -->

## Why
SRI issues newer company RUCs (e.g. 1793213150001 = CARNADA S.A.S.) without a recomputable módulo-11 check digit, so stdnum wrongly rejected valid, active businesses at checkout (#12168). Verified real via SRI's registry. Natural-person (3rd digit 0–5) and public (6) RUCs keep their full checksum, so personal numbers stay strict — the regex requires 9 at position 3.


<!-- Explain why this change is needed -->

## How
Only the checksum is forgiven, and only for third-digit-9 company RUCs; province/length/digits are still enforced by stdnum (they raise other errors before the fallback). Temporary shim around upstream stdnum#497 — remove when that lands.
<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxes Ecuador RUC validation for juridical (third digit 9) numbers that lack a recomputable check digit so valid companies aren’t blocked. Personal and public RUCs remain strict.

- **Bug Fixes**
  - Added `ECRUCValidator` for `ec_ruc`: when `stdnum.ec.ruc.validate` raises `InvalidChecksum`, fall back to a self-contained structural check `^(0[1-9]|1[0-9]|2[0-4]|30)9[0-9]{7}001$` (province 01–24 or 30 + 9 + 7 digits + head office `001`).
  - Added tests for normal checksum passes, relaxed company cases, and failures (non-`001` establishment, invalid province, wrong length).
  - Only relaxes checksum for third-digit 9; natural-person (0–5) and public (6) RUCs still require a valid checksum.

<sup>Written for commit 7b364aa7ffb14d48a7a47a11e56fa28607fe14b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

