### PR TITLE
feat: add --skip-tinybird option to seed commands

### DIFF
--- a/dev/cli/commands/seed.py
+++ b/dev/cli/commands/seed.py
@@ -86,14 +86,20 @@ def _print_seeded_login_info(new_org: str | None = None) -> None:
     login_info.add_row("Email", f"{new_org}@polar.sh" if new_org else "admin@polar.sh")
     login_info.add_row("OTP", "Check the terminal running dev api")
     if not new_org:
-        login_info.add_row("Note", "This account has access to multiple seeded organizations")
+        login_info.add_row(
+            "Note", "This account has access to multiple seeded organizations"
+        )
 
     console.print()
     console.print(
         Panel(
             login_info,
-            title="[bold green]Organization Seeded![/bold green]" if new_org else "[bold green]Default Seed Loaded![/bold green]",
-            subtitle="[dim]Log in with[/dim]" if new_org else "[dim]Use this account to access the seeded organizations[/dim]",
+            title="[bold green]Organization Seeded![/bold green]"
+            if new_org
+            else "[bold green]Default Seed Loaded![/bold green]",
+            subtitle="[dim]Log in with[/dim]"
+            if new_org
+            else "[dim]Use this account to access the seeded organizations[/dim]",
             border_style="green",
             padding=(1, 2),
         )
@@ -114,20 +120,27 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             "--reset",
             help="Recreate the database before loading fresh seed data.",
         ),
+        skip_tinybird: bool = typer.Option(
+            False,
+            "--skip-tinybird",
+            help="Skip seeding events to Tinybird.",
+        ),
     ) -> None:
         """Load sample data (users, organizations, products) into the database."""
         console.print()
 
         if reset and new_org:
-            console.print(
-                "\n[red]--reset cannot be combined with --new-org.[/red]\n"
-            )
+            console.print("\n[red]--reset cannot be combined with --new-org.[/red]\n")
             raise typer.Exit(1)
 
         if reset:
-            console.print("[bold blue]Recreating database and loading fresh seeds...[/bold blue]\n")
+            console.print(
+                "[bold blue]Recreating database and loading fresh seeds...[/bold blue]\n"
+            )
 
-            console.print("[yellow]This will delete all local database data before reseeding.[/yellow]")
+            console.print(
+                "[yellow]This will delete all local database data before reseeding.[/yellow]"
+            )
             if not _confirm("Continue?"):
                 raise typer.Abort()
             console.print()
@@ -145,12 +158,11 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             step_status(True, "Database recreated")
 
             _print_info("Loading fresh seed data. This usually takes a few minutes.")
+            seed_cmd = ["uv", "run", "task", "seeds_load"]
+            if skip_tinybird:
+                seed_cmd.append("--skip-tinybird")
             with step_spinner("Seeding database..."):
-                result = run_command(
-                    ["uv", "run", "task", "seeds_load"],
-                    cwd=SERVER_DIR,
-                    capture=True,
-                )
+                result = run_command(seed_cmd, cwd=SERVER_DIR, capture=True)
             if not result or result.returncode != 0:
                 _print_command_output(result)
                 console.print("\n[red]Seeding failed after database recreate.[/red]\n")
@@ -162,17 +174,24 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             return
 
         if new_org:
-            console.print(f"[bold blue]Creating organization '{new_org}'...[/bold blue]")
+            console.print(
+                f"[bold blue]Creating organization '{new_org}'...[/bold blue]"
+            )
             _print_info("With products, customers, and timeline events.")
             console.print()
 
             cmd = ["uv", "run", "task", "seeds_load", f"--new-org={new_org}"]
         else:
             console.print("[bold blue]Seeding database...[/bold blue]")
-            _print_info("Creating sample organizations, products, customers, and subscriptions.")
+            _print_info(
+                "Creating sample organizations, products, customers, and subscriptions."
+            )
             console.print()
 
             cmd = ["uv", "run", "task", "seeds_load"]
+
+        if skip_tinybird:
+            cmd.append("--skip-tinybird")
 
         _print_info("This usually takes a few minutes.")
         with step_spinner("Seeding database..."):
@@ -180,12 +199,14 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
 
         if result and result.returncode == 2:
             console.print()
-            console.print(Panel(
-                "[dim]Use [bold]dev seed --new-org <slug>[/bold] to create additional organizations.[/dim]\n[dim]Use [bold]dev seed --reset[/bold] to recreate the database and load fresh seeds.[/dim]",
-                title="[bold yellow]Already seeded[/bold yellow]",
-                border_style="yellow",
-                padding=(1, 2),
-            ))
+            console.print(
+                Panel(
+                    "[dim]Use [bold]dev seed --new-org <slug>[/bold] to create additional organizations.[/dim]\n[dim]Use [bold]dev seed --reset[/bold] to recreate the database and load fresh seeds.[/dim]",
+                    title="[bold yellow]Already seeded[/bold yellow]",
+                    border_style="yellow",
+                    padding=(1, 2),
+                )
+            )
             console.print()
             return
 

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -1069,7 +1069,9 @@ async def _subscribe_seeded_orgs_to_polar_self(
     return subscribed
 
 
-async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
+async def create_seed_data(
+    session: AsyncSession, redis: Redis, *, skip_tinybird: bool = False
+) -> None:
     """Create sample data for development and testing."""
 
     # Check if seed data already exists
@@ -1924,9 +1926,10 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
                     pending_tinybird_events.extend(inserted)
                     pending_tinybird_ancestors.update(ancestors_by_event)
 
-        await _flush_tinybird_events(
-            pending_tinybird_events, pending_tinybird_ancestors
-        )
+        if not skip_tinybird:
+            await _flush_tinybird_events(
+                pending_tinybird_events, pending_tinybird_ancestors
+            )
 
         # Create real Subscription rows for acme-corp customers so that PG-based
         # metrics (MRR, Trial MRR, Active Subscriptions) have data to display.
@@ -2197,7 +2200,7 @@ def _write_webhook_secret_to_env(secret: str) -> None:
 
 
 async def create_single_org_seed(
-    session: AsyncSession, redis: Redis, slug: str
+    session: AsyncSession, redis: Redis, slug: str, *, skip_tinybird: bool = False
 ) -> None:
     """Create a single organization with products, customers, and timeline events."""
     name = slug.replace("-", " ").title()
@@ -2346,7 +2349,10 @@ async def create_single_org_seed(
                 pending_tinybird_events.extend(inserted)
                 pending_tinybird_ancestors.update(ancestors_by_event)
 
-    await _flush_tinybird_events(pending_tinybird_events, pending_tinybird_ancestors)
+    if not skip_tinybird:
+        await _flush_tinybird_events(
+            pending_tinybird_events, pending_tinybird_ancestors
+        )
 
     await session.commit()
     print(f"✅ Created organization '{name}' ({slug})")
@@ -2363,6 +2369,11 @@ def seeds_load(
         "--new-org",
         help="Create a single new organization with this slug, with products, customers, and timeline events.",
     ),
+    skip_tinybird: bool = typer.Option(
+        False,
+        "--skip-tinybird",
+        help="Skip seeding events to Tinybird.",
+    ),
 ) -> None:
     """Load sample/test data into the database."""
     if ctx.invoked_subcommand is not None:
@@ -2375,9 +2386,11 @@ def seeds_load(
             sessionmaker = create_async_sessionmaker(engine)
             async with sessionmaker() as session:
                 if new_org:
-                    await create_single_org_seed(session, redis, new_org)
+                    await create_single_org_seed(
+                        session, redis, new_org, skip_tinybird=skip_tinybird
+                    )
                 else:
-                    await create_seed_data(session, redis)
+                    await create_seed_data(session, redis, skip_tinybird=skip_tinybird)
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

Adds a `--skip-tinybird` flag to the seed scripts so developers can seed the database without sending events to Tinybird.

## What

- Added `--skip-tinybird` option to the `seeds_load` CLI callback in `server/scripts/seeds_load.py`
- Propagated the flag to `create_seed_data` and `create_single_org_seed` as a keyword-only parameter
- Wired the same flag into `dev/cli/commands/seed.py` for all three invocation paths (default seed, `--new-org`, and `--reset`)

## Why

Tinybird may be unavailable or simply unnecessary in certain local development scenarios (e.g. no API key configured, offline work, or faster iteration). Skipping the ingest step avoids errors and speeds up seeding significantly since each Tinybird flush is an HTTP round-trip.

## How

When `--skip-tinybird` is passed, the `_flush_tinybird_events` call is skipped entirely. All events are still inserted into PostgreSQL as usual; only the Tinybird ingest is bypassed.

Usage:
```bash
# via the dev CLI
dev seed --skip-tinybird
dev seed --new-org my-org --skip-tinybird
dev seed --reset --skip-tinybird

# directly
uv run task seeds_load --skip-tinybird
uv run task seeds_load --new-org my-org --skip-tinybird
```

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--skip-tinybird` flag to seed commands to bypass Tinybird event ingestion during local seeding. This avoids errors when Tinybird isn’t configured and speeds up seeds while keeping PostgreSQL inserts intact.

- **New Features**
  - New `--skip-tinybird` option in `dev seed` and `seeds_load`.
  - Works with default, `--new-org`, and `--reset` flows; flag is passed through CLI and seed functions.
  - Skips `_flush_tinybird_events`; all data still writes to PostgreSQL.

<sup>Written for commit b57b3c4a0a3d934712be6ec6ee467889faf9432e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

