### PR TITLE
server/subscription: fix lazy loading when applying subscription update

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -780,6 +780,8 @@ class SubscriptionService:
                     pending_update.discount = await discount_repository.get_by_id(
                         pending_update.discount_id
                     )
+                else:
+                    pending_update.discount = None
                 # Check before apply_update() changes subscription.product
                 pending_update_changed_interval = pending_update.is_interval_changed()
                 pending_update.apply_update()
@@ -1919,6 +1921,8 @@ class SubscriptionService:
                 pending_update.discount = await discount_repository.get_by_id(
                     pending_update.discount_id
                 )
+            else:
+                pending_update.discount = None
             pending_update.apply_update()
 
         # If subscription is set to cancel at period end, there's no base charge


### PR DESCRIPTION
Fix #12243

- server/subscription: fix lazy loading when applying subscription update


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes discount lazy-loading when applying subscription updates and calculating charge previews. If no discount_id is present, we now clear the discount to avoid stale data and errors, aligning with Linear POL-12243.

<sup>Written for commit 4225437b2bed44d7cad2cb16611cea380df4d35f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

