### PR TITLE
Backfill free prices to fixed prices with amount 0

### DIFF
--- a/server/scripts/free_price_to_fixed_backfill.py
+++ b/server/scripts/free_price_to_fixed_backfill.py
@@ -1,0 +1,69 @@
+"""Backfill existing free prices to fixed prices with an amount of 0.
+
+We're dropping the dedicated `free` product price type in favor of a fixed price
+with an amount of 0. New prices are already persisted that way (see
+`ProductService`); this script converts the existing `free` rows.
+
+The `amount_type` discriminator is a computed expression (see `ProductPrice`), so
+updating `amount_type` alone reclassifies the row: `free` -> `fixed` and, for legacy
+recurring prices, `legacy_free` -> `legacy_fixed` (the `type` column is untouched).
+
+The update is idempotent: once a row is converted it no longer matches the filter,
+so the script can be safely re-run or resumed.
+"""
+
+import typer
+from sqlalchemy import select, update
+
+from polar.models import ProductPrice
+from polar.models.product_price import ProductPriceAmountType
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+product_prices = ProductPrice.__table__
+
+subquery = (
+    select(ProductPrice.id)
+    .where(ProductPrice.amount_type == ProductPriceAmountType.free)
+    .order_by(ProductPrice.id)
+    .limit(limit_bindparam())
+    .scalar_subquery()
+)
+
+update_statement = (
+    update(ProductPrice)
+    .values(
+        {
+            ProductPrice.amount_type: ProductPriceAmountType.fixed,
+            # `price_amount` is only mapped on the fixed subclass; target the
+            # underlying column directly on the base entity's table.
+            product_prices.c.price_amount_v2: 0,
+        }
+    )
+    .where(ProductPrice.id.in_(subquery))
+)
+
+
+@cli.command()
+@typer_async
+async def free_price_to_fixed_backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    await run_batched_update(
+        update_statement,
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/scripts/test_free_price_to_fixed_backfill.py
+++ b/server/tests/scripts/test_free_price_to_fixed_backfill.py
@@ -1,0 +1,87 @@
+import uuid
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import CursorResult, select
+
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Organization, ProductPrice
+from polar.models.product_price import (
+    LegacyRecurringProductPriceFree,
+    ProductPriceAmountType,
+    ProductPriceType,
+)
+from scripts.free_price_to_fixed_backfill import update_statement
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_product,
+    create_product_price_custom,
+    create_product_price_fixed,
+    create_product_price_free,
+)
+
+product_prices = ProductPrice.__table__
+
+
+async def _row(
+    session: AsyncSession, price_id: uuid.UUID
+) -> tuple[str, int | None, str | None]:
+    result = await session.execute(
+        select(
+            product_prices.c.amount_type,
+            product_prices.c.price_amount_v2,
+            product_prices.c.type,
+        ).where(product_prices.c.id == price_id)
+    )
+    row = result.one()
+    return row.amount_type, row.price_amount_v2, row.type
+
+
+@pytest.mark.asyncio
+async def test_free_price_to_fixed_backfill(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    organization: Organization,
+) -> None:
+    product = await create_product(
+        save_fixture, organization=organization, recurring_interval=None, prices=[]
+    )
+
+    free = await create_product_price_free(save_fixture, product=product)
+    legacy_free = LegacyRecurringProductPriceFree(
+        product=product, price_currency="usd", tax_behavior=None, is_archived=False
+    )
+    legacy_free.type = ProductPriceType.recurring
+    legacy_free.recurring_interval = SubscriptionRecurringInterval.month
+    await save_fixture(legacy_free)
+    fixed = await create_product_price_fixed(save_fixture, product=product, amount=1000)
+    custom = await create_product_price_custom(save_fixture, product=product)
+
+    result = await session.execute(update_statement, {"limit": 1000})
+    await session.commit()
+    # Only the two free prices are converted.
+    assert cast(CursorResult[Any], result).rowcount == 2
+
+    # New free price -> fixed amount 0, `type` stays NULL (identity: fixed).
+    assert await _row(session, free.id) == (ProductPriceAmountType.fixed, 0, None)
+
+    # Legacy recurring free price -> fixed amount 0, `type` stays "recurring"
+    # (identity: legacy_fixed).
+    assert await _row(session, legacy_free.id) == (
+        ProductPriceAmountType.fixed,
+        0,
+        "recurring",
+    )
+
+    # Paid fixed price is left untouched.
+    assert await _row(session, fixed.id) == (ProductPriceAmountType.fixed, 1000, None)
+
+    # Custom price is left untouched.
+    amount_type, _, _ = await _row(session, custom.id)
+    assert amount_type == ProductPriceAmountType.custom
+
+    # Idempotent: a second run converts nothing.
+    result = await session.execute(update_statement, {"limit": 1000})
+    await session.commit()
+    assert cast(CursorResult[Any], result).rowcount == 0


### PR DESCRIPTION
**Related issue**: https://github.com/polarsource/polar/issues/12205

## Migration plan

1. ~Make a `fixed` price of `0` behave identically to a `free` price everywhere~ **Done**
2. ~Stop producing `free`: Change the frontend “Free” option and the API to create `fixed`-`0` prices instead of `free` ones (while still _accepting_ `free` for back-compat), freezing the `free` population so no new rows are added.~
3. Backfill: Convert all existing `free` (and `legacy_free`) rows to `fixed` with `price_amount = 0`. **<- this step**
4. Remove `ProductPriceFree` & `LegacyRecurringProductPriceFree`


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backfills existing `free` product prices to `fixed` with amount 0. Adds a batched, idempotent script to convert `free` and legacy recurring free rows, finalizing removal of the `free` price type.

- **Migration**
  - Run: `server/scripts/free_price_to_fixed_backfill.py` (Typer CLI; supports `--batch-size` and `--sleep-seconds`).
  - Safe to re-run; batches by id and commits per batch.
  - Converts rows with `amount_type=free` to `fixed` and sets `price_amount_v2=0`; leaves `type` unchanged (e.g., `recurring`).

<sup>Written for commit c2ea5fb17283cfa63a060cc3e03709c12a1f288d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

