### PR TITLE
meters: Get distinct customers from Tinybird events

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -9,25 +9,18 @@ from sqlalchemy import (
 from sqlalchemy import (
     ColumnElement,
     ColumnExpressionArgument,
-    Numeric,
     Select,
     String,
-    UnaryExpression,
     and_,
-    asc,
-    case,
     cast,
-    desc,
     func,
     literal,
-    literal_column,
     or_,
     select,
-    text,
     update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
-from sqlalchemy.orm import aliased, joinedload
+from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import RepositoryBase, RepositoryIDMixin
@@ -38,7 +31,6 @@ from polar.models import (
     BillingEntry,
     Customer,
     Event,
-    EventType,
     Meter,
 )
 from polar.models.event import EventSource
@@ -56,19 +48,12 @@ _MAX_RESOLVE_DEPTH = 100
 class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
     model = Event
 
-    # Note: this method is deprecated. Typically when you get_all you want to use
-    # Tinybird instead of postgres.
-    async def get_all_by_name(self, name: str) -> Sequence[Event]:
-        statement = self.get_base_statement().where(Event.name == name)
-        return await self.get_all(statement)
-
-    # Note: this method is deprecated. Typically when you get_all you want to use
-    # Tinybird instead of postgres.
-    async def get_all_by_organization(self, organization_id: UUID) -> Sequence[Event]:
-        statement = self.get_base_statement().where(
-            Event.organization_id == organization_id
-        )
-        return await self.get_all(statement)
+    def get_statement_by_org_ids(
+        self, org_ids: set[AccessibleOrganizationID]
+    ) -> Select[tuple[Event]]:
+        statement = self.get_base_statement()
+        statement = statement.where(Event.organization_id.in_(org_ids))
+        return statement
 
     async def get_recent_balance_order_exchange_rate(
         self,
@@ -293,28 +278,6 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         )
         return await self.get_one_or_none(statement)
 
-    def get_event_names_statement(
-        self, org_ids: set[AccessibleOrganizationID]
-    ) -> Select[tuple[str, EventSource, int, datetime, datetime]]:
-        return (
-            self.get_statement_by_org_ids(org_ids)
-            .with_only_columns(
-                Event.name,
-                Event.source,
-                func.count(Event.id).label("occurrences"),
-                func.min(Event.timestamp).label("first_seen"),
-                func.max(Event.timestamp).label("last_seen"),
-            )
-            .group_by(Event.name, Event.source)
-        )
-
-    def get_statement_by_org_ids(
-        self, org_ids: set[AccessibleOrganizationID]
-    ) -> Select[tuple[Event]]:
-        statement = self.get_base_statement()
-        statement = statement.where(Event.organization_id.in_(org_ids))
-        return statement
-
     def get_customer_id_filter_clause(
         self, customer_id: Sequence[UUID]
     ) -> ColumnElement[bool]:
@@ -456,333 +419,6 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         return {
             row.event_id: [str(aid) for aid in row.ancestors] for row in result.all()
         }
-
-    async def get_hierarchy_stats(
-        self,
-        statement: Select[tuple[Event]],
-        aggregate_fields: Sequence[str] = ("cost.amount",),
-        sorting: Sequence[tuple[str, bool]] = (("total", True),),
-        timestamp_series: Any = None,
-        interval: TimeInterval | None = None,
-        timezone: str | None = None,
-    ) -> Sequence[dict[str, Any]]:
-        """
-        Get aggregate statistics grouped by root event name across all hierarchies.
-
-        Uses root_id for efficient rollup and joins with event_types for labels:
-        1. Filter root events based on statement
-        2. Roll up costs from all events in each hierarchy (via root_id)
-        3. Calculate avg, p10, p90, p99 on those rolled-up totals across root events with same name
-        4. Join with event_types to include labels
-
-        Args:
-            statement: Base query for root events to include
-            aggregate_fields: List of user_metadata field paths to aggregate
-            sorting: List of (property, is_desc) tuples for sorting
-            timestamp_series: Optional CTE for time bucketing. If provided, stats are grouped by timestamp.
-            interval: Time interval for bucketing (required when timestamp_series is provided)
-            timezone: Timezone for date_trunc (required when timestamp_series is provided)
-
-        Returns:
-            List of dicts containing name, label, occurrences, and statistics for each field.
-            If timestamp_series is provided, also includes timestamp for each row.
-        """
-        root_events_subquery = (
-            statement.where(
-                and_(Event.parent_id.is_(None), Event.source == EventSource.user)
-            )
-            .order_by(None)
-            .subquery()
-        )
-
-        all_events = aliased(Event, name="all_events")
-        customer = aliased(Customer, name="customer")
-
-        bucket_expr: ColumnElement[datetime] | None = None
-        if (
-            timestamp_series is not None
-            and interval is not None
-            and timezone is not None
-        ):
-            bucket_expr = func.date_trunc(
-                interval.value,
-                literal_column("root_event.timestamp"),
-                literal_column(f"'{timezone}'"),
-            )
-
-        per_root_select_exprs: list[ColumnElement[Any]] = [
-            literal_column("root_event.id").label("root_id"),
-            literal_column("root_event.name").label("root_name"),
-            literal_column("root_event.organization_id").label("root_org_id"),
-            customer.id.label("customer_id"),
-            literal_column("root_event.external_customer_id").label(
-                "external_customer_id"
-            ),
-        ]
-
-        if bucket_expr is not None:
-            per_root_select_exprs.append(bucket_expr.label("bucket"))
-
-        for field_path in aggregate_fields:
-            field_parts = field_path.split(".")
-            pg_path = "{" + ",".join(field_parts) + "}"
-            safe_field_name = field_path.replace(".", "_")
-
-            field_expr = cast(
-                all_events.user_metadata.op("#>>")(literal_column(f"'{pg_path}'")),
-                Numeric,
-            )
-
-            sum_expr = func.sum(field_expr).label(f"{safe_field_name}_total")
-            per_root_select_exprs.append(sum_expr)
-
-        group_by_exprs: list[ColumnElement[Any]] = [
-            literal_column("root_event.id"),
-            literal_column("root_event.name"),
-            literal_column("root_event.organization_id"),
-            literal_column("customer.id"),
-            literal_column("root_event.external_customer_id"),
-        ]
-        if bucket_expr is not None:
-            group_by_exprs.append(bucket_expr)
-
-        per_root_query = (
-            select(*per_root_select_exprs)
-            .select_from(root_events_subquery.alias("root_event"))
-            .join(all_events, all_events.root_id == literal_column("root_event.id"))
-            .outerjoin(
-                customer,
-                or_(
-                    customer.id == literal_column("root_event.customer_id"),
-                    and_(
-                        customer.external_id
-                        == literal_column("root_event.external_customer_id"),
-                        customer.organization_id
-                        == literal_column("root_event.organization_id"),
-                    ),
-                ),
-            )
-            .group_by(*group_by_exprs)
-        )
-
-        per_root_subquery = per_root_query.subquery("per_root_totals")
-
-        event_type = aliased(EventType, name="event_type")
-
-        if timestamp_series is not None:
-            timestamp_column: ColumnElement[datetime] = timestamp_series.c.timestamp
-
-            aggregation_exprs = []
-            for field_path in aggregate_fields:
-                safe_field_name = field_path.replace(".", "_")
-                total_col: ColumnElement[Any] = getattr(
-                    per_root_subquery.c, f"{safe_field_name}_total"
-                )
-
-                aggregation_exprs.extend(
-                    [
-                        func.sum(total_col).label(f"{safe_field_name}_sum"),
-                        func.avg(func.coalesce(total_col, 0)).label(
-                            f"{safe_field_name}_avg"
-                        ),
-                        func.percentile_cont(0.10)
-                        .within_group(func.coalesce(total_col, 0))
-                        .label(f"{safe_field_name}_p10"),
-                        func.percentile_cont(0.90)
-                        .within_group(func.coalesce(total_col, 0))
-                        .label(f"{safe_field_name}_p90"),
-                        func.percentile_cont(0.99)
-                        .within_group(func.coalesce(total_col, 0))
-                        .label(f"{safe_field_name}_p99"),
-                    ]
-                )
-
-            stats_query = (
-                select(
-                    timestamp_column.label("timestamp"),
-                    per_root_subquery.c.root_name.label("name"),
-                    event_type.id.label("event_type_id"),
-                    event_type.label.label("label"),
-                    func.count(
-                        getattr(
-                            per_root_subquery.c,
-                            f"{aggregate_fields[0].replace('.', '_')}_total",
-                        )
-                    ).label("occurrences"),
-                    (
-                        func.count(per_root_subquery.c.customer_id.distinct())
-                        + func.count(
-                            case(
-                                (
-                                    per_root_subquery.c.customer_id.is_(None),
-                                    per_root_subquery.c.external_customer_id,
-                                )
-                            ).distinct()
-                        )
-                    ).label("customers"),
-                    *aggregation_exprs,
-                )
-                .select_from(
-                    timestamp_series.outerjoin(
-                        per_root_subquery,
-                        per_root_subquery.c.bucket == timestamp_column,
-                    )
-                )
-                .outerjoin(
-                    event_type,
-                    and_(
-                        event_type.name == per_root_subquery.c.root_name,
-                        event_type.organization_id == per_root_subquery.c.root_org_id,
-                    ),
-                )
-                .group_by(
-                    timestamp_column,
-                    per_root_subquery.c.root_name,
-                    event_type.id,
-                    event_type.label,
-                )
-            )
-        else:
-            aggregation_exprs = []
-            for field_path in aggregate_fields:
-                safe_field_name = field_path.replace(".", "_")
-                total_col_ref: ColumnElement[Any] = literal_column(
-                    f"{safe_field_name}_total"
-                )
-
-                aggregation_exprs.extend(
-                    [
-                        func.sum(total_col_ref).label(f"{safe_field_name}_sum"),
-                        func.avg(func.coalesce(total_col_ref, 0)).label(
-                            f"{safe_field_name}_avg"
-                        ),
-                        func.percentile_cont(0.10)
-                        .within_group(func.coalesce(total_col_ref, 0))
-                        .label(f"{safe_field_name}_p10"),
-                        func.percentile_cont(0.90)
-                        .within_group(func.coalesce(total_col_ref, 0))
-                        .label(f"{safe_field_name}_p90"),
-                        func.percentile_cont(0.99)
-                        .within_group(func.coalesce(total_col_ref, 0))
-                        .label(f"{safe_field_name}_p99"),
-                    ]
-                )
-
-            stats_query = (
-                select(
-                    per_root_subquery.c.root_name.label("name"),
-                    event_type.id.label("event_type_id"),
-                    event_type.label.label("label"),
-                    func.count(per_root_subquery.c.root_id).label("occurrences"),
-                    (
-                        func.count(per_root_subquery.c.customer_id.distinct())
-                        + func.count(
-                            case(
-                                (
-                                    per_root_subquery.c.customer_id.is_(None),
-                                    per_root_subquery.c.external_customer_id,
-                                )
-                            ).distinct()
-                        )
-                    ).label("customers"),
-                    *aggregation_exprs,
-                )
-                .select_from(per_root_subquery)
-                .outerjoin(
-                    event_type,
-                    and_(
-                        event_type.name == per_root_subquery.c.root_name,
-                        event_type.organization_id == per_root_subquery.c.root_org_id,
-                    ),
-                )
-                .group_by(
-                    per_root_subquery.c.root_name, event_type.id, event_type.label
-                )
-            )
-
-        order_by_clauses: list[UnaryExpression[Any]] = []
-
-        if timestamp_series is not None:
-            order_by_clauses.append(asc(text("timestamp")))
-
-        for criterion, is_desc_sort in sorting:
-            clause_function = desc if is_desc_sort else asc
-            if criterion == "name":
-                order_by_clauses.append(clause_function(text("name")))
-            elif criterion == "occurrences":
-                order_by_clauses.append(clause_function(text("occurrences")))
-            elif criterion in ("total", "average", "p10", "p90", "p99"):
-                if aggregate_fields:
-                    safe_field_name = aggregate_fields[0].replace(".", "_")
-                    suffix_map = {
-                        "total": "sum",
-                        "average": "avg",
-                        "p10": "p10",
-                        "p90": "p90",
-                        "p99": "p99",
-                    }
-                    suffix = suffix_map[criterion]
-                    order_by_clauses.append(
-                        clause_function(text(f"{safe_field_name}_{suffix}"))
-                    )
-
-        if order_by_clauses:
-            stats_query = stats_query.order_by(*order_by_clauses)
-
-        result = await self.session.execute(stats_query)
-        rows = result.all()
-
-        result_list = []
-        for row in rows:
-            row_dict = {
-                "name": row.name,
-                "label": row.label,
-                "event_type_id": row.event_type_id,
-                "occurrences": row.occurrences,
-                "customers": row.customers,
-                "totals": {
-                    field.replace(".", "_"): getattr(
-                        row, f"{field.replace('.', '_')}_sum"
-                    )
-                    or 0
-                    for field in aggregate_fields
-                },
-                "averages": {
-                    field.replace(".", "_"): getattr(
-                        row, f"{field.replace('.', '_')}_avg"
-                    )
-                    or 0
-                    for field in aggregate_fields
-                },
-                "p10": {
-                    field.replace(".", "_"): getattr(
-                        row, f"{field.replace('.', '_')}_p10"
-                    )
-                    or 0
-                    for field in aggregate_fields
-                },
-                "p90": {
-                    field.replace(".", "_"): getattr(
-                        row, f"{field.replace('.', '_')}_p90"
-                    )
-                    or 0
-                    for field in aggregate_fields
-                },
-                "p99": {
-                    field.replace(".", "_"): getattr(
-                        row, f"{field.replace('.', '_')}_p99"
-                    )
-                    or 0
-                    for field in aggregate_fields
-                },
-            }
-
-            if timestamp_series is not None:
-                row_dict["timestamp"] = row.timestamp
-
-            result_list.append(row_dict)
-
-        return result_list
 
     async def get_timestamp_series(
         self,

--- a/server/polar/event/tinybird_repository.py
+++ b/server/polar/event/tinybird_repository.py
@@ -13,6 +13,7 @@ from polar.integrations.tinybird.service import (
 )
 from polar.kit.metadata import MetadataQuery
 from polar.meter.filter import Filter
+from polar.models import Meter
 from polar.models.event import EventSource
 
 type EventNameStats = tuple[str, EventSource, int, datetime, datetime]
@@ -175,6 +176,19 @@ class TinybirdEventRepository:
             event_id=event_id,
         )
         return count > 0
+
+    async def get_meter_customer_ids(
+        self, meter: Meter
+    ) -> tuple[list[UUID], list[str]]:
+        tinybird_query = TinybirdEventsQuery((meter.organization_id,))
+        tinybird_query.filter_by_filter(meter.filter)
+        tinybird_query.filter_by_aggregation(meter.aggregation)
+
+        (
+            customer_ids,
+            external_customer_ids,
+        ) = await tinybird_query.get_distinct_customer_ids()
+        return [UUID(c) for c in customer_ids], external_customer_ids
 
     async def get_descendant_aggregates(
         self,

--- a/server/polar/integrations/tinybird/service.py
+++ b/server/polar/integrations/tinybird/service.py
@@ -33,6 +33,7 @@ from sqlalchemy.sql.util import ClauseAdapter
 from polar.event.repository import EventRepository
 from polar.kit.db.postgres import AsyncReadSession
 from polar.logging import Logger
+from polar.meter.aggregation import Aggregation, PropertyAggregation
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
 from polar.models import Event
 from polar.models.event import EventSource
@@ -480,6 +481,16 @@ class TinybirdEventsQuery:
         self._filters.append(self._translate_filter(f))
         return self
 
+    def filter_by_aggregation(self, aggregation: Aggregation) -> Self:
+        if not isinstance(aggregation, PropertyAggregation):
+            return self
+        if aggregation.property in Event._filterable_fields:
+            allowed_type, _ = Event._filterable_fields[aggregation.property]
+            if allowed_type is not int:
+                self._filters.append(false())
+            return self
+        return self.filter_numeric_metadata_property(aggregation.property)
+
     def filter_by_metadata(self, query: dict[str, list[str]]) -> Self:
         for key, values in query.items():
             col = DENORMALIZED_COLUMNS.get(key)
@@ -694,6 +705,34 @@ class TinybirdEventsQuery:
         event_ids = [str(row["id"]) for row in id_rows]
 
         return event_ids, total
+
+    async def get_distinct_customer_ids(self) -> tuple[list[str], list[str]]:
+        base_filter = self._get_organization_filter()
+
+        customer_statement = (
+            sqlalchemy.select(events_table.c.customer_id)
+            .distinct()
+            .where(base_filter, events_table.c.customer_id.is_not(None))
+        )
+        external_statement = (
+            sqlalchemy.select(events_table.c.external_customer_id)
+            .distinct()
+            .where(base_filter, events_table.c.external_customer_id.is_not(None))
+        )
+        for f in self._filters:
+            customer_statement = customer_statement.where(f)
+            external_statement = external_statement.where(f)
+
+        customer_sql, customer_template = _compile(customer_statement)
+        external_sql, external_template = _compile(external_statement)
+
+        customer_rows = await client.query(customer_sql, db_statement=customer_template)
+        external_rows = await client.query(external_sql, db_statement=external_template)
+
+        return (
+            [str(row["customer_id"]) for row in customer_rows],
+            [str(row["external_customer_id"]) for row in external_rows],
+        )
 
     @staticmethod
     def _get_agg_col_for_table(table: Any, field_path: str) -> Any:

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -32,6 +32,7 @@ from polar.billing_entry.repository import BillingEntryRepository
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
 from polar.event.repository import EventRepository
+from polar.event.tinybird_repository import TinybirdEventRepository
 from polar.exceptions import PolarRequestValidationError, ValidationError
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause, get_metadata_clause
 from polar.kit.pagination import PaginationParams
@@ -280,26 +281,13 @@ class MeterService:
         repository = MeterRepository.from_session(session)
         meter = await repository.update(meter, update_dict={"archived_at": None})
 
-        event_repository = EventRepository.from_session(session)
+        tinybird_repository = TinybirdEventRepository()
         customer_repository = CustomerRepository.from_session(session)
 
-        # Find customers by customer_id on matching events
-        customer_ids_statement = (
-            event_repository.get_meter_statement(meter)
-            .with_only_columns(Event.customer_id)
-            .where(Event.customer_id.is_not(None))
-            .distinct()
-        )
-        customer_ids = list(await session.scalars(customer_ids_statement))
-
-        # Find customers by external_customer_id on matching events
-        external_ids_statement = (
-            event_repository.get_meter_statement(meter)
-            .with_only_columns(Event.external_customer_id)
-            .where(Event.external_customer_id.is_not(None))
-            .distinct()
-        )
-        external_customer_ids = list(await session.scalars(external_ids_statement))
+        (
+            customer_ids,
+            external_customer_ids,
+        ) = await tinybird_repository.get_meter_customer_ids(meter)
 
         # Get all affected customers and touch their meters
         clauses = []

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -317,21 +317,6 @@ class MeterService:
 
         return meter
 
-    async def events(
-        self,
-        session: AsyncSession,
-        meter: Meter,
-        *,
-        pagination: PaginationParams,
-    ) -> tuple[Sequence[Event], int]:
-        repository = EventRepository.from_session(session)
-        statement = repository.get_meter_statement(meter).order_by(
-            Event.timestamp.desc()
-        )
-        return await repository.paginate(
-            statement, limit=pagination.limit, page=pagination.page
-        )
-
     async def get_quantities(
         self,
         session: AsyncReadSession,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -43,7 +43,6 @@ from polar.enums import (
     TaxBehavior,
     TaxProcessor,
 )
-from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
 from polar.exceptions import NotPermitted, PaymentNotReady, PolarRequestValidationError
 from polar.integrations.stripe.service import StripeService
@@ -101,6 +100,7 @@ from polar.tax.tax_id import TaxIDFormat
 from polar.trial_redemption.repository import TrialRedemptionRepository
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_checkout,
@@ -6415,8 +6415,7 @@ class TestCheckoutCreatedEvent:
             auth_subject,
         )
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.checkout_created)
+        events = await get_all_by_name(session, SystemEvent.checkout_created)
 
         assert len(events) == 1
         event = events[0]

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -48,6 +48,7 @@ from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name, get_all_by_organization
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_checkout,
@@ -568,8 +569,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_organization(organization.id)
+        events = await get_all_by_organization(session, organization.id)
         assert len(events) == count
 
         for event in events:
@@ -599,8 +599,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == count
 
         for event in events:
@@ -640,8 +639,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 1
 
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
@@ -652,7 +650,6 @@ class TestIngest:
         auth_subject: AuthSubject[Organization],
     ) -> None:
         event_type_repository = EventTypeRepository.from_session(session)
-        event_repository = EventRepository.from_session(session)
 
         ingest_first = EventsIngest(
             events=[
@@ -672,7 +669,7 @@ class TestIngest:
         assert event_type.name == "api.request"
         assert event_type.label == "api.request"
 
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 1
         assert events[0].event_type_id == event_type.id
 
@@ -687,7 +684,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest_second)
 
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 2
         assert events[0].event_type_id == event_type.id
         assert events[1].event_type_id == event_type.id
@@ -706,8 +703,6 @@ class TestIngest:
         session: AsyncSession,
         auth_subject: AuthSubject[Organization],
     ) -> None:
-        event_repository = EventRepository.from_session(session)
-
         ingest = EventsIngest(
             events=[
                 EventCreateExternalCustomer(
@@ -731,7 +726,7 @@ class TestIngest:
         await event_service.ingest(session, auth_subject, ingest)
         await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 3
 
         parent = next(e for e in events if e.name == "support_request")
@@ -765,8 +760,6 @@ class TestIngest:
         session: AsyncSession,
         auth_subject: AuthSubject[Organization],
     ) -> None:
-        event_repository = EventRepository.from_session(session)
-
         child_ingest = EventsIngest(
             events=[
                 EventCreateExternalCustomer(
@@ -779,7 +772,7 @@ class TestIngest:
         await event_service.ingest(session, auth_subject, child_ingest)
         await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 1
         child = events[0]
         assert child.parent_id is None
@@ -798,7 +791,7 @@ class TestIngest:
         await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
         await session.refresh(child)
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         parent = next(e for e in events if e.name == "support_request")
 
         assert child.parent_id == parent.id
@@ -828,8 +821,6 @@ class TestIngest:
         session: AsyncSession,
         auth_subject: AuthSubject[Organization],
     ) -> None:
-        event_repository = EventRepository.from_session(session)
-
         for name, external_id, parent_id in [
             ("ggc", "ggc-id", "gc-id"),
             ("gc", "gc-id", "c-id"),
@@ -853,7 +844,7 @@ class TestIngest:
                 session, list(enqueue_events_mock.call_args[0])
             )
 
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 3
         by_name = {e.name: e for e in events}
         # ggc and gc are linked to their parent rows as those rows now exist,
@@ -884,7 +875,7 @@ class TestIngest:
         )
         await event_service.ingested(session, list(enqueue_events_mock.call_args[0]))
 
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         by_name = {e.name: e for e in events}
         p = by_name["p"]
         c = by_name["c"]
@@ -955,8 +946,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 1
         assert events[0].member_id == member.id
         assert events[0].customer_id == customer.id
@@ -1033,8 +1023,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 1
         assert events[0].external_member_id == "member-abc"
         assert events[0].external_customer_id == "test-customer"
@@ -1057,8 +1046,7 @@ class TestIngest:
 
         await event_service.ingest(session, auth_subject, ingest)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_organization(auth_subject.subject.id)
+        events = await get_all_by_organization(session, auth_subject.subject.id)
         assert len(events) == 1
         assert events[0].member_id is None
         assert events[0].external_member_id is None
@@ -1892,8 +1880,7 @@ class TestSystemEvents:
 
         await order_service.handle_payment(session, order, payment)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.order_paid)
+        events = await get_all_by_name(session, SystemEvent.order_paid)
         assert len(events) == 1
         event = events[0]
 
@@ -1944,8 +1931,7 @@ class TestSystemEvents:
 
         await order_service.handle_payment(session, order, payment)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.order_paid)
+        events = await get_all_by_name(session, SystemEvent.order_paid)
         assert len(events) == 1
         event = events[0]
 
@@ -1985,8 +1971,7 @@ class TestSystemEvents:
 
         await order_service.handle_payment(session, order, payment)
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.order_paid)
+        events = await get_all_by_name(session, SystemEvent.order_paid)
         assert len(events) == 1
         event = events[0]
 
@@ -2011,10 +1996,7 @@ class TestSystemEvents:
             session, checkout
         )
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_created
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_created)
         assert len(events) == 1
         event = events[0]
 
@@ -2052,10 +2034,7 @@ class TestSystemEvents:
                 customer_comment="Too pricey for me",
             )
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_canceled
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_canceled)
         assert len(events) == 1
         event = events[0]
 

--- a/server/tests/fixtures/events.py
+++ b/server/tests/fixtures/events.py
@@ -1,0 +1,23 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from polar.authz.types import AccessibleOrganizationID
+from polar.event.repository import EventRepository
+from polar.models import Event
+from polar.postgres import AsyncSession
+
+
+async def get_all_by_name(session: AsyncSession, name: str) -> Sequence[Event]:
+    repository = EventRepository.from_session(session)
+    statement = repository.get_base_statement().where(Event.name == name)
+    return await repository.get_all(statement)
+
+
+async def get_all_by_organization(
+    session: AsyncSession, organization_id: UUID
+) -> Sequence[Event]:
+    repository = EventRepository.from_session(session)
+    statement = repository.get_statement_by_org_ids(
+        {AccessibleOrganizationID(organization_id)}
+    )
+    return await repository.get_all(statement)

--- a/server/tests/meter/conftest.py
+++ b/server/tests/meter/conftest.py
@@ -1,0 +1,61 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+import pytest_asyncio
+
+from polar.integrations.tinybird.client import TinybirdClient
+from polar.integrations.tinybird.schemas import TinybirdEvent
+from polar.integrations.tinybird.service import DATASOURCE_EVENTS, _event_to_tinybird
+from polar.kit.db.models import Model
+from polar.models import Event
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture, save_fixture_factory
+
+
+@dataclass
+class TinybirdEventBuffer:
+    events: list[TinybirdEvent] = field(default_factory=list)
+
+
+@pytest_asyncio.fixture
+async def tinybird_event_buffer() -> TinybirdEventBuffer:
+    return TinybirdEventBuffer()
+
+
+@pytest_asyncio.fixture
+async def buffered_save_fixture(
+    session: AsyncSession,
+    tinybird_event_buffer: TinybirdEventBuffer,
+) -> SaveFixture:
+    original = save_fixture_factory(session)
+
+    async def _save_and_buffer(model: Model) -> None:
+        await original(model)
+        if isinstance(model, Event):
+            ancestors: list[str] = []
+            if model.parent_id is not None:
+                ancestors.append(str(model.parent_id))
+                if model.root_id and model.root_id != model.parent_id:
+                    ancestors.append(str(model.root_id))
+            tinybird_event_buffer.events.append(_event_to_tinybird(model, ancestors))
+
+    return _save_and_buffer
+
+
+@pytest_asyncio.fixture
+async def flush_tinybird_events(
+    tinybird_client: TinybirdClient,
+    tinybird_event_buffer: TinybirdEventBuffer,
+) -> Callable[[], Awaitable[None]]:
+    async def _flush() -> None:
+        if not tinybird_event_buffer.events:
+            return
+
+        await tinybird_client.ingest(
+            DATASOURCE_EVENTS,
+            tinybird_event_buffer.events,
+            wait=True,
+        )
+        tinybird_event_buffer.events.clear()
+
+    return _flush

--- a/server/tests/meter/test_archive.py
+++ b/server/tests/meter/test_archive.py
@@ -1,3 +1,4 @@
+from collections.abc import Awaitable, Callable
 from decimal import Decimal
 from unittest.mock import MagicMock
 
@@ -8,6 +9,7 @@ from pytest_mock.plugin import MockerFixture
 from polar.auth.models import AuthSubject
 from polar.enums import SubscriptionRecurringInterval
 from polar.exceptions import PolarRequestValidationError
+from polar.integrations.tinybird.client import TinybirdClient
 from polar.meter.service import meter as meter_service
 from polar.models import Benefit, Customer, Meter, Organization, Product, Subscription
 from polar.models.benefit import BenefitType
@@ -126,6 +128,7 @@ class TestMeterArchive:
     async def test_unarchive_success(
         self,
         save_fixture: SaveFixture,
+        tinybird_client: TinybirdClient,
         session: AsyncSession,
         meter: Meter,
         organization: Organization,
@@ -144,6 +147,8 @@ class TestMeterArchive:
     async def test_unarchive_queues_customer_meter_updates(
         self,
         save_fixture: SaveFixture,
+        buffered_save_fixture: SaveFixture,
+        flush_tinybird_events: Callable[[], Awaitable[None]],
         enqueue_job_mock: MagicMock,
         session: AsyncSession,
         meter: Meter,
@@ -160,17 +165,19 @@ class TestMeterArchive:
         # Create an event that matches the meter for this customer
         # (default name="TEST_EVENT" matches the default meter filter)
         await create_event(
-            save_fixture,
+            buffered_save_fixture,
             organization=organization,
             customer=customer,
         )
 
         # Create an event for the deleted customer that matches the meter - should be ignored
         await create_event(
-            save_fixture,
+            buffered_save_fixture,
             organization=organization,
             customer=deleted_customer,
         )
+
+        await flush_tinybird_events()
 
         # First archive the meter
         await meter_service.archive(session, meter)
@@ -188,6 +195,7 @@ class TestMeterArchive:
         self,
         enqueue_job_mock: MagicMock,
         save_fixture: SaveFixture,
+        tinybird_client: TinybirdClient,
         session: AsyncSession,
         meter: Meter,
         customer: Customer,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -25,7 +25,6 @@ from polar.enums import (
     TaxBehaviorOption,
     TaxProcessor,
 )
-from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
 from polar.exceptions import PolarRequestValidationError
 from polar.integrations.stripe.service import StripeService
@@ -108,6 +107,7 @@ from polar.transaction.service.platform_fee import PlatformFeeTransactionService
 from polar.wallet.service import wallet as wallet_service
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_billing_entry,
@@ -5001,8 +5001,7 @@ class TestVoidOrder:
         assert result_order.status == OrderStatus.void
         assert result_order.id == order.id
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.order_voided)
+        events = await get_all_by_name(session, SystemEvent.order_voided)
         assert len(events) == 1
         assert events[0].user_metadata["order_id"] == str(order.id)
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -97,6 +97,7 @@ from polar.subscription.service import subscription as subscription_service
 from polar.subscription.update import generate_subscription_update
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_canceled_subscription,
@@ -987,8 +988,7 @@ class TestCycle:
         assert updated_subscription.current_period_end > previous_current_period_end
         assert updated_subscription.scheduler_locked_at is None
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.subscription_cycled)
+        events = await get_all_by_name(session, SystemEvent.subscription_cycled)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -1283,10 +1283,7 @@ class TestCycle:
         assert updated_subscription.current_period_end == previous_current_period_end
         assert updated_subscription.scheduler_locked_at is None
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_revoked
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_revoked)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -3604,10 +3601,7 @@ class TestUpdateProduct:
         price = updated_subscription.prices[0]
         assert price.price_currency == "usd"
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -3742,10 +3736,7 @@ class TestUpdateProduct:
 
         assert updated_subscription.product == product_recurring_multiple_currencies
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -3806,10 +3797,7 @@ class TestUpdateProduct:
 
         assert updated_subscription.product == product_recurring_multiple_currencies
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -3916,10 +3904,7 @@ class TestUpdateProduct:
 
         assert updated_subscription.product == product_recurring_multiple_currencies
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -4283,10 +4268,7 @@ class TestUpdateDiscount:
 
         assert subscription.discount is None
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -4315,10 +4297,7 @@ class TestUpdateDiscount:
 
         assert subscription.discount == discount_percentage_50
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -4351,10 +4330,7 @@ class TestUpdateDiscount:
 
         assert subscription.discount == discount_percentage_100
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -4427,10 +4403,7 @@ class TestUpdateTrial:
         # Verify that the webhook was triggered
         assert_hooks_called_once(subscription_hooks, {"updated"})
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -4494,10 +4467,7 @@ class TestUpdateTrial:
         assert updated_subscription.current_period_end == trial_end
         assert updated_subscription.trialing
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -5205,10 +5175,7 @@ class TestUpdateSeats:
         )
         assert subscription_update is None
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 0
 
     @pytest.mark.parametrize(
@@ -5528,10 +5495,7 @@ class TestUpdateSeats:
         for call_args in enqueue_job_mock.call_args_list:
             assert call_args[0][0] != "order.create_subscription_order"
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -5584,10 +5548,7 @@ class TestUpdateSeats:
         await session.flush()
 
         # Then: subscription.updated event emitted with invoice proration behavior
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)
@@ -6782,10 +6743,7 @@ class TestUpdateBillingPeriod:
         assert updated_subscription.current_period_end == new_period_end
         assert updated_subscription.anchor_day == new_period_end.day
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.subscription_updated
-        )
+        events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 1
         event = events[0]
         assert event.user_metadata["subscription_id"] == str(subscription.id)

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -13,7 +13,6 @@ from pytest_mock import MockerFixture
 
 from polar.billing_entry.repository import BillingEntryRepository
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
-from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
 from polar.models import (
     BillingEntry,
@@ -39,6 +38,7 @@ from polar.subscription.repository import SubscriptionUpdateRepository
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_discount,
@@ -94,10 +94,7 @@ async def assert_system_events(
     customer: Customer,
     num_events_expected: int,
 ) -> list[Event]:
-    event_repository = EventRepository.from_session(session)
-    events = await event_repository.get_all_by_name(
-        SystemEvent.subscription_product_updated
-    )
+    events = await get_all_by_name(session, SystemEvent.subscription_product_updated)
     assert len(events) == num_events_expected
 
     events = sorted(events, key=lambda e: e.ingested_at)
@@ -397,9 +394,8 @@ class TestUpdateProductProrations:
                         == time_of_update + relativedelta(years=1)
                     )
 
-            event_repository = EventRepository.from_session(session)
-            events = await event_repository.get_all_by_name(
-                SystemEvent.subscription_product_updated
+            events = await get_all_by_name(
+                session, SystemEvent.subscription_product_updated
             )
             assert len(events) == 1
             event = events[0]
@@ -901,9 +897,8 @@ class TestUpdateProductProrations:
             assert subscriptions[2].product_id           == products[2].id
             # fmt: on
 
-            event_repository = EventRepository.from_session(session)
-            events = await event_repository.get_all_by_name(
-                SystemEvent.subscription_product_updated
+            events = await get_all_by_name(
+                session, SystemEvent.subscription_product_updated
             )
             assert len(events) == 1
             event = events[0]

--- a/server/tests/transaction/service/test_refund.py
+++ b/server/tests/transaction/service/test_refund.py
@@ -4,7 +4,6 @@ import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import joinedload
 
-from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
 from polar.integrations.stripe.service import StripeService
 from polar.models import (
@@ -37,6 +36,7 @@ from polar.transaction.service.refund import (
     refund_transaction as refund_transaction_service,
 )
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import create_order, create_payment, create_refund
 from tests.fixtures.stripe import (
     build_stripe_balance_transaction,
@@ -293,8 +293,7 @@ class TestCreate:
 
         assert refund_transaction.order_id == order.id
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(SystemEvent.balance_refund)
+        events = await get_all_by_name(session, SystemEvent.balance_refund)
         balance_refund_event = next(
             event
             for event in events
@@ -579,10 +578,7 @@ class TestRevert:
         assert refund_reversal_transaction.processor == Processor.stripe
         assert refund_reversal_transaction.amount == refund.amount
 
-        event_repository = EventRepository.from_session(session)
-        events = await event_repository.get_all_by_name(
-            SystemEvent.balance_refund_reversal
-        )
+        events = await get_all_by_name(session, SystemEvent.balance_refund_reversal)
         assert len(events) == 1
         assert events[0].user_metadata["transaction_id"] == str(
             refund_reversal_transaction.id


### PR DESCRIPTION
Instead of reading customer IDs + external IDs from the event repository, we read them from events in Tinybird. Used in meter_service.unarchive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch meter customer discovery from Postgres to Tinybird, using event data to find distinct `customer_id` and `external_customer_id`. Unarchive now touches only customers with matching Tinybird events and reduces DB reads.

- **Refactors**
  - Added Tinybird query `get_distinct_customer_ids` and `filter_by_aggregation` (ignores non-numeric fields; supports numeric metadata). New repository method `get_meter_customer_ids(meter)` returns UUID customer IDs and external IDs from Tinybird.
  - Updated meter unarchive to use Tinybird for customer lookup, applying the meter’s filter and aggregation rules.
  - Adjusted tests to buffer Tinybird events, call `flush_tinybird_events`, and use `tinybird_client` where needed.

<sup>Written for commit d5e29578ae5d00c906d1039d8b1dba4e4ff08e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

