### PR TITLE
slack: Link slack app to benefits

### DIFF
--- a/clients/apps/web/src/components/Benefit/utils.tsx
+++ b/clients/apps/web/src/components/Benefit/utils.tsx
@@ -71,4 +71,5 @@ export const benefitsDisplayNames: {
   custom: 'Custom',
   meter_credit: 'Meter Credits',
   feature_flag: 'Feature Flag',
+  slack_shared_channel: 'Slack Shared Channel',
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -411,6 +411,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/integrations/slack/link': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Link
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['integrations_slack:link']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/notifications': {
     parameters: {
       query?: never
@@ -10262,6 +10282,7 @@ export interface components {
       | 'license_keys'
       | 'meter_credit'
       | 'feature_flag'
+      | 'slack_shared_channel'
     /**
      * BenefitUpdatedEvent
      * @description An event created by Polar when a benefit is updated.
@@ -28650,6 +28671,35 @@ export interface components {
        */
       signing_secret?: string | null
     }
+    /** SlackIntegrationLink */
+    SlackIntegrationLink: {
+      /**
+       * Benefit Id
+       * Format: uuid4
+       * @description Benefit to link the integration to.
+       */
+      benefit_id: string
+      /**
+       * Integration Id
+       * Format: uuid4
+       * @description Slack integration to link.
+       */
+      integration_id: string
+    }
+    /** SlackIntegrationLinkBadRequestResponse */
+    SlackIntegrationLinkBadRequestResponse: {
+      /**
+       * Error
+       * @enum {string}
+       */
+      error:
+        | 'BadRequest'
+        | 'SlackIntegrationAlreadyLinked'
+        | 'SlackIntegrationNotInstalled'
+        | 'SlackIntegrationBenefitAlreadyLinked'
+      /** Detail */
+      detail: string
+    }
     /** SlackIntegrationManifest */
     SlackIntegrationManifest: {
       /**
@@ -28665,6 +28715,16 @@ export interface components {
        * @description Name shown in your Slack workspace for the app and bot user. Defaults to your organization name; customize before pasting into Slack.
        */
       display_name: string
+    }
+    /** SlackIntegrationQueryBadRequestResponse */
+    SlackIntegrationQueryBadRequestResponse: {
+      /**
+       * Error
+       * @constant
+       */
+      error: 'BadRequest'
+      /** Detail */
+      detail: string
     }
     /** SlackWorkspaceUser */
     SlackWorkspaceUser: {
@@ -33413,8 +33473,9 @@ export interface operations {
   }
   'integrations_slack:get_integration': {
     parameters: {
-      query: {
-        integration_id: string
+      query?: {
+        integration_id?: string | null
+        benefit_id?: string | null
       }
       header?: never
       path?: never
@@ -33429,6 +33490,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['SlackIntegration']
+        }
+      }
+      /** @description Provide exactly one of integration_id or benefit_id. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SlackIntegrationQueryBadRequestResponse']
         }
       }
       /** @description No Slack integration configured. */
@@ -33656,6 +33726,55 @@ export interface operations {
         content: {
           'application/json': unknown
         }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'integrations_slack:link': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SlackIntegrationLink']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SlackIntegration']
+        }
+      }
+      /** @description Slack integration is not installed, already linked, or belongs to a different organization. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SlackIntegrationLinkBadRequestResponse']
+        }
+      }
+      /** @description Benefit or Slack integration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
       /** @description Validation Error */
       422: {
@@ -55541,6 +55660,7 @@ export const benefitTypeValues: ReadonlyArray<
   'license_keys',
   'meter_credit',
   'feature_flag',
+  'slack_shared_channel',
 ]
 export const benefitUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitUpdatedEvent']['name']
@@ -58301,6 +58421,14 @@ export const seatStatusValues: ReadonlyArray<
 export const seatTierTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SeatTierType']
 > = ['volume', 'graduated']
+export const slackIntegrationLinkBadRequestResponseErrorValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SlackIntegrationLinkBadRequestResponse']['error']
+> = [
+  'BadRequest',
+  'SlackIntegrationAlreadyLinked',
+  'SlackIntegrationNotInstalled',
+  'SlackIntegrationBenefitAlreadyLinked',
+]
 export const stripeAccountCountryValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['StripeAccountCountry']
 > = [

--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -236,6 +236,32 @@ class BenefitGrantRepository(
         )
         return await self.get_all(statement)
 
+    async def get_by_property_and_organization(
+        self,
+        organization_id: UUID,
+        key: str,
+        value: str,
+        *,
+        benefit_id: UUID | None = None,
+        for_update: bool = False,
+    ) -> BenefitGrant | None:
+        filters = [
+            BenefitGrant.properties[key].as_string() == value,
+            Benefit.organization_id == organization_id,
+        ]
+        if benefit_id is not None:
+            filters.append(BenefitGrant.benefit_id == benefit_id)
+
+        statement = (
+            self.get_base_statement()
+            .join(Benefit, BenefitGrant.benefit_id == Benefit.id)
+            .where(*filters)
+            .limit(1)
+        )
+        if for_update:
+            statement = statement.with_for_update(of=BenefitGrant)
+        return await self.get_one_or_none(statement)
+
     async def list_outdated_grants(
         self, product: Product, **scope: Unpack[BenefitGrantScope]
     ) -> Sequence[BenefitGrant]:

--- a/server/polar/benefit/repository.py
+++ b/server/polar/benefit/repository.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import Select
@@ -13,6 +14,7 @@ from polar.kit.repository import (
     SortingClause,
 )
 from polar.models import Benefit
+from polar.models.benefit import BenefitType
 from polar.models.product_benefit import ProductBenefit
 
 from .sorting import BenefitSortProperty
@@ -40,6 +42,19 @@ class BenefitRepository(
             .options(*options)
         )
         return await self.get_one_or_none(statement)
+
+    async def list_by_slack_integration_id(
+        self,
+        organization_id: UUID,
+        slack_integration_id: UUID,
+    ) -> Sequence[Benefit]:
+        statement = self.get_base_statement().where(
+            Benefit.organization_id == organization_id,
+            Benefit.type == BenefitType.slack_shared_channel,
+            Benefit.properties["slack_integration_id"].as_string()
+            == str(slack_integration_id),
+        )
+        return await self.get_all(statement)
 
     def get_eager_options(self) -> Options:
         return (joinedload(Benefit.organization),)

--- a/server/polar/integrations/slack/endpoints.py
+++ b/server/polar/integrations/slack/endpoints.py
@@ -1,5 +1,5 @@
 import json
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from fastapi import Depends, Header, Query, Request
@@ -9,11 +9,14 @@ from pydantic import UUID4
 from polar.auth.models import AuthSubject
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import assert_organization_permission
+from polar.benefit.repository import BenefitRepository
 from polar.exceptions import BadRequest, ResourceNotFound, Unauthorized
 from polar.kit.db.postgres import AsyncReadSession as AsyncReadSessionT
 from polar.kit.db.postgres import AsyncSession as AsyncSessionT
 from polar.kit.http import ReturnTo, add_query_parameters, get_safe_return_url
-from polar.models import SlackApp
+from polar.kit.schemas import Schema
+from polar.models import Benefit, SlackApp
+from polar.models.benefit import BenefitType
 from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import (
@@ -30,6 +33,7 @@ from .repository import SlackAppRepository
 from .schemas import (
     SlackIntegration,
     SlackIntegrationCredentialsUpdate,
+    SlackIntegrationLink,
     SlackIntegrationManifest,
     SlackIntegrationManifestRequest,
     SlackWorkspaceUser,
@@ -50,6 +54,40 @@ router = APIRouter(
 CALLBACK_ROUTE_NAME = "integrations.slack.callback"
 
 
+class SlackIntegrationLinkBadRequestResponse(Schema):
+    error: Literal[
+        "BadRequest",
+        "SlackIntegrationAlreadyLinked",
+        "SlackIntegrationNotInstalled",
+        "SlackIntegrationBenefitAlreadyLinked",
+    ]
+    detail: str
+
+
+class SlackIntegrationQueryBadRequestResponse(Schema):
+    error: Literal["BadRequest"]
+    detail: str
+
+
+async def _get_writable_benefit(
+    session: AsyncSessionT | AsyncReadSessionT,
+    auth_subject: AuthSubject[Any],
+    benefit_id: UUID,
+) -> Benefit:
+    benefit_repository = BenefitRepository.from_session(session)
+    benefit = await benefit_repository.get_by_id(benefit_id)
+    if benefit is None or benefit.type != BenefitType.slack_shared_channel:
+        raise ResourceNotFound()
+    await assert_organization_permission(
+        session,
+        auth_subject,
+        benefit.organization_id,
+        OrganizationPermission.organization_manage,
+    )
+    await _assert_slack_benefit_enabled(session, benefit.organization_id)
+    return benefit
+
+
 async def _get_writable_integration(
     session: AsyncSessionT | AsyncReadSessionT,
     auth_subject: AuthSubject[Any],
@@ -68,6 +106,32 @@ async def _get_writable_integration(
     return integration
 
 
+async def _resolve_writable_integration(
+    session: AsyncSessionT | AsyncReadSessionT,
+    auth_subject: AuthSubject[Any],
+    *,
+    integration_id: UUID | None,
+    benefit_id: UUID | None,
+) -> SlackApp:
+    if (integration_id is None) == (benefit_id is None):
+        raise BadRequest("Provide exactly one of integration_id or benefit_id.")
+    if integration_id is not None:
+        return await _get_writable_integration(session, auth_subject, integration_id)
+
+    assert benefit_id is not None
+    benefit = await _get_writable_benefit(session, auth_subject, benefit_id)
+    slack_integration_id = benefit.properties.get("slack_integration_id")
+    if not isinstance(slack_integration_id, str):
+        raise ResourceNotFound()
+    try:
+        resolved_integration_id = UUID(slack_integration_id)
+    except ValueError as e:
+        raise ResourceNotFound() from e
+    return await _get_writable_integration(
+        session, auth_subject, resolved_integration_id
+    )
+
+
 async def _assert_slack_benefit_enabled(
     session: AsyncSessionT | AsyncReadSessionT,
     organization_id: UUID,
@@ -83,14 +147,23 @@ async def _assert_slack_benefit_enabled(
 @router.get(
     "/integration",
     response_model=SlackIntegration,
-    responses={404: {"description": "No Slack integration configured."}},
+    responses={
+        400: {
+            "description": "Provide exactly one of integration_id or benefit_id.",
+            "model": SlackIntegrationQueryBadRequestResponse,
+        },
+        404: {"description": "No Slack integration configured."},
+    },
 )
 async def get_integration(
     auth_subject: SlackIntegrationRead,
-    integration_id: Annotated[UUID4, Query()],
+    integration_id: Annotated[UUID4 | None, Query()] = None,
+    benefit_id: Annotated[UUID4 | None, Query()] = None,
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> SlackIntegration:
-    integration = await _get_writable_integration(session, auth_subject, integration_id)
+    integration = await _resolve_writable_integration(
+        session, auth_subject, integration_id=integration_id, benefit_id=benefit_id
+    )
     return SlackIntegration.model_validate(integration)
 
 
@@ -217,6 +290,37 @@ async def callback(
     )
 
     return RedirectResponse(get_safe_return_url(return_to), 303)
+
+
+@router.post(
+    "/link",
+    response_model=SlackIntegration,
+    responses={
+        400: {
+            "description": (
+                "Slack integration is not installed, already linked, "
+                "or belongs to a different organization."
+            ),
+            "model": SlackIntegrationLinkBadRequestResponse,
+        },
+        404: {"description": "Benefit or Slack integration not found."},
+    },
+)
+async def link(
+    payload: SlackIntegrationLink,
+    auth_subject: SlackIntegrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> SlackIntegration:
+    benefit = await _get_writable_benefit(session, auth_subject, payload.benefit_id)
+    integration = await _get_writable_integration(
+        session, auth_subject, payload.integration_id
+    )
+    if integration.organization_id != benefit.organization_id:
+        raise BadRequest(
+            "The Slack integration and benefit must belong to the same organization."
+        )
+    linked = await slack_app_service.link(session, benefit, integration)
+    return SlackIntegration.model_validate(linked)
 
 
 @router.post(

--- a/server/polar/integrations/slack/repository.py
+++ b/server/polar/integrations/slack/repository.py
@@ -13,6 +13,14 @@ class SlackAppRepository(
         statement = self.get_base_statement().where(SlackApp.id == id)
         return await self.get_one_or_none(statement)
 
+    async def get_by_id_for_update(self, id: UUID) -> SlackApp | None:
+        statement = (
+            self.get_base_statement()
+            .where(SlackApp.id == id)
+            .with_for_update(of=SlackApp)
+        )
+        return await self.get_one_or_none(statement)
+
     async def get_by_app_id(self, slack_app_id: str) -> SlackApp | None:
         statement = self.get_base_statement().where(
             SlackApp.slack_app_id == slack_app_id

--- a/server/polar/integrations/slack/schemas.py
+++ b/server/polar/integrations/slack/schemas.py
@@ -116,6 +116,11 @@ class SlackWorkspaceUsersResponse(Schema):
     )
 
 
+class SlackIntegrationLink(Schema):
+    benefit_id: UUID4 = Field(description="Benefit to link the integration to.")
+    integration_id: UUID4 = Field(description="Slack integration to link.")
+
+
 class SlackIntegration(TimestampedSchema):
     id: UUID4 = Field(description="ID of the Slack integration.")
     organization_id: UUID4 = Field(

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -4,12 +4,14 @@ from uuid import UUID
 
 import structlog
 
+from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.repository import BenefitRepository
 from polar.config import settings
 from polar.exceptions import BadRequest, PolarError, ResourceNotFound
 from polar.kit import jwt
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.utils import utc_now
-from polar.models import SlackApp
+from polar.models import Benefit, SlackApp
 
 from .client import SlackClient
 from .manifest import BOT_SCOPES
@@ -46,6 +48,23 @@ class SlackIntegrationAppIdAlreadyLinked(BadRequest):
         super().__init__(
             "This Slack app is already connected to another Polar organization."
         )
+
+
+class SlackIntegrationNotInstalled(BadRequest):
+    def __init__(self) -> None:
+        super().__init__(
+            "Authorize the Slack workspace before linking it to a benefit."
+        )
+
+
+class SlackIntegrationAlreadyLinked(BadRequest):
+    def __init__(self) -> None:
+        super().__init__("This Slack integration is already linked to a benefit.")
+
+
+class SlackIntegrationBenefitAlreadyLinked(BadRequest):
+    def __init__(self) -> None:
+        super().__init__("This benefit is already linked to a Slack integration.")
 
 
 # Errors that mean credentials parsed but code was rejected; credentials are OK.
@@ -146,6 +165,49 @@ class SlackAppService:
                 }
             )
         return await repository.update(existing, update_dict=update_dict)
+
+    async def link(
+        self,
+        session: AsyncSession,
+        benefit: Benefit,
+        integration: SlackApp,
+    ) -> SlackApp:
+        repository = SlackAppRepository.from_session(session)
+        locked_integration = await repository.get_by_id_for_update(integration.id)
+        if locked_integration is None:
+            raise SlackIntegrationNotConfigured()
+        integration = locked_integration
+
+        if integration.bot_token is None:
+            raise SlackIntegrationNotInstalled()
+
+        properties = dict(benefit.properties or {})
+        existing_integration_id = properties.get("slack_integration_id")
+        if isinstance(existing_integration_id, str) and existing_integration_id != str(
+            integration.id
+        ):
+            raise SlackIntegrationBenefitAlreadyLinked()
+
+        if existing_integration_id == str(integration.id):
+            return integration
+
+        benefit_repository = BenefitRepository.from_session(session)
+        linked_benefits = await benefit_repository.list_by_slack_integration_id(
+            benefit.organization_id, integration.id
+        )
+        if any(linked_benefit.id != benefit.id for linked_benefit in linked_benefits):
+            raise SlackIntegrationAlreadyLinked()
+
+        await benefit_repository.update(
+            benefit,
+            update_dict={
+                "properties": {
+                    **properties,
+                    "slack_integration_id": str(integration.id),
+                }
+            },
+        )
+        return integration
 
     def build_authorize_url(
         self,
@@ -304,8 +366,15 @@ class SlackAppService:
             )
             log.info(
                 "slack.events.integration_revoked",
+                integration_id=str(integration.id),
                 api_app_id=api_app_id,
                 event_type=event_type,
+            )
+            return
+
+        if event_type == "channel_shared":
+            await self._handle_channel_shared(
+                session, integration=integration, event=event
             )
             return
 
@@ -314,6 +383,40 @@ class SlackAppService:
             api_app_id=api_app_id,
             event_type=event_type,
         )
+
+    async def _handle_channel_shared(
+        self,
+        session: AsyncSession,
+        *,
+        integration: SlackApp,
+        event: dict[str, Any],
+    ) -> None:
+        channel_id = event.get("channel")
+        connected_team_id = event.get("connected_team_id")
+        if not isinstance(channel_id, str):
+            return
+
+        benefit_repository = BenefitRepository.from_session(session)
+        benefits = await benefit_repository.list_by_slack_integration_id(
+            integration.organization_id, integration.id
+        )
+
+        grant_repository = BenefitGrantRepository.from_session(session)
+        for benefit in benefits:
+            grant = await grant_repository.get_by_property_and_organization(
+                integration.organization_id,
+                "channel_id",
+                channel_id,
+                benefit_id=benefit.id,
+                for_update=True,
+            )
+            if grant is None:
+                continue
+
+            properties = dict(grant.properties or {})
+            if isinstance(connected_team_id, str):
+                properties["connected_team_id"] = connected_team_id
+            await grant_repository.update(grant, update_dict={"properties": properties})
 
     async def _validate_credentials(
         self,

--- a/server/polar/models/benefit.py
+++ b/server/polar/models/benefit.py
@@ -34,6 +34,7 @@ class BenefitType(StrEnum):
     license_keys = "license_keys"
     meter_credit = "meter_credit"
     feature_flag = "feature_flag"
+    slack_shared_channel = "slack_shared_channel"
 
     def get_display_name(self) -> str:
         return {
@@ -44,6 +45,7 @@ class BenefitType(StrEnum):
             BenefitType.license_keys: "License Keys",
             BenefitType.meter_credit: "Meter Credit",
             BenefitType.feature_flag: "Feature Flag",
+            BenefitType.slack_shared_channel: "Slack Shared Channel",
         }[self]
 
     def is_tax_applicable(self) -> bool:
@@ -56,6 +58,7 @@ class BenefitType(StrEnum):
                 BenefitType.license_keys: True,
                 BenefitType.meter_credit: True,
                 BenefitType.feature_flag: True,
+                BenefitType.slack_shared_channel: True,
             }
             return _is_tax_applicable_map[self]
         except KeyError as e:

--- a/server/tests/integrations/slack/test_endpoints.py
+++ b/server/tests/integrations/slack/test_endpoints.py
@@ -10,17 +10,21 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
+from polar.benefit.repository import BenefitRepository
 from polar.config import settings
 from polar.integrations.slack.repository import SlackAppRepository
 from polar.kit import jwt
 from polar.models import (
+    Benefit,
     Organization,
     SlackApp,
     UserOrganization,
 )
+from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit
 
 
 async def _enable_slack_benefit(
@@ -33,10 +37,29 @@ async def _enable_slack_benefit(
     await save_fixture(organization)
 
 
+async def _create_benefit(
+    save_fixture: SaveFixture, organization: Organization
+) -> Benefit:
+    await _enable_slack_benefit(save_fixture, organization)
+    return await create_benefit(
+        save_fixture,
+        organization=organization,
+        type=BenefitType.slack_shared_channel,
+        properties={
+            "channel_name_template": "support-{customer_name}",
+            "private": True,
+            "welcome_message": None,
+            "archive_on_revoke": True,
+            "team_invitees": [],
+        },
+    )
+
+
 async def _create_integration(
     save_fixture: SaveFixture,
     organization: Organization,
     *,
+    benefit: Benefit | None = None,
     bot_token: str | None = "xoxb-test-token",
     slack_benefit_enabled: bool = True,
     slack_app_id: str = "A0TESTAPPID",
@@ -60,6 +83,12 @@ async def _create_integration(
         scopes=["channels:manage"] if bot_token else None,
     )
     await save_fixture(integration)
+    if benefit is not None:
+        benefit.properties = {
+            **benefit.properties,
+            "slack_integration_id": str(integration.id),
+        }
+        await save_fixture(benefit)
     return integration
 
 
@@ -127,6 +156,28 @@ class TestGetIntegration:
     @pytest.mark.auth(
         AuthSubjectFixture(scopes={Scope.organizations_write}),
     )
+    async def test_user_returns_integration_by_benefit(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(save_fixture, organization, benefit=benefit)
+        response = await client.get(
+            "/v1/integrations/slack/integration",
+            params={"benefit_id": str(benefit.id)},
+        )
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["team_id"] == "T1"
+        assert "bot_token" not in json_body
+        assert "client_secret" not in json_body
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organizations_write}),
+    )
     async def test_not_configured_returns_404(
         self,
         client: AsyncClient,
@@ -137,6 +188,23 @@ class TestGetIntegration:
         response = await client.get(
             "/v1/integrations/slack/integration",
             params={"integration_id": str(uuid4())},
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organizations_write}),
+    )
+    async def test_not_configured_for_benefit_returns_404(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        response = await client.get(
+            "/v1/integrations/slack/integration",
+            params={"benefit_id": str(benefit.id)},
         )
         assert response.status_code == 404
 
@@ -412,6 +480,97 @@ class TestPostManifest:
         )
         assert response.status_code == 200
         assert "Acme Support" in response.json()["manifest"]
+
+
+@pytest.mark.asyncio
+class TestLink:
+    async def test_anonymous(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(save_fixture, organization)
+        response = await client.post(
+            "/v1/integrations/slack/link",
+            json={
+                "benefit_id": str(benefit.id),
+                "integration_id": str(integration.id),
+            },
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organizations_write}),
+    )
+    async def test_not_member_returns_403(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(save_fixture, organization)
+        response = await client.post(
+            "/v1/integrations/slack/link",
+            json={
+                "benefit_id": str(benefit.id),
+                "integration_id": str(integration.id),
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organizations_write}),
+    )
+    async def test_links_integration(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(save_fixture, organization)
+        response = await client.post(
+            "/v1/integrations/slack/link",
+            json={
+                "benefit_id": str(benefit.id),
+                "integration_id": str(integration.id),
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["id"] == str(integration.id)
+
+        repo = BenefitRepository.from_session(session)
+        linked = await repo.get_by_id(benefit.id)
+        assert linked is not None
+        assert dict(linked.properties)["slack_integration_id"] == str(integration.id)
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organizations_write}),
+    )
+    async def test_uninstalled_integration_returns_400(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(
+            save_fixture, organization, bot_token=None
+        )
+        response = await client.post(
+            "/v1/integrations/slack/link",
+            json={
+                "benefit_id": str(benefit.id),
+                "integration_id": str(integration.id),
+            },
+        )
+        assert response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -4,32 +4,60 @@ from uuid import uuid4
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.repository import BenefitRepository
 from polar.config import settings
 from polar.integrations.slack.repository import SlackAppRepository
 from polar.integrations.slack.schemas import SlackIntegrationCredentialsUpdate
 from polar.integrations.slack.service import (
     OAUTH_STATE_JWT_TYPE,
     SlackAppService,
+    SlackIntegrationAlreadyLinked,
     SlackIntegrationAppIdAlreadyLinked,
+    SlackIntegrationBenefitAlreadyLinked,
     SlackIntegrationInvalidCredentials,
     SlackIntegrationInvalidState,
     SlackIntegrationNotConfigured,
+    SlackIntegrationNotInstalled,
 )
 from polar.kit import jwt
 from polar.models import (
+    Benefit,
+    Customer,
     Organization,
     SlackApp,
 )
+from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit, create_benefit_grant
 
 _REDIRECT_URI = "https://api.polar.sh/v1/integrations/slack/callback"
+_BASE_PROPERTIES = {
+    "channel_name_template": "support-{customer_name}",
+    "private": True,
+    "welcome_message": None,
+    "archive_on_revoke": True,
+    "team_invitees": [],
+}
+
+
+async def _create_benefit(
+    save_fixture: SaveFixture, organization: Organization
+) -> Benefit:
+    return await create_benefit(
+        save_fixture,
+        organization=organization,
+        type=BenefitType.slack_shared_channel,
+        properties=_BASE_PROPERTIES,
+    )
 
 
 async def _create_integration(
     save_fixture: SaveFixture,
     organization: Organization,
     *,
+    benefit: Benefit | None = None,
     bot_token: str | None = "xoxb-test-token",
     slack_app_id: str = "A0TESTAPPID",
 ) -> SlackApp:
@@ -48,6 +76,12 @@ async def _create_integration(
         scopes=["channels:manage"] if bot_token else None,
     )
     await save_fixture(integration)
+    if benefit is not None:
+        benefit.properties = {
+            **benefit.properties,
+            "slack_integration_id": str(integration.id),
+        }
+        await save_fixture(benefit)
     return integration
 
 
@@ -391,6 +425,81 @@ class TestHandleEvent:
             event={"type": "tokens_revoked"},
         )
 
+    async def test_channel_shared_records_connected_team(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(save_fixture, organization, benefit=benefit)
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={
+                "invited_email": "a@example.com",
+                "channel_id": "C123",
+            },
+        )
+        await session.flush()
+        service, _client = _service_with_mock(mocker)
+
+        await service.handle_event(
+            session,
+            api_app_id="A0TESTAPPID",
+            event={
+                "type": "channel_shared",
+                "channel": "C123",
+                "connected_team_id": "TCUST",
+            },
+        )
+
+        repo = BenefitGrantRepository.from_session(session)
+        refreshed = await repo.get_by_id(grant.id)
+        assert refreshed is not None
+        assert (refreshed.properties or {}).get("connected_team_id") == "TCUST"
+
+    async def test_channel_shared_ignores_same_channel_id_for_other_benefit(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        other_benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(save_fixture, organization, benefit=benefit)
+        other_grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            other_benefit,
+            properties={
+                "invited_email": "a@example.com",
+                "channel_id": "C123",
+            },
+        )
+        await session.flush()
+        service, _client = _service_with_mock(mocker)
+
+        await service.handle_event(
+            session,
+            api_app_id="A0TESTAPPID",
+            event={
+                "type": "channel_shared",
+                "channel": "C123",
+                "connected_team_id": "TCUST",
+            },
+        )
+
+        repo = BenefitGrantRepository.from_session(session)
+        refreshed = await repo.get_by_id(other_grant.id)
+        assert refreshed is not None
+        assert "connected_team_id" not in (refreshed.properties or {})
+
 
 @pytest.mark.asyncio
 class TestDelete:
@@ -409,3 +518,106 @@ class TestDelete:
         await service.delete(session, integration)
 
         assert await service.get(session, created.id) is None
+
+
+@pytest.mark.asyncio
+class TestLink:
+    async def test_links_installed_integration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(save_fixture, organization)
+        service, _client = _service_with_mock(mocker)
+        get_by_id_for_update = mocker.spy(SlackAppRepository, "get_by_id_for_update")
+
+        linked = await service.link(session, benefit, integration)
+
+        assert linked.id == integration.id
+        assert get_by_id_for_update.call_count == 1
+        assert get_by_id_for_update.call_args.args[1] == integration.id
+        repo = BenefitRepository.from_session(session)
+        refreshed = await repo.get_by_id(benefit.id)
+        assert refreshed is not None
+        assert dict(refreshed.properties)["slack_integration_id"] == str(integration.id)
+
+    async def test_idempotent_when_already_linked_to_same_benefit(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(
+            save_fixture, organization, benefit=benefit
+        )
+        service, _client = _service_with_mock(mocker)
+
+        linked = await service.link(session, benefit, integration)
+
+        assert linked.id == integration.id
+        repo = BenefitRepository.from_session(session)
+        refreshed = await repo.get_by_id(benefit.id)
+        assert refreshed is not None
+        assert dict(refreshed.properties)["slack_integration_id"] == str(integration.id)
+
+    async def test_rejects_uninstalled_integration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(
+            save_fixture, organization, bot_token=None
+        )
+        service, _client = _service_with_mock(mocker)
+
+        with pytest.raises(SlackIntegrationNotInstalled):
+            await service.link(session, benefit, integration)
+
+    async def test_rejects_integration_linked_to_another_benefit(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        other_benefit = await _create_benefit(save_fixture, organization)
+        integration = await _create_integration(
+            save_fixture, organization, benefit=other_benefit
+        )
+        benefit = await _create_benefit(save_fixture, organization)
+        service, _client = _service_with_mock(mocker)
+
+        with pytest.raises(SlackIntegrationAlreadyLinked):
+            await service.link(session, benefit, integration)
+
+        repo = BenefitRepository.from_session(session)
+        refreshed = await repo.get_by_id(benefit.id)
+        assert refreshed is not None
+        assert "slack_integration_id" not in dict(refreshed.properties)
+
+    async def test_rejects_benefit_already_linked(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(
+            save_fixture, organization, benefit=benefit, slack_app_id="A0FIRSTAPPX"
+        )
+        other_integration = await _create_integration(
+            save_fixture, organization, slack_app_id="A0SECONDAPP"
+        )
+        service, _client = _service_with_mock(mocker)
+
+        with pytest.raises(SlackIntegrationBenefitAlreadyLinked):
+            await service.link(session, benefit, other_integration)


### PR DESCRIPTION
Extracted out from https://github.com/polarsource/polar/pull/12188 to only be the Slack/Benefit link


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support to link a Slack app installation to a specific Slack Shared Channel benefit and exposes APIs to create and query that link. This enables per-benefit Slack workspace targeting and records shared channel metadata.

- **New Features**
  - New benefit type `slack_shared_channel` with display name and tax applicability.
  - POST `/v1/integrations/slack/link`: link a benefit and Slack integration. Validates installation, org match, and uniqueness; returns specific 400 errors when invalid.
  - GET `/v1/integrations/slack/integration` now accepts exactly one of `integration_id` or `benefit_id`.
  - Link is persisted as `slack_integration_id` in benefit properties; added queries to fetch benefits by linked integration.
  - Slack event `channel_shared` updates matching grants with `connected_team_id`.
  - Generated `v1` client updated with new routes, schemas, and `slack_shared_channel` enum.

- **Migration**
  - Create/select a `slack_shared_channel` benefit, then call POST `/v1/integrations/slack/link` with `benefit_id` and `integration_id`.
  - For GET `/v1/integrations/slack/integration`, pass only one of `integration_id` or `benefit_id`.
  - Update to the latest generated `v1` client to consume new enums, operations, and error types.

<sup>Written for commit bee0590d4fcf54306fe9909f75fc44170a2c84a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

