### PR TITLE
Show held payouts as payment metrics

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -779,6 +779,13 @@ async def get_organization_detail(
 
         p50_risk, p90_risk = payment_analytics.calculate_risk_percentiles(risk_scores)
 
+        (
+            held_payout_count,
+            held_payout_amount,
+        ) = await PayoutRepository.from_session(session).get_held_stats_by_account(
+            organization.account_id
+        )
+
         payment_stats = {
             "payment_count": payment_count,
             "total_amount": total_amount,
@@ -799,6 +806,8 @@ async def get_organization_detail(
             "p90_risk": p90_risk,
             "risk_scores_count": len(risk_scores),
             "next_review_threshold": organization.next_review_threshold,
+            "held_payout_count": held_payout_count,
+            "held_payout_amount": held_payout_amount,
         }
 
         orders_count, unrefunded_orders_count = await count_test_sales(

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -399,6 +399,14 @@ class OverviewSection(ChecklistMixin):
                         "Current Balance",
                         f"${payment_stats.get('account_balance', 0) / 100:,.2f}",
                     )
+                    self._payment_line(
+                        "Held Payouts",
+                        str(payment_stats.get("held_payout_count", 0)),
+                    )
+                    self._payment_line(
+                        "Held Payouts Amount",
+                        f"${payment_stats.get('held_payout_amount', 0) / 100:,.2f}",
+                    )
                     next_review_threshold = payment_stats.get("next_review_threshold")
                     if next_review_threshold:
                         self._payment_line(

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -57,6 +57,25 @@ class PayoutRepository(
         result = await self.session.execute(statement)
         return {account_id: count for account_id, count in result.all()}
 
+    async def get_held_stats_by_account(self, account: UUID) -> tuple[int, int]:
+        """Count and sum the amount of held payouts for a single account.
+        Returns `(count, total_amount)` with the amount in USD cents.
+        """
+        statement = (
+            self.get_base_statement()
+            .with_only_columns(
+                func.count(Payout.id),
+                func.coalesce(func.sum(Payout.amount), 0),
+            )
+            .where(
+                Payout.account_id == account,
+                Payout.status == PayoutStatus.held,
+            )
+        )
+        result = await self.session.execute(statement)
+        count, total_amount = result.one()
+        return count, total_amount
+
     async def get_latest_by_account(self, account: UUID) -> Payout | None:
         statement = (
             self.get_base_statement()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds held payout metrics to the organization overview so teams can see how many payouts are held and the total amount on hold.

- **New Features**
  - Backend: `PayoutRepository.get_held_stats_by_account` returns count and total (in cents) of held payouts for an account.
  - API: Organization detail now includes `held_payout_count` and `held_payout_amount`.
  - UI: Overview payments card shows “Held Payouts” and “Held Payouts Amount” (displayed in dollars).

<sup>Written for commit adb150737ed7773396a72664d1ef796a609485b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

