### PR TITLE
adjust how roles are displayed in members table

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/MembersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/MembersPage.tsx
@@ -147,9 +147,18 @@ export default function ClientPage({
           <Box display="flex" flexDirection="row" alignItems="center" gap="s">
             <Avatar avatar_url={member.avatar_url} name={member.email} />
             <Text>{member.email}</Text>
-            <RowBadge>{ROLE_LABELS[member.role]}</RowBadge>
           </Box>
         )
+      },
+    },
+    {
+      accessorKey: 'role',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Role" />
+      ),
+      cell: ({ row: { original: member } }) => {
+        return <Text>{ROLE_LABELS[member.role]}</Text>
       },
     },
     {
@@ -216,7 +225,7 @@ export default function ClientPage({
 
   return (
     <DashboardBody
-      wrapperClassName="max-w-(--breakpoint-sm)!"
+      wrapperClassName="max-w-(--breakpoint-md)!"
       className="flex flex-col gap-y-8"
       header={
         canManageMembers ? (
@@ -288,21 +297,5 @@ export default function ClientPage({
         />
       )}
     </DashboardBody>
-  )
-}
-
-function RowBadge({ children }: { children: React.ReactNode }) {
-  return (
-    <Box
-      as="span"
-      paddingHorizontal="s"
-      paddingVertical="xs"
-      borderRadius="full"
-      backgroundColor="background-pending"
-    >
-      <Text variant="caption" color="muted">
-        {children}
-      </Text>
-    </Box>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show roles in a dedicated, sortable Role column in the Members table and widen the page to the md breakpoint for better readability. Removed the inline role badge next to email and the unused RowBadge component.

<sup>Written for commit 6f60d544ad3c267fcd514a12cdda8f7d32881dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

