### PR TITLE
tf: Add module for the AWS task worker

### DIFF
--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -1,0 +1,130 @@
+locals {
+  in_vpc = length(var.subnet_ids) > 0
+}
+
+resource "aws_sqs_queue" "dlq" {
+  name                      = "${var.queue_name}-dlq"
+  message_retention_seconds = 1209600
+
+  tags = var.tags
+}
+
+resource "aws_sqs_queue" "task" {
+  name = var.queue_name
+
+  # Visibility must exceed the function timeout so a slow task is not redelivered while still running.
+  visibility_timeout_seconds = max(180, var.timeout_seconds + 60)
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq.arn
+    maxReceiveCount     = min(var.max_retries + 1, 5)
+  })
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = var.function_name
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    sid = "Logs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.task.arn}:*"]
+  }
+
+  statement {
+    sid = "TaskQueue"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ChangeMessageVisibility",
+      "sqs:SendMessage",
+    ]
+    resources = [aws_sqs_queue.task.arn]
+  }
+
+  statement {
+    sid       = "DeadLetterQueue"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.dlq.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda" {
+  name   = var.function_name
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda.json
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_access" {
+  count      = local.in_vpc ? 1 : 0
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_cloudwatch_log_group" "task" {
+  name              = "/aws/lambda/${var.function_name}"
+  retention_in_days = var.log_retention_days
+
+  tags = var.tags
+}
+
+resource "aws_lambda_function" "task" {
+  function_name = var.function_name
+  role          = aws_iam_role.lambda.arn
+  package_type  = "Image"
+  image_uri     = var.image_uri
+
+  timeout     = var.timeout_seconds
+  memory_size = var.memory_size
+
+  reserved_concurrent_executions = var.reserved_concurrency == null ? -1 : var.reserved_concurrency
+
+  environment {
+    variables = merge(
+      var.environment_variables,
+      var.secret_environment_variables,
+      { POLAR_DATABASE_POOL_SIZE = "1" },
+    )
+  }
+
+  dynamic "vpc_config" {
+    for_each = local.in_vpc ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.task]
+
+  tags = var.tags
+}
+
+resource "aws_lambda_event_source_mapping" "task" {
+  event_source_arn        = aws_sqs_queue.task.arn
+  function_name           = aws_lambda_function.task.arn
+  batch_size              = var.batch_size
+  enabled                 = var.enabled
+  function_response_types = ["ReportBatchItemFailures"]
+}

--- a/terraform/modules/aws_task_worker/outputs.tf
+++ b/terraform/modules/aws_task_worker/outputs.tf
@@ -1,0 +1,29 @@
+output "queue_url" {
+  description = "Task SQS queue URL."
+  value       = aws_sqs_queue.task.url
+}
+
+output "queue_arn" {
+  description = "Task SQS queue ARN."
+  value       = aws_sqs_queue.task.arn
+}
+
+output "dlq_arn" {
+  description = "Dead-letter queue ARN."
+  value       = aws_sqs_queue.dlq.arn
+}
+
+output "function_name" {
+  description = "Lambda function name (used by CI to update-function-code)."
+  value       = aws_lambda_function.task.function_name
+}
+
+output "function_arn" {
+  description = "Lambda function ARN."
+  value       = aws_lambda_function.task.arn
+}
+
+output "lambda_role_arn" {
+  description = "ARN of the Lambda execution role."
+  value       = aws_iam_role.lambda.arn
+}

--- a/terraform/modules/aws_task_worker/terraform.tf
+++ b/terraform/modules/aws_task_worker/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -1,0 +1,87 @@
+variable "queue_name" {
+  description = "Full task SQS queue name. The producer addresses this queue by name, so the caller must match it."
+  type        = string
+}
+
+variable "function_name" {
+  description = "Lambda function name. Also bases the role, policy and log group names."
+  type        = string
+}
+
+variable "image_uri" {
+  description = "Container image URI the task Lambda runs."
+  type        = string
+}
+
+variable "timeout_seconds" {
+  description = "Lambda function timeout. Must stay below the queue visibility timeout."
+  type        = number
+  default     = 120
+}
+
+variable "memory_size" {
+  description = "Lambda memory in MB."
+  type        = number
+  default     = 512
+}
+
+variable "reserved_concurrency" {
+  description = "null leaves the function unreserved (-1). Bounds warm containers, and therefore DB connections."
+  type        = number
+  default     = 5
+}
+
+variable "max_retries" {
+  description = "DLQ redrive maxReceiveCount is min(max_retries + 1, 5)."
+  type        = number
+  default     = 4
+}
+
+variable "batch_size" {
+  description = "SQS event source mapping batch size."
+  type        = number
+  default     = 1
+}
+
+variable "enabled" {
+  description = "Event source mapping toggle. false provisions the worker dormant."
+  type        = bool
+  default     = true
+}
+
+variable "subnet_ids" {
+  description = "Empty runs the Lambda outside a VPC."
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_ids" {
+  description = "Lambda VPC security groups. Used only when subnet_ids is set."
+  type        = list(string)
+  default     = []
+}
+
+variable "environment_variables" {
+  description = "Non-secret environment variables for the task Lambda."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_environment_variables" {
+  description = "Secret environment variables for the task Lambda."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days."
+  type        = number
+  default     = 14
+}
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This sets up the infra that will connect AWS queues to lambdas.

Not used today

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable Terraform module for an AWS task worker: an SQS queue with DLQ wired to a container-image Lambda via event source mapping. Not used yet; no behavior change.

- **New Features**
  - SQS task queue + DLQ with visibility timeout >= 180s and timeout+60 headroom; redrive capped at 5.
  - Lambda (Image) with IAM role, log group, env vars (incl. secrets) and optional VPC; sets POLAR_DATABASE_POOL_SIZE=1.
  - SQS→Lambda event source mapping with batch size, enabled toggle, and batch item failure reporting.
  - Tuning: timeout, memory, reserved concurrency, batch size, retries, log retention, tags.
  - Outputs for CI: queue URL/ARN, DLQ ARN, function name/ARN, Lambda role ARN.

<sup>Written for commit 032591b9729ef2e357c099d6aab649b92993ae91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

