### PR TITLE
Create fixed seat count checkout links

### DIFF
--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkForm.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkForm.tsx
@@ -31,6 +31,7 @@ import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form'
 import ProductSelect from '../Products/ProductSelect'
 import { toast } from '../Toast/use-toast'
 import { TrialConfigurationForm } from '../TrialConfiguration/TrialConfigurationForm'
+import { CheckoutLinkSeatsField } from './CheckoutLinkSeatsField'
 
 type CheckoutLinkCreateForm = Omit<
   schemas['CheckoutLinkCreateProducts'],
@@ -84,6 +85,7 @@ export const CheckoutLinkForm = ({
         success_url: checkoutLink.success_url ?? '',
         return_url: checkoutLink.return_url ?? '',
         discount_id: checkoutLink.discount_id ?? '',
+        seats: checkoutLink.seats ?? null,
       }
     }
 
@@ -96,6 +98,7 @@ export const CheckoutLinkForm = ({
       success_url: '',
       return_url: '',
       discount_id: '',
+      seats: null,
     }
   }, [checkoutLink, productIds])
 
@@ -428,6 +431,8 @@ export const CheckoutLinkForm = ({
             )
           }}
         />
+
+        <CheckoutLinkSeatsField selectedProducts={selectedProducts} />
 
         {hasRecurringProducts && (
           <TrialConfigurationForm bottomText="This will override the trial configuration set on products." />

--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkSeatsField.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkSeatsField.tsx
@@ -1,0 +1,134 @@
+import { schemas } from '@polar-sh/client'
+import { Input } from '@polar-sh/orbit'
+import Switch from '@polar-sh/ui/components/atoms/Switch'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { useEffect } from 'react'
+import { useFormContext } from 'react-hook-form'
+
+interface SeatConfiguration {
+  configurable: boolean
+  min: number
+  max: number | null
+}
+
+// Seats can only be preconfigured when *every* selected product is seat-based.
+// The allowed range is the intersection of each product's seat tier bounds.
+const computeSeatConfiguration = (
+  selectedProducts?: schemas['Product'][],
+): SeatConfiguration => {
+  if (!selectedProducts || selectedProducts.length === 0) {
+    return { configurable: false, min: 1, max: null }
+  }
+
+  let min = 1
+  let max: number | null = null
+  for (const product of selectedProducts) {
+    const seatPrice = product.prices.find(
+      (price) => price.amount_type === 'seat_based',
+    )
+    if (!seatPrice || !('seat_tiers' in seatPrice) || !seatPrice.seat_tiers) {
+      return { configurable: false, min: 1, max: null }
+    }
+    const tiers = [...(seatPrice.seat_tiers.tiers ?? [])].sort(
+      (a, b) => a.min_seats - b.min_seats,
+    )
+    const tierMin = tiers[0]?.min_seats ?? 1
+    const tierMax = tiers[tiers.length - 1]?.max_seats ?? null
+    min = Math.max(min, tierMin)
+    if (tierMax !== null) {
+      max = max === null ? tierMax : Math.min(max, tierMax)
+    }
+  }
+
+  return { configurable: true, min, max }
+}
+
+export const CheckoutLinkSeatsField = ({
+  selectedProducts,
+}: {
+  selectedProducts?: schemas['Product'][]
+}) => {
+  const { control, setValue } = useFormContext<{ seats: number | null }>()
+
+  const seatConfiguration = computeSeatConfiguration(selectedProducts)
+
+  const seatRangeEmpty =
+    seatConfiguration.configurable &&
+    seatConfiguration.max !== null &&
+    seatConfiguration.min > seatConfiguration.max
+
+  // Drop a stale seat lock once the products are loaded and confirmed not to all
+  // be seat-based (mirrors the backend auto-clear). Gated on loaded products so we
+  // don't clobber an existing lock before the products query resolves.
+  useEffect(() => {
+    if (
+      selectedProducts &&
+      selectedProducts.length > 0 &&
+      !seatConfiguration.configurable
+    ) {
+      setValue('seats', null)
+    }
+  }, [selectedProducts, seatConfiguration.configurable, setValue])
+
+  if (!seatConfiguration.configurable) {
+    return null
+  }
+
+  return (
+    <FormField
+      control={control}
+      name="seats"
+      rules={{
+        validate: (value) => {
+          if (value === null || value === undefined) return true
+          if (seatRangeEmpty)
+            return 'The selected products have incompatible seat ranges.'
+          if (value < seatConfiguration.min)
+            return `Must be at least ${seatConfiguration.min}.`
+          if (seatConfiguration.max !== null && value > seatConfiguration.max)
+            return `Must be at most ${seatConfiguration.max}.`
+          return true
+        },
+      }}
+      render={({ field }) => {
+        const seatsLocked = field.value !== null && field.value !== undefined
+        return (
+          <FormItem>
+            <div className="flex flex-row items-center justify-between space-y-0 space-x-2">
+              <FormLabel htmlFor="seats-lock">Lock number of seats</FormLabel>
+              <FormControl>
+                <Switch
+                  id="seats-lock"
+                  checked={seatsLocked}
+                  disabled={seatRangeEmpty}
+                  onCheckedChange={(enabled) =>
+                    field.onChange(enabled ? seatConfiguration.min : null)
+                  }
+                />
+              </FormControl>
+            </div>
+            {seatsLocked && (
+              <Input
+                type="number"
+                min={seatConfiguration.min}
+                max={seatConfiguration.max ?? undefined}
+                value={field.value ?? ''}
+                onChange={(e) => {
+                  const value = e.target.value
+                  field.onChange(value === '' ? null : Number(value))
+                }}
+              />
+            )}
+            <FormMessage />
+          </FormItem>
+        )
+      }}
+    />
+  )
+}

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -11147,6 +11147,11 @@ export interface components {
        */
       discount_id: string | null
       /**
+       * Seats
+       * @description Preconfigured number of seats for seat-based pricing. When set, checkout sessions created from this link are locked to this number of seats and the customer won't be able to change it. All products on the link must use seat-based pricing and allow this number of seats. If the products no longer accommodate this value when the link is opened, it'll be ignored.
+       */
+      seats: number | null
+      /**
        * Organization Id
        * Format: uuid4
        * @description The organization ID.
@@ -11231,6 +11236,11 @@ export interface components {
        */
       discount_id?: string | null
       /**
+       * Seats
+       * @description Preconfigured number of seats for seat-based pricing. When set, checkout sessions created from this link are locked to this number of seats and the customer won't be able to change it. All products on the link must use seat-based pricing and allow this number of seats. If the products no longer accommodate this value when the link is opened, it'll be ignored.
+       */
+      seats?: number | null
+      /**
        * Success Url
        * @description URL where the customer will be redirected after a successful payment.You can add the `checkout_id={CHECKOUT_ID}` query parameter to retrieve the checkout session id.
        */
@@ -11306,6 +11316,11 @@ export interface components {
        */
       discount_id?: string | null
       /**
+       * Seats
+       * @description Preconfigured number of seats for seat-based pricing. When set, checkout sessions created from this link are locked to this number of seats and the customer won't be able to change it. All products on the link must use seat-based pricing and allow this number of seats. If the products no longer accommodate this value when the link is opened, it'll be ignored.
+       */
+      seats?: number | null
+      /**
        * Success Url
        * @description URL where the customer will be redirected after a successful payment.You can add the `checkout_id={CHECKOUT_ID}` query parameter to retrieve the checkout session id.
        */
@@ -11378,6 +11393,11 @@ export interface components {
        * @description ID of the discount to apply to the checkout. If the discount is not applicable anymore when opening the checkout link, it'll be ignored.
        */
       discount_id?: string | null
+      /**
+       * Seats
+       * @description Preconfigured number of seats for seat-based pricing. When set, checkout sessions created from this link are locked to this number of seats and the customer won't be able to change it. All products on the link must use seat-based pricing and allow this number of seats. If the products no longer accommodate this value when the link is opened, it'll be ignored.
+       */
+      seats?: number | null
       /**
        * Success Url
        * @description URL where the customer will be redirected after a successful payment.You can add the `checkout_id={CHECKOUT_ID}` query parameter to retrieve the checkout session id.
@@ -11544,6 +11564,11 @@ export interface components {
        * @description ID of the discount to apply to the checkout. If the discount is not applicable anymore when opening the checkout link, it'll be ignored.
        */
       discount_id?: string | null
+      /**
+       * Seats
+       * @description Preconfigured number of seats for seat-based pricing. When set, checkout sessions created from this link are locked to this number of seats and the customer won't be able to change it. All products on the link must use seat-based pricing and allow this number of seats. If the products no longer accommodate this value when the link is opened, it'll be ignored.
+       */
+      seats?: number | null
       /**
        * Success Url
        * @description URL where the customer will be redirected after a successful payment.You can add the `checkout_id={CHECKOUT_ID}` query parameter to retrieve the checkout session id.

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -707,8 +707,23 @@ class CheckoutService:
 
         seat_price = currency_prices.get_seat_price()
         seats = None
+        min_seats: int | None = None
+        max_seats: int | None = None
         if seat_price is not None:
             seats = seat_price.get_minimum_seats()
+            # Honor a seat lock preconfigured on the checkout link, but only if it
+            # still fits the product's current seat tiers. On drift (tiers changed
+            # since the link was created, or a different product was selected), fall
+            # back to the tier minimum so the customer is never blocked.
+            if checkout_link.seats is not None:
+                tier_minimum = seat_price.get_minimum_seats()
+                tier_maximum = seat_price.get_maximum_seats()
+                if checkout_link.seats >= tier_minimum and (
+                    tier_maximum is None or checkout_link.seats <= tier_maximum
+                ):
+                    seats = checkout_link.seats
+                    min_seats = checkout_link.seats
+                    max_seats = checkout_link.seats
 
         custom_price = currency_prices.get_custom_price()
         custom_amount: int | None = None
@@ -754,6 +769,8 @@ class CheckoutService:
             amount=amount,
             currency=currency,
             seats=seats,
+            min_seats=min_seats,
+            max_seats=max_seats,
             trial_interval=checkout_link.trial_interval,
             trial_interval_count=checkout_link.trial_interval_count,
             allow_discount_codes=checkout_link.allow_discount_codes,

--- a/server/polar/checkout_link/schemas.py
+++ b/server/polar/checkout_link/schemas.py
@@ -66,6 +66,14 @@ _discount_id_description = (
     "If the discount is not applicable anymore when opening the checkout link, "
     "it'll be ignored."
 )
+_seats_description = (
+    "Preconfigured number of seats for seat-based pricing. "
+    "When set, checkout sessions created from this link are locked to this number "
+    "of seats and the customer won't be able to change it. "
+    "All products on the link must use seat-based pricing and allow this number of "
+    "seats. If the products no longer accommodate this value when the link is "
+    "opened, it'll be ignored."
+)
 
 
 class CheckoutLinkCreateBase(TrialConfigurationInputMixin, MetadataInputMixin, Schema):
@@ -83,6 +91,9 @@ class CheckoutLinkCreateBase(TrialConfigurationInputMixin, MetadataInputMixin, S
     )
     discount_id: UUID4 | None = Field(
         default=None, description=_discount_id_description
+    )
+    seats: int | None = Field(
+        default=None, ge=1, le=1000, description=_seats_description
     )
     success_url: SuccessURL = None
     return_url: ReturnURL = None
@@ -143,6 +154,9 @@ class CheckoutLinkUpdate(MetadataInputMixin, TrialConfigurationInputMixin):
     discount_id: UUID4 | None = Field(
         default=None, description=_discount_id_description
     )
+    seats: int | None = Field(
+        default=None, ge=1, le=1000, description=_seats_description
+    )
     success_url: SuccessURL = None
     return_url: ReturnURL = None
 
@@ -173,6 +187,7 @@ class CheckoutLinkBase(
         description=_require_billing_address_description
     )
     discount_id: UUID4 | None = Field(description=_discount_id_description)
+    seats: int | None = Field(description=_seats_description)
     organization_id: OrganizationID
 
     @computed_field  # type: ignore[prop-decorator]

--- a/server/polar/checkout_link/service.py
+++ b/server/polar/checkout_link/service.py
@@ -30,6 +30,7 @@ from polar.models import (
     User,
 )
 from polar.postgres import AsyncSession
+from polar.product.guard import SeatPrice, is_seat_price
 from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.service import product as product_service
 
@@ -155,6 +156,9 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
                 session, checkout_link_create.discount_id, organization, products
             )
 
+        if checkout_link_create.seats is not None:
+            self._validate_seats_for_products(checkout_link_create.seats, products)
+
         checkout_link = CheckoutLink(
             client_secret=generate_token(prefix=CHECKOUT_LINK_CLIENT_SECRET_PREFIX),
             organization=organization,
@@ -228,12 +232,30 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
                 )
                 checkout_link.discount = discount
 
+        # An explicit `seats` value is strict-validated against the (possibly
+        # updated) product set. A products-only change that leaves the existing lock
+        # invalid auto-clears it, mirroring how trial config is dropped above.
+        if "seats" in checkout_link_update.model_fields_set:
+            if checkout_link_update.seats is not None:
+                self._validate_seats_for_products(
+                    checkout_link_update.seats, checkout_link.products
+                )
+            checkout_link.seats = checkout_link_update.seats
+        elif (
+            checkout_link_update.products is not None
+            and checkout_link.seats is not None
+            and not self._seats_valid_for_products(
+                checkout_link.seats, checkout_link.products
+            )
+        ):
+            checkout_link.seats = None
+
         repository = CheckoutLinkRepository.from_session(session)
         return await repository.update(
             checkout_link,
             update_dict=checkout_link_update.model_dump(
                 exclude_unset=True,
-                exclude={"products", "discount_id"},
+                exclude={"products", "discount_id", "seats"},
                 by_alias=True,
             ),
         )
@@ -414,6 +436,73 @@ class CheckoutLinkService(ResourceServiceReader[CheckoutLink]):
             )
 
         return discount
+
+    def _get_seat_price(self, product: Product) -> SeatPrice | None:
+        for price in product.prices:
+            if is_seat_price(price):
+                return price
+        return None
+
+    def _seats_valid_for_products(
+        self, seats: int, products: Sequence[Product]
+    ) -> bool:
+        """Whether `seats` fits the seat tiers of *every* product on the link.
+
+        Seat-count bounds are currency-independent, so no currency is needed.
+        """
+        for product in products:
+            seat_price = self._get_seat_price(product)
+            if seat_price is None:
+                return False
+            minimum_seats = seat_price.get_minimum_seats()
+            maximum_seats = seat_price.get_maximum_seats()
+            if seats < minimum_seats or (
+                maximum_seats is not None and seats > maximum_seats
+            ):
+                return False
+        return True
+
+    def _validate_seats_for_products(
+        self, seats: int, products: Sequence[Product]
+    ) -> None:
+        """Strict-validate a seat lock against every product, raising on mismatch."""
+        for product in products:
+            seat_price = self._get_seat_price(product)
+            if seat_price is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "seats"),
+                            "msg": (
+                                "Seats can only be preconfigured when all products "
+                                "use seat-based pricing."
+                            ),
+                            "input": seats,
+                        }
+                    ]
+                )
+            minimum_seats = seat_price.get_minimum_seats()
+            maximum_seats = seat_price.get_maximum_seats()
+            if seats < minimum_seats or (
+                maximum_seats is not None and seats > maximum_seats
+            ):
+                maximum_label = (
+                    str(maximum_seats) if maximum_seats is not None else "unlimited"
+                )
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "seats"),
+                            "msg": (
+                                f"Product '{product.name}' allows between "
+                                f"{minimum_seats} and {maximum_label} seats."
+                            ),
+                            "input": seats,
+                        }
+                    ]
+                )
 
 
 checkout_link = CheckoutLinkService(CheckoutLink)

--- a/server/polar/models/checkout_link.py
+++ b/server/polar/models/checkout_link.py
@@ -40,6 +40,8 @@ class CheckoutLink(TrialConfigurationMixin, MetadataMixin, RecordModel):
         Boolean, nullable=False, default=False
     )
 
+    # Preconfigured seat count for seat-based pricing. When set, checkout sessions
+    # created from this link are locked to this number of seats (min == max == seats).
     seats: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
 
     discount_id: Mapped[UUID | None] = mapped_column(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2429,6 +2429,46 @@ class TestCheckoutLinkCreate:
         assert checkout.seats == price.get_minimum_seats()
         assert checkout.amount == price.calculate_amount(price.get_minimum_seats())
 
+    async def test_valid_seat_lock(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based_with_min_max: Product,
+    ) -> None:
+        price = product_seat_based_with_min_max.prices[0]
+        assert isinstance(price, ProductPriceSeatUnit)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based_with_min_max], seats=5
+        )
+
+        checkout = await checkout_service.checkout_link_create(session, checkout_link)
+
+        assert checkout.seats == 5
+        assert checkout.min_seats == 5
+        assert checkout.max_seats == 5
+        assert checkout.amount == price.calculate_amount(5)
+
+    async def test_seat_lock_drift_falls_back_to_minimum(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based_with_min: Product,
+    ) -> None:
+        # Link locked to a seat count the product's tiers no longer accommodate
+        # (e.g. the tiers changed after the link was created): fall back to the
+        # tier minimum, unlocked, rather than blocking the customer.
+        price = product_seat_based_with_min.prices[0]
+        assert isinstance(price, ProductPriceSeatUnit)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based_with_min], seats=2
+        )
+
+        checkout = await checkout_service.checkout_link_create(session, checkout_link)
+
+        assert checkout.seats == price.get_minimum_seats()
+        assert checkout.min_seats is None
+        assert checkout.max_seats is None
+
     async def test_valid_with_discount(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -127,6 +127,43 @@ class TestCreateCheckoutLink:
         assert json["client_secret"] in json["url"]
         assert "metadata" in json
 
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkout_links_write}))
+    async def test_valid_seats(
+        self,
+        client: AsyncClient,
+        product_recurring_seat_based: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/checkout-links/",
+            json={
+                "payment_processor": "stripe",
+                "products": [str(product_recurring_seat_based.id)],
+                "seats": 5,
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["seats"] == 5
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkout_links_write}))
+    async def test_seats_on_non_seat_based_product(
+        self,
+        client: AsyncClient,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/checkout-links/",
+            json={
+                "payment_processor": "stripe",
+                "products": [str(product.id)],
+                "seats": 5,
+            },
+        )
+
+        assert response.status_code == 422
+
 
 @pytest.mark.asyncio
 class TestUpdateCheckoutLink:

--- a/server/tests/checkout_link/test_service.py
+++ b/server/tests/checkout_link/test_service.py
@@ -10,7 +10,7 @@ from polar.checkout_link.schemas import (
     CheckoutLinkUpdate,
 )
 from polar.checkout_link.service import checkout_link as checkout_link_service
-from polar.enums import PaymentProcessor
+from polar.enums import PaymentProcessor, SubscriptionRecurringInterval
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.pagination import PaginationParams
 from polar.models import Discount, Organization, Product, User, UserOrganization
@@ -21,7 +21,49 @@ from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_checkout_link,
+    create_product,
+    create_product_price_seat_unit,
 )
+
+
+@pytest_asyncio.fixture
+async def product_seat_based(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    """Seat-based product allowing 1+ seats (no maximum)."""
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=SubscriptionRecurringInterval.month,
+        prices=[],
+    )
+    price = await create_product_price_seat_unit(
+        save_fixture, product=product, price_per_seat=1000
+    )
+    product.prices = [price]
+    return product
+
+
+@pytest_asyncio.fixture
+async def product_seat_based_2_to_20(
+    save_fixture: SaveFixture, organization: Organization
+) -> Product:
+    """Seat-based product requiring between 2 and 20 seats."""
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=SubscriptionRecurringInterval.month,
+        prices=[],
+    )
+    price = await create_product_price_seat_unit(
+        save_fixture,
+        product=product,
+        price_per_seat=1000,
+        minimum_seats=2,
+        maximum_seats=20,
+    )
+    product.prices = [price]
+    return product
 
 
 @pytest_asyncio.fixture
@@ -204,6 +246,106 @@ class TestCreate:
 
 
 @pytest.mark.asyncio
+class TestCreateSeats:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        checkout_link = await checkout_link_service.create(
+            session,
+            CheckoutLinkCreateProducts(
+                payment_processor=PaymentProcessor.stripe,
+                products=[product_seat_based_2_to_20.id],
+                seats=5,
+            ),
+            auth_subject,
+        )
+
+        assert checkout_link.seats == 5
+
+    @pytest.mark.auth
+    async def test_non_seat_based_product(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_one_time: Product,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await checkout_link_service.create(
+                session,
+                CheckoutLinkCreateProducts(
+                    payment_processor=PaymentProcessor.stripe,
+                    products=[product_one_time.id],
+                    seats=5,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_mixed_seat_and_non_seat_products(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+        product_one_time: Product,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await checkout_link_service.create(
+                session,
+                CheckoutLinkCreateProducts(
+                    payment_processor=PaymentProcessor.stripe,
+                    products=[product_seat_based_2_to_20.id, product_one_time.id],
+                    seats=5,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_seats_below_minimum(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await checkout_link_service.create(
+                session,
+                CheckoutLinkCreateProducts(
+                    payment_processor=PaymentProcessor.stripe,
+                    products=[product_seat_based_2_to_20.id],
+                    seats=1,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_seats_above_maximum(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await checkout_link_service.create(
+                session,
+                CheckoutLinkCreateProducts(
+                    payment_processor=PaymentProcessor.stripe,
+                    products=[product_seat_based_2_to_20.id],
+                    seats=21,
+                ),
+                auth_subject,
+            )
+
+
+@pytest.mark.asyncio
 class TestUpdate:
     @pytest.mark.auth
     async def test_metadata(
@@ -343,6 +485,119 @@ class TestUpdate:
 
         assert updated.trial_interval is None
         assert updated.trial_interval_count is None
+
+    @pytest.mark.auth
+    async def test_seats_valid(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based_2_to_20]
+        )
+
+        updated = await checkout_link_service.update(
+            session,
+            checkout_link,
+            CheckoutLinkUpdate(seats=10),
+            auth_subject,
+        )
+
+        assert updated.seats == 10
+
+    @pytest.mark.auth
+    async def test_seats_invalid(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based_2_to_20]
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            await checkout_link_service.update(
+                session,
+                checkout_link,
+                CheckoutLinkUpdate(seats=21),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_seats_explicit_clear(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based_2_to_20], seats=5
+        )
+
+        updated = await checkout_link_service.update(
+            session,
+            checkout_link,
+            CheckoutLinkUpdate(seats=None),
+            auth_subject,
+        )
+
+        assert updated.seats is None
+
+    @pytest.mark.auth
+    async def test_products_change_auto_clears_incompatible_seats(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based_2_to_20: Product,
+        product_one_time: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based_2_to_20], seats=5
+        )
+
+        updated = await checkout_link_service.update(
+            session,
+            checkout_link,
+            CheckoutLinkUpdate(products=[product_one_time.id]),
+            auth_subject,
+        )
+        await session.flush()
+
+        assert updated.seats is None
+
+    @pytest.mark.auth
+    async def test_products_change_keeps_compatible_seats(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        product_seat_based: Product,
+        product_seat_based_2_to_20: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_seat_based], seats=5
+        )
+
+        updated = await checkout_link_service.update(
+            session,
+            checkout_link,
+            CheckoutLinkUpdate(products=[product_seat_based_2_to_20.id]),
+            auth_subject,
+        )
+        await session.flush()
+
+        assert updated.seats == 5
 
 
 @pytest.mark.asyncio

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1612,6 +1612,7 @@ async def create_checkout_link(
     success_url: str | None = None,
     trial_interval: TrialInterval | None = None,
     trial_interval_count: int | None = None,
+    seats: int | None = None,
     user_metadata: dict[str, Any] = {},
 ) -> CheckoutLink:
     checkout_link = CheckoutLink(
@@ -1628,6 +1629,7 @@ async def create_checkout_link(
         discount=discount,
         trial_interval=trial_interval,
         trial_interval_count=trial_interval_count,
+        seats=seats,
         user_metadata=user_metadata,
     )
     await save_fixture(checkout_link)


### PR DESCRIPTION
Add support to pre-configure # of seats on a checkout link. The use case is to send a customer-specific checkout link for a pre-agreed upon number of seats. 

I decided to implement `seats` only and make it a fixed / locked number of seats. It's forwards-compatible with eventually adding min seats & max seats if we eventually want to do that, but I don't really see the need for it right now.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fixed seat count support to checkout links so you can send customer-specific links with a locked number of seats. The lock applies only when all products are seat-based and the count fits each product’s tiers; if tiers drift by the time the link is opened, the lock is ignored and checkout falls back to the tier minimum.

- **New Features**
  - API: optional `seats` on checkout links (create/update/read) with strict validation across all products; product-only changes that invalidate a lock auto-clear it.
  - Checkout: when valid, sessions set seats with min=max=seats; on tier drift, fall back to the tier minimum and keep unlocked.
  - Web: “Lock number of seats” toggle and input shown only when all selected products are seat-based; validates against intersected tier bounds and auto-clears when incompatible or when products aren’t all seat-based.
  - SDK: update `@polar-sh/client` types to include `seats`.

- **Migration**
  - Adds nullable `seats` column to `checkout_links`. Run DB migrations.

<sup>Written for commit 88fdc96b61ad06b3419fe3a83b7fdc39b53cf812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

