### PR TITLE
Pull migrations from #12223

### DIFF
--- a/server/migrations/versions/2026-06-05-2127_add_checkoutlink_seats.py
+++ b/server/migrations/versions/2026-06-05-2127_add_checkoutlink_seats.py
@@ -1,0 +1,30 @@
+"""Add CheckoutLink.seats
+
+Revision ID: 31bc85d4a4c4
+Revises: 325c6505b262
+Create Date: 2026-06-05 21:27:53.233163
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "31bc85d4a4c4"
+down_revision = "325c6505b262"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column("checkout_links", sa.Column("seats", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_column("checkout_links", "seats")

--- a/server/polar/models/checkout_link.py
+++ b/server/polar/models/checkout_link.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import Boolean, ForeignKey, String, Uuid
+from sqlalchemy import Boolean, ForeignKey, Integer, String, Uuid
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
@@ -39,6 +39,8 @@ class CheckoutLink(TrialConfigurationMixin, MetadataMixin, RecordModel):
     require_billing_address: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
+
+    seats: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
 
     discount_id: Mapped[UUID | None] = mapped_column(
         Uuid, ForeignKey("discounts.id", ondelete="set null"), nullable=True


### PR DESCRIPTION
Migrations for #12223

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `seats` field to `CheckoutLink` and the database to let checkout links set a seat count.

- **Migration**
  - Adds a nullable Integer `seats` column to `checkout_links` (defaults to null).
  - Sets `lock_timeout` to 5s in upgrade/downgrade to reduce lock contention.

<sup>Written for commit 029f1ec7760d4c7f4123f682592bbdf65ade7526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

