### PR TITLE
fix creating checkout link or benefit showing stale empty state

### DIFF
--- a/clients/apps/web/src/components/Benefit/BenefitListSidebar.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitListSidebar.tsx
@@ -10,6 +10,7 @@ import { useModal } from '@/components/Modal/useModal'
 import Spinner from '@/components/Shared/Spinner'
 import { useInfiniteBenefits } from '@/hooks/queries'
 import { useInViewport } from '@/hooks/utils'
+import { usePushRouteWithoutCache } from '@/utils/router'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import ArrowDownward from '@mui/icons-material/ArrowDownward'
 import ArrowUpward from '@mui/icons-material/ArrowUpward'
@@ -25,7 +26,7 @@ import {
   parseAsStringLiteral,
   useQueryState,
 } from 'nuqs'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export const BenefitListSidebar = ({
@@ -35,6 +36,7 @@ export const BenefitListSidebar = ({
 }) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const pushRouteWithoutCache = usePushRouteWithoutCache()
 
   const [sorting, setSorting] = useQueryState(
     'sorting',
@@ -95,6 +97,27 @@ export const BenefitListSidebar = ({
     }
     return null
   }, [pathname])
+
+  const handleSelectBenefit = useCallback(
+    (benefit: schemas['Benefit']) => {
+      hideCreateBenefitModal()
+
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('query')
+      params.delete('create_benefit')
+      const queryString = params.toString()
+
+      pushRouteWithoutCache(
+        `/dashboard/${organization.slug}/products/benefits/${benefit.id}${queryString ? `?${queryString}` : ''}`,
+      )
+    },
+    [
+      hideCreateBenefitModal,
+      searchParams,
+      pushRouteWithoutCache,
+      organization.slug,
+    ],
+  )
 
   return (
     <>
@@ -189,10 +212,7 @@ export const BenefitListSidebar = ({
           <CreateBenefitModalContent
             organization={organization}
             hideModal={hideCreateBenefitModal}
-            onSelectBenefit={(benefit) => {
-              hideCreateBenefitModal()
-              window.location.href = `/dashboard/${organization.slug}/products/benefits/${benefit.id}`
-            }}
+            onSelectBenefit={handleSelectBenefit}
           />
         }
       />

--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkListSidebar.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkListSidebar.tsx
@@ -8,6 +8,7 @@ import Spinner from '@/components/Shared/Spinner'
 import { toast } from '@/components/Toast/use-toast'
 import { useCheckoutLinks } from '@/hooks/queries'
 import { useInViewport } from '@/hooks/utils'
+import { usePushRouteWithoutCache } from '@/utils/router'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import ArrowDownward from '@mui/icons-material/ArrowDownward'
 import ArrowUpward from '@mui/icons-material/ArrowUpward'
@@ -15,7 +16,7 @@ import LinkOutlined from '@mui/icons-material/LinkOutlined'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import Link from 'next/link'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import {
   parseAsArrayOf,
   parseAsBoolean,
@@ -23,7 +24,7 @@ import {
   parseAsStringLiteral,
   useQueryState,
 } from 'nuqs'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export const CheckoutLinkListSidebar = ({
@@ -32,8 +33,8 @@ export const CheckoutLinkListSidebar = ({
   organization: schemas['Organization']
 }) => {
   const pathname = usePathname()
-  const router = useRouter()
   const searchParams = useSearchParams()
+  const pushRouteWithoutCache = usePushRouteWithoutCache()
 
   const [productIds, setProductIds] = useQueryState(
     'productId',
@@ -94,6 +95,26 @@ export const CheckoutLinkListSidebar = ({
     }
     return null
   }, [pathname])
+
+  const handleCreateCheckoutLinkClose = useCallback(
+    (checkoutLink: schemas['CheckoutLink']) => {
+      hideCreateCheckoutLinkModal()
+
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('productId')
+      const queryString = params.toString()
+
+      pushRouteWithoutCache(
+        `/dashboard/${organization.slug}/products/checkout-links/${checkoutLink.id}${queryString ? `?${queryString}` : ''}`,
+      )
+    },
+    [
+      hideCreateCheckoutLinkModal,
+      searchParams,
+      pushRouteWithoutCache,
+      organization.slug,
+    ],
+  )
 
   return (
     <>
@@ -204,13 +225,7 @@ export const CheckoutLinkListSidebar = ({
           <CheckoutLinkManagementModal
             organization={organization}
             productIds={productIds ?? []}
-            onClose={(checkoutLink) => {
-              setProductIds([])
-              hideCreateCheckoutLinkModal()
-              router.push(
-                `/dashboard/${organization.slug}/products/checkout-links/${checkoutLink.id}`,
-              )
-            }}
+            onClose={handleCreateCheckoutLinkClose}
           />
         }
       />


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/d491452a-57d4-40f9-bfc6-ea37d55e0e4d

https://github.com/user-attachments/assets/2d7d10e1-7398-4fdb-86c6-000fa279815a



Small fix for post-create navigation on checkout links and benefits so newly created items open automatically, without a full page reload or failed client-side routing.

Before when starting from an empty state and creating a new checkout link, the router didn’t navigate correctly and the page stayed on the empty state until the item was clicked in the sidebar. I’ve seen similar issues with nuqs racing with other navigations before.

One possible fix would have been to await setProductIds([]) (as it returns a promise)ƒ, but I instead included the query string directly in router.push. That fixed the issue and now the new item opens automatically. It also fixes creating additional items, which before left the view on the previously visible item.

This wasn’t an issue in the Benefits component because it used window.location.href, but that caused a full page flash. I added the same client-side navigation behavior there as well. (can be seen in _before_ video)

Please let me know if I missed anything or if this does not look good to you. See videos for before and after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes post-create navigation for checkout links and benefits so the newly created item opens immediately via client-side routing, avoiding stale empty states and full page reloads.

- **Bug Fixes**
  - Checkout links: use `usePushRouteWithoutCache` on modal close to navigate to the new link, preserving query params while removing `productId`. Prevents `nuqs`/routing race and stale sidebar selection.
  - Benefits: replace `window.location.href` with `usePushRouteWithoutCache` and remove `query`/`create_benefit` before navigating to the new benefit. Eliminates page flash and ensures smooth client-side routing.

<sup>Written for commit 8745b202f26788995ad860f7e5a4d8908223c64a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

