### PR TITLE
Stop producing free prices (persist as fixed amount 0)

### DIFF
--- a/clients/apps/app/components/Products/ProductPriceLabel.tsx
+++ b/clients/apps/app/components/Products/ProductPriceLabel.tsx
@@ -24,7 +24,7 @@ export const ProductPriceLabel = ({
     return null
   }
 
-  if (staticPrice.amount_type === 'fixed') {
+  if (staticPrice.amount_type === 'fixed' && staticPrice.price_amount !== 0) {
     return (
       <AmountLabel
         amount={staticPrice.price_amount}

--- a/clients/apps/web/src/components/Products/EditProductPage.tsx
+++ b/clients/apps/web/src/components/Products/EditProductPage.tsx
@@ -9,7 +9,10 @@ import {
   findFirstErrorMessage,
   setProductValidationErrors,
 } from '@/utils/api/errors'
-import { ProductEditOrCreateForm } from '@/utils/product'
+import {
+  ProductEditOrCreateForm,
+  productPriceToFormPrice,
+} from '@/utils/product'
 import { isValidationError, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
@@ -58,10 +61,14 @@ export const EditProductPage = ({
       ...product,
       medias: product.medias.map((media) => media.id),
       full_medias: product.medias,
-      prices: product.prices.map((price) => ({
-        ...price,
-        price_currency: price.price_currency as schemas['PresentmentCurrency'],
-      })),
+      prices: product.prices.map((price) => {
+        const formPrice = productPriceToFormPrice(price)
+        return {
+          ...formPrice,
+          price_currency:
+            formPrice.price_currency as schemas['PresentmentCurrency'],
+        }
+      }),
       metadata: Object.entries(product.metadata).map(([key, value]) => ({
         key,
         value,

--- a/clients/apps/web/src/components/Products/ProductPriceLabel.tsx
+++ b/clients/apps/web/src/components/Products/ProductPriceLabel.tsx
@@ -27,7 +27,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
     return null
   }
 
-  if (staticPrice.amount_type === 'fixed') {
+  if (staticPrice.amount_type === 'fixed' && staticPrice.price_amount !== 0) {
     return (
       <AmountLabel
         amount={staticPrice.price_amount}

--- a/clients/apps/web/src/utils/product.ts
+++ b/clients/apps/web/src/utils/product.ts
@@ -22,6 +22,20 @@ export const isStaticPrice = (
   | schemas['ProductPriceSeatBased'] =>
   ['fixed', 'custom', 'free', 'seat_based'].includes(price.amount_type)
 
+// A fixed price of 0 is the free-pricing representation (we're dropping the dedicated
+// `free` price type). When loading a product into the form, surface such prices as the
+// form's `free` price type so they display and edit as "Free".
+export const productPriceToFormPrice = (
+  price: schemas['ProductPrice'],
+): schemas['ProductPrice'] => {
+  if (price.amount_type === 'fixed' && price.price_amount === 0) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { price_amount, ...rest } = price
+    return { ...rest, amount_type: 'free' } as schemas['ProductPrice']
+  }
+  return price
+}
+
 export const isMeteredPrice = (
   price: schemas['ProductPrice'] | schemas['LegacyRecurringProductPrice'],
 ): price is schemas['ProductPriceMeteredUnit'] =>
@@ -98,7 +112,7 @@ export const productToCreateForm = (
         is_archived,
         source,
         ...priceRest
-      } = price
+      } = productPriceToFormPrice(price)
       return {
         ...priceRest,
         price_currency: price.price_currency as schemas['PresentmentCurrency'],

--- a/clients/packages/checkout/src/components/ProductPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/ProductPriceLabel.tsx
@@ -23,7 +23,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
 }) => {
   const t = useTranslations(locale)
 
-  if (price.amount_type === 'fixed') {
+  if (price.amount_type === 'fixed' && price.price_amount !== 0) {
     return (
       <AmountLabel
         amount={price.price_amount}
@@ -44,7 +44,10 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
         {t('checkout.pricing.payWhatYouWant')}
       </div>
     )
-  } else if (price.amount_type === 'free') {
+  } else if (
+    price.amount_type === 'free' ||
+    (price.amount_type === 'fixed' && price.price_amount === 0)
+  ) {
     return (
       <div className="text-[min(1em,24px)]">{t('checkout.pricing.free')}</div>
     )

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -39,7 +39,7 @@ from polar.models import (
     User,
 )
 from polar.models.product_custom_field import ProductCustomField
-from polar.models.product_price import ProductPriceSource
+from polar.models.product_price import ProductPriceFixed, ProductPriceSource
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.organization.repository import OrganizationRepository
 from polar.organization.resolver import get_payload_organization
@@ -56,6 +56,7 @@ from .schemas import (
     ExistingProductPrice,
     ProductCreate,
     ProductPriceCreate,
+    ProductPriceFreeCreate,
     ProductPriceMeteredCreateBase,
     ProductPriceSeatBasedCreate,
     ProductUpdate,
@@ -572,8 +573,20 @@ class ProductService:
                 existing_prices.add(price)
             else:
                 model_class = price_schema.get_model_class()
+                price_kwargs = price_schema.model_dump()
+                # We no longer create `free` prices: we're dropping the free price
+                # type in favor of a fixed price with an amount of 0. Incoming `free`
+                # prices are still accepted for backward compatibility, but persisted
+                # as a fixed price with an amount of 0.
+                if isinstance(price_schema, ProductPriceFreeCreate):
+                    model_class = ProductPriceFixed
+                    price_kwargs = {
+                        "price_currency": price_schema.price_currency,
+                        "tax_behavior": price_schema.tax_behavior,
+                        "price_amount": 0,
+                    }
                 price = model_class(
-                    product=product, source=source, **price_schema.model_dump()
+                    product=product, source=source, **price_kwargs
                 )
                 if isinstance(price_schema, ProductPriceSeatBasedCreate):
                     if not organization.feature_settings.get(

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -585,9 +585,7 @@ class ProductService:
                         "tax_behavior": price_schema.tax_behavior,
                         "price_amount": 0,
                     }
-                price = model_class(
-                    product=product, source=source, **price_kwargs
-                )
+                price = model_class(product=product, source=source, **price_kwargs)
                 if isinstance(price_schema, ProductPriceSeatBasedCreate):
                     if not organization.feature_settings.get(
                         "seat_based_pricing_enabled", False

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -660,6 +660,35 @@ class TestCreate:
         assert len(product.prices) == len(create_schema.prices)
 
     @pytest.mark.auth
+    async def test_free_price_persisted_as_fixed_zero(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # We no longer create `free` prices: an incoming free price is accepted for
+        # backward compatibility but persisted as a fixed price with an amount of 0.
+        product = await product_service.create(
+            session,
+            ProductCreateOneTime(
+                name="Free product",
+                prices=[
+                    ProductPriceFreeCreate(amount_type=ProductPriceAmountType.free),
+                ],
+                organization_id=organization.id,
+            ),
+            auth_subject,
+        )
+
+        assert len(product.prices) == 1
+        price = product.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+        assert price.amount_type == ProductPriceAmountType.fixed
+        assert price.price_amount == 0
+        assert price.is_free is True
+
+    @pytest.mark.auth
     async def test_invalid_several_static_prices(
         self,
         auth_subject: AuthSubject[User],


### PR DESCRIPTION
**Related issue**: https://github.com/polarsource/polar/issues/12205

## Migration plan

1. ~Make a `fixed` price of `0` behave identically to a `free` price everywhere~ **Done**
2. Stop producing `free`: Change the frontend “Free” option and the API to create `fixed`-`0` prices instead of `free` ones (while still _accepting_ `free` for back-compat), freezing the `free` population so no new rows are added. **<-- this step**
3. Backfill: Convert all existing `free` (and `legacy_free`) rows to `fixed` with `price_amount = 0`.
4. Remove `ProductPriceFree` & `LegacyRecurringProductPriceFree`

### Comment re: frontend artifacts
The idea is to wait with cleaning up the `free` type from the frontend entirely until step 4 to keep this PR cleaner. So frontend ships `free` prices to the API which converts them to `fixed` with amount `0`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop creating `free` prices. New free prices are persisted as `fixed` with amount 0, and the UI still shows them as “Free”.

- **Refactors**
  - Backend maps incoming `free` prices to `ProductPriceFixed` with `price_amount: 0` (no new `free` rows); applied ruff formatting in product service.
  - UI (dashboard, native, checkout) shows fixed-0 as “Free”, not $0.
  - Forms treat fixed-0 as `free` via `productPriceToFormPrice`.
  - Tests cover persistence and “Free” display.

<sup>Written for commit 515a35ec39552fe629e15857e69fa555abee4093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



