### PR TITLE
tf/test: Allow regional s3 endpoint

### DIFF
--- a/terraform/test/vercel.tf
+++ b/terraform/test/vercel.tf
@@ -36,7 +36,7 @@ module "vercel" {
     s3_public_images_bucket_hostname                = "polar-public-files.s3.amazonaws.com"
     s3_public_images_bucket_port                    = null
     s3_public_images_bucket_pathname                = "/product_media/**"
-    s3_upload_origins                               = "https://polar-test-files.s3.amazonaws.com https://polar-public-files.s3.amazonaws.com"
+    s3_upload_origins                               = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-public-files.s3.amazonaws.com https://polar-public-files.s3.us-east-2.amazonaws.com"
     polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
     polar_openapi_schema_url                        = "https://api.polar.sh/openapi.json"
     enable_experimental_corepack                    = "1"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow regional S3 endpoints for uploads in the test environment by expanding `s3_upload_origins` to include `us-east-2` hosts for `polar-test-files` and `polar-public-files`. This avoids blocked uploads when AWS returns regional URLs.

<sup>Written for commit df208c332825577eb87996b7267083b588d1edd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

