### PR TITLE
tf: Add AWS user and policies for test env

### DIFF
--- a/terraform/modules/application_access/main.tf
+++ b/terraform/modules/application_access/main.tf
@@ -16,6 +16,10 @@ variable "username" {
 
 resource "aws_iam_user" "this" {
   name = var.username
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 variable "buckets" {

--- a/terraform/modules/application_access/main.tf
+++ b/terraform/modules/application_access/main.tf
@@ -14,6 +14,10 @@ variable "username" {
   type        = string
 }
 
+resource "aws_iam_user" "this" {
+  name = var.username
+}
+
 variable "buckets" {
   description = "Bucket names and policy descriptions"
   type = object({
@@ -146,31 +150,31 @@ resource "aws_iam_policy" "logs" {
 }
 
 resource "aws_iam_user_policy_attachment" "customer_invoices" {
-  user       = var.username
+  user       = aws_iam_user.this.name
   policy_arn = aws_iam_policy.customer_invoices.arn
 }
 
 resource "aws_iam_user_policy_attachment" "customer_receipts" {
-  user       = var.username
+  user       = aws_iam_user.this.name
   policy_arn = aws_iam_policy.customer_receipts.arn
 }
 
 resource "aws_iam_user_policy_attachment" "payout_invoices" {
-  user       = var.username
+  user       = aws_iam_user.this.name
   policy_arn = aws_iam_policy.payout_invoices.arn
 }
 
 resource "aws_iam_user_policy_attachment" "files" {
-  user       = var.username
+  user       = aws_iam_user.this.name
   policy_arn = aws_iam_policy.files.arn
 }
 
 resource "aws_iam_user_policy_attachment" "public_files" {
-  user       = var.username
+  user       = aws_iam_user.this.name
   policy_arn = aws_iam_policy.public_files.arn
 }
 
 resource "aws_iam_user_policy_attachment" "logs" {
-  user       = var.username
+  user       = aws_iam_user.this.name
   policy_arn = aws_iam_policy.logs.arn
 }

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -398,6 +398,12 @@ module "application_access_production" {
   }
 }
 
+# Adopt the IAM user that already exists in AWS (console-created).
+import {
+  to = module.application_access_production.aws_iam_user.this
+  id = "polar-production-files"
+}
+
 # =============================================================================
 # Athena for Span Logs
 # =============================================================================

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -15,6 +15,12 @@ module "application_access_sandbox" {
   }
 }
 
+# Adopt the IAM user that already exists in AWS (console-created).
+import {
+  to = module.application_access_sandbox.aws_iam_user.this
+  id = "polar-sandbox-files"
+}
+
 # =============================================================================
 # Image Resizer Lambda@Edge
 # =============================================================================

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -1,0 +1,17 @@
+# =============================================================================
+# Application Access (IAM user policies)
+# =============================================================================
+
+module "application_access_test" {
+  count    = local.test_enabled ? 1 : 0
+  source   = "../modules/application_access"
+  username = "polar-test-files"
+  buckets = {
+    customer_invoices = { name = "polar-test-customer-invoices" }
+    customer_receipts = { name = "polar-test-customer-receipts" }
+    payout_invoices   = { name = "polar-test-payout-invoices" }
+    files             = { name = "polar-test-files", description = "Policy used by our TEST app for downloadable benefits. Keep permissions to a bare minimum." }
+    public_files      = { name = "polar-test-public-files", description = "Policy used by our TEST app for public uploads -products medias and such-. Keep permissions to a bare minimum." }
+    logs              = { name = "polar-test-logs", description = "Policy used by our TEST app to write OpenTelemetry spans to S3 for long-term backup." }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an IAM user and S3 access policies for the test environment. Also update the module to manage the IAM user directly and adopt existing prod/sandbox users to remove drift.

- **New Features**
  - Create `aws_iam_user.this` in the `application_access` module, attach all policies to it, and ignore tag changes to avoid drift.
  - Add test env module `application_access_test` (gated by `local.test_enabled`) to create user `polar-test-files` and S3 policies for customer invoices, receipts, payout invoices, files, public files, and logs.
  - Add import blocks in production and sandbox to adopt console-created users `polar-production-files` and `polar-sandbox-files` instead of recreating them.

<sup>Written for commit dd268e8ec79a68a2d26ff613534a9450f7147a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

