### PR TITLE
Change OTA policy to appVersion instead of fingerprint

### DIFF
--- a/clients/apps/app/README.md
+++ b/clients/apps/app/README.md
@@ -74,17 +74,27 @@ This is how `expo-updates` works by default: it downloads updates in the backgro
 
 ### Publishing an OTA update
 
+Publish through `pnpm ota`, **not** raw `eas update`. It runs a preflight guard
+(`tooling/ota-preflight/`) that refuses to publish if the update can't safely
+reach devices then forwards to `eas update` for you:
+
 ```bash
-# Test on preview first
-eas update --channel preview --message "Description of changes"
+# Test on preview first if it's a larger change
+pnpm ota --channel preview --message "Description of changes"
 
 # Then push to production
-eas update --channel production --message "Description of changes"
+pnpm ota --channel production --message "Description of changes"
 ```
 
-### Runtime version
+The guard verifies, per platform, against the latest finished build on the channel:
 
-The `runtimeVersion` in `app.config.js` uses the `fingerprint` policy. This automatically generates a hash of all native dependencies, config plugins, and native project files. OTA updates are only delivered to app builds with a matching fingerprint. If any native code changes (e.g. adding a native module or bumping a native dependency), the fingerprint changes automatically, preventing OTA updates from being delivered to incompatible builds.
+1. **A build with the current runtime exists** otherwise the update would reach
+   0 devices (the classic "I published but nothing changed" trap).
+2. **The native layer matches that build** comparing fingerprints while ignoring
+   pnpm's virtual-store path churn, so only _real_ native changes block you.
+
+If it blocks, you need a new native build (see below) — not an OTA. Use
+`--check-only` to run the checks without publishing.
 
 ### When to OTA vs native build
 
@@ -132,11 +142,11 @@ You don't need to rebuild the preview build for every change — only when nativ
 ### Recommended workflow
 
 1. Make your JS changes
-2. Push to preview: `eas update --channel preview --message "Description"`
+2. Push to preview: `pnpm ota --channel preview --message "Description"`
 3. Open the preview build on your device and verify
-4. Ship to users: `eas update --channel production --message "Description"`
+4. Ship to users: `pnpm ota --channel production --message "Description"`
 
-When making native changes:
+When making native changes (or if `pnpm ota` blocks you):
 
 1. Bump `version` in `app.config.js`
 2. Run `eas build --profile production`

--- a/clients/apps/app/app.config.js
+++ b/clients/apps/app/app.config.js
@@ -109,7 +109,7 @@ module.exports = {
       },
     },
     runtimeVersion: {
-      policy: 'fingerprint',
+      policy: 'appVersion',
     },
     updates: {
       url: 'https://u.expo.dev/0c79977b-c070-4416-8878-d8b8febe2e25',

--- a/clients/apps/app/eslint.config.js
+++ b/clients/apps/app/eslint.config.js
@@ -50,4 +50,20 @@ module.exports = defineConfig([
       '@polar/no-hardcoded-dimensions': 'error',
     },
   },
+  {
+    files: ['tooling/**/*.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: {
+        process: 'readonly',
+        console: 'readonly',
+        require: 'readonly',
+        module: 'writable',
+        __dirname: 'readonly',
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
 ])

--- a/clients/apps/app/package.json
+++ b/clients/apps/app/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web",
     "test": "jest",
     "test:watch": "jest --watchAll",
+    "ota": "node tooling/ota-preflight",
     "build:production": "eas build --platform all --profile production",
     "build:development": "eas build --platform all --profile development",
     "build:simulator": "eas build --platform all --profile simulator",

--- a/clients/apps/app/tooling/ota-preflight/fingerprint-diff.js
+++ b/clients/apps/app/tooling/ota-preflight/fingerprint-diff.js
@@ -1,0 +1,65 @@
+'use strict'
+const PNPM_VIRTUAL_STORE = /\.pnpm\/([^/]+)\/node_modules\//g
+
+function stripPnpmPeerHashes(value) {
+  return String(value).replace(
+    PNPM_VIRTUAL_STORE,
+    (_match, segment) => `.pnpm/${segment.split('_')[0]}/node_modules/`,
+  )
+}
+
+function sourceIdentity(source) {
+  const locator =
+    source.filePath != null ? stripPnpmPeerHashes(source.filePath) : source.id
+  return JSON.stringify([source.type, locator, source.reasons ?? []])
+}
+
+function sourceDigest(source) {
+  switch (source.type) {
+    case 'contents':
+      return stripPnpmPeerHashes(source.contents ?? '')
+    case 'dir':
+      return ''
+    default:
+      return source.hash ?? ''
+  }
+}
+
+function indexByIdentity(fingerprint) {
+  return new Map(
+    fingerprint.sources.map((source) => [
+      sourceIdentity(source),
+      { digest: sourceDigest(source), source },
+    ]),
+  )
+}
+
+function diffFingerprints(baseline, candidate) {
+  const before = indexByIdentity(baseline)
+  const after = indexByIdentity(candidate)
+  const changes = []
+
+  for (const [identity, entry] of after) {
+    const prior = before.get(identity)
+    if (!prior) {
+      changes.push({ kind: 'added', source: entry.source })
+    } else if (prior.digest !== entry.digest) {
+      changes.push({ kind: 'modified', source: entry.source })
+    }
+  }
+
+  for (const [identity, entry] of before) {
+    if (!after.has(identity)) {
+      changes.push({ kind: 'removed', source: entry.source })
+    }
+  }
+
+  return changes
+}
+
+module.exports = {
+  stripPnpmPeerHashes,
+  sourceIdentity,
+  sourceDigest,
+  diffFingerprints,
+}

--- a/clients/apps/app/tooling/ota-preflight/index.js
+++ b/clients/apps/app/tooling/ota-preflight/index.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+'use strict'
+
+/**
+ * OTA preflight guard.
+ *
+ * We run EAS Update with the `appVersion` runtime, meaning there is a possibility
+ * to ship native changes as an OTA.
+ *
+ * This script checks if the current working tree is compatible with the latest
+ * finished build on the target channel.
+ *
+ * Usage:
+ *   pnpm ota --channel production --message "Fix X"   # check, then publish
+ *   pnpm ota --channel production --check-only        # check only, don't publish
+ */
+
+const { execFileSync, spawnSync } = require('node:child_process')
+const path = require('node:path')
+
+const { diffFingerprints, stripPnpmPeerHashes } = require('./fingerprint-diff')
+
+const APP_DIR = path.resolve(__dirname, '../..')
+const PLATFORMS = ['ios', 'android']
+const OWN_FLAGS = new Set(['--check-only'])
+
+const REASON_LABELS = {
+  expoAutolinkingIos: 'native module (iOS autolinking)',
+  expoAutolinkingAndroid: 'native module (Android autolinking)',
+  rncoreAutolinkingIos: 'native module (iOS RN-core autolinking)',
+  rncoreAutolinkingAndroid: 'native module (Android RN-core autolinking)',
+  expoConfigPlugins: 'config plugin',
+  expoConfig: 'app config (native-affecting fields)',
+  expoConfigExternalFile: 'native asset baked into the binary',
+  'package:react-native': 'react-native version',
+  'packageJson:scripts': 'package.json scripts',
+  easBuild: 'eas.json build config',
+  bareGitIgnore: '.gitignore',
+}
+
+const CHANGE_VERBS = {
+  added: 'added (only in working tree)',
+  removed: 'removed (gone from working tree)',
+  modified: 'modified',
+}
+
+function parseArgs(argv) {
+  return {
+    channel: readOption(argv, '--channel'),
+    checkOnly: argv.includes('--check-only'),
+    forwarded: argv.filter((arg) => !OWN_FLAGS.has(arg)),
+  }
+}
+
+function readOption(argv, name) {
+  const flagIndex = argv.indexOf(name)
+  if (flagIndex !== -1) {
+    const value = argv[flagIndex + 1]
+    return value && !value.startsWith('--') ? value : undefined
+  }
+  const inline = argv.find((arg) => arg.startsWith(`${name}=`))
+  return inline ? inline.slice(name.length + 1) : undefined
+}
+
+function resolveRuntimeVersion() {
+  const { expo } = require(path.join(APP_DIR, 'app.config.js'))
+  const policy = expo.runtimeVersion
+  if (typeof policy === 'string') return policy
+  if (policy?.policy === 'appVersion' || policy?.policy === 'nativeVersion') {
+    return expo.version
+  }
+  return undefined
+}
+
+function resolveEasCommand() {
+  try {
+    execFileSync('eas', ['--version'], { stdio: 'ignore' })
+    return ['eas']
+  } catch {
+    return ['npx', 'eas']
+  }
+}
+
+function createEasClient() {
+  const [cmd, ...prefix] = resolveEasCommand()
+
+  const runJson = (args) => {
+    const stdout = execFileSync(cmd, [...prefix, ...args], {
+      cwd: APP_DIR,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    })
+    return JSON.parse(stdout)
+  }
+
+  return {
+    listFinishedBuilds(platform, channel) {
+      const builds = runJson([
+        'build:list',
+        '--platform',
+        platform,
+        '--status',
+        'finished',
+        '--channel',
+        channel,
+        '--limit',
+        '20',
+        '--json',
+        '--non-interactive',
+      ])
+      return Array.isArray(builds) ? builds : []
+    },
+
+    compareToBuild(buildId) {
+      return runJson([
+        'fingerprint:compare',
+        '--build-id',
+        buildId,
+        '--json',
+        '--non-interactive',
+      ])
+    },
+
+    publish(args) {
+      const { status } = spawnSync(cmd, [...prefix, 'update', ...args], {
+        cwd: APP_DIR,
+        stdio: 'inherit',
+      })
+      return status ?? 0
+    },
+  }
+}
+
+const buildRuntime = (build) =>
+  String(build.runtimeVersion ?? build.runtime?.version ?? '')
+
+function checkPlatform(eas, platform, { channel, runtime }) {
+  const builds = eas.listFinishedBuilds(platform, channel)
+  if (builds.length === 0) {
+    return { platform, status: 'skipped' }
+  }
+
+  const build = runtime
+    ? builds.find((candidate) => buildRuntime(candidate) === runtime)
+    : builds[0]
+  if (!build) {
+    return { platform, status: 'missing-build' }
+  }
+
+  const { fingerprint1, fingerprint2 } = eas.compareToBuild(build.id)
+  const changes = diffFingerprints(fingerprint1, fingerprint2)
+  return changes.length === 0
+    ? { platform, status: 'ok', build }
+    : { platform, status: 'native-drift', build, changes }
+}
+
+const isBlocking = (result) =>
+  result.status === 'missing-build' || result.status === 'native-drift'
+
+function blockerMessage(result, runtime) {
+  if (result.status === 'missing-build') {
+    return (
+      `No finished ${result.platform} build on this channel has runtime "${runtime}". ` +
+      `An OTA for this runtime would reach 0 devices, so bump the build and submit it first.`
+    )
+  }
+  return (
+    `${result.platform}: native layer differs from the installed build. OTA-delivered JS may crash. ` +
+    'Bump `version` in app.config.js and cut a new store build.'
+  )
+}
+
+function describeSourceChange({ kind, source }) {
+  const locator =
+    source.filePath != null ? stripPnpmPeerHashes(source.filePath) : source.id
+  const marker = 'node_modules/'
+  const cut = locator.lastIndexOf(marker)
+  const name = cut === -1 ? locator : locator.slice(cut + marker.length)
+  const reasons = (source.reasons ?? []).map((r) => REASON_LABELS[r] ?? r)
+  const suffix = reasons.length ? `  [${reasons.join(', ')}]` : ''
+  return `      • ${CHANGE_VERBS[kind]}: ${name}${suffix}`
+}
+
+function reportResult(result) {
+  const label = result.platform.padEnd(8)
+  const where = result.build
+    ? `build ${String(result.build.id).slice(0, 8)} (v${buildRuntime(result.build)})`
+    : ''
+
+  switch (result.status) {
+    case 'skipped':
+      console.log(`   ${label} no finished builds on this channel — skipped`)
+      return
+    case 'missing-build':
+      console.log(`   ${label} no matching build for this runtime`)
+      return
+    case 'ok':
+      console.log(`   ${label} native layer matches ${where}`)
+      return
+    case 'native-drift':
+      console.log(`   ${label} native changes vs ${where}:`)
+      result.changes.forEach((change) =>
+        console.log(describeSourceChange(change)),
+      )
+      return
+  }
+}
+
+function reportBlockers(blockers) {
+  console.error('\n──────────────────────────────────────────────')
+  console.error('OTA preflight found native incompatibilities:\n')
+  blockers.forEach((reason) => console.error(`  • ${reason}`))
+  console.error(
+    '\nThese changes cannot be delivered as an OTA. Build & submit a new binary, then OTA JS-only fixes on top of it.',
+  )
+}
+
+function main(argv) {
+  const { channel, checkOnly, forwarded } = parseArgs(argv)
+  if (!channel) {
+    console.error(
+      '\n❌ Missing --channel. Usage: pnpm ota --channel production --message "…"\n',
+    )
+    return 2
+  }
+
+  const runtime = resolveRuntimeVersion()
+  console.log(
+    `\n🔎 OTA preflight — channel "${channel}"` +
+      (runtime ? `, runtime "${runtime}" (appVersion policy)` : '') +
+      '\n',
+  )
+
+  const eas = createEasClient()
+  const results = PLATFORMS.map((platform) =>
+    checkPlatform(eas, platform, { channel, runtime }),
+  )
+  results.forEach(reportResult)
+
+  const blockers = results
+    .filter(isBlocking)
+    .map((result) => blockerMessage(result, runtime))
+
+  if (blockers.length > 0) {
+    reportBlockers(blockers)
+    return 1
+  }
+  console.log('\n✅ Preflight passed, safe to ship!\n')
+
+  if (checkOnly) return 0
+
+  const updateArgs = forwarded[0] === 'update' ? forwarded.slice(1) : forwarded
+  console.log(`eas update ${updateArgs.join(' ')}\n`)
+  return eas.publish(updateArgs)
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main(process.argv.slice(2)))
+  } catch (error) {
+    console.error(`\n❌ ${error.message || error}\n`)
+    process.exit(1)
+  }
+}
+
+module.exports = { main, checkPlatform }


### PR DESCRIPTION
The `fingerprint` policy for OTA updates is fragile and prone to false positives, this PR changes the policy to `appVersion` instead.

It also adds a guard rail to prevent us from shipping _native_ code/dependencies as an OTA. It's quite hacky, and hard to test properly since everything in Expo uses `fingerprint` as a policy right now. But I'll test it properly after we pushed a new build (with `appVersion` as policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches OTA runtime policy to `appVersion` and adds a preflight guard to stop native changes from shipping as OTAs. Improves safety and makes it clear when a new native build is required.

- **New Features**
  - Set `runtimeVersion.policy` to `appVersion` in `app.config.js`.
  - Added `pnpm ota` script with a preflight that checks the latest finished build per platform on the target channel, compares native fingerprints (ignores pnpm virtual-store noise), blocks when no matching runtime build exists or when native drift is detected, supports `--check-only`, then forwards to `eas update`.
  - Updated README with the new workflow and added ESLint settings for `tooling/**` CommonJS scripts.

- **Migration**
  - Publish with `pnpm ota --channel <name> --message "<desc>"` instead of raw `eas update`.
  - If blocked, bump `version` in `app.config.js`, build and submit a new binary, then OTA JS-only fixes.
  - Use `pnpm ota --check-only` to validate without publishing.

<sup>Written for commit e13ce80212fcaf8dd02649c35336d36d6d55f730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

