### PR TITLE
Unify different states of customer portal

### DIFF
--- a/clients/apps/web/src/app/(main)/[organization]/portal/overview/OverviewPage.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/overview/OverviewPage.tsx
@@ -9,12 +9,14 @@ const ClientPage = ({
   products,
   subscriptions,
   claimedSubscriptions,
+  orders,
   customerSessionToken,
 }: {
   organization: schemas['CustomerOrganization']
   products: schemas['CustomerProduct'][]
   subscriptions: schemas['ListResource_CustomerSubscription_']
   claimedSubscriptions: schemas['ListResource_CustomerSubscription_']
+  orders: schemas['CustomerOrder'][]
   customerSessionToken: string
 }) => {
   return (
@@ -24,6 +26,7 @@ const ClientPage = ({
         products={products}
         subscriptions={subscriptions.items ?? []}
         claimedSubscriptions={claimedSubscriptions.items ?? []}
+        orders={orders}
         customerSessionToken={customerSessionToken}
       />
     </NuqsAdapter>

--- a/clients/apps/web/src/app/(main)/[organization]/portal/overview/page.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/overview/page.tsx
@@ -81,6 +81,7 @@ export default async function Page(props: {
       error: claimedSubscriptionsError,
       response: claimedSubscriptionsResponse,
     },
+    { data: orders, response: ordersResponse },
   ] = await Promise.all([
     api.GET('/v1/customer-portal/subscriptions/', {
       params: {
@@ -92,6 +93,15 @@ export default async function Page(props: {
     }),
 
     api.GET('/v1/customer-portal/seats/subscriptions', {
+      params: {
+        query: {
+          limit: 100,
+        },
+      },
+      ...cacheConfig,
+    }),
+
+    api.GET('/v1/customer-portal/orders/', {
       params: {
         query: {
           limit: 100,
@@ -124,6 +134,7 @@ export default async function Page(props: {
       products={products}
       subscriptions={subscriptions}
       claimedSubscriptions={claimedSubscriptions!}
+      orders={ordersResponse.ok ? (orders?.items ?? []) : []}
       customerSessionToken={token as string}
     />
   )

--- a/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
@@ -3,6 +3,7 @@ import { Client, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { useMemo } from 'react'
 import ProductPriceLabel from '../Products/ProductPriceLabel'
+import { OverviewSummaryCard } from './OverviewSummaryCard'
 
 interface CurrentPeriodOverviewProps {
   subscription: schemas['CustomerSubscription']
@@ -73,137 +74,126 @@ export const CurrentPeriodOverview = ({
     dateLabel = 'Subscription Ends'
   }
 
+  const chargeDateLabel = `${dateLabel} — ${
+    chargeDate
+      ? new Date(chargeDate).toLocaleDateString('en-US', {
+          dateStyle: 'medium',
+        })
+      : 'N/A'
+  }`
+
   return (
-    <div className="dark:border-polar-700 flex flex-col gap-4 rounded-3xl border border-gray-200 p-8">
-      <div className="items-center justify-between space-y-1.5 sm:flex sm:space-y-0">
-        <h4 className="text-lg font-medium">{headerTitle}</h4>
-        <span className="dark:text-polar-500 text-sm text-gray-500">
-          {dateLabel} —{' '}
-          {chargeDate
-            ? new Date(chargeDate).toLocaleDateString('en-US', {
-                dateStyle: 'medium',
-              })
-            : 'N/A'}
-        </span>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        {product && subscriptionPreview && (
-          <div className="flex items-center justify-between">
-            <span className="dark:text-polar-400 text-gray-600">
-              {product.name}
-            </span>
-            <span
-              className={
-                isCancelingAtPeriodEnd ? 'text-gray-500' : 'font-medium'
-              }
-            >
-              {isCancelingAtPeriodEnd ? (
-                'Canceled'
-              ) : (
-                <ProductPriceLabel
-                  product={product}
-                  currency={subscription.currency}
-                />
-              )}
-            </span>
-          </div>
-        )}
-
-        {hasMeters && (
-          <>
-            <span className="font-medium">Metered Charges</span>
-
-            {subscription.meters.map((meter) => (
-              <div key={meter.id} className="flex items-center justify-between">
-                <span className="dark:text-polar-400 text-gray-600">
-                  {meter.meter.name}
-                </span>
-                <span className="font-medium">
-                  {formatCurrency('compact')(
-                    meter.amount,
-                    subscription.currency,
-                  )}
-                </span>
-              </div>
-            ))}
-          </>
-        )}
-
-        <div className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-2">
-          {(hasTaxes || hasDiscount) && (
-            <div className="dark:text-polar-500 mb-1.5 flex items-center justify-between text-gray-500">
-              <span>Subtotal</span>
-              <span>
-                {formatCurrency('compact')(
-                  subscriptionPreview.subtotal_amount,
-                  subscription.currency,
-                )}
-              </span>
-            </div>
-          )}
-
-          {hasDiscount && (
-            <div className="dark:text-polar-500 mb-1 flex items-center justify-between text-gray-500">
-              <span>Discount</span>
-              <span>
-                {formatCurrency('compact')(
-                  -1 * subscriptionPreview.discount_amount,
-                  subscription.currency,
-                )}
-              </span>
-            </div>
-          )}
-
-          {hasTaxes && (
-            <div className="dark:text-polar-500 mb-1 flex items-center justify-between text-gray-500">
-              <span>Taxes</span>
-              <span>
-                {formatCurrency('compact')(
-                  subscriptionPreview.tax_amount,
-                  subscription.currency,
-                )}
-              </span>
-            </div>
-          )}
-
-          <div className="flex items-center justify-between">
-            <span className="font-medium">
-              {hasMeters ? 'Estimated Total' : 'Total'}
-            </span>
-            <span className="text-lg font-medium">
-              {subscriptionPreview ? (
-                formatCurrency('compact')(
-                  subscriptionPreview.total_amount,
-                  subscription.currency,
-                )
-              ) : (
-                <span className="dark:text-polar-500 animate-pulse text-gray-500">
-                  Loading…
-                </span>
-              )}
-            </span>
-          </div>
-
-          {isCancelingAtPeriodEnd && (
-            <p className="max-w-sm text-xs text-gray-500">
-              This will be the final charge before the subscription ends.
-              {hasMeters &&
-                ' Final amount may vary based on usage until the end of the billing period.'}
-            </p>
-          )}
-
-          {!isCancelingAtPeriodEnd && hasMeters && (
-            <p className="max-w-sm text-xs text-gray-500">
-              {isActive
-                ? 'Final charges may vary based on usage until the end of the billing period.'
-                : isTrialing
-                  ? 'Final charges may vary based on usage during the trial period.'
-                  : 'Final charges may vary.'}
-            </p>
-          )}
+    <OverviewSummaryCard title={headerTitle} meta={chargeDateLabel}>
+      {product && subscriptionPreview && (
+        <div className="flex items-center justify-between">
+          <span className="dark:text-polar-400 text-gray-600">
+            {product.name}
+          </span>
+          <span
+            className={isCancelingAtPeriodEnd ? 'text-gray-500' : 'font-medium'}
+          >
+            {isCancelingAtPeriodEnd ? (
+              'Canceled'
+            ) : (
+              <ProductPriceLabel
+                product={product}
+                currency={subscription.currency}
+              />
+            )}
+          </span>
         </div>
+      )}
+
+      {hasMeters && (
+        <>
+          <span className="font-medium">Metered Charges</span>
+
+          {subscription.meters.map((meter) => (
+            <div key={meter.id} className="flex items-center justify-between">
+              <span className="dark:text-polar-400 text-gray-600">
+                {meter.meter.name}
+              </span>
+              <span className="font-medium">
+                {formatCurrency('compact')(meter.amount, subscription.currency)}
+              </span>
+            </div>
+          ))}
+        </>
+      )}
+
+      <div className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-2">
+        {(hasTaxes || hasDiscount) && (
+          <div className="dark:text-polar-500 mb-1.5 flex items-center justify-between text-gray-500">
+            <span>Subtotal</span>
+            <span>
+              {formatCurrency('compact')(
+                subscriptionPreview.subtotal_amount,
+                subscription.currency,
+              )}
+            </span>
+          </div>
+        )}
+
+        {hasDiscount && (
+          <div className="dark:text-polar-500 mb-1 flex items-center justify-between text-gray-500">
+            <span>Discount</span>
+            <span>
+              {formatCurrency('compact')(
+                -1 * subscriptionPreview.discount_amount,
+                subscription.currency,
+              )}
+            </span>
+          </div>
+        )}
+
+        {hasTaxes && (
+          <div className="dark:text-polar-500 mb-1 flex items-center justify-between text-gray-500">
+            <span>Taxes</span>
+            <span>
+              {formatCurrency('compact')(
+                subscriptionPreview.tax_amount,
+                subscription.currency,
+              )}
+            </span>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between">
+          <span className="font-medium">
+            {hasMeters ? 'Estimated Total' : 'Total'}
+          </span>
+          <span className="text-lg font-medium">
+            {subscriptionPreview ? (
+              formatCurrency('compact')(
+                subscriptionPreview.total_amount,
+                subscription.currency,
+              )
+            ) : (
+              <span className="dark:text-polar-500 animate-pulse text-gray-500">
+                Loading…
+              </span>
+            )}
+          </span>
+        </div>
+
+        {isCancelingAtPeriodEnd && (
+          <p className="max-w-sm text-xs text-gray-500">
+            This will be the final charge before the subscription ends.
+            {hasMeters &&
+              ' Final amount may vary based on usage until the end of the billing period.'}
+          </p>
+        )}
+
+        {!isCancelingAtPeriodEnd && hasMeters && (
+          <p className="max-w-sm text-xs text-gray-500">
+            {isActive
+              ? 'Final charges may vary based on usage until the end of the billing period.'
+              : isTrialing
+                ? 'Final charges may vary based on usage during the trial period.'
+                : 'Final charges may vary.'}
+          </p>
+        )}
       </div>
-    </div>
+    </OverviewSummaryCard>
   )
 }

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalOverview.tsx
@@ -7,16 +7,19 @@ import AllInclusiveOutlined from '@mui/icons-material/AllInclusiveOutlined'
 import { schemas } from '@polar-sh/client'
 import { CurrentPeriodOverview } from './CurrentPeriodOverview'
 import { CustomerPortalGrants } from './CustomerPortalGrants'
+import { CustomerPortalOrders } from './CustomerPortalOrders'
 import {
   ActiveSubscriptionsOverview,
   InactiveSubscriptionsOverview,
 } from './CustomerPortalSubscriptions'
 import { EmptyState } from './EmptyState'
+import { LatestPurchaseOverview } from './LatestPurchaseOverview'
 export interface CustomerPortalProps {
   organization: schemas['CustomerOrganization']
   products: schemas['CustomerProduct'][]
   subscriptions: schemas['CustomerSubscription'][]
   claimedSubscriptions: schemas['CustomerSubscription'][]
+  orders: schemas['CustomerOrder'][]
   customerSessionToken: string
 }
 
@@ -25,6 +28,7 @@ export const CustomerPortalOverview = ({
   products,
   subscriptions,
   claimedSubscriptions,
+  orders,
   customerSessionToken,
 }: CustomerPortalProps) => {
   const api = createClientSideAPI(customerSessionToken)
@@ -44,6 +48,8 @@ export const CustomerPortalOverview = ({
     (s) => s.status === 'active' || s.status === 'trialing',
   )
 
+  const latestOrder = orders.at(0) ?? null
+
   const hasAnyActiveSubscriptions =
     activeOwnedSubscriptions.length > 0 || activeClaimedSubscriptions.length > 0
 
@@ -51,10 +57,7 @@ export const CustomerPortalOverview = ({
     <div className="flex flex-col gap-y-12">
       {/* Billing sections - only visible to users with billing permissions */}
       {canManageBilling && activeOwnedSubscriptions.length > 0 && (
-        <div className="flex flex-col gap-y-6">
-          {activeClaimedSubscriptions.length > 0 && (
-            <h3 className="text-xl">Your Subscriptions</h3>
-          )}
+        <div className="flex flex-col gap-y-12">
           <div className="flex flex-col gap-y-4">
             {activeOwnedSubscriptions.map((s) => (
               <CurrentPeriodOverview
@@ -100,20 +103,32 @@ export const CustomerPortalOverview = ({
         </div>
       )}
 
-      {/* Empty state - adjusted based on permissions */}
-      {!hasAnyActiveSubscriptions && (
-        <EmptyState
-          icon={<AllInclusiveOutlined />}
-          title={
-            canManageBilling ? 'No Active Subscriptions' : 'No Team Access'
-          }
-          description={
-            canManageBilling
-              ? "You don't have any active subscriptions at the moment."
-              : "You don't have any team seat access at the moment."
-          }
+      {hasAnyActiveSubscriptions && canManageBilling && orders.length > 0 && (
+        <CustomerPortalOrders
+          organization={organization}
+          orders={orders}
+          customerSessionToken={customerSessionToken}
         />
       )}
+
+      {!hasAnyActiveSubscriptions && canManageBilling && latestOrder && (
+        <LatestPurchaseOverview order={latestOrder} />
+      )}
+
+      {!hasAnyActiveSubscriptions &&
+        !(canManageBilling && orders.length > 0) && (
+          <EmptyState
+            icon={<AllInclusiveOutlined />}
+            title={
+              canManageBilling ? 'No Active Subscriptions' : 'No Team Access'
+            }
+            description={
+              canManageBilling
+                ? "You don't have any active subscriptions at the moment."
+                : "You don't have any team seat access at the moment."
+            }
+          />
+        )}
 
       {/* Benefit Grants - visible to all users */}
       <CustomerPortalGrants organization={organization} api={api} />

--- a/clients/apps/web/src/components/CustomerPortal/LatestPurchaseOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/LatestPurchaseOverview.tsx
@@ -1,0 +1,38 @@
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { OrderStatus } from '../Orders/OrderStatus'
+import { OverviewSummaryCard } from './OverviewSummaryCard'
+
+interface LatestPurchaseOverviewProps {
+  order: schemas['CustomerOrder']
+}
+
+export const LatestPurchaseOverview = ({
+  order,
+}: LatestPurchaseOverviewProps) => {
+  return (
+    <OverviewSummaryCard
+      title="Latest Purchase"
+      meta={`Purchased — ${new Date(order.created_at).toLocaleDateString(
+        'en-US',
+        { dateStyle: 'medium' },
+      )}`}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <span className="dark:text-polar-400 text-gray-600">
+          {order.product?.name ?? order.description}
+        </span>
+        <OrderStatus status={order.status} />
+      </div>
+
+      <div className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-2">
+        <div className="flex items-center justify-between">
+          <span className="font-medium">Total</span>
+          <span className="text-lg font-medium">
+            {formatCurrency('compact')(order.total_amount, order.currency)}
+          </span>
+        </div>
+      </div>
+    </OverviewSummaryCard>
+  )
+}

--- a/clients/apps/web/src/components/CustomerPortal/OverviewSummaryCard.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/OverviewSummaryCard.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react'
+
+interface OverviewSummaryCardProps {
+  title: string
+  meta?: ReactNode
+  children: ReactNode
+}
+
+export const OverviewSummaryCard = ({
+  title,
+  meta,
+  children,
+}: OverviewSummaryCardProps) => {
+  return (
+    <div className="dark:border-polar-700 flex flex-col gap-4 rounded-3xl border border-gray-200 p-8">
+      <div className="items-center justify-between space-y-1.5 sm:flex sm:space-y-0">
+        <h4 className="text-lg font-medium">{title}</h4>
+        {meta && (
+          <span className="dark:text-polar-500 text-sm text-gray-500">
+            {meta}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

This PR will give our customer portal some love:

* Never show a title at the top of the page (e.g `Your subscriptions`)
* If the user only has a one-time-purchase, don't show an empty state, show the actual orders
* Unify the UI of the top summary card with a shared component
* If the user has both subscriptions and orders, make sure to show both on the overview page
* Unify spacings between sections on the overview page

## Screenshots

### One time purchase
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 59 11" src="https://github.com/user-attachments/assets/a39aae37-fcf7-41ef-b89d-f9579c8d6cea" /> | <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 42 15" src="https://github.com/user-attachments/assets/02af782f-950e-4e01-a1be-bc0a87511674" /> |

### One time purchase (with benefits)
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 59 13" src="https://github.com/user-attachments/assets/11747ffb-e4e3-41f0-b5e4-560a44ff56a0" /> | <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 43 06" src="https://github.com/user-attachments/assets/0b56057d-51b6-47f3-a770-dc87216ec5cc" /> |

### Seats
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 59 06" src="https://github.com/user-attachments/assets/b6463771-6f4c-4d41-b5d5-f45409daa025" /> | <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 42 11" src="https://github.com/user-attachments/assets/100e96a8-f5c1-4977-a034-5ee12138afa1" /> |

### Monthly sub
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 59 09" src="https://github.com/user-attachments/assets/3d0a0e1e-c6e0-4fbf-895c-2a72f4a9f839" /> | <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 16 57 41" src="https://github.com/user-attachments/assets/0f964540-b9e4-46e1-a1b7-2759f6a35dd8" /> |


### On time purchase & Subscription
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 17 03 40" src="https://github.com/user-attachments/assets/753649b1-253d-46ff-bb15-74627e768bea" /> | <img width="1840" height="1134" alt="Screenshot 2026-06-09 at 17 06 08" src="https://github.com/user-attachments/assets/5678b227-9e7a-4139-8e2c-b688d9dd06c5" /> |





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the customer portal overview for subscriptions and one‑time purchases, adds order fetching/display, and standardizes the summary card UI. Removes the top page title and improves empty states so customers always see relevant info.

- New Features
  - Orders: fetch via `GET /v1/customer-portal/orders/` (limit 100) and pass `orders` to the overview.
  - Display logic: for billing managers, show subscriptions and the orders list together when active subscriptions exist; if no active subs but orders exist, show the latest purchase; show empty state only when neither exist or no billing access.
  - Shared UI: new `OverviewSummaryCard` used by `CurrentPeriodOverview` and `LatestPurchaseOverview` for consistent headers.
  - Latest purchase: `LatestPurchaseOverview` shows product/status, total, and purchase date.
  - Spacing cleanups across overview sections.

<sup>Written for commit afa528bf4abe8346f2a0227f0a74667d118d47ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

