### PR TITLE
feat(support-case): add backend for review appeals

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -974,6 +974,72 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/organizations/{id}/appeal/human-review': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Request Human Review
+     * @description Open a human-review case after the AI appeal was denied.
+     *
+     *     **Scopes**: `organizations:write`
+     */
+    post: operations['organizations:request_human_review']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/organizations/{id}/appeal/case': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Appeal Case
+     * @description Get the merchant's human-review case and its visible timeline.
+     *
+     *     **Scopes**: `organizations:read` `organizations:write`
+     */
+    get: operations['organizations:get_appeal_case']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/organizations/{id}/appeal/case/messages': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Reply to Appeal Case
+     * @description Post a merchant reply to the human-review case.
+     *
+     *     **Scopes**: `organizations:write`
+     */
+    post: operations['organizations:reply_to_appeal_case']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/organizations/{id}/ai-onboarding-complete': {
     parameters: {
       query?: never
@@ -19624,6 +19690,11 @@ export interface components {
       /** Detail */
       detail?: components['schemas']['ValidationError'][]
     }
+    /** HumanReviewRequest */
+    HumanReviewRequest: {
+      /** Reason */
+      reason: string
+    }
     /**
      * IdentityVerificationStatus
      * @enum {string}
@@ -30615,6 +30686,77 @@ export interface components {
       /** Github Username */
       github_username?: string | null
     }
+    /** SupportCase */
+    SupportCase: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string
+      type: components['schemas']['SupportCaseType']
+      /** Is Open */
+      is_open: boolean
+    }
+    /** SupportCaseMessage */
+    SupportCaseMessage: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string
+      /** Type */
+      type: string
+      author_kind: components['schemas']['SupportCaseMessageAuthorKind']
+      /** Body */
+      body: string | null
+    }
+    /**
+     * SupportCaseMessageAuthorKind
+     * @enum {string}
+     */
+    SupportCaseMessageAuthorKind:
+      | 'platform'
+      | 'merchant'
+      | 'customer'
+      | 'system'
+    /** SupportCaseMessageCreate */
+    SupportCaseMessageCreate: {
+      /** Body */
+      body: string
+    }
+    /** SupportCaseThread */
+    SupportCaseThread: {
+      case: components['schemas']['SupportCase']
+      /** Messages */
+      messages: components['schemas']['SupportCaseMessage'][]
+    }
+    /**
+     * SupportCaseType
+     * @enum {string}
+     */
+    SupportCaseType: 'review_appeal'
     SystemEvent:
       | components['schemas']['MeterCreditEvent']
       | components['schemas']['MeterResetEvent']
@@ -34905,6 +35047,130 @@ export interface operations {
         content: {
           'application/json': components['schemas']['HTTPValidationError']
         }
+      }
+    }
+  }
+  'organizations:request_human_review': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['HumanReviewRequest']
+      }
+    }
+    responses: {
+      /** @description Human review case opened. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SupportCase']
+        }
+      }
+      /** @description Support case not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Invalid request. */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'organizations:get_appeal_case': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Appeal case thread returned. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SupportCaseThread']
+        }
+      }
+      /** @description Support case not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'organizations:reply_to_appeal_case': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SupportCaseMessageCreate']
+      }
+    }
+    responses: {
+      /** @description Reply posted. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SupportCaseMessage']
+        }
+      }
+      /** @description Support case not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Case is locked or request is invalid. */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
     }
   }
@@ -58622,6 +58888,12 @@ export const subscriptionUpdateClearedEventNameValues: ReadonlyArray<
 export const subscriptionUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionUpdatedEvent']['name']
 > = ['subscription.updated']
+export const supportCaseMessageAuthorKindValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SupportCaseMessageAuthorKind']
+> = ['platform', 'merchant', 'customer', 'system']
+export const supportCaseTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SupportCaseType']
+> = ['review_appeal']
 export const taxBehaviorValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TaxBehavior']
 > = ['inclusive', 'exclusive']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -35083,12 +35083,14 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
-      /** @description Invalid request. */
+      /** @description Validation Error */
       422: {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
       }
     }
   }
@@ -35165,12 +35167,14 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
-      /** @description Case is locked or request is invalid. */
+      /** @description Validation Error */
       422: {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
       }
     }
   }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -30702,6 +30702,7 @@ export interface components {
       /**
        * Id
        * Format: uuid4
+       * @description The ID of the object.
        */
       id: string
       type: components['schemas']['SupportCaseType']
@@ -30724,10 +30725,10 @@ export interface components {
       /**
        * Id
        * Format: uuid4
+       * @description The ID of the object.
        */
       id: string
-      /** Type */
-      type: string
+      type: components['schemas']['SupportCaseMessageType']
       author_kind: components['schemas']['SupportCaseMessageAuthorKind']
       /** Body */
       body: string | null
@@ -30746,6 +30747,20 @@ export interface components {
       /** Body */
       body: string
     }
+    /**
+     * SupportCaseMessageType
+     * @description Known message types. Stored as a plain string column (not a DB enum):
+     *     ``chat`` and lifecycle values are generic, while action values are
+     *     domain-specific and grow per case type. Validated at the app boundary.
+     * @enum {string}
+     */
+    SupportCaseMessageType:
+      | 'chat'
+      | 'opened'
+      | 'closed'
+      | 'appeal_approved'
+      | 'appeal_denied'
+      | 'info_requested'
     /** SupportCaseThread */
     SupportCaseThread: {
       case: components['schemas']['SupportCase']
@@ -58895,6 +58910,16 @@ export const subscriptionUpdatedEventNameValues: ReadonlyArray<
 export const supportCaseMessageAuthorKindValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseMessageAuthorKind']
 > = ['platform', 'merchant', 'customer', 'system']
+export const supportCaseMessageTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SupportCaseMessageType']
+> = [
+  'chat',
+  'opened',
+  'closed',
+  'appeal_approved',
+  'appeal_denied',
+  'info_requested',
+]
 export const supportCaseTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseType']
 > = ['review_appeal']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -10568,6 +10568,28 @@ export interface components {
        */
       last4: string
     }
+    /** CaseAlreadyExistsError */
+    CaseAlreadyExistsError: {
+      /**
+       * Error
+       * @example CaseAlreadyExistsError
+       * @constant
+       */
+      error: 'CaseAlreadyExistsError'
+      /** Detail */
+      detail: string
+    }
+    /** CaseClosedError */
+    CaseClosedError: {
+      /**
+       * Error
+       * @example CaseClosedError
+       * @constant
+       */
+      error: 'CaseClosedError'
+      /** Detail */
+      detail: string
+    }
     /**
      * Checkout
      * @description Checkout session data retrieved using an access token.
@@ -35098,6 +35120,15 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
+      /** @description A human-review case already exists for this review. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CaseAlreadyExistsError']
+        }
+      }
       /** @description Validation Error */
       422: {
         headers: {
@@ -35180,6 +35211,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description The case is closed. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CaseClosedError']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -30728,8 +30728,6 @@ export interface components {
        */
       id: string
       type: components['schemas']['SupportCaseType']
-      /** Is Open */
-      is_open: boolean
     }
     /** SupportCaseMessage */
     SupportCaseMessage: {
@@ -30788,6 +30786,8 @@ export interface components {
       case: components['schemas']['SupportCase']
       /** Messages */
       messages: components['schemas']['SupportCaseMessage'][]
+      /** Is Open */
+      is_open: boolean
     }
     /**
      * SupportCaseType

--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -22,7 +22,10 @@ from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 
 if TYPE_CHECKING:
+    from polar.models.customer import Customer
+    from polar.models.organization import Organization
     from polar.models.organization_review import OrganizationReview
+    from polar.models.user import User
 
 
 class SupportCaseType(StrEnum):
@@ -213,6 +216,18 @@ class SupportCaseParticipant(RecordModel):
     def case(cls) -> Mapped["SupportCase"]:
         return relationship("SupportCase", lazy="raise", back_populates="participants")
 
+    @declared_attr
+    def organization(cls) -> Mapped["Organization | None"]:
+        return relationship("Organization", lazy="raise")
+
+    @declared_attr
+    def platform_user(cls) -> Mapped["User | None"]:
+        return relationship("User", lazy="raise")
+
+    @declared_attr
+    def customer(cls) -> Mapped["Customer | None"]:
+        return relationship("Customer", lazy="raise")
+
 
 class SupportCaseMessage(RecordModel):
     """An entry in the case timeline.
@@ -255,6 +270,10 @@ class SupportCaseMessage(RecordModel):
     @declared_attr
     def case(cls) -> Mapped["SupportCase"]:
         return relationship("SupportCase", lazy="raise", back_populates="messages")
+
+    @declared_attr
+    def author_user(cls) -> Mapped["User | None"]:
+        return relationship("User", lazy="raise")
 
 
 class SupportCaseAttachment(RecordModel):

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -705,7 +705,6 @@ async def submit_appeal(
     responses={
         200: {"description": "Human review case opened."},
         404: SupportCaseNotFound,
-        422: {"description": "Invalid request."},
     },
     tags=[APITag.private],
 )
@@ -796,7 +795,6 @@ async def get_appeal_case(
     responses={
         200: {"description": "Reply posted."},
         404: SupportCaseNotFound,
-        422: {"description": "Case is locked or request is invalid."},
     },
     tags=[APITag.private],
 )

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -56,7 +56,8 @@ from polar.organization.repository import (
     OrganizationReviewRepository,
 )
 from polar.organization_review.appeal_case import (
-    AppealCaseError,
+    CaseAlreadyExistsError,
+    CaseClosedError,
 )
 from polar.organization_review.appeal_case import (
     appeal_case as appeal_case_service,
@@ -710,6 +711,10 @@ async def submit_appeal(
     responses={
         200: {"description": "Human review case opened."},
         404: SupportCaseNotFound,
+        409: {
+            "description": "A human-review case already exists for this review.",
+            "model": CaseAlreadyExistsError.schema(),
+        },
     },
     tags=[APITag.private],
 )
@@ -724,25 +729,13 @@ async def request_human_review(
     if review is None:
         raise ResourceNotFound()
 
-    try:
-        case = await appeal_case_service.request_human_review(
-            session,
-            review,
-            organization=authz.organization,
-            reason=request.reason,
-            requested_by_user=authz.auth_subject.subject,
-        )
-    except AppealCaseError as e:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "value_error",
-                    "loc": ("body", "reason"),
-                    "msg": e.args[0],
-                    "input": request.reason,
-                }
-            ]
-        )
+    case = await appeal_case_service.request_human_review(
+        session,
+        review,
+        organization=authz.organization,
+        reason=request.reason,
+        requested_by_user=authz.auth_subject.subject,
+    )
 
     return SupportCaseSchema(
         id=case.id,
@@ -801,6 +794,10 @@ async def get_appeal_case(
     responses={
         200: {"description": "Reply posted."},
         404: SupportCaseNotFound,
+        409: {
+            "description": "The case is closed.",
+            "model": CaseClosedError.schema(),
+        },
     },
     tags=[APITag.private],
 )
@@ -819,25 +816,13 @@ async def reply_to_appeal_case(
     if case is None:
         raise ResourceNotFound()
 
-    try:
-        posted = await appeal_case_service.add_reply(
-            session,
-            case,
-            author_kind=SupportCaseMessageAuthorKind.merchant,
-            author_user=authz.auth_subject.subject,
-            body=message.body,
-        )
-    except AppealCaseError as e:
-        raise PolarRequestValidationError(
-            [
-                {
-                    "type": "value_error",
-                    "loc": ("body", "body"),
-                    "msg": e.args[0],
-                    "input": message.body,
-                }
-            ]
-        )
+    posted = await appeal_case_service.add_reply(
+        session,
+        case,
+        author_kind=SupportCaseMessageAuthorKind.merchant,
+        author_user=authz.auth_subject.subject,
+        body=message.body,
+    )
 
     return SupportCaseMessageSchema.model_validate(posted)
 

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -55,7 +55,12 @@ from polar.openapi import APITag
 from polar.organization.repository import (
     OrganizationReviewRepository,
 )
-from polar.organization_review.appeal_case import AppealCaseError, appeal_case
+from polar.organization_review.appeal_case import (
+    AppealCaseError,
+)
+from polar.organization_review.appeal_case import (
+    appeal_case as appeal_case_service,
+)
 from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import (
     AsyncReadSession,
@@ -720,7 +725,7 @@ async def request_human_review(
         raise ResourceNotFound()
 
     try:
-        case = await appeal_case.request_human_review(
+        case = await appeal_case_service.request_human_review(
             session,
             review,
             reason=request.reason,
@@ -767,7 +772,7 @@ async def get_appeal_case(
     if review is None:
         raise ResourceNotFound()
 
-    thread = await appeal_case.get_thread(
+    thread = await appeal_case_service.get_thread(
         session, review, visible_to=SupportCaseAudience.merchant
     )
     if thread is None:
@@ -809,12 +814,12 @@ async def reply_to_appeal_case(
     if review is None:
         raise ResourceNotFound()
 
-    case = await appeal_case.get_case(session, review)
+    case = await appeal_case_service.get_case(session, review)
     if case is None:
         raise ResourceNotFound()
 
     try:
-        posted = await appeal_case.add_reply(
+        posted = await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.merchant,

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -49,7 +49,12 @@ from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.http import check_url_reachable
 from polar.kit.pagination import ListResource, Pagination, PaginationParamsQuery
 from polar.models import Account, Organization, UserOrganization
-from polar.models.support_case import SupportCaseAudience, SupportCaseMessageAuthorKind
+from polar.models.support_case import (
+    SupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+)
 from polar.models.user_organization import OrganizationRole
 from polar.openapi import APITag
 from polar.organization.repository import (
@@ -722,27 +727,19 @@ async def request_human_review(
     authz: AuthorizeOrgManageUser,
     request: HumanReviewRequest,
     session: AsyncSession = Depends(get_db_session),
-) -> SupportCaseSchema:
+) -> SupportCase:
     """Open a human-review case after the AI appeal was denied."""
     review_repository = OrganizationReviewRepository.from_session(session)
     review = await review_repository.get_by_organization(authz.organization.id)
     if review is None:
         raise ResourceNotFound()
 
-    case = await appeal_case_service.request_human_review(
+    return await appeal_case_service.request_human_review(
         session,
         review,
         organization=authz.organization,
         reason=request.reason,
         requested_by_user=authz.auth_subject.subject,
-    )
-
-    return SupportCaseSchema(
-        id=case.id,
-        type=case.type,
-        is_open=True,
-        created_at=case.created_at,
-        modified_at=case.modified_at,
     )
 
 
@@ -773,17 +770,8 @@ async def get_appeal_case(
         raise ResourceNotFound()
 
     case, is_open, messages = thread
-    return SupportCaseThread(
-        case=SupportCaseSchema(
-            id=case.id,
-            type=case.type,
-            is_open=is_open,
-            created_at=case.created_at,
-            modified_at=case.modified_at,
-        ),
-        messages=[
-            SupportCaseMessageSchema.model_validate(message) for message in messages
-        ],
+    return SupportCaseThread.model_validate(
+        {"case": case, "is_open": is_open, "messages": messages}
     )
 
 
@@ -805,7 +793,7 @@ async def reply_to_appeal_case(
     authz: AuthorizeOrgManageUser,
     message: SupportCaseMessageCreate,
     session: AsyncSession = Depends(get_db_session),
-) -> SupportCaseMessageSchema:
+) -> SupportCaseMessage:
     """Post a merchant reply to the human-review case."""
     review_repository = OrganizationReviewRepository.from_session(session)
     review = await review_repository.get_by_organization(authz.organization.id)
@@ -816,15 +804,13 @@ async def reply_to_appeal_case(
     if case is None:
         raise ResourceNotFound()
 
-    posted = await appeal_case_service.add_reply(
+    return await appeal_case_service.add_reply(
         session,
         case,
         author_kind=SupportCaseMessageAuthorKind.merchant,
         author_user=authz.auth_subject.subject,
         body=message.body,
     )
-
-    return SupportCaseMessageSchema.model_validate(posted)
 
 
 @router.post(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -49,11 +49,13 @@ from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.http import check_url_reachable
 from polar.kit.pagination import ListResource, Pagination, PaginationParamsQuery
 from polar.models import Account, Organization, UserOrganization
+from polar.models.support_case import SupportCaseAudience, SupportCaseMessageAuthorKind
 from polar.models.user_organization import OrganizationRole
 from polar.openapi import APITag
 from polar.organization.repository import (
     OrganizationReviewRepository,
 )
+from polar.organization_review.appeal_case import AppealCaseError, appeal_case
 from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import (
     AsyncReadSession,
@@ -67,6 +69,18 @@ from polar.startup_program.service import (
 )
 from polar.startup_program.service import (
     startup_program as startup_program_service,
+)
+from polar.support_case.schemas import (
+    HumanReviewRequest,
+    SupportCaseMessageCreate,
+    SupportCaseNotFound,
+    SupportCaseThread,
+)
+from polar.support_case.schemas import (
+    SupportCase as SupportCaseSchema,
+)
+from polar.support_case.schemas import (
+    SupportCaseMessage as SupportCaseMessageSchema,
 )
 from polar.user.service import user as user_service
 from polar.user_organization.schemas import (
@@ -682,6 +696,146 @@ async def submit_appeal(
                 }
             ]
         )
+
+
+@router.post(
+    "/{id}/appeal/human-review",
+    response_model=SupportCaseSchema,
+    summary="Request Human Review",
+    responses={
+        200: {"description": "Human review case opened."},
+        404: SupportCaseNotFound,
+        422: {"description": "Invalid request."},
+    },
+    tags=[APITag.private],
+)
+async def request_human_review(
+    authz: AuthorizeOrgManageUser,
+    request: HumanReviewRequest,
+    session: AsyncSession = Depends(get_db_session),
+) -> SupportCaseSchema:
+    """Open a human-review case after the AI appeal was denied."""
+    review_repository = OrganizationReviewRepository.from_session(session)
+    review = await review_repository.get_by_organization(authz.organization.id)
+    if review is None:
+        raise ResourceNotFound()
+
+    try:
+        case = await appeal_case.request_human_review(
+            session,
+            review,
+            reason=request.reason,
+            requested_by_user_id=authz.auth_subject.subject.id,
+        )
+    except AppealCaseError as e:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "reason"),
+                    "msg": e.args[0],
+                    "input": request.reason,
+                }
+            ]
+        )
+
+    return SupportCaseSchema(
+        id=case.id,
+        type=case.type,
+        is_open=True,
+        created_at=case.created_at,
+        modified_at=case.modified_at,
+    )
+
+
+@router.get(
+    "/{id}/appeal/case",
+    response_model=SupportCaseThread,
+    summary="Get Appeal Case",
+    responses={
+        200: {"description": "Appeal case thread returned."},
+        404: SupportCaseNotFound,
+    },
+    tags=[APITag.private],
+)
+async def get_appeal_case(
+    authz: AuthorizeOrgManageRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> SupportCaseThread:
+    """Get the merchant's human-review case and its visible timeline."""
+    review_repository = OrganizationReviewRepository.from_session(session)
+    review = await review_repository.get_by_organization(authz.organization.id)
+    if review is None:
+        raise ResourceNotFound()
+
+    thread = await appeal_case.get_thread(
+        session, review, visible_to=SupportCaseAudience.merchant
+    )
+    if thread is None:
+        raise ResourceNotFound()
+
+    case, is_open, messages = thread
+    return SupportCaseThread(
+        case=SupportCaseSchema(
+            id=case.id,
+            type=case.type,
+            is_open=is_open,
+            created_at=case.created_at,
+            modified_at=case.modified_at,
+        ),
+        messages=[
+            SupportCaseMessageSchema.model_validate(message) for message in messages
+        ],
+    )
+
+
+@router.post(
+    "/{id}/appeal/case/messages",
+    response_model=SupportCaseMessageSchema,
+    summary="Reply to Appeal Case",
+    responses={
+        200: {"description": "Reply posted."},
+        404: SupportCaseNotFound,
+        422: {"description": "Case is locked or request is invalid."},
+    },
+    tags=[APITag.private],
+)
+async def reply_to_appeal_case(
+    authz: AuthorizeOrgManageUser,
+    message: SupportCaseMessageCreate,
+    session: AsyncSession = Depends(get_db_session),
+) -> SupportCaseMessageSchema:
+    """Post a merchant reply to the human-review case."""
+    review_repository = OrganizationReviewRepository.from_session(session)
+    review = await review_repository.get_by_organization(authz.organization.id)
+    if review is None:
+        raise ResourceNotFound()
+
+    case = await appeal_case.get_case(session, review)
+    if case is None:
+        raise ResourceNotFound()
+
+    try:
+        posted = await appeal_case.add_reply(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+            author_user_id=authz.auth_subject.subject.id,
+            body=message.body,
+        )
+    except AppealCaseError as e:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "body"),
+                    "msg": e.args[0],
+                    "input": message.body,
+                }
+            ]
+        )
+
+    return SupportCaseMessageSchema.model_validate(posted)
 
 
 @router.post(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -728,8 +728,9 @@ async def request_human_review(
         case = await appeal_case_service.request_human_review(
             session,
             review,
+            organization=authz.organization,
             reason=request.reason,
-            requested_by_user_id=authz.auth_subject.subject.id,
+            requested_by_user=authz.auth_subject.subject,
         )
     except AppealCaseError as e:
         raise PolarRequestValidationError(
@@ -823,7 +824,7 @@ async def reply_to_appeal_case(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.merchant,
-            author_user_id=authz.auth_subject.subject.id,
+            author_user=authz.auth_subject.subject,
             body=message.body,
         )
     except AppealCaseError as e:

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -19,12 +19,6 @@ from polar.support_case.repository import (
 )
 from polar.support_case.service import support_case as support_case_service
 
-# A final decision locks the case: no more replies, no reopen.
-_FINAL_ACTION_TYPES = (
-    SupportCaseMessageType.appeal_approved,
-    SupportCaseMessageType.appeal_denied,
-)
-
 
 class AppealCaseError(PolarError): ...
 
@@ -32,13 +26,14 @@ class AppealCaseError(PolarError): ...
 class CaseAlreadyExistsError(AppealCaseError):
     def __init__(self, organization_review_id: UUID) -> None:
         super().__init__(
-            f"Review {organization_review_id} already has a human-review case."
+            f"Review {organization_review_id} already has a human-review case.",
+            409,
         )
 
 
-class CaseLockedError(AppealCaseError):
+class CaseClosedError(AppealCaseError):
     def __init__(self, case_id: UUID) -> None:
-        super().__init__(f"Case {case_id} is locked: a final decision was recorded.")
+        super().__init__(f"Case {case_id} is closed.", 409)
 
 
 class AppealCaseService:
@@ -87,7 +82,7 @@ class AppealCaseService:
         body: str,
         internal: bool = False,
     ) -> SupportCaseMessage:
-        await self._assert_not_locked(session, case)
+        await self._assert_open(session, case)
         return await support_case_service.post_message(
             session,
             case,
@@ -106,7 +101,7 @@ class AppealCaseService:
         staff_user: User,
         reason: str | None = None,
     ) -> SupportCaseMessage:
-        await self._assert_not_locked(session, case)
+        await self._assert_open(session, case)
         message = await support_case_service.post_message(
             session,
             case,
@@ -154,12 +149,12 @@ class AppealCaseService:
         messages = await message_repository.list_by_case(case.id, visible_to=visible_to)
         return case, is_open, messages
 
-    async def _assert_not_locked(
+    async def _assert_open(
         self, session: AsyncSession, case: ReviewAppealSupportCase
     ) -> None:
         repository = SupportCaseMessageRepository.from_session(session)
-        if await repository.has_message_of_type(case.id, _FINAL_ACTION_TYPES):
-            raise CaseLockedError(case.id)
+        if not await repository.is_open(case.id):
+            raise CaseClosedError(case.id)
 
 
 appeal_case = AppealCaseService()

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from polar.exceptions import PolarError
+from polar.models import Organization, User
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     ReviewAppealSupportCase,
@@ -46,8 +47,9 @@ class AppealCaseService:
         session: AsyncSession,
         review: OrganizationReview,
         *,
+        organization: Organization,
         reason: str,
-        requested_by_user_id: UUID,
+        requested_by_user: User,
     ) -> ReviewAppealSupportCase:
         if await self.get_case(session, review) is not None:
             raise CaseAlreadyExistsError(review.id)
@@ -56,20 +58,20 @@ class AppealCaseService:
             session,
             ReviewAppealSupportCase(organization_review_id=review.id),
             author_kind=SupportCaseMessageAuthorKind.merchant,
-            author_user_id=requested_by_user_id,
+            author_user=requested_by_user,
             audience=[SupportCaseAudience.merchant],
         )
         await support_case_service.add_participant(
             session,
             case,
             SupportCaseParticipantKind.merchant,
-            organization_id=review.organization_id,
+            organization=organization,
         )
         await support_case_service.post_message(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.merchant,
-            author_user_id=requested_by_user_id,
+            author_user=requested_by_user,
             body=reason,
             audience=[SupportCaseAudience.merchant],
         )
@@ -81,7 +83,7 @@ class AppealCaseService:
         case: ReviewAppealSupportCase,
         *,
         author_kind: SupportCaseMessageAuthorKind,
-        author_user_id: UUID | None = None,
+        author_user: User | None = None,
         body: str,
         internal: bool = False,
     ) -> SupportCaseMessage:
@@ -90,7 +92,7 @@ class AppealCaseService:
             session,
             case,
             author_kind=author_kind,
-            author_user_id=author_user_id,
+            author_user=author_user,
             body=body,
             audience=[] if internal else [SupportCaseAudience.merchant],
         )
@@ -101,7 +103,7 @@ class AppealCaseService:
         case: ReviewAppealSupportCase,
         *,
         approved: bool,
-        staff_user_id: UUID,
+        staff_user: User,
         reason: str | None = None,
     ) -> SupportCaseMessage:
         await self._assert_not_locked(session, case)
@@ -114,7 +116,7 @@ class AppealCaseService:
                 else SupportCaseMessageType.appeal_denied
             ),
             author_kind=SupportCaseMessageAuthorKind.platform,
-            author_user_id=staff_user_id,
+            author_user=staff_user,
             body=reason,
             audience=[SupportCaseAudience.merchant],
         )
@@ -122,7 +124,7 @@ class AppealCaseService:
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.platform,
-            author_user_id=staff_user_id,
+            author_user=staff_user,
             audience=[SupportCaseAudience.merchant],
         )
         # This records the decision on the case only. The caller drives org

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -1,0 +1,163 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from polar.exceptions import PolarError
+from polar.models.organization_review import OrganizationReview
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseParticipantKind,
+)
+from polar.postgres import AsyncReadSession, AsyncSession
+from polar.support_case.repository import (
+    ReviewAppealSupportCaseRepository,
+    SupportCaseMessageRepository,
+)
+from polar.support_case.service import support_case as support_case_service
+
+# A final decision locks the case: no more replies, no reopen.
+_FINAL_ACTION_TYPES = (
+    SupportCaseMessageType.appeal_approved,
+    SupportCaseMessageType.appeal_denied,
+)
+
+
+class AppealCaseError(PolarError): ...
+
+
+class CaseAlreadyExistsError(AppealCaseError):
+    def __init__(self, organization_review_id: UUID) -> None:
+        super().__init__(
+            f"Review {organization_review_id} already has a human-review case."
+        )
+
+
+class CaseLockedError(AppealCaseError):
+    def __init__(self, case_id: UUID) -> None:
+        super().__init__(f"Case {case_id} is locked: a final decision was recorded.")
+
+
+class AppealCaseService:
+    async def request_human_review(
+        self,
+        session: AsyncSession,
+        review: OrganizationReview,
+        *,
+        reason: str,
+        requested_by_user_id: UUID,
+    ) -> ReviewAppealSupportCase:
+        if await self.get_case(session, review) is not None:
+            raise CaseAlreadyExistsError(review.id)
+
+        case = await support_case_service.create(
+            session,
+            ReviewAppealSupportCase(organization_review_id=review.id),
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+            author_user_id=requested_by_user_id,
+            audience=[SupportCaseAudience.merchant],
+        )
+        await support_case_service.add_participant(
+            session,
+            case,
+            SupportCaseParticipantKind.merchant,
+            organization_id=review.organization_id,
+        )
+        await support_case_service.post_message(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+            author_user_id=requested_by_user_id,
+            body=reason,
+            audience=[SupportCaseAudience.merchant],
+        )
+        return case
+
+    async def add_reply(
+        self,
+        session: AsyncSession,
+        case: ReviewAppealSupportCase,
+        *,
+        author_kind: SupportCaseMessageAuthorKind,
+        author_user_id: UUID | None = None,
+        body: str,
+        internal: bool = False,
+    ) -> SupportCaseMessage:
+        await self._assert_not_locked(session, case)
+        return await support_case_service.post_message(
+            session,
+            case,
+            author_kind=author_kind,
+            author_user_id=author_user_id,
+            body=body,
+            audience=[] if internal else [SupportCaseAudience.merchant],
+        )
+
+    async def record_decision(
+        self,
+        session: AsyncSession,
+        case: ReviewAppealSupportCase,
+        *,
+        approved: bool,
+        staff_user_id: UUID,
+        reason: str | None = None,
+    ) -> SupportCaseMessage:
+        await self._assert_not_locked(session, case)
+        message = await support_case_service.post_message(
+            session,
+            case,
+            type=(
+                SupportCaseMessageType.appeal_approved
+                if approved
+                else SupportCaseMessageType.appeal_denied
+            ),
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            author_user_id=staff_user_id,
+            body=reason,
+            audience=[SupportCaseAudience.merchant],
+        )
+        await support_case_service.close(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            author_user_id=staff_user_id,
+            audience=[SupportCaseAudience.merchant],
+        )
+        # This records the decision on the case only. The caller drives org
+        # state: approve via organization.backoffice_approve (built to override
+        # a denial after the AI rejected the appeal); deny needs no change, as
+        # the org is already denied.
+        return message
+
+    async def get_case(
+        self, session: AsyncSession | AsyncReadSession, review: OrganizationReview
+    ) -> ReviewAppealSupportCase | None:
+        repository = ReviewAppealSupportCaseRepository.from_session(session)
+        return await repository.get_by_organization_review(review.id)
+
+    async def get_thread(
+        self,
+        session: AsyncSession | AsyncReadSession,
+        review: OrganizationReview,
+        *,
+        visible_to: SupportCaseAudience | None,
+    ) -> tuple[ReviewAppealSupportCase, bool, Sequence[SupportCaseMessage]] | None:
+        case = await self.get_case(session, review)
+        if case is None:
+            return None
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        is_open = await message_repository.is_open(case.id)
+        messages = await message_repository.list_by_case(case.id, visible_to=visible_to)
+        return case, is_open, messages
+
+    async def _assert_not_locked(
+        self, session: AsyncSession, case: ReviewAppealSupportCase
+    ) -> None:
+        repository = SupportCaseMessageRepository.from_session(session)
+        if await repository.has_message_of_type(case.id, _FINAL_ACTION_TYPES):
+            raise CaseLockedError(case.id)
+
+
+appeal_case = AppealCaseService()

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -1,0 +1,112 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from polar.kit.repository.base import (
+    RepositoryBase,
+    RepositorySoftDeletionIDMixin,
+    RepositorySoftDeletionMixin,
+)
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageType,
+    SupportCaseParticipant,
+)
+
+# Message types whose latest occurrence determines the open/closed state.
+_LIFECYCLE_TYPES = (
+    SupportCaseMessageType.opened,
+    SupportCaseMessageType.closed,
+)
+
+
+class SupportCaseRepository(
+    RepositorySoftDeletionIDMixin[SupportCase, UUID],
+    RepositorySoftDeletionMixin[SupportCase],
+    RepositoryBase[SupportCase],
+):
+    model = SupportCase
+
+
+class SupportCaseMessageRepository(
+    RepositorySoftDeletionIDMixin[SupportCaseMessage, UUID],
+    RepositorySoftDeletionMixin[SupportCaseMessage],
+    RepositoryBase[SupportCaseMessage],
+):
+    model = SupportCaseMessage
+
+    async def list_by_case(
+        self, case_id: UUID, *, visible_to: SupportCaseAudience | None = None
+    ) -> Sequence[SupportCaseMessage]:
+        """A case's messages in chronological order (oldest first).
+
+        ``visible_to`` filters by audience for a non-platform reader (merchant
+        or customer). Pass ``None`` for the platform, which sees everything —
+        including internal notes (``audience == []``).
+        """
+        statement = (
+            self.get_base_statement()
+            .where(SupportCaseMessage.case_id == case_id)
+            .order_by(SupportCaseMessage.created_at.asc())
+        )
+        if visible_to is not None:
+            statement = statement.where(
+                SupportCaseMessage.audience.contains([visible_to])
+            )
+        return await self.get_all(statement)
+
+    async def get_latest_lifecycle_event(
+        self, case_id: UUID
+    ) -> SupportCaseMessage | None:
+        statement = (
+            self.get_base_statement()
+            .where(
+                SupportCaseMessage.case_id == case_id,
+                SupportCaseMessage.type.in_(_LIFECYCLE_TYPES),
+            )
+            .order_by(SupportCaseMessage.created_at.desc())
+            .limit(1)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def is_open(self, case_id: UUID) -> bool:
+        latest = await self.get_latest_lifecycle_event(case_id)
+        assert latest is not None  # always created with an `opened` event
+        return latest.type != SupportCaseMessageType.closed
+
+    async def has_message_of_type(self, case_id: UUID, types: Sequence[str]) -> bool:
+        statement = (
+            self.get_base_statement()
+            .where(
+                SupportCaseMessage.case_id == case_id,
+                SupportCaseMessage.type.in_(types),
+            )
+            .limit(1)
+        )
+        return await self.get_one_or_none(statement) is not None
+
+
+class SupportCaseParticipantRepository(
+    RepositorySoftDeletionIDMixin[SupportCaseParticipant, UUID],
+    RepositorySoftDeletionMixin[SupportCaseParticipant],
+    RepositoryBase[SupportCaseParticipant],
+):
+    model = SupportCaseParticipant
+
+
+class ReviewAppealSupportCaseRepository(
+    RepositorySoftDeletionIDMixin[ReviewAppealSupportCase, UUID],
+    RepositorySoftDeletionMixin[ReviewAppealSupportCase],
+    RepositoryBase[ReviewAppealSupportCase],
+):
+    model = ReviewAppealSupportCase
+
+    async def get_by_organization_review(
+        self, organization_review_id: UUID
+    ) -> ReviewAppealSupportCase | None:
+        statement = self.get_base_statement().where(
+            ReviewAppealSupportCase.organization_review_id == organization_review_id
+        )
+        return await self.get_one_or_none(statement)

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -76,17 +76,6 @@ class SupportCaseMessageRepository(
         assert latest is not None  # always created with an `opened` event
         return latest.type != SupportCaseMessageType.closed
 
-    async def has_message_of_type(self, case_id: UUID, types: Sequence[str]) -> bool:
-        statement = (
-            self.get_base_statement()
-            .where(
-                SupportCaseMessage.case_id == case_id,
-                SupportCaseMessage.type.in_(types),
-            )
-            .limit(1)
-        )
-        return await self.get_one_or_none(statement) is not None
-
 
 class SupportCaseParticipantRepository(
     RepositorySoftDeletionIDMixin[SupportCaseParticipant, UUID],

--- a/server/polar/support_case/schemas.py
+++ b/server/polar/support_case/schemas.py
@@ -22,12 +22,12 @@ class SupportCaseMessage(IDSchema, TimestampedSchema):
 
 class SupportCase(IDSchema, TimestampedSchema):
     type: SupportCaseType
-    is_open: bool
 
 
 class SupportCaseThread(Schema):
     case: SupportCase
     messages: list[SupportCaseMessage]
+    is_open: bool
 
 
 class SupportCaseMessageCreate(Schema):

--- a/server/polar/support_case/schemas.py
+++ b/server/polar/support_case/schemas.py
@@ -1,8 +1,12 @@
-from pydantic import UUID4, Field
+from pydantic import Field
 
 from polar.exceptions import ResourceNotFound
-from polar.kit.schemas import Schema, TimestampedSchema
-from polar.models.support_case import SupportCaseMessageAuthorKind, SupportCaseType
+from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
+from polar.models.support_case import (
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseType,
+)
 
 SupportCaseNotFound = {
     "description": "Support case not found.",
@@ -10,15 +14,13 @@ SupportCaseNotFound = {
 }
 
 
-class SupportCaseMessage(TimestampedSchema):
-    id: UUID4
-    type: str
+class SupportCaseMessage(IDSchema, TimestampedSchema):
+    type: SupportCaseMessageType
     author_kind: SupportCaseMessageAuthorKind
     body: str | None
 
 
-class SupportCase(TimestampedSchema):
-    id: UUID4
+class SupportCase(IDSchema, TimestampedSchema):
     type: SupportCaseType
     is_open: bool
 

--- a/server/polar/support_case/schemas.py
+++ b/server/polar/support_case/schemas.py
@@ -1,0 +1,36 @@
+from pydantic import UUID4, Field
+
+from polar.exceptions import ResourceNotFound
+from polar.kit.schemas import Schema, TimestampedSchema
+from polar.models.support_case import SupportCaseMessageAuthorKind, SupportCaseType
+
+SupportCaseNotFound = {
+    "description": "Support case not found.",
+    "model": ResourceNotFound.schema(),
+}
+
+
+class SupportCaseMessage(TimestampedSchema):
+    id: UUID4
+    type: str
+    author_kind: SupportCaseMessageAuthorKind
+    body: str | None
+
+
+class SupportCase(TimestampedSchema):
+    id: UUID4
+    type: SupportCaseType
+    is_open: bool
+
+
+class SupportCaseThread(Schema):
+    case: SupportCase
+    messages: list[SupportCaseMessage]
+
+
+class SupportCaseMessageCreate(Schema):
+    body: str = Field(min_length=1, max_length=5000)
+
+
+class HumanReviewRequest(Schema):
+    reason: str = Field(min_length=50, max_length=5000)

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
-from uuid import UUID
 
+from polar.models import Customer, Organization, User
 from polar.models.support_case import (
     SupportCase,
     SupportCaseAudience,
@@ -26,7 +26,7 @@ class SupportCaseService:
         case: CaseT,
         *,
         author_kind: SupportCaseMessageAuthorKind,
-        author_user_id: UUID | None = None,
+        author_user: User | None = None,
         audience: Sequence[SupportCaseAudience] = (),
     ) -> CaseT:
         """Persist a (typed) case and emit its ``opened`` event atomically."""
@@ -37,7 +37,7 @@ class SupportCaseService:
             case,
             type=SupportCaseMessageType.opened,
             author_kind=author_kind,
-            author_user_id=author_user_id,
+            author_user=author_user,
             audience=audience,
         )
         return case
@@ -48,18 +48,18 @@ class SupportCaseService:
         case: SupportCase,
         kind: SupportCaseParticipantKind,
         *,
-        organization_id: UUID | None = None,
-        platform_user_id: UUID | None = None,
-        customer_id: UUID | None = None,
+        organization: Organization | None = None,
+        platform_user: User | None = None,
+        customer: Customer | None = None,
     ) -> SupportCaseParticipant:
         repository = SupportCaseParticipantRepository.from_session(session)
         return await repository.create(
             SupportCaseParticipant(
                 case_id=case.id,
                 kind=kind,
-                organization_id=organization_id,
-                platform_user_id=platform_user_id,
-                customer_id=customer_id,
+                organization_id=organization.id if organization else None,
+                platform_user_id=platform_user.id if platform_user else None,
+                customer_id=customer.id if customer else None,
             ),
             flush=True,
         )
@@ -71,7 +71,7 @@ class SupportCaseService:
         *,
         author_kind: SupportCaseMessageAuthorKind,
         type: SupportCaseMessageType = SupportCaseMessageType.chat,
-        author_user_id: UUID | None = None,
+        author_user: User | None = None,
         body: str | None = None,
         audience: Sequence[SupportCaseAudience] = (),
     ) -> SupportCaseMessage:
@@ -81,7 +81,7 @@ class SupportCaseService:
                 case_id=case.id,
                 type=type,
                 author_kind=author_kind,
-                author_user_id=author_user_id,
+                author_user_id=author_user.id if author_user else None,
                 body=body,
                 audience=list(audience),
             ),
@@ -94,7 +94,7 @@ class SupportCaseService:
         case: SupportCase,
         *,
         author_kind: SupportCaseMessageAuthorKind,
-        author_user_id: UUID | None = None,
+        author_user: User | None = None,
         body: str | None = None,
         audience: Sequence[SupportCaseAudience] = (),
     ) -> SupportCaseMessage:
@@ -103,7 +103,7 @@ class SupportCaseService:
             case,
             type=SupportCaseMessageType.closed,
             author_kind=author_kind,
-            author_user_id=author_user_id,
+            author_user=author_user,
             body=body,
             audience=audience,
         )

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -55,11 +55,11 @@ class SupportCaseService:
         repository = SupportCaseParticipantRepository.from_session(session)
         return await repository.create(
             SupportCaseParticipant(
-                case_id=case.id,
+                case=case,
                 kind=kind,
-                organization_id=organization.id if organization else None,
-                platform_user_id=platform_user.id if platform_user else None,
-                customer_id=customer.id if customer else None,
+                organization=organization,
+                platform_user=platform_user,
+                customer=customer,
             ),
             flush=True,
         )
@@ -78,10 +78,10 @@ class SupportCaseService:
         repository = SupportCaseMessageRepository.from_session(session)
         return await repository.create(
             SupportCaseMessage(
-                case_id=case.id,
+                case=case,
                 type=type,
                 author_kind=author_kind,
-                author_user_id=author_user.id if author_user else None,
+                author_user=author_user,
                 body=body,
                 audience=list(audience),
             ),

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -1,0 +1,112 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from polar.models.support_case import (
+    SupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseParticipant,
+    SupportCaseParticipantKind,
+)
+from polar.postgres import AsyncSession
+
+from .repository import (
+    SupportCaseMessageRepository,
+    SupportCaseParticipantRepository,
+    SupportCaseRepository,
+)
+
+
+class SupportCaseService:
+    async def create[CaseT: SupportCase](
+        self,
+        session: AsyncSession,
+        case: CaseT,
+        *,
+        author_kind: SupportCaseMessageAuthorKind,
+        author_user_id: UUID | None = None,
+        audience: Sequence[SupportCaseAudience] = (),
+    ) -> CaseT:
+        """Persist a (typed) case and emit its ``opened`` event atomically."""
+        repository = SupportCaseRepository.from_session(session)
+        await repository.create(case, flush=True)
+        await self.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.opened,
+            author_kind=author_kind,
+            author_user_id=author_user_id,
+            audience=audience,
+        )
+        return case
+
+    async def add_participant(
+        self,
+        session: AsyncSession,
+        case: SupportCase,
+        kind: SupportCaseParticipantKind,
+        *,
+        organization_id: UUID | None = None,
+        platform_user_id: UUID | None = None,
+        customer_id: UUID | None = None,
+    ) -> SupportCaseParticipant:
+        repository = SupportCaseParticipantRepository.from_session(session)
+        return await repository.create(
+            SupportCaseParticipant(
+                case_id=case.id,
+                kind=kind,
+                organization_id=organization_id,
+                platform_user_id=platform_user_id,
+                customer_id=customer_id,
+            ),
+            flush=True,
+        )
+
+    async def post_message(
+        self,
+        session: AsyncSession,
+        case: SupportCase,
+        *,
+        author_kind: SupportCaseMessageAuthorKind,
+        type: SupportCaseMessageType = SupportCaseMessageType.chat,
+        author_user_id: UUID | None = None,
+        body: str | None = None,
+        audience: Sequence[SupportCaseAudience] = (),
+    ) -> SupportCaseMessage:
+        repository = SupportCaseMessageRepository.from_session(session)
+        return await repository.create(
+            SupportCaseMessage(
+                case_id=case.id,
+                type=type,
+                author_kind=author_kind,
+                author_user_id=author_user_id,
+                body=body,
+                audience=list(audience),
+            ),
+            flush=True,
+        )
+
+    async def close(
+        self,
+        session: AsyncSession,
+        case: SupportCase,
+        *,
+        author_kind: SupportCaseMessageAuthorKind,
+        author_user_id: UUID | None = None,
+        body: str | None = None,
+        audience: Sequence[SupportCaseAudience] = (),
+    ) -> SupportCaseMessage:
+        return await self.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.closed,
+            author_kind=author_kind,
+            author_user_id=author_user_id,
+            body=body,
+            audience=audience,
+        )
+
+
+support_case = SupportCaseService()

--- a/server/tests/models/test_support_case.py
+++ b/server/tests/models/test_support_case.py
@@ -1,0 +1,120 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from polar.models import OrganizationReview
+from polar.models.file import File, FileServiceTypes
+from polar.models.organization import Organization
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseAttachment,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseParticipant,
+    SupportCaseParticipantKind,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+async def _review(
+    save_fixture: SaveFixture, organization: Organization
+) -> OrganizationReview:
+    review = OrganizationReview(
+        organization_id=organization.id,
+        verdict=OrganizationReview.Verdict.FAIL,
+        risk_score=90.0,
+        violated_sections=[],
+        reason="denied",
+        model_used="test",
+    )
+    await save_fixture(review)
+    return review
+
+
+@pytest.mark.asyncio
+class TestReviewAppealRequiresReview:
+    async def test_orphan_rejected(self, session: AsyncSession) -> None:
+        # A review_appeal case with no organization_review_id violates the CHECK.
+        session.add(ReviewAppealSupportCase())
+        with pytest.raises(IntegrityError):
+            await session.flush()
+
+
+@pytest.mark.asyncio
+class TestParticipantUniqueness:
+    async def test_duplicate_subject_rejected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        review = await _review(save_fixture, organization)
+        case = ReviewAppealSupportCase(organization_review_id=review.id)
+        await save_fixture(case)
+
+        await save_fixture(
+            SupportCaseParticipant(
+                case_id=case.id,
+                kind=SupportCaseParticipantKind.merchant,
+                organization_id=organization.id,
+            )
+        )
+        session.add(
+            SupportCaseParticipant(
+                case_id=case.id,
+                kind=SupportCaseParticipantKind.merchant,
+                organization_id=organization.id,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.flush()
+
+
+@pytest.mark.asyncio
+class TestAttachmentCaseConsistency:
+    async def test_message_from_other_case_rejected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        case_a = ReviewAppealSupportCase(
+            organization_review_id=(await _review(save_fixture, organization)).id
+        )
+        await save_fixture(case_a)
+        case_b = ReviewAppealSupportCase(
+            organization_review_id=(await _review(save_fixture, organization_second)).id
+        )
+        await save_fixture(case_b)
+
+        message_a = SupportCaseMessage(
+            case_id=case_a.id,
+            type=SupportCaseMessageType.chat,
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+            audience=[],
+        )
+        await save_fixture(message_a)
+
+        file = File(
+            organization_id=organization.id,
+            name="evidence.pdf",
+            path="evidence.pdf",
+            mime_type="application/pdf",
+            size=1,
+            service=FileServiceTypes.downloadable,
+        )
+        await save_fixture(file)
+
+        # An attachment on case_b pointing at a message that lives in case_a.
+        session.add(
+            SupportCaseAttachment(
+                case_id=case_b.id,
+                message_id=message_a.id,
+                file_id=file.id,
+                audience=[],
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.flush()

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -14,7 +14,7 @@ from polar.models.support_case import (
 from polar.models.user import User
 from polar.organization_review.appeal_case import (
     CaseAlreadyExistsError,
-    CaseLockedError,
+    CaseClosedError,
 )
 from polar.organization_review.appeal_case import (
     appeal_case as appeal_case_service,
@@ -147,7 +147,7 @@ class TestReplyAndLock:
         message_repository = SupportCaseMessageRepository.from_session(session)
         assert await message_repository.is_open(case.id) is False
 
-        with pytest.raises(CaseLockedError):
+        with pytest.raises(CaseClosedError):
             await appeal_case_service.add_reply(
                 session,
                 case,

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -1,0 +1,174 @@
+import pytest
+import pytest_asyncio
+
+from polar.models import OrganizationReview
+from polar.models.organization import Organization
+from polar.models.support_case import (
+    SupportCaseAudience,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseParticipant,
+    SupportCaseParticipantKind,
+    SupportCaseType,
+)
+from polar.models.user import User
+from polar.organization_review.appeal_case import (
+    CaseAlreadyExistsError,
+    CaseLockedError,
+    appeal_case,
+)
+from polar.postgres import AsyncSession
+from polar.support_case.repository import (
+    SupportCaseMessageRepository,
+    SupportCaseParticipantRepository,
+)
+from tests.fixtures.database import SaveFixture
+
+
+@pytest_asyncio.fixture
+async def denied_review(
+    save_fixture: SaveFixture, organization: Organization
+) -> OrganizationReview:
+    review = OrganizationReview(
+        organization_id=organization.id,
+        verdict=OrganizationReview.Verdict.FAIL,
+        risk_score=90.0,
+        violated_sections=[],
+        reason="Automated review denied.",
+        model_used="test",
+        appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+    )
+    await save_fixture(review)
+    return review
+
+
+async def _participants(
+    session: AsyncSession, case_id: object
+) -> list[SupportCaseParticipant]:
+    repository = SupportCaseParticipantRepository.from_session(session)
+    statement = repository.get_base_statement().where(
+        SupportCaseParticipant.case_id == case_id
+    )
+    return list(await repository.get_all(statement))
+
+
+@pytest.mark.asyncio
+class TestRequestHumanReview:
+    async def test_creates_linked_case(
+        self,
+        session: AsyncSession,
+        denied_review: OrganizationReview,
+        user: User,
+    ) -> None:
+        case = await appeal_case.request_human_review(
+            session,
+            denied_review,
+            reason="Please reconsider — here is the missing context.",
+            requested_by_user_id=user.id,
+        )
+
+        assert case.type == SupportCaseType.review_appeal
+        assert case.organization_review_id == denied_review.id
+
+        participants = await _participants(session, case.id)
+        assert len(participants) == 1
+        assert participants[0].kind == SupportCaseParticipantKind.merchant
+        assert participants[0].organization_id == denied_review.organization_id
+        assert participants[0].platform_user_id is None
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        messages = await message_repository.list_by_case(case.id)
+        types = {m.type for m in messages}
+        assert SupportCaseMessageType.opened in types
+        chat = [m for m in messages if m.type == SupportCaseMessageType.chat]
+        assert len(chat) == 1
+        assert chat[0].body == "Please reconsider — here is the missing context."
+        assert chat[0].author_kind == SupportCaseMessageAuthorKind.merchant
+
+        assert await message_repository.is_open(case.id) is True
+
+    async def test_duplicate_raises(
+        self,
+        session: AsyncSession,
+        denied_review: OrganizationReview,
+        user: User,
+    ) -> None:
+        await appeal_case.request_human_review(
+            session, denied_review, reason="first", requested_by_user_id=user.id
+        )
+        with pytest.raises(CaseAlreadyExistsError):
+            await appeal_case.request_human_review(
+                session, denied_review, reason="second", requested_by_user_id=user.id
+            )
+
+
+@pytest.mark.asyncio
+class TestReplyAndLock:
+    async def test_locked_after_final_decision(
+        self,
+        session: AsyncSession,
+        denied_review: OrganizationReview,
+        user: User,
+    ) -> None:
+        case = await appeal_case.request_human_review(
+            session, denied_review, reason="reason", requested_by_user_id=user.id
+        )
+
+        await appeal_case.add_reply(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+            author_user_id=user.id,
+            body="some more info",
+        )
+
+        await appeal_case.record_decision(
+            session, case, approved=False, staff_user_id=user.id, reason="denied again"
+        )
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is False
+
+        with pytest.raises(CaseLockedError):
+            await appeal_case.add_reply(
+                session,
+                case,
+                author_kind=SupportCaseMessageAuthorKind.merchant,
+                author_user_id=user.id,
+                body="please reconsider again",
+            )
+
+
+@pytest.mark.asyncio
+class TestThreadAudience:
+    async def test_internal_note_hidden_from_merchant(
+        self,
+        session: AsyncSession,
+        denied_review: OrganizationReview,
+        user: User,
+    ) -> None:
+        case = await appeal_case.request_human_review(
+            session, denied_review, reason="reason", requested_by_user_id=user.id
+        )
+        await appeal_case.add_reply(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            author_user_id=user.id,
+            body="internal staff note",
+            internal=True,
+        )
+
+        merchant_thread = await appeal_case.get_thread(
+            session, denied_review, visible_to=SupportCaseAudience.merchant
+        )
+        assert merchant_thread is not None
+        _case, _is_open, merchant_messages = merchant_thread
+        assert "internal staff note" not in [m.body for m in merchant_messages]
+
+        full_thread = await appeal_case.get_thread(
+            session, denied_review, visible_to=None
+        )
+        assert full_thread is not None
+        _c, _o, all_messages = full_thread
+        assert "internal staff note" in [m.body for m in all_messages]

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -60,13 +60,15 @@ class TestRequestHumanReview:
         self,
         session: AsyncSession,
         denied_review: OrganizationReview,
+        organization: Organization,
         user: User,
     ) -> None:
         case = await appeal_case_service.request_human_review(
             session,
             denied_review,
             reason="Please reconsider — here is the missing context.",
-            requested_by_user_id=user.id,
+            requested_by_user=user,
+            organization=organization,
         )
 
         assert case.type == SupportCaseType.review_appeal
@@ -93,14 +95,23 @@ class TestRequestHumanReview:
         self,
         session: AsyncSession,
         denied_review: OrganizationReview,
+        organization: Organization,
         user: User,
     ) -> None:
         await appeal_case_service.request_human_review(
-            session, denied_review, reason="first", requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason="first",
+            requested_by_user=user,
+            organization=organization,
         )
         with pytest.raises(CaseAlreadyExistsError):
             await appeal_case_service.request_human_review(
-                session, denied_review, reason="second", requested_by_user_id=user.id
+                session,
+                denied_review,
+                reason="second",
+                requested_by_user=user,
+                organization=organization,
             )
 
 
@@ -110,22 +121,27 @@ class TestReplyAndLock:
         self,
         session: AsyncSession,
         denied_review: OrganizationReview,
+        organization: Organization,
         user: User,
     ) -> None:
         case = await appeal_case_service.request_human_review(
-            session, denied_review, reason="reason", requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason="reason",
+            requested_by_user=user,
+            organization=organization,
         )
 
         await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.merchant,
-            author_user_id=user.id,
+            author_user=user,
             body="some more info",
         )
 
         await appeal_case_service.record_decision(
-            session, case, approved=False, staff_user_id=user.id, reason="denied again"
+            session, case, approved=False, staff_user=user, reason="denied again"
         )
 
         message_repository = SupportCaseMessageRepository.from_session(session)
@@ -136,7 +152,7 @@ class TestReplyAndLock:
                 session,
                 case,
                 author_kind=SupportCaseMessageAuthorKind.merchant,
-                author_user_id=user.id,
+                author_user=user,
                 body="please reconsider again",
             )
 
@@ -147,16 +163,21 @@ class TestThreadAudience:
         self,
         session: AsyncSession,
         denied_review: OrganizationReview,
+        organization: Organization,
         user: User,
     ) -> None:
         case = await appeal_case_service.request_human_review(
-            session, denied_review, reason="reason", requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason="reason",
+            requested_by_user=user,
+            organization=organization,
         )
         await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.platform,
-            author_user_id=user.id,
+            author_user=user,
             body="internal staff note",
             internal=True,
         )

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -15,7 +15,9 @@ from polar.models.user import User
 from polar.organization_review.appeal_case import (
     CaseAlreadyExistsError,
     CaseLockedError,
-    appeal_case,
+)
+from polar.organization_review.appeal_case import (
+    appeal_case as appeal_case_service,
 )
 from polar.postgres import AsyncSession
 from polar.support_case.repository import (
@@ -60,7 +62,7 @@ class TestRequestHumanReview:
         denied_review: OrganizationReview,
         user: User,
     ) -> None:
-        case = await appeal_case.request_human_review(
+        case = await appeal_case_service.request_human_review(
             session,
             denied_review,
             reason="Please reconsider — here is the missing context.",
@@ -93,11 +95,11 @@ class TestRequestHumanReview:
         denied_review: OrganizationReview,
         user: User,
     ) -> None:
-        await appeal_case.request_human_review(
+        await appeal_case_service.request_human_review(
             session, denied_review, reason="first", requested_by_user_id=user.id
         )
         with pytest.raises(CaseAlreadyExistsError):
-            await appeal_case.request_human_review(
+            await appeal_case_service.request_human_review(
                 session, denied_review, reason="second", requested_by_user_id=user.id
             )
 
@@ -110,11 +112,11 @@ class TestReplyAndLock:
         denied_review: OrganizationReview,
         user: User,
     ) -> None:
-        case = await appeal_case.request_human_review(
+        case = await appeal_case_service.request_human_review(
             session, denied_review, reason="reason", requested_by_user_id=user.id
         )
 
-        await appeal_case.add_reply(
+        await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.merchant,
@@ -122,7 +124,7 @@ class TestReplyAndLock:
             body="some more info",
         )
 
-        await appeal_case.record_decision(
+        await appeal_case_service.record_decision(
             session, case, approved=False, staff_user_id=user.id, reason="denied again"
         )
 
@@ -130,7 +132,7 @@ class TestReplyAndLock:
         assert await message_repository.is_open(case.id) is False
 
         with pytest.raises(CaseLockedError):
-            await appeal_case.add_reply(
+            await appeal_case_service.add_reply(
                 session,
                 case,
                 author_kind=SupportCaseMessageAuthorKind.merchant,
@@ -147,10 +149,10 @@ class TestThreadAudience:
         denied_review: OrganizationReview,
         user: User,
     ) -> None:
-        case = await appeal_case.request_human_review(
+        case = await appeal_case_service.request_human_review(
             session, denied_review, reason="reason", requested_by_user_id=user.id
         )
-        await appeal_case.add_reply(
+        await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.platform,
@@ -159,14 +161,14 @@ class TestThreadAudience:
             internal=True,
         )
 
-        merchant_thread = await appeal_case.get_thread(
+        merchant_thread = await appeal_case_service.get_thread(
             session, denied_review, visible_to=SupportCaseAudience.merchant
         )
         assert merchant_thread is not None
         _case, _is_open, merchant_messages = merchant_thread
         assert "internal staff note" not in [m.body for m in merchant_messages]
 
-        full_thread = await appeal_case.get_thread(
+        full_thread = await appeal_case_service.get_thread(
             session, denied_review, visible_to=None
         )
         assert full_thread is not None

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -21,7 +21,7 @@ from polar.models.support_case import (
 from polar.models.user import User
 from polar.organization.service import organization as organization_service
 from polar.organization_review.appeal_case import (
-    CaseLockedError,
+    CaseClosedError,
 )
 from polar.organization_review.appeal_case import (
     appeal_case as appeal_case_service,
@@ -173,7 +173,7 @@ class TestDenyDecision:
 
         # A second decision must fail once the case is locked. (Reply-after-lock
         # is covered by test_appeal_case.py::TestReplyAndLock.)
-        with pytest.raises(CaseLockedError):
+        with pytest.raises(CaseClosedError):
             await appeal_case_service.record_decision(
                 session, case, approved=True, staff_user=user, reason="oops"
             )

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -20,7 +20,12 @@ from polar.models.support_case import (
 )
 from polar.models.user import User
 from polar.organization.service import organization as organization_service
-from polar.organization_review.appeal_case import CaseLockedError, appeal_case
+from polar.organization_review.appeal_case import (
+    CaseLockedError,
+)
+from polar.organization_review.appeal_case import (
+    appeal_case as appeal_case_service,
+)
 from polar.postgres import AsyncSession
 from polar.support_case.repository import SupportCaseMessageRepository
 from tests.fixtures.database import SaveFixture
@@ -57,7 +62,7 @@ async def denied_review_with_case(
     )
     await save_fixture(review)
 
-    case = await appeal_case.request_human_review(
+    case = await appeal_case_service.request_human_review(
         session, review, reason=REASON, requested_by_user_id=user.id
     )
     return organization, review, case
@@ -79,7 +84,7 @@ class TestApproveDecision:
         await organization_service.backoffice_approve(
             session, organization, reason="Looks legitimate after human review."
         )
-        await appeal_case.record_decision(
+        await appeal_case_service.record_decision(
             session,
             case,
             approved=True,
@@ -128,7 +133,7 @@ class TestDenyDecision:
         organization, review, case = denied_review_with_case
 
         # What appeal_case_deny_dialog does on POST (org needs no status change).
-        await appeal_case.record_decision(
+        await appeal_case_service.record_decision(
             session,
             case,
             approved=False,
@@ -158,13 +163,13 @@ class TestDenyDecision:
     ) -> None:
         _organization, _review, case = denied_review_with_case
 
-        await appeal_case.record_decision(
+        await appeal_case_service.record_decision(
             session, case, approved=False, staff_user_id=user.id, reason="final"
         )
 
         # A second decision must fail once the case is locked. (Reply-after-lock
         # is covered by test_appeal_case.py::TestReplyAndLock.)
         with pytest.raises(CaseLockedError):
-            await appeal_case.record_decision(
+            await appeal_case_service.record_decision(
                 session, case, approved=True, staff_user_id=user.id, reason="oops"
             )

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -1,0 +1,170 @@
+"""Decision orchestration performed by the backoffice support-case handlers.
+
+The backoffice runs as a separately-mounted sub-app, so its HTTP handlers are
+not exercised through the standard test client. These tests cover the exact
+service orchestration the approve/deny handlers perform — the genuinely new
+behavior the backoffice introduces — independent of the HTTP layer.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from polar.models import OrganizationReview
+from polar.models.organization import Organization, OrganizationStatus
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseAudience,
+    SupportCaseMessageType,
+)
+from polar.models.user import User
+from polar.organization.service import organization as organization_service
+from polar.organization_review.appeal_case import CaseLockedError, appeal_case
+from polar.postgres import AsyncSession
+from polar.support_case.repository import SupportCaseMessageRepository
+from tests.fixtures.database import SaveFixture
+
+REASON = "Please reconsider — here is the additional context for the review."
+
+
+@pytest_asyncio.fixture
+async def denied_review_with_case(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    organization: Organization,
+    user: User,
+) -> tuple[Organization, OrganizationReview, ReviewAppealSupportCase]:
+    """A denied org whose AI appeal was already rejected, with an open case.
+
+    This is the real precondition a human-review case is opened in: the org is
+    DENIED and ``appeal_decision`` is already REJECTED.
+    """
+    organization.status = OrganizationStatus.DENIED
+    await save_fixture(organization)
+
+    review = OrganizationReview(
+        organization_id=organization.id,
+        verdict=OrganizationReview.Verdict.FAIL,
+        risk_score=90.0,
+        violated_sections=[],
+        reason="Automated review denied.",
+        model_used="test",
+        appeal_submitted_at=datetime.now(UTC),
+        appeal_reason="My earlier appeal text.",
+        appeal_reviewed_at=datetime.now(UTC),
+        appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+    )
+    await save_fixture(review)
+
+    case = await appeal_case.request_human_review(
+        session, review, reason=REASON, requested_by_user_id=user.id
+    )
+    return organization, review, case
+
+
+@pytest.mark.asyncio
+class TestApproveDecision:
+    async def test_reactivates_org_and_closes_case(
+        self,
+        session: AsyncSession,
+        denied_review_with_case: tuple[
+            Organization, OrganizationReview, ReviewAppealSupportCase
+        ],
+        user: User,
+    ) -> None:
+        organization, review, case = denied_review_with_case
+
+        # Exactly what appeal_case_approve_dialog does on POST.
+        await organization_service.backoffice_approve(
+            session, organization, reason="Looks legitimate after human review."
+        )
+        await appeal_case.record_decision(
+            session,
+            case,
+            approved=True,
+            staff_user_id=user.id,
+            reason="Looks legitimate after human review.",
+        )
+
+        # Org reactivated (CREATED, since onboarding gates aren't met in tests).
+        assert organization.status != OrganizationStatus.DENIED
+        # backoffice_approve flips the already-rejected appeal to APPROVED.
+        assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is False
+        merchant_messages = await message_repository.list_by_case(
+            case.id, visible_to=SupportCaseAudience.merchant
+        )
+        assert any(
+            m.type == SupportCaseMessageType.appeal_approved for m in merchant_messages
+        )
+
+    async def test_approve_appeal_would_reject_already_reviewed(
+        self,
+        session: AsyncSession,
+        denied_review_with_case: tuple[
+            Organization, OrganizationReview, ReviewAppealSupportCase
+        ],
+    ) -> None:
+        # Documents why approve uses backoffice_approve, not approve_appeal:
+        # the appeal is already decided, so approve_appeal refuses.
+        organization, _review, _case = denied_review_with_case
+        with pytest.raises(ValueError, match="already been reviewed"):
+            await organization_service.approve_appeal(session, organization)
+
+
+@pytest.mark.asyncio
+class TestDenyDecision:
+    async def test_closes_case_and_org_stays_denied(
+        self,
+        session: AsyncSession,
+        denied_review_with_case: tuple[
+            Organization, OrganizationReview, ReviewAppealSupportCase
+        ],
+        user: User,
+    ) -> None:
+        organization, review, case = denied_review_with_case
+
+        # What appeal_case_deny_dialog does on POST (org needs no status change).
+        await appeal_case.record_decision(
+            session,
+            case,
+            approved=False,
+            staff_user_id=user.id,
+            reason="Still doesn't meet policy.",
+        )
+
+        assert organization.status == OrganizationStatus.DENIED
+        assert review.appeal_decision == OrganizationReview.AppealDecision.REJECTED
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is False
+        merchant_messages = await message_repository.list_by_case(
+            case.id, visible_to=SupportCaseAudience.merchant
+        )
+        assert any(
+            m.type == SupportCaseMessageType.appeal_denied for m in merchant_messages
+        )
+
+    async def test_decision_locks_the_case(
+        self,
+        session: AsyncSession,
+        denied_review_with_case: tuple[
+            Organization, OrganizationReview, ReviewAppealSupportCase
+        ],
+        user: User,
+    ) -> None:
+        _organization, _review, case = denied_review_with_case
+
+        await appeal_case.record_decision(
+            session, case, approved=False, staff_user_id=user.id, reason="final"
+        )
+
+        # A second decision must fail once the case is locked. (Reply-after-lock
+        # is covered by test_appeal_case.py::TestReplyAndLock.)
+        with pytest.raises(CaseLockedError):
+            await appeal_case.record_decision(
+                session, case, approved=True, staff_user_id=user.id, reason="oops"
+            )

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -63,7 +63,11 @@ async def denied_review_with_case(
     await save_fixture(review)
 
     case = await appeal_case_service.request_human_review(
-        session, review, reason=REASON, requested_by_user_id=user.id
+        session,
+        review,
+        reason=REASON,
+        requested_by_user=user,
+        organization=organization,
     )
     return organization, review, case
 
@@ -88,7 +92,7 @@ class TestApproveDecision:
             session,
             case,
             approved=True,
-            staff_user_id=user.id,
+            staff_user=user,
             reason="Looks legitimate after human review.",
         )
 
@@ -137,7 +141,7 @@ class TestDenyDecision:
             session,
             case,
             approved=False,
-            staff_user_id=user.id,
+            staff_user=user,
             reason="Still doesn't meet policy.",
         )
 
@@ -164,12 +168,12 @@ class TestDenyDecision:
         _organization, _review, case = denied_review_with_case
 
         await appeal_case_service.record_decision(
-            session, case, approved=False, staff_user_id=user.id, reason="final"
+            session, case, approved=False, staff_user=user, reason="final"
         )
 
         # A second decision must fail once the case is locked. (Reply-after-lock
         # is covered by test_appeal_case.py::TestReplyAndLock.)
         with pytest.raises(CaseLockedError):
             await appeal_case_service.record_decision(
-                session, case, approved=True, staff_user_id=user.id, reason="oops"
+                session, case, approved=True, staff_user=user, reason="oops"
             )

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -1,0 +1,212 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from polar.models import OrganizationReview
+from polar.models.organization import Organization
+from polar.models.support_case import SupportCaseMessageAuthorKind
+from polar.models.user import User
+from polar.models.user_organization import UserOrganization
+from polar.organization_review.appeal_case import appeal_case
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+REASON = "Please reconsider my account — here is the additional context for the review."
+
+
+@pytest_asyncio.fixture
+async def denied_review(
+    save_fixture: SaveFixture, organization: Organization
+) -> OrganizationReview:
+    review = OrganizationReview(
+        organization_id=organization.id,
+        verdict=OrganizationReview.Verdict.FAIL,
+        risk_score=90.0,
+        violated_sections=[],
+        reason="Automated review denied.",
+        model_used="test",
+        appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+    )
+    await save_fixture(review)
+    return review
+
+
+@pytest.mark.asyncio
+class TestRequestHumanReview:
+    async def test_unauthorized(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        denied_review: OrganizationReview,
+    ) -> None:
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/human-review",
+            json={"reason": REASON},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/human-review",
+            json={"reason": REASON},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["type"] == "review_appeal"
+        assert data["is_open"] is True
+
+    @pytest.mark.auth
+    async def test_reason_too_short(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/human-review",
+            json={"reason": "too short"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_duplicate(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        await appeal_case.request_human_review(
+            session, denied_review, reason=REASON, requested_by_user_id=user.id
+        )
+        await session.flush()
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/human-review",
+            json={"reason": REASON},
+        )
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestGetAppealCase:
+    @pytest.mark.auth
+    async def test_not_found_without_case(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/appeal/case"
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_returns_thread(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        await appeal_case.request_human_review(
+            session, denied_review, reason=REASON, requested_by_user_id=user.id
+        )
+        await session.flush()
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/appeal/case"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["case"]["is_open"] is True
+        assert REASON in [m["body"] for m in data["messages"]]
+
+    @pytest.mark.auth
+    async def test_internal_note_hidden(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await appeal_case.request_human_review(
+            session, denied_review, reason=REASON, requested_by_user_id=user.id
+        )
+        await appeal_case.add_reply(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            author_user_id=user.id,
+            body="internal staff note",
+            internal=True,
+        )
+        await session.flush()
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/appeal/case"
+        )
+        assert response.status_code == 200
+        assert "internal staff note" not in [
+            m["body"] for m in response.json()["messages"]
+        ]
+
+
+@pytest.mark.asyncio
+class TestReplyToAppealCase:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        await appeal_case.request_human_review(
+            session, denied_review, reason=REASON, requested_by_user_id=user.id
+        )
+        await session.flush()
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/case/messages",
+            json={"body": "here is more detail"},
+        )
+        assert response.status_code == 200
+        assert response.json()["body"] == "here is more detail"
+
+    @pytest.mark.auth
+    async def test_locked_after_decision(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        denied_review: OrganizationReview,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await appeal_case.request_human_review(
+            session, denied_review, reason=REASON, requested_by_user_id=user.id
+        )
+        await appeal_case.record_decision(
+            session, case, approved=False, staff_user_id=user.id, reason="final"
+        )
+        await session.flush()
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/case/messages",
+            json={"body": "please reconsider again"},
+        )
+        assert response.status_code == 422

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -98,7 +98,7 @@ class TestRequestHumanReview:
             f"/v1/organizations/{organization.id}/appeal/human-review",
             json={"reason": REASON},
         )
-        assert response.status_code == 422
+        assert response.status_code == 409
 
 
 @pytest.mark.asyncio
@@ -223,4 +223,4 @@ class TestReplyToAppealCase:
             f"/v1/organizations/{organization.id}/appeal/case/messages",
             json={"body": "please reconsider again"},
         )
-        assert response.status_code == 422
+        assert response.status_code == 409

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -7,7 +7,7 @@ from polar.models.organization import Organization
 from polar.models.support_case import SupportCaseMessageAuthorKind
 from polar.models.user import User
 from polar.models.user_organization import UserOrganization
-from polar.organization_review.appeal_case import appeal_case
+from polar.organization_review.appeal_case import appeal_case as appeal_case_service
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 
@@ -86,7 +86,7 @@ class TestRequestHumanReview:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
-        await appeal_case.request_human_review(
+        await appeal_case_service.request_human_review(
             session, denied_review, reason=REASON, requested_by_user_id=user.id
         )
         await session.flush()
@@ -120,7 +120,7 @@ class TestGetAppealCase:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
-        await appeal_case.request_human_review(
+        await appeal_case_service.request_human_review(
             session, denied_review, reason=REASON, requested_by_user_id=user.id
         )
         await session.flush()
@@ -140,10 +140,10 @@ class TestGetAppealCase:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
-        case = await appeal_case.request_human_review(
+        case = await appeal_case_service.request_human_review(
             session, denied_review, reason=REASON, requested_by_user_id=user.id
         )
-        await appeal_case.add_reply(
+        await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.platform,
@@ -171,7 +171,7 @@ class TestReplyToAppealCase:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
-        await appeal_case.request_human_review(
+        await appeal_case_service.request_human_review(
             session, denied_review, reason=REASON, requested_by_user_id=user.id
         )
         await session.flush()
@@ -192,10 +192,10 @@ class TestReplyToAppealCase:
         user: User,
         user_organization: UserOrganization,
     ) -> None:
-        case = await appeal_case.request_human_review(
+        case = await appeal_case_service.request_human_review(
             session, denied_review, reason=REASON, requested_by_user_id=user.id
         )
-        await appeal_case.record_decision(
+        await appeal_case_service.record_decision(
             session, case, approved=False, staff_user_id=user.id, reason="final"
         )
         await session.flush()

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -60,7 +60,6 @@ class TestRequestHumanReview:
         assert response.status_code == 200
         data = response.json()
         assert data["type"] == "review_appeal"
-        assert data["is_open"] is True
 
     @pytest.mark.auth
     async def test_reason_too_short(
@@ -135,7 +134,7 @@ class TestGetAppealCase:
         response = await client.get(f"/v1/organizations/{organization.id}/appeal/case")
         assert response.status_code == 200
         data = response.json()
-        assert data["case"]["is_open"] is True
+        assert data["is_open"] is True
         assert REASON in [m["body"] for m in data["messages"]]
 
     @pytest.mark.auth

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -107,9 +107,7 @@ class TestGetAppealCase:
         denied_review: OrganizationReview,
         user_organization: UserOrganization,
     ) -> None:
-        response = await client.get(
-            f"/v1/organizations/{organization.id}/appeal/case"
-        )
+        response = await client.get(f"/v1/organizations/{organization.id}/appeal/case")
         assert response.status_code == 404
 
     @pytest.mark.auth
@@ -126,9 +124,7 @@ class TestGetAppealCase:
             session, denied_review, reason=REASON, requested_by_user_id=user.id
         )
         await session.flush()
-        response = await client.get(
-            f"/v1/organizations/{organization.id}/appeal/case"
-        )
+        response = await client.get(f"/v1/organizations/{organization.id}/appeal/case")
         assert response.status_code == 200
         data = response.json()
         assert data["case"]["is_open"] is True
@@ -156,9 +152,7 @@ class TestGetAppealCase:
             internal=True,
         )
         await session.flush()
-        response = await client.get(
-            f"/v1/organizations/{organization.id}/appeal/case"
-        )
+        response = await client.get(f"/v1/organizations/{organization.id}/appeal/case")
         assert response.status_code == 200
         assert "internal staff note" not in [
             m["body"] for m in response.json()["messages"]

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -87,7 +87,11 @@ class TestRequestHumanReview:
         user_organization: UserOrganization,
     ) -> None:
         await appeal_case_service.request_human_review(
-            session, denied_review, reason=REASON, requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason=REASON,
+            requested_by_user=user,
+            organization=organization,
         )
         await session.flush()
         response = await client.post(
@@ -121,7 +125,11 @@ class TestGetAppealCase:
         user_organization: UserOrganization,
     ) -> None:
         await appeal_case_service.request_human_review(
-            session, denied_review, reason=REASON, requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason=REASON,
+            requested_by_user=user,
+            organization=organization,
         )
         await session.flush()
         response = await client.get(f"/v1/organizations/{organization.id}/appeal/case")
@@ -141,13 +149,17 @@ class TestGetAppealCase:
         user_organization: UserOrganization,
     ) -> None:
         case = await appeal_case_service.request_human_review(
-            session, denied_review, reason=REASON, requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason=REASON,
+            requested_by_user=user,
+            organization=organization,
         )
         await appeal_case_service.add_reply(
             session,
             case,
             author_kind=SupportCaseMessageAuthorKind.platform,
-            author_user_id=user.id,
+            author_user=user,
             body="internal staff note",
             internal=True,
         )
@@ -172,7 +184,11 @@ class TestReplyToAppealCase:
         user_organization: UserOrganization,
     ) -> None:
         await appeal_case_service.request_human_review(
-            session, denied_review, reason=REASON, requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason=REASON,
+            requested_by_user=user,
+            organization=organization,
         )
         await session.flush()
         response = await client.post(
@@ -193,10 +209,14 @@ class TestReplyToAppealCase:
         user_organization: UserOrganization,
     ) -> None:
         case = await appeal_case_service.request_human_review(
-            session, denied_review, reason=REASON, requested_by_user_id=user.id
+            session,
+            denied_review,
+            reason=REASON,
+            requested_by_user=user,
+            organization=organization,
         )
         await appeal_case_service.record_decision(
-            session, case, approved=False, staff_user_id=user.id, reason="final"
+            session, case, approved=False, staff_user=user, reason="final"
         )
         await session.flush()
         response = await client.post(


### PR DESCRIPTION
**Related Issue**: polarsource/feedback#151

Backend for the support-case system, scoped to its first use case: organization review appeals. Lets a merchant open a case with us after the AI review has rejected their appeal, and converse until it's resolved. Builds on the models/migration from #12269. Merchant dashboard UI and backoffice ship in follow-up PRs.

## What

- `support_case`: service, repository and schemas for the thin, type-agnostic conversation primitive (thread + participants + messages).
- `organization_review.appeal_case`: orchestrator that drives the primitive for review appeals — request human review, reply, record decision (locks the case).
- Merchant API (`/organizations/{id}/appeal/...`): request human review, fetch the case thread, post a reply.

## Why

A rejected AI appeal is currently a dead end. This gives merchants an in-app way to escalate to a human and have a back-and-forth, instead of "contact support" with no path. The primitive is deliberately generic so disputes/refunds can reuse it later.

## How

Single-table polymorphic case (`ReviewAppealSupportCase`) owns the FK to the review; open/closed state is derived from lifecycle events, not stored. Audience tags on messages keep internal notes staff-only. A final decision locks the thread. No new migration — the tables landed in #12269.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the backend for support cases for organization review appeals. Merchants can request human review after an AI‑denied appeal, chat until a final decision, and the thread locks once decided.

- New Features
  - Generic support-case primitive (case, messages, participants) with open/closed derived from lifecycle events and audience-scoped messages for internal notes.
  - Appeal-case orchestrator: open a case, add merchant participant, handle replies, record approve/deny, then close and lock; uses ORM relationships for participants and message authors.
  - Merchant API: POST /v1/organizations/{id}/appeal/human-review, GET /v1/organizations/{id}/appeal/case, POST /v1/organizations/{id}/appeal/case/messages; reason min 50 chars, message 1–5000 chars; GET returns thread with is_open; 404 if missing; 409 on duplicate or when locked; 422 on invalid input.

- Dependencies
  - Regenerated OpenAPI TypeScript client (`clients/packages/client/src/v1.ts`) with new schemas and operations, including conflict error types (CaseAlreadyExistsError, CaseClosedError).

<sup>Written for commit e2fe5620633c48f22195f79ed96eb2e19f15000a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

