### PR TITLE
Add seat count to seat-based line item

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -90,7 +90,7 @@ class BillingEntryService:
         ):
             static_price = cast(StaticPrice, entry.product_price)
             static_line_item = await self._get_static_price_line_item(
-                session, static_price, entry
+                session, static_price, entry, seats=subscription.seats
             )
             yield static_line_item, [entry.id]
 
@@ -182,7 +182,12 @@ class BillingEntryService:
             yield metered_line_item, pending_entries_ids
 
     async def _get_static_price_line_item(
-        self, session: AsyncSession, price: StaticPrice, entry: BillingEntry
+        self,
+        session: AsyncSession,
+        price: StaticPrice,
+        entry: BillingEntry,
+        *,
+        seats: int | None,
     ) -> StaticLineItem:
         assert entry.amount is not None
         assert entry.currency is not None
@@ -195,12 +200,14 @@ class BillingEntryService:
         end = format_date(entry.end_timestamp.date(), locale="en_US")
         amount = entry.amount
 
+        price_label = OrderItem.format_price_label(product, price, seats=seats)
+
         match entry.direction:
             case BillingEntryDirection.credit:
-                label = f"Remaining time on {product.name} — From {start} to {end}"
+                label = f"Remaining time on {price_label} — From {start} to {end}"
                 amount = -amount
             case BillingEntryDirection.debit:
-                label = f"{product.name} — From {start} to {end}"
+                label = f"{price_label} — From {start} to {end}"
                 amount = amount
 
         return StaticLineItem(

--- a/server/polar/models/order_item.py
+++ b/server/polar/models/order_item.py
@@ -61,6 +61,20 @@ class OrderItem(RecordModel):
         return not self.proration
 
     @classmethod
+    def format_price_label(
+        cls, product: "Product", price: ProductPrice, *, seats: int | None
+    ) -> str:
+        """
+        Human-readable label for a static-price line item: the product name,
+        with a seat count appended for seat-based prices (e.g.
+        "Acme Pro (14 seats)"). Falls back to the bare product name for every
+        other price type, or when the seat count is unknown.
+        """
+        if isinstance(price, ProductPriceSeatUnit) and seats is not None:
+            return f"{product.name} ({seats} seat{'' if seats == 1 else 's'})"
+        return product.name
+
+    @classmethod
     def from_price(
         cls,
         price: ProductPrice,
@@ -79,7 +93,9 @@ class OrderItem(RecordModel):
             assert seats is not None, "seats must be provided for seat-based prices"
             amount = price.calculate_amount(seats)
         return cls(
-            label=label if label is not None else price.product.name,
+            label=label
+            if label is not None
+            else cls.format_price_label(price.product, price, seats=seats),
             amount=amount,
             tax_amount=tax_amount,
             net_amount=amount,

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -197,6 +197,9 @@ async def create_static_price_billing_entry(
         amount = price.price_amount
     elif is_free_price(price):
         amount = 0
+    elif is_seat_price(price):
+        assert subscription.seats is not None
+        amount = price.calculate_amount(subscription.seats)
     elif is_custom_price(price):
         raise NotImplementedError()
 
@@ -612,6 +615,10 @@ class TestCreateOrderItemsFromPending:
             order_item_2 = order_items[1]
             assert product.name in order_item_2.label
             assert order_item_2.proration is True
+
+            # Fixed-only product: no seats qualifier should appear.
+            assert "seat" not in order_item_1.label
+            assert "seat" not in order_item_2.label
 
             order = await create_order(
                 save_fixture,

--- a/server/tests/order/test_models.py
+++ b/server/tests/order/test_models.py
@@ -1,0 +1,35 @@
+from polar.models import OrderItem, Product
+from polar.models.product_price import (
+    ProductPriceFixed,
+    ProductPriceSeatUnit,
+)
+
+
+class TestFormatPriceLabel:
+    def test_seat_plural(self) -> None:
+        product = Product(name="Acme Pro")
+        assert (
+            OrderItem.format_price_label(product, ProductPriceSeatUnit(), seats=14)
+            == "Acme Pro (14 seats)"
+        )
+
+    def test_seat_singular(self) -> None:
+        product = Product(name="Acme Pro")
+        assert (
+            OrderItem.format_price_label(product, ProductPriceSeatUnit(), seats=1)
+            == "Acme Pro (1 seat)"
+        )
+
+    def test_seat_without_count(self) -> None:
+        product = Product(name="Acme Pro")
+        assert (
+            OrderItem.format_price_label(product, ProductPriceSeatUnit(), seats=None)
+            == "Acme Pro"
+        )
+
+    def test_fixed(self) -> None:
+        product = Product(name="Acme Pro")
+        assert (
+            OrderItem.format_price_label(product, ProductPriceFixed(), seats=10)
+            == "Acme Pro"
+        )


### PR DESCRIPTION
Less ambitious than the previous time I tried to render the # of seats on an invoice 😁 

Append the seat count to static price line item labels for seat-based subscriptions, so an invoice line reads Acme Pro (14 seats) instead of just Acme Pro. The logic lives in a new `OrderItem.format_price_label` class method, which is reused both by `OrderItem.from_price` and by `BillingEntryService._get_static_price_line_item`. It falls back to the bare product name for every other price type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show seat counts on invoice line items for seat-based subscriptions, e.g. "Acme Pro (14 seats)". Centralizes label formatting via `OrderItem.format_price_label` and applies it to order items and billing entries.

- New Features
  - Add seat count to static price line items for `ProductPriceSeatUnit`, including proration lines (e.g. "Remaining time on Acme Pro (14 seats)").
  - Fall back to the product name when seats are unknown or for non-seat prices; correct singular/plural ("1 seat"/"N seats").

<sup>Written for commit cae205e4cd9762863b87dd0cd6e2b1e61a87f80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

