### PR TITLE
Allow 0 for fixed price products and treat them as a free price

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27123,7 +27123,7 @@ export interface components {
       tax_behavior?: components['schemas']['TaxBehaviorOption'] | null
       /**
        * Price Amount
-       * @description The price in cents.
+       * @description The price in cents. Set to `0` for a free price.
        *     Minimum amounts per currency:
        *     - USD: 0.5
        *     - AED: 2

--- a/server/polar/backoffice/products/endpoints.py
+++ b/server/polar/backoffice/products/endpoints.py
@@ -14,7 +14,6 @@ from polar.product import sorting
 from polar.product.guard import (
     is_custom_price,
     is_fixed_price,
-    is_free_price,
     is_metered_price,
     is_seat_price,
 )
@@ -30,7 +29,7 @@ router = APIRouter()
 
 def _format_price_display(price: ProductPrice) -> str:
     """Format a price for display based on its amount type."""
-    if is_free_price(price):
+    if price.is_free and not is_seat_price(price):
         return "Free"
     elif is_custom_price(price):
         parts = []

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -33,7 +33,6 @@ from polar.kit.trial import TrialConfigurationMixin, TrialInterval
 from polar.kit.utils import utc_now
 from polar.product.guard import (
     is_discount_applicable,
-    is_free_price,
     is_metered_price,
 )
 from polar.tax.calculation import TaxBreakdownItem
@@ -322,7 +321,7 @@ class Checkout(
     def is_free_product_price(self) -> bool:
         if self.product_prices is None:
             return False
-        return all(is_free_price(price) for price in self.product_prices)
+        return all(price.is_free for price in self.product_prices)
 
     @property
     def has_metered_prices(self) -> bool:

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -241,6 +241,10 @@ class _ProductPriceFixed(ProductPrice):
         use_existing_column=True, default=ProductPriceAmountType.fixed
     )
 
+    @property
+    def is_free(self) -> bool:
+        return self.price_amount == 0
+
     __mapper_args__ = {
         "polymorphic_abstract": True,
         "polymorphic_load": "inline",

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -161,7 +161,16 @@ class ProductPriceFixedCreate(ProductPriceCreateBase):
     """
 
     amount_type: Literal[ProductPriceAmountType.fixed]
-    price_amount: PriceAmount
+    price_amount: Annotated[
+        PriceAmount,
+        Field(
+            ge=0,
+            description=(
+                "The price in cents. Set to `0` for a free price.\n"
+                f"Minimum amounts per currency:\n{MINIMUM_PRICE_PER_CURRENCY_DOCSTRING}"
+            ),
+        ),
+    ]
 
     @field_validator("price_amount")
     @classmethod
@@ -171,7 +180,7 @@ class ProductPriceFixedCreate(ProductPriceCreateBase):
             # price_currency failed its own validation; skip currency-specific check
             # (Pydantic will already report the currency error)
             return v
-        return validate_price_amount(currency, v)
+        return validate_price_amount(currency, v, allow_zero=True)
 
     def get_model_class(self) -> builtins.type[ProductPriceFixedModel]:
         return ProductPriceFixedModel

--- a/server/tests/models/test_checkout.py
+++ b/server/tests/models/test_checkout.py
@@ -6,11 +6,11 @@ import pytest
 from polar.config import settings
 from polar.kit.address import Address, CountryAlpha2
 from polar.kit.trial import TrialInterval
-from polar.models import Checkout, Product
+from polar.models import Checkout, Organization, Product
 from polar.models.checkout import BillingAddressFieldMode, CheckoutStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_checkout
+from tests.fixtures.random_objects import create_checkout, create_product
 
 
 @pytest.mark.asyncio
@@ -119,6 +119,25 @@ async def test_success_url(
 
     expected = expected_factory(checkout)
     assert checkout.success_url == expected
+
+
+@pytest.mark.asyncio
+async def test_is_free_product_price_for_zero_fixed_price(
+    save_fixture: SaveFixture,
+    organization: Organization,
+) -> None:
+    """A fixed price of 0 must be treated as a free product price, so checkout skips
+    the payment form just like a free-typed price."""
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=None,
+        prices=[(0, "usd")],
+    )
+    checkout = await create_checkout(save_fixture, products=[product])
+
+    assert checkout.is_free_product_price is True
+    assert checkout.is_payment_form_required is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -4,7 +4,11 @@ from typing import Any
 import pytest
 
 from polar.models import Meter, Product
-from polar.models.product_price import ProductPriceSeatUnit, SeatTierType
+from polar.models.product_price import (
+    ProductPriceFixed,
+    ProductPriceSeatUnit,
+    SeatTierType,
+)
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_product_price_metered_unit
 
@@ -78,6 +82,19 @@ async def test_get_amount_and_label(
     amount, label = price.get_amount_and_label(units)
     assert amount == expected_amount
     assert label == expected_label
+
+
+class TestFixedPriceIsFree:
+    """A fixed price with an amount of 0 is the free-pricing representation and must
+    behave like a free price (`is_free` is True)."""
+
+    def test_zero_amount_is_free(self) -> None:
+        price = ProductPriceFixed(price_amount=0, price_currency="usd")
+        assert price.is_free is True
+
+    def test_positive_amount_is_not_free(self) -> None:
+        price = ProductPriceFixed(price_amount=1000, price_currency="usd")
+        assert price.is_free is False
 
 
 def _make_seat_price(

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -250,6 +250,26 @@ class TestProductPriceFixedCurrencyMinimums:
         )
         assert price.price_amount == amount
 
+    @pytest.mark.parametrize(
+        "currency",
+        [
+            PresentmentCurrency.usd,
+            PresentmentCurrency.inr,
+            PresentmentCurrency.gbp,
+        ],
+    )
+    def test_zero_amount_is_accepted_as_free(
+        self, currency: PresentmentCurrency
+    ) -> None:
+        """A fixed price of 0 is the free-pricing representation and must be allowed,
+        even though it is below the currency minimum."""
+        price = ProductPriceFixedCreate(
+            amount_type=ProductPriceAmountType.fixed,
+            price_amount=0,
+            price_currency=currency,
+        )
+        assert price.price_amount == 0
+
     def test_error_loc_includes_price_amount(self) -> None:
         """Ensure the error loc targets price_amount so frontend can show inline error."""
         with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
**Related issue**: https://github.com/polarsource/polar/issues/12205

## Migration plan

1. Make a `fixed` price of `0` behave identically to a `free` price everywhere    <-- _this step_
2. Stop producing `free`: Change the frontend “Free” option and the API to create `fixed`-`0` prices instead of `free` ones (while still _accepting_ `free` for back-compat), freezing the `free` population so no new rows are added.
3. Backfill: Convert all existing `free` (and `legacy_free`) rows to `fixed` with `price_amount = 0`.
4. Remove `ProductPriceFree` & `LegacyRecurringProductPriceFree`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a fixed price of 0 as a free price across the app, so zero-amount fixed prices behave like the old free type. This is the first step toward removing the dedicated free price type.

- **New Features**
  - `ProductPriceFixed.is_free` returns true when `price_amount == 0`.
  - Checkout `is_free_product_price` now checks `price.is_free`, so zero fixed prices skip the payment form.
  - Backoffice displays a zero fixed price as “Free” (excluding seat prices).
  - `ProductPriceFixedCreate` accepts `price_amount: 0` and documents zero as the free option.
  - Regenerated client to describe fixed `price_amount` as “Set to `0` for a free price”.

- **Migration**
  - Create free prices by setting fixed `price_amount` to `0`; no other changes needed.

<sup>Written for commit 6fb400867a157b1c876f14943adf4cc151526f61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



