### PR TITLE
Bump customer cache key version

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -879,7 +879,7 @@ class CustomerService:
     ) -> CustomerState:
         # 👋 Whenever you change the state schema,
         # please also update the cache key with a version number.
-        cache_key = f"polar:customer_state:v4:{customer.id}"
+        cache_key = f"polar:customer_state:v5:{customer.id}"
 
         if cache:
             raw_state = await redis.get(cache_key)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the customer state cache key to v5 to invalidate old entries after schema changes. This ensures stale customer state is not served and the cache repopulates on next access.

<sup>Written for commit b053de9b219c65a6b933291ce3037658e870d54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

