### PR TITLE
Stop emitting free prices from the product form

### DIFF
--- a/clients/apps/web/src/components/Products/CreateProductPage.tsx
+++ b/clients/apps/web/src/components/Products/CreateProductPage.tsx
@@ -8,7 +8,11 @@ import {
   findFirstErrorMessage,
   setProductValidationErrors,
 } from '@/utils/api/errors'
-import { ProductEditOrCreateForm, productToCreateForm } from '@/utils/product'
+import {
+  formPriceToApiPrice,
+  ProductEditOrCreateForm,
+  productToCreateForm,
+} from '@/utils/product'
 import { isValidationError, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
@@ -124,6 +128,7 @@ export const CreateProductPage = ({
 
         const { data: product, error } = await createProduct.mutateAsync({
           ...productCreateRest,
+          prices: productCreateRest.prices.map(formPriceToApiPrice),
           medias: mediaIds,
           metadata: metadata.reduce(
             (acc, { key, value }) => ({ ...acc, [key]: value }),

--- a/clients/apps/web/src/components/Products/EditProductPage.tsx
+++ b/clients/apps/web/src/components/Products/EditProductPage.tsx
@@ -10,6 +10,7 @@ import {
   setProductValidationErrors,
 } from '@/utils/api/errors'
 import {
+  formPriceToApiPrice,
   ProductEditOrCreateForm,
   productPriceToFormPrice,
 } from '@/utils/product'
@@ -117,6 +118,7 @@ export const EditProductPage = ({
             id: product.id,
             body: {
               ...productUpdateRest,
+              prices: productUpdateRest.prices.map(formPriceToApiPrice),
               medias: full_medias.map((media) => media.id),
               metadata: metadata.reduce(
                 (acc, { key, value }) => ({ ...acc, [key]: value }),

--- a/clients/apps/web/src/utils/product.test.ts
+++ b/clients/apps/web/src/utils/product.test.ts
@@ -1,0 +1,68 @@
+import { schemas } from '@polar-sh/client'
+import { describe, expect, it } from 'vitest'
+import { formPriceToApiPrice, productPriceToFormPrice } from './product'
+
+type FormPrice = schemas['ProductCreate']['prices'][number]
+
+const formPrice = (overrides: Record<string, unknown>): FormPrice =>
+  ({ price_currency: 'usd', ...overrides }) as unknown as FormPrice
+
+const apiPrice = (
+  overrides: Record<string, unknown>,
+): schemas['ProductPrice'] =>
+  ({
+    id: 'price_1',
+    price_currency: 'usd',
+    ...overrides,
+  }) as unknown as schemas['ProductPrice']
+
+describe('formPriceToApiPrice', () => {
+  it('converts a free price to a fixed price of 0', () => {
+    const result = formPriceToApiPrice(formPrice({ amount_type: 'free' }))
+    expect(result).toMatchObject({
+      amount_type: 'fixed',
+      price_amount: 0,
+      price_currency: 'usd',
+    })
+  })
+
+  it('leaves a paid fixed price untouched', () => {
+    const price = formPrice({ amount_type: 'fixed', price_amount: 1000 })
+    expect(formPriceToApiPrice(price)).toBe(price)
+  })
+
+  it('leaves a custom price untouched', () => {
+    const price = formPrice({ amount_type: 'custom', minimum_amount: 50 })
+    expect(formPriceToApiPrice(price)).toBe(price)
+  })
+})
+
+describe('productPriceToFormPrice', () => {
+  it('surfaces a fixed price of 0 as a free price', () => {
+    const result = productPriceToFormPrice(
+      apiPrice({ amount_type: 'fixed', price_amount: 0 }),
+    )
+    expect(result.amount_type).toBe('free')
+    expect('price_amount' in result).toBe(false)
+  })
+
+  it('leaves a paid fixed price untouched', () => {
+    const price = apiPrice({ amount_type: 'fixed', price_amount: 1000 })
+    expect(productPriceToFormPrice(price)).toBe(price)
+  })
+
+  it('leaves an existing free price untouched', () => {
+    const price = apiPrice({ amount_type: 'free' })
+    expect(productPriceToFormPrice(price)).toBe(price)
+  })
+})
+
+describe('free price round-trips through the form as fixed-0', () => {
+  it('form free -> api fixed-0 -> form free', () => {
+    const api = formPriceToApiPrice(formPrice({ amount_type: 'free' }))
+    expect(api.amount_type).toBe('fixed')
+
+    const backToForm = productPriceToFormPrice(api as schemas['ProductPrice'])
+    expect(backToForm.amount_type).toBe('free')
+  })
+})

--- a/clients/apps/web/src/utils/product.ts
+++ b/clients/apps/web/src/utils/product.ts
@@ -36,6 +36,16 @@ export const productPriceToFormPrice = (
   return price
 }
 
+// Inverse of `productPriceToFormPrice`: the form keeps `free` as a UI-only price type,
+// so convert it back to a fixed price of 0 before sending to the API. We no longer
+// create `free` prices (they're being dropped in favor of a fixed price of 0).
+export const formPriceToApiPrice = (
+  price: schemas['ProductCreate']['prices'][number],
+): schemas['ProductCreate']['prices'][number] =>
+  price.amount_type === 'free'
+    ? { ...price, amount_type: 'fixed', price_amount: 0 }
+    : price
+
 export const isMeteredPrice = (
   price: schemas['ProductPrice'] | schemas['LegacyRecurringProductPrice'],
 ): price is schemas['ProductPriceMeteredUnit'] =>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop emitting the `free` price type from the product form. "Free" stays in the UI, but submitted prices are converted to `fixed` with amount 0 so the API never receives `free`.

- **Refactors**
  - Added `formPriceToApiPrice` and applied it in create/edit flows to map form `prices` before API calls.
  - Preserved `productPriceToFormPrice` so fixed-0 still appears as "Free" in the form.
  - Added unit tests to cover conversions and round-trips.

<sup>Written for commit 1624901cccf1518c3a41bb71189ee23fee64b819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

