### PR TITLE
Allow reverting back from offboarding decision

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -657,10 +657,39 @@ class OrganizationDetailView:
                             ):
                                 text("Deny")
 
-                    elif self.org.status in (
-                        OrganizationStatus.CREATED,
-                        OrganizationStatus.OFFBOARDING,
-                    ):
+                    elif self.org.status == OrganizationStatus.OFFBOARDING:
+                        # Offboarding can be reverted to review or denied
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:under_review_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Set Under Review")
+
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:deny_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Deny")
+
+                    elif self.org.status == OrganizationStatus.CREATED:
                         with tag.div(classes="w-full"):
                             with button(
                                 variant="secondary",

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -405,6 +405,7 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
     ),
     OrganizationStatus.OFFBOARDING: frozenset(
         {
+            OrganizationStatus.REVIEW,
             OrganizationStatus.DENIED,
             OrganizationStatus.BLOCKED,
         }

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -994,6 +994,10 @@ class OrganizationService:
             await self._exit_snooze_to_review(session, organization)
             return organization
 
+        # Only ACTIVE orgs are auto-pulled into review when they cross the
+        # threshold. Other statuses — notably OFFBOARDING — must never flip
+        # to review automatically; they can only return via a manual
+        # "Set under review" action (set_organization_under_review).
         if organization.status != OrganizationStatus.ACTIVE:
             return organization
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -866,8 +866,8 @@ class TestCheckReviewThreshold:
         organization: Organization,
     ) -> None:
         # Given: offboarding org with threshold 0 and a positive balance
-        # (OFFBOARDING -> REVIEW is not a legal transition, so the check
-        # must skip without raising InvalidStatusTransitionError)
+        # (check_review_threshold only auto-transitions ACTIVE orgs, so an
+        # offboarding org must be skipped regardless of its threshold)
         organization.status = OrganizationStatus.OFFBOARDING
         organization.next_review_threshold = 0
 
@@ -1542,6 +1542,25 @@ class TestSetOrganizationUnderReview:
         enqueue_job_mock.assert_called_once_with(
             "organization.under_review", organization_id=organization.id
         )
+
+    async def test_set_organization_under_review_from_offboarding(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Given an offboarding organization
+        organization.status = OrganizationStatus.OFFBOARDING
+
+        mocker.patch("polar.organization.service.enqueue_job")
+
+        # When reverting it to review
+        result = await organization_service.set_organization_under_review(
+            session, organization
+        )
+
+        # Then it transitions back into the review flow
+        assert result.status == OrganizationStatus.REVIEW
 
 
 class TestGetPaymentStatus:
@@ -3915,6 +3934,14 @@ class TestStatusTransitions:
         organization.status = OrganizationStatus.OFFBOARDING
         organization.set_status(OrganizationStatus.DENIED)
         assert organization.status == OrganizationStatus.DENIED
+
+    async def test_offboarding_can_go_to_review(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.set_status(OrganizationStatus.REVIEW)
+        assert organization.status == OrganizationStatus.REVIEW
 
     @pytest.mark.parametrize(
         "current",

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -865,9 +865,10 @@ class TestCheckReviewThreshold:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        # Given: offboarding org with threshold 0 and a positive balance
-        # (check_review_threshold only auto-transitions ACTIVE orgs, so an
-        # offboarding org must be skipped regardless of its threshold)
+        # Given: offboarding org with threshold 0 and a positive balance.
+        # Crossing the review threshold must NEVER pull an offboarding org
+        # back into review — only a manual "Set under review" action may do
+        # that. check_review_threshold only auto-transitions ACTIVE orgs.
         organization.status = OrganizationStatus.OFFBOARDING
         organization.next_review_threshold = 0
 


### PR DESCRIPTION
Offboarding currently is irreversible, but humans make mistakes 😊 so allow to move organizations back into offboarding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow reverting organizations from offboarding back to review in the backoffice. Offboarding decisions are now reversible, and OFFBOARDING orgs never auto-flip to review.

- **New Features**
  - Backoffice: For OFFBOARDING orgs, add "Set Under Review" and "Deny" actions in the right sidebar.
  - Status model/service: Allow OFFBOARDING → REVIEW via `set_organization_under_review`; auto review-threshold transitions apply to `ACTIVE` only so OFFBOARDING stays put. Added tests for these paths.

<sup>Written for commit 09ca3a2ce8e0696785688379fdf7a3464ab296e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

