### PR TITLE
slack: Add shared channel benefit

### DIFF
--- a/clients/apps/web/src/components/Benefit/BenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitForm.tsx
@@ -1,6 +1,6 @@
 import { useDiscordGuild } from '@/hooks/queries'
 import { getBotDiscordAuthorizeURL } from '@/utils/auth'
-import { enums, schemas } from '@polar-sh/client'
+import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Input } from '@polar-sh/orbit'
 import {
@@ -31,7 +31,7 @@ import { DownloadablesBenefitForm } from './Downloadables/BenefitForm'
 import { GitHubRepositoryBenefitForm } from './GitHubRepositoryBenefitForm'
 import { LicenseKeysBenefitForm } from './LicenseKeys/BenefitForm'
 import { MeterCreditBenefitForm } from './MeterCredit/BenefitForm'
-import { benefitsDisplayNames } from './utils'
+import { benefitsDisplayNames, getCreatableBenefitTypes } from './utils'
 
 export const NewBenefitForm = ({
   organization,
@@ -114,7 +114,7 @@ const BenefitForm = ({
         }}
       />
 
-      {!update ? <BenefitTypeSelect /> : null}
+      {!update ? <BenefitTypeSelect organization={organization} /> : null}
       {type === 'custom' && <CustomBenefitForm update={update} />}
       {type === 'discord' && <DiscordBenefitForm />}
       {type === 'github_repository' && (
@@ -393,8 +393,13 @@ const DiscordBenefitForm = () => {
   )
 }
 
-const BenefitTypeSelect = () => {
+const BenefitTypeSelect = ({
+  organization,
+}: {
+  organization: schemas['Organization']
+}) => {
   const { control } = useFormContext<schemas['BenefitCustomCreate']>()
+  const benefitTypes = getCreatableBenefitTypes(organization)
 
   return (
     <FormField
@@ -413,7 +418,7 @@ const BenefitTypeSelect = () => {
                   <SelectValue placeholder="Select a benefit type" />
                 </SelectTrigger>
                 <SelectContent>
-                  {enums.benefitTypeValues.map((value) => (
+                  {benefitTypes.map((value) => (
                     <SelectItem key={value} value={value}>
                       {benefitsDisplayNames[value]}
                     </SelectItem>

--- a/clients/apps/web/src/components/Benefit/BenefitGrant.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitGrant.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_LOCALE,
   useTranslations,
   type AcceptedLocale,
+  type TranslationKey,
 } from '@polar-sh/i18n'
 import { Button } from '@polar-sh/orbit'
 import {
@@ -27,6 +28,17 @@ interface BenefitGrantProps {
   benefitGrant: schemas['CustomerBenefitGrant']
   locale?: AcceptedLocale
 }
+
+const benefitTypeTranslationKeys = {
+  custom: 'benefitTypes.custom',
+  discord: 'benefitTypes.discord',
+  downloadables: 'benefitTypes.downloadables',
+  feature_flag: 'benefitTypes.feature_flag',
+  github_repository: 'benefitTypes.github_repository',
+  license_keys: 'benefitTypes.license_keys',
+  meter_credit: 'benefitTypes.meter_credit',
+  slack_shared_channel: 'benefitTypes.slack_shared_channel',
+} as const satisfies Record<schemas['BenefitType'], TranslationKey>
 
 const BenefitGrantCustom = ({
   benefitGrant,
@@ -354,7 +366,7 @@ export const BenefitGrant = ({
         <div className="flex flex-col">
           <h3 className="text-sm font-medium">{benefit.description}</h3>
           <p className="dark:text-polar-500 flex flex-row gap-x-1 truncate text-sm text-gray-500">
-            {t(`benefitTypes.${benefit.type}`)}
+            {t(benefitTypeTranslationKeys[benefit.type])}
           </p>
         </div>
       </div>

--- a/clients/apps/web/src/components/Benefit/utils.tsx
+++ b/clients/apps/web/src/components/Benefit/utils.tsx
@@ -1,4 +1,4 @@
-import { schemas } from '@polar-sh/client'
+import { enums, schemas } from '@polar-sh/client'
 import { Download, Flag, Gauge, Key, Loader } from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
 import GitHubIcon from '../Icons/GitHubIcon'
@@ -73,3 +73,12 @@ export const benefitsDisplayNames: {
   feature_flag: 'Feature Flag',
   slack_shared_channel: 'Slack Shared Channel',
 }
+
+export const getCreatableBenefitTypes = (
+  organization: schemas['Organization'],
+): schemas['BenefitType'][] =>
+  enums.benefitTypeValues.filter(
+    (type) =>
+      type !== 'slack_shared_channel' ||
+      !!organization.feature_settings?.slack_benefit_enabled,
+  )

--- a/clients/apps/web/src/components/Products/Benefits/Benefits.tsx
+++ b/clients/apps/web/src/components/Products/Benefits/Benefits.tsx
@@ -3,9 +3,10 @@
 import {
   benefitsDisplayNames,
   CreatableBenefit,
+  getCreatableBenefitTypes,
   resolveBenefitIcon,
 } from '@/components/Benefit/utils'
-import { enums, schemas } from '@polar-sh/client'
+import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import {
   DropdownMenu,
@@ -108,7 +109,7 @@ export const Benefits = ({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="min-w-[200px]">
-                {enums.benefitTypeValues.map((type) => (
+                {getCreatableBenefitTypes(organization).map((type) => (
                   <DropdownMenuItem
                     key={type}
                     onClick={() => {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -10549,9 +10549,10 @@ export interface components {
     BenefitSlackSharedChannelProperties: {
       /**
        * Slack Integration Id
-       * @description Polar Slack integration ID linked to this benefit, if any.
+       * Format: uuid4
+       * @description Polar Slack integration linked to this benefit.
        */
-      slack_integration_id?: string | null
+      slack_integration_id: string
       /**
        * Channel Name Template
        * @description Template for the channel name. Supports placeholders: {customer_name}, {customer_email_local}, and {metadata.<key>} for any value stored in customer user metadata.

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -411,26 +411,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/v1/integrations/slack/link': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Link
-     * @description **Scopes**: `organizations:write`
-     */
-    post: operations['integrations_slack:link']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/v1/notifications': {
     parameters: {
       query?: never
@@ -10536,6 +10516,12 @@ export interface components {
     }
     /** BenefitSlackSharedChannelCreateProperties */
     BenefitSlackSharedChannelCreateProperties: {
+      /**
+       * Slack Integration Id
+       * Format: uuid4
+       * @description Polar Slack integration to use for this benefit.
+       */
+      slack_integration_id: string
       /** Channel Name Template */
       channel_name_template: string
       /**
@@ -29303,35 +29289,6 @@ export interface components {
        */
       signing_secret?: string | null
     }
-    /** SlackIntegrationLink */
-    SlackIntegrationLink: {
-      /**
-       * Benefit Id
-       * Format: uuid4
-       * @description Benefit to link the integration to.
-       */
-      benefit_id: string
-      /**
-       * Integration Id
-       * Format: uuid4
-       * @description Slack integration to link.
-       */
-      integration_id: string
-    }
-    /** SlackIntegrationLinkBadRequestResponse */
-    SlackIntegrationLinkBadRequestResponse: {
-      /**
-       * Error
-       * @enum {string}
-       */
-      error:
-        | 'BadRequest'
-        | 'SlackIntegrationAlreadyLinked'
-        | 'SlackIntegrationNotInstalled'
-        | 'SlackIntegrationBenefitAlreadyLinked'
-      /** Detail */
-      detail: string
-    }
     /** SlackIntegrationManifest */
     SlackIntegrationManifest: {
       /**
@@ -34446,55 +34403,6 @@ export interface operations {
         content: {
           'application/json': unknown
         }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['HTTPValidationError']
-        }
-      }
-    }
-  }
-  'integrations_slack:link': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['SlackIntegrationLink']
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['SlackIntegration']
-        }
-      }
-      /** @description Slack integration is not installed, already linked, or belongs to a different organization. */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['SlackIntegrationLinkBadRequestResponse']
-        }
-      }
-      /** @description Benefit or Slack integration not found. */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
       }
       /** @description Validation Error */
       422: {
@@ -59338,14 +59246,6 @@ export const seatStatusValues: ReadonlyArray<
 export const seatTierTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SeatTierType']
 > = ['volume', 'graduated']
-export const slackIntegrationLinkBadRequestResponseErrorValues: ReadonlyArray<
-  FlattenedDeepRequired<components>['schemas']['SlackIntegrationLinkBadRequestResponse']['error']
-> = [
-  'BadRequest',
-  'SlackIntegrationAlreadyLinked',
-  'SlackIntegrationNotInstalled',
-  'SlackIntegrationBenefitAlreadyLinked',
-]
 export const stripeAccountCountryValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['StripeAccountCountry']
 > = [

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -2043,6 +2043,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/benefits/slack/preview-channel-name': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Preview Channel Name
+     * @description **Scopes**: `benefits:write`
+     */
+    post: operations['benefits:preview_channel_name']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/benefit-grants/': {
     parameters: {
       query?: never
@@ -7741,6 +7761,7 @@ export interface components {
       | components['schemas']['BenefitLicenseKeys']
       | components['schemas']['BenefitMeterCredit']
       | components['schemas']['BenefitFeatureFlag']
+      | components['schemas']['BenefitSlackSharedChannel']
     BenefitCreate:
       | components['schemas']['BenefitCustomCreate']
       | components['schemas']['BenefitDiscordCreate']
@@ -7749,6 +7770,7 @@ export interface components {
       | components['schemas']['BenefitLicenseKeysCreate']
       | components['schemas']['BenefitMeterCreditCreate']
       | components['schemas']['BenefitFeatureFlagCreate']
+      | components['schemas']['BenefitSlackSharedChannelCreate']
     /**
      * BenefitCustom
      * @description A benefit of type `custom`.
@@ -9025,6 +9047,7 @@ export interface components {
         | components['schemas']['BenefitGrantLicenseKeysProperties']
         | components['schemas']['BenefitGrantCustomProperties']
         | components['schemas']['BenefitGrantFeatureFlagProperties']
+        | components['schemas']['BenefitGrantSlackSharedChannelProperties']
     }
     /** BenefitGrantCustomProperties */
     BenefitGrantCustomProperties: Record<string, never>
@@ -9631,6 +9654,97 @@ export interface components {
         | components['schemas']['BenefitGrantMeterCreditProperties']
         | null
     }
+    /** BenefitGrantSlackSharedChannelProperties */
+    BenefitGrantSlackSharedChannelProperties: {
+      /** Invited Email */
+      invited_email?: string
+      /** Channel Id */
+      channel_id?: string
+      /** Channel Name */
+      channel_name?: string
+      /** Invite Id */
+      invite_id?: string
+      /** Invite Url */
+      invite_url?: string
+      /** Connected Team Id */
+      connected_team_id?: string
+    }
+    /** BenefitGrantSlackSharedChannelWebhook */
+    BenefitGrantSlackSharedChannelWebhook: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the grant.
+       */
+      id: string
+      /**
+       * Granted At
+       * @description The timestamp when the benefit was granted. If `None`, the benefit is not granted.
+       */
+      granted_at?: string | null
+      /**
+       * Is Granted
+       * @description Whether the benefit is granted.
+       */
+      is_granted: boolean
+      /**
+       * Revoked At
+       * @description The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.
+       */
+      revoked_at?: string | null
+      /**
+       * Is Revoked
+       * @description Whether the benefit is revoked.
+       */
+      is_revoked: boolean
+      /**
+       * Subscription Id
+       * @description The ID of the subscription that granted this benefit.
+       */
+      subscription_id: string | null
+      /**
+       * Order Id
+       * @description The ID of the order that granted this benefit.
+       */
+      order_id: string | null
+      /**
+       * Customer Id
+       * Format: uuid4
+       * @description The ID of the customer concerned by this grant.
+       */
+      customer_id: string
+      /**
+       * Member Id
+       * @description The ID of the member concerned by this grant.
+       */
+      member_id?: string | null
+      /**
+       * Benefit Id
+       * Format: uuid4
+       * @description The ID of the benefit concerned by this grant.
+       */
+      benefit_id: string
+      /** @description The error information if the benefit grant failed with an unrecoverable error. */
+      error?: components['schemas']['BenefitGrantError'] | null
+      customer: components['schemas']['Customer']
+      member?: components['schemas']['Member'] | null
+      benefit: components['schemas']['BenefitSlackSharedChannel']
+      properties: components['schemas']['BenefitGrantSlackSharedChannelProperties']
+      previous_properties?:
+        | components['schemas']['BenefitGrantSlackSharedChannelProperties']
+        | null
+    }
     /**
      * BenefitGrantSortProperty
      * @enum {string}
@@ -9650,6 +9764,7 @@ export interface components {
       | components['schemas']['BenefitGrantLicenseKeysWebhook']
       | components['schemas']['BenefitGrantMeterCreditWebhook']
       | components['schemas']['BenefitGrantFeatureFlagWebhook']
+      | components['schemas']['BenefitGrantSlackSharedChannelWebhook']
     /**
      * BenefitGrantedEvent
      * @description An event created by Polar when a benefit is granted to a customer.
@@ -10330,6 +10445,240 @@ export interface components {
       name: 'benefit.revoked'
       metadata: components['schemas']['BenefitGrantMetadata']
     }
+    /** BenefitSlackSharedChannel */
+    BenefitSlackSharedChannel: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'slack_shared_channel'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+      metadata: components['schemas']['MetadataOutputType']
+      properties: components['schemas']['BenefitSlackSharedChannelProperties']
+    }
+    /** BenefitSlackSharedChannelCreate */
+    BenefitSlackSharedChannelCreate: {
+      /**
+       * Metadata
+       * @description Key-value object allowing you to store additional information.
+       *
+       *     The key must be a string with a maximum length of **40 characters**.
+       *     The value must be either:
+       *
+       *     * A string with a maximum length of **500 characters**
+       *     * An integer
+       *     * A floating-point number
+       *     * A boolean
+       *
+       *     You can store up to **50 key-value pairs**.
+       */
+      metadata?: {
+        [key: string]: string | number | boolean
+      }
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'slack_shared_channel'
+      /**
+       * Description
+       * @description The description of the benefit. Will be displayed on products having this benefit.
+       */
+      description: string
+      /**
+       * Organization Id
+       * @description The ID of the organization owning the benefit. **Required unless you use an organization token.**
+       */
+      organization_id?: string | null
+      properties: components['schemas']['BenefitSlackSharedChannelCreateProperties']
+    }
+    /** BenefitSlackSharedChannelCreateProperties */
+    BenefitSlackSharedChannelCreateProperties: {
+      /** Slack Integration Id */
+      slack_integration_id?: string | null
+      /** Channel Name Template */
+      channel_name_template: string
+      /**
+       * Private
+       * @default true
+       */
+      private: boolean
+      /** Welcome Message */
+      welcome_message?: string | null
+      /**
+       * Archive On Revoke
+       * @default true
+       */
+      archive_on_revoke: boolean
+      /** Team Invitees */
+      team_invitees?: string[]
+    }
+    /** BenefitSlackSharedChannelProperties */
+    BenefitSlackSharedChannelProperties: {
+      /**
+       * Slack Integration Id
+       * @description Polar Slack integration ID linked to this benefit, if any.
+       */
+      slack_integration_id?: string | null
+      /**
+       * Channel Name Template
+       * @description Template for the channel name. Supports placeholders: {customer_name}, {customer_email_local}, and {metadata.<key>} for any value stored in customer user metadata.
+       */
+      channel_name_template: string
+      /**
+       * Private
+       * @description Create the channel as private (recommended).
+       * @default true
+       */
+      private: boolean
+      /**
+       * Welcome Message
+       * @description Optional message posted to the channel right after creation.
+       */
+      welcome_message?: string | null
+      /**
+       * Archive On Revoke
+       * @description Archive the channel when the benefit is revoked.
+       * @default true
+       */
+      archive_on_revoke: boolean
+      /**
+       * Team Invitees
+       * @description Slack user IDs from the merchant workspace to invite to every channel created for this benefit.
+       */
+      team_invitees?: string[]
+    }
+    /** BenefitSlackSharedChannelSubscriber */
+    BenefitSlackSharedChannelSubscriber: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Type
+       * @constant
+       */
+      type: 'slack_shared_channel'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+      metadata: components['schemas']['MetadataOutputType']
+      organization: components['schemas']['BenefitSubscriberOrganization']
+      properties: components['schemas']['BenefitSlackSharedChannelSubscriberProperties']
+    }
+    /** BenefitSlackSharedChannelSubscriberProperties */
+    BenefitSlackSharedChannelSubscriberProperties: Record<string, never>
+    /** BenefitSlackSharedChannelUpdate */
+    BenefitSlackSharedChannelUpdate: {
+      /**
+       * Metadata
+       * @description Key-value object allowing you to store additional information.
+       *
+       *     The key must be a string with a maximum length of **40 characters**.
+       *     The value must be either:
+       *
+       *     * A string with a maximum length of **500 characters**
+       *     * An integer
+       *     * A floating-point number
+       *     * A boolean
+       *
+       *     You can store up to **50 key-value pairs**.
+       */
+      metadata?: {
+        [key: string]: string | number | boolean
+      }
+      /**
+       * Description
+       * @description The description of the benefit. Will be displayed on products having this benefit.
+       */
+      description?: string | null
+      /**
+       * Type
+       * @constant
+       */
+      type: 'slack_shared_channel'
+      properties?:
+        | components['schemas']['BenefitSlackSharedChannelCreateProperties']
+        | null
+    }
     /**
      * BenefitSortProperty
      * @enum {string}
@@ -10643,6 +10992,41 @@ export interface components {
       error: 'CaseClosedError'
       /** Detail */
       detail: string
+    }
+    /** ChannelNamePreviewRequest */
+    ChannelNamePreviewRequest: {
+      /** Organization Id */
+      organization_id?: string | null
+      /** Template */
+      template: string
+      /**
+       * Customer Name
+       * @default Sample Customer
+       */
+      customer_name: string
+      /**
+       * Customer Email
+       * @default customer@example.com
+       */
+      customer_email: string
+      /** Customer Metadata */
+      customer_metadata?: {
+        [key: string]: string | number | boolean
+      }
+    }
+    /** ChannelNamePreviewResponse */
+    ChannelNamePreviewResponse: {
+      /** Channel Name */
+      channel_name: string
+    }
+    /** ChannelNamePreviewValidationErrorResponse */
+    ChannelNamePreviewValidationErrorResponse: {
+      /** Error */
+      error: string
+      /** Detail */
+      detail: {
+        [key: string]: unknown
+      }[]
     }
     /**
      * Checkout
@@ -14351,6 +14735,7 @@ export interface components {
       | components['schemas']['CustomerBenefitGrantCustom']
       | components['schemas']['CustomerBenefitGrantMeterCredit']
       | components['schemas']['CustomerBenefitGrantFeatureFlag']
+      | components['schemas']['CustomerBenefitGrantSlackSharedChannel']
     /** CustomerBenefitGrantCustom */
     CustomerBenefitGrantCustom: {
       /**
@@ -14755,6 +15140,71 @@ export interface components {
        */
       benefit_type: 'meter_credit'
     }
+    /** CustomerBenefitGrantSlackSharedChannel */
+    CustomerBenefitGrantSlackSharedChannel: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /** Granted At */
+      granted_at: string | null
+      /** Revoked At */
+      revoked_at: string | null
+      /**
+       * Customer Id
+       * Format: uuid4
+       */
+      customer_id: string
+      /** Member Id */
+      member_id?: string | null
+      /**
+       * Benefit Id
+       * Format: uuid4
+       */
+      benefit_id: string
+      /** Subscription Id */
+      subscription_id: string | null
+      /** Order Id */
+      order_id: string | null
+      /** Is Granted */
+      is_granted: boolean
+      /** Is Revoked */
+      is_revoked: boolean
+      error?: components['schemas']['BenefitGrantError'] | null
+      customer: components['schemas']['CustomerPortalCustomer']
+      benefit: components['schemas']['BenefitSlackSharedChannelSubscriber']
+      properties: components['schemas']['BenefitGrantSlackSharedChannelProperties']
+    }
+    /** CustomerBenefitGrantSlackSharedChannelPropertiesUpdate */
+    CustomerBenefitGrantSlackSharedChannelPropertiesUpdate: {
+      /**
+       * Invited Email
+       * Format: email
+       */
+      invited_email: string
+    }
+    /** CustomerBenefitGrantSlackSharedChannelUpdate */
+    CustomerBenefitGrantSlackSharedChannelUpdate: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      benefit_type: 'slack_shared_channel'
+      properties: components['schemas']['CustomerBenefitGrantSlackSharedChannelPropertiesUpdate']
+    }
     /**
      * CustomerBenefitGrantSortProperty
      * @enum {string}
@@ -14776,6 +15226,7 @@ export interface components {
       | components['schemas']['CustomerBenefitGrantCustomUpdate']
       | components['schemas']['CustomerBenefitGrantMeterCreditUpdate']
       | components['schemas']['CustomerBenefitGrantFeatureFlagUpdate']
+      | components['schemas']['CustomerBenefitGrantSlackSharedChannelUpdate']
     /**
      * CustomerCancellationReason
      * @enum {string}
@@ -16647,6 +17098,7 @@ export interface components {
         | components['schemas']['BenefitGrantLicenseKeysProperties']
         | components['schemas']['BenefitGrantCustomProperties']
         | components['schemas']['BenefitGrantFeatureFlagProperties']
+        | components['schemas']['BenefitGrantSlackSharedChannelProperties']
     }
     /**
      * CustomerStateIndividual
@@ -37457,6 +37909,7 @@ export interface operations {
           | components['schemas']['BenefitLicenseKeysUpdate']
           | components['schemas']['BenefitMeterCreditUpdate']
           | components['schemas']['BenefitFeatureFlagUpdate']
+          | components['schemas']['BenefitSlackSharedChannelUpdate']
       }
     }
     responses: {
@@ -37536,6 +37989,39 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'benefits:preview_channel_name': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ChannelNamePreviewRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ChannelNamePreviewResponse']
+        }
+      }
+      /** @description Invalid channel name template. */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ChannelNamePreviewValidationErrorResponse']
         }
       }
     }
@@ -56062,6 +56548,12 @@ export const benefitMeterCreditCreateTypeValues: ReadonlyArray<
 export const benefitRevokedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitRevokedEvent']['name']
 > = ['benefit.revoked']
+export const benefitSlackSharedChannelTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitSlackSharedChannel']['type']
+> = ['slack_shared_channel']
+export const benefitSlackSharedChannelCreateTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitSlackSharedChannelCreate']['type']
+> = ['slack_shared_channel']
 export const benefitSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitSortProperty']
 > = [
@@ -56711,6 +57203,9 @@ export const customerBenefitGrantLicenseKeysUpdateBenefit_typeValues: ReadonlyAr
 export const customerBenefitGrantMeterCreditUpdateBenefit_typeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['CustomerBenefitGrantMeterCreditUpdate']['benefit_type']
 > = ['meter_credit']
+export const customerBenefitGrantSlackSharedChannelUpdateBenefit_typeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['CustomerBenefitGrantSlackSharedChannelUpdate']['benefit_type']
+> = ['slack_shared_channel']
 export const customerBenefitGrantSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['CustomerBenefitGrantSortProperty']
 > = [

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -10476,7 +10476,11 @@ export interface components {
        */
       organization_id: string
       metadata: components['schemas']['MetadataOutputType']
+      /** @description The visibility of the benefit in the customer portal. */
+      visibility: components['schemas']['BenefitVisibility']
       properties: components['schemas']['BenefitSlackSharedChannelProperties']
+      /** Visibility Configurable */
+      readonly visibility_configurable: boolean
     }
     /** BenefitSlackSharedChannelCreate */
     BenefitSlackSharedChannelCreate: {
@@ -10512,6 +10516,8 @@ export interface components {
        * @description The ID of the organization owning the benefit. **Required unless you use an organization token.**
        */
       organization_id?: string | null
+      /** @description The visibility of the benefit in the customer portal. */
+      visibility?: components['schemas']['BenefitVisibility'] | null
       properties: components['schemas']['BenefitSlackSharedChannelCreateProperties']
     }
     /** BenefitSlackSharedChannelCreateProperties */
@@ -10624,7 +10630,6 @@ export interface components {
        * @description The ID of the organization owning the benefit.
        */
       organization_id: string
-      metadata: components['schemas']['MetadataOutputType']
       organization: components['schemas']['BenefitSubscriberOrganization']
       properties: components['schemas']['BenefitSlackSharedChannelSubscriberProperties']
     }
@@ -10654,6 +10659,8 @@ export interface components {
        * @description The description of the benefit. Will be displayed on products having this benefit.
        */
       description?: string | null
+      /** @description The visibility of the benefit in the customer portal. */
+      visibility?: components['schemas']['BenefitVisibility'] | null
       /**
        * Type
        * @constant

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -10536,8 +10536,6 @@ export interface components {
     }
     /** BenefitSlackSharedChannelCreateProperties */
     BenefitSlackSharedChannelCreateProperties: {
-      /** Slack Integration Id */
-      slack_integration_id?: string | null
       /** Channel Name Template */
       channel_name_template: string
       /**

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -184,7 +184,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -371,7 +372,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -558,7 +560,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -745,7 +748,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -932,7 +936,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1111,7 +1116,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1290,7 +1296,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1469,7 +1476,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1648,7 +1656,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1827,7 +1836,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2006,7 +2016,8 @@
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
     "checkout.pricing.seats.included.other": "# seats included",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2185,6 +2196,7 @@
     "embedPaymentMethod.errors.unauthorized": "Session expired.",
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
-    "checkout.pricing.basePrice": "Base price"
+    "checkout.pricing.basePrice": "Base price",
+    "benefitTypes.slack_shared_channel": "Slack shared channel"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -283,6 +283,7 @@ export default {
     downloadables: 'Dateidownloads',
     meter_credit: 'Verbrauchsguthaben',
     feature_flag: 'Feature-Flag',
+    slack_shared_channel: 'Gemeinsamer Slack-Kanal',
   },
   ordinal: {
     zero: '.',

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -328,6 +328,7 @@ export default {
     custom: 'Custom',
     meter_credit: 'Meter credits',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'Slack shared channel',
   },
   ordinal: {
     zero: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -279,6 +279,7 @@ export default {
     downloadables: 'Descargas de archivos',
     meter_credit: 'Créditos de consumo',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'canal compartido de Slack',
   },
   ordinal: {
     zero: 'º',

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -281,6 +281,7 @@ export default {
     downloadables: 'Fichiers',
     meter_credit: 'Crédits prépayés',
     feature_flag: 'Accès à une fonctionnalité',
+    slack_shared_channel: 'canal partagé Slack',
   },
   ordinal: {
     zero: 'e',

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -278,6 +278,7 @@ export default {
     downloadables: 'Fájlletöltések',
     meter_credit: 'Használat alapú kreditek',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'Slack megosztott csatorna',
   },
   ordinal: {
     zero: '.',

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -280,6 +280,7 @@ export default {
     downloadables: 'File scaricabili',
     meter_credit: 'Crediti a consumo',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'canale condiviso di Slack',
   },
   ordinal: {
     zero: '°',

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -281,6 +281,7 @@ export default {
     custom: 'カスタム',
     meter_credit: 'メータークレジット',
     feature_flag: '機能フラグ',
+    slack_shared_channel: 'Slack 共有チャンネル',
   },
   ordinal: {
     one: '番目',

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -277,6 +277,7 @@ export default {
     downloadables: '파일 다운로드',
     meter_credit: '사용량 크레딧',
     feature_flag: '기능 플래그',
+    slack_shared_channel: 'Slack 공유 채널',
   },
   ordinal: {
     zero: '번째',

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -280,6 +280,7 @@ export default {
     downloadables: 'Bestandsdownloads',
     meter_credit: 'Verbruikstegoed',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'Gedeeld Slack-kanaal',
   },
   ordinal: {
     zero: 'de',

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -278,6 +278,7 @@ export default {
     downloadables: 'Download de arquivos',
     meter_credit: 'Créditos de uso',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'canal partilhado do Slack',
   },
   ordinal: {
     zero: 'º',

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -278,6 +278,7 @@ export default {
     downloadables: 'Download de arquivos',
     meter_credit: 'Créditos de uso',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'canal compartilhado do Slack',
   },
   ordinal: {
     zero: 'º',

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -277,6 +277,7 @@ export default {
     downloadables: 'Filnedladdningar',
     meter_credit: 'Mätarkrediter',
     feature_flag: 'Feature flag',
+    slack_shared_channel: 'Slack delad kanal',
   },
   ordinal: {
     zero: ':e',

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -278,6 +278,7 @@ export default {
     custom: 'Özel',
     meter_credit: 'Ölçüm kredileri',
     feature_flag: 'Özellik bayrağı',
+    slack_shared_channel: 'Slack paylaşılan kanal',
   },
   ordinal: {
     zero: '.',

--- a/server/polar/api.py
+++ b/server/polar/api.py
@@ -4,6 +4,9 @@ from polar.account.endpoints import router as accounts_router
 from polar.auth.endpoints import router as auth_router
 from polar.benefit.endpoints import router as benefits_router
 from polar.benefit.grant.endpoints import router as benefit_grants_router
+from polar.benefit.strategies.slack_shared_channel.endpoints import (
+    router as slack_shared_channel_benefit_router,
+)
 from polar.checkout.endpoints import router as checkout_router
 from polar.checkout_link.endpoints import router as checkout_link_router
 from polar.cli.endpoints import router as cli_router
@@ -94,6 +97,8 @@ router.include_router(auth_router)
 router.include_router(oauth2_router)
 # /benefits
 router.include_router(benefits_router)
+# /benefits/slack
+router.include_router(slack_shared_channel_benefit_router)
 # /benefit-grants
 router.include_router(benefit_grants_router)
 # /webhooks

--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import Unpack
 from uuid import UUID
 
-from sqlalchemy import Select, select
+from sqlalchemy import Select, func, select
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
@@ -261,6 +261,25 @@ class BenefitGrantRepository(
         if for_update:
             statement = statement.with_for_update(of=BenefitGrant)
         return await self.get_one_or_none(statement)
+
+    async def count_granted_by_property_and_organization(
+        self,
+        organization_id: UUID,
+        key: str,
+        value: str,
+    ) -> int:
+        statement = (
+            select(func.count(BenefitGrant.id))
+            .join(Benefit, BenefitGrant.benefit_id == Benefit.id)
+            .where(
+                BenefitGrant.properties[key].as_string() == value,
+                Benefit.organization_id == organization_id,
+                BenefitGrant.is_granted.is_(True),
+                BenefitGrant.is_deleted.is_(False),
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one()
 
     async def list_outdated_grants(
         self, product: Product, **scope: Unpack[BenefitGrantScope]

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -240,6 +240,8 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 member=member,
             )
         except BenefitActionRequiredError as e:
+            if e.grant_properties is not None:
+                grant.properties = e.grant_properties
             grant.set_grant_failed(e)
         else:
             grant.properties = properties
@@ -521,6 +523,8 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 member=member,
             )
         except BenefitActionRequiredError as e:
+            if e.grant_properties is not None:
+                grant.properties = e.grant_properties
             grant.set_grant_failed(e)
         else:
             grant.properties = properties

--- a/server/polar/benefit/registry.py
+++ b/server/polar/benefit/registry.py
@@ -20,6 +20,7 @@ from .strategies.feature_flag.service import BenefitFeatureFlagService
 from .strategies.github_repository.service import BenefitGitHubRepositoryService
 from .strategies.license_keys.service import BenefitLicenseKeysService
 from .strategies.meter_credit.service import BenefitMeterCreditService
+from .strategies.slack_shared_channel.service import BenefitSlackSharedChannelService
 
 _STRATEGY_CLASS_MAP: dict[
     BenefitType,
@@ -32,6 +33,7 @@ _STRATEGY_CLASS_MAP: dict[
     BenefitType.license_keys: BenefitLicenseKeysService,
     BenefitType.meter_credit: BenefitMeterCreditService,
     BenefitType.feature_flag: BenefitFeatureFlagService,
+    BenefitType.slack_shared_channel: BenefitSlackSharedChannelService,
 }
 
 

--- a/server/polar/benefit/schemas.py
+++ b/server/polar/benefit/schemas.py
@@ -19,6 +19,9 @@ from polar.benefit.strategies.license_keys.properties import (
 from polar.benefit.strategies.meter_credit.properties import (
     BenefitGrantMeterCreditProperties,
 )
+from polar.benefit.strategies.slack_shared_channel.properties import (
+    BenefitGrantSlackSharedChannelProperties,
+)
 from polar.customer.schemas.customer import CustomerResponse as Customer
 from polar.kit.schemas import (
     ClassName,
@@ -66,6 +69,11 @@ from .strategies.meter_credit.schemas import (
     BenefitMeterCreditCreate,
     BenefitMeterCreditUpdate,
 )
+from .strategies.slack_shared_channel.schemas import (
+    BenefitSlackSharedChannel,
+    BenefitSlackSharedChannelCreate,
+    BenefitSlackSharedChannelUpdate,
+)
 
 BENEFIT_DESCRIPTION_MIN_LENGTH = 3
 BENEFIT_DESCRIPTION_MAX_LENGTH = 42
@@ -84,7 +92,8 @@ BenefitCreate = Annotated[
     | BenefitDownloadablesCreate
     | BenefitLicenseKeysCreate
     | BenefitMeterCreditCreate
-    | BenefitFeatureFlagCreate,
+    | BenefitFeatureFlagCreate
+    | BenefitSlackSharedChannelCreate,
     Discriminator("type"),
     SetSchemaReference("BenefitCreate"),
 ]
@@ -98,6 +107,7 @@ BenefitUpdate = (
     | BenefitLicenseKeysUpdate
     | BenefitMeterCreditUpdate
     | BenefitFeatureFlagUpdate
+    | BenefitSlackSharedChannelUpdate
 )
 
 
@@ -108,7 +118,8 @@ Benefit = Annotated[
     | BenefitDownloadables
     | BenefitLicenseKeys
     | BenefitMeterCredit
-    | BenefitFeatureFlag,
+    | BenefitFeatureFlag
+    | BenefitSlackSharedChannel,
     Discriminator("type"),
     SetSchemaReference("Benefit"),
     MergeJSONSchema({"title": "Benefit"}),
@@ -123,6 +134,7 @@ benefit_schema_map: dict[BenefitType, type[Benefit]] = {
     BenefitType.license_keys: BenefitLicenseKeys,
     BenefitType.meter_credit: BenefitMeterCredit,
     BenefitType.feature_flag: BenefitFeatureFlag,
+    BenefitType.slack_shared_channel: BenefitSlackSharedChannel,
 }
 
 
@@ -180,6 +192,12 @@ class BenefitGrantFeatureFlagWebhook(BenefitGrantWebhookBase):
     previous_properties: BenefitGrantFeatureFlagProperties | None = None
 
 
+class BenefitGrantSlackSharedChannelWebhook(BenefitGrantWebhookBase):
+    benefit: BenefitSlackSharedChannel
+    properties: BenefitGrantSlackSharedChannelProperties
+    previous_properties: BenefitGrantSlackSharedChannelProperties | None = None
+
+
 BenefitGrantWebhook = Annotated[
     BenefitGrantDiscordWebhook
     | BenefitGrantCustomWebhook
@@ -187,7 +205,8 @@ BenefitGrantWebhook = Annotated[
     | BenefitGrantDownloadablesWebhook
     | BenefitGrantLicenseKeysWebhook
     | BenefitGrantMeterCreditWebhook
-    | BenefitGrantFeatureFlagWebhook,
+    | BenefitGrantFeatureFlagWebhook
+    | BenefitGrantSlackSharedChannelWebhook,
     SetSchemaReference("BenefitGrantWebhook"),
     MergeJSONSchema({"title": "BenefitGrantWebhook"}),
     ClassName("BenefitGrantWebhook"),

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -234,8 +234,11 @@ class BenefitService:
         )
         if properties_update is not None:
             benefit_strategy = get_benefit_strategy(benefit.type, session, redis)
-            update_dict["properties"] = await benefit_strategy.validate_properties(
+            update_dict[
+                "properties"
+            ] = await benefit_strategy.validate_properties_update(
                 auth_subject,
+                benefit,
                 properties_update.model_dump(mode="json", by_alias=True),
             )
 

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -136,6 +136,21 @@ class BenefitService:
             OrganizationPermission.products_manage,
         )
 
+        if (
+            create_schema.type == BenefitType.slack_shared_channel
+            and not organization.feature_settings.get("slack_benefit_enabled", False)
+        ):
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "type"),
+                        "msg": "Slack shared channel benefit is not enabled for this organization.",
+                        "input": create_schema.type,
+                    }
+                ]
+            )
+
         try:
             is_tax_applicable = getattr(create_schema, "is_tax_applicable")
         except AttributeError:

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -234,11 +234,8 @@ class BenefitService:
         )
         if properties_update is not None:
             benefit_strategy = get_benefit_strategy(benefit.type, session, redis)
-            update_dict[
-                "properties"
-            ] = await benefit_strategy.validate_properties_update(
+            update_dict["properties"] = await benefit_strategy.validate_properties(
                 auth_subject,
-                benefit,
                 properties_update.model_dump(mode="json", by_alias=True),
             )
 

--- a/server/polar/benefit/strategies/__init__.py
+++ b/server/polar/benefit/strategies/__init__.py
@@ -12,6 +12,7 @@ from .downloadables.properties import BenefitGrantDownloadablesProperties
 from .feature_flag.properties import BenefitGrantFeatureFlagProperties
 from .github_repository.properties import BenefitGrantGitHubRepositoryProperties
 from .license_keys.properties import BenefitGrantLicenseKeysProperties
+from .slack_shared_channel.properties import BenefitGrantSlackSharedChannelProperties
 
 BenefitGrantProperties = (
     BenefitGrantDiscordProperties
@@ -20,6 +21,7 @@ BenefitGrantProperties = (
     | BenefitGrantLicenseKeysProperties
     | BenefitGrantCustomProperties
     | BenefitGrantFeatureFlagProperties
+    | BenefitGrantSlackSharedChannelProperties
 )
 
 __all__ = [

--- a/server/polar/benefit/strategies/base/service.py
+++ b/server/polar/benefit/strategies/base/service.py
@@ -58,6 +58,17 @@ class BenefitActionRequiredError(BenefitServiceError):
     Typically, we need the customer to connect an external OAuth account.
     """
 
+    grant_properties: BenefitGrantProperties | None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        grant_properties: BenefitGrantProperties | None = None,
+    ) -> None:
+        self.grant_properties = grant_properties
+        super().__init__(message)
+
 
 class BenefitServiceProtocol[BP: BenefitProperties, BGP: BenefitGrantProperties](
     Protocol

--- a/server/polar/benefit/strategies/base/service.py
+++ b/server/polar/benefit/strategies/base/service.py
@@ -225,17 +225,6 @@ class BenefitServiceProtocol[BP: BenefitProperties, BGP: BenefitGrantProperties]
         """
         ...
 
-    async def validate_properties_update(
-        self,
-        auth_subject: AuthSubject[User | Organization],
-        benefit: Benefit,
-        properties: dict[str, Any],
-    ) -> BP:
-        """
-        Validates the benefit properties on update, with access to the existing benefit.
-        """
-        return await self.validate_properties(auth_subject, properties)
-
     def _get_properties(self, benefit: Benefit) -> BP:
         """
         Returns the Benefit properties.

--- a/server/polar/benefit/strategies/base/service.py
+++ b/server/polar/benefit/strategies/base/service.py
@@ -225,6 +225,17 @@ class BenefitServiceProtocol[BP: BenefitProperties, BGP: BenefitGrantProperties]
         """
         ...
 
+    async def validate_properties_update(
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        benefit: Benefit,
+        properties: dict[str, Any],
+    ) -> BP:
+        """
+        Validates the benefit properties on update, with access to the existing benefit.
+        """
+        return await self.validate_properties(auth_subject, properties)
+
     def _get_properties(self, benefit: Benefit) -> BP:
         """
         Returns the Benefit properties.

--- a/server/polar/benefit/strategies/slack_shared_channel/endpoints.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/endpoints.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+from fastapi import Depends
+from pydantic import Field
+
+from polar.exceptions import PolarRequestValidationError
+from polar.kit.schemas import Schema
+from polar.openapi import APITag
+from polar.organization.resolver import get_payload_organization
+from polar.organization.schemas import OrganizationID
+from polar.postgres import AsyncSession, get_db_session
+from polar.routing import APIRouter
+
+from ...auth import BenefitsWrite
+from .schemas import ChannelNameTemplate
+from .template import (
+    InvalidTemplateError,
+    TemplateContext,
+    render_channel_name,
+    validate_template,
+)
+
+router = APIRouter(
+    prefix="/benefits/slack",
+    tags=["benefits", APITag.private],
+)
+
+
+class ChannelNamePreviewRequest(Schema):
+    organization_id: OrganizationID | None = None
+    template: ChannelNameTemplate
+    customer_name: str = Field(default="Sample Customer")
+    customer_email: str = Field(default="customer@example.com")
+    customer_metadata: dict[str, str | int | float | bool] = Field(default_factory=dict)
+
+
+class ChannelNamePreviewResponse(Schema):
+    channel_name: str
+
+
+class ChannelNamePreviewValidationErrorResponse(Schema):
+    error: str
+    detail: list[dict[str, Any]]
+
+
+@router.post(
+    "/preview-channel-name",
+    response_model=ChannelNamePreviewResponse,
+    responses={
+        422: {
+            "description": "Invalid channel name template.",
+            "model": ChannelNamePreviewValidationErrorResponse,
+        },
+    },
+)
+async def preview_channel_name(
+    payload: ChannelNamePreviewRequest,
+    auth_subject: BenefitsWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> ChannelNamePreviewResponse:
+    await get_payload_organization(session, auth_subject, payload)
+
+    try:
+        validate_template(payload.template)
+    except InvalidTemplateError as e:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "template"),
+                    "msg": str(e),
+                    "input": payload.template,
+                }
+            ]
+        ) from e
+
+    email = payload.customer_email
+    context = TemplateContext(
+        customer_name=payload.customer_name,
+        customer_email_local=email.split("@", 1)[0] if email else "customer",
+        metadata=dict(payload.customer_metadata),
+    )
+    try:
+        channel_name = render_channel_name(payload.template, context, tolerant=True)
+    except InvalidTemplateError as e:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "template"),
+                    "msg": str(e),
+                    "input": payload.template,
+                }
+            ]
+        ) from e
+
+    return ChannelNamePreviewResponse(channel_name=channel_name)

--- a/server/polar/benefit/strategies/slack_shared_channel/properties.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/properties.py
@@ -1,10 +1,8 @@
-from typing import NotRequired
-
 from ..base.properties import BenefitGrantProperties, BenefitProperties
 
 
 class BenefitSlackSharedChannelProperties(BenefitProperties):
-    slack_integration_id: NotRequired[str | None]
+    slack_integration_id: str
     channel_name_template: str
     private: bool
     welcome_message: str | None

--- a/server/polar/benefit/strategies/slack_shared_channel/properties.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/properties.py
@@ -1,0 +1,21 @@
+from typing import NotRequired
+
+from ..base.properties import BenefitGrantProperties, BenefitProperties
+
+
+class BenefitSlackSharedChannelProperties(BenefitProperties):
+    slack_integration_id: NotRequired[str | None]
+    channel_name_template: str
+    private: bool
+    welcome_message: str | None
+    archive_on_revoke: bool
+    team_invitees: list[str]
+
+
+class BenefitGrantSlackSharedChannelProperties(BenefitGrantProperties, total=False):
+    invited_email: str
+    channel_id: str
+    channel_name: str
+    invite_id: str
+    invite_url: str
+    connected_team_id: str

--- a/server/polar/benefit/strategies/slack_shared_channel/schemas.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/schemas.py
@@ -1,0 +1,84 @@
+from typing import Annotated, Literal
+
+from pydantic import Field, StringConstraints
+from pydantic.json_schema import SkipJsonSchema
+
+from polar.kit.schemas import Schema
+from polar.models.benefit import BenefitType
+
+from ..base.schemas import (
+    BenefitBase,
+    BenefitCreateBase,
+    BenefitSubscriberBase,
+    BenefitUpdateBase,
+)
+
+ChannelNameTemplate = Annotated[str, StringConstraints(min_length=1, max_length=80)]
+WelcomeMessage = Annotated[str | None, StringConstraints(max_length=4000)]
+
+
+class BenefitSlackSharedChannelProperties(Schema):
+    slack_integration_id: str | None = Field(
+        default=None,
+        description="Polar Slack integration ID linked to this benefit, if any.",
+    )
+    channel_name_template: ChannelNameTemplate = Field(
+        description=(
+            "Template for the channel name. Supports placeholders: "
+            "{customer_name}, {customer_email_local}, and {metadata.<key>} "
+            "for any value stored in customer user metadata."
+        ),
+    )
+    private: bool = Field(
+        default=True,
+        description="Create the channel as private (recommended).",
+    )
+    welcome_message: WelcomeMessage = Field(
+        default=None,
+        description="Optional message posted to the channel right after creation.",
+    )
+    archive_on_revoke: bool = Field(
+        default=True,
+        description="Archive the channel when the benefit is revoked.",
+    )
+    team_invitees: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Slack user IDs from the merchant workspace to invite to every "
+            "channel created for this benefit."
+        ),
+    )
+
+
+class BenefitSlackSharedChannelCreateProperties(Schema):
+    slack_integration_id: str | None = None
+    channel_name_template: ChannelNameTemplate
+    private: bool = True
+    welcome_message: WelcomeMessage = None
+    archive_on_revoke: bool = True
+    team_invitees: list[str] = Field(default_factory=list)
+
+
+class BenefitSlackSharedChannelCreate(BenefitCreateBase):
+    type: Literal[BenefitType.slack_shared_channel]
+    properties: BenefitSlackSharedChannelCreateProperties
+
+
+class BenefitSlackSharedChannelUpdate(BenefitUpdateBase):
+    type: Literal[BenefitType.slack_shared_channel]
+    properties: BenefitSlackSharedChannelCreateProperties | None = None
+
+
+class BenefitSlackSharedChannel(BenefitBase):
+    type: Literal[BenefitType.slack_shared_channel]
+    properties: BenefitSlackSharedChannelProperties
+    is_tax_applicable: SkipJsonSchema[bool] = Field(deprecated=True)
+
+
+class BenefitSlackSharedChannelSubscriberProperties(Schema):
+    pass
+
+
+class BenefitSlackSharedChannelSubscriber(BenefitSubscriberBase):
+    type: Literal[BenefitType.slack_shared_channel]
+    properties: BenefitSlackSharedChannelSubscriberProperties

--- a/server/polar/benefit/strategies/slack_shared_channel/schemas.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/schemas.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import UUID4, Field, StringConstraints
+from pydantic import UUID4, AfterValidator, Field, StringConstraints
 from pydantic.json_schema import SkipJsonSchema
 
 from polar.kit.schemas import Schema
@@ -12,8 +12,18 @@ from ..base.schemas import (
     BenefitSubscriberBase,
     BenefitUpdateBase,
 )
+from .template import validate_template
+
+
+def _validate_channel_name_template(value: str) -> str:
+    validate_template(value)
+    return value
+
 
 ChannelNameTemplate = Annotated[str, StringConstraints(min_length=1, max_length=80)]
+ValidatedChannelNameTemplate = Annotated[
+    ChannelNameTemplate, AfterValidator(_validate_channel_name_template)
+]
 WelcomeMessage = Annotated[str | None, StringConstraints(max_length=4000)]
 
 
@@ -51,7 +61,10 @@ class BenefitSlackSharedChannelProperties(Schema):
 
 
 class BenefitSlackSharedChannelCreateProperties(Schema):
-    channel_name_template: ChannelNameTemplate
+    slack_integration_id: UUID4 = Field(
+        description="Polar Slack integration to use for this benefit.",
+    )
+    channel_name_template: ValidatedChannelNameTemplate
     private: bool = True
     welcome_message: WelcomeMessage = None
     archive_on_revoke: bool = True

--- a/server/polar/benefit/strategies/slack_shared_channel/schemas.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/schemas.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints
+from pydantic import UUID4, Field, StringConstraints
 from pydantic.json_schema import SkipJsonSchema
 
 from polar.kit.schemas import Schema
@@ -18,7 +18,7 @@ WelcomeMessage = Annotated[str | None, StringConstraints(max_length=4000)]
 
 
 class BenefitSlackSharedChannelProperties(Schema):
-    slack_integration_id: str | None = Field(
+    slack_integration_id: UUID4 | None = Field(
         default=None,
         description="Polar Slack integration ID linked to this benefit, if any.",
     )
@@ -51,7 +51,7 @@ class BenefitSlackSharedChannelProperties(Schema):
 
 
 class BenefitSlackSharedChannelCreateProperties(Schema):
-    slack_integration_id: str | None = None
+    slack_integration_id: UUID4 | None = None
     channel_name_template: ChannelNameTemplate
     private: bool = True
     welcome_message: WelcomeMessage = None

--- a/server/polar/benefit/strategies/slack_shared_channel/schemas.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/schemas.py
@@ -28,9 +28,8 @@ WelcomeMessage = Annotated[str | None, StringConstraints(max_length=4000)]
 
 
 class BenefitSlackSharedChannelProperties(Schema):
-    slack_integration_id: UUID4 | None = Field(
-        default=None,
-        description="Polar Slack integration ID linked to this benefit, if any.",
+    slack_integration_id: UUID4 = Field(
+        description="Polar Slack integration linked to this benefit.",
     )
     channel_name_template: ChannelNameTemplate = Field(
         description=(

--- a/server/polar/benefit/strategies/slack_shared_channel/schemas.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/schemas.py
@@ -51,7 +51,6 @@ class BenefitSlackSharedChannelProperties(Schema):
 
 
 class BenefitSlackSharedChannelCreateProperties(Schema):
-    slack_integration_id: UUID4 | None = None
     channel_name_template: ChannelNameTemplate
     private: bool = True
     welcome_message: WelcomeMessage = None

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -1,0 +1,461 @@
+import secrets
+from typing import Any, cast
+from uuid import UUID
+
+import httpx
+import structlog
+
+from polar.auth.models import AuthSubject
+from polar.integrations.slack.client import SlackClient
+from polar.integrations.slack.repository import SlackAppRepository
+from polar.kit.db.postgres import AsyncSession
+from polar.logging import Logger
+from polar.models import (
+    Benefit,
+    Customer,
+    Member,
+    Organization,
+    SlackApp,
+    User,
+)
+from polar.redis import Redis
+
+from ..base.service import (
+    BenefitActionRequiredError,
+    BenefitPropertiesValidationError,
+    BenefitRetriableError,
+    BenefitServiceProtocol,
+)
+from .properties import (
+    BenefitGrantSlackSharedChannelProperties,
+    BenefitSlackSharedChannelProperties,
+)
+from .template import (
+    InvalidTemplateError,
+    TemplateContext,
+    render_channel_name,
+    validate_template,
+)
+
+log: Logger = structlog.get_logger()
+
+_PROVISIONING_LOCK_TTL_SECONDS = 60
+
+
+class BenefitSlackSharedChannelService(
+    BenefitServiceProtocol[
+        BenefitSlackSharedChannelProperties,
+        BenefitGrantSlackSharedChannelProperties,
+    ]
+):
+    def __init__(self, session: AsyncSession, redis: Redis) -> None:
+        super().__init__(session, redis)
+        self._client = SlackClient()
+
+    async def grant(
+        self,
+        benefit: Benefit,
+        customer: Customer,
+        grant_properties: BenefitGrantSlackSharedChannelProperties,
+        *,
+        update: bool = False,
+        attempt: int = 1,
+        member: Member | None = None,
+    ) -> BenefitGrantSlackSharedChannelProperties:
+        bound_logger = log.bind(
+            benefit_id=str(benefit.id), customer_id=str(customer.id)
+        )
+
+        invited_email = grant_properties.get("invited_email")
+        if not invited_email:
+            raise BenefitActionRequiredError(
+                "Enter the email of an admin in your Slack workspace to "
+                "receive the Slack Connect invite."
+            )
+
+        existing_channel_id = grant_properties.get("channel_id")
+        if update and existing_channel_id and grant_properties.get("invite_id"):
+            properties = self._get_properties(benefit)
+            team_invitees = properties.get("team_invitees") or []
+            if team_invitees:
+                integration = await self._get_installed_integration(benefit)
+                await self._safe_invite_team(
+                    bot_token=cast(str, integration.bot_token),
+                    channel=existing_channel_id,
+                    users=team_invitees,
+                    bound_logger=bound_logger,
+                )
+            return grant_properties
+
+        if not existing_channel_id:
+            lock_key = f"slack_benefit_grant:{benefit.id}:{customer.id}"
+            acquired = await self.redis.set(
+                lock_key, "1", ex=_PROVISIONING_LOCK_TTL_SECONDS, nx=True
+            )
+            if not acquired:
+                raise BenefitRetriableError(_PROVISIONING_LOCK_TTL_SECONDS)
+
+        properties = self._get_properties(benefit)
+        integration = await self._get_installed_integration(benefit)
+
+        context = self._build_context(customer)
+        bot_token = cast(str, integration.bot_token)
+
+        if existing_channel_id:
+            channel_id = existing_channel_id
+            channel_name = grant_properties.get("channel_name", "")
+        else:
+            channel_id, channel_name = await self._find_channel_by_name(
+                bot_token=bot_token,
+                template=properties["channel_name_template"],
+                context=context,
+                is_private=properties["private"],
+                bound_logger=bound_logger,
+            ) or await self._create_channel(
+                bot_token=bot_token,
+                template=properties["channel_name_template"],
+                context=context,
+                is_private=properties["private"],
+            )
+
+            team_invitees = properties.get("team_invitees") or []
+            if team_invitees:
+                await self._safe_invite_team(
+                    bot_token=bot_token,
+                    channel=channel_id,
+                    users=team_invitees,
+                    bound_logger=bound_logger,
+                )
+
+            welcome_message = properties.get("welcome_message")
+            if welcome_message:
+                await self._safe_post_welcome(
+                    bot_token=bot_token,
+                    channel=channel_id,
+                    text=welcome_message,
+                    bound_logger=bound_logger,
+                )
+
+        provisioned_properties: BenefitGrantSlackSharedChannelProperties = {
+            **grant_properties,
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+        }
+
+        try:
+            invite = await self._invite_shared(
+                bot_token=bot_token, channel=channel_id, email=invited_email
+            )
+        except BenefitActionRequiredError as e:
+            raise BenefitActionRequiredError(
+                e.message, grant_properties=provisioned_properties
+            ) from e
+
+        completed_properties: BenefitGrantSlackSharedChannelProperties = {
+            **provisioned_properties
+        }
+        invite_id = invite.get("invite_id")
+        if isinstance(invite_id, str):
+            completed_properties["invite_id"] = invite_id
+        invite_url = invite.get("url")
+        if isinstance(invite_url, str) and invite_url:
+            completed_properties["invite_url"] = invite_url
+        return completed_properties
+
+    async def cycle(
+        self,
+        benefit: Benefit,
+        customer: Customer,
+        grant_properties: BenefitGrantSlackSharedChannelProperties,
+        *,
+        attempt: int = 1,
+        member: Member | None = None,
+    ) -> BenefitGrantSlackSharedChannelProperties:
+        return grant_properties
+
+    async def revoke(
+        self,
+        benefit: Benefit,
+        customer: Customer,
+        grant_properties: BenefitGrantSlackSharedChannelProperties,
+        *,
+        attempt: int = 1,
+        member: Member | None = None,
+    ) -> BenefitGrantSlackSharedChannelProperties:
+        bound_logger = log.bind(
+            benefit_id=str(benefit.id), customer_id=str(customer.id)
+        )
+
+        properties = self._get_properties(benefit)
+        channel_id = grant_properties.get("channel_id")
+
+        if not properties.get("archive_on_revoke") or not channel_id:
+            return {"invited_email": grant_properties.get("invited_email", "")}
+
+        integration = await self._get_integration(benefit)
+        if integration is None or integration.bot_token is None:
+            bound_logger.info("Slack integration uninstalled; skipping archive")
+            return {"invited_email": grant_properties.get("invited_email", "")}
+
+        try:
+            await self._client.conversations_archive(
+                bot_token=integration.bot_token, channel=channel_id
+            )
+        except httpx.HTTPError as e:
+            bound_logger.warning("Slack archive failed", error=str(e))
+            raise BenefitRetriableError() from e
+
+        return {"invited_email": grant_properties.get("invited_email", "")}
+
+    async def requires_update(
+        self,
+        benefit: Benefit,
+        previous_properties: BenefitSlackSharedChannelProperties,
+    ) -> bool:
+        current = self._get_properties(benefit)
+        return set(current.get("team_invitees") or []) != set(
+            previous_properties.get("team_invitees") or []
+        )
+
+    async def validate_properties(
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        properties: dict[str, Any],
+    ) -> BenefitSlackSharedChannelProperties:
+        template = properties.get("channel_name_template", "")
+        try:
+            validate_template(template)
+        except InvalidTemplateError as e:
+            raise BenefitPropertiesValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "msg": str(e),
+                        "loc": ("channel_name_template",),
+                        "input": template,
+                    }
+                ]
+            ) from e
+
+        return cast(BenefitSlackSharedChannelProperties, properties)
+
+    async def _get_installed_integration(self, benefit: Benefit) -> SlackApp:
+        integration = await self._get_integration(benefit)
+        if integration is None or integration.bot_token is None:
+            raise BenefitActionRequiredError(
+                "The Slack integration is not installed for this benefit."
+            )
+        return integration
+
+    async def _get_integration(self, benefit: Benefit) -> SlackApp | None:
+        integration_id = benefit.properties.get("slack_integration_id")
+        if not isinstance(integration_id, str):
+            return None
+        try:
+            slack_integration_id = UUID(integration_id)
+        except ValueError:
+            return None
+
+        repository = SlackAppRepository.from_session(self.session)
+        integration = await repository.get_by_id(slack_integration_id)
+        if (
+            integration is None
+            or integration.organization_id != benefit.organization_id
+        ):
+            return None
+        return integration
+
+    def _build_context(self, customer: Customer) -> TemplateContext:
+        email = customer.email or ""
+        return TemplateContext(
+            customer_name=customer.name or email or "customer",
+            customer_email_local=email.split("@", 1)[0] if email else "customer",
+            metadata=dict(customer.user_metadata or {}),
+        )
+
+    def _render_channel_name(
+        self, template: str, context: TemplateContext, *, suffix: str | None = None
+    ) -> str:
+        try:
+            return render_channel_name(template, context, suffix=suffix)
+        except InvalidTemplateError as e:
+            raise BenefitActionRequiredError(str(e)) from e
+
+    async def _find_channel_by_name(
+        self,
+        *,
+        bot_token: str,
+        template: str,
+        context: TemplateContext,
+        is_private: bool,
+        bound_logger: Any,
+    ) -> tuple[str, str] | None:
+        name = self._render_channel_name(template, context)
+        types = ["private_channel"] if is_private else ["public_channel"]
+        cursor: str | None = None
+
+        while True:
+            try:
+                result = await self._client.conversations_list(
+                    bot_token=bot_token, cursor=cursor, types=types
+                )
+            except httpx.HTTPError as e:
+                raise BenefitRetriableError() from e
+
+            if not result.get("ok"):
+                error = result.get("error", "")
+                if error == "missing_scope":
+                    bound_logger.info("Slack channel lookup skipped", error=error)
+                    return None
+                raise BenefitActionRequiredError(f"Slack channel lookup error: {error}")
+
+            for channel in result.get("channels") or []:
+                channel_name = channel.get("name") or channel.get("name_normalized")
+                if not isinstance(channel_name, str) or channel_name != name:
+                    continue
+
+                channel_id = channel.get("id")
+                if not isinstance(channel_id, str):
+                    continue
+
+                if channel.get("is_private"):
+                    if not channel.get("is_member"):
+                        bound_logger.info(
+                            "Slack private channel found but app is not a member",
+                            channel_id=channel_id,
+                        )
+                        return None
+                    return channel_id, channel_name
+
+                if not channel.get("is_member"):
+                    joined = await self._join_public_channel(
+                        bot_token=bot_token,
+                        channel=channel_id,
+                        bound_logger=bound_logger,
+                    )
+                    if not joined:
+                        return None
+
+                return channel_id, channel_name
+
+            cursor = (result.get("response_metadata") or {}).get("next_cursor")
+            if not cursor:
+                return None
+
+    async def _join_public_channel(
+        self,
+        *,
+        bot_token: str,
+        channel: str,
+        bound_logger: Any,
+    ) -> bool:
+        try:
+            result = await self._client.conversations_join(
+                bot_token=bot_token, channel=channel
+            )
+        except httpx.HTTPError as e:
+            raise BenefitRetriableError() from e
+
+        if result.get("ok"):
+            return True
+
+        bound_logger.info(
+            "Slack public channel join skipped",
+            channel_id=channel,
+            error=result.get("error"),
+        )
+        return False
+
+    async def _create_channel(
+        self,
+        *,
+        bot_token: str,
+        template: str,
+        context: TemplateContext,
+        is_private: bool,
+    ) -> tuple[str, str]:
+        name = self._render_channel_name(template, context)
+        try:
+            result = await self._client.conversations_create(
+                bot_token=bot_token, name=name, is_private=is_private
+            )
+        except httpx.HTTPError as e:
+            raise BenefitRetriableError() from e
+
+        if result.get("ok"):
+            channel = result.get("channel") or {}
+            return channel["id"], channel.get("name", name)
+
+        error = result.get("error", "")
+        if error != "name_taken":
+            raise BenefitActionRequiredError(f"Slack error: {error}")
+
+        name = self._render_channel_name(template, context, suffix=secrets.token_hex(2))
+        try:
+            result = await self._client.conversations_create(
+                bot_token=bot_token, name=name, is_private=is_private
+            )
+        except httpx.HTTPError as e:
+            raise BenefitRetriableError() from e
+
+        if result.get("ok"):
+            channel = result.get("channel") or {}
+            return channel["id"], channel.get("name", name)
+
+        error = result.get("error", "")
+        raise BenefitActionRequiredError(f"Slack error: {error}")
+
+    async def _safe_invite_team(
+        self,
+        *,
+        bot_token: str,
+        channel: str,
+        users: list[str],
+        bound_logger: Any,
+    ) -> None:
+        try:
+            result = await self._client.conversations_invite(
+                bot_token=bot_token, channel=channel, users=users
+            )
+        except httpx.HTTPError as e:
+            bound_logger.warning("Slack team invite failed", error=str(e))
+            return
+        if not result.get("ok"):
+            bound_logger.warning(
+                "Slack team invite returned error", error=result.get("error")
+            )
+
+    async def _safe_post_welcome(
+        self,
+        *,
+        bot_token: str,
+        channel: str,
+        text: str,
+        bound_logger: Any,
+    ) -> None:
+        try:
+            await self._client.chat_post_message(
+                bot_token=bot_token, channel=channel, text=text
+            )
+        except httpx.HTTPError as e:
+            bound_logger.warning("Slack welcome post failed", error=str(e))
+
+    async def _invite_shared(
+        self,
+        *,
+        bot_token: str,
+        channel: str,
+        email: str,
+    ) -> dict[str, Any]:
+        try:
+            result = await self._client.conversations_invite_shared(
+                bot_token=bot_token, channel=channel, email=email
+            )
+        except httpx.HTTPError as e:
+            raise BenefitRetriableError() from e
+
+        if not result.get("ok"):
+            error = result.get("error", "")
+            raise BenefitActionRequiredError(f"Slack invite error: {error}")
+
+        return result

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -6,6 +6,8 @@ import httpx
 import structlog
 
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.integrations.slack.client import SlackClient
 from polar.integrations.slack.repository import SlackAppRepository
@@ -34,7 +36,6 @@ from .template import (
     InvalidTemplateError,
     TemplateContext,
     render_channel_name,
-    validate_template,
 )
 
 log: Logger = structlog.get_logger()
@@ -258,36 +259,37 @@ class BenefitSlackSharedChannelService(
         auth_subject: AuthSubject[User | Organization],
         properties: dict[str, Any],
     ) -> BenefitSlackSharedChannelProperties:
-        template = properties.get("channel_name_template", "")
-        try:
-            validate_template(template)
-        except InvalidTemplateError as e:
+        integration_id = properties["slack_integration_id"]
+        repository = SlackAppRepository.from_session(self.session)
+        integration = await repository.get_by_id(UUID(integration_id))
+        accessible_org_ids = await get_accessible_org_ids(
+            self.session,
+            auth_subject,
+            permission=OrganizationPermission.products_manage,
+        )
+        if integration is None or integration.organization_id not in accessible_org_ids:
             raise BenefitPropertiesValidationError(
                 [
                     {
                         "type": "value_error",
-                        "msg": str(e),
-                        "loc": ("channel_name_template",),
-                        "input": template,
+                        "msg": "Slack integration not found.",
+                        "loc": ("slack_integration_id",),
+                        "input": integration_id,
                     }
                 ]
-            ) from e
-
+            )
+        if integration.bot_token is None:
+            raise BenefitPropertiesValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "msg": "The Slack integration is not installed.",
+                        "loc": ("slack_integration_id",),
+                        "input": integration_id,
+                    }
+                ]
+            )
         return cast(BenefitSlackSharedChannelProperties, properties)
-
-    async def validate_properties_update(
-        self,
-        auth_subject: AuthSubject[User | Organization],
-        benefit: Benefit,
-        properties: dict[str, Any],
-    ) -> BenefitSlackSharedChannelProperties:
-        validated: dict[str, Any] = dict(
-            await self.validate_properties(auth_subject, properties)
-        )
-        integration_id = benefit.properties.get("slack_integration_id")
-        if integration_id is not None:
-            validated["slack_integration_id"] = integration_id
-        return cast(BenefitSlackSharedChannelProperties, validated)
 
     async def _get_installed_integration(self, benefit: Benefit) -> SlackApp:
         integration = await self._get_integration(benefit)

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -136,7 +136,7 @@ class BenefitSlackSharedChannelService(
         elif sibling_channel := await self._find_sibling_channel(benefit, customer):
             channel_id, channel_name = sibling_channel
         else:
-            channel_id, channel_name = await self._create_channel(
+            channel_id, channel_name, created = await self._create_channel(
                 bot_token=bot_token,
                 template=properties["channel_name_template"],
                 context=context,
@@ -144,23 +144,24 @@ class BenefitSlackSharedChannelService(
                 bound_logger=bound_logger,
             )
 
-            team_invitees = properties.get("team_invitees") or []
-            if team_invitees:
-                await self._safe_invite_team(
-                    bot_token=bot_token,
-                    channel=channel_id,
-                    users=team_invitees,
-                    bound_logger=bound_logger,
-                )
+            if created:
+                team_invitees = properties.get("team_invitees") or []
+                if team_invitees:
+                    await self._safe_invite_team(
+                        bot_token=bot_token,
+                        channel=channel_id,
+                        users=team_invitees,
+                        bound_logger=bound_logger,
+                    )
 
-            welcome_message = properties.get("welcome_message")
-            if welcome_message:
-                await self._safe_post_welcome(
-                    bot_token=bot_token,
-                    channel=channel_id,
-                    text=welcome_message,
-                    bound_logger=bound_logger,
-                )
+                welcome_message = properties.get("welcome_message")
+                if welcome_message:
+                    await self._safe_post_welcome(
+                        bot_token=bot_token,
+                        channel=channel_id,
+                        text=welcome_message,
+                        bound_logger=bound_logger,
+                    )
 
         provisioned_properties: BenefitGrantSlackSharedChannelProperties = {
             **grant_properties,
@@ -441,14 +442,14 @@ class BenefitSlackSharedChannelService(
         context: TemplateContext,
         is_private: bool,
         bound_logger: Any,
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, bool]:
         name = self._render_channel_name(template, context)
         result = await self._create_channel_once(
             bot_token=bot_token, name=name, is_private=is_private
         )
         if result.get("ok"):
             channel = result.get("channel") or {}
-            return channel["id"], channel.get("name", name)
+            return channel["id"], channel.get("name", name), True
 
         error = result.get("error", "")
         if error != "name_taken":
@@ -462,7 +463,8 @@ class BenefitSlackSharedChannelService(
             bound_logger=bound_logger,
         )
         if existing:
-            return existing
+            channel_id, channel_name = existing
+            return channel_id, channel_name, False
 
         name = self._render_channel_name(template, context, suffix=secrets.token_hex(2))
         result = await self._create_channel_once(
@@ -470,7 +472,7 @@ class BenefitSlackSharedChannelService(
         )
         if result.get("ok"):
             channel = result.get("channel") or {}
-            return channel["id"], channel.get("name", name)
+            return channel["id"], channel.get("name", name), True
 
         error = result.get("error", "")
         raise BenefitActionRequiredError(f"Slack error: {error}")

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -133,17 +133,12 @@ class BenefitSlackSharedChannelService(
             channel_id = existing_channel_id
             channel_name = grant_properties.get("channel_name", "")
         else:
-            channel_id, channel_name = await self._find_channel_by_name(
+            channel_id, channel_name = await self._create_channel(
                 bot_token=bot_token,
                 template=properties["channel_name_template"],
                 context=context,
                 is_private=properties["private"],
                 bound_logger=bound_logger,
-            ) or await self._create_channel(
-                bot_token=bot_token,
-                template=properties["channel_name_template"],
-                context=context,
-                is_private=properties["private"],
             )
 
             team_invitees = properties.get("team_invitees") or []
@@ -428,15 +423,12 @@ class BenefitSlackSharedChannelService(
         template: str,
         context: TemplateContext,
         is_private: bool,
+        bound_logger: Any,
     ) -> tuple[str, str]:
         name = self._render_channel_name(template, context)
-        try:
-            result = await self._client.conversations_create(
-                bot_token=bot_token, name=name, is_private=is_private
-            )
-        except httpx.HTTPError as e:
-            raise BenefitRetriableError() from e
-
+        result = await self._create_channel_once(
+            bot_token=bot_token, name=name, is_private=is_private
+        )
         if result.get("ok"):
             channel = result.get("channel") or {}
             return channel["id"], channel.get("name", name)
@@ -445,20 +437,36 @@ class BenefitSlackSharedChannelService(
         if error != "name_taken":
             raise BenefitActionRequiredError(f"Slack error: {error}")
 
-        name = self._render_channel_name(template, context, suffix=secrets.token_hex(2))
-        try:
-            result = await self._client.conversations_create(
-                bot_token=bot_token, name=name, is_private=is_private
-            )
-        except httpx.HTTPError as e:
-            raise BenefitRetriableError() from e
+        existing = await self._find_channel_by_name(
+            bot_token=bot_token,
+            template=template,
+            context=context,
+            is_private=is_private,
+            bound_logger=bound_logger,
+        )
+        if existing:
+            return existing
 
+        name = self._render_channel_name(template, context, suffix=secrets.token_hex(2))
+        result = await self._create_channel_once(
+            bot_token=bot_token, name=name, is_private=is_private
+        )
         if result.get("ok"):
             channel = result.get("channel") or {}
             return channel["id"], channel.get("name", name)
 
         error = result.get("error", "")
         raise BenefitActionRequiredError(f"Slack error: {error}")
+
+    async def _create_channel_once(
+        self, *, bot_token: str, name: str, is_private: bool
+    ) -> dict[str, Any]:
+        try:
+            return await self._client.conversations_create(
+                bot_token=bot_token, name=name, is_private=is_private
+            )
+        except httpx.HTTPError as e:
+            raise BenefitRetriableError() from e
 
     async def _safe_invite_team(
         self,

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -9,6 +9,7 @@ from polar.auth.models import AuthSubject
 from polar.integrations.slack.client import SlackClient
 from polar.integrations.slack.repository import SlackAppRepository
 from polar.kit.db.postgres import AsyncSession
+from polar.locker import Locker, TimeoutLockError
 from polar.logging import Logger
 from polar.models import (
     Benefit,
@@ -87,20 +88,39 @@ class BenefitSlackSharedChannelService(
                 )
             return grant_properties
 
-        if not existing_channel_id:
-            lock_key = f"slack_benefit_grant:{benefit.id}:{customer.id}"
-            acquired = await self.redis.set(
-                lock_key, "1", ex=_PROVISIONING_LOCK_TTL_SECONDS, nx=True
+        if existing_channel_id:
+            return await self._provision(
+                benefit, customer, grant_properties, invited_email, bound_logger
             )
-            if not acquired:
-                raise BenefitRetriableError(_PROVISIONING_LOCK_TTL_SECONDS)
 
+        locker = Locker(self.redis)
+        try:
+            async with locker.lock(
+                f"slack_benefit_grant:{benefit.id}:{customer.id}",
+                timeout=_PROVISIONING_LOCK_TTL_SECONDS,
+                blocking_timeout=0,
+            ):
+                return await self._provision(
+                    benefit, customer, grant_properties, invited_email, bound_logger
+                )
+        except TimeoutLockError as e:
+            raise BenefitRetriableError(_PROVISIONING_LOCK_TTL_SECONDS) from e
+
+    async def _provision(
+        self,
+        benefit: Benefit,
+        customer: Customer,
+        grant_properties: BenefitGrantSlackSharedChannelProperties,
+        invited_email: str,
+        bound_logger: Any,
+    ) -> BenefitGrantSlackSharedChannelProperties:
         properties = self._get_properties(benefit)
         integration = await self._get_installed_integration(benefit)
 
         context = self._build_context(customer)
         bot_token = cast(str, integration.bot_token)
 
+        existing_channel_id = grant_properties.get("channel_id")
         if existing_channel_id:
             channel_id = existing_channel_id
             channel_name = grant_properties.get("channel_name", "")

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -264,6 +264,20 @@ class BenefitSlackSharedChannelService(
 
         return cast(BenefitSlackSharedChannelProperties, properties)
 
+    async def validate_properties_update(
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        benefit: Benefit,
+        properties: dict[str, Any],
+    ) -> BenefitSlackSharedChannelProperties:
+        validated: dict[str, Any] = dict(
+            await self.validate_properties(auth_subject, properties)
+        )
+        integration_id = benefit.properties.get("slack_integration_id")
+        if integration_id is not None:
+            validated["slack_integration_id"] = integration_id
+        return cast(BenefitSlackSharedChannelProperties, validated)
+
     async def _get_installed_integration(self, benefit: Benefit) -> SlackApp:
         integration = await self._get_integration(benefit)
         if integration is None or integration.bot_token is None:

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -198,12 +198,17 @@ class BenefitSlackSharedChannelService(
             return {"invited_email": grant_properties.get("invited_email", "")}
 
         try:
-            await self._client.conversations_archive(
+            result = await self._client.conversations_archive(
                 bot_token=integration.bot_token, channel=channel_id
             )
         except httpx.HTTPError as e:
             bound_logger.warning("Slack archive failed", error=str(e))
             raise BenefitRetriableError() from e
+
+        if not result.get("ok"):
+            error = result.get("error", "")
+            bound_logger.warning("Slack archive returned error", error=error)
+            raise BenefitRetriableError()
 
         return {"invited_email": grant_properties.get("invited_email", "")}
 

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -42,6 +42,14 @@ log: Logger = structlog.get_logger()
 
 _PROVISIONING_LOCK_TTL_SECONDS = 60
 
+_ARCHIVE_NOOP_ERRORS = {"already_archived", "channel_not_found"}
+_ARCHIVE_TRANSIENT_ERRORS = {
+    "ratelimited",
+    "internal_error",
+    "fatal_error",
+    "service_unavailable",
+}
+
 
 class BenefitSlackSharedChannelService(
     BenefitServiceProtocol[
@@ -208,14 +216,17 @@ class BenefitSlackSharedChannelService(
 
         properties = self._get_properties(benefit)
         channel_id = grant_properties.get("channel_id")
+        revoked_properties: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": grant_properties.get("invited_email", "")
+        }
 
         if not properties.get("archive_on_revoke") or not channel_id:
-            return {"invited_email": grant_properties.get("invited_email", "")}
+            return revoked_properties
 
         integration = await self._get_integration(benefit)
         if integration is None or integration.bot_token is None:
             bound_logger.info("Slack integration uninstalled; skipping archive")
-            return {"invited_email": grant_properties.get("invited_email", "")}
+            return revoked_properties
 
         try:
             result = await self._client.conversations_archive(
@@ -227,10 +238,15 @@ class BenefitSlackSharedChannelService(
 
         if not result.get("ok"):
             error = result.get("error", "")
+            if error in _ARCHIVE_NOOP_ERRORS:
+                bound_logger.info("Slack channel already archived or gone", error=error)
+                return revoked_properties
             bound_logger.warning("Slack archive returned error", error=error)
-            raise BenefitRetriableError()
+            if error in _ARCHIVE_TRANSIENT_ERRORS:
+                raise BenefitRetriableError()
+            raise BenefitActionRequiredError(f"Slack archive error: {error}")
 
-        return {"invited_email": grant_properties.get("invited_email", "")}
+        return revoked_properties
 
     async def requires_update(
         self,

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -9,7 +9,6 @@ from polar.auth.models import AuthSubject
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.integrations.slack.client import SlackClient
 from polar.integrations.slack.repository import SlackAppRepository
-from polar.kit.db.postgres import AsyncSession
 from polar.locker import Locker, TimeoutLockError
 from polar.logging import Logger
 from polar.models import (
@@ -20,7 +19,6 @@ from polar.models import (
     SlackApp,
     User,
 )
-from polar.redis import Redis
 
 from ..base.service import (
     BenefitActionRequiredError,
@@ -58,9 +56,7 @@ class BenefitSlackSharedChannelService(
         BenefitGrantSlackSharedChannelProperties,
     ]
 ):
-    def __init__(self, session: AsyncSession, redis: Redis) -> None:
-        super().__init__(session, redis)
-        self._client = SlackClient()
+    _client = SlackClient()
 
     async def grant(
         self,

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -219,6 +219,27 @@ class BenefitSlackSharedChannelService(
         if not properties.get("archive_on_revoke") or not channel_id:
             return revoked_properties
 
+        grant_repository = BenefitGrantRepository.from_session(self.session)
+        total_grants = (
+            await grant_repository.count_granted_by_property_and_organization(
+                benefit.organization_id, "channel_id", channel_id
+            )
+        )
+        own_grants = await grant_repository.list_granted_by_benefit_and_customer(
+            benefit, customer
+        )
+        own_count = sum(
+            1
+            for grant in own_grants
+            if grant.properties.get("channel_id") == channel_id
+        )
+        if total_grants - own_count > 0:
+            bound_logger.info(
+                "Slack channel still used by other grants; skipping archive",
+                channel_id=channel_id,
+            )
+            return revoked_properties
+
         integration = await self._get_integration(benefit)
         if integration is None or integration.bot_token is None:
             bound_logger.info("Slack integration uninstalled; skipping archive")

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -6,6 +6,7 @@ import httpx
 import structlog
 
 from polar.auth.models import AuthSubject
+from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.integrations.slack.client import SlackClient
 from polar.integrations.slack.repository import SlackAppRepository
 from polar.kit.db.postgres import AsyncSession
@@ -132,6 +133,8 @@ class BenefitSlackSharedChannelService(
         if existing_channel_id:
             channel_id = existing_channel_id
             channel_name = grant_properties.get("channel_name", "")
+        elif sibling_channel := await self._find_sibling_channel(benefit, customer):
+            channel_id, channel_name = sibling_channel
         else:
             channel_id, channel_name = await self._create_channel(
                 bot_token=bot_token,
@@ -314,6 +317,20 @@ class BenefitSlackSharedChannelService(
         ):
             return None
         return integration
+
+    async def _find_sibling_channel(
+        self, benefit: Benefit, customer: Customer
+    ) -> tuple[str, str] | None:
+        repository = BenefitGrantRepository.from_session(self.session)
+        grants = await repository.list_granted_by_benefit_and_customer(
+            benefit, customer
+        )
+        for grant in grants:
+            channel_id = grant.properties.get("channel_id")
+            if isinstance(channel_id, str) and channel_id:
+                channel_name = grant.properties.get("channel_name")
+                return channel_id, channel_name if isinstance(channel_name, str) else ""
+        return None
 
     def _build_context(self, customer: Customer) -> TemplateContext:
         email = customer.email or ""

--- a/server/polar/benefit/strategies/slack_shared_channel/template.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/template.py
@@ -3,13 +3,11 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
-from polar.kit.metadata import get_nested_metadata_value
-
 _FIXED_PLACEHOLDERS = {"customer_name", "customer_email_local"}
 _METADATA_PREFIX = "metadata."
 _PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
 _PLACEHOLDER_NAME_RE = re.compile(r"^[\w.]+$")
-_METADATA_PLACEHOLDER_RE = re.compile(r"^metadata\.[\w-]+(?:\.[\w-]+)*$")
+_METADATA_PLACEHOLDER_RE = re.compile(r"^metadata\.[^{}]+$")
 _SLACK_CHANNEL_NAME_MAX_LENGTH = 80
 _NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
 
@@ -78,7 +76,7 @@ def _resolve(name: str, context: TemplateContext, *, tolerant: bool) -> str:
         return str(getattr(context, name))
     if _METADATA_PLACEHOLDER_RE.fullmatch(name):
         key = name[len(_METADATA_PREFIX) :]
-        value = get_nested_metadata_value(context.metadata, key)
+        value = context.metadata.get(key)
         if value is None:
             if tolerant:
                 return key

--- a/server/polar/benefit/strategies/slack_shared_channel/template.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/template.py
@@ -3,13 +3,14 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
+from slugify import slugify
+
 _FIXED_PLACEHOLDERS = {"customer_name", "customer_email_local"}
 _METADATA_PREFIX = "metadata."
 _PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
 _PLACEHOLDER_NAME_RE = re.compile(r"^[\w.]+$")
 _METADATA_PLACEHOLDER_RE = re.compile(r"^metadata\.[^{}]+$")
 _SLACK_CHANNEL_NAME_MAX_LENGTH = 80
-_NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
 
 
 @dataclass(frozen=True)
@@ -54,16 +55,16 @@ def render_channel_name(
         template,
     )
     if suffix:
-        suffix_slug = _slugify(suffix)
+        suffix_slug = slugify(suffix)
         if suffix_slug:
             if len(suffix_slug) >= _SLACK_CHANNEL_NAME_MAX_LENGTH:
                 return suffix_slug[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
             max_base_length = _SLACK_CHANNEL_NAME_MAX_LENGTH - len(suffix_slug) - 1
-            rendered = _slugify(rendered)[:max_base_length].strip("-")
+            rendered = slugify(rendered, max_length=max_base_length)
             if not rendered:
                 return suffix_slug[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
             return f"{rendered}-{suffix_slug}"[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
-    slug = _slugify(rendered)[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
+    slug = slugify(rendered, max_length=_SLACK_CHANNEL_NAME_MAX_LENGTH)
     if not slug:
         raise InvalidTemplateError(
             "Template renders to an empty channel name for this customer."
@@ -101,7 +102,7 @@ def _render_permissive(template: str) -> str:
             return "sample"
         return ""
 
-    return _slugify(_PLACEHOLDER_RE.sub(lambda match: sub(match.group(1)), template))
+    return slugify(_PLACEHOLDER_RE.sub(lambda match: sub(match.group(1)), template))
 
 
 def _iter_placeholder_names(template: str) -> Iterator[str]:
@@ -135,9 +136,3 @@ def _malformed_placeholder(placeholder: str) -> InvalidTemplateError:
         f"Allowed: {{customer_name}}, {{customer_email_local}}, "
         f"or {{metadata.<key>}} for customer metadata."
     )
-
-
-def _slugify(value: str) -> str:
-    value = value.lower().strip()
-    value = _NON_ALPHANUMERIC.sub("-", value)
-    return value.strip("-")

--- a/server/polar/benefit/strategies/slack_shared_channel/template.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/template.py
@@ -9,6 +9,7 @@ _FIXED_PLACEHOLDERS = {"customer_name", "customer_email_local"}
 _METADATA_PREFIX = "metadata."
 _PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
 _PLACEHOLDER_NAME_RE = re.compile(r"^[\w.]+$")
+_METADATA_PLACEHOLDER_RE = re.compile(r"^metadata\.[\w-]+(?:\.[\w-]+)*$")
 _SLACK_CHANNEL_NAME_MAX_LENGTH = 80
 _NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
 
@@ -28,7 +29,7 @@ def validate_template(template: str) -> None:
     for name in _iter_placeholder_names(template):
         if name in _FIXED_PLACEHOLDERS:
             continue
-        if name.startswith(_METADATA_PREFIX) and len(name) > len(_METADATA_PREFIX):
+        if _METADATA_PLACEHOLDER_RE.fullmatch(name):
             continue
         raise InvalidTemplateError(
             f"Unknown placeholder: {{{name}}}. "
@@ -75,7 +76,7 @@ def render_channel_name(
 def _resolve(name: str, context: TemplateContext, *, tolerant: bool) -> str:
     if name in _FIXED_PLACEHOLDERS:
         return str(getattr(context, name))
-    if name.startswith(_METADATA_PREFIX):
+    if _METADATA_PLACEHOLDER_RE.fullmatch(name):
         key = name[len(_METADATA_PREFIX) :]
         value = get_nested_metadata_value(context.metadata, key)
         if value is None:
@@ -98,7 +99,7 @@ def _render_permissive(template: str) -> str:
     def sub(name: str) -> str:
         if name in _FIXED_PLACEHOLDERS:
             return str(getattr(sample, name))
-        if name.startswith(_METADATA_PREFIX):
+        if _METADATA_PLACEHOLDER_RE.fullmatch(name):
             return "sample"
         return ""
 
@@ -110,7 +111,10 @@ def _iter_placeholder_names(template: str) -> Iterator[str]:
     for match in _PLACEHOLDER_RE.finditer(template):
         _raise_for_malformed_braces(template[position : match.start()])
         name = match.group(1)
-        if _PLACEHOLDER_NAME_RE.fullmatch(name) is None:
+        if (
+            _PLACEHOLDER_NAME_RE.fullmatch(name) is None
+            and _METADATA_PLACEHOLDER_RE.fullmatch(name) is None
+        ):
             raise _malformed_placeholder(f"{{{name}}}")
         yield name
         position = match.end()

--- a/server/polar/benefit/strategies/slack_shared_channel/template.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/template.py
@@ -1,0 +1,141 @@
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from polar.kit.metadata import get_nested_metadata_value
+
+_FIXED_PLACEHOLDERS = {"customer_name", "customer_email_local"}
+_METADATA_PREFIX = "metadata."
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
+_PLACEHOLDER_NAME_RE = re.compile(r"^[\w.]+$")
+_SLACK_CHANNEL_NAME_MAX_LENGTH = 80
+_NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class TemplateContext:
+    customer_name: str
+    customer_email_local: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class InvalidTemplateError(ValueError):
+    pass
+
+
+def validate_template(template: str) -> None:
+    for name in _iter_placeholder_names(template):
+        if name in _FIXED_PLACEHOLDERS:
+            continue
+        if name.startswith(_METADATA_PREFIX) and len(name) > len(_METADATA_PREFIX):
+            continue
+        raise InvalidTemplateError(
+            f"Unknown placeholder: {{{name}}}. "
+            f"Allowed: {{customer_name}}, {{customer_email_local}}, "
+            f"or {{metadata.<key>}} for customer metadata."
+        )
+
+    if not _render_permissive(template):
+        raise InvalidTemplateError(
+            "Template renders to an empty channel name against a sample customer."
+        )
+
+
+def render_channel_name(
+    template: str,
+    context: TemplateContext,
+    *,
+    suffix: str | None = None,
+    tolerant: bool = False,
+) -> str:
+    _validate_placeholder_syntax(template)
+    rendered = _PLACEHOLDER_RE.sub(
+        lambda match: _resolve(match.group(1), context, tolerant=tolerant),
+        template,
+    )
+    if suffix:
+        suffix_slug = _slugify(suffix)
+        if suffix_slug:
+            if len(suffix_slug) >= _SLACK_CHANNEL_NAME_MAX_LENGTH:
+                return suffix_slug[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
+            max_base_length = _SLACK_CHANNEL_NAME_MAX_LENGTH - len(suffix_slug) - 1
+            rendered = _slugify(rendered)[:max_base_length].strip("-")
+            if not rendered:
+                return suffix_slug[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
+            return f"{rendered}-{suffix_slug}"[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
+    slug = _slugify(rendered)[:_SLACK_CHANNEL_NAME_MAX_LENGTH]
+    if not slug:
+        raise InvalidTemplateError(
+            "Template renders to an empty channel name for this customer."
+        )
+    return slug
+
+
+def _resolve(name: str, context: TemplateContext, *, tolerant: bool) -> str:
+    if name in _FIXED_PLACEHOLDERS:
+        return str(getattr(context, name))
+    if name.startswith(_METADATA_PREFIX):
+        key = name[len(_METADATA_PREFIX) :]
+        value = get_nested_metadata_value(context.metadata, key)
+        if value is None:
+            if tolerant:
+                return key
+            raise InvalidTemplateError(
+                f"Customer is missing metadata key {key!r} required by the "
+                f"channel name template."
+            )
+        return str(value)
+    raise InvalidTemplateError(f"Unknown placeholder: {{{name}}}.")
+
+
+def _render_permissive(template: str) -> str:
+    sample = TemplateContext(
+        customer_name="sample customer",
+        customer_email_local="sample",
+    )
+
+    def sub(name: str) -> str:
+        if name in _FIXED_PLACEHOLDERS:
+            return str(getattr(sample, name))
+        if name.startswith(_METADATA_PREFIX):
+            return "sample"
+        return ""
+
+    return _slugify(_PLACEHOLDER_RE.sub(lambda match: sub(match.group(1)), template))
+
+
+def _iter_placeholder_names(template: str) -> Iterator[str]:
+    position = 0
+    for match in _PLACEHOLDER_RE.finditer(template):
+        _raise_for_malformed_braces(template[position : match.start()])
+        name = match.group(1)
+        if _PLACEHOLDER_NAME_RE.fullmatch(name) is None:
+            raise _malformed_placeholder(f"{{{name}}}")
+        yield name
+        position = match.end()
+    _raise_for_malformed_braces(template[position:])
+
+
+def _validate_placeholder_syntax(template: str) -> None:
+    for _ in _iter_placeholder_names(template):
+        pass
+
+
+def _raise_for_malformed_braces(value: str) -> None:
+    if "{" in value or "}" in value:
+        raise _malformed_placeholder(value)
+
+
+def _malformed_placeholder(placeholder: str) -> InvalidTemplateError:
+    return InvalidTemplateError(
+        f"Malformed placeholder: {placeholder}. "
+        f"Allowed: {{customer_name}}, {{customer_email_local}}, "
+        f"or {{metadata.<key>}} for customer metadata."
+    )
+
+
+def _slugify(value: str) -> str:
+    value = value.lower().strip()
+    value = _NON_ALPHANUMERIC.sub("-", value)
+    return value.strip("-")

--- a/server/polar/customer_portal/schemas/benefit_grant.py
+++ b/server/polar/customer_portal/schemas/benefit_grant.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Annotated, Literal, TypedDict
 
-from pydantic import UUID4, Discriminator, TypeAdapter
+from pydantic import UUID4, Discriminator, EmailStr, TypeAdapter
 
 from polar.benefit.strategies.custom.properties import BenefitGrantCustomProperties
 from polar.benefit.strategies.custom.schemas import BenefitCustomSubscriber
@@ -33,6 +33,12 @@ from polar.benefit.strategies.meter_credit.properties import (
     BenefitGrantMeterCreditProperties,
 )
 from polar.benefit.strategies.meter_credit.schemas import BenefitMeterCreditSubscriber
+from polar.benefit.strategies.slack_shared_channel.properties import (
+    BenefitGrantSlackSharedChannelProperties,
+)
+from polar.benefit.strategies.slack_shared_channel.schemas import (
+    BenefitSlackSharedChannelSubscriber,
+)
 from polar.kit.schemas import (
     ClassName,
     IDSchema,
@@ -103,6 +109,12 @@ class CustomerBenefitGrantFeatureFlag(CustomerBenefitGrantBase):
     properties: BenefitGrantFeatureFlagProperties
 
 
+class CustomerBenefitGrantSlackSharedChannel(CustomerBenefitGrantBase):
+    customer: CustomerPortalCustomer
+    benefit: BenefitSlackSharedChannelSubscriber
+    properties: BenefitGrantSlackSharedChannelProperties
+
+
 CustomerBenefitGrant = Annotated[
     CustomerBenefitGrantDiscord
     | CustomerBenefitGrantGitHubRepository
@@ -110,7 +122,8 @@ CustomerBenefitGrant = Annotated[
     | CustomerBenefitGrantLicenseKeys
     | CustomerBenefitGrantCustom
     | CustomerBenefitGrantMeterCredit
-    | CustomerBenefitGrantFeatureFlag,
+    | CustomerBenefitGrantFeatureFlag
+    | CustomerBenefitGrantSlackSharedChannel,
     SetSchemaReference("CustomerBenefitGrant"),
     MergeJSONSchema({"title": "CustomerBenefitGrant"}),
     ClassName("CustomerBenefitGrant"),
@@ -168,6 +181,15 @@ class CustomerBenefitGrantFeatureFlagUpdate(CustomerBenefitGrantUpdateBase):
     benefit_type: Literal[BenefitType.feature_flag]
 
 
+class CustomerBenefitGrantSlackSharedChannelPropertiesUpdate(TypedDict):
+    invited_email: EmailStr
+
+
+class CustomerBenefitGrantSlackSharedChannelUpdate(CustomerBenefitGrantUpdateBase):
+    benefit_type: Literal[BenefitType.slack_shared_channel]
+    properties: CustomerBenefitGrantSlackSharedChannelPropertiesUpdate
+
+
 CustomerBenefitGrantUpdate = Annotated[
     CustomerBenefitGrantDiscordUpdate
     | CustomerBenefitGrantGitHubRepositoryUpdate
@@ -175,7 +197,8 @@ CustomerBenefitGrantUpdate = Annotated[
     | CustomerBenefitGrantLicenseKeysUpdate
     | CustomerBenefitGrantCustomUpdate
     | CustomerBenefitGrantMeterCreditUpdate
-    | CustomerBenefitGrantFeatureFlagUpdate,
+    | CustomerBenefitGrantFeatureFlagUpdate
+    | CustomerBenefitGrantSlackSharedChannelUpdate,
     SetSchemaReference("CustomerBenefitGrantUpdate"),
     MergeJSONSchema({"title": "CustomerBenefitGrantUpdate"}),
     Discriminator("benefit_type"),

--- a/server/polar/customer_portal/service/benefit_grant.py
+++ b/server/polar/customer_portal/service/benefit_grant.py
@@ -225,13 +225,11 @@ class CustomerBenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 **benefit_grant.properties,
                 **benefit_grant_update.properties,
             }
-            if (
-                isinstance(
-                    benefit_grant_update, CustomerBenefitGrantSlackSharedChannelUpdate
-                )
-                and benefit_grant_update.properties["invited_email"]
-                != benefit_grant.properties.get("invited_email")
-            ):
+            if isinstance(
+                benefit_grant_update, CustomerBenefitGrantSlackSharedChannelUpdate
+            ) and benefit_grant_update.properties[
+                "invited_email"
+            ] != benefit_grant.properties.get("invited_email"):
                 properties.pop("invite_id", None)
                 properties.pop("invite_url", None)
             benefit_grant.properties = cast(Any, properties)

--- a/server/polar/customer_portal/service/benefit_grant.py
+++ b/server/polar/customer_portal/service/benefit_grant.py
@@ -221,13 +221,20 @@ class CustomerBenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 CustomerBenefitGrantSlackSharedChannelUpdate,
             ),
         ):
-            benefit_grant.properties = cast(
-                Any,
-                {
-                    **benefit_grant.properties,
-                    **benefit_grant_update.properties,
-                },
-            )
+            properties = {
+                **benefit_grant.properties,
+                **benefit_grant_update.properties,
+            }
+            if (
+                isinstance(
+                    benefit_grant_update, CustomerBenefitGrantSlackSharedChannelUpdate
+                )
+                and benefit_grant_update.properties["invited_email"]
+                != benefit_grant.properties.get("invited_email")
+            ):
+                properties.pop("invite_id", None)
+                properties.pop("invite_url", None)
+            benefit_grant.properties = cast(Any, properties)
             benefit_grant.error = None
             enqueue_job("benefit.update", benefit_grant.id)
 

--- a/server/polar/customer_portal/service/benefit_grant.py
+++ b/server/polar/customer_portal/service/benefit_grant.py
@@ -28,6 +28,7 @@ from polar.worker import enqueue_job
 from ..schemas.benefit_grant import (
     CustomerBenefitGrantDiscordUpdate,
     CustomerBenefitGrantGitHubRepositoryUpdate,
+    CustomerBenefitGrantSlackSharedChannelUpdate,
     CustomerBenefitGrantUpdate,
 )
 
@@ -171,9 +172,11 @@ class CustomerBenefitGrantService(ResourceServiceReader[BenefitGrant]):
             )
 
         if isinstance(
-            benefit_grant_update, CustomerBenefitGrantDiscordUpdate
-        ) or isinstance(
-            benefit_grant_update, CustomerBenefitGrantGitHubRepositoryUpdate
+            benefit_grant_update,
+            (
+                CustomerBenefitGrantDiscordUpdate,
+                CustomerBenefitGrantGitHubRepositoryUpdate,
+            ),
         ):
             account_id = benefit_grant_update.properties["account_id"]
             if account_id is not None:
@@ -210,6 +213,14 @@ class CustomerBenefitGrantService(ResourceServiceReader[BenefitGrant]):
                         ]
                     )
 
+        if isinstance(
+            benefit_grant_update,
+            (
+                CustomerBenefitGrantDiscordUpdate,
+                CustomerBenefitGrantGitHubRepositoryUpdate,
+                CustomerBenefitGrantSlackSharedChannelUpdate,
+            ),
+        ):
             benefit_grant.properties = cast(
                 Any,
                 {
@@ -217,7 +228,7 @@ class CustomerBenefitGrantService(ResourceServiceReader[BenefitGrant]):
                     **benefit_grant_update.properties,
                 },
             )
-
+            benefit_grant.error = None
             enqueue_job("benefit.update", benefit_grant.id)
 
         for attr, value in benefit_grant_update.model_dump(

--- a/server/polar/integrations/slack/endpoints.py
+++ b/server/polar/integrations/slack/endpoints.py
@@ -33,7 +33,6 @@ from .repository import SlackAppRepository
 from .schemas import (
     SlackIntegration,
     SlackIntegrationCredentialsUpdate,
-    SlackIntegrationLink,
     SlackIntegrationManifest,
     SlackIntegrationManifestRequest,
     SlackWorkspaceUser,
@@ -52,16 +51,6 @@ router = APIRouter(
 )
 
 CALLBACK_ROUTE_NAME = "integrations.slack.callback"
-
-
-class SlackIntegrationLinkBadRequestResponse(Schema):
-    error: Literal[
-        "BadRequest",
-        "SlackIntegrationAlreadyLinked",
-        "SlackIntegrationNotInstalled",
-        "SlackIntegrationBenefitAlreadyLinked",
-    ]
-    detail: str
 
 
 class SlackIntegrationQueryBadRequestResponse(Schema):
@@ -290,37 +279,6 @@ async def callback(
     )
 
     return RedirectResponse(get_safe_return_url(return_to), 303)
-
-
-@router.post(
-    "/link",
-    response_model=SlackIntegration,
-    responses={
-        400: {
-            "description": (
-                "Slack integration is not installed, already linked, "
-                "or belongs to a different organization."
-            ),
-            "model": SlackIntegrationLinkBadRequestResponse,
-        },
-        404: {"description": "Benefit or Slack integration not found."},
-    },
-)
-async def link(
-    payload: SlackIntegrationLink,
-    auth_subject: SlackIntegrationWrite,
-    session: AsyncSession = Depends(get_db_session),
-) -> SlackIntegration:
-    benefit = await _get_writable_benefit(session, auth_subject, payload.benefit_id)
-    integration = await _get_writable_integration(
-        session, auth_subject, payload.integration_id
-    )
-    if integration.organization_id != benefit.organization_id:
-        raise BadRequest(
-            "The Slack integration and benefit must belong to the same organization."
-        )
-    linked = await slack_app_service.link(session, benefit, integration)
-    return SlackIntegration.model_validate(linked)
 
 
 @router.post(

--- a/server/polar/integrations/slack/repository.py
+++ b/server/polar/integrations/slack/repository.py
@@ -13,14 +13,6 @@ class SlackAppRepository(
         statement = self.get_base_statement().where(SlackApp.id == id)
         return await self.get_one_or_none(statement)
 
-    async def get_by_id_for_update(self, id: UUID) -> SlackApp | None:
-        statement = (
-            self.get_base_statement()
-            .where(SlackApp.id == id)
-            .with_for_update(of=SlackApp)
-        )
-        return await self.get_one_or_none(statement)
-
     async def get_by_app_id(self, slack_app_id: str) -> SlackApp | None:
         statement = self.get_base_statement().where(
             SlackApp.slack_app_id == slack_app_id

--- a/server/polar/integrations/slack/schemas.py
+++ b/server/polar/integrations/slack/schemas.py
@@ -116,11 +116,6 @@ class SlackWorkspaceUsersResponse(Schema):
     )
 
 
-class SlackIntegrationLink(Schema):
-    benefit_id: UUID4 = Field(description="Benefit to link the integration to.")
-    integration_id: UUID4 = Field(description="Slack integration to link.")
-
-
 class SlackIntegration(TimestampedSchema):
     id: UUID4 = Field(description="ID of the Slack integration.")
     organization_id: UUID4 = Field(

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -181,6 +181,7 @@ class SlackAppService:
         if integration.bot_token is None:
             raise SlackIntegrationNotInstalled()
 
+        await session.refresh(benefit, with_for_update=True)
         properties = dict(benefit.properties or {})
         existing_integration_id = properties.get("slack_integration_id")
         if isinstance(existing_integration_id, str) and existing_integration_id != str(

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -11,7 +11,7 @@ from polar.exceptions import BadRequest, PolarError, ResourceNotFound
 from polar.kit import jwt
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.utils import utc_now
-from polar.models import Benefit, SlackApp
+from polar.models import SlackApp
 
 from .client import SlackClient
 from .manifest import BOT_SCOPES
@@ -48,23 +48,6 @@ class SlackIntegrationAppIdAlreadyLinked(BadRequest):
         super().__init__(
             "This Slack app is already connected to another Polar organization."
         )
-
-
-class SlackIntegrationNotInstalled(BadRequest):
-    def __init__(self) -> None:
-        super().__init__(
-            "Authorize the Slack workspace before linking it to a benefit."
-        )
-
-
-class SlackIntegrationAlreadyLinked(BadRequest):
-    def __init__(self) -> None:
-        super().__init__("This Slack integration is already linked to a benefit.")
-
-
-class SlackIntegrationBenefitAlreadyLinked(BadRequest):
-    def __init__(self) -> None:
-        super().__init__("This benefit is already linked to a Slack integration.")
 
 
 # Errors that mean credentials parsed but code was rejected; credentials are OK.
@@ -165,50 +148,6 @@ class SlackAppService:
                 }
             )
         return await repository.update(existing, update_dict=update_dict)
-
-    async def link(
-        self,
-        session: AsyncSession,
-        benefit: Benefit,
-        integration: SlackApp,
-    ) -> SlackApp:
-        repository = SlackAppRepository.from_session(session)
-        locked_integration = await repository.get_by_id_for_update(integration.id)
-        if locked_integration is None:
-            raise SlackIntegrationNotConfigured()
-        integration = locked_integration
-
-        if integration.bot_token is None:
-            raise SlackIntegrationNotInstalled()
-
-        await session.refresh(benefit, with_for_update=True)
-        properties = dict(benefit.properties or {})
-        existing_integration_id = properties.get("slack_integration_id")
-        if isinstance(existing_integration_id, str) and existing_integration_id != str(
-            integration.id
-        ):
-            raise SlackIntegrationBenefitAlreadyLinked()
-
-        if existing_integration_id == str(integration.id):
-            return integration
-
-        benefit_repository = BenefitRepository.from_session(session)
-        linked_benefits = await benefit_repository.list_by_slack_integration_id(
-            benefit.organization_id, integration.id
-        )
-        if any(linked_benefit.id != benefit.id for linked_benefit in linked_benefits):
-            raise SlackIntegrationAlreadyLinked()
-
-        await benefit_repository.update(
-            benefit,
-            update_dict={
-                "properties": {
-                    **properties,
-                    "slack_integration_id": str(integration.id),
-                }
-            },
-        )
-        return integration
 
     def build_authorize_url(
         self,

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.benefit.strategies import BenefitActionRequiredError, BenefitServiceProtocol
+from polar.benefit.strategies.base.properties import BenefitGrantProperties
 from polar.benefit.strategies.base.service import BenefitRetriableError
 from polar.config import settings
 from polar.models import (
@@ -139,6 +140,31 @@ class TestGrantBenefit:
         assert grant.error["message"] == error_message
         assert grant.error["type"] == "BenefitActionRequiredError"
         assert "timestamp" in grant.error
+
+    async def test_action_required_error_with_grant_properties(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        subscription: Subscription,
+        customer: Customer,
+        benefit_organization: Benefit,
+        benefit_strategy_mock: MagicMock,
+    ) -> None:
+        error_message = "Action required error message"
+        grant_properties = cast(BenefitGrantProperties, {"external_id": "abc"})
+        benefit_strategy_mock.grant.side_effect = BenefitActionRequiredError(
+            error_message, grant_properties=grant_properties
+        )
+
+        grant = await benefit_grant_service.grant_benefit(
+            session, redis, customer, benefit_organization, subscription=subscription
+        )
+
+        assert not grant.is_granted
+        assert cast(Any, grant.properties) == {"external_id": "abc"}
+        assert grant.error is not None
+        assert grant.error["message"] == error_message
+        assert grant.error["type"] == "BenefitActionRequiredError"
 
     async def test_revoked_grant_action_required_error(
         self,
@@ -811,6 +837,44 @@ class TestUpdateBenefitGrant:
         assert updated_grant.error["message"] == error_message
         assert updated_grant.error["type"] == "BenefitActionRequiredError"
         assert "timestamp" in updated_grant.error
+
+    async def test_action_required_error_with_grant_properties(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        customer: Customer,
+        benefit_organization: Benefit,
+        benefit_strategy_mock: MagicMock,
+    ) -> None:
+        grant = BenefitGrant(
+            subscription=subscription,
+            customer=customer,
+            benefit=benefit_organization,
+            properties={"external_id": "abc"},
+        )
+        grant.set_granted()
+        await save_fixture(grant)
+
+        error_message = "Update action required error message"
+        grant_properties = cast(BenefitGrantProperties, {"external_id": "xyz"})
+        benefit_strategy_mock.grant.side_effect = BenefitActionRequiredError(
+            error_message, grant_properties=grant_properties
+        )
+
+        grant_loaded = await benefit_grant_service.get(session, grant.id, loaded=True)
+        assert grant_loaded
+
+        updated_grant = await benefit_grant_service.update_benefit_grant(
+            session, redis, grant_loaded
+        )
+
+        assert not updated_grant.is_granted
+        assert cast(Any, updated_grant.properties) == {"external_id": "xyz"}
+        assert updated_grant.error is not None
+        assert updated_grant.error["message"] == error_message
+        assert updated_grant.error["type"] == "BenefitActionRequiredError"
 
 
 @pytest.mark.asyncio

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1104,6 +1104,69 @@ class TestSlackSharedChannelRevoke:
                 {"invited_email": "admin@customer.example", "channel_id": "C123"},
             )
 
+    @pytest.mark.parametrize("error", ["already_archived", "channel_not_found"])
+    async def test_revoke_archive_noop_error_succeeds(
+        self,
+        error: str,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_archive=AsyncMock(return_value={"ok": False, "error": error}),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example", "channel_id": "C123"},
+        )
+
+        assert result == {"invited_email": "admin@customer.example"}
+
+    async def test_revoke_archive_permanent_error_raises_action_required(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_archive=AsyncMock(
+                return_value={"ok": False, "error": "restricted_action"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitActionRequiredError, match="restricted_action"):
+            await strategy.revoke(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example", "channel_id": "C123"},
+            )
+
 
 @pytest.mark.asyncio
 class TestSlackSharedChannelValidate:

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from polar.benefit.strategies import (
@@ -13,9 +12,6 @@ from polar.benefit.strategies import (
 from polar.benefit.strategies.slack_shared_channel.properties import (
     BenefitGrantSlackSharedChannelProperties,
     BenefitSlackSharedChannelProperties,
-)
-from polar.benefit.strategies.slack_shared_channel.schemas import (
-    BenefitSlackSharedChannelCreateProperties,
 )
 from polar.benefit.strategies.slack_shared_channel.service import (
     BenefitSlackSharedChannelService,
@@ -458,10 +454,8 @@ class TestSlackSharedChannelGrant:
         client.conversations_create.assert_not_awaited()
         client.conversations_invite_shared.assert_not_awaited()
 
-    @pytest.mark.parametrize("attempt", [0, 1])
     async def test_grant_lock_contention_is_retriable(
         self,
-        attempt: int,
         session: AsyncSession,
         redis: Redis,
         save_fixture: SaveFixture,
@@ -517,23 +511,26 @@ class TestSlackSharedChannelGrant:
         )
         strategy = _strategy(session, redis, client)
 
-        with pytest.raises(BenefitRetriableError) as exc_info:
+        with pytest.raises(BenefitRetriableError):
             await strategy.grant(
                 benefit,
                 customer,
                 {"invited_email": "admin@customer.example"},
-                attempt=attempt,
             )
 
-        assert exc_info.value.defer_seconds == 60
-        redis_set.assert_awaited_once_with(
-            f"slack_benefit_grant:{benefit.id}:{customer.id}",
-            "1",
-            ex=60,
-            nx=True,
+        client.conversations_create = AsyncMock(
+            return_value={
+                "ok": True,
+                "channel": {"id": "C123", "name": "support-acme"},
+            }
         )
-        client.conversations_create.assert_not_awaited()
-        client.conversations_invite_shared.assert_not_awaited()
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+        assert result["channel_id"] == "C123"
 
     async def test_grant_on_update_invites_team_to_existing_channel(
         self,
@@ -1110,14 +1107,38 @@ class TestSlackSharedChannelRevoke:
 
 @pytest.mark.asyncio
 class TestSlackSharedChannelValidate:
-    async def test_schema_rejects_invalid_slack_integration_id(self) -> None:
-        with pytest.raises(ValidationError):
-            BenefitSlackSharedChannelCreateProperties.model_validate(
-                {
-                    "slack_integration_id": "not-a-uuid",
-                    "channel_name_template": "support-{customer_name}",
-                }
-            )
+    async def test_validate_properties_update_preserves_slack_integration_id(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        integration = await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.validate_properties_update(
+            None,  # type: ignore[arg-type]
+            benefit,
+            {
+                "channel_name_template": "vip-{customer_name}",
+                "private": True,
+                "welcome_message": None,
+                "archive_on_revoke": True,
+                "team_invitees": [],
+            },
+        )
+
+        assert result["slack_integration_id"] == str(integration.id)
+        assert result["channel_name_template"] == "vip-{customer_name}"
 
     async def test_validate_rejects_unknown_placeholder(
         self,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1,17 +1,24 @@
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import httpx
 import pytest
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
+from polar.auth.models import AuthSubject
 from polar.benefit.strategies import (
     BenefitActionRequiredError,
+    BenefitPropertiesValidationError,
     BenefitRetriableError,
 )
 from polar.benefit.strategies.slack_shared_channel.properties import (
     BenefitGrantSlackSharedChannelProperties,
     BenefitSlackSharedChannelProperties,
+)
+from polar.benefit.strategies.slack_shared_channel.schemas import (
+    BenefitSlackSharedChannelCreateProperties,
 )
 from polar.benefit.strategies.slack_shared_channel.service import (
     BenefitSlackSharedChannelService,
@@ -22,6 +29,8 @@ from polar.models import (
     Customer,
     Organization,
     SlackApp,
+    User,
+    UserOrganization,
 )
 from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
@@ -599,7 +608,7 @@ class TestSlackSharedChannelGrant:
         customer: Customer,
         organization: Organization,
     ) -> None:
-        customer.name = "李雷"
+        customer.name = "!!!"
         benefit = await create_benefit(
             save_fixture,
             organization=organization,
@@ -1337,13 +1346,16 @@ class TestSlackSharedChannelRevoke:
 
 @pytest.mark.asyncio
 class TestSlackSharedChannelValidate:
-    async def test_validate_properties_update_preserves_slack_integration_id(
+    @pytest.mark.auth
+    async def test_validate_properties_accepts_installed_integration(
         self,
         session: AsyncSession,
         redis: Redis,
         save_fixture: SaveFixture,
         mocker: MockerFixture,
         organization: Organization,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
     ) -> None:
         benefit = await create_benefit(
             save_fixture,
@@ -1352,60 +1364,94 @@ class TestSlackSharedChannelValidate:
             properties=_BASE_PROPERTIES,
         )
         integration = await _create_integration(save_fixture, benefit)
-        client = _mock_client(mocker)
-        strategy = _strategy(session, redis, client)
+        strategy = _strategy(session, redis, _mock_client(mocker))
 
-        result = await strategy.validate_properties_update(
-            None,  # type: ignore[arg-type]
-            benefit,
-            {
-                "channel_name_template": "vip-{customer_name}",
-                "private": True,
-                "welcome_message": None,
-                "archive_on_revoke": True,
-                "team_invitees": [],
-            },
+        result = await strategy.validate_properties(
+            auth_subject,
+            {**_BASE_PROPERTIES, "slack_integration_id": str(integration.id)},
         )
 
         assert result["slack_integration_id"] == str(integration.id)
-        assert result["channel_name_template"] == "vip-{customer_name}"
 
-    async def test_validate_rejects_unknown_placeholder(
+    @pytest.mark.auth
+    async def test_validate_properties_rejects_unknown_integration(
         self,
         session: AsyncSession,
         redis: Redis,
         mocker: MockerFixture,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
     ) -> None:
-        from polar.benefit.strategies import BenefitPropertiesValidationError
+        strategy = _strategy(session, redis, _mock_client(mocker))
 
-        client = _mock_client(mocker)
-        strategy = _strategy(session, redis, client)
         with pytest.raises(BenefitPropertiesValidationError):
             await strategy.validate_properties(
-                None,  # type: ignore[arg-type]
-                {
-                    "channel_name_template": "{organization_slug}-foo",
-                    "private": True,
-                    "welcome_message": None,
-                    "archive_on_revoke": True,
-                },
+                auth_subject,
+                {**_BASE_PROPERTIES, "slack_integration_id": str(uuid4())},
             )
 
-    async def test_validate_accepts_valid_template(
+    @pytest.mark.auth
+    async def test_validate_properties_rejects_uninstalled_integration(
         self,
         session: AsyncSession,
         redis: Redis,
+        save_fixture: SaveFixture,
         mocker: MockerFixture,
+        organization: Organization,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
     ) -> None:
-        client = _mock_client(mocker)
-        strategy = _strategy(session, redis, client)
-        result = await strategy.validate_properties(
-            None,  # type: ignore[arg-type]
-            {
-                "channel_name_template": "support-{customer_name}",
-                "private": True,
-                "welcome_message": None,
-                "archive_on_revoke": True,
-            },
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
         )
-        assert result["channel_name_template"] == "support-{customer_name}"
+        integration = await _create_integration(save_fixture, benefit, bot_token=None)
+        strategy = _strategy(session, redis, _mock_client(mocker))
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await strategy.validate_properties(
+                auth_subject,
+                {**_BASE_PROPERTIES, "slack_integration_id": str(integration.id)},
+            )
+
+    @pytest.mark.auth
+    async def test_validate_properties_rejects_foreign_organization_integration(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization_second: Organization,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+    ) -> None:
+        foreign_benefit = await create_benefit(
+            save_fixture,
+            organization=organization_second,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        integration = await _create_integration(save_fixture, foreign_benefit)
+        strategy = _strategy(session, redis, _mock_client(mocker))
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await strategy.validate_properties(
+                auth_subject,
+                {**_BASE_PROPERTIES, "slack_integration_id": str(integration.id)},
+            )
+
+    async def test_schema_rejects_unknown_placeholder(self) -> None:
+        with pytest.raises(ValidationError, match="Unknown placeholder"):
+            BenefitSlackSharedChannelCreateProperties(
+                slack_integration_id=uuid4(),
+                channel_name_template="{organization_slug}-foo",
+            )
+
+    async def test_schema_accepts_valid_template(self) -> None:
+        properties = BenefitSlackSharedChannelCreateProperties(
+            slack_integration_id=uuid4(),
+            channel_name_template="support-{customer_name}",
+        )
+        assert properties.channel_name_template == "support-{customer_name}"

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -27,7 +27,7 @@ from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_benefit
+from tests.fixtures.random_objects import create_benefit, create_benefit_grant
 
 _BASE_PROPERTIES = {
     "channel_name_template": "support-{customer_name}",
@@ -414,6 +414,100 @@ class TestSlackSharedChannelGrant:
             channel="C123",
             email="admin@customer.example",
         )
+
+    async def test_grant_adopts_channel_from_sibling_grant(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={
+                **_BASE_PROPERTIES,
+                "welcome_message": "Welcome!",
+                "team_invitees": ["U01"],
+            },
+        )
+        await _create_integration(save_fixture, benefit)
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=True,
+            properties={
+                "invited_email": "first@customer.example",
+                "channel_id": "CSIBLING",
+                "channel_name": "support-acme",
+                "invite_id": "I001",
+            },
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "colleague@customer.example"},
+        )
+
+        assert result["channel_id"] == "CSIBLING"
+        assert result["channel_name"] == "support-acme"
+        client.conversations_create.assert_not_awaited()
+        client.conversations_list.assert_not_awaited()
+        client.chat_post_message.assert_not_awaited()
+        client.conversations_invite.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CSIBLING",
+            email="colleague@customer.example",
+        )
+
+    async def test_grant_ignores_revoked_sibling_grant(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=False,
+            properties={
+                "invited_email": "first@customer.example",
+                "channel_id": "CSIBLING",
+                "channel_name": "support-acme",
+            },
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "colleague@customer.example"},
+        )
+
+        assert result["channel_id"] == "C123"
+        client.conversations_create.assert_awaited_once()
 
     async def test_grant_missing_email_raises_action_required(
         self,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1037,6 +1037,15 @@ class TestSlackSharedChannelRevoke:
 
 @pytest.mark.asyncio
 class TestSlackSharedChannelValidate:
+    async def test_schema_rejects_invalid_slack_integration_id(self) -> None:
+        with pytest.raises(ValidationError):
+            BenefitSlackSharedChannelCreateProperties.model_validate(
+                {
+                    "slack_integration_id": "not-a-uuid",
+                    "channel_name_template": "support-{customer_name}",
+                }
+            )
+
     async def test_validate_rejects_unknown_placeholder(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from polar.benefit.strategies import (
@@ -12,6 +13,9 @@ from polar.benefit.strategies import (
 from polar.benefit.strategies.slack_shared_channel.properties import (
     BenefitGrantSlackSharedChannelProperties,
     BenefitSlackSharedChannelProperties,
+)
+from polar.benefit.strategies.slack_shared_channel.schemas import (
+    BenefitSlackSharedChannelCreateProperties,
 )
 from polar.benefit.strategies.slack_shared_channel.service import (
     BenefitSlackSharedChannelService,
@@ -1024,6 +1028,37 @@ class TestSlackSharedChannelRevoke:
         client = _mock_client(
             mocker,
             conversations_archive=AsyncMock(side_effect=httpx.ConnectError("boom")),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitRetriableError):
+            await strategy.revoke(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example", "channel_id": "C123"},
+            )
+
+    async def test_revoke_archive_slack_error_raises_retriable(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_archive=AsyncMock(
+                return_value={"ok": False, "error": "ratelimited"}
+            ),
         )
         strategy = _strategy(session, redis, client)
 

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -415,6 +415,63 @@ class TestSlackSharedChannelGrant:
             email="admin@customer.example",
         )
 
+    async def test_grant_adopted_channel_skips_welcome_and_team_invite(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={
+                **_BASE_PROPERTIES,
+                "welcome_message": "Welcome!",
+                "team_invitees": ["U01"],
+            },
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CEXIST",
+                            "name": "support-acme",
+                            "is_private": False,
+                            "is_member": True,
+                        }
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "CEXIST"
+        client.chat_post_message.assert_not_awaited()
+        client.conversations_invite.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CEXIST",
+            email="admin@customer.example",
+        )
+
     async def test_grant_adopts_channel_from_sibling_grant(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1139,6 +1139,100 @@ class TestSlackSharedChannelRevoke:
         )
         assert result == {"invited_email": "admin@customer.example"}
 
+    async def test_revoke_archives_when_last_grant_on_channel(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=True,
+            properties={
+                "invited_email": "admin@customer.example",
+                "channel_id": "C123",
+            },
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example", "channel_id": "C123"},
+        )
+
+        client.conversations_archive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="C123"
+        )
+        assert result == {"invited_email": "admin@customer.example"}
+
+    async def test_revoke_skips_archive_when_channel_used_by_other_benefit(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        other_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=True,
+            properties={
+                "invited_email": "admin@customer.example",
+                "channel_id": "C123",
+            },
+        )
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            other_benefit,
+            granted=True,
+            properties={
+                "invited_email": "admin@customer.example",
+                "channel_id": "C123",
+            },
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example", "channel_id": "C123"},
+        )
+
+        client.conversations_archive.assert_not_awaited()
+        assert result == {"invited_email": "admin@customer.example"}
+
     async def test_revoke_skips_when_archive_disabled(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -148,6 +148,7 @@ class TestSlackSharedChannelGrant:
         assert result["invite_url"].startswith("https://slack.com/share/")
 
         client.conversations_create.assert_awaited_once()
+        client.conversations_list.assert_not_awaited()
         client.conversations_invite_shared.assert_awaited_once_with(
             bot_token="xoxb-test-token",
             channel="C123",
@@ -211,6 +212,9 @@ class TestSlackSharedChannelGrant:
         await _create_integration(save_fixture, benefit)
         client = _mock_client(
             mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
             conversations_list=AsyncMock(
                 return_value={
                     "ok": True,
@@ -235,7 +239,7 @@ class TestSlackSharedChannelGrant:
 
         assert result["channel_id"] == "CEXIST"
         assert result["channel_name"] == "support-acme"
-        client.conversations_create.assert_not_awaited()
+        client.conversations_create.assert_awaited_once()
         client.conversations_join.assert_not_awaited()
         client.conversations_invite_shared.assert_awaited_once_with(
             bot_token="xoxb-test-token",
@@ -262,6 +266,9 @@ class TestSlackSharedChannelGrant:
         await _create_integration(save_fixture, benefit)
         client = _mock_client(
             mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
             conversations_list=AsyncMock(
                 return_value={
                     "ok": True,
@@ -288,7 +295,7 @@ class TestSlackSharedChannelGrant:
         client.conversations_join.assert_awaited_once_with(
             bot_token="xoxb-test-token", channel="CEXIST"
         )
-        client.conversations_create.assert_not_awaited()
+        client.conversations_create.assert_awaited_once()
         client.conversations_invite_shared.assert_awaited_once_with(
             bot_token="xoxb-test-token",
             channel="CEXIST",
@@ -314,6 +321,9 @@ class TestSlackSharedChannelGrant:
         await _create_integration(save_fixture, benefit)
         client = _mock_client(
             mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
             conversations_list=AsyncMock(
                 return_value={
                     "ok": True,
@@ -337,7 +347,7 @@ class TestSlackSharedChannelGrant:
         )
 
         assert result["channel_id"] == "GEXIST"
-        client.conversations_create.assert_not_awaited()
+        client.conversations_create.assert_awaited_once()
         client.conversations_invite_shared.assert_awaited_once_with(
             bot_token="xoxb-test-token",
             channel="GEXIST",
@@ -363,6 +373,12 @@ class TestSlackSharedChannelGrant:
         await _create_integration(save_fixture, benefit)
         client = _mock_client(
             mocker,
+            conversations_create=AsyncMock(
+                side_effect=[
+                    {"ok": False, "error": "name_taken"},
+                    {"ok": True, "channel": {"id": "C123", "name": "support-acme"}},
+                ]
+            ),
             conversations_list=AsyncMock(
                 return_value={
                     "ok": True,
@@ -392,7 +408,7 @@ class TestSlackSharedChannelGrant:
         client.conversations_join.assert_awaited_once_with(
             bot_token="xoxb-test-token", channel="CEXIST"
         )
-        client.conversations_create.assert_awaited_once()
+        assert client.conversations_create.await_count == 2
         client.conversations_invite_shared.assert_awaited_once_with(
             bot_token="xoxb-test-token",
             channel="C123",

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -20,6 +20,7 @@ from polar.benefit.strategies.slack_shared_channel.schemas import (
 from polar.benefit.strategies.slack_shared_channel.service import (
     BenefitSlackSharedChannelService,
 )
+from polar.locker import Locker
 from polar.models import (
     Benefit,
     Customer,
@@ -445,7 +446,6 @@ class TestSlackSharedChannelGrant:
         await _create_integration(save_fixture, benefit)
         client = _mock_client(mocker)
         strategy = _strategy(session, redis, client)
-        mocker.patch.object(redis, "set", AsyncMock(return_value=True))
 
         with pytest.raises(BenefitActionRequiredError, match="empty channel name"):
             await strategy.grant(
@@ -477,7 +477,45 @@ class TestSlackSharedChannelGrant:
         )
         client = _mock_client(mocker)
         strategy = _strategy(session, redis, client)
-        redis_set = mocker.patch.object(redis, "set", AsyncMock(return_value=False))
+        locker = Locker(redis)
+
+        async with locker.lock(
+            f"slack_benefit_grant:{benefit.id}:{customer.id}",
+            timeout=60,
+            blocking_timeout=0,
+        ):
+            with pytest.raises(BenefitRetriableError) as exc_info:
+                await strategy.grant(
+                    benefit,
+                    customer,
+                    {"invited_email": "admin@customer.example"},
+                )
+
+        assert exc_info.value.defer_seconds == 60
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_not_awaited()
+
+    async def test_grant_lock_released_after_retriable_failure(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(side_effect=httpx.ConnectError("boom")),
+        )
+        strategy = _strategy(session, redis, client)
 
         with pytest.raises(BenefitRetriableError) as exc_info:
             await strategy.grant(

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1,0 +1,1078 @@
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.benefit.strategies import (
+    BenefitActionRequiredError,
+    BenefitRetriableError,
+)
+from polar.benefit.strategies.slack_shared_channel.properties import (
+    BenefitGrantSlackSharedChannelProperties,
+    BenefitSlackSharedChannelProperties,
+)
+from polar.benefit.strategies.slack_shared_channel.service import (
+    BenefitSlackSharedChannelService,
+)
+from polar.models import (
+    Benefit,
+    Customer,
+    Organization,
+    SlackApp,
+)
+from polar.models.benefit import BenefitType
+from polar.postgres import AsyncSession
+from polar.redis import Redis
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit
+
+_BASE_PROPERTIES = {
+    "channel_name_template": "support-{customer_name}",
+    "private": True,
+    "welcome_message": None,
+    "archive_on_revoke": True,
+    "team_invitees": [],
+}
+
+
+async def _create_integration(
+    save_fixture: SaveFixture,
+    benefit: Benefit,
+    *,
+    bot_token: str | None = "xoxb-test-token",
+) -> SlackApp:
+    integration = SlackApp(
+        organization_id=benefit.organization_id,
+        display_name="Test",
+        slack_app_id="A0TESTAPPID",
+        client_id="100.200",
+        client_secret="cs-test",
+        signing_secret="ss-test",
+        team_id="T1" if bot_token else None,
+        team_name="Test team" if bot_token else None,
+        bot_user_id="U1" if bot_token else None,
+        bot_token=bot_token,
+        authed_user_id="U2" if bot_token else None,
+        scopes=["channels:manage"] if bot_token else None,
+    )
+    await save_fixture(integration)
+    benefit.properties = {
+        **benefit.properties,
+        "slack_integration_id": str(integration.id),
+    }
+    await save_fixture(benefit)
+    return integration
+
+
+def _mock_client(mocker: MockerFixture, **overrides: Any) -> AsyncMock:
+    defaults: dict[str, Any] = {
+        "conversations_create": AsyncMock(
+            return_value={
+                "ok": True,
+                "channel": {"id": "C123", "name": "support-acme"},
+            }
+        ),
+        "conversations_list": AsyncMock(
+            return_value={
+                "ok": True,
+                "channels": [],
+                "response_metadata": {"next_cursor": ""},
+            }
+        ),
+        "conversations_join": AsyncMock(
+            return_value={
+                "ok": True,
+                "channel": {"id": "CEXIST", "name": "support-acme"},
+            }
+        ),
+        "chat_post_message": AsyncMock(return_value={"ok": True}),
+        "conversations_invite": AsyncMock(return_value={"ok": True}),
+        "conversations_invite_shared": AsyncMock(
+            return_value={
+                "ok": True,
+                "invite_id": "I123",
+                "url": "https://slack.com/share/I123",
+            }
+        ),
+        "conversations_archive": AsyncMock(return_value={"ok": True}),
+    }
+    defaults.update(overrides)
+    client = AsyncMock()
+    for name, mock in defaults.items():
+        setattr(client, name, mock)
+    return client
+
+
+def _strategy(
+    session: AsyncSession, redis: Redis, client: AsyncMock
+) -> BenefitSlackSharedChannelService:
+    strategy = BenefitSlackSharedChannelService(session, redis)
+    strategy._client = client
+    return strategy
+
+
+@pytest.mark.asyncio
+class TestSlackSharedChannelGrant:
+    async def test_grant_happy_path(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "C123"
+        assert result["channel_name"] == "support-acme"
+        assert result["invite_id"] == "I123"
+        assert result["invite_url"].startswith("https://slack.com/share/")
+
+        client.conversations_create.assert_awaited_once()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="C123",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_handles_external_limited_invite_without_url(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_invite_shared=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "invite_id": "I123",
+                    "is_legacy_shared_channel": False,
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["invite_id"] == "I123"
+        assert "invite_url" not in result
+
+    async def test_grant_reuses_existing_public_channel_by_rendered_name(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CEXIST",
+                            "name": "support-acme",
+                            "is_private": False,
+                            "is_member": True,
+                        }
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "CEXIST"
+        assert result["channel_name"] == "support-acme"
+        client.conversations_create.assert_not_awaited()
+        client.conversations_join.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CEXIST",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_joins_and_reuses_existing_public_channel_by_rendered_name(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CEXIST",
+                            "name": "support-acme",
+                            "is_private": False,
+                            "is_member": False,
+                        }
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "CEXIST"
+        client.conversations_join.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST"
+        )
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CEXIST",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_reuses_existing_private_channel_when_app_is_member(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "private": True},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "GEXIST",
+                            "name": "support-acme",
+                            "is_private": True,
+                            "is_member": True,
+                        }
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "GEXIST"
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="GEXIST",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_creates_channel_when_existing_public_channel_cannot_be_joined(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CEXIST",
+                            "name": "support-acme",
+                            "is_private": False,
+                            "is_member": False,
+                        }
+                    ],
+                }
+            ),
+            conversations_join=AsyncMock(
+                return_value={"ok": False, "error": "missing_scope"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "C123"
+        client.conversations_join.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST"
+        )
+        client.conversations_create.assert_awaited_once()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="C123",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_missing_email_raises_action_required(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitActionRequiredError):
+            await strategy.grant(benefit, customer, {})
+
+        client.conversations_create.assert_not_awaited()
+
+    async def test_grant_empty_channel_name_raises_action_required(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "李雷"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "channel_name_template": "{customer_name}"},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+        mocker.patch.object(redis, "set", AsyncMock(return_value=True))
+
+        with pytest.raises(BenefitActionRequiredError, match="empty channel name"):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+        client.conversations_list.assert_not_awaited()
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_not_awaited()
+
+    @pytest.mark.parametrize("attempt", [0, 1])
+    async def test_grant_lock_contention_is_retriable(
+        self,
+        attempt: int,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+        redis_set = mocker.patch.object(redis, "set", AsyncMock(return_value=False))
+
+        with pytest.raises(BenefitRetriableError) as exc_info:
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+                attempt=attempt,
+            )
+
+        assert exc_info.value.defer_seconds == 60
+        redis_set.assert_awaited_once_with(
+            f"slack_benefit_grant:{benefit.id}:{customer.id}",
+            "1",
+            ex=60,
+            nx=True,
+        )
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_not_awaited()
+
+    async def test_grant_on_update_invites_team_to_existing_channel(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CEXIST",
+            "channel_name": "support-existing",
+            "invite_id": "I123",
+        }
+        result = await strategy.grant(benefit, customer, existing, update=True)
+
+        assert result == existing
+        client.conversations_invite.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST", users=["U01", "U02"]
+        )
+        client.conversations_create.assert_not_awaited()
+
+    async def test_requires_update_when_team_invitees_change(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        previous_changed: BenefitSlackSharedChannelProperties = {
+            **_BASE_PROPERTIES,  # type: ignore[typeddict-item]
+            "team_invitees": ["U01"],
+        }
+        previous_same: BenefitSlackSharedChannelProperties = {
+            **_BASE_PROPERTIES,  # type: ignore[typeddict-item]
+            "team_invitees": ["U02", "U01"],
+        }
+        assert await strategy.requires_update(benefit, previous_changed) is True
+        assert await strategy.requires_update(benefit, previous_same) is False
+
+    async def test_grant_skips_when_channel_already_provisioned_on_update(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CEXIST",
+            "channel_name": "support-existing",
+            "invite_id": "I123",
+        }
+        result = await strategy.grant(benefit, customer, existing, update=True)
+
+        assert result == existing
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_not_awaited()
+
+    async def test_grant_retries_shared_invite_for_existing_channel(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CEXIST",
+            "channel_name": "support-existing",
+        }
+        result = await strategy.grant(benefit, customer, existing, update=True)
+
+        assert result["channel_id"] == "CEXIST"
+        assert result["channel_name"] == "support-existing"
+        assert result["invite_id"] == "I123"
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CEXIST",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_retries_on_name_taken(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                side_effect=[
+                    {"ok": False, "error": "name_taken"},
+                    {
+                        "ok": True,
+                        "channel": {"id": "C456", "name": "support-acme-1234"},
+                    },
+                ]
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "C456"
+        assert client.conversations_create.await_count == 2
+
+    async def test_grant_name_taken_twice_raises(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitActionRequiredError, match="name_taken"):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+    async def test_grant_without_integration_raises_action_required(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitActionRequiredError, match="not installed"):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+    async def test_grant_with_uninstalled_integration_raises(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit, bot_token=None)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitActionRequiredError, match="not installed"):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+    async def test_grant_invites_team_members(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        client.conversations_invite.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="C123", users=["U01", "U02"]
+        )
+
+    async def test_grant_skips_invite_when_team_invitees_empty(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        client.conversations_invite.assert_not_awaited()
+
+    async def test_grant_continues_when_team_invite_fails(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "team_invitees": ["U01"]},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_invite=AsyncMock(
+                return_value={"ok": False, "error": "not_in_channel"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "C123"
+        client.conversations_invite_shared.assert_awaited_once()
+
+    async def test_grant_posts_welcome_message(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "welcome_message": "Welcome!"},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        client.chat_post_message.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="C123", text="Welcome!"
+        )
+
+    async def test_grant_invite_http_error_is_retriable(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_invite_shared=AsyncMock(
+                side_effect=httpx.ConnectError("boom")
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitRetriableError):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+
+@pytest.mark.asyncio
+class TestSlackSharedChannelRevoke:
+    async def test_revoke_archives_when_enabled(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example", "channel_id": "C123"},
+        )
+
+        client.conversations_archive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="C123"
+        )
+        assert result == {"invited_email": "admin@customer.example"}
+
+    async def test_revoke_skips_when_archive_disabled(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "archive_on_revoke": False},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example", "channel_id": "C123"},
+        )
+
+        client.conversations_archive.assert_not_awaited()
+
+    async def test_revoke_skips_when_no_channel_id(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        client.conversations_archive.assert_not_awaited()
+
+    async def test_revoke_skips_when_integration_uninstalled(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit, bot_token=None)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.revoke(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example", "channel_id": "C123"},
+        )
+
+        client.conversations_archive.assert_not_awaited()
+
+    async def test_revoke_archive_http_error_raises_retriable(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_archive=AsyncMock(side_effect=httpx.ConnectError("boom")),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitRetriableError):
+            await strategy.revoke(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example", "channel_id": "C123"},
+            )
+
+
+@pytest.mark.asyncio
+class TestSlackSharedChannelValidate:
+    async def test_validate_rejects_unknown_placeholder(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        mocker: MockerFixture,
+    ) -> None:
+        from polar.benefit.strategies import BenefitPropertiesValidationError
+
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+        with pytest.raises(BenefitPropertiesValidationError):
+            await strategy.validate_properties(
+                None,  # type: ignore[arg-type]
+                {
+                    "channel_name_template": "{organization_slug}-foo",
+                    "private": True,
+                    "welcome_message": None,
+                    "archive_on_revoke": True,
+                },
+            )
+
+    async def test_validate_accepts_valid_template(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        mocker: MockerFixture,
+    ) -> None:
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+        result = await strategy.validate_properties(
+            None,  # type: ignore[arg-type]
+            {
+                "channel_name_template": "support-{customer_name}",
+                "private": True,
+                "welcome_message": None,
+                "archive_on_revoke": True,
+            },
+        )
+        assert result["channel_name_template"] == "support-{customer_name}"

--- a/server/tests/benefit/strategies/test_slack_shared_channel_endpoints.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel_endpoints.py
@@ -1,0 +1,38 @@
+import pytest
+from httpx import AsyncClient
+
+from polar.auth.scope import Scope
+from polar.models import Organization, UserOrganization
+from tests.fixtures.auth import AuthSubjectFixture
+
+
+@pytest.mark.asyncio
+class TestPreviewChannelName:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/benefits/slack/preview-channel-name",
+            json={"template": "support-{customer_name}"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.benefits_write}))
+    async def test_returns_preview(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/benefits/slack/preview-channel-name",
+            json={
+                "organization_id": str(organization.id),
+                "template": "support-{customer_name}-{metadata.tier}",
+                "customer_name": "Acme Inc",
+                "customer_email": "admin@example.com",
+                "customer_metadata": {"tier": "gold"},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"channel_name": "support-acme-inc-gold"}

--- a/server/tests/benefit/strategies/test_slack_template.py
+++ b/server/tests/benefit/strategies/test_slack_template.py
@@ -1,0 +1,144 @@
+import pytest
+
+from polar.benefit.strategies.slack_shared_channel.template import (
+    InvalidTemplateError,
+    TemplateContext,
+    render_channel_name,
+    validate_template,
+)
+
+
+class TestValidateTemplate:
+    def test_fixed_placeholders(self) -> None:
+        validate_template("support-{customer_name}")
+        validate_template("{customer_email_local}")
+
+    def test_metadata_placeholder(self) -> None:
+        validate_template("{metadata.tier}-{customer_name}")
+
+    def test_unknown_placeholder(self) -> None:
+        with pytest.raises(InvalidTemplateError, match="organization_slug"):
+            validate_template("{organization_slug}-x")
+
+    def test_metadata_without_key(self) -> None:
+        with pytest.raises(InvalidTemplateError, match="metadata"):
+            validate_template("{metadata.}")
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "support-{customer_name",
+            "support-customer_name}",
+            "support-{customer-name}",
+            "support-{}",
+            "support-{{customer_name}}",
+        ],
+    )
+    def test_malformed_placeholder_raises(self, template: str) -> None:
+        with pytest.raises(InvalidTemplateError, match="Malformed placeholder"):
+            validate_template(template)
+
+    def test_empty_renders_against_sample(self) -> None:
+        with pytest.raises(InvalidTemplateError, match="empty"):
+            validate_template("---")
+
+    def test_literal_only(self) -> None:
+        validate_template("support")
+
+
+class TestRenderChannelName:
+    def test_fixed_placeholders(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme Inc.",
+            customer_email_local="admin",
+        )
+        assert (
+            render_channel_name("support-{customer_name}", context)
+            == "support-acme-inc"
+        )
+        assert render_channel_name("{customer_email_local}", context) == "admin"
+
+    def test_metadata_lookup(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"tier": "gold"},
+        )
+        assert render_channel_name("{metadata.tier}-acme", context) == "gold-acme"
+
+    def test_metadata_missing_key_raises(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={},
+        )
+        with pytest.raises(InvalidTemplateError, match="metadata key 'tier'"):
+            render_channel_name("{metadata.tier}", context)
+
+    def test_slugify_lowercase_and_dashes(self) -> None:
+        context = TemplateContext(
+            customer_name="Hello WORLD!",
+            customer_email_local="x",
+        )
+        assert render_channel_name("{customer_name}", context) == "hello-world"
+
+    def test_truncates_to_80_chars(self) -> None:
+        context = TemplateContext(
+            customer_name="x" * 200,
+            customer_email_local="x",
+        )
+        rendered = render_channel_name("{customer_name}", context)
+        assert len(rendered) == 80
+
+    def test_suffix_appended(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="x",
+        )
+        assert (
+            render_channel_name("{customer_name}", context, suffix="abcd")
+            == "acme-abcd"
+        )
+
+    def test_suffix_survives_truncation(self) -> None:
+        context = TemplateContext(
+            customer_name="x" * 200,
+            customer_email_local="x",
+        )
+        rendered = render_channel_name("{customer_name}", context, suffix="abcd")
+        assert len(rendered) == 80
+        assert rendered.endswith("-abcd")
+
+    def test_tolerant_substitutes_missing_metadata_with_key(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="x",
+            metadata={},
+        )
+        assert (
+            render_channel_name("support-{metadata.slug}", context, tolerant=True)
+            == "support-slug"
+        )
+
+    def test_strips_trailing_dashes(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme!!!",
+            customer_email_local="x",
+        )
+        assert render_channel_name("{customer_name}", context) == "acme"
+
+    def test_empty_runtime_channel_name_raises(self) -> None:
+        context = TemplateContext(
+            customer_name="李雷",
+            customer_email_local="李雷",
+        )
+        with pytest.raises(InvalidTemplateError, match="empty channel name"):
+            render_channel_name("{customer_name}", context)
+
+    def test_malformed_placeholder_raises(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="x",
+        )
+        with pytest.raises(InvalidTemplateError, match="Malformed placeholder"):
+            render_channel_name("support-{customer-name}", context)

--- a/server/tests/benefit/strategies/test_slack_template.py
+++ b/server/tests/benefit/strategies/test_slack_template.py
@@ -66,6 +66,18 @@ class TestRenderChannelName:
         )
         assert render_channel_name("{metadata.tier}-acme", context) == "gold-acme"
 
+    def test_metadata_lookup_with_hyphenated_key(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"plan-name": "gold"},
+        )
+        validate_template("{metadata.plan-name}-{customer_name}")
+        assert (
+            render_channel_name("{metadata.plan-name}-{customer_name}", context)
+            == "gold-acme"
+        )
+
     def test_metadata_missing_key_raises(self) -> None:
         context = TemplateContext(
             customer_name="Acme",

--- a/server/tests/benefit/strategies/test_slack_template.py
+++ b/server/tests/benefit/strategies/test_slack_template.py
@@ -192,8 +192,8 @@ class TestRenderChannelName:
 
     def test_empty_runtime_channel_name_raises(self) -> None:
         context = TemplateContext(
-            customer_name="李雷",
-            customer_email_local="李雷",
+            customer_name="!!!",
+            customer_email_local="!!!",
         )
         with pytest.raises(InvalidTemplateError, match="empty channel name"):
             render_channel_name("{customer_name}", context)

--- a/server/tests/benefit/strategies/test_slack_template.py
+++ b/server/tests/benefit/strategies/test_slack_template.py
@@ -78,6 +78,39 @@ class TestRenderChannelName:
             == "gold-acme"
         )
 
+    def test_metadata_lookup_with_dotted_key(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"plan.name": "gold"},
+        )
+        validate_template("{metadata.plan.name}-{customer_name}")
+        assert (
+            render_channel_name("{metadata.plan.name}-{customer_name}", context)
+            == "gold-acme"
+        )
+
+    def test_metadata_lookup_with_space_key(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"plan name": "gold"},
+        )
+        validate_template("{metadata.plan name}-{customer_name}")
+        assert (
+            render_channel_name("{metadata.plan name}-{customer_name}", context)
+            == "gold-acme"
+        )
+
+    def test_metadata_lookup_with_colon_key(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"tier:level": "gold"},
+        )
+        validate_template("{metadata.tier:level}")
+        assert render_channel_name("{metadata.tier:level}", context) == "gold"
+
     def test_metadata_missing_key_raises(self) -> None:
         context = TemplateContext(
             customer_name="Acme",
@@ -86,6 +119,24 @@ class TestRenderChannelName:
         )
         with pytest.raises(InvalidTemplateError, match="metadata key 'tier'"):
             render_channel_name("{metadata.tier}", context)
+
+    def test_metadata_dotted_key_missing_raises(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"plan": "gold"},
+        )
+        with pytest.raises(InvalidTemplateError, match="metadata key 'plan.name'"):
+            render_channel_name("{metadata.plan.name}", context)
+
+    def test_metadata_dotted_key_does_not_traverse(self) -> None:
+        context = TemplateContext(
+            customer_name="Acme",
+            customer_email_local="admin",
+            metadata={"plan": "gold", "name": "team"},
+        )
+        with pytest.raises(InvalidTemplateError, match="metadata key 'plan.name'"):
+            render_channel_name("{metadata.plan.name}", context)
 
     def test_slugify_lowercase_and_dashes(self) -> None:
         context = TemplateContext(

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -24,6 +24,7 @@ from polar.benefit.strategies.feature_flag.schemas import BenefitFeatureFlagUpda
 from polar.benefit.strategies.slack_shared_channel.schemas import (
     BenefitSlackSharedChannelCreate,
     BenefitSlackSharedChannelCreateProperties,
+    BenefitSlackSharedChannelUpdate,
 )
 from polar.exceptions import NotPermitted, PolarRequestValidationError
 from polar.kit.pagination import PaginationParams
@@ -526,6 +527,56 @@ class TestUpdate:
         assert updated_benefit.description == "Description update"
 
         enqueue_benefit_grant_updates_mock.assert_awaited_once()
+
+    @pytest.mark.auth
+    async def test_slack_shared_channel_preserves_integration_link(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+    ) -> None:
+        mocker.patch.object(
+            benefit_grant_service,
+            "enqueue_benefit_grant_updates",
+            spec=BenefitGrantService.enqueue_benefit_grant_updates,
+        )
+        integration_id = str(uuid.uuid4())
+        benefit = await create_benefit(
+            save_fixture,
+            type=BenefitType.slack_shared_channel,
+            organization=organization,
+            properties={
+                "channel_name_template": "support-{customer_name}",
+                "private": True,
+                "welcome_message": None,
+                "archive_on_revoke": True,
+                "team_invitees": [],
+                "slack_integration_id": integration_id,
+            },
+        )
+
+        update_schema = BenefitSlackSharedChannelUpdate(
+            type=BenefitType.slack_shared_channel,
+            properties=BenefitSlackSharedChannelCreateProperties(
+                channel_name_template="vip-{customer_name}",
+                private=True,
+                welcome_message=None,
+                archive_on_revoke=True,
+                team_invitees=[],
+            ),
+        )
+
+        updated_benefit = await benefit_service.update(
+            session, redis, benefit, update_schema, auth_subject
+        )
+
+        properties = dict(updated_benefit.properties)
+        assert properties["slack_integration_id"] == integration_id
+        assert properties["channel_name_template"] == "vip-{customer_name}"
 
     @pytest.mark.auth
     @pytest.mark.parametrize("visibility", [Visibility.private, None])

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -29,13 +29,34 @@ from polar.benefit.strategies.slack_shared_channel.schemas import (
 from polar.exceptions import NotPermitted, PolarRequestValidationError
 from polar.kit.pagination import PaginationParams
 from polar.kit.visibility import Visibility
-from polar.models import Benefit, Organization, User, UserOrganization
+from polar.models import Benefit, Organization, SlackApp, User, UserOrganization
 from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_benefit
+
+
+async def create_slack_integration(
+    save_fixture: SaveFixture, organization: Organization
+) -> SlackApp:
+    integration = SlackApp(
+        organization_id=organization.id,
+        display_name="Test",
+        slack_app_id="A0TESTAPPID",
+        client_id="100.200",
+        client_secret="cs-test",
+        signing_secret="ss-test",
+        team_id="T1",
+        team_name="Test team",
+        bot_user_id="U1",
+        bot_token="xoxb-test-token",
+        authed_user_id="U2",
+        scopes=["channels:manage"],
+    )
+    await save_fixture(integration)
+    return integration
 
 
 @pytest.fixture
@@ -318,6 +339,7 @@ class TestUserCreate:
             type=BenefitType.slack_shared_channel,
             description="Benefit",
             properties=BenefitSlackSharedChannelCreateProperties(
+                slack_integration_id=uuid.uuid4(),
                 channel_name_template="support-{customer_name}",
                 private=True,
                 welcome_message=None,
@@ -349,10 +371,12 @@ class TestUserCreate:
             "slack_benefit_enabled": True,
         }
         await save_fixture(organization)
+        integration = await create_slack_integration(save_fixture, organization)
         create_schema = BenefitSlackSharedChannelCreate(
             type=BenefitType.slack_shared_channel,
             description="Benefit",
             properties=BenefitSlackSharedChannelCreateProperties(
+                slack_integration_id=integration.id,
                 channel_name_template="support-{customer_name}",
                 private=True,
                 welcome_message="Welcome",
@@ -370,6 +394,7 @@ class TestUserCreate:
 
         assert benefit.organization_id == organization.id
         assert benefit.type == BenefitType.slack_shared_channel
+        assert dict(benefit.properties)["slack_integration_id"] == str(integration.id)
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_organization_set_organization_id(
@@ -529,7 +554,7 @@ class TestUpdate:
         enqueue_benefit_grant_updates_mock.assert_awaited_once()
 
     @pytest.mark.auth
-    async def test_slack_shared_channel_preserves_integration_link(
+    async def test_slack_shared_channel_update_keeps_integration(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -544,7 +569,7 @@ class TestUpdate:
             "enqueue_benefit_grant_updates",
             spec=BenefitGrantService.enqueue_benefit_grant_updates,
         )
-        integration_id = str(uuid.uuid4())
+        integration = await create_slack_integration(save_fixture, organization)
         benefit = await create_benefit(
             save_fixture,
             type=BenefitType.slack_shared_channel,
@@ -555,13 +580,14 @@ class TestUpdate:
                 "welcome_message": None,
                 "archive_on_revoke": True,
                 "team_invitees": [],
-                "slack_integration_id": integration_id,
+                "slack_integration_id": str(integration.id),
             },
         )
 
         update_schema = BenefitSlackSharedChannelUpdate(
             type=BenefitType.slack_shared_channel,
             properties=BenefitSlackSharedChannelCreateProperties(
+                slack_integration_id=integration.id,
                 channel_name_template="vip-{customer_name}",
                 private=True,
                 welcome_message=None,
@@ -575,7 +601,7 @@ class TestUpdate:
         )
 
         properties = dict(updated_benefit.properties)
-        assert properties["slack_integration_id"] == integration_id
+        assert properties["slack_integration_id"] == str(integration.id)
         assert properties["channel_name_template"] == "vip-{customer_name}"
 
     @pytest.mark.auth

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -21,6 +21,10 @@ from polar.benefit.strategies.custom.schemas import (
 )
 from polar.benefit.strategies.discord.schemas import BenefitDiscordUpdate
 from polar.benefit.strategies.feature_flag.schemas import BenefitFeatureFlagUpdate
+from polar.benefit.strategies.slack_shared_channel.schemas import (
+    BenefitSlackSharedChannelCreate,
+    BenefitSlackSharedChannelCreateProperties,
+)
 from polar.exceptions import NotPermitted, PolarRequestValidationError
 from polar.kit.pagination import PaginationParams
 from polar.kit.visibility import Visibility
@@ -299,6 +303,72 @@ class TestUserCreate:
             session, redis, create_schema, auth_subject
         )
         assert benefit.organization_id == organization.id
+
+    @pytest.mark.auth
+    async def test_slack_shared_channel_disabled_organization(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        redis: Redis,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        create_schema = BenefitSlackSharedChannelCreate(
+            type=BenefitType.slack_shared_channel,
+            description="Benefit",
+            properties=BenefitSlackSharedChannelCreateProperties(
+                channel_name_template="support-{customer_name}",
+                private=True,
+                welcome_message=None,
+                archive_on_revoke=True,
+                team_invitees=[],
+            ),
+            organization_id=organization.id,
+        )
+
+        session.expunge_all()
+
+        with pytest.raises(PolarRequestValidationError):
+            await benefit_service.user_create(
+                session, redis, create_schema, auth_subject
+            )
+
+    @pytest.mark.auth
+    async def test_slack_shared_channel_enabled_organization(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "slack_benefit_enabled": True,
+        }
+        await save_fixture(organization)
+        create_schema = BenefitSlackSharedChannelCreate(
+            type=BenefitType.slack_shared_channel,
+            description="Benefit",
+            properties=BenefitSlackSharedChannelCreateProperties(
+                channel_name_template="support-{customer_name}",
+                private=True,
+                welcome_message="Welcome",
+                archive_on_revoke=True,
+                team_invitees=[],
+            ),
+            organization_id=organization.id,
+        )
+
+        session.expunge_all()
+
+        benefit = await benefit_service.user_create(
+            session, redis, create_schema, auth_subject
+        )
+
+        assert benefit.organization_id == organization.id
+        assert benefit.type == BenefitType.slack_shared_channel
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_organization_set_organization_id(

--- a/server/tests/customer_portal/service/test_benefit_grant.py
+++ b/server/tests/customer_portal/service/test_benefit_grant.py
@@ -1,6 +1,13 @@
+from typing import Any, cast
+
 import pytest
+from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
+from polar.benefit.strategies import BenefitActionRequiredError
+from polar.customer_portal.schemas.benefit_grant import (
+    CustomerBenefitGrantSlackSharedChannelUpdate,
+)
 from polar.customer_portal.service.benefit_grant import CustomerBenefitGrantSortProperty
 from polar.customer_portal.service.benefit_grant import (
     customer_benefit_grant as customer_benefit_grant_service,
@@ -9,10 +16,15 @@ from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.models import Benefit, Customer, Member, Organization, Subscription
+from polar.models.benefit import BenefitType
 from polar.models.member import MemberRole
 from tests.fixtures.auth import MEMBER_AUTH_SUBJECT, AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_benefit_grant, create_member
+from tests.fixtures.random_objects import (
+    create_benefit,
+    create_benefit_grant,
+    create_member,
+)
 
 
 @pytest.mark.asyncio
@@ -426,3 +438,57 @@ class TestGetByIdMember:
         )
 
         assert result is None
+
+
+@pytest.mark.asyncio
+class TestUpdate:
+    async def test_slack_shared_channel_updates_invited_email(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch(
+            "polar.customer_portal.service.benefit_grant.enqueue_job"
+        )
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={
+                "channel_name_template": "support-{customer_name}",
+                "private": True,
+                "welcome_message": None,
+                "archive_on_revoke": True,
+                "team_invitees": [],
+            },
+        )
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={
+                "channel_id": "C123",
+                "invited_email": "old@example.com",
+            },
+        )
+        grant.set_grant_failed(BenefitActionRequiredError("Email required"))
+        await save_fixture(grant)
+
+        updated = await customer_benefit_grant_service.update(
+            session,
+            grant,
+            CustomerBenefitGrantSlackSharedChannelUpdate(
+                benefit_type=BenefitType.slack_shared_channel,
+                properties={"invited_email": "admin@example.com"},
+            ),
+        )
+
+        assert cast(Any, updated.properties) == {
+            "channel_id": "C123",
+            "invited_email": "admin@example.com",
+        }
+        assert updated.error is None
+        enqueue_job_mock.assert_called_once_with("benefit.update", grant.id)

--- a/server/tests/customer_portal/service/test_benefit_grant.py
+++ b/server/tests/customer_portal/service/test_benefit_grant.py
@@ -492,3 +492,109 @@ class TestUpdate:
         }
         assert updated.error is None
         enqueue_job_mock.assert_called_once_with("benefit.update", grant.id)
+
+    async def test_slack_shared_channel_email_change_clears_invite(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch(
+            "polar.customer_portal.service.benefit_grant.enqueue_job"
+        )
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={
+                "channel_name_template": "support-{customer_name}",
+                "private": True,
+                "welcome_message": None,
+                "archive_on_revoke": True,
+                "team_invitees": [],
+            },
+        )
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={
+                "channel_id": "C123",
+                "channel_name": "support-acme",
+                "invited_email": "old@example.com",
+                "invite_id": "I123",
+                "invite_url": "https://slack.com/share/I123",
+            },
+        )
+
+        updated = await customer_benefit_grant_service.update(
+            session,
+            grant,
+            CustomerBenefitGrantSlackSharedChannelUpdate(
+                benefit_type=BenefitType.slack_shared_channel,
+                properties={"invited_email": "admin@example.com"},
+            ),
+        )
+
+        assert cast(Any, updated.properties) == {
+            "channel_id": "C123",
+            "channel_name": "support-acme",
+            "invited_email": "admin@example.com",
+        }
+        enqueue_job_mock.assert_called_once_with("benefit.update", grant.id)
+
+    async def test_slack_shared_channel_same_email_keeps_invite(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch(
+            "polar.customer_portal.service.benefit_grant.enqueue_job"
+        )
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={
+                "channel_name_template": "support-{customer_name}",
+                "private": True,
+                "welcome_message": None,
+                "archive_on_revoke": True,
+                "team_invitees": [],
+            },
+        )
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={
+                "channel_id": "C123",
+                "channel_name": "support-acme",
+                "invited_email": "admin@example.com",
+                "invite_id": "I123",
+                "invite_url": "https://slack.com/share/I123",
+            },
+        )
+
+        updated = await customer_benefit_grant_service.update(
+            session,
+            grant,
+            CustomerBenefitGrantSlackSharedChannelUpdate(
+                benefit_type=BenefitType.slack_shared_channel,
+                properties={"invited_email": "admin@example.com"},
+            ),
+        )
+
+        assert cast(Any, updated.properties) == {
+            "channel_id": "C123",
+            "channel_name": "support-acme",
+            "invited_email": "admin@example.com",
+            "invite_id": "I123",
+            "invite_url": "https://slack.com/share/I123",
+        }
+        enqueue_job_mock.assert_called_once_with("benefit.update", grant.id)

--- a/server/tests/integrations/slack/test_endpoints.py
+++ b/server/tests/integrations/slack/test_endpoints.py
@@ -10,7 +10,6 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
-from polar.benefit.repository import BenefitRepository
 from polar.config import settings
 from polar.integrations.slack.repository import SlackAppRepository
 from polar.kit import jwt
@@ -480,97 +479,6 @@ class TestPostManifest:
         )
         assert response.status_code == 200
         assert "Acme Support" in response.json()["manifest"]
-
-
-@pytest.mark.asyncio
-class TestLink:
-    async def test_anonymous(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(save_fixture, organization)
-        response = await client.post(
-            "/v1/integrations/slack/link",
-            json={
-                "benefit_id": str(benefit.id),
-                "integration_id": str(integration.id),
-            },
-        )
-        assert response.status_code == 401
-
-    @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.organizations_write}),
-    )
-    async def test_not_member_returns_403(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(save_fixture, organization)
-        response = await client.post(
-            "/v1/integrations/slack/link",
-            json={
-                "benefit_id": str(benefit.id),
-                "integration_id": str(integration.id),
-            },
-        )
-        assert response.status_code == 403
-
-    @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.organizations_write}),
-    )
-    async def test_links_integration(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(save_fixture, organization)
-        response = await client.post(
-            "/v1/integrations/slack/link",
-            json={
-                "benefit_id": str(benefit.id),
-                "integration_id": str(integration.id),
-            },
-        )
-        assert response.status_code == 200
-        assert response.json()["id"] == str(integration.id)
-
-        repo = BenefitRepository.from_session(session)
-        linked = await repo.get_by_id(benefit.id)
-        assert linked is not None
-        assert dict(linked.properties)["slack_integration_id"] == str(integration.id)
-
-    @pytest.mark.auth(
-        AuthSubjectFixture(scopes={Scope.organizations_write}),
-    )
-    async def test_uninstalled_integration_returns_400(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(
-            save_fixture, organization, bot_token=None
-        )
-        response = await client.post(
-            "/v1/integrations/slack/link",
-            json={
-                "benefit_id": str(benefit.id),
-                "integration_id": str(integration.id),
-            },
-        )
-        assert response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import update
 
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.benefit.repository import BenefitRepository
@@ -621,3 +622,43 @@ class TestLink:
 
         with pytest.raises(SlackIntegrationBenefitAlreadyLinked):
             await service.link(session, benefit, other_integration)
+
+    async def test_rejects_concurrent_link_to_same_benefit(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        first_integration = await _create_integration(
+            save_fixture, organization, slack_app_id="A0FIRSTAPPX"
+        )
+        second_integration = await _create_integration(
+            save_fixture, organization, slack_app_id="A0SECONDAPP"
+        )
+
+        await session.execute(
+            update(Benefit)
+            .where(Benefit.id == benefit.id)
+            .values(
+                properties={
+                    **benefit.properties,
+                    "slack_integration_id": str(first_integration.id),
+                }
+            )
+            .execution_options(synchronize_session=False)
+        )
+        assert "slack_integration_id" not in dict(benefit.properties)
+
+        service, _client = _service_with_mock(mocker)
+
+        with pytest.raises(SlackIntegrationBenefitAlreadyLinked):
+            await service.link(session, benefit, second_integration)
+
+        repo = BenefitRepository.from_session(session)
+        refreshed = await repo.get_by_id(benefit.id)
+        assert refreshed is not None
+        assert dict(refreshed.properties)["slack_integration_id"] == str(
+            first_integration.id
+        )

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -3,23 +3,18 @@ from uuid import uuid4
 
 import pytest
 from pytest_mock import MockerFixture
-from sqlalchemy import update
 
 from polar.benefit.grant.repository import BenefitGrantRepository
-from polar.benefit.repository import BenefitRepository
 from polar.config import settings
 from polar.integrations.slack.repository import SlackAppRepository
 from polar.integrations.slack.schemas import SlackIntegrationCredentialsUpdate
 from polar.integrations.slack.service import (
     OAUTH_STATE_JWT_TYPE,
     SlackAppService,
-    SlackIntegrationAlreadyLinked,
     SlackIntegrationAppIdAlreadyLinked,
-    SlackIntegrationBenefitAlreadyLinked,
     SlackIntegrationInvalidCredentials,
     SlackIntegrationInvalidState,
     SlackIntegrationNotConfigured,
-    SlackIntegrationNotInstalled,
 )
 from polar.kit import jwt
 from polar.models import (
@@ -519,146 +514,3 @@ class TestDelete:
         await service.delete(session, integration)
 
         assert await service.get(session, created.id) is None
-
-
-@pytest.mark.asyncio
-class TestLink:
-    async def test_links_installed_integration(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(save_fixture, organization)
-        service, _client = _service_with_mock(mocker)
-        get_by_id_for_update = mocker.spy(SlackAppRepository, "get_by_id_for_update")
-
-        linked = await service.link(session, benefit, integration)
-
-        assert linked.id == integration.id
-        assert get_by_id_for_update.call_count == 1
-        assert get_by_id_for_update.call_args.args[1] == integration.id
-        repo = BenefitRepository.from_session(session)
-        refreshed = await repo.get_by_id(benefit.id)
-        assert refreshed is not None
-        assert dict(refreshed.properties)["slack_integration_id"] == str(integration.id)
-
-    async def test_idempotent_when_already_linked_to_same_benefit(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(
-            save_fixture, organization, benefit=benefit
-        )
-        service, _client = _service_with_mock(mocker)
-
-        linked = await service.link(session, benefit, integration)
-
-        assert linked.id == integration.id
-        repo = BenefitRepository.from_session(session)
-        refreshed = await repo.get_by_id(benefit.id)
-        assert refreshed is not None
-        assert dict(refreshed.properties)["slack_integration_id"] == str(integration.id)
-
-    async def test_rejects_uninstalled_integration(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(
-            save_fixture, organization, bot_token=None
-        )
-        service, _client = _service_with_mock(mocker)
-
-        with pytest.raises(SlackIntegrationNotInstalled):
-            await service.link(session, benefit, integration)
-
-    async def test_rejects_integration_linked_to_another_benefit(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        organization: Organization,
-    ) -> None:
-        other_benefit = await _create_benefit(save_fixture, organization)
-        integration = await _create_integration(
-            save_fixture, organization, benefit=other_benefit
-        )
-        benefit = await _create_benefit(save_fixture, organization)
-        service, _client = _service_with_mock(mocker)
-
-        with pytest.raises(SlackIntegrationAlreadyLinked):
-            await service.link(session, benefit, integration)
-
-        repo = BenefitRepository.from_session(session)
-        refreshed = await repo.get_by_id(benefit.id)
-        assert refreshed is not None
-        assert "slack_integration_id" not in dict(refreshed.properties)
-
-    async def test_rejects_benefit_already_linked(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        await _create_integration(
-            save_fixture, organization, benefit=benefit, slack_app_id="A0FIRSTAPPX"
-        )
-        other_integration = await _create_integration(
-            save_fixture, organization, slack_app_id="A0SECONDAPP"
-        )
-        service, _client = _service_with_mock(mocker)
-
-        with pytest.raises(SlackIntegrationBenefitAlreadyLinked):
-            await service.link(session, benefit, other_integration)
-
-    async def test_rejects_concurrent_link_to_same_benefit(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await _create_benefit(save_fixture, organization)
-        first_integration = await _create_integration(
-            save_fixture, organization, slack_app_id="A0FIRSTAPPX"
-        )
-        second_integration = await _create_integration(
-            save_fixture, organization, slack_app_id="A0SECONDAPP"
-        )
-
-        await session.execute(
-            update(Benefit)
-            .where(Benefit.id == benefit.id)
-            .values(
-                properties={
-                    **benefit.properties,
-                    "slack_integration_id": str(first_integration.id),
-                }
-            )
-            .execution_options(synchronize_session=False)
-        )
-        assert "slack_integration_id" not in dict(benefit.properties)
-
-        service, _client = _service_with_mock(mocker)
-
-        with pytest.raises(SlackIntegrationBenefitAlreadyLinked):
-            await service.link(session, benefit, second_integration)
-
-        repo = BenefitRepository.from_session(session)
-        refreshed = await repo.get_by_id(benefit.id)
-        assert refreshed is not None
-        assert dict(refreshed.properties)["slack_integration_id"] == str(
-            first_integration.id
-        )


### PR DESCRIPTION
Extracted out from #12188

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Slack Shared Channel benefit that provisions customer-specific channels with Slack-safe templates and a channel-name preview API. Creation now requires selecting a Slack integration on the benefit (integration ID is required), gated by an org flag, with safer grant/update flows and smarter channel lifecycle.

- **New Features**
  - New benefit type: `slack_shared_channel` (schemas, grant properties, service, customer portal; `slack_integration_id` is required `UUID4`).
  - API: POST `/v1/benefits/slack/preview-channel-name` (scope `benefits:write`) to render a channel name; returns 422 on invalid templates.
  - Templates support `{customer_name}`, `{customer_email_local}`, and `{metadata.<key>}` with Slack-safe formatting (max 80 chars); dots in `<key>` aren’t traversed.
  - Require a Slack integration when creating the benefit; removed `/v1/integrations/slack/link`. Regenerated `@polar-sh/client` and updated server routes (`/benefits/slack`).
  - UI/i18n: hide this type unless `organization.feature_settings.slack_benefit_enabled`; added `benefitTypes.slack_shared_channel` with translations and grant-view mapping. Server also blocks creation if the flag is disabled.

- **Bug Fixes**
  - Preserve `grant.properties` when `BenefitActionRequiredError` occurs on grant/update (supports passing properties via the exception).
  - Customer portal: allow changing `invited_email` and re-send the invite.
  - Prevent benefit updates from unlinking Slack apps; handle transient vs non-recoverable errors safely.
  - Provisioning improvements: use a Polar lock, reuse a shared Slack client, try channel creation before search, reuse sibling grants, and don’t resend the welcome message when attaching to existing channels.
  - Only archive a channel on revoke if no other grant references it.

<sup>Written for commit dcd745153a8cd2b2bdcaa00d56b97be16ea26efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

