### PR TITLE
Add benefit visibility column and model rules

### DIFF
--- a/server/migrations/versions/2026-06-10-1024_add_benefit_visibility.py
+++ b/server/migrations/versions/2026-06-10-1024_add_benefit_visibility.py
@@ -1,0 +1,29 @@
+"""add benefit visibility
+
+Revision ID: c471909b640d
+Revises: 2326c1c6236b
+Create Date: 2026-06-10 10:24:08.541092
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c471909b640d"
+down_revision = "2326c1c6236b"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "benefits",
+        sa.Column("visibility", sa.VARCHAR(), nullable=True, server_default="public"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("benefits", "visibility")

--- a/server/polar/models/benefit.py
+++ b/server/polar/models/benefit.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
 from alembic_utils.pg_function import PGFunction
@@ -13,6 +13,8 @@ from polar.exceptions import PolarError
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.metadata import MetadataMixin
+from polar.kit.schemas import SetSchemaReference
+from polar.kit.visibility import Visibility, VisibilityMixin
 
 if TYPE_CHECKING:
     from polar.benefit.strategies import BenefitProperties
@@ -24,6 +26,9 @@ class TaxApplicationMustBeSpecified(PolarError):
         self.type = type
         message = "The tax application should be specified for this type."
         super().__init__(message)
+
+
+BenefitVisibility = Annotated[Visibility, SetSchemaReference("BenefitVisibility")]
 
 
 class BenefitType(StrEnum):
@@ -64,8 +69,35 @@ class BenefitType(StrEnum):
         except KeyError as e:
             raise TaxApplicationMustBeSpecified(self) from e
 
+    def is_visibility_configurable(self) -> bool:
+        return self in VISIBILITY_CONFIGURABLE_BENEFIT_TYPES
 
-class Benefit(MetadataMixin, RecordModel):
+    def default_visibility(self) -> Visibility:
+        match self:
+            case BenefitType.feature_flag:
+                return Visibility.private
+            case _:
+                return Visibility.public
+
+    def resolve_visibility(self, visibility: Visibility | None) -> Visibility:
+        if not self.is_visibility_configurable():
+            # Benefits requiring customer action in the portal (e.g. Discord,
+            # GitHub, downloads) must stay visible.
+            return Visibility.public
+        return visibility if visibility is not None else self.default_visibility()
+
+
+VISIBILITY_CONFIGURABLE_BENEFIT_TYPES: frozenset[BenefitType] = frozenset(
+    {
+        BenefitType.custom,
+        BenefitType.license_keys,
+        BenefitType.meter_credit,
+        BenefitType.feature_flag,
+    }
+)
+
+
+class Benefit(VisibilityMixin, MetadataMixin, RecordModel):
     __tablename__ = "benefits"
     __table_args__ = (
         Index(

--- a/server/tests/models/test_benefit.py
+++ b/server/tests/models/test_benefit.py
@@ -1,0 +1,46 @@
+import pytest
+
+from polar.kit.visibility import Visibility
+from polar.models.benefit import BenefitType
+
+
+class TestBenefitTypeVisibility:
+    @pytest.mark.parametrize(
+        ("benefit_type", "expected"),
+        [
+            (BenefitType.discord, False),
+            (BenefitType.github_repository, False),
+            (BenefitType.downloadables, False),
+            (BenefitType.custom, True),
+            (BenefitType.meter_credit, True),
+            (BenefitType.feature_flag, True),
+            (BenefitType.license_keys, True),
+        ],
+    )
+    def test_is_visibility_configurable(
+        self, benefit_type: BenefitType, expected: bool
+    ) -> None:
+        assert benefit_type.is_visibility_configurable() is expected
+
+    @pytest.mark.parametrize(
+        ("benefit_type", "expected"),
+        [
+            (BenefitType.custom, Visibility.public),
+            (BenefitType.meter_credit, Visibility.public),
+            (BenefitType.feature_flag, Visibility.private),
+            (BenefitType.discord, Visibility.public),
+        ],
+    )
+    def test_default_visibility(
+        self, benefit_type: BenefitType, expected: Visibility
+    ) -> None:
+        assert benefit_type.default_visibility() == expected
+
+    def test_resolve_visibility_forces_public_when_not_configurable(self) -> None:
+        assert (
+            BenefitType.discord.resolve_visibility(Visibility.private)
+            == Visibility.public
+        )
+
+    def test_resolve_visibility_uses_default_for_feature_flag(self) -> None:
+        assert BenefitType.feature_flag.resolve_visibility(None) == Visibility.private


### PR DESCRIPTION
Part 1 for the Benefit Visibility feature in: https://github.com/polarsource/feedback/issues/159.

Appreciate all feedback!

 ## Summary
  - Adds a `visibility` column to `benefits` (defaults to `public` for all existing rows)
  - Uses the shared `VisibilityMixin` to the `Benefit` model
  - Introduces per-type visibility rules on `BenefitType` (which types are configurable, defaults, and forced-public behavior for downloadables etc.) No API or customer-facing behavior changes yet and all benefits should remain public after merge.
  ## Context
  Part 1 the benefit visibility feature rollout. Merchants will eventually be able to hide benefits from customer-facing surfaces
  while keeping them granted and queryable via merchant APIs.
  ## Type rules (implemented in model)
  | Type | Configurable | Default |
  |------|-------------|---------|
  | Custom | Yes | `public` |
  | Meter credit | Yes | `public` |
  | Feature flag | Yes | `private` |
  | License keys | Yes | `public` |
  | Discord, GitHub, Downloadables | No (forced `public`) | `public` |

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [X] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add benefit visibility to prepare for merchant-controlled visibility. Adds a `visibility` column and per-type rules on `BenefitType` with no API or user-facing changes; all existing benefits stay public.

- **New Features**
  - Added `benefits.visibility` (server default `public`) via migration.
  - Adopted `VisibilityMixin` on `Benefit`.
  - Implemented `BenefitType` helpers: `is_visibility_configurable`, `default_visibility`, `resolve_visibility`.
  - Visibility rules: configurable types are `custom`, `meter_credit`, `feature_flag`, `license_keys`; default `private` for `feature_flag`, `public` for others; forced `public` for `discord`, `github_repository`, `downloadables`.
  - Added tests covering configurability, defaults, and forced-public behavior.

<sup>Written for commit 45c8abe8a093f337a572794f4bea0e0ebce3f621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

