### PR TITLE
fix app handling of 404 endpoint in retry

### DIFF
--- a/clients/apps/app/hooks/polar/finance.ts
+++ b/clients/apps/app/hooks/polar/finance.ts
@@ -1,6 +1,7 @@
 import { usePolarClient } from '@/providers/PolarClientProvider'
 import { queryClient } from '@/utils/query'
-import { schemas, unwrap } from '@polar-sh/client'
+import { ClientResponseError, schemas, unwrap } from '@polar-sh/client'
+import { defaultRetry } from './retry'
 import {
   skipToken,
   useMutation,
@@ -21,6 +22,16 @@ export const useOrganizationAccount = (organizationId?: string) => {
             }),
           )
       : skipToken,
+    retry: (failureCount, error) => {
+      if (
+        error instanceof ClientResponseError &&
+        (error.response.status === 403 || error.response.status === 404)
+      ) {
+        return false
+      }
+      return defaultRetry(failureCount, error as ClientResponseError)
+    },
+    throwOnError: false,
   })
 }
 
@@ -37,6 +48,8 @@ export const usePayoutAccount = (payoutAccountId?: string) => {
             }),
           )
       : skipToken,
+    retry: defaultRetry,
+    throwOnError: false,
   })
 }
 

--- a/clients/apps/app/hooks/polar/retry.ts
+++ b/clients/apps/app/hooks/polar/retry.ts
@@ -1,0 +1,29 @@
+import {
+  ClientResponseError,
+  NotFoundResponseError,
+  UnauthorizedResponseError,
+} from '@polar-sh/client'
+
+const authenticatingRetry = (
+  failureCount: number,
+  error:
+    | ClientResponseError
+    | UnauthorizedResponseError
+    | NotFoundResponseError,
+): boolean => {
+  if (error instanceof UnauthorizedResponseError) {
+    return false
+  }
+
+  if (error instanceof NotFoundResponseError) {
+    return false
+  }
+
+  if (failureCount > 2) {
+    return false
+  }
+
+  return true
+}
+
+export const defaultRetry = authenticatingRetry


### PR DESCRIPTION
App handles 404 on different than web on some requests which affect some accounts and others not. This should fix it


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app retry logic for 404/403 responses to match the web, preventing useless retries and UI errors on missing or forbidden accounts. Adds a shared retry helper and updates finance hooks to use it.

- **Bug Fixes**
  - Added `defaultRetry` in `clients/apps/app/hooks/polar/retry.ts` to stop retries on `UnauthorizedResponseError`, `NotFoundResponseError`, and after 2 failures.
  - Updated `useOrganizationAccount` and `usePayoutAccount` to use `defaultRetry`; `useOrganizationAccount` also skips retries on 403/404 and sets `throwOnError: false`.
  - Imports `ClientResponseError` from `@polar-sh/client` to detect 403/404 cases.

<sup>Written for commit 0a19998d23aec177a314a4ae6e99a8a3cd8d3b36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

