### PR TITLE
remove unnecessary "You" callout on member page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/MembersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/MembersPage.tsx
@@ -143,13 +143,11 @@ export default function ClientPage({
         <DataTableColumnHeader column={column} title="User" />
       ),
       cell: ({ row: { original: member } }) => {
-        const isCurrentUser = member.user_id === currentUser?.id
         return (
           <Box display="flex" flexDirection="row" alignItems="center" gap="s">
             <Avatar avatar_url={member.avatar_url} name={member.email} />
             <Text>{member.email}</Text>
             <RowBadge>{ROLE_LABELS[member.role]}</RowBadge>
-            {isCurrentUser && <RowBadge>You</RowBadge>}
           </Box>
         )
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the "You" badge for the current user in the Members list to reduce visual noise and keep rows consistent.
Email, avatar, and role badges are unchanged.

<sup>Written for commit 8902a47a92c1ef343c173d86300e5d79a926cd1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

