### PR TITLE
add more landing sections

### DIFF
--- a/clients/apps/web/src/components/Landing/CostInsights.tsx
+++ b/clients/apps/web/src/components/Landing/CostInsights.tsx
@@ -125,6 +125,7 @@ export const CostInsights = () => {
           gridColumn={{ base: 'auto', lg: 'span 2' }}
           overflow="hidden"
           backgroundColor="background-secondary"
+          display={{ base: 'none', md: 'block' }}
         >
           {/* Column headers */}
           <Box
@@ -136,21 +137,13 @@ export const CostInsights = () => {
             paddingVertical="m"
             borderBottomWidth={1}
             borderStyle="solid"
-            borderColor="border-primary"
+            borderColor="border-secondary"
           >
             <Text color="muted">Customer</Text>
-            <Text
-              color="muted"
-              align="right"
-              display={{ base: 'none', md: 'block' }}
-            >
+            <Text color="muted" align="right">
               Revenue
             </Text>
-            <Text
-              color="muted"
-              align="right"
-              display={{ base: 'none', md: 'block' }}
-            >
+            <Text color="muted" align="right">
               LLM cost
             </Text>
             <Text color="muted" align="right">
@@ -183,14 +176,8 @@ export const CostInsights = () => {
                     </Text>
                   </Box>
                 </Box>
-                <Text align="right" display={{ base: 'none', md: 'block' }}>
-                  {currency(row.revenue)}
-                </Text>
-                <Text
-                  align="right"
-                  color="muted"
-                  display={{ base: 'none', md: 'block' }}
-                >
+                <Text align="right">{currency(row.revenue)}</Text>
+                <Text align="right" color="muted">
                   {currency(row.cost)}
                 </Text>
                 <Box

--- a/clients/apps/web/src/components/Landing/CostInsights.tsx
+++ b/clients/apps/web/src/components/Landing/CostInsights.tsx
@@ -1,0 +1,214 @@
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { MarginPulse } from './graphics/MarginPulse'
+
+interface MarginRow {
+  name: string
+  plan: string
+  tokens: string
+  revenue: number
+  cost: number
+}
+
+const ROWS: MarginRow[] = [
+  {
+    name: 'Jane Doe',
+    plan: 'Enterprise',
+    tokens: '4.1M tokens',
+    revenue: 4200,
+    cost: 294,
+  },
+  {
+    name: 'John Doe',
+    plan: 'Growth',
+    tokens: '3.3M tokens',
+    revenue: 1800,
+    cost: 234,
+  },
+  {
+    name: 'Emily Carter',
+    plan: 'Growth',
+    tokens: '2.6M tokens',
+    revenue: 920,
+    cost: 184,
+  },
+  {
+    name: 'Michael Chen',
+    plan: 'Hobby',
+    tokens: '5.5M tokens',
+    revenue: 480,
+    cost: 389,
+  },
+  {
+    name: 'Sarah Müller',
+    plan: 'Hobby',
+    tokens: '8.7M tokens',
+    revenue: 90,
+    cost: 612,
+  },
+]
+
+const currency = (value: number) =>
+  `$${value.toLocaleString('en-US', { maximumFractionDigits: 0 })}`
+
+const marginPercent = (row: MarginRow) =>
+  Math.round(((row.revenue - row.cost) / row.revenue) * 100)
+
+const GRID_COLUMNS = {
+  base: '1.4fr 1.2fr',
+  md: '1.8fr 0.9fr 0.9fr 1.5fr',
+}
+
+export const CostInsights = () => {
+  return (
+    <Box
+      position="relative"
+      display="flex"
+      flexDirection="column"
+      rowGap={{ base: '2xl', md: '4xl' }}
+      paddingTop={{ base: 'l', md: '3xl' }}
+      paddingBottom={{ base: '2xl', md: '4xl' }}
+    >
+      <Box
+        gridTemplateColumns={{ base: '1fr', lg: '1fr 1fr' }}
+        gap="xl"
+        display="grid"
+      >
+        <Box display="flex" flex={1}>
+          <Text variant="heading-xl" as="h2" wrap="balance">
+            Your power users cost you money
+          </Text>
+        </Box>
+        <Box
+          display="flex"
+          flex={1}
+          flexDirection="column"
+          rowGap="xl"
+          justifyContent="between"
+        >
+          <Box
+            borderTopWidth={4}
+            borderColor="border-primary"
+            width="3rem"
+            display={{ base: 'none', xl: 'flex' }}
+          />
+          <Text variant="heading-xs" wrap="pretty">
+            Polar breaks down LLM spend customer by customer, so you catch the
+            ones bleeding your margins before they bleed your runway.
+          </Text>
+        </Box>
+      </Box>
+
+      <Box
+        display="grid"
+        gridTemplateColumns={{ base: '1fr', lg: 'repeat(3, 1fr)' }}
+        gap="l"
+      >
+        {/* Animated margin graphic */}
+        <Box
+          minHeight={{ base: '14rem', lg: 'auto' }}
+          overflow="hidden"
+          backgroundColor="background-secondary"
+          display="flex"
+          flexDirection="column"
+          justifyContent="between"
+          padding="xl"
+          rowGap="l"
+        >
+          <Box flex={1} minHeight={0} aspectRatio="1/1">
+            <MarginPulse />
+          </Box>
+        </Box>
+
+        {/* Leaderboard */}
+        <Box
+          gridColumn={{ base: 'auto', lg: 'span 2' }}
+          overflow="hidden"
+          backgroundColor="background-secondary"
+        >
+          {/* Column headers */}
+          <Box
+            display="grid"
+            gridTemplateColumns={GRID_COLUMNS}
+            alignItems="center"
+            columnGap="l"
+            paddingHorizontal={{ base: 'l', md: '2xl' }}
+            paddingVertical="m"
+            borderBottomWidth={1}
+            borderStyle="solid"
+            borderColor="border-primary"
+          >
+            <Text color="muted">Customer</Text>
+            <Text
+              color="muted"
+              align="right"
+              display={{ base: 'none', md: 'block' }}
+            >
+              Revenue
+            </Text>
+            <Text
+              color="muted"
+              align="right"
+              display={{ base: 'none', md: 'block' }}
+            >
+              LLM cost
+            </Text>
+            <Text color="muted" align="right">
+              Gross margin
+            </Text>
+          </Box>
+
+          {/* Rows */}
+          {ROWS.map((row, index) => {
+            const margin = marginPercent(row)
+            const negative = margin < 0
+            return (
+              <Box
+                key={row.name}
+                display="grid"
+                gridTemplateColumns={GRID_COLUMNS}
+                alignItems="center"
+                columnGap="l"
+                paddingHorizontal={{ base: 'l', md: '2xl' }}
+                paddingVertical="l"
+                borderBottomWidth={index === ROWS.length - 1 ? 0 : 1}
+                borderStyle="solid"
+                borderColor="border-secondary"
+              >
+                <Box display="flex" alignItems="center" columnGap="m">
+                  <Box display="flex" flexDirection="column" rowGap="xs">
+                    <Text>{row.name}</Text>
+                    <Text color="muted">
+                      {row.plan} · {row.tokens}
+                    </Text>
+                  </Box>
+                </Box>
+                <Text align="right" display={{ base: 'none', md: 'block' }}>
+                  {currency(row.revenue)}
+                </Text>
+                <Text
+                  align="right"
+                  color="muted"
+                  display={{ base: 'none', md: 'block' }}
+                >
+                  {currency(row.cost)}
+                </Text>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="end"
+                  columnGap="m"
+                >
+                  <Text align="right" color={negative ? 'danger' : undefined}>
+                    {margin > 0 ? '+' : ''}
+                    {margin}%
+                  </Text>
+                </Box>
+              </Box>
+            )
+          })}
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Landing/Dashboard.tsx
+++ b/clients/apps/web/src/components/Landing/Dashboard.tsx
@@ -45,7 +45,10 @@ export const Dashboard = () => {
         width="100%"
         overflow="hidden"
         position="relative"
-        borderRadius="l"
+        borderRadius={{
+          base: 's',
+          md: 'm',
+        }}
         borderWidth={1}
         borderStyle="solid"
         borderColor="border-primary"

--- a/clients/apps/web/src/components/Landing/Dashboard.tsx
+++ b/clients/apps/web/src/components/Landing/Dashboard.tsx
@@ -45,30 +45,17 @@ export const Dashboard = () => {
         width="100%"
         overflow="hidden"
         position="relative"
-        borderRadius="m"
+        borderRadius="l"
         borderWidth={1}
         borderStyle="solid"
         borderColor="border-primary"
-        padding={{
-          base: 'l',
-          md: '5xl',
-        }}
       >
         <StaticImage
           src="/assets/landing/dashboard.jpg"
           alt="Polar dashboard"
           width={3840}
           height={2160}
-          className="relative z-10 h-auto w-full rounded-xs md:rounded-xl"
-          sizes="(min-width: 1280px) 1280px, 100vw"
-          priority
-        />
-        <StaticImage
-          src="/assets/brand/polar_gradient.jpg"
-          alt="Polar dashboard"
-          width={3840}
-          height={2160}
-          className="absolute inset-0 h-full object-cover"
+          className="relative z-10 h-auto w-full"
           sizes="(min-width: 1280px) 1280px, 100vw"
           priority
         />

--- a/clients/apps/web/src/components/Landing/LandingPage.tsx
+++ b/clients/apps/web/src/components/Landing/LandingPage.tsx
@@ -15,6 +15,7 @@ import { Features } from './Features'
 import { Logotypes } from './Logotypes'
 import { UseCases } from './UseCases'
 import { Dashboard } from './Dashboard'
+import { CostInsights } from './CostInsights'
 
 export default function Page() {
   return (
@@ -51,6 +52,7 @@ const PageContent = () => {
       <Features />
 
       <Section>
+        <CostInsights />
         <Vision />
       </Section>
 

--- a/clients/apps/web/src/components/Landing/LandingPage.tsx
+++ b/clients/apps/web/src/components/Landing/LandingPage.tsx
@@ -16,6 +16,7 @@ import { Logotypes } from './Logotypes'
 import { UseCases } from './UseCases'
 import { Dashboard } from './Dashboard'
 import { CostInsights } from './CostInsights'
+import { Pipeline } from './Pipeline'
 
 export default function Page() {
   return (
@@ -53,6 +54,7 @@ const PageContent = () => {
 
       <Section>
         <CostInsights />
+        <Pipeline />
         <Vision />
       </Section>
 

--- a/clients/apps/web/src/components/Landing/Pipeline.tsx
+++ b/clients/apps/web/src/components/Landing/Pipeline.tsx
@@ -1,0 +1,392 @@
+'use client'
+
+import { Avatar, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import Link from 'next/link'
+import { useState } from 'react'
+
+const ArrowRight = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <line x1="5" y1="12" x2="19" y2="12" />
+    <polyline points="12 5 19 12 12 19" />
+  </svg>
+)
+
+interface Aspect {
+  title: string
+  desc: string
+  href: string
+}
+
+const ASPECTS: Aspect[] = [
+  {
+    title: 'Customer invoiced automatically',
+    desc: 'Usage rolls straight into invoices and charges, with no manual billing runs.',
+    href: '/docs/features/orders',
+  },
+  {
+    title: 'LLM Usage Breakdown',
+    desc: 'Every model call metered token by token, per customer, across all of your providers.',
+    href: '/docs/features/usage-based-billing/ingestion-strategies/llm-strategy',
+  },
+  {
+    title: 'Margins, Profits & Cashflow Metrics',
+    desc: 'Revenue minus cost in real time, per customer and across your whole business.',
+    href: '/docs/features/analytics',
+  },
+  {
+    title: 'Cost Anomalies & Insights',
+    desc: 'LLM spend attributed back to each customer, so your true COGS is never a guess.',
+    href: '/docs/features/cost-insights/introduction',
+  },
+  {
+    title: 'Tax Collection & Remittance',
+    desc: 'Sales tax, VAT, and GST calculated, collected, and filed for you as merchant of record.',
+    href: '/docs/merchant-of-record/introduction',
+  },
+  {
+    title: 'Payment Processing',
+    desc: 'Cards, wallets, and bank debits captured and settled across 100+ markets.',
+    href: '/docs/features/checkout/session',
+  },
+  {
+    title: 'Refunds & Chargebacks',
+    desc: 'Disputes, refunds, and usage reconciliation handled end to end.',
+    href: '/docs/features/refunds',
+  },
+  {
+    title: 'Risk Analysis & Fraud',
+    desc: 'Every transaction screened for fraud before it ever hits your books.',
+    href: '/docs/merchant-of-record/account-reviews',
+  },
+]
+
+const GROUPS = [ASPECTS.slice(0, 4), ASPECTS.slice(4)]
+
+const CheckIcon = ({ active }: { active: boolean }) => (
+  <Box
+    width="1.5rem"
+    height="1.5rem"
+    borderRadius="full"
+    backgroundColor="background-success"
+    color="text-success"
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    flexShrink={0}
+    opacity={active ? 1 : 0.4}
+  >
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  </Box>
+)
+
+const BankIcon = () => (
+  <Box
+    width="3rem"
+    height="3rem"
+    borderRadius="full"
+    backgroundColor="background-card"
+    color="text-secondary"
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    flexShrink={0}
+  >
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="3" y1="22" x2="21" y2="22" />
+      <line x1="6" y1="18" x2="6" y2="11" />
+      <line x1="10" y1="18" x2="10" y2="11" />
+      <line x1="14" y1="18" x2="14" y2="11" />
+      <line x1="18" y1="18" x2="18" y2="11" />
+      <polygon points="12 2 20 7 4 7" />
+    </svg>
+  </Box>
+)
+
+const ArrowDown = () => (
+  <Box
+    display="flex"
+    justifyContent="center"
+    color="text-tertiary"
+    paddingVertical="m"
+  >
+    <svg
+      width="20"
+      height="30"
+      viewBox="0 0 20 30"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.25}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="10" y1="2" x2="10" y2="26" />
+      <polyline points="3 19 10 26 17 19" />
+    </svg>
+  </Box>
+)
+
+const Chevron = ({ open }: { open: boolean }) => (
+  <Box color="text-tertiary" display="flex" flexShrink={0}>
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{
+        transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+        transition: 'transform 150ms ease',
+      }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  </Box>
+)
+
+export const Pipeline = () => {
+  const [active, setActive] = useState(0)
+
+  return (
+    <Box
+      position="relative"
+      display="flex"
+      flexDirection="column"
+      rowGap={{ base: '2xl', md: '4xl' }}
+      paddingTop={{ base: 'l', md: '3xl' }}
+      paddingBottom={{ base: '2xl', md: '4xl' }}
+    >
+      <Box
+        display="grid"
+        gridTemplateColumns={{ base: '1fr', lg: '1fr 1fr' }}
+        gap={{ base: '2xl', lg: '4xl' }}
+        alignItems="center"
+      >
+        {/* Accordion */}
+        <Box as="ul" display="flex" flexDirection="column" rowGap="2xl">
+          <Box display="flex" flexDirection="column" rowGap="2xl">
+            <Text variant="heading-l" as="h2" wrap="balance">
+              Everything between usage & revenue
+            </Text>
+            <Text variant="heading-xxs" color="muted" wrap="pretty">
+              Usage goes in, settled revenue goes out to your bank account. In
+              between, Polar handles billing, invoicing, metrics, tax, payments
+              & fraud as your merchant of record.
+            </Text>
+          </Box>
+
+          <Box display={{ base: 'none', md: 'flex' }} flexDirection="column">
+            {ASPECTS.map((aspect, index) => {
+              const open = index === active
+              return (
+                <Box
+                  as="li"
+                  key={aspect.title}
+                  borderBottomWidth={1}
+                  borderStyle="solid"
+                  borderColor="border-secondary"
+                  paddingVertical="l"
+                  display="flex"
+                  flexDirection="column"
+                  rowGap="l"
+                >
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="between"
+                    columnGap="l"
+                    cursor="pointer"
+                    onClick={() => setActive(index)}
+                  >
+                    <Box display="flex" flexDirection="row" columnGap="s">
+                      <Text
+                        variant="heading-xxs"
+                        color={open ? undefined : 'muted'}
+                      >
+                        0{index + 1}.
+                      </Text>
+                      <Text
+                        variant="heading-xxs"
+                        color={open ? undefined : 'muted'}
+                      >
+                        {aspect.title}
+                      </Text>
+                    </Box>
+                    <Chevron open={open} />
+                  </Box>
+                  {open && (
+                    <Box
+                      maxWidth="28rem"
+                      paddingBottom="l"
+                      display="flex"
+                      flexDirection="column"
+                      rowGap="m"
+                    >
+                      <Text color="muted" variant="heading-xxs">
+                        {aspect.desc}
+                      </Text>
+                      <Link href={aspect.href}>
+                        <Box
+                          display="flex"
+                          alignItems="center"
+                          columnGap="m"
+                          width="fit-content"
+                          color={{
+                            base: 'text-primary',
+                            hover: 'text-secondary',
+                          }}
+                          cursor="pointer"
+                        >
+                          <Text variant="body" color="inherit">
+                            Learn more
+                          </Text>
+                          <ArrowRight />
+                        </Box>
+                      </Link>
+                    </Box>
+                  )}
+                </Box>
+              )
+            })}
+          </Box>
+        </Box>
+
+        {/* Flow */}
+        <Box
+          width="100%"
+          maxWidth={{ base: '100%' }}
+          marginHorizontal="auto"
+          display="flex"
+          flexDirection="column"
+          paddingVertical={{ base: '2xl', md: '5xl' }}
+          paddingHorizontal={{ base: '2xl', md: '5xl' }}
+          rowGap="xl"
+          borderWidth={1}
+          borderColor="border-secondary"
+        >
+          {/* Customer */}
+          <Box
+            display="flex"
+            alignItems="center"
+            columnGap="m"
+            backgroundColor="background-secondary"
+            padding="l"
+          >
+            <Avatar
+              name="John Doe"
+              avatar_url="/assets/team/emil.png"
+              className="h-10 w-10 text-sm"
+            />
+            <Box display="flex" flexDirection="column">
+              <Text>John Doe</Text>
+              <Text color="muted">Consumed 23,820 tokens</Text>
+            </Box>
+          </Box>
+
+          <ArrowDown />
+
+          {/* Polar */}
+          <Box display="flex" flexDirection="column" rowGap="s">
+            <Box
+              paddingVertical="m"
+              display="flex"
+              justifyContent="center"
+              backgroundColor="background-secondary"
+            >
+              <Text variant="body">Polar</Text>
+            </Box>
+            {GROUPS.map((group, groupIndex) => (
+              <Box
+                key={groupIndex}
+                display="flex"
+                flexDirection="column"
+                backgroundColor="background-secondary"
+                padding="s"
+              >
+                {group.map((aspect) => {
+                  const globalIndex = ASPECTS.indexOf(aspect)
+                  const isActive = globalIndex === active
+                  return (
+                    <Box
+                      key={aspect.title}
+                      display="flex"
+                      alignItems="center"
+                      columnGap="l"
+                      paddingVertical="s"
+                      paddingHorizontal="s"
+                      cursor="pointer"
+                      onClick={() => setActive(globalIndex)}
+                    >
+                      <CheckIcon active={isActive} />
+                      <Text
+                        variant="body"
+                        color={isActive ? undefined : 'muted'}
+                      >
+                        {aspect.title}
+                      </Text>
+                    </Box>
+                  )
+                })}
+              </Box>
+            ))}
+          </Box>
+
+          <ArrowDown />
+
+          {/* Payout */}
+          <Box
+            display="flex"
+            alignItems="center"
+            columnGap="l"
+            backgroundColor="background-secondary"
+            padding="l"
+          >
+            <BankIcon />
+            <Box display="flex" flexDirection="column" rowGap="xs">
+              <Box display="flex" alignItems="baseline" columnGap="s">
+                <Text>Merchant Payout</Text>
+                <Text color="muted">Acme Inc</Text>
+              </Box>
+              <Box display="flex" alignItems="baseline" columnGap="s">
+                <Text color="success">$9,311</Text>
+                <Text color="muted">SEB **** 9128</Text>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Landing/UseCases.tsx
+++ b/clients/apps/web/src/components/Landing/UseCases.tsx
@@ -85,28 +85,34 @@ export const UseCases = () => {
       <div className="mx-auto w-full max-w-7xl py-32">
         <Box
           display="flex"
-          flexDirection={{ base: 'column', md: 'row' }}
-          columnGap="5xl"
-          rowGap="3xl"
+          flexDirection="column"
+          rowGap={{ base: '2xl', md: '3xl' }}
         >
           <Box
             display="flex"
-            flexDirection="column"
-            rowGap="3xl"
-            flex={1}
+            flexDirection={{ base: 'column', xl: 'row' }}
+            rowGap="2xl"
             paddingHorizontal={{ base: 'l', md: 'none' }}
           >
-            <Text variant="heading-xl" as="h2" wrap="balance">
-              Built for the shape of AI.
-            </Text>
+            <Box display="flex" flex={1}>
+              <Text variant="heading-xl" as="h2" wrap="balance">
+                Built for the shape of AI
+              </Text>
+            </Box>
             <Box
-              borderTopWidth={3}
-              borderStyle="solid"
-              borderColor="border-primary"
-              width="3rem"
-            />
-            <Box maxWidth="32rem">
-              <Text variant="heading-xs" color="muted">
+              display="flex"
+              flex={1}
+              flexDirection="column"
+              rowGap="xl"
+              justifyContent="between"
+            >
+              <Box
+                borderTopWidth={4}
+                borderColor="border-primary"
+                width="3rem"
+                display={{ base: 'none', xl: 'flex' }}
+              />
+              <Text variant="heading-xs" wrap="pretty">
                 From token-metered APIs to autonomous agents and GPU workloads.
                 Polar fits how modern AI products actually charge.
               </Text>
@@ -114,7 +120,6 @@ export const UseCases = () => {
           </Box>
 
           <Box
-            flex={1}
             display="flex"
             flexDirection="column"
             overflow="hidden"

--- a/clients/apps/web/src/components/Landing/graphics/MarginPulse.tsx
+++ b/clients/apps/web/src/components/Landing/graphics/MarginPulse.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useInView } from '@/hooks/useInView'
+
+/**
+ * MarginPulse — a vertical stack of horizontal bars emanating from a
+ * center axis. Each bar's signed length is driven by a slow
+ * multi-frequency wave: positive lengths extend right (profit, green),
+ * negative lengths extend left (loss, red). A positive bias keeps most
+ * bars in the green with the occasional dip into the red, echoing the
+ * margin leaderboard beside it. Canvas 2D.
+ */
+
+const ROWS = 14
+const SUCCESS = '#fff'
+const DANGER = 'hsl(233, 4%, 18.5%)'
+
+export const MarginPulse = () => {
+  const { ref: wrapperRef, inView } = useInView()
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const animRef = useRef<number>(0)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    if (!inView) return
+
+    const dpr = window.devicePixelRatio ?? 1
+    const width = canvas.offsetWidth
+    const height = canvas.offsetHeight
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+    ctx.scale(dpr, dpr)
+
+    const padX = width * 0.12
+    const padY = height * 0.12
+    const innerH = height - padY * 2
+    const cx = width / 2
+    const rowH = innerH / ROWS
+    const barH = rowH * 0.06
+    const maxLen = width / 2 - padX
+
+    let lastTime: number | null = null
+    let time = 0
+
+    const drawBar = (x: number, y: number, w: number, h: number) => {
+      ctx.beginPath()
+      ctx.rect(x, y, w, h)
+
+      ctx.fill()
+    }
+
+    const draw = (now: number) => {
+      const dt = lastTime === null ? 0 : (now - lastTime) / 1000
+      lastTime = now
+      time += dt
+
+      ctx.clearRect(0, 0, width, height)
+
+      for (let r = 0; r < ROWS; r++) {
+        const baseY = padY + r * rowH + (rowH - barH) / 2
+
+        const phase1 = r * 0.55 - time * 1.1
+        const phase2 = r * 0.27 + time * 0.6
+        const wave = Math.sin(phase1) * 0.6 + Math.sin(phase2) * 0.4
+
+        // Positive bias: mostly profit, occasional dip into the red
+        const signed = wave * 0.72
+        const len = signed * maxLen
+
+        ctx.fillStyle = signed >= 0 ? SUCCESS : DANGER
+        if (signed >= 0) {
+          drawBar(cx, baseY, len, barH)
+        } else {
+          drawBar(cx + len, baseY, -len, barH)
+        }
+      }
+
+      animRef.current = requestAnimationFrame(draw)
+    }
+
+    animRef.current = requestAnimationFrame(draw)
+
+    return () => cancelAnimationFrame(animRef.current)
+  }, [inView])
+
+  return (
+    <div ref={wrapperRef} className="h-full w-full">
+      <canvas ref={canvasRef} className="h-full w-full" />
+    </div>
+  )
+}


### PR DESCRIPTION
- **cost insights module**
- **more billing features on landing**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cost Insights and Billing Pipeline sections to the landing page to explain LLM cost visibility and the end-to-end usage→revenue flow. Polishes copy/visuals and fixes the Cost Insights leaderboard.

- **New Features**
  - Cost Insights: customer margin table with revenue, LLM cost, and gross margin, plus an animated `MarginPulse` graphic; fully responsive.
  - Billing Pipeline: interactive accordion showing the path from usage metering to merchant payout (invoicing, analytics, cost insights, tax, payments, refunds, risk), with “learn more” links to docs.
  - Landing integration: inserts both sections before Vision on the landing page.

- **Refactors & Fixes**
  - Dashboard card: larger border radius, removed gradient overlay and extra padding; uses a single static image.
  - Use Cases: tightened copy and responsive layout; adjusted headline and visual accent behavior.
  - Cost Insights: fixed leaderboard calculation/display (correct sign, negative styling, and responsive columns).

<sup>Written for commit 6195b0568cccce149bc7ebfe0f658f07921ed8d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

