### PR TITLE
Add <TreeMultiSelect /> component to tokens and webhooks

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -21,7 +21,6 @@ import {
   SelectValue,
 } from '@polar-sh/orbit'
 import Banner from '@polar-sh/ui/components/molecules/Banner'
-import { Checkbox } from '@polar-sh/ui/components/ui/checkbox'
 import {
   Form,
   FormControl,
@@ -30,11 +29,12 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useCallback, useMemo, useState, type MouseEvent } from 'react'
+import { useCallback, useState } from 'react'
 import { useForm, useFormContext } from 'react-hook-form'
 import { ConfirmModal } from '../Modal/ConfirmModal'
 import { toast, useToast } from '../Toast/use-toast'
 import { CreateAccessTokenModal } from './CreateAccessTokenModal'
+import { TreeMultiSelect } from './TreeMultiSelect'
 
 export interface AccessTokenCreate {
   comment: string
@@ -48,33 +48,7 @@ interface AccessTokenUpdate {
 }
 
 export const AccessTokenForm = ({ update }: { update?: boolean }) => {
-  const { control, setValue, watch } = useFormContext<
-    AccessTokenCreate | AccessTokenUpdate
-  >()
-
-  const sortedScopes = Array.from(enums.availableScopeValues).sort((a, b) =>
-    a.localeCompare(b),
-  )
-
-  const currentScopes = watch('scopes')
-
-  const allSelected = useMemo(
-    () => sortedScopes.every((scope) => currentScopes.includes(scope)),
-    [currentScopes, sortedScopes],
-  )
-
-  const onToggleAll = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-
-      let values: Array<schemas['AvailableScope']> = []
-      if (!allSelected) {
-        values = sortedScopes
-      }
-      setValue('scopes', values)
-    },
-    [setValue, allSelected, sortedScopes],
-  )
+  const { control } = useFormContext<AccessTokenCreate | AccessTokenUpdate>()
 
   return (
     <>
@@ -129,53 +103,23 @@ export const AccessTokenForm = ({ update }: { update?: boolean }) => {
           )}
         />
       )}
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-row items-center">
-          <h2 className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-            Scopes
-          </h2>
-
-          <div className="-my-2 flex-auto text-right">
-            <Button onClick={onToggleAll} variant="secondary" size="sm">
-              {!allSelected ? 'Select all' : 'Unselect all'}
-            </Button>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          {sortedScopes.map((scope) => (
-            <FormField
-              key={scope}
-              control={control}
-              name="scopes"
-              render={({ field }) => {
-                return (
-                  <FormItem className="flex flex-row items-center space-y-0 space-x-2">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value?.includes(scope)}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            field.onChange([...(field.value || []), scope])
-                          } else {
-                            field.onChange(
-                              (field.value || []).filter((v) => v !== scope),
-                            )
-                          }
-                        }}
-                      />
-                    </FormControl>
-                    <FormLabel className="font-mono text-xs leading-none font-medium">
-                      {scope}
-                    </FormLabel>
-                    <FormMessage />
-                  </FormItem>
-                )
-              }}
-            />
-          ))}
-        </div>
-      </div>
+      <FormField
+        control={control}
+        name="scopes"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <TreeMultiSelect
+                title="Scopes"
+                options={enums.availableScopeValues}
+                value={field.value ?? []}
+                onChange={field.onChange}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
     </>
   )
 }

--- a/clients/apps/web/src/components/Settings/TreeMultiSelect.tsx
+++ b/clients/apps/web/src/components/Settings/TreeMultiSelect.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { Box } from '@polar-sh/orbit/Box'
+import { Button, Text } from '@polar-sh/orbit'
+import { Checkbox } from '@polar-sh/ui/components/ui/checkbox'
+import { useMemo, type MouseEvent, type ReactNode } from 'react'
+
+interface OptionGroup<T extends string> {
+  key: string
+  label: string
+  options: T[]
+}
+
+const UNGROUPED_KEY = '__ungrouped__'
+
+const humanize = (value: string): string =>
+  value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+
+const buildGroups = <T extends string>(
+  options: readonly T[],
+  separator: string,
+): OptionGroup<T>[] => {
+  const groupsByKey = new Map<string, OptionGroup<T>>()
+
+  for (const option of options) {
+    const separatorIndex = option.indexOf(separator)
+    const key =
+      separatorIndex === -1 ? UNGROUPED_KEY : option.slice(0, separatorIndex)
+
+    let group = groupsByKey.get(key)
+    if (!group) {
+      group = {
+        key,
+        label: key === UNGROUPED_KEY ? 'General' : humanize(key),
+        options: [],
+      }
+      groupsByKey.set(key, group)
+    }
+    group.options.push(option)
+  }
+
+  return Array.from(groupsByKey.values())
+    .map((group) => ({
+      ...group,
+      options: group.options.sort((a, b) => a.localeCompare(b)),
+    }))
+    .sort((a, b) => {
+      if (a.key === UNGROUPED_KEY) return -1
+      if (b.key === UNGROUPED_KEY) return 1
+      return a.label.localeCompare(b.label)
+    })
+}
+
+interface TreeMultiSelectProps<T extends string> {
+  options: readonly T[]
+  value: T[]
+  onChange: (next: T[]) => void
+  title?: ReactNode
+  separator?: string
+  renderOptionSuffix?: (option: T) => ReactNode
+}
+
+export function TreeMultiSelect<T extends string>({
+  options,
+  value,
+  onChange,
+  title,
+  separator = ':',
+  renderOptionSuffix,
+}: TreeMultiSelectProps<T>) {
+  const groups = useMemo(
+    () => buildGroups(options, separator),
+    [options, separator],
+  )
+
+  const selected = useMemo(() => new Set(value), [value])
+  const allSelected =
+    options.length > 0 && options.every((o) => selected.has(o))
+
+  const setOptions = (next: Iterable<T>) => onChange(Array.from(next))
+
+  const onToggleAll = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    setOptions(allSelected ? [] : options)
+  }
+
+  const onToggleOption = (option: T) => {
+    const next = new Set(selected)
+    if (next.has(option)) next.delete(option)
+    else next.add(option)
+    setOptions(next)
+  }
+
+  const onToggleGroup = (group: OptionGroup<T>) => {
+    const next = new Set(selected)
+    const fullySelected = group.options.every((o) => next.has(o))
+    for (const option of group.options) {
+      if (fullySelected) next.delete(option)
+      else next.add(option)
+    }
+    setOptions(next)
+  }
+
+  return (
+    <Box display="flex" flexDirection="column">
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="between"
+        columnGap="m"
+      >
+        {title ? <Text variant="label">{title}</Text> : <span />}
+        <Button onClick={onToggleAll} variant="secondary" size="sm">
+          {allSelected ? 'Unselect all' : 'Select all'}
+        </Button>
+      </Box>
+
+      <Box display="flex" flexDirection="column" rowGap="xs">
+        {groups.map((group) => {
+          const selectedCount = group.options.filter((o) =>
+            selected.has(o),
+          ).length
+          const groupChecked =
+            selectedCount === 0
+              ? false
+              : selectedCount === group.options.length
+                ? true
+                : 'indeterminate'
+
+          return (
+            <Box key={group.key} display="flex" flexDirection="column">
+              <Box
+                as="label"
+                display="flex"
+                alignItems="center"
+                columnGap="s"
+                paddingVertical="xs"
+                cursor={{ hover: 'pointer' }}
+              >
+                <Checkbox
+                  checked={groupChecked}
+                  onCheckedChange={() => onToggleGroup(group)}
+                />
+                <Text variant="mono">{group.label}</Text>
+              </Box>
+
+              <Box display="flex" flexDirection="column" pl="xl">
+                {group.options.map((option) => (
+                  <Box
+                    key={option}
+                    as="label"
+                    display="flex"
+                    alignItems="center"
+                    columnGap="s"
+                    paddingVertical="xs"
+                    cursor={{ hover: 'pointer' }}
+                  >
+                    <Checkbox
+                      checked={selected.has(option)}
+                      onCheckedChange={() => onToggleOption(option)}
+                    />
+                    <Text variant="mono">{option}</Text>
+                    {renderOptionSuffix?.(option)}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -1,5 +1,4 @@
 import { enums, schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
 import { Input } from '@polar-sh/orbit'
 import {
   Select,
@@ -8,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@polar-sh/orbit'
-import { Checkbox } from '@polar-sh/ui/components/ui/checkbox'
 import {
   FormControl,
   FormField,
@@ -17,8 +15,9 @@ import {
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
 import Link from 'next/link'
-import { useCallback, useEffect, useMemo, type MouseEvent } from 'react'
+import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
+import { TreeMultiSelect } from '../TreeMultiSelect'
 
 type CreateOrUpdate =
   | schemas['WebhookEndpointCreate']
@@ -172,91 +171,35 @@ export const FieldFormat = () => {
 }
 
 export const FieldEvents = () => {
-  const { control, setValue, watch } = useFormContext<CreateOrUpdate>()
-
-  const allEvents = useMemo(
-    () => Object.values(enums.webhookEventTypeValues),
-    [],
-  )
-
-  const currentEvents = watch('events')
-
-  const allSelected = useMemo(
-    () => allEvents.every((event) => currentEvents?.includes(event)),
-    [currentEvents, allEvents],
-  )
-
-  const onToggleAll = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-
-      let values: Array<schemas['WebhookEventType']> = []
-      if (!allSelected) {
-        values = allEvents
-      }
-      setValue('events', values)
-    },
-    [setValue, allSelected, allEvents],
-  )
+  const { control } = useFormContext<CreateOrUpdate>()
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-row items-center">
-        <h2 className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-          Events
-        </h2>
-
-        <div className="flex-auto text-right">
-          <Button onClick={onToggleAll} variant="secondary" size="sm">
-            {!allSelected ? 'Select All' : 'Unselect All'}
-          </Button>
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-y-2">
-        {allEvents.map((event) => (
-          <FormField
-            key={event}
-            control={control}
-            name="events"
-            render={({ field }) => {
-              const href = `https://polar.sh/docs/api-reference/webhooks/${event}`
-
-              return (
-                <FormItem className="flex flex-row items-center space-y-0 space-x-3">
-                  <FormControl>
-                    <Checkbox
-                      checked={
-                        field.value ? field.value.includes(event) : false
-                      }
-                      onCheckedChange={(checked) => {
-                        if (checked) {
-                          field.onChange([...(field.value || []), event])
-                        } else {
-                          field.onChange(
-                            (field.value || []).filter((v) => v !== event),
-                          )
-                        }
-                      }}
-                    />
-                  </FormControl>
-                  <FormLabel className="text-sm leading-none">
-                    {event}
-                  </FormLabel>
-                  <Link
-                    className="text-xs text-blue-400"
-                    href={href}
-                    target="_blank"
-                  >
-                    Schema
-                  </Link>
-                  <FormMessage />
-                </FormItem>
-              )
-            }}
-          />
-        ))}
-      </div>
-    </div>
+    <FormField
+      control={control}
+      name="events"
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <TreeMultiSelect
+              title="Events"
+              options={enums.webhookEventTypeValues}
+              value={field.value ?? []}
+              onChange={field.onChange}
+              separator="."
+              renderOptionSuffix={(event) => (
+                <Link
+                  className="text-xs text-blue-400"
+                  href={`https://polar.sh/docs/api-reference/webhooks/${event}`}
+                  target="_blank"
+                >
+                  Schema
+                </Link>
+              )}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   )
 }

--- a/clients/packages/ui/src/components/ui/checkbox.tsx
+++ b/clients/packages/ui/src/components/ui/checkbox.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { Check } from 'lucide-react'
+import { Check, Minus } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
@@ -20,9 +20,15 @@ const Checkbox = ({
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      className={cn('flex items-center justify-center text-current')}
+      className={cn(
+        'group flex h-full w-full items-center justify-center text-current',
+      )}
     >
-      <Check className="h-4 w-4" />
+      <Check className="h-4 w-4 group-data-[state=indeterminate]:hidden" />
+      <Minus
+        className="text-primary hidden h-3 w-3 group-data-[state=indeterminate]:block"
+        strokeWidth={3}
+      />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 )


### PR DESCRIPTION
It's quite difficult to get an overview of our token scopes + webhook events right now due to the list being flat. This PR will introduce a new generic `<TreeMultiSelect />` component that solves that for us.

It's built to be very generic, so any backend changes (e.g scope renames, removals, additions) will automatically be reflected.

Fixes https://github.com/polarsource/feedback/issues/125

## Screenshots

### Token scopes
| Before | After  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-06-09 at 13 14 47" src="https://github.com/user-attachments/assets/54cd26b5-3764-4ec1-8d7a-1eadff2bccd9" /> | <img width="1840" height="1133" alt="Screenshot 2026-06-09 at 13 21 05" src="https://github.com/user-attachments/assets/a94169e5-96ca-47c6-8b0b-6aa4bcdd887b" /> |

### Webhook creation
| Before | After  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-06-09 at 13 15 14" src="https://github.com/user-attachments/assets/6e1d15d8-3d16-4c58-834d-6736515ca644" /> | <img width="1840" height="1133" alt="Screenshot 2026-06-09 at 13 13 23" src="https://github.com/user-attachments/assets/a28daad7-4778-42d8-8b71-cd7f3dc5057b" /> |


### Webhook details
| Before | After  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-06-09 at 13 15 19" src="https://github.com/user-attachments/assets/c75eb738-5774-4d64-bc54-ea92e7702df5" /> | <img width="1840" height="1133" alt="Screenshot 2026-06-09 at 13 13 14" src="https://github.com/user-attachments/assets/a28aafea-3703-46ad-aae6-7483a039bdd9" /> |






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `TreeMultiSelect` to group and select token scopes and webhook events. Replaces flat lists with a clearer tree, plus select-all and tri-state group toggles that adapt to backend changes.

- **New Features**
  - Introduced `TreeMultiSelect` with grouping by prefix (default `:`; webhooks use `.`), select all, and tri-state group selection. Supports optional suffix content per option.
  - Token scopes and webhook events now use it; webhook events show a “Schema” link per event.

- **Refactors**
  - Removed custom selection logic in tokens and webhooks forms in favor of `TreeMultiSelect`.
  - Updated `Checkbox` in `@polar-sh/ui` to support indeterminate state (minus icon).

<sup>Written for commit 8859709d6b1a52c8db5691c68a16628b4ef1198f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

