### PR TITLE
bump expo app version to 1.5.0

### DIFF
--- a/clients/apps/app/app.config.js
+++ b/clients/apps/app/app.config.js
@@ -44,7 +44,7 @@ module.exports = {
   expo: {
     name: 'Polar',
     slug: 'Polar',
-    version: '1.4.0',
+    version: '1.5.0',
     orientation: 'portrait',
     icon: './assets/images/icon.png',
     scheme: 'polar',


### PR DESCRIPTION
Version bump before submit to eas

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `expo` app version from 1.4.0 to 1.5.0 to prepare for EAS submission. No runtime or UI changes.

<sup>Written for commit db0d4e98d8b9114e1cb569d39f989babb9e33a11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

