### PR TITLE
Escape some more LaTeX in docs

### DIFF
--- a/docs/features/subscriptions/proration.mdx
+++ b/docs/features/subscriptions/proration.mdx
@@ -98,8 +98,8 @@ For an upgrade the difference is positive, so the customer is charged; for a dow
 
 A customer subscribed to a \$5/month plan on a 30-day month (2,592,000 seconds total). After 1 day (86,400 seconds elapsed, 2,505,600 seconds remaining) they upgrade to a \$20/month plan.
 
-- Unused credit on the $5 plan: `$5 * 2,505,600 / 2,592,000 = $4.83`
-- New charge for the remaining 2,505,600 seconds on the $20 plan: `$20 * 2,505,600 / 2,592,000 = $19.33`
+- Unused credit on the $5 plan: `\$5 * 2,505,600 / 2,592,000 = \$4.83`
+- New charge for the remaining 2,505,600 seconds on the $20 plan: `\$20 * 2,505,600 / 2,592,000 = $19.33`
 - **Prorated difference: $14.50**
 
 With `invoice`, that \$14.50 is charged immediately. With `prorate`, it's added to the next monthly invoice (which is also the new \$20 charge for the next cycle).
@@ -108,8 +108,8 @@ With `invoice`, that \$14.50 is charged immediately. With `prorate`, it's added 
 
 A customer subscribed to a \$20/month plan on a 30-day month (2,592,000 seconds total). After 1 day (2,505,600 seconds remaining) they downgrade to a \$5/month plan.
 
-- Unused credit on the $20 plan: `$20 * 2,505,600 / 2,592,000 = $19.33`
-- New charge for the remaining 2,505,600 seconds on the $5 plan: `$5 * 2,505,600 / 2,592,000 = $4.83`
+- Unused credit on the $20 plan: `\$20 * 2,505,600 / 2,592,000 = \$19.33`
+- New charge for the remaining 2,505,600 seconds on the $5 plan: `\$5 * 2,505,600 / 2,592,000 = \$4.83`
 - **Prorated difference: -$14.50** (credit to the customer)
 
 With `invoice`, a credit invoice for $14.50 is issued immediately. With `prorate`, the credit is applied on the next invoice.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Escaped dollar signs in `docs/features/subscriptions/proration.mdx` so inline code shows price formulas instead of triggering math rendering. Fixes display in both upgrade and downgrade examples.

<sup>Written for commit a8847be99dd399602545971c04fac9d65c4f3d1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

