### PR TITLE
Mark v1.ts as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+clients/packages/client/src/v1.ts linguist-generated=true


### PR DESCRIPTION
Our `v1.ts` diff is pretty distracting, this PR will mark it as `linguist-generated` meaning in PR diffs it will automatically collapse like this:

<img width="992" height="496" alt="A8Lqm" src="https://github.com/user-attachments/assets/123fe506-d805-4c3f-bd64-4356b2a0f586" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `clients/packages/client/src/v1.ts` as `linguist-generated` so GitHub auto-collapses its diff in PRs. This reduces noise and keeps reviews focused on real changes.

<sup>Written for commit 4ab9cddf1fa9952f66d6651ba3ad451ac6114bf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

