### PR TITLE
Implement status-filter on subscriptions api

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -33,9 +33,7 @@ interface ClientPageProps {
   pagination: DataTablePaginationState
   sorting: DataTableSortingState
   productId?: string
-  subscriptionStatus?:
-    | Extract<schemas['SubscriptionStatus'], 'active' | 'canceled'>
-    | 'any'
+  subscriptionStatus?: schemas['SubscriptionStatus'] | 'any'
   cancelAtPeriodEnd?: 'all' | 'true' | 'false'
   metadata?: string[]
 }
@@ -185,7 +183,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const subscriptionsHook = useSubscriptions(organization.id, {
     ...getAPIParams(pagination, sorting),
     ...(productId ? { product_id: productId } : {}),
-    ...(status !== 'any' ? { active: status === 'active' } : {}),
+    ...(status !== 'any' ? { status: [status] } : {}),
     ...(cancelAtPeriodEndFilter === 'false'
       ? { cancel_at_period_end: false }
       : cancelAtPeriodEndFilter === 'true'
@@ -326,7 +324,13 @@ const ClientPage: React.FC<ClientPageProps> = ({
           <div className="flex items-center gap-4">
             <div className="w-auto">
               <SubscriptionStatusSelect
-                statuses={['active', 'canceled']}
+                statuses={[
+                  'active',
+                  'trialing',
+                  'past_due',
+                  'canceled',
+                  'unpaid',
+                ]}
                 value={subscriptionStatus || 'any'}
                 onChange={setStatus}
               />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/page.tsx
@@ -1,6 +1,7 @@
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { DataTableSearchParams, parseSearchParams } from '@/utils/datatable'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { schemas } from '@polar-sh/client'
 import { Metadata } from 'next'
 import SubscriptionsPage from './SubscriptionsPage'
 
@@ -15,7 +16,7 @@ export default async function Page(props: {
   searchParams: Promise<
     DataTableSearchParams & {
       product_id?: string
-      status?: 'active' | 'canceled' | 'any'
+      status?: schemas['SubscriptionStatus'] | 'any'
       cancel_at_period_end?: 'all' | 'true' | 'false'
       metadata?: string[]
     }

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
@@ -1,3 +1,4 @@
+import { schemas } from '@polar-sh/client'
 import {
   Select,
   SelectContent,
@@ -11,7 +12,7 @@ import React from 'react'
 import { subscriptionStatusDisplayNames } from './utils'
 
 interface SubscriptionStatusSelectProps {
-  statuses: ('active' | 'canceled')[]
+  statuses: schemas['SubscriptionStatus'][]
   value: string
   onChange: (value: string) => void
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -35674,7 +35674,10 @@ export interface operations {
         external_customer_id?: string | string[] | null
         /** @description Filter by discount ID. */
         discount_id?: string | string[] | null
-        /** @description Filter by active or inactive subscription. */
+        /**
+         * @deprecated
+         * @description Filter by active or inactive subscription.
+         */
         active?: boolean | null
         /** @description Filter by subscription status. */
         status?:

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -35676,6 +35676,11 @@ export interface operations {
         discount_id?: string | string[] | null
         /** @description Filter by active or inactive subscription. */
         active?: boolean | null
+        /** @description Filter by subscription status. */
+        status?:
+          | components['schemas']['SubscriptionStatus']
+          | components['schemas']['SubscriptionStatus'][]
+          | null
         /** @description Filter by subscriptions that are set to cancel at period end. */
         cancel_at_period_end?: boolean | null
         /** @description Filter by customer cancellation reason. */

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -83,7 +83,9 @@ async def list(
         None, title="DiscountID Filter", description="Filter by discount ID."
     ),
     active: bool | None = Query(
-        None, description="Filter by active or inactive subscription."
+        None,
+        description="Filter by active or inactive subscription.",
+        deprecated=True,
     ),
     status: MultipleQueryFilter[SubscriptionStatus] | None = Query(
         None, title="Status Filter", description="Filter by subscription status."

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -14,7 +14,7 @@ from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParams, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.models import Subscription
-from polar.models.subscription import CustomerCancellationReason
+from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.openapi import APITag
 from polar.order.service import PaymentFailed
 from polar.organization.schemas import OrganizationID
@@ -85,6 +85,9 @@ async def list(
     active: bool | None = Query(
         None, description="Filter by active or inactive subscription."
     ),
+    status: MultipleQueryFilter[SubscriptionStatus] | None = Query(
+        None, title="Status Filter", description="Filter by subscription status."
+    ),
     cancel_at_period_end: bool | None = Query(
         None,
         description="Filter by subscriptions that are set to cancel at period end.",
@@ -115,6 +118,7 @@ async def list(
         external_customer_id=external_customer_id,
         discount_id=discount_id,
         active=active,
+        status=status,
         cancel_at_period_end=cancel_at_period_end,
         customer_cancellation_reason=customer_cancellation_reason,
         canceled_at_after=canceled_at_after,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -317,6 +317,7 @@ class SubscriptionService:
         external_customer_id: Sequence[str] | None = None,
         discount_id: Sequence[uuid.UUID] | None = None,
         active: bool | None = None,
+        status: Sequence[SubscriptionStatus] | None = None,
         cancel_at_period_end: bool | None = None,
         customer_cancellation_reason: Sequence[CustomerCancellationReason]
         | None = None,
@@ -359,6 +360,9 @@ class SubscriptionService:
                 statement = statement.where(Subscription.active.is_(True))
             else:
                 statement = statement.where(Subscription.revoked.is_(True))
+
+        if status is not None:
+            statement = statement.where(Subscription.status.in_(status))
 
         if cancel_at_period_end is not None:
             statement = statement.where(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a `status` filter to the subscriptions API and wire it up in the dashboard. Users can filter by status (active, trialing, past_due, canceled, unpaid); the old `active` flag is still accepted but deprecated.

- **New Features**
  - API: `GET /subscriptions` accepts `status` (single or array of `SubscriptionStatus`) and filters with `Subscription.status IN (...)`; `active` is kept for backward compatibility but marked deprecated.
  - Client: `@polar-sh/client` adds `status` to the subscriptions list operation typing and deprecates `active`.
  - Web: Dashboard sends `status` when selected and the status dropdown now includes all statuses.

<sup>Written for commit 99341343f14a0aa5f2de57fc1b37c94cf2ddbe45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



