### PR TITLE
Trigger support modal from URL params

### DIFF
--- a/clients/apps/web/src/components/Feedback/FeedbackForm.tsx
+++ b/clients/apps/web/src/components/Feedback/FeedbackForm.tsx
@@ -41,19 +41,21 @@ const MAX_MESSAGE_LENGTH = 5000
 export const FeedbackForm = ({
   organization,
   conversationId,
+  defaultType = 'question',
   onSuccess,
   onAskQuestion,
   onCancel,
 }: {
   organization: schemas['Organization']
   conversationId: string
+  defaultType?: schemas['FeedbackType']
   onSuccess: (type: schemas['FeedbackType']) => void
   onAskQuestion: (message: string) => void
   onCancel: () => void
 }) => {
   const form = useForm<FormSchema>({
     defaultValues: {
-      type: 'question',
+      type: defaultType,
       message: '',
     },
   })

--- a/clients/apps/web/src/components/Feedback/FeedbackModal.tsx
+++ b/clients/apps/web/src/components/Feedback/FeedbackModal.tsx
@@ -16,10 +16,12 @@ export const FeedbackModal = ({
   isShown,
   hide,
   organization,
+  defaultType = 'question',
 }: {
   isShown: boolean
   hide: () => void
   organization: schemas['Organization']
+  defaultType?: schemas['FeedbackType']
 }) => {
   const [submittedType, setSubmittedType] = useState<
     schemas['FeedbackType'] | null
@@ -80,6 +82,7 @@ export const FeedbackModal = ({
       <FeedbackForm
         organization={organization}
         conversationId={conversationId}
+        defaultType={defaultType}
         onSuccess={setSubmittedType}
         onAskQuestion={setPendingQuestion}
         onCancel={handleHide}

--- a/clients/apps/web/src/components/Feedback/SupportButton.tsx
+++ b/clients/apps/web/src/components/Feedback/SupportButton.tsx
@@ -1,10 +1,10 @@
 import SupportIcon from '@mui/icons-material/Support'
 import { schemas } from '@polar-sh/client'
 import { useSidebar } from '@polar-sh/ui/components/atoms/Sidebar'
-import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { FeedbackModal } from './FeedbackModal'
+import { useSupportModal } from './useSupportModal'
 
 export const SupportButton = ({
   organization,
@@ -13,13 +13,13 @@ export const SupportButton = ({
 }) => {
   const { state } = useSidebar()
   const isCollapsed = state === 'collapsed'
-  const [isShown, setIsShown] = useState(false)
+  const { isShown, defaultType, open, hide } = useSupportModal()
 
   return (
     <>
       <button
         type="button"
-        onClick={() => setIsShown(true)}
+        onClick={open}
         className={twMerge(
           'flex cursor-pointer flex-row items-center rounded-lg border border-transparent px-2 text-sm transition-colors dark:border-transparent',
           'dark:text-polar-500 dark:hover:text-polar-200 text-gray-500 hover:text-black',
@@ -30,8 +30,9 @@ export const SupportButton = ({
       </button>
       <FeedbackModal
         isShown={isShown}
-        hide={() => setIsShown(false)}
+        hide={hide}
         organization={organization}
+        defaultType={defaultType}
       />
     </>
   )

--- a/clients/apps/web/src/components/Feedback/useSupportModal.ts
+++ b/clients/apps/web/src/components/Feedback/useSupportModal.ts
@@ -1,0 +1,65 @@
+import { schemas } from '@polar-sh/client'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+const SUPPORT_QUERY_PARAM = 'support'
+
+const FEEDBACK_TYPES: schemas['FeedbackType'][] = [
+  'question',
+  'feedback',
+  'bug',
+]
+
+const parseFeedbackType = (value: string | null): schemas['FeedbackType'] =>
+  FEEDBACK_TYPES.includes(value as schemas['FeedbackType'])
+    ? (value as schemas['FeedbackType'])
+    : 'question'
+
+export interface SupportModalState {
+  isShown: boolean
+  defaultType: schemas['FeedbackType']
+  open: () => void
+  hide: () => void
+}
+
+export const useSupportModal = (): SupportModalState => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const supportParam = searchParams.get(SUPPORT_QUERY_PARAM)
+  const paramPresent = searchParams.has(SUPPORT_QUERY_PARAM)
+
+  const [isShown, setIsShown] = useState(false)
+  const [defaultType, setDefaultType] =
+    useState<schemas['FeedbackType']>('question')
+  const [handledParam, setHandledParam] = useState(false)
+
+  if (paramPresent && !handledParam) {
+    setIsShown(true)
+    setDefaultType(parseFeedbackType(supportParam))
+    setHandledParam(true)
+  } else if (!paramPresent && handledParam) {
+    setHandledParam(false)
+  }
+
+  useEffect(() => {
+    if (!paramPresent) {
+      return
+    }
+
+    const params = new URLSearchParams(searchParams)
+    params.delete(SUPPORT_QUERY_PARAM)
+    const query = params.toString()
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+  }, [paramPresent, searchParams, pathname, router])
+
+  const open = () => {
+    setDefaultType('question')
+    setIsShown(true)
+  }
+
+  const hide = () => setIsShown(false)
+
+  return { isShown, defaultType, open, hide }
+}


### PR DESCRIPTION
This PR will allow us to trigger our support modal from query params, as well as pre-selecting a specific tab. Examples:

* https://polar.sh/dashboard?support=bug
* https://polar.sh/dashboard?support=question
* https://polar.sh/dashboard?support=feedback

We can also append that parameter to any type of URL, for example: https://polar.sh/to/dashboard/products?support=bug

After navigating it will remove the query param. The `collectClientContext` function also works as expected.


<img width="1840" height="1134" alt="Screenshot 2026-06-07 at 17 23 53" src="https://github.com/user-attachments/assets/a46c8627-1471-40c6-823e-076eb2014ad4" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add URL-triggered support modal with optional preselected tab via the `support` query param. The param is removed from the URL after navigation; clicking the button still opens the modal with the default "question" type.

- **New Features**
  - Added `useSupportModal` to read `support` from `next/navigation`, preselect type (`question` | `feedback` | `bug`), open/close the modal, and clean the URL with `router.replace`.
  - Passed `defaultType` through `FeedbackModal` → `FeedbackForm`; `SupportButton` now uses `useSupportModal`.
  - Example: `/dashboard?support=bug`, `/to/dashboard/products?support=question`.

<sup>Written for commit 5e8ede784025acfaf41d02d9c47b53312079001b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

