### PR TITLE
Front-end for fixed + seat prices

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { isStaticPrice } from '@/utils/product'
 import CloseOutlined from '@mui/icons-material/CloseOutlined'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
@@ -24,7 +23,15 @@ import { ProductPriceCustomItem } from './ProductPriceCustomItem'
 import { ProductPriceFixedItem } from './ProductPriceFixedItem'
 import { ProductPriceMeteredUnitItem } from './ProductPriceMeteredUnitItem'
 import { ProductPriceSeatBasedItem } from './ProductPriceSeatBasedItem'
-import { hasPriceCurrency, ProductPrice, ProductPriceCreate } from './utils'
+import { ProductPriceCreate } from './utils'
+
+const AMOUNT_TYPE_LABELS: Record<string, string> = {
+  fixed: 'Fixed price',
+  custom: 'Pay what you want',
+  free: 'Free',
+  seat_based: 'Seats',
+  metered_unit: 'Metered price',
+}
 
 interface ProductPriceItemProps {
   organization: schemas['Organization']
@@ -36,6 +43,7 @@ interface ProductPriceItemProps {
     amountType: ProductPriceCreate['amount_type'],
   ) => void
   canRemove: boolean
+  canChangeType?: boolean
 }
 
 export const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
@@ -45,29 +53,20 @@ export const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
   onRemove,
   onAmountTypeChange,
   canRemove,
+  canChangeType = true,
 }) => {
   const { register, control, watch } = useFormContext<ProductFormType>()
   const amountType = watch(`prices.${index}.amount_type`)
   const recurringInterval = watch('recurring_interval')
 
-  const prices = watch('prices')
-  const pricesForCurrency = (prices || []).filter(
-    (p) => hasPriceCurrency(p) && p.price_currency === currency,
-  )
-  const staticPriceForCurrency = pricesForCurrency.find((p) =>
-    isStaticPrice(p as ProductPrice),
-  )
-  const currentPrice = prices?.[index]
-  const isCurrentPriceStatic =
-    currentPrice && isStaticPrice(currentPrice as ProductPrice)
-  const hasOtherStaticPrice = staticPriceForCurrency && !isCurrentPriceStatic
-
   return (
     <div className="flex flex-col gap-y-6">
       <input type="hidden" {...register(`prices.${index}.id`)} />
-      {hasOtherStaticPrice ? (
+      {!canChangeType ? (
         <div className="flex flex-row items-center justify-between">
-          <h4 className="text-sm font-medium">Metered price</h4>
+          <h4 className="text-sm font-medium">
+            {amountType ? AMOUNT_TYPE_LABELS[amountType] : 'Price'}
+          </h4>
           {canRemove && (
             <Button
               variant="secondary"

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
@@ -105,18 +105,24 @@ export const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
                         <SelectValue placeholder="Select a price type" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="fixed">Fixed price</SelectItem>
-                        <SelectItem value="custom">
-                          Pay what you want
+                        <SelectItem value="fixed">
+                          {AMOUNT_TYPE_LABELS.fixed}
                         </SelectItem>
-                        <SelectItem value="free">Free</SelectItem>
+                        <SelectItem value="custom">
+                          {AMOUNT_TYPE_LABELS.custom}
+                        </SelectItem>
+                        <SelectItem value="free">
+                          {AMOUNT_TYPE_LABELS.free}
+                        </SelectItem>
                         {organization.feature_settings
                           ?.seat_based_pricing_enabled && (
-                          <SelectItem value="seat_based">Seats</SelectItem>
+                          <SelectItem value="seat_based">
+                            {AMOUNT_TYPE_LABELS.seat_based}
+                          </SelectItem>
                         )}
                         {recurringInterval !== null && (
                           <SelectItem value="metered_unit">
-                            Metered price
+                            {AMOUNT_TYPE_LABELS.metered_unit}
                           </SelectItem>
                         )}
                       </SelectContent>

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceSeatBasedItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceSeatBasedItem.tsx
@@ -177,19 +177,22 @@ export const ProductPriceSeatBasedItem: React.FC<
         <FormLabel>
           <span className="flex items-center gap-x-1.5">Tiering model</span>
         </FormLabel>
-        <Select
-          value={tieringModel}
-          onValueChange={(v) => handleTieringModelChange(v as TieringModel)}
-        >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="fixed">Fixed price per seat</SelectItem>
-            <SelectItem value="graduated">Graduated</SelectItem>
-            <SelectItem value="volume">Volume discounts</SelectItem>
-          </SelectContent>
-        </Select>
+        <div>
+          {/* We need an extra div for space-y-2 to work */}
+          <Select
+            value={tieringModel}
+            onValueChange={(v) => handleTieringModelChange(v as TieringModel)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="fixed">Fixed price per seat</SelectItem>
+              <SelectItem value="graduated">Graduated</SelectItem>
+              <SelectItem value="volume">Volume discounts</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </FormItem>
 
       {/* Hidden field to keep seat_tier_type in sync */}

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -61,7 +61,7 @@ export const ProductPricingSection = ({
     name: 'prices',
   })
 
-  const { fields: prices, append, remove, replace } = pricesFieldArray
+  const { fields: prices, append, prepend, remove, replace } = pricesFieldArray
 
   const defaultCurrency = organization.default_presentment_currency
 
@@ -304,6 +304,31 @@ export const ProductPricingSection = ({
     })
   }, [activeCurrencies, append])
 
+  const handleAddSeatPrice = useCallback(() => {
+    const newPrices: ProductPriceCreate[] = activeCurrencies.map(
+      (currency) => ({
+        price_currency: currency as schemas['PresentmentCurrency'],
+        amount_type: 'seat_based',
+        seat_tiers: {
+          seat_tier_type: 'volume',
+          tiers: [{ min_seats: 1, max_seats: null, price_per_seat: 0 }],
+        },
+      }),
+    )
+    append(newPrices)
+  }, [activeCurrencies, append])
+
+  const handleAddBasePrice = useCallback(() => {
+    const newPrices: ProductPriceCreate[] = activeCurrencies.map(
+      (currency) => ({
+        price_currency: currency as schemas['PresentmentCurrency'],
+        amount_type: 'fixed',
+        price_amount: 0,
+      }),
+    )
+    prepend(newPrices)
+  }, [activeCurrencies, prepend])
+
   const handleRemovePrice = useCallback(
     (indexToRemove: number) => {
       const currentPrices = getValues('prices')
@@ -333,6 +358,26 @@ export const ProductPricingSection = ({
     },
     [getValues, remove],
   )
+
+  const staticPricesForSelectedCurrency = pricesForSelectedCurrency.filter(
+    (p) => !isMeteredPrice(p.price as ProductPrice),
+  )
+
+  const onlyStaticPrice =
+    staticPricesForSelectedCurrency.length === 1
+      ? staticPricesForSelectedCurrency[0]?.price
+      : undefined
+
+  const onlyStaticAmountType =
+    onlyStaticPrice && 'amount_type' in onlyStaticPrice
+      ? onlyStaticPrice.amount_type
+      : null
+
+  const canAddSeatPricing =
+    onlyStaticAmountType === 'fixed' &&
+    !!organization.feature_settings?.seat_based_pricing_enabled
+
+  const canAddBasePrice = onlyStaticAmountType === 'seat_based'
 
   if (isLegacyRecurringProduct) {
     return (
@@ -497,47 +542,71 @@ export const ProductPricingSection = ({
 
         <div className="flex flex-col gap-y-6 py-6">
           <div className="flex flex-row items-center justify-between">
-            <h3>Price Type</h3>
-            {recurringInterval !== null && (
-              <Button
-                className="self-start"
-                variant="secondary"
-                size="sm"
-                onClick={handleAddMeteredPrice}
-              >
-                Add metered price
-              </Button>
-            )}
-          </div>
-          {pricesForSelectedCurrency.map(({ price, index }) => (
-            <div
-              key={`${selectedCurrency}-${index}`}
-              className={
-                pricesForSelectedCurrency.length > 1 &&
-                isMeteredPrice(price as ProductPrice)
-                  ? 'dark:border-polar-700 rounded-2xl border border-gray-200 p-4'
-                  : ''
-              }
-            >
-              <ProductPriceItem
-                organization={organization}
-                index={index}
-                currency={validatedSelectedCurrency}
-                onRemove={handleRemovePrice}
-                onAmountTypeChange={handleAmountTypeChange}
-                canRemove={
-                  isMeteredPrice(price as ProductPrice) &&
-                  (pricesForSelectedCurrency.filter((p) =>
-                    isMeteredPrice(p.price as ProductPrice),
-                  ).length > 1 ||
-                    pricesForSelectedCurrency.filter(
-                      (p) => !isMeteredPrice(p.price as ProductPrice),
-                    ).length >= 1)
-                }
-                key={`${selectedCurrency}-${index}`}
-              />
+            <h3>Price Configuration</h3>
+            <div className="flex flex-row items-center gap-2">
+              {canAddSeatPricing && (
+                <Button
+                  className="self-start"
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleAddSeatPrice}
+                >
+                  Add seat pricing
+                </Button>
+              )}
+              {canAddBasePrice && (
+                <Button
+                  className="self-start"
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleAddBasePrice}
+                >
+                  Add base price
+                </Button>
+              )}
+              {recurringInterval !== null &&
+                pricesForSelectedCurrency.length > 0 && (
+                  <Button
+                    className="self-start"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleAddMeteredPrice}
+                  >
+                    Add metered price
+                  </Button>
+                )}
             </div>
-          ))}
+          </div>
+          {pricesForSelectedCurrency.map(({ price, index }) => {
+            const isMetered = isMeteredPrice(price as ProductPrice)
+            const meteredPriceCount = pricesForSelectedCurrency.filter((p) =>
+              isMeteredPrice(p.price as ProductPrice),
+            ).length
+            const staticPriceCount =
+              pricesForSelectedCurrency.length - meteredPriceCount
+
+            return (
+              <div
+                key={`${selectedCurrency}-${index}`}
+                className="dark:border-polar-700 rounded-2xl border border-gray-200 p-4"
+              >
+                <ProductPriceItem
+                  organization={organization}
+                  index={index}
+                  currency={validatedSelectedCurrency}
+                  onRemove={handleRemovePrice}
+                  onAmountTypeChange={handleAmountTypeChange}
+                  canChangeType={!isMetered && staticPriceCount <= 1}
+                  canRemove={
+                    staticPriceCount > 1 ||
+                    (isMetered &&
+                      (meteredPriceCount > 1 || staticPriceCount >= 1))
+                  }
+                  key={`${selectedCurrency}-${index}`}
+                />
+              </div>
+            )
+          })}
         </div>
 
         {recurringInterval && (

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -352,8 +352,24 @@ export const ProductPricingSection = ({
           .reverse()
 
         indicesToRemove.forEach((i) => remove(i))
-      } else {
+      } else if (!hasPriceCurrency(priceToRemove)) {
         remove(indexToRemove)
+      } else {
+        // Static prices are kept in sync across currencies by their position
+        // within each currency group (see handleAmountTypeChange). Remove the
+        // corresponding price in every currency so the rows don't desynchronize.
+        const removedCurrency = priceToRemove.price_currency || 'usd'
+        const pricesByCurr = groupPricesByCurrency(currentPrices)
+        const positionInCurrency = (
+          pricesByCurr.get(removedCurrency) || []
+        ).findIndex((p) => p.index === indexToRemove)
+
+        const indicesToRemove = Array.from(pricesByCurr.values())
+          .map((currencyPrices) => currencyPrices[positionInCurrency]?.index)
+          .filter((i): i is number => i !== undefined)
+          .sort((a, b) => b - a)
+
+        indicesToRemove.forEach((i) => remove(i))
       }
     },
     [getValues, remove],

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createBaseCheckout,
   createCheckout,
+  createFixedPrice,
   createMeteredPrice,
   createSeatBasedPrice,
 } from '../test-utils/makeCheckout'
@@ -819,6 +820,75 @@ describe('CheckoutPricingBreakdown', () => {
 
       expect(screen.queryByText(/seats included/i)).not.toBeInTheDocument()
       expect(screen.getByTestId('detail-row-4 seats')).toBeInTheDocument()
+    })
+  })
+
+  describe('fixed + seat pricing', () => {
+    const seatPrice = createSeatBasedPrice({
+      id: 'price_seat',
+      seat_tiers: {
+        seat_tier_type: 'volume',
+        tiers: [{ min_seats: 1, max_seats: null, price_per_seat: 2000 }],
+        minimum_seats: 1,
+        maximum_seats: null,
+      },
+    })
+
+    it('shows a base price row above the seat rows', () => {
+      const fixedPrice = createFixedPrice({
+        id: 'price_fixed',
+        price_amount: 2900,
+      })
+      const checkout = createCheckout({
+        amount: 12900,
+        net_amount: 12900,
+        tax_amount: null,
+        total_amount: 12900,
+        seats: 5,
+        product_price: seatPrice,
+        prices: { prod_1: [fixedPrice, seatPrice] },
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      expect(getRowValue('Base price')).toBe('$29')
+      const seatRow = screen.getByTestId('detail-row-5 seats')
+      expect(seatRow).toHaveTextContent('$20 per seat')
+      expect(seatRow).toHaveTextContent('$100')
+      expect(getRowValue('Subtotal')).toBe('$129')
+      expect(getRowValue('Total')).toBe('$129')
+    })
+
+    it('does not show a base price row for seat-only pricing', () => {
+      const checkout = createCheckout({
+        amount: 5000,
+        net_amount: 5000,
+        tax_amount: null,
+        total_amount: 5000,
+        seats: 5,
+        product_price: seatPrice,
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      expect(
+        screen.queryByTestId('detail-row-Base price'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show a base price row for fixed-only pricing', () => {
+      const checkout = createBaseCheckout({
+        amount: 999,
+        net_amount: 999,
+        tax_amount: null,
+        total_amount: 999,
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      expect(
+        screen.queryByTestId('detail-row-Base price'),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -10,7 +10,12 @@ import {
 import { formatDate } from '@polar-sh/i18n/formatters/date'
 import { addDays, addMonths, addWeeks, addYears } from 'date-fns'
 import { useMemo } from 'react'
-import { hasProductCheckout, isLegacyRecurringProductPrice } from '../guards'
+import {
+  getFixedPrice,
+  getSeatPrice,
+  hasProductCheckout,
+  isLegacyRecurringProductPrice,
+} from '../guards'
 import { getSeatRows } from '../utils/seats'
 import { getDiscountDisplay } from '../utils/discount'
 import { getMeteredPrices } from '../utils/product'
@@ -158,6 +163,13 @@ const CheckoutPricingBreakdown = ({
 
   const seatRows = useMemo(() => getSeatRows(checkout), [checkout])
 
+  // A product may combine a fixed base fee with per-seat pricing. When both
+  // exist, the fixed portion is baked into `checkout.amount` but has no row of
+  // its own — without it the seat rows visibly sum to less than the subtotal.
+  const fixedPrice = useMemo(() => getFixedPrice(checkout), [checkout])
+  const seatPrice = useMemo(() => getSeatPrice(checkout), [checkout])
+  const showBasePrice = Boolean(fixedPrice && seatPrice)
+
   if (checkout.is_free_product_price) {
     return null
   }
@@ -166,6 +178,21 @@ const CheckoutPricingBreakdown = ({
     <div className="flex flex-col gap-y-2">
       {checkout.currency ? (
         <>
+          {showBasePrice && fixedPrice && (
+            <DetailRow
+              title={t('checkout.pricing.basePrice')}
+              className="text-gray-600"
+            >
+              <AmountLabel
+                amount={fixedPrice.price_amount}
+                currency={checkout.currency}
+                interval={interval}
+                intervalCount={intervalCount}
+                mode="standard"
+                locale={locale}
+              />
+            </DetailRow>
+          )}
           {seatRows?.map((row, i) => (
             <SeatDetailRow
               key={i}

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
@@ -35,6 +35,29 @@ export const CheckoutProductSwitcherItemPrice = ({
   checkout,
   locale,
 }: CheckoutProductSwitcherItemPriceProps) => {
+  const productPrices = checkout.prices[product.id] ?? []
+  const fixedPrice = productPrices.find(
+    (p): p is schemas['ProductPriceFixed'] => p.amount_type === 'fixed',
+  )
+  const seatPrice = productPrices.find(
+    (p): p is schemas['ProductPriceSeatBased'] =>
+      p.amount_type === 'seat_based',
+  )
+
+  // Fixed + seat products are billed as `base + seat_charge`. Show the decomposed
+  // structure for every option, selected or not, so the pricing model stays
+  // legible across the switcher.
+  if (fixedPrice && seatPrice) {
+    return (
+      <FixedSeatPrice
+        fixedPrice={fixedPrice}
+        seatPrice={seatPrice}
+        product={product}
+        locale={locale}
+      />
+    )
+  }
+
   if (price.amount_type === 'seat_based') {
     if (isSelected) {
       return (
@@ -71,6 +94,44 @@ export const CheckoutProductSwitcherItemPrice = ({
       locale={locale}
       mode="standard"
     />
+  )
+}
+
+const FixedSeatPrice = ({
+  fixedPrice,
+  seatPrice,
+  product,
+  locale,
+}: {
+  fixedPrice: schemas['ProductPriceFixed']
+  seatPrice: schemas['ProductPriceSeatBased']
+  product: ProductCheckoutPublic['product']
+  locale?: AcceptedLocale
+}) => {
+  const t = useTranslations(locale ?? DEFAULT_LOCALE)
+  const sortedTiers = [...(seatPrice.seat_tiers?.tiers ?? [])].sort(
+    (a, b) => a.min_seats - b.min_seats,
+  )
+  const basePricePerSeat = sortedTiers[0]?.price_per_seat ?? 0
+  return (
+    <span className="flex flex-wrap items-baseline justify-end gap-x-1">
+      <AmountLabel
+        amount={fixedPrice.price_amount}
+        currency={fixedPrice.price_currency}
+        interval={product.recurring_interval}
+        intervalCount={product.recurring_interval_count}
+        mode="standard"
+        locale={locale}
+      />
+      <span>+</span>
+      <AmountLabel
+        amount={basePricePerSeat}
+        currency={seatPrice.price_currency}
+        mode="standard"
+        locale={locale}
+      />
+      <span>{t('checkout.pricing.perSeat')}</span>
+    </span>
   )
 }
 

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
@@ -35,7 +35,12 @@ export const CheckoutProductSwitcherItemPrice = ({
   checkout,
   locale,
 }: CheckoutProductSwitcherItemPriceProps) => {
-  const productPrices = checkout.prices[product.id] ?? []
+  // Products with presentment currencies hold the same logical price in several
+  // currencies. Filter to the checkout's currency first, otherwise `find` could
+  // return a fixed/seat price in the wrong currency and show the wrong amounts.
+  const productPrices = (checkout.prices[product.id] ?? []).filter(
+    (p) => p.price_currency === checkout.currency,
+  )
   const fixedPrice = productPrices.find(
     (p): p is schemas['ProductPriceFixed'] => p.amount_type === 'fixed',
   )

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcherItemPrice.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcherItemPrice.test.tsx
@@ -200,6 +200,64 @@ describe('CheckoutProductSwitcherItemPrice', () => {
       expect(text).toContain('per seat')
       expect(text).not.toContain('From')
     })
+
+    it('uses the prices matching the checkout currency in multi-currency checkouts', () => {
+      const usdFixed = createFixedPrice({
+        id: 'price_fixed_usd',
+        price_currency: 'usd',
+        price_amount: 2900,
+      })
+      const usdSeat = createSeatBasedPrice({
+        id: 'price_seat_usd',
+        price_currency: 'usd',
+        seat_tiers: {
+          seat_tier_type: 'volume',
+          tiers: [{ min_seats: 1, max_seats: null, price_per_seat: 2000 }],
+          minimum_seats: 1,
+          maximum_seats: null,
+        },
+      })
+      const eurFixed = createFixedPrice({
+        id: 'price_fixed_eur',
+        price_currency: 'eur',
+        price_amount: 2700,
+      })
+      const eurSeat = createSeatBasedPrice({
+        id: 'price_seat_eur',
+        price_currency: 'eur',
+        seat_tiers: {
+          seat_tier_type: 'volume',
+          tiers: [{ min_seats: 1, max_seats: null, price_per_seat: 1800 }],
+          minimum_seats: 1,
+          maximum_seats: null,
+        },
+      })
+      const checkout = createCheckout({
+        currency: 'eur',
+        net_amount: 11700,
+        total_amount: 11700,
+        seats: 5,
+        product_price: eurSeat,
+        // USD prices listed first so a currency-blind `find` would pick them.
+        prices: { prod_1: [usdFixed, usdSeat, eurFixed, eurSeat] },
+      })
+
+      const { container } = render(
+        <CheckoutProductSwitcherItemPrice
+          isSelected={true}
+          product={checkout.product}
+          price={eurSeat}
+          checkout={checkout}
+          locale="en"
+        />,
+      )
+
+      const text = getRenderedText(container)
+      expect(text).toContain('€27')
+      expect(text).toContain('€18')
+      expect(text).toContain('per seat')
+      expect(text).not.toContain('$')
+    })
   })
 
   describe('free price', () => {

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcherItemPrice.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcherItemPrice.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import {
   createCheckout,
+  createFixedPrice,
   createFreePrice,
   createSeatBasedPrice,
 } from '../test-utils/makeCheckout'
@@ -136,6 +137,68 @@ describe('CheckoutProductSwitcherItemPrice', () => {
       )
 
       expect(getRenderedText(container)).toBe('From\u00a0$50')
+    })
+  })
+
+  describe('fixed + seat price', () => {
+    const fixedPrice = createFixedPrice({
+      id: 'price_fixed',
+      price_amount: 2900,
+    })
+    const seatPrice = createSeatBasedPrice({
+      id: 'price_seat',
+      seat_tiers: {
+        seat_tier_type: 'volume',
+        tiers: [{ min_seats: 1, max_seats: null, price_per_seat: 2000 }],
+        minimum_seats: 1,
+        maximum_seats: null,
+      },
+    })
+
+    const fixedSeatCheckout = () =>
+      createCheckout({
+        net_amount: 12900,
+        total_amount: 12900,
+        seats: 5,
+        product_price: seatPrice,
+        prices: { prod_1: [fixedPrice, seatPrice] },
+      })
+
+    it('shows the decomposed base + per-seat label when selected', () => {
+      const checkout = fixedSeatCheckout()
+      const { container } = render(
+        <CheckoutProductSwitcherItemPrice
+          isSelected={true}
+          product={checkout.product}
+          price={seatPrice}
+          checkout={checkout}
+          locale="en"
+        />,
+      )
+
+      const text = getRenderedText(container)
+      expect(text).toContain('$29')
+      expect(text).toContain('$20')
+      expect(text).toContain('per seat')
+    })
+
+    it('shows the same decomposed label when not selected', () => {
+      const checkout = fixedSeatCheckout()
+      const { container } = render(
+        <CheckoutProductSwitcherItemPrice
+          isSelected={false}
+          product={checkout.product}
+          price={seatPrice}
+          checkout={checkout}
+          locale="en"
+        />,
+      )
+
+      const text = getRenderedText(container)
+      expect(text).toContain('$29')
+      expect(text).toContain('$20')
+      expect(text).toContain('per seat')
+      expect(text).not.toContain('From')
     })
   })
 

--- a/clients/packages/checkout/src/guards.test.ts
+++ b/clients/packages/checkout/src/guards.test.ts
@@ -1,6 +1,15 @@
 import type { schemas } from '@polar-sh/client'
 import { describe, expect, it } from 'vitest'
-import { hasProductCheckout, isLegacyRecurringProductPrice } from './guards'
+import {
+  createCheckout,
+  createFixedPrice,
+  createSeatBasedPrice,
+} from './test-utils/makeCheckout'
+import {
+  getFixedPrice,
+  hasProductCheckout,
+  isLegacyRecurringProductPrice,
+} from './guards'
 
 describe('hasProductCheckout', () => {
   const baseCheckout = {
@@ -48,6 +57,29 @@ describe('hasProductCheckout', () => {
     } as unknown as schemas['CheckoutPublic']
 
     expect(hasProductCheckout(checkout)).toBe(false)
+  })
+})
+
+describe('getFixedPrice', () => {
+  it('returns the fixed price when combined with a seat price', () => {
+    const fixedPrice = createFixedPrice({ id: 'price_fixed' })
+    const seatPrice = createSeatBasedPrice({ id: 'price_seat' })
+    const checkout = createCheckout({
+      product_price: seatPrice,
+      prices: { prod_1: [fixedPrice, seatPrice] },
+    })
+
+    expect(getFixedPrice(checkout)).toBe(fixedPrice)
+  })
+
+  it('returns null when there is no fixed price', () => {
+    const seatPrice = createSeatBasedPrice({ id: 'price_seat' })
+    const checkout = createCheckout({
+      product_price: seatPrice,
+      prices: { prod_1: [seatPrice] },
+    })
+
+    expect(getFixedPrice(checkout)).toBeNull()
   })
 })
 

--- a/clients/packages/checkout/src/guards.test.ts
+++ b/clients/packages/checkout/src/guards.test.ts
@@ -81,6 +81,24 @@ describe('getFixedPrice', () => {
 
     expect(getFixedPrice(checkout)).toBeNull()
   })
+
+  it('returns the fixed price matching the checkout currency', () => {
+    const usdPrice = createFixedPrice({
+      id: 'price_fixed_usd',
+      price_currency: 'usd',
+    })
+    const eurPrice = createFixedPrice({
+      id: 'price_fixed_eur',
+      price_currency: 'eur',
+    })
+    const checkout = createCheckout({
+      currency: 'eur',
+      product_price: eurPrice,
+      prices: { prod_1: [usdPrice, eurPrice] },
+    })
+
+    expect(getFixedPrice(checkout)).toBe(eurPrice)
+  })
 })
 
 describe('isLegacyRecurringProductPrice', () => {

--- a/clients/packages/checkout/src/guards.ts
+++ b/clients/packages/checkout/src/guards.ts
@@ -45,3 +45,24 @@ export const getSeatPrice = (
       ) ?? null
   )
 }
+
+export const getFixedPrice = (
+  checkout: schemas['CheckoutPublic'],
+): schemas['ProductPriceFixed'] | null => {
+  if (!checkout.product || !checkout.prices) {
+    return null
+  }
+
+  const prices = checkout.prices[checkout.product.id]
+
+  if (!prices) {
+    return null
+  }
+
+  return (
+    prices.find(
+      (price): price is schemas['ProductPriceFixed'] =>
+        price.amount_type === 'fixed',
+    ) ?? null
+  )
+}

--- a/clients/packages/checkout/src/guards.ts
+++ b/clients/packages/checkout/src/guards.ts
@@ -60,9 +60,11 @@ export const getFixedPrice = (
   }
 
   return (
-    prices.find(
-      (price): price is schemas['ProductPriceFixed'] =>
-        price.amount_type === 'fixed',
-    ) ?? null
+    prices
+      .filter((price) => price.price_currency === checkout.currency)
+      .find(
+        (price): price is schemas['ProductPriceFixed'] =>
+          price.amount_type === 'fixed',
+      ) ?? null
   )
 }

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -183,7 +183,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -369,7 +370,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -555,7 +557,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -741,7 +744,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -927,7 +931,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1105,7 +1110,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1283,7 +1289,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1461,7 +1468,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1639,7 +1647,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1817,7 +1826,8 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1995,6 +2005,7 @@
     "embedPaymentMethod.errors.processingFailed": "Could not process the payment method. Please try again.",
     "embedPaymentMethod.errors.unknown": "Something went wrong.",
     "checkout.pricing.seats.included.=1": "One seat included",
-    "checkout.pricing.seats.included.other": "# seats included"
+    "checkout.pricing.seats.included.other": "# seats included",
+    "checkout.pricing.basePrice": "Base price"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'MwSt. (inklusive)',
+      basePrice: 'Grundpreis',
     },
     trial: {
       ends: 'Testphase endet am {endDate}',

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -98,6 +98,11 @@ export default {
       additionalMeteredUsage: 'Additional metered usage',
       perUnit: '/ unit',
       perSeat: 'per seat',
+      basePrice: {
+        value: 'Base price',
+        _llmContext:
+          'Label for the flat, fixed portion of a product that combines a fixed base fee with per-seat pricing. Shown as a line item above the per-seat rows in the checkout pricing breakdown.',
+      },
       seats: {
         label: 'Seats',
         numberOfSeats: 'Number of seats',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'Impuestos (incluidos)',
+      basePrice: 'Precio base',
     },
     trial: {
       ends: 'La prueba finaliza el {endDate}',

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'TVA (incluse)',
+      basePrice: 'Prix de base',
     },
     trial: {
       ends: "L'essai se termine le {endDate}",

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'ÁFA (tartalmazza)',
+      basePrice: 'Alapár',
     },
     trial: {
       ends: 'A próbaidőszak ekkor jár le: {endDate}',

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'IVA (inclusa)',
+      basePrice: 'Prezzo base',
     },
     trial: {
       ends: 'La prova termina il {endDate}',

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -108,6 +108,7 @@ export default {
         },
         until: '{date}まで',
       },
+      basePrice: '基本料金',
     },
     trial: {
       ends: 'トライアル終了日 {endDate}',

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: '부가세 (포함)',
+      basePrice: '기본 가격',
     },
     trial: {
       ends: '체험 종료일: {endDate}',

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'Btw (inbegrepen)',
+      basePrice: 'Basisprijs',
     },
     trial: {
       ends: 'Proefperiode eindigt op {endDate}',

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'IVA (incluído)',
+      basePrice: 'Preço base',
     },
     trial: {
       ends: 'Teste termina a {endDate}',

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'Impostos (inclusos)',
+      basePrice: 'Preço base',
     },
     trial: {
       ends: 'Teste termina a {endDate}',

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -108,7 +108,7 @@ export default {
         },
       },
       inclTax: 'Moms (ingår)',
-      basePrice: 'Grundpris',
+      basePrice: 'Grundavgift',
     },
     trial: {
       ends: 'Testperioden slutar {endDate}',

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -108,6 +108,7 @@ export default {
         },
       },
       inclTax: 'Moms (ingår)',
+      basePrice: 'Grundpris',
     },
     trial: {
       ends: 'Testperioden slutar {endDate}',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for products that combine a fixed base price with per-seat pricing in the product editor and checkout. Pricing now clearly shows base + seat charges in all relevant views, with correct amounts in multi-currency checkouts.

- New Features
  - Product editor
    - Add “Add seat pricing” when a fixed price exists (gated by `organization.feature_settings.seat_based_pricing_enabled`).
    - Add “Add base price” when a seat price exists.
    - Show “Add metered price” only when recurring and at least one price exists.
    - Disable type selection when it would create multiple static prices; show a clear read-only type label.
    - Removing a static price removes its counterparts across currencies to keep rows aligned.
  - Checkout
    - Show a “Base price” row above seat rows when both fixed + seat prices exist.
    - Product switcher displays decomposed “base + per-seat” label for fixed + seat products.
    - Add `getFixedPrice` helper; extend guards and i18n (`checkout.pricing.basePrice`, translations added across locales).
    - Tests added for pricing breakdown, product switcher (including multi-currency), and guards.

- Bug Fixes
  - `getFixedPrice` now respects the checkout currency to show the correct base fee in multi-currency checkouts.
  - Product switcher selects prices matching the checkout currency to avoid incorrect amounts.

<sup>Written for commit 9d815b1d83409a71096a7b97ed2fe38665b36132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

