### PR TITLE
server/auth: implicitly disable backup codes when disabling TOTP

### DIFF
--- a/server/migrations/versions/2026-06-08-1928_delete_backup_codes_if_totp_is_not_.py
+++ b/server/migrations/versions/2026-06-08-1928_delete_backup_codes_if_totp_is_not_.py
@@ -1,0 +1,38 @@
+"""Delete backup codes if TOTP is not available
+
+Revision ID: fe0c257b531e
+Revises: ea537f8efa51
+Create Date: 2026-06-08 19:28:38.857184
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "fe0c257b531e"
+down_revision = "ea537f8efa51"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute(
+        """
+        DELETE FROM backup_codes_enrollments
+        WHERE identity_id NOT IN (
+            SELECT identity_id
+            FROM totp_enrollments
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    pass

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -274,12 +274,19 @@ async def totp_enable(
 async def totp_delete(
     auth_subject: AuthorizeWebUserWrite,
     totp_factor: TOTPFactor = Depends(get_totp_factor),
+    backup_codes_factor: BackupCodesFactor = Depends(get_backup_codes_factor),
 ) -> None:
     user = auth_subject.subject
     enrollment = await totp_factor.get_enrollment(user.id)
     if enrollment is None:
         raise ResourceNotFound()
     await totp_factor.delete(enrollment)
+
+    # Disable backup codes as well since they are meant to be used as a backup for TOTP
+    backup_codes_enrollment = await backup_codes_factor.get_enrollment(user.id)
+    if backup_codes_enrollment is not None:
+        await backup_codes_factor.delete(backup_codes_enrollment)
+
     return None
 
 


### PR DESCRIPTION

It doesn't make sense to have backup codes if TOTP is disabled, so we should automatically delete backup codes when TOTP is disabled.

This also comes with a migration that deletes backup codes for users that have TOTP disabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically delete backup codes when users disable TOTP to keep 2FA states consistent. Includes a migration that removes backup codes for accounts without TOTP.

- **Bug Fixes**
  - When TOTP is disabled, also delete the user’s backup codes enrollment.

- **Migration**
  - Deletes rows in `backup_codes_enrollments` where the `identity_id` has no matching `totp_enrollments`.
  - Applies a 5s `lock_timeout` to reduce lock contention during cleanup.

<sup>Written for commit 217094301ddc20ba1a8dd4fc097ef4fb781b8454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

