### PR TITLE
Fix #12236: Check for current currency when retrieving price

### DIFF
--- a/clients/packages/checkout/src/guards.ts
+++ b/clients/packages/checkout/src/guards.ts
@@ -37,9 +37,11 @@ export const getSeatPrice = (
   }
 
   return (
-    prices.find(
-      (price): price is schemas['ProductPriceSeatBased'] =>
-        price.amount_type === 'seat_based',
-    ) ?? null
+    prices
+      .filter((price) => price.price_currency === checkout.currency)
+      .find(
+        (price): price is schemas['ProductPriceSeatBased'] =>
+          price.amount_type === 'seat_based',
+      ) ?? null
   )
 }


### PR DESCRIPTION
Fixes #12236


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures we pick the seat-based price in the shopper’s current currency to avoid wrong amounts in multi-currency checkouts. We now filter `prices` by `price_currency === checkout.currency` before selecting the seat-based price.

<sup>Written for commit 39b3a1cd3db6c7507dc2b021ba2ea243b683f0c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

