### PR TITLE
Refactor <Box /> to default to flexbox

### DIFF
--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -179,13 +179,13 @@ auto-resolves light vs dark.
 
 **Motion** — durations (`DurationToken`) and easings (`EasingToken`) for transitions:
 
-| Duration  | Value  | Easing       | Curve                            |
-| --------- | ------ | ------------ | -------------------------------- |
-| `instant` | 0ms    | `standard`   | general-purpose, symmetric       |
-| `fast`    | 120ms  | `decelerate` | enter (fast → settle)            |
-| `base`    | 200ms  | `accelerate` | exit (settle → fast)             |
-| `slow`    | 320ms  | `spring`     | slight overshoot                 |
-| `slower`  | 480ms  |              |                                  |
+| Duration  | Value | Easing       | Curve                      |
+| --------- | ----- | ------------ | -------------------------- |
+| `instant` | 0ms   | `standard`   | general-purpose, symmetric |
+| `fast`    | 120ms | `decelerate` | enter (fast → settle)      |
+| `base`    | 200ms | `accelerate` | exit (settle → fast)       |
+| `slow`    | 320ms | `spring`     | slight overshoot           |
+| `slower`  | 480ms |              |                            |
 
 Durations are CSS variables, so motion can be globally tuned (or zeroed for reduced
 motion). Easings are compile-time constants.

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -164,6 +164,19 @@ auto-resolves light vs dark.
 
 **Shadow** (`ShadowToken`): `none`, `s`, `m`, `l`, `xl`.
 
+**Motion** — durations (`DurationToken`) and easings (`EasingToken`) for transitions:
+
+| Duration  | Value  | Easing       | Curve                            |
+| --------- | ------ | ------------ | -------------------------------- |
+| `instant` | 0ms    | `standard`   | general-purpose, symmetric       |
+| `fast`    | 120ms  | `decelerate` | enter (fast → settle)            |
+| `base`    | 200ms  | `accelerate` | exit (settle → fast)             |
+| `slow`    | 320ms  | `spring`     | slight overshoot                 |
+| `slower`  | 480ms  |              |                                  |
+
+Durations are CSS variables, so motion can be globally tuned (or zeroed for reduced
+motion). Easings are compile-time constants.
+
 **Breakpoints** (`BreakpointKey`): `sm` (640), `md` (768), `lg` (1024), `xl` (1280). Used
 as keys in responsive prop objects (see below).
 
@@ -231,6 +244,22 @@ position: 'relative'|'absolute'|'fixed'|'sticky'|'static'
 top, right, bottom, left, inset: string | number
 zIndex: number | string
 ```
+
+**Motion** (transitions; pair with pseudo-state props to animate hover/focus/active):
+
+```
+transitionProperty: 'none'|'all'|'common'|'colors'|'opacity'|'shadow'|'transform'
+transitionDuration: DurationToken                     // 'instant'|'fast'|'base'|'slow'|'slower'
+transitionTimingFunction (alias: ease): EasingToken   // 'standard'|'decelerate'|'accelerate'|'spring'
+transitionDelay: DurationToken
+transform: string                                      // e.g. 'translateY(-2px)', 'scale(1.02)'
+transformOrigin: string
+willChange: string
+```
+
+`transitionProperty` keywords expand to real property lists — `colors` → color +
+background-color + border-color, `common` → colors + box-shadow + opacity + transform.
+Without `transitionProperty`, `transitionDuration` applies to `all`.
 
 **Visual**:
 
@@ -303,6 +332,25 @@ queries, pseudo-state keys generate scoped pseudo-class rules.
     Title
   </Text>
   <Text color="muted">Description</Text>
+</Box>
+```
+
+**Interactive card (smooth hover)** — pseudo-state props animate instead of snapping when
+you add a transition:
+
+```tsx
+<Box
+  borderRadius="l"
+  backgroundColor={{ base: 'background-card', hover: 'background-secondary' }}
+  boxShadow={{ base: 's', hover: 'm' }}
+  transform={{ hover: 'translateY(-2px)' }}
+  transitionProperty="common"
+  transitionDuration="fast"
+  ease="decelerate"
+  cursor={{ hover: 'pointer' }}
+  padding="xl"
+>
+  …
 </Box>
 ```
 

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -74,6 +74,19 @@ styles + scoped CSS at build time. Tokens use the CSS `light-dark()` function to
 auto-swap between light and dark mode, so you author one styling pass and dark mode
 is free.
 
+### `display` defaults to `flex`
+
+Box defaults to `display: flex` for block-level elements (~90% of usage is flex), so a
+bare `<Box>` is a flex row. Set `flexDirection`, `gap`, etc. directly without repeating
+`display="flex"`. Inline elements (`as="span"`, `as="label"`) and `as="li"` keep their
+native display so semantics aren't broken. Pass an explicit `display` (e.g.
+`display="block"`, `display="grid"`) to override.
+
+```tsx
+<Box flexDirection="column" gap="m">…</Box>   // already flex
+<Box display="block">…</Box>                    // opt out of flex
+```
+
 ### Importing
 
 ```tsx
@@ -213,6 +226,7 @@ borderStyle: 'solid' | 'dashed' | 'dotted' | 'none'
 
 ```
 display: 'flex' | 'grid' | 'block' | 'inline' | 'inline-flex' | 'inline-block' | 'none' | 'contents'
+         // defaults to 'flex' for block-level elements (see "display defaults to flex" above)
 overflow / overflowX / overflowY: 'hidden' | 'auto' | 'scroll' | 'visible'
 width, height, minWidth, maxWidth, minHeight, maxHeight: string | number   // numbers → px
 aspectRatio: string                                                         // '16 / 9'

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/downloads/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/downloads/page.tsx
@@ -72,7 +72,6 @@ const plugins = [
 export default function Downloads() {
   return (
     <Box
-      display="flex"
       flexDirection="column"
       marginHorizontal="auto"
       height="100%"
@@ -81,15 +80,8 @@ export default function Downloads() {
       maxWidth="72rem"
       rowGap={{ base: '2xl', md: '5xl' }}
     >
-      <Box
-        display="flex"
-        width="100%"
-        flexDirection="column"
-        alignItems="center"
-        rowGap="2xl"
-      >
+      <Box width="100%" flexDirection="column" alignItems="center" rowGap="2xl">
         <Box
-          display="flex"
           flexDirection="column"
           alignItems="center"
           rowGap="2xl"
@@ -110,7 +102,7 @@ export default function Downloads() {
           </p>
         </Box>
       </Box>
-      <Box display="flex" flexDirection="column" rowGap="2xl">
+      <Box flexDirection="column" rowGap="2xl">
         <Box
           display="grid"
           gridTemplateColumns={{
@@ -119,7 +111,7 @@ export default function Downloads() {
           }}
           gap="2xl"
         >
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <h3 className="text-2xl">Mobile Apps</h3>
             <p className="dark:text-polar-500 text-lg text-gray-500">
               Your business in the palm of your hand
@@ -134,12 +126,7 @@ export default function Downloads() {
               href={link.href ?? '#'}
               target={link.target}
             >
-              <Box
-                display="flex"
-                flexDirection="row"
-                alignItems="center"
-                columnGap="l"
-              >
+              <Box flexDirection="row" alignItems="center" columnGap="l">
                 <span>{link.icon}</span>
                 {!link.href ? (
                   <span className="dark:text-polar-500 font-mono text-sm text-gray-500">
@@ -147,7 +134,7 @@ export default function Downloads() {
                   </span>
                 ) : null}
               </Box>
-              <Box display="flex" flexDirection="column" gap="s">
+              <Box flexDirection="column" gap="s">
                 <h3 className="text-xl">{link.title}</h3>
                 <p className="dark:text-polar-500 font-sm text-gray-500">
                   {link.description}
@@ -157,7 +144,7 @@ export default function Downloads() {
           ))}
         </Box>
       </Box>
-      <Box display="flex" flexDirection="column" rowGap="2xl">
+      <Box flexDirection="column" rowGap="2xl">
         <Box
           display="grid"
           gridTemplateColumns={{
@@ -166,7 +153,7 @@ export default function Downloads() {
           }}
           gap="2xl"
         >
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <h3 className="text-2xl">Plugins</h3>
             <p className="dark:text-polar-500 text-lg text-gray-500">
               Polar integrated in your favourite apps
@@ -179,12 +166,7 @@ export default function Downloads() {
               href={link.href}
               target="_blank"
             >
-              <Box
-                display="flex"
-                flexDirection="row"
-                alignItems="center"
-                columnGap="l"
-              >
+              <Box flexDirection="row" alignItems="center" columnGap="l">
                 <span>{link.icon}</span>
                 {!link.href ? (
                   <span className="dark:text-polar-500 font-mono text-sm text-gray-500">
@@ -192,7 +174,7 @@ export default function Downloads() {
                   </span>
                 ) : null}
               </Box>
-              <Box display="flex" flexDirection="column" gap="s">
+              <Box flexDirection="column" gap="s">
                 <h3 className="text-xl">{link.title}</h3>
                 <p className="dark:text-polar-500 font-sm text-gray-500">
                   {link.description}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DeniedBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DeniedBanner.tsx
@@ -12,7 +12,6 @@ interface DeniedBannerProps {
 export const DeniedBanner = ({ organization }: DeniedBannerProps) => {
   return (
     <Box
-      display="flex"
       flexDirection={{ base: 'column', md: 'row' }}
       justifyContent="between"
       gap="l"
@@ -20,8 +19,8 @@ export const DeniedBanner = ({ organization }: DeniedBannerProps) => {
       backgroundColor="background-card"
       padding={{ base: 'l', md: 'xl' }}
     >
-      <Box display="flex" flexDirection="column" rowGap="s">
-        <Box display="flex" alignItems="center" columnGap="s">
+      <Box flexDirection="column" rowGap="s">
+        <Box alignItems="center" columnGap="s">
           <AlertCircleIcon className="h-4 w-4 shrink-0" />
           <Text as="strong">
             Payments are unavailable for your organization

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardingBanner.tsx
@@ -12,7 +12,6 @@ interface OffboardingBannerProps {
 export const OffboardingBanner = ({ organization }: OffboardingBannerProps) => {
   return (
     <Box
-      display="flex"
       flexDirection={{ base: 'column', md: 'row' }}
       justifyContent="between"
       gap="l"
@@ -20,8 +19,8 @@ export const OffboardingBanner = ({ organization }: OffboardingBannerProps) => {
       backgroundColor="background-card"
       padding={{ base: 'l', md: 'xl' }}
     >
-      <Box display="flex" flexDirection="column" rowGap="s">
-        <Box display="flex" alignItems="center" columnGap="s">
+      <Box flexDirection="column" rowGap="s">
+        <Box alignItems="center" columnGap="s">
           <AlertTriangleIcon className="h-4 w-4 shrink-0" />
           <Text as="strong">Your organization is being offboarded</Text>
         </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard.tsx
@@ -71,14 +71,13 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
       borderColor="border-primary"
     >
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="l"
         padding="xl"
         justifyContent="center"
       >
-        <Box display="flex" flexDirection="column" rowGap="m">
-          <Box display="flex" alignItems="center" columnGap="m">
+        <Box flexDirection="column" rowGap="m">
+          <Box alignItems="center" columnGap="m">
             <RocketIcon className="h-4 w-4 shrink-0" />
             <Text as="strong">Finish setting up your account</Text>
           </Box>
@@ -89,7 +88,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
           </Text>
         </Box>
 
-        <Box display="flex" flexDirection="column" rowGap="s">
+        <Box flexDirection="column" rowGap="s">
           <Text color="muted">
             {completed} of {total} complete
           </Text>
@@ -113,7 +112,6 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
       </Box>
 
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="l"
         padding="xl"
@@ -123,7 +121,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
         borderStyle="solid"
         borderColor="border-primary"
       >
-        <Box display="flex" flexDirection="column" rowGap="xs">
+        <Box flexDirection="column" rowGap="xs">
           {nextLabel ? (
             <>
               <Text color="muted">Up next</Text>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard.tsx
@@ -94,6 +94,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
             {completed} of {total} complete
           </Text>
           <Box
+            display="block"
             width="100%"
             height={6}
             borderRadius="full"
@@ -101,6 +102,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
             overflow="hidden"
           >
             <Box
+              display="block"
               height={6}
               borderRadius="full"
               backgroundColor="background-inverse"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
@@ -96,12 +96,7 @@ export const AccountPageDetailsRequired = ({ organization }: Props) => {
         </Button>
       }
     >
-      <Box
-        display="flex"
-        flexDirection="column"
-        rowGap="xl"
-        paddingBottom="3xl"
-      >
+      <Box flexDirection="column" rowGap="xl" paddingBottom="3xl">
         <Text variant="body" color="muted">
           Verify your business so customers can buy from you. After you submit,
           our team will review your details and get back to you shortly.

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/taxes/TaxesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/taxes/TaxesPage.tsx
@@ -36,7 +36,7 @@ const columns: DataTableColumnDef<schemas['TaxJurisdiction']>[] = [
       <DataTableColumnHeader column={column} title="Jurisdiction" />
     ),
     cell: ({ row: { original } }) => (
-      <Box display="flex" flexDirection="column" rowGap="xs">
+      <Box flexDirection="column" rowGap="xs">
         <Text>{original.state_name ?? original.country_name}</Text>
         <Text color="muted">
           {original.state_name
@@ -108,7 +108,6 @@ const SummaryCard = ({
     borderStyle="solid"
     borderColor="border-primary"
     padding="xl"
-    display="flex"
     flexDirection="column"
     rowGap="l"
   >
@@ -187,11 +186,10 @@ export default function TaxesPage({
 
   return (
     <DashboardBody wrapperClassName="max-w-(--breakpoint-lg)!">
-      <Box display="flex" flexDirection="column" rowGap="2xl">
+      <Box flexDirection="column" rowGap="2xl">
         {!isMoRDismissed && (
           <Box
             position="relative"
-            display="flex"
             flexDirection="column"
             alignItems="start"
             columnGap="l"
@@ -202,7 +200,7 @@ export default function TaxesPage({
             borderColor="border-primary"
             padding="xl"
           >
-            <Box display="flex" flexDirection="column" rowGap="xs">
+            <Box flexDirection="column" rowGap="xs">
               <Text variant="body" as="h2">
                 Merchant of Record
               </Text>
@@ -233,7 +231,6 @@ export default function TaxesPage({
           </Box>
         )}
         <Box
-          display="flex"
           flexDirection={{ base: 'column', md: 'row' }}
           gap="xl"
           flexWrap="wrap"
@@ -253,9 +250,9 @@ export default function TaxesPage({
           />
         </Box>
 
-        <Box display="flex" flexDirection="column" rowGap="xl">
-          <Box display="flex" flexDirection="column" rowGap="l">
-            <Box display="flex" justifyContent="between" alignItems="center">
+        <Box flexDirection="column" rowGap="xl">
+          <Box flexDirection="column" rowGap="l">
+            <Box justifyContent="between" alignItems="center">
               <Text variant="heading-xs" as="h2">
                 Breakdown
               </Text>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/taxes/TaxesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/taxes/TaxesPage.tsx
@@ -80,7 +80,7 @@ const columns: DataTableColumnDef<schemas['TaxJurisdiction']>[] = [
       />
     ),
     cell: ({ row: { original } }) => (
-      <Box textAlign="right">
+      <Box display="block" textAlign="right">
         <Text>
           {formatCurrency('accounting')(original.tax_amount, original.currency)}
         </Text>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
@@ -129,12 +129,12 @@ export default function BillingPage({
 
   return (
     <DashboardBody wrapperClassName="max-w-(--breakpoint-md)!" title="Billing">
-      <Box display="flex" flexDirection="column" rowGap="3xl">
+      <Box flexDirection="column" rowGap="3xl">
         <Section id="subscription">
           {subscriptionQuery.isLoading || !subscriptionQuery.data ? (
             <LoadingBox height={240} borderRadius="l" />
           ) : (
-            <Box display="flex" flexDirection="column" rowGap="xl">
+            <Box flexDirection="column" rowGap="xl">
               <StartupProgramCallout
                 organization={organization}
                 subscription={subscriptionQuery.data}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -317,6 +317,7 @@ export default function ChangePlanPage({
 
         {blockChanges && (
           <Box
+            display="block"
             borderRadius="m"
             backgroundColor="background-warning"
             padding="l"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -252,8 +252,8 @@ export default function ChangePlanPage({
 
   return (
     <DashboardBody title={null} wide>
-      <Box display="flex" flexDirection="column" rowGap="2xl">
-        <Box display="flex" flexDirection="column" rowGap="l">
+      <Box flexDirection="column" rowGap="2xl">
+        <Box flexDirection="column" rowGap="l">
           <Link
             href={billingHref}
             className="dark:text-polar-400 dark:hover:text-polar-200 inline-flex w-fit items-center gap-x-1 text-sm text-gray-500 hover:text-gray-700"
@@ -261,7 +261,7 @@ export default function ChangePlanPage({
             <ArrowBackOutlined fontSize="inherit" />
             <span>Back to Billing</span>
           </Link>
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <Text variant="heading-s" as="h1">
               Change plan
             </Text>
@@ -336,7 +336,7 @@ export default function ChangePlanPage({
         )}
 
         {selectedPlan && (
-          <Box display="flex" flexDirection="row-reverse" columnGap="s">
+          <Box flexDirection="row-reverse" columnGap="s">
             <Button
               onClick={showConfirm}
               disabled={isSubmitting || blockChanges}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/PlanCard.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/PlanCard.tsx
@@ -47,8 +47,8 @@ export const PlanCard = ({
             : 'dark:hover:border-polar-600 cursor-pointer hover:border-gray-300',
       )}
     >
-      <Box display="flex" flexDirection="column" rowGap="s">
-        <Box display="flex" alignItems="center" columnGap="m">
+      <Box flexDirection="column" rowGap="s">
+        <Box alignItems="center" columnGap="m">
           <Text variant="heading-xs" as="h3">
             {plan.name}
           </Text>
@@ -61,8 +61,8 @@ export const PlanCard = ({
         {plan.description && <Text color="muted">{plan.description}</Text>}
       </Box>
 
-      <Box display="flex" flexDirection="column" rowGap="s">
-        <Box display="flex" alignItems="baseline" columnGap="m">
+      <Box flexDirection="column" rowGap="s">
+        <Box alignItems="baseline" columnGap="m">
           {hasOffer ? (
             <>
               <Text variant="heading-s" as="span">
@@ -103,7 +103,6 @@ export const PlanCard = ({
       {(plan.features?.length ?? 0) > 0 && (
         <Box
           as="ul"
-          display="flex"
           flexDirection="column"
           rowGap="s"
           borderTopWidth={1}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ChangeRoleModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ChangeRoleModal.tsx
@@ -80,7 +80,7 @@ export function ChangeRoleModal({
   }
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="xl" padding="2xl">
+    <Box flexDirection="column" rowGap="xl" padding="2xl">
       <Text variant="heading-xxs" as="h3">
         Change Role
       </Text>
@@ -157,7 +157,7 @@ export function ChangeRoleModal({
           </table>
         </Box>
       )}
-      <Box display="flex" columnGap="s">
+      <Box columnGap="s">
         <Button
           onClick={handleSave}
           disabled={updateMemberRole.isPending}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ChangeRoleModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ChangeRoleModal.tsx
@@ -111,6 +111,7 @@ export function ChangeRoleModal({
       </Select>
       {orderedRoles.length > 0 && (
         <Box
+          display="block"
           maxHeight="30vh"
           overflowY="auto"
           borderRadius="m"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/InviteMemberModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/InviteMemberModal.tsx
@@ -56,7 +56,6 @@ export function InviteMemberModal({
     <Box
       as="form"
       onSubmit={handleSubmit}
-      display="flex"
       flexDirection="column"
       rowGap="xl"
       padding="2xl"
@@ -71,7 +70,7 @@ export function InviteMemberModal({
         onChange={(e) => setEmail(e.target.value)}
         autoFocus
       />
-      <Box display="flex" columnGap="s">
+      <Box columnGap="s">
         <Button
           type="submit"
           disabled={!email || inviteMember.isPending}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/MembersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/MembersPage.tsx
@@ -144,7 +144,7 @@ export default function ClientPage({
       ),
       cell: ({ row: { original: member } }) => {
         return (
-          <Box display="flex" flexDirection="row" alignItems="center" gap="s">
+          <Box flexDirection="row" alignItems="center" gap="s">
             <Avatar avatar_url={member.avatar_url} name={member.email} />
             <Text>{member.email}</Text>
           </Box>
@@ -187,7 +187,7 @@ export default function ClientPage({
         }
 
         return (
-          <Box display="flex" justifyContent="end">
+          <Box justifyContent="end">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="secondary" size="icon">

--- a/clients/apps/web/src/app/(main)/oauth2/authorize/components/SupportedUseCases.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/components/SupportedUseCases.tsx
@@ -46,6 +46,7 @@ export default function SupportedUseCases() {
       </Box>
 
       <Box
+        display="block"
         borderTopWidth={1}
         borderStyle="solid"
         borderColor="border-primary"

--- a/clients/apps/web/src/app/(main)/oauth2/authorize/components/SupportedUseCases.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/components/SupportedUseCases.tsx
@@ -2,8 +2,8 @@ import { Box } from '@polar-sh/orbit/Box'
 
 export default function SupportedUseCases() {
   return (
-    <Box display="flex" flexDirection="column" rowGap="l">
-      <Box display="flex" flexDirection="column" rowGap="s">
+    <Box flexDirection="column" rowGap="l">
+      <Box flexDirection="column" rowGap="s">
         <p className="text-sm font-medium">Supported Usecases</p>
         <p className="dark:text-polar-500 text-sm text-gray-500">
           SaaS subscriptions, digital downloads, software licenses, online
@@ -11,9 +11,9 @@ export default function SupportedUseCases() {
         </p>
       </Box>
 
-      <Box display="flex" flexDirection="column" rowGap="s">
+      <Box flexDirection="column" rowGap="s">
         <p className="text-sm font-medium">Prohibited Usecases</p>
-        <Box as="ul" display="flex" flexDirection="column" rowGap="xs">
+        <Box as="ul" flexDirection="column" rowGap="xs">
           <Box as="li">
             <p className="dark:text-polar-500 text-sm text-gray-500">
               • Physical goods or products requiring shipping

--- a/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
+++ b/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
@@ -124,7 +124,7 @@ export default function Page() {
                 payments. No real money, no setup required.
               </p>
             </Box>
-            <Box marginTop="xl">
+            <Box display="block" marginTop="xl">
               <Button fullWidth onClick={handleSandbox}>
                 Launch sandbox
               </Button>
@@ -151,7 +151,7 @@ export default function Page() {
                 Set up your organization and start accepting payments.
               </p>
             </Box>
-            <Box marginTop="xl">
+            <Box display="block" marginTop="xl">
               <Button fullWidth onClick={handleGetStarted}>
                 Get started
               </Button>

--- a/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
+++ b/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
@@ -41,7 +41,6 @@ export default function Page() {
   return (
     <Box
       backgroundColor="background-primary"
-      display="flex"
       minHeight="100vh"
       alignItems="center"
       justifyContent="center"
@@ -52,7 +51,6 @@ export default function Page() {
         position="absolute"
         bottom={24}
         left={24}
-        display="flex"
         gap="l"
         color="text-tertiary"
       >
@@ -70,7 +68,6 @@ export default function Page() {
         </a>
       </Box>
       <Box
-        display="flex"
         width="100%"
         maxWidth="48rem"
         flexDirection="column"
@@ -80,7 +77,6 @@ export default function Page() {
         <LogoIcon size={48} />
 
         <Box
-          display="flex"
           flexDirection="column"
           alignItems="center"
           rowGap="s"
@@ -110,12 +106,11 @@ export default function Page() {
             borderWidth={1}
             borderStyle="solid"
             borderRadius="l"
-            display="flex"
             flexDirection="column"
             justifyContent="between"
             padding="xl"
           >
-            <Box display="flex" flexDirection="column" rowGap="s">
+            <Box flexDirection="column" rowGap="s">
               <h2 className="text-lg font-medium text-gray-900 dark:text-white">
                 I&apos;m just exploring
               </h2>
@@ -138,12 +133,11 @@ export default function Page() {
             borderWidth={1}
             borderStyle="solid"
             borderRadius="l"
-            display="flex"
             flexDirection="column"
             justifyContent="between"
             padding="xl"
           >
-            <Box display="flex" flexDirection="column" rowGap="s">
+            <Box flexDirection="column" rowGap="s">
               <h2 className="text-lg font-medium text-gray-900 dark:text-white">
                 I&apos;m setting up my business
               </h2>

--- a/clients/apps/web/src/components/Feedback/ChatMessageBubble.tsx
+++ b/clients/apps/web/src/components/Feedback/ChatMessageBubble.tsx
@@ -38,6 +38,7 @@ export const ChatMessageBubble = ({ message }: { message: UIMessage }) => {
   if (message.role === 'user') {
     return (
       <Box
+        display="block"
         alignSelf="end"
         backgroundColor="background-card"
         borderRadius="l"

--- a/clients/apps/web/src/components/Feedback/EscalationCard.tsx
+++ b/clients/apps/web/src/components/Feedback/EscalationCard.tsx
@@ -37,7 +37,6 @@ export const EscalationCard = ({
 
   return (
     <Box
-      display="flex"
       flexDirection="column"
       rowGap="m"
       padding="l"
@@ -46,7 +45,7 @@ export const EscalationCard = ({
       borderStyle="solid"
       borderColor="border-primary"
     >
-      <Box display="flex" flexDirection="column" rowGap="xs">
+      <Box flexDirection="column" rowGap="xs">
         <h3 className="text-sm font-medium">Send to the Polar team</h3>
         <p className="dark:text-polar-500 text-sm text-gray-500">
           The full transcript is included automatically. Add anything else
@@ -60,12 +59,7 @@ export const EscalationCard = ({
         rows={4}
         disabled={isSubmitting}
       />
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="between"
-        columnGap="s"
-      >
+      <Box alignItems="center" justifyContent="between" columnGap="s">
         <Select
           value={type}
           onValueChange={(value) => setType(value as schemas['FeedbackType'])}
@@ -82,7 +76,7 @@ export const EscalationCard = ({
             ))}
           </SelectContent>
         </Select>
-        <Box display="flex" columnGap="s">
+        <Box columnGap="s">
           <Button
             type="button"
             variant="ghost"

--- a/clients/apps/web/src/components/Feedback/FeedbackForm.tsx
+++ b/clients/apps/web/src/components/Feedback/FeedbackForm.tsx
@@ -230,6 +230,7 @@ export const FeedbackForm = ({
 
         {validationOutcome?.kind === 'rejection' && (
           <Box
+            display="block"
             borderRadius="l"
             backgroundColor="background-warning"
             color="text-warning"
@@ -241,6 +242,7 @@ export const FeedbackForm = ({
 
         {validationOutcome?.kind === 'info' && (
           <Box
+            display="block"
             borderRadius="l"
             backgroundColor="background-pending"
             color="text-pending"
@@ -254,6 +256,7 @@ export const FeedbackForm = ({
 
         {apiError && (
           <Box
+            display="block"
             borderRadius="l"
             backgroundColor="background-danger"
             color="text-danger"

--- a/clients/apps/web/src/components/Feedback/QuestionFlow.tsx
+++ b/clients/apps/web/src/components/Feedback/QuestionFlow.tsx
@@ -198,6 +198,7 @@ export const QuestionFlow = ({
         )}
         {error && (
           <Box
+            display="block"
             borderRadius="l"
             backgroundColor="background-warning"
             borderWidth={1}

--- a/clients/apps/web/src/components/Feedback/QuestionFlow.tsx
+++ b/clients/apps/web/src/components/Feedback/QuestionFlow.tsx
@@ -157,7 +157,6 @@ export const QuestionFlow = ({
 
   return (
     <Box
-      display="flex"
       flexDirection="column"
       rowGap="l"
       flex={1}
@@ -166,7 +165,6 @@ export const QuestionFlow = ({
     >
       <Box
         ref={scrollerRef}
-        display="flex"
         flexDirection="column"
         rowGap="l"
         overflowY="auto"
@@ -186,12 +184,7 @@ export const QuestionFlow = ({
           </div>
         )}
         {isStreaming && (
-          <Box
-            display="flex"
-            alignItems="center"
-            columnGap="s"
-            color="text-tertiary"
-          >
+          <Box alignItems="center" columnGap="s" color="text-tertiary">
             <span className="dark:bg-polar-400 h-2 w-2 animate-pulse rounded-full bg-gray-400" />
             <span className="text-sm">{streamingStatus}</span>
           </Box>
@@ -223,7 +216,7 @@ export const QuestionFlow = ({
           isSubmitting={isEscalating}
         />
       ) : (
-        <Box display="flex" flexDirection="column" rowGap="s">
+        <Box flexDirection="column" rowGap="s">
           <TextArea
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
@@ -243,7 +236,7 @@ export const QuestionFlow = ({
               }
             }}
           />
-          <Box display="flex" justifyContent="end" columnGap="s">
+          <Box justifyContent="end" columnGap="s">
             <Button
               type="button"
               variant="ghost"

--- a/clients/apps/web/src/components/Finance/AccessRestricted.tsx
+++ b/clients/apps/web/src/components/Finance/AccessRestricted.tsx
@@ -11,7 +11,6 @@ export default function AccessRestricted({ message }: AccessRestrictedProps) {
       backgroundColor="background-card"
       borderRadius="l"
       padding="3xl"
-      display="flex"
       flexDirection="column"
       alignItems="center"
       rowGap="m"

--- a/clients/apps/web/src/components/Finance/Account/ChecklistRow.tsx
+++ b/clients/apps/web/src/components/Finance/Account/ChecklistRow.tsx
@@ -36,7 +36,7 @@ export const ChecklistRow = ({ step, isLoading }: Props) => {
 
   if (isLoading || !step) {
     return (
-      <Box display="flex" alignItems="center" columnGap="s">
+      <Box alignItems="center" columnGap="s">
         <LoadingBox width={24} height={24} borderRadius="full" />
         <LoadingBox width={140} height={26} borderRadius="s" />
         <Box display="block" marginLeft="auto">
@@ -66,9 +66,9 @@ export const ChecklistRow = ({ step, isLoading }: Props) => {
   const showExpanded = isExpanded && !!renderSection
 
   return (
-    <Box display="flex" flexDirection="column">
-      <Box display="flex" flexDirection="column" rowGap="m">
-        <Box display="flex" alignItems="center" columnGap="s">
+    <Box flexDirection="column">
+      <Box flexDirection="column" rowGap="m">
+        <Box alignItems="center" columnGap="s">
           <StatusIcon status={step.status} />
           <Text variant="label">{label}</Text>
           {reasonText && (

--- a/clients/apps/web/src/components/Finance/Account/ChecklistRow.tsx
+++ b/clients/apps/web/src/components/Finance/Account/ChecklistRow.tsx
@@ -39,7 +39,7 @@ export const ChecklistRow = ({ step, isLoading }: Props) => {
       <Box display="flex" alignItems="center" columnGap="s">
         <LoadingBox width={24} height={24} borderRadius="full" />
         <LoadingBox width={140} height={26} borderRadius="s" />
-        <Box marginLeft="auto">
+        <Box display="block" marginLeft="auto">
           <LoadingBox width={46} height={32} borderRadius="m" />
         </Box>
       </Box>
@@ -77,7 +77,7 @@ export const ChecklistRow = ({ step, isLoading }: Props) => {
             </Text>
           )}
           {isActionable && (
-            <Box marginLeft="auto">
+            <Box display="block" marginLeft="auto">
               <Button
                 variant="ghost"
                 size="sm"
@@ -112,6 +112,7 @@ export const ChecklistRow = ({ step, isLoading }: Props) => {
               style={{ overflow: 'hidden' }}
             >
               <Box
+                display="block"
                 borderTopWidth={1}
                 borderStyle="solid"
                 borderColor="border-primary"
@@ -127,7 +128,7 @@ export const ChecklistRow = ({ step, isLoading }: Props) => {
               transition={{ duration: 0.25, ease: [0.04, 0.62, 0.23, 0.98] }}
               className="overflow-hidden focus-within:overflow-visible"
             >
-              <Box paddingTop="m">
+              <Box display="block" paddingTop="m">
                 {renderSection({ organization, step, reasonItems })}
               </Box>
             </motion.div>

--- a/clients/apps/web/src/components/Finance/Account/ReviewChecklist.tsx
+++ b/clients/apps/web/src/components/Finance/Account/ReviewChecklist.tsx
@@ -35,7 +35,6 @@ export const ReviewChecklist = ({
 
   return (
     <Box
-      display="flex"
       flexDirection="column"
       rowGap="s"
       // eslint-disable-next-line polar/no-style-box

--- a/clients/apps/web/src/components/Finance/Account/ReviewChecklist.tsx
+++ b/clients/apps/web/src/components/Finance/Account/ReviewChecklist.tsx
@@ -43,7 +43,7 @@ export const ReviewChecklist = ({
     >
       {isLoading ? (
         Array.from({ length: 8 }, (_, i) => (
-          <Box key={`placeholder-${i}`} {...cardStyles}>
+          <Box display="block" key={`placeholder-${i}`} {...cardStyles}>
             <ChecklistRow isLoading={true} />
           </Box>
         ))
@@ -67,7 +67,7 @@ export const ReviewChecklist = ({
                     ease: [0.4, 0, 0.2, 1],
                   }}
                 >
-                  <Box {...cardStyles}>
+                  <Box display="block" {...cardStyles}>
                     <ChecklistRow isLoading={false} step={step} />
                   </Box>
                 </motion.div>

--- a/clients/apps/web/src/components/Finance/Account/StatusIcon.tsx
+++ b/clients/apps/web/src/components/Finance/Account/StatusIcon.tsx
@@ -50,7 +50,6 @@ export const StatusIcon = ({ status }: Props) => {
 
   return (
     <Box
-      display="flex"
       alignItems="center"
       justifyContent="center"
       width={24}

--- a/clients/apps/web/src/components/Finance/Account/sections/EmailSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/EmailSection.tsx
@@ -96,7 +96,7 @@ export const EmailSection = ({
             name="email"
             rules={{ required: 'Support email is required' }}
             render={({ field }) => (
-              <Box>
+              <Box display="block">
                 <Input type="email" {...field} placeholder="support@acme.com" />
                 <FormMessage />
               </Box>

--- a/clients/apps/web/src/components/Finance/Account/sections/IdentityVerificationSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/IdentityVerificationSection.tsx
@@ -46,7 +46,7 @@ export const IdentityVerificationSection = ({
         onStart={start}
       />
       {showBanners && (
-        <Box display="flex" flexDirection="column" rowGap="m">
+        <Box flexDirection="column" rowGap="m">
           {reasonItems.map((reason) => (
             <PathCardBanner key={reason} tone={tone} title={reason} />
           ))}

--- a/clients/apps/web/src/components/Finance/Account/sections/PathCard.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PathCard.tsx
@@ -85,12 +85,7 @@ const Inner = ({
   recommended,
 }: InnerProps) => (
   <>
-    <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="between"
-      columnGap="s"
-    >
+    <Box alignItems="center" justifyContent="between" columnGap="s">
       <Text variant="default">{title}</Text>
       <Badge status={status} required={required} recommended={recommended} />
     </Box>
@@ -116,7 +111,7 @@ const Inner = ({
 )
 
 const Header = ({ children }: { children: ReactNode }) => (
-  <Box display="flex" flexDirection="column" rowGap="s" padding="l">
+  <Box flexDirection="column" rowGap="s" padding="l">
     {children}
   </Box>
 )
@@ -165,7 +160,6 @@ export const PathCard = ({
   return (
     <Box
       as="article"
-      display="flex"
       flexDirection="column"
       borderRadius="m"
       borderWidth={1}

--- a/clients/apps/web/src/components/Finance/Account/sections/PathCard.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PathCard.tsx
@@ -186,7 +186,7 @@ export const PathCard = ({
           />
         </Header>
         {extra && (
-          <Box paddingHorizontal="l" paddingBottom="l">
+          <Box display="block" paddingHorizontal="l" paddingBottom="l">
             {extra}
           </Box>
         )}

--- a/clients/apps/web/src/components/Finance/Account/sections/PathCardBanner.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PathCardBanner.tsx
@@ -27,8 +27,8 @@ export const PathCardBanner = ({
   const iconColor = tone === 'danger' ? 'text-danger' : 'text-warning'
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="xs">
-      <Box display="flex" alignItems="center" columnGap="xs">
+    <Box flexDirection="column" rowGap="xs">
+      <Box alignItems="center" columnGap="xs">
         <Box color={iconColor} display="inline-flex">
           <Icon className="h-3.5 w-3.5" />
         </Box>

--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -22,7 +22,7 @@ export const PayoutAccountSection = ({
 }: Props) => {
   const tone = step.status === 'failed' ? 'danger' : 'warning'
   const banners = reasonItems.length > 0 && (
-    <Box display="flex" flexDirection="column" rowGap="m">
+    <Box flexDirection="column" rowGap="m">
       {reasonItems.map((reason) => (
         <PathCardBanner key={reason} tone={tone} title={reason} />
       ))}

--- a/clients/apps/web/src/components/Finance/Account/sections/ProductConfigurationSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/ProductConfigurationSection.tsx
@@ -19,12 +19,7 @@ export const ProductConfigurationSection = ({ organization }: Props) => {
 
   if (isLoading) {
     return (
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        paddingVertical="xl"
-      >
+      <Box alignItems="center" justifyContent="center" paddingVertical="xl">
         <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
       </Box>
     )

--- a/clients/apps/web/src/components/Finance/Account/sections/ProductDescriptionSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/ProductDescriptionSection.tsx
@@ -150,12 +150,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
 
   if (isKYCLoading) {
     return (
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        paddingVertical="xl"
-      >
+      <Box alignItems="center" justifyContent="center" paddingVertical="xl">
         <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
       </Box>
     )
@@ -186,7 +181,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
         <SectionLayout
           description="Describe what your product is and does, who it's for, and your pricing model."
           footerEnd={
-            <Box display="flex" alignItems="center" columnGap="s">
+            <Box alignItems="center" columnGap="s">
               {showContinueAnyway && (
                 <Button
                   type="button"
@@ -211,7 +206,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
             </Box>
           }
         >
-          <Box display="flex" flexDirection="column" rowGap="xl">
+          <Box flexDirection="column" rowGap="xl">
             <FormField
               control={control}
               name="product_description"
@@ -227,7 +222,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
                 },
               }}
               render={({ field }) => (
-                <Box display="flex" flexDirection="column" rowGap="xs">
+                <Box flexDirection="column" rowGap="xs">
                   <TextArea
                     {...field}
                     rows={4}
@@ -235,7 +230,6 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
                     className="resize-none"
                   />
                   <Box
-                    display="flex"
                     alignItems="center"
                     justifyContent="between"
                     columnGap="s"
@@ -249,7 +243,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
               )}
             />
 
-            <Box display="flex" flexDirection="column" rowGap="m">
+            <Box flexDirection="column" rowGap="m">
               <Text variant="label" color="default">
                 What are you selling?
               </Text>
@@ -267,7 +261,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
               )}
             </Box>
 
-            <Box display="flex" flexDirection="column" rowGap="m">
+            <Box flexDirection="column" rowGap="m">
               <Text variant="label" color="default">
                 Pricing model
               </Text>
@@ -282,7 +276,6 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
 
             {aup.verdict && (
               <Box
-                display="flex"
                 flexDirection="column"
                 rowGap="s"
                 borderRadius="m"

--- a/clients/apps/web/src/components/Finance/Account/sections/ProductUrlSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/ProductUrlSection.tsx
@@ -112,7 +112,7 @@ export const ProductUrlSection = ({
               },
             }}
             render={({ field }) => (
-              <Box>
+              <Box display="block">
                 <Input
                   type="url"
                   {...field}

--- a/clients/apps/web/src/components/Finance/Account/sections/SectionLayout.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SectionLayout.tsx
@@ -34,7 +34,7 @@ export const SectionLayout = ({
           justifyContent="between"
           columnGap="s"
         >
-          <Box>{footerStart}</Box>
+          <Box display="block">{footerStart}</Box>
           {footerEnd}
         </Box>
       )}

--- a/clients/apps/web/src/components/Finance/Account/sections/SectionLayout.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SectionLayout.tsx
@@ -20,7 +20,7 @@ export const SectionLayout = ({
   const hasFooter = !!footerStart || !!footerEnd
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="m">
+    <Box flexDirection="column" rowGap="m">
       {description && (
         <Text variant="default" color="muted">
           {description}
@@ -28,12 +28,7 @@ export const SectionLayout = ({
       )}
       {children}
       {hasFooter && (
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="between"
-          columnGap="s"
-        >
+        <Box alignItems="center" justifyContent="between" columnGap="s">
           <Box display="block">{footerStart}</Box>
           {footerEnd}
         </Box>

--- a/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
@@ -136,6 +136,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
 
         <Box display="flex" alignItems="center" columnGap="m">
           <Box
+            display="block"
             flexGrow={1}
             borderTopWidth={1}
             borderStyle="solid"
@@ -150,6 +151,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
             or
           </Text>
           <Box
+            display="block"
             flexGrow={1}
             borderTopWidth={1}
             borderStyle="solid"

--- a/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
@@ -72,14 +72,14 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
   }
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="xl">
+    <Box flexDirection="column" rowGap="xl">
       <Text variant="default" color="muted">
         You&rsquo;re not integrated with Polar yet. Pick the option that fits
         your setup. You can always switch later.
       </Text>
 
-      <Box display="flex" flexDirection="column" rowGap="xl">
-        <Box display="flex" flexDirection="column" rowGap="s">
+      <Box flexDirection="column" rowGap="xl">
+        <Box flexDirection="column" rowGap="s">
           <Text variant="caption" color="muted">
             No-code
           </Text>
@@ -134,7 +134,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
           />
         </Box>
 
-        <Box display="flex" alignItems="center" columnGap="m">
+        <Box alignItems="center" columnGap="m">
           <Box
             display="block"
             flexGrow={1}
@@ -159,8 +159,8 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
           />
         </Box>
 
-        <Box display="flex" flexDirection="column" rowGap="s">
-          <Box display="flex" alignItems="baseline" columnGap="s">
+        <Box flexDirection="column" rowGap="s">
+          <Box alignItems="baseline" columnGap="s">
             <Text variant="caption" color="muted">
               API integration
             </Text>
@@ -246,7 +246,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
         isShown={!!createdToken}
         hide={() => setCreatedToken(undefined)}
         modalContent={
-          <Box display="flex" flexDirection="column" rowGap="m" padding="xl">
+          <Box flexDirection="column" rowGap="m" padding="xl">
             <CopyToClipboardInput
               value={createdToken?.token ?? ''}
               onCopy={() => toast({ title: 'Copied to clipboard' })}
@@ -258,7 +258,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
                 won&rsquo;t be able to see it again.
               </span>
             </Banner>
-            <Box display="flex" justifyContent="end">
+            <Box justifyContent="end">
               <Button onClick={() => setCreatedToken(undefined)}>Done</Button>
             </Box>
           </Box>

--- a/clients/apps/web/src/components/Finance/Account/sections/StatusBlock.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/StatusBlock.tsx
@@ -42,7 +42,6 @@ export const StatusBlock = ({
 
   return (
     <Box
-      display="flex"
       flexDirection="column"
       alignItems="center"
       rowGap="m"
@@ -57,7 +56,6 @@ export const StatusBlock = ({
           transition={{ type: 'spring', stiffness: 400, damping: 22 }}
         >
           <Box
-            display="flex"
             alignItems="center"
             justifyContent="center"
             width={40}
@@ -70,12 +68,7 @@ export const StatusBlock = ({
           </Box>
         </motion.div>
       )}
-      <Box
-        display="flex"
-        flexDirection="column"
-        rowGap="xs"
-        alignItems="center"
-      >
+      <Box flexDirection="column" rowGap="xs" alignItems="center">
         <Text variant="body" color="default">
           {title}
         </Text>

--- a/clients/apps/web/src/components/Finance/Account/sections/StatusBlock.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/StatusBlock.tsx
@@ -80,14 +80,18 @@ export const StatusBlock = ({
           {title}
         </Text>
         {description && (
-          <Box maxWidth={420}>
+          <Box display="block" maxWidth={420}>
             <Text variant="caption" color="muted" wrap="balance">
               {description}
             </Text>
           </Box>
         )}
       </Box>
-      {action && <Box marginTop="m">{action}</Box>}
+      {action && (
+        <Box display="block" marginTop="m">
+          {action}
+        </Box>
+      )}
     </Box>
   )
 }

--- a/clients/apps/web/src/components/Form/ChipSelect.tsx
+++ b/clients/apps/web/src/components/Form/ChipSelect.tsx
@@ -39,7 +39,7 @@ export function ChipSelect({
   }
 
   return (
-    <Box display="flex" flexWrap="wrap" gap="s">
+    <Box flexWrap="wrap" gap="s">
       {options.map((option) => {
         const { value, label } = normalizeOption(option)
         const isSelected = selected.includes(value)

--- a/clients/apps/web/src/components/Landing/CostInsights.tsx
+++ b/clients/apps/web/src/components/Landing/CostInsights.tsx
@@ -64,7 +64,6 @@ export const CostInsights = () => {
   return (
     <Box
       position="relative"
-      display="flex"
       flexDirection="column"
       rowGap={{ base: '2xl', md: '4xl' }}
       paddingTop={{ base: 'l', md: '3xl' }}
@@ -85,7 +84,6 @@ export const CostInsights = () => {
           minHeight={{ base: '14rem', lg: 'auto' }}
           overflow="hidden"
           backgroundColor="background-secondary"
-          display="flex"
           flexDirection="column"
           justifyContent="between"
           padding="xl"
@@ -144,8 +142,8 @@ export const CostInsights = () => {
                 borderStyle="solid"
                 borderColor="border-secondary"
               >
-                <Box display="flex" alignItems="center" columnGap="m">
-                  <Box display="flex" flexDirection="column" rowGap="xs">
+                <Box alignItems="center" columnGap="m">
+                  <Box flexDirection="column" rowGap="xs">
                     <Text>{row.name}</Text>
                     <Text color="muted">
                       {row.plan} · {row.tokens}
@@ -156,12 +154,7 @@ export const CostInsights = () => {
                 <Text align="right" color="muted">
                   {currency(row.cost)}
                 </Text>
-                <Box
-                  display="flex"
-                  alignItems="center"
-                  justifyContent="end"
-                  columnGap="m"
-                >
+                <Box alignItems="center" justifyContent="end" columnGap="m">
                   <Text align="right" color={negative ? 'danger' : undefined}>
                     {margin > 0 ? '+' : ''}
                     {margin}%

--- a/clients/apps/web/src/components/Landing/CostInsights.tsx
+++ b/clients/apps/web/src/components/Landing/CostInsights.tsx
@@ -91,7 +91,7 @@ export const CostInsights = () => {
           padding="xl"
           rowGap="l"
         >
-          <Box flex={1} minHeight={0} aspectRatio="1/1">
+          <Box display="block" flex={1} minHeight={0} aspectRatio="1/1">
             <MarginPulse />
           </Box>
         </Box>

--- a/clients/apps/web/src/components/Landing/Dashboard.tsx
+++ b/clients/apps/web/src/components/Landing/Dashboard.tsx
@@ -17,6 +17,7 @@ export const Dashboard = () => {
         description="Revenue, costs & margins in one overview. The unit economics every AI startup needs to scale with confidence."
       />
       <Box
+        display="block"
         width="100%"
         overflow="hidden"
         position="relative"

--- a/clients/apps/web/src/components/Landing/Dashboard.tsx
+++ b/clients/apps/web/src/components/Landing/Dashboard.tsx
@@ -6,7 +6,6 @@ export const Dashboard = () => {
   return (
     <Box
       position="relative"
-      display="flex"
       flexDirection="column"
       rowGap={{ base: '2xl', md: '3xl' }}
       paddingTop={{ base: 'l', md: '3xl' }}

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -29,7 +29,7 @@ export const Hero = () => {
       whileInView="visible"
       viewport={{ once: true }}
     >
-      <Box display="flex">
+      <Box>
         <Text variant="heading-2xl">
           Turn Usage
           <br />

--- a/clients/apps/web/src/components/Landing/Pipeline.tsx
+++ b/clients/apps/web/src/components/Landing/Pipeline.tsx
@@ -79,7 +79,6 @@ const CheckIcon = ({ active }: { active: boolean }) => (
     borderRadius="full"
     backgroundColor="background-success"
     color="text-success"
-    display="flex"
     alignItems="center"
     justifyContent="center"
     flexShrink={0}
@@ -107,7 +106,6 @@ const BankIcon = () => (
     borderRadius="full"
     backgroundColor="background-card"
     color="text-secondary"
-    display="flex"
     alignItems="center"
     justifyContent="center"
     flexShrink={0}
@@ -133,12 +131,7 @@ const BankIcon = () => (
 )
 
 const ArrowDown = () => (
-  <Box
-    display="flex"
-    justifyContent="center"
-    color="text-tertiary"
-    paddingVertical="m"
-  >
+  <Box justifyContent="center" color="text-tertiary" paddingVertical="m">
     <svg
       width="20"
       height="30"
@@ -156,7 +149,7 @@ const ArrowDown = () => (
 )
 
 const Chevron = ({ open }: { open: boolean }) => (
-  <Box color="text-tertiary" display="flex" flexShrink={0}>
+  <Box color="text-tertiary" flexShrink={0}>
     <svg
       width="16"
       height="16"
@@ -182,7 +175,6 @@ export const Pipeline = () => {
   return (
     <Box
       position="relative"
-      display="flex"
       flexDirection="column"
       rowGap={{ base: '2xl', md: '4xl' }}
       paddingTop={{ base: 'l', md: '3xl' }}
@@ -195,8 +187,8 @@ export const Pipeline = () => {
         alignItems="start"
       >
         {/* Accordion */}
-        <Box as="ul" display="flex" flexDirection="column" rowGap="2xl">
-          <Box display="flex" flexDirection="column" rowGap="2xl">
+        <Box as="ul" flexDirection="column" rowGap="2xl">
+          <Box flexDirection="column" rowGap="2xl">
             <Text variant="heading-l" as="h2" wrap="balance">
               Everything between usage & revenue
             </Text>
@@ -218,14 +210,13 @@ export const Pipeline = () => {
                   rowGap="l"
                 >
                   <Box
-                    display="flex"
                     alignItems="center"
                     justifyContent="between"
                     columnGap="l"
                     cursor="pointer"
                     onClick={() => setActive(index)}
                   >
-                    <Box display="flex" flexDirection="row" columnGap="s">
+                    <Box flexDirection="row" columnGap="s">
                       <Text
                         variant="heading-xxs"
                         color={open ? undefined : 'muted'}
@@ -236,18 +227,12 @@ export const Pipeline = () => {
                     <Chevron open={open} />
                   </Box>
                   {open && (
-                    <Box
-                      paddingBottom="l"
-                      display="flex"
-                      flexDirection="column"
-                      rowGap="m"
-                    >
+                    <Box paddingBottom="l" flexDirection="column" rowGap="m">
                       <Text variant="body" color="muted">
                         {aspect.desc}
                       </Text>
                       <Link href={aspect.href}>
                         <Box
-                          display="flex"
                           alignItems="center"
                           columnGap="m"
                           width="fit-content"
@@ -274,7 +259,6 @@ export const Pipeline = () => {
           width="100%"
           maxWidth={{ base: '100%' }}
           marginHorizontal="auto"
-          display="flex"
           flexDirection="column"
           paddingVertical={{ base: '2xl', md: '5xl' }}
           paddingHorizontal={{ base: '2xl', md: '5xl' }}
@@ -284,7 +268,6 @@ export const Pipeline = () => {
         >
           {/* Customer */}
           <Box
-            display="flex"
             alignItems="center"
             columnGap="m"
             backgroundColor="background-secondary"
@@ -295,7 +278,7 @@ export const Pipeline = () => {
               avatar_url="/assets/team/emil.png"
               className="h-10 w-10 text-sm"
             />
-            <Box display="flex" flexDirection="column">
+            <Box flexDirection="column">
               <Text>John Doe</Text>
               <Text color="muted">Consumed 23,820 tokens</Text>
             </Box>
@@ -304,10 +287,9 @@ export const Pipeline = () => {
           <ArrowDown />
 
           {/* Polar */}
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <Box
               paddingVertical="m"
-              display="flex"
               justifyContent="center"
               backgroundColor="background-secondary"
             >
@@ -316,7 +298,6 @@ export const Pipeline = () => {
             {GROUPS.map((group, groupIndex) => (
               <Box
                 key={groupIndex}
-                display="flex"
                 flexDirection="column"
                 backgroundColor="background-secondary"
                 padding="s"
@@ -327,7 +308,6 @@ export const Pipeline = () => {
                   return (
                     <Box
                       key={aspect.title}
-                      display="flex"
                       alignItems="center"
                       columnGap="l"
                       paddingVertical="s"
@@ -353,19 +333,18 @@ export const Pipeline = () => {
 
           {/* Payout */}
           <Box
-            display="flex"
             alignItems="center"
             columnGap="l"
             backgroundColor="background-secondary"
             padding="l"
           >
             <BankIcon />
-            <Box display="flex" flexDirection="column" rowGap="xs">
-              <Box display="flex" alignItems="baseline" columnGap="s">
+            <Box flexDirection="column" rowGap="xs">
+              <Box alignItems="baseline" columnGap="s">
                 <Text>Merchant Payout</Text>
                 <Text color="muted">Acme Inc</Text>
               </Box>
-              <Box display="flex" alignItems="baseline" columnGap="s">
+              <Box alignItems="baseline" columnGap="s">
                 <Text color="success">$9,311</Text>
                 <Text color="muted">SEB **** 9128</Text>
               </Box>

--- a/clients/apps/web/src/components/Landing/Pricing.tsx
+++ b/clients/apps/web/src/components/Landing/Pricing.tsx
@@ -54,8 +54,8 @@ const TIERS: Tier[] = [
 export const Pricing = () => (
   <>
     <span id="pricing" className="block scroll-mt-12 md:scroll-mt-28" />
-    <Box as="section" display="flex" flexDirection="column" rowGap="5xl">
-      <Box display="flex" flexDirection="column" rowGap="xl">
+    <Box as="section" flexDirection="column" rowGap="5xl">
+      <Box flexDirection="column" rowGap="xl">
         <Text variant="heading-xl" as="h2" wrap="balance">
           Built to scale with you.
         </Text>
@@ -64,7 +64,7 @@ export const Pricing = () => (
             Start free. Upgrade as you grow. Enterprise needs? Let&apos;s talk.
           </Text>
         </Box>
-        <Box display="flex" alignItems="center" columnGap="m" paddingTop="m">
+        <Box alignItems="center" columnGap="m" paddingTop="m">
           <GetStartedButton size="default" />
           <Link href="mailto:support@polar.sh">
             <Button variant="secondary">Contact Sales</Button>
@@ -98,23 +98,12 @@ const StartupProgramCard = () => (
     backgroundColor="background-secondary"
     overflow="hidden"
   >
-    <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      padding="2xl"
-    >
-      <Box display="flex" width="100%" aspectRatio="1 / 1">
+    <Box alignItems="center" justifyContent="center" padding="2xl">
+      <Box width="100%" aspectRatio="1 / 1">
         <VolumetricSlices />
       </Box>
     </Box>
-    <Box
-      position="relative"
-      display="flex"
-      flexDirection="column"
-      rowGap="xl"
-      padding="3xl"
-    >
+    <Box position="relative" flexDirection="column" rowGap="xl" padding="3xl">
       <Box
         position="absolute"
         top="3rem"
@@ -125,8 +114,8 @@ const StartupProgramCard = () => (
         borderColor="border-primary"
         display={{ base: 'none', sm: 'block' }}
       />
-      <Box display="flex" flexDirection="column" rowGap="xl">
-        <Box display="flex" flexDirection="column" rowGap="m">
+      <Box flexDirection="column" rowGap="xl">
+        <Box flexDirection="column" rowGap="m">
           <Text variant="heading-s" as="h3">
             Startup Program
           </Text>
@@ -136,7 +125,7 @@ const StartupProgramCard = () => (
             </Text>
           </Box>
         </Box>
-        <Box display="flex" alignItems="baseline" columnGap="m">
+        <Box alignItems="baseline" columnGap="m">
           <Text variant="heading-s" as="span">
             Free
           </Text>
@@ -158,14 +147,13 @@ const StartupProgramCard = () => (
 
 const TierCard = ({ tier }: { tier: Tier }) => (
   <Box
-    display="flex"
     flexDirection="column"
     justifyContent="between"
     backgroundColor="background-secondary"
   >
-    <Box display="flex" flexDirection="column" rowGap="xl" padding="3xl">
-      <Box display="flex" flexDirection="column" rowGap="xl">
-        <Box display="flex" flexDirection="column" rowGap="m">
+    <Box flexDirection="column" rowGap="xl" padding="3xl">
+      <Box flexDirection="column" rowGap="xl">
+        <Box flexDirection="column" rowGap="m">
           <Text variant="heading-s" as="h3">
             {tier.name}
           </Text>
@@ -175,7 +163,7 @@ const TierCard = ({ tier }: { tier: Tier }) => (
             </Text>
           </Box>
         </Box>
-        <Box display="flex" alignItems="baseline" columnGap="m">
+        <Box alignItems="baseline" columnGap="m">
           <Text variant="heading-s" as="span">
             {tier.free ? 'Free' : tier.price}
           </Text>
@@ -194,7 +182,6 @@ const TierCard = ({ tier }: { tier: Tier }) => (
 
 const CardSection = ({ label, items }: { label: string; items: string[] }) => (
   <Box
-    display="flex"
     flexDirection="column"
     rowGap="s"
     paddingTop="xl"
@@ -205,7 +192,7 @@ const CardSection = ({ label, items }: { label: string; items: string[] }) => (
     <Text variant="body" color="muted">
       {label}
     </Text>
-    <Box as="ul" display="flex" flexDirection="column" rowGap="s">
+    <Box as="ul" flexDirection="column" rowGap="s">
       {items.map((item) => (
         <Box as="li" display="flex" key={item}>
           <Text variant="body">{item}</Text>

--- a/clients/apps/web/src/components/Landing/Pricing.tsx
+++ b/clients/apps/web/src/components/Landing/Pricing.tsx
@@ -59,7 +59,7 @@ export const Pricing = () => (
         <Text variant="heading-xl" as="h2" wrap="balance">
           Built to scale with you.
         </Text>
-        <Box maxWidth="56rem">
+        <Box display="block" maxWidth="56rem">
           <Text variant="heading-xs" wrap="balance" color="muted">
             Start free. Upgrade as you grow. Enterprise needs? Let&apos;s talk.
           </Text>
@@ -130,7 +130,7 @@ const StartupProgramCard = () => (
           <Text variant="heading-s" as="h3">
             Startup Program
           </Text>
-          <Box>
+          <Box display="block">
             <Text variant="body" color="muted">
               A year on our most generous plan.
             </Text>
@@ -147,7 +147,7 @@ const StartupProgramCard = () => (
       </Box>
       <CardSection label="Fees" items={['3.40% + 30¢ per transaction']} />
       <CardSection label="Features" items={['Everything on Scale']} />
-      <Box paddingTop="m">
+      <Box display="block" paddingTop="m">
         <Link href="/startup-program" prefetch>
           <Button>Apply now</Button>
         </Link>
@@ -169,7 +169,7 @@ const TierCard = ({ tier }: { tier: Tier }) => (
           <Text variant="heading-s" as="h3">
             {tier.name}
           </Text>
-          <Box>
+          <Box display="block">
             <Text variant="body" color="muted">
               {tier.desc}
             </Text>

--- a/clients/apps/web/src/components/Landing/SectionHeader.tsx
+++ b/clients/apps/web/src/components/Landing/SectionHeader.tsx
@@ -23,13 +23,13 @@ export const SectionHeader = ({ title, description }: SectionHeaderProps) => (
     columnGap="4xl"
   >
     <Box flex={1} display="flex">
-      <Box maxWidth={{ base: '100%', xl: '32rem' }}>
+      <Box display="block" maxWidth={{ base: '100%', xl: '32rem' }}>
         <Text variant="heading-l" as="h2" wrap="balance">
           {title}
         </Text>
       </Box>
     </Box>
-    <Box flex={1}>
+    <Box display="block" flex={1}>
       <Text variant="heading-xs" color="muted" wrap="pretty">
         {description}
       </Text>

--- a/clients/apps/web/src/components/Landing/SectionHeader.tsx
+++ b/clients/apps/web/src/components/Landing/SectionHeader.tsx
@@ -16,13 +16,12 @@ interface SectionHeaderProps {
  */
 export const SectionHeader = ({ title, description }: SectionHeaderProps) => (
   <Box
-    display="flex"
     flexDirection={{ base: 'column', xl: 'row' }}
     alignItems={{ base: 'start', xl: 'center' }}
     rowGap="l"
     columnGap="4xl"
   >
-    <Box flex={1} display="flex">
+    <Box flex={1}>
       <Box display="block" maxWidth={{ base: '100%', xl: '32rem' }}>
         <Text variant="heading-l" as="h2" wrap="balance">
           {title}

--- a/clients/apps/web/src/components/Landing/Testimonials.tsx
+++ b/clients/apps/web/src/components/Landing/Testimonials.tsx
@@ -135,6 +135,7 @@ export const Testimonials = () => (
               {t.text}
             </Box>
             <Box
+              display="block"
               borderTopWidth={2}
               borderStyle="solid"
               borderColor="border-primary"

--- a/clients/apps/web/src/components/Landing/Testimonials.tsx
+++ b/clients/apps/web/src/components/Landing/Testimonials.tsx
@@ -97,7 +97,7 @@ const userTestimonials = [
 ]
 
 export const Testimonials = () => (
-  <Box display="flex" flexDirection="column" rowGap="3xl">
+  <Box flexDirection="column" rowGap="3xl">
     <SectionHeader
       title="What industry leaders think about Polar"
       description="From AI startups to infrastructure veterans, the teams building the future ship production billing on Polar in days, not weeks."
@@ -115,7 +115,6 @@ export const Testimonials = () => (
           className="dark:bg-polar-900 dark:hover:bg-polar-900 bg-gray-50 transition-colors hover:bg-gray-100"
         >
           <Box
-            display="flex"
             flexDirection="column"
             justifyContent="between"
             rowGap="2xl"
@@ -131,7 +130,7 @@ export const Testimonials = () => (
                 className="size-10"
               />
             )}
-            <Box display="flex" flexDirection="column" rowGap="m" flexGrow={1}>
+            <Box flexDirection="column" rowGap="m" flexGrow={1}>
               {t.text}
             </Box>
             <Box
@@ -141,7 +140,7 @@ export const Testimonials = () => (
               borderColor="border-primary"
               width="1.5rem"
             />
-            <Box display="flex" flexDirection="column">
+            <Box flexDirection="column">
               <Text variant="body" as="span">
                 {t.name}
               </Text>

--- a/clients/apps/web/src/components/Landing/UseCases.tsx
+++ b/clients/apps/web/src/components/Landing/UseCases.tsx
@@ -84,7 +84,6 @@ export const UseCases = () => {
   return (
     <SyntaxHighlighterProvider>
       <Box
-        display="flex"
         flexDirection="column"
         rowGap={{ base: '2xl', md: '3xl' }}
         width="100%"
@@ -95,7 +94,6 @@ export const UseCases = () => {
         />
 
         <Box
-          display="flex"
           flexDirection="column"
           overflow="hidden"
           borderWidth={1}
@@ -124,9 +122,8 @@ export const UseCases = () => {
             })}
           </div>
 
-          <Box display="flex" flexDirection={{ base: 'column', md: 'row' }}>
+          <Box flexDirection={{ base: 'column', md: 'row' }}>
             <Box
-              display="flex"
               flexDirection="column"
               rowGap="l"
               padding="2xl"

--- a/clients/apps/web/src/components/Landing/UseCases.tsx
+++ b/clients/apps/web/src/components/Landing/UseCases.tsx
@@ -139,12 +139,12 @@ export const UseCases = () => {
                 {active.title}
               </Text>
 
-              <Box maxWidth="28rem">
+              <Box display="block" maxWidth="28rem">
                 <Text variant="heading-xxs" color="muted">
                   {active.desc}
                 </Text>
               </Box>
-              <Box paddingTop="xs">
+              <Box display="block" paddingTop="xs">
                 <Link href={active.docsHref}>
                   <Button className="dark:hover:bg-polar-50 rounded-full border-none bg-black hover:bg-gray-900 dark:bg-white dark:text-black">
                     Read the docs

--- a/clients/apps/web/src/components/Landing/startup-program/StartupProgramFAQ.tsx
+++ b/clients/apps/web/src/components/Landing/startup-program/StartupProgramFAQ.tsx
@@ -66,7 +66,7 @@ export const StartupProgramFAQ = () => {
       <Text as="h2" variant="heading-l" wrap="balance">
         Questions and answers
       </Text>
-      <Box gridColumn={{ md: 'span 2' }}>
+      <Box display="block" gridColumn={{ md: 'span 2' }}>
         <Accordion type="multiple" className="flex flex-col">
           {FAQS.map((faq, i) => (
             <AccordionItem
@@ -78,7 +78,7 @@ export const StartupProgramFAQ = () => {
                 {faq.question}
               </AccordionTrigger>
               <AccordionContent>
-                <Box paddingBottom="m" maxWidth="42rem">
+                <Box display="block" paddingBottom="m" maxWidth="42rem">
                   <Text variant="body" color="muted">
                     {faq.answer}
                   </Text>

--- a/clients/apps/web/src/components/Landing/startup-program/StartupProgramForm.tsx
+++ b/clients/apps/web/src/components/Landing/startup-program/StartupProgramForm.tsx
@@ -62,7 +62,7 @@ interface FieldProps {
 }
 
 const Field = ({ label, htmlFor, children }: FieldProps) => (
-  <Box display="flex" flexDirection="column" rowGap="s">
+  <Box flexDirection="column" rowGap="s">
     <Text as="label" htmlFor={htmlFor}>
       {label}
     </Text>
@@ -126,7 +126,6 @@ export const StartupProgramForm = () => {
   return (
     <Box
       as="form"
-      display="flex"
       flexDirection="column"
       rowGap="l"
       padding={{

--- a/clients/apps/web/src/components/Landing/startup-program/StartupProgramHero.tsx
+++ b/clients/apps/web/src/components/Landing/startup-program/StartupProgramHero.tsx
@@ -16,8 +16,8 @@ const SCALE_FEATURES = ['Slack Channel', 'Prioritized Ticket support']
 
 export const StartupProgramHero = () => {
   return (
-    <Box display="flex" flexDirection="column" rowGap="3xl">
-      <Box display="flex" flexDirection="column" rowGap="2xl">
+    <Box flexDirection="column" rowGap="3xl">
+      <Box flexDirection="column" rowGap="2xl">
         <Text as="h3" variant="heading-l" wrap="pretty">
           Polar for Startups
         </Text>
@@ -28,11 +28,10 @@ export const StartupProgramHero = () => {
         </Text>
       </Box>
 
-      <Box display="flex" flexDirection="row">
+      <Box flexDirection="row">
         {STATS.map((s, i) => (
           <Box
             key={s.label}
-            display="flex"
             flexDirection="column"
             rowGap="xs"
             paddingHorizontal="xl"
@@ -50,7 +49,6 @@ export const StartupProgramHero = () => {
       </Box>
 
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="xl"
         padding={{
@@ -59,20 +57,15 @@ export const StartupProgramHero = () => {
         }}
         backgroundColor="background-secondary"
       >
-        <Box display="flex" flexDirection="column" rowGap="m">
+        <Box flexDirection="column" rowGap="m">
           <Text variant="heading-s">Scale</Text>
           <Text variant="body" color="muted">
             For fast growing businesses
           </Text>
         </Box>
 
-        <Box display="flex" flexDirection="column" rowGap="s">
-          <Box
-            display="flex"
-            flexDirection="row"
-            alignItems="baseline"
-            columnGap="m"
-          >
+        <Box flexDirection="column" rowGap="s">
+          <Box flexDirection="row" alignItems="baseline" columnGap="m">
             <Text variant="heading-s">Free</Text>
             <Text variant="body" color="muted">
               for 1 year
@@ -80,25 +73,19 @@ export const StartupProgramHero = () => {
           </Box>
         </Box>
 
-        <Box display="flex" flexDirection="column" rowGap="xs">
+        <Box flexDirection="column" rowGap="xs">
           <Text variant="body" color="muted">
             Transaction Fee
           </Text>
           <Text variant="body">3.40% + $0.30</Text>
         </Box>
 
-        <Box display="flex" flexDirection="column" rowGap="s">
+        <Box flexDirection="column" rowGap="s">
           <Text variant="body" color="muted">
             Features
           </Text>
           {SCALE_FEATURES.map((f) => (
-            <Box
-              key={f}
-              display="flex"
-              flexDirection="row"
-              alignItems="center"
-              columnGap="s"
-            >
+            <Box key={f} flexDirection="row" alignItems="center" columnGap="s">
               <CheckOutlined fontSize="inherit" />
               <Text variant="body">{f}</Text>
             </Box>

--- a/clients/apps/web/src/components/Landing/startup-program/StartupProgramPage.tsx
+++ b/clients/apps/web/src/components/Landing/startup-program/StartupProgramPage.tsx
@@ -10,15 +10,14 @@ import { VolumetricSlices } from '../graphics/VolumetricSlices'
 
 export const StartupProgramPage = () => {
   return (
-    <Box display="flex" flexDirection="column" alignItems="center">
+    <Box flexDirection="column" alignItems="center">
       <Box
-        display="flex"
         alignItems="center"
         flexDirection="column"
         paddingVertical="2xl"
         rowGap="2xl"
       >
-        <Box width="16rem" display="flex" aspectRatio="1 / 1">
+        <Box width="16rem" aspectRatio="1 / 1">
           <VolumetricSlices />
         </Box>
         <Text as="h1" variant="heading-xl">
@@ -29,7 +28,7 @@ export const StartupProgramPage = () => {
         </Text>
       </Box>
 
-      <Box width="4rem" marginTop="2xl" display="flex" />
+      <Box width="4rem" marginTop="2xl" />
 
       <Section>
         <Box

--- a/clients/apps/web/src/components/Onboarding/APIPreview.tsx
+++ b/clients/apps/web/src/components/Onboarding/APIPreview.tsx
@@ -165,9 +165,8 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
       : 'text-amber-600 dark:text-amber-500'
 
   return (
-    <Box display="flex" flexDirection="column">
+    <Box flexDirection="column">
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="xs"
         borderBottomWidth={1}
@@ -175,7 +174,7 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
         borderColor="border-primary"
         paddingBottom="m"
       >
-        <Box display="flex" alignItems="center" gap="s">
+        <Box alignItems="center" gap="s">
           <p
             className={`font-mono text-[11px] leading-relaxed font-semibold ${methodColor}`}
           >
@@ -185,7 +184,7 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
             {path}
           </p>
         </Box>
-        <Box display="flex" flexDirection="column">
+        <Box flexDirection="column">
           <p className="font-mono text-[10px] leading-relaxed text-gray-400 dark:text-gray-600">
             Host: api.polar.sh
           </p>
@@ -205,11 +204,11 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
         Request Body
       </p>
 
-      <Box display="flex" flexDirection="column">
+      <Box flexDirection="column">
         {lines.map((line, i) => {
           const isFlashed = flashedKeys.has(line.key)
           return (
-            <Box key={line.key} display="flex">
+            <Box key={line.key}>
               <p
                 className="mr-3 shrink-0 text-right font-mono text-[11px] leading-relaxed text-gray-300 select-none dark:text-gray-700"
                 style={{ minWidth: '1.5ch' }}
@@ -238,7 +237,6 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
       {apiLoading && (
         <Box
           marginTop="m"
-          display="flex"
           alignItems="center"
           gap="s"
           borderTopWidth={1}
@@ -256,7 +254,6 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
       {apiResponse && (
         <Box
           marginTop="m"
-          display="flex"
           flexDirection="column"
           rowGap="m"
           borderTopWidth={1}
@@ -264,7 +261,7 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
           borderColor="border-primary"
           paddingTop="m"
         >
-          <Box display="flex" alignItems="center" gap="s">
+          <Box alignItems="center" gap="s">
             <p
               className={`rounded-sm px-1.5 py-0.5 font-mono text-[10px] leading-relaxed font-bold ${
                 apiResponse.status >= 400

--- a/clients/apps/web/src/components/Onboarding/APIPreview.tsx
+++ b/clients/apps/web/src/components/Onboarding/APIPreview.tsx
@@ -246,7 +246,7 @@ export function APIPreview({ step }: { step: APIPreviewStep }) {
           borderColor="border-primary"
           paddingTop="m"
         >
-          <Box height={6} width={6} borderRadius="full" />
+          <Box display="block" height={6} width={6} borderRadius="full" />
           <p className="font-mono text-[10px] leading-relaxed text-gray-400 dark:text-gray-500">
             Sending request...
           </p>

--- a/clients/apps/web/src/components/Onboarding/AUPBlocker.tsx
+++ b/clients/apps/web/src/components/Onboarding/AUPBlocker.tsx
@@ -5,7 +5,6 @@ import { Box } from '@polar-sh/orbit/Box'
 export function AUPBlocker({ categories }: { categories: string[] }) {
   return (
     <Box
-      display="flex"
       flexDirection="column"
       rowGap="m"
       borderRadius="m"

--- a/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/BusinessDetailsStep.tsx
@@ -143,7 +143,7 @@ function CurrencyAndCountryFields() {
   }, [country])
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="s">
+    <Box flexDirection="column" rowGap="s">
       <Box
         display="grid"
         gap="m"
@@ -194,7 +194,6 @@ function CurrencyAndCountryFields() {
 
       {organizationType === 'company' && isUnsupportedCountry && (
         <Box
-          display="flex"
           flexDirection="column"
           rowGap="m"
           borderRadius="m"
@@ -283,7 +282,6 @@ export function BusinessDetailsStep() {
         <Box
           as="form"
           onSubmit={handleSubmit(onSubmit)}
-          display="flex"
           flexDirection="column"
           rowGap="xl"
         >

--- a/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
@@ -361,6 +361,7 @@ POLAR_SUCCESS_URL=https://example.com/success?checkout_id={CHECKOUT_ID}`}
 const CodeWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
     <Box
+      display="block"
       width="100%"
       borderRadius="m"
       borderWidth={1}
@@ -405,6 +406,7 @@ const FrameworkCard = ({
       >
         {icon ?? (
           <Box
+            display="block"
             height={32}
             width={32}
             borderRadius="full"

--- a/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
@@ -196,13 +196,8 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
   const isPython = currentFramework?.slug === 'python'
 
   return (
-    <Box
-      display="flex"
-      height="100%"
-      flexDirection={{ base: 'column', md: 'row' }}
-    >
+    <Box height="100%" flexDirection={{ base: 'column', md: 'row' }}>
       <Box
-        display="flex"
         height="100%"
         minHeight={0}
         width="100%"
@@ -213,9 +208,9 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
         maxWidth={{ md: '32rem' }}
         backgroundColor="background-card"
       >
-        <Box display="flex" flexDirection="column" rowGap="3xl">
+        <Box flexDirection="column" rowGap="3xl">
           <LogoIcon size={50} />
-          <Box display="flex" flexDirection="column" rowGap="l">
+          <Box flexDirection="column" rowGap="l">
             <h1 className="text-3xl">Integrate Checkout</h1>
             <p className="dark:text-polar-400 text-lg text-gray-600">
               Integrate checkouts with your favorite framework.
@@ -242,7 +237,7 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
               />
             ))}
           </Box>
-          <Box display="flex" flexDirection="column" rowGap="l">
+          <Box flexDirection="column" rowGap="l">
             <Link
               href={`https://polar.sh/docs/integrate/sdk/adapters/nextjs`}
               target="_blank"
@@ -272,7 +267,6 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
           padding="4xl"
         >
           <Box
-            display="flex"
             width="100%"
             maxWidth="48rem"
             flexDirection="column"
@@ -281,9 +275,8 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
             backgroundColor="background-card"
             padding="3xl"
           >
-            <Box display="flex" flexDirection="column" rowGap="xl">
+            <Box flexDirection="column" rowGap="xl">
               <Box
-                display="flex"
                 flexDirection="row"
                 alignItems="center"
                 justifyContent="between"
@@ -315,7 +308,7 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
               </CodeWrapper>
             </Box>
 
-            <Box display="flex" flexDirection="column" rowGap="xl">
+            <Box flexDirection="column" rowGap="xl">
               <h2 className="text-lg">2. Add Environment Variables</h2>
               <OrganizationAccessTokensSettings
                 organization={organization}
@@ -332,7 +325,7 @@ POLAR_SUCCESS_URL=https://example.com/success?checkout_id={CHECKOUT_ID}`}
               </CodeWrapper>
             </Box>
 
-            <Box display="flex" flexDirection="column" rowGap="xl">
+            <Box flexDirection="column" rowGap="xl">
               <h2 className="text-lg">3. Integrate the Checkout</h2>
               <CodeWrapper>
                 <SyntaxHighlighterClient
@@ -394,7 +387,6 @@ const FrameworkCard = ({
     <button type="button" onClick={() => onClick(slug)}>
       <Box
         cursor="pointer"
-        display="flex"
         flexDirection="column"
         rowGap="l"
         borderRadius="m"

--- a/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
@@ -40,7 +40,6 @@ export function OnboardingShell({
 
   return (
     <Box
-      display="flex"
       minHeight="100vh"
       justifyContent="center"
       backgroundColor="background-primary"
@@ -51,7 +50,6 @@ export function OnboardingShell({
         position="absolute"
         bottom={24}
         left={24}
-        display="flex"
         gap="l"
         color="text-tertiary"
       >
@@ -68,10 +66,9 @@ export function OnboardingShell({
           Log out
         </a>
       </Box>
-      <Box display="flex" width="100%" maxWidth="60rem">
+      <Box width="100%" maxWidth="60rem">
         {/* Left: form */}
         <Box
-          display="flex"
           flex={1}
           flexDirection="column"
           alignItems="center"
@@ -87,14 +84,9 @@ export function OnboardingShell({
             className="flex w-full max-w-md flex-col gap-y-8"
           >
             {/* Logo + back + progress */}
-            <Box
-              position="relative"
-              display="flex"
-              flexDirection="column"
-              rowGap="xl"
-            >
-              <Box display="flex" flexDirection="column" rowGap="xl">
-                <Box display="flex" alignItems="center" justifyContent="center">
+            <Box position="relative" flexDirection="column" rowGap="xl">
+              <Box flexDirection="column" rowGap="xl">
+                <Box alignItems="center" justifyContent="center">
                   {currentIndex > 0 && (
                     <button
                       type="button"
@@ -107,9 +99,9 @@ export function OnboardingShell({
                   <LogoIcon size={36} />
                 </Box>
                 {step && (
-                  <Box display="flex" width="100%" alignItems="center" gap="s">
+                  <Box width="100%" alignItems="center" gap="s">
                     {STEPS.map((s, i) => (
-                      <Box key={s} display="flex" flex={1}>
+                      <Box key={s} flex={1}>
                         <Box
                           display="block"
                           height={2}
@@ -127,7 +119,7 @@ export function OnboardingShell({
                 )}
               </Box>
 
-              <Box display="flex" flexDirection="column" rowGap="m">
+              <Box flexDirection="column" rowGap="m">
                 <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
                   {title}
                 </h1>

--- a/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
@@ -111,6 +111,7 @@ export function OnboardingShell({
                     {STEPS.map((s, i) => (
                       <Box key={s} display="flex" flex={1}>
                         <Box
+                          display="block"
                           height={2}
                           width="100%"
                           borderRadius="full"
@@ -161,6 +162,7 @@ export function OnboardingShell({
           paddingBottom="3xl"
         >
           <Box
+            display="block"
             position="absolute"
             top={0}
             bottom={0}
@@ -168,7 +170,7 @@ export function OnboardingShell({
             right={-10000}
             backgroundColor="background-secondary"
           />
-          <Box position="sticky" top={150} zIndex={1}>
+          <Box display="block" position="sticky" top={150} zIndex={1}>
             {(apiStep ?? step) && <APIPreview step={(apiStep ?? step)!} />}
           </Box>
         </Box>

--- a/clients/apps/web/src/components/Onboarding/PersonalDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/PersonalDetailsStep.tsx
@@ -227,7 +227,6 @@ export function PersonalDetailsStep({ geoCountry }: { geoCountry?: string }) {
         <Box
           as="form"
           onSubmit={handleSubmit(onSubmit)}
-          display="flex"
           flexDirection="column"
           rowGap="xl"
         >
@@ -267,7 +266,7 @@ export function PersonalDetailsStep({ geoCountry }: { geoCountry?: string }) {
             />
           </Box>
 
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <FormField
               control={control}
               name="country"
@@ -290,7 +289,6 @@ export function PersonalDetailsStep({ geoCountry }: { geoCountry?: string }) {
 
             {isUnsupportedCountry && (
               <Box
-                display="flex"
                 flexDirection="column"
                 rowGap="m"
                 borderRadius="m"
@@ -309,9 +307,9 @@ export function PersonalDetailsStep({ geoCountry }: { geoCountry?: string }) {
             )}
           </Box>
 
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <FormLabel>Date of Birth</FormLabel>
-            <Box display="flex" gap="m">
+            <Box gap="m">
               <FormField
                 control={control}
                 name="dobMonth"
@@ -406,7 +404,7 @@ export function PersonalDetailsStep({ geoCountry }: { geoCountry?: string }) {
             />
           )}
 
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <SubmitButton loading={submitting} />
             {submitError && (
               <p className="text-sm text-red-500 dark:text-red-500">

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -234,11 +234,10 @@ export function ProductDetailsStep() {
         <Box
           as="form"
           onSubmit={handleSubmit(onSubmit)}
-          display="flex"
           flexDirection="column"
           rowGap="xl"
         >
-          <Box display="flex" flexDirection="column" rowGap="m">
+          <Box flexDirection="column" rowGap="m">
             <FormLabel>What are you selling?</FormLabel>
             <ChipSelect
               options={SELLING_CATEGORIES.map((c) => c.name)}
@@ -274,7 +273,6 @@ export function ProductDetailsStep() {
 
           {aup.verdict && (
             <Box
-              display="flex"
               flexDirection="column"
               rowGap="m"
               borderRadius="m"
@@ -295,7 +293,7 @@ export function ProductDetailsStep() {
             </Box>
           )}
 
-          <Box display="flex" flexDirection="column" rowGap="m">
+          <Box flexDirection="column" rowGap="m">
             <FormLabel>Pricing model</FormLabel>
             <ChipSelect
               options={PRICING_MODELS}
@@ -304,7 +302,7 @@ export function ProductDetailsStep() {
             />
           </Box>
 
-          <Box display="flex" flexDirection="column" rowGap="m">
+          <Box flexDirection="column" rowGap="m">
             <FormLabel>
               Currently selling on{' '}
               <Box as="span" color="text-tertiary">
@@ -373,7 +371,7 @@ export function ProductDetailsStep() {
             />
           </Box>
 
-          <Box display="flex" flexDirection="column" rowGap="s">
+          <Box flexDirection="column" rowGap="s">
             <Button
               type="submit"
               onClick={() => form.clearErrors()}

--- a/clients/apps/web/src/components/Onboarding/SandboxFormFields.tsx
+++ b/clients/apps/web/src/components/Onboarding/SandboxFormFields.tsx
@@ -161,12 +161,7 @@ export function SandboxFormFields({
         rules={{ required: 'You must accept the terms to continue' }}
         render={({ field }) => (
           <FormItem>
-            <Box
-              display="flex"
-              flexDirection="row"
-              alignItems="start"
-              columnGap="m"
-            >
+            <Box flexDirection="row" alignItems="start" columnGap="m">
               <Checkbox
                 id="terms"
                 checked={field.value}

--- a/clients/apps/web/src/components/Onboarding/SandboxStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/SandboxStep.tsx
@@ -116,7 +116,6 @@ export function SandboxStep() {
         <Box
           as="form"
           onSubmit={form.handleSubmit(onSubmit)}
-          display="flex"
           flexDirection="column"
           rowGap="xl"
         >

--- a/clients/apps/web/src/components/Onboarding/TermsCheckbox.tsx
+++ b/clients/apps/web/src/components/Onboarding/TermsCheckbox.tsx
@@ -29,12 +29,7 @@ export function TermsCheckbox<T extends FieldValues>({
       render={({ field }) => (
         <FormItem>
           <FormControl>
-            <Box
-              display="flex"
-              flexDirection="row"
-              alignItems="start"
-              columnGap="m"
-            >
+            <Box flexDirection="row" alignItems="start" columnGap="m">
               <Checkbox
                 id="terms"
                 checked={field.value}
@@ -46,7 +41,7 @@ export function TermsCheckbox<T extends FieldValues>({
                 }}
                 className="mt-0.5"
               />
-              <Box display="flex" flexDirection="column" rowGap="xs">
+              <Box flexDirection="column" rowGap="xs">
                 <Box as="label" htmlFor="terms">
                   <p className="cursor-pointer text-sm leading-snug font-medium">
                     I agree to Polar&apos;s{' '}

--- a/clients/apps/web/src/components/Onboarding/ToolCallGroup.tsx
+++ b/clients/apps/web/src/components/Onboarding/ToolCallGroup.tsx
@@ -184,7 +184,7 @@ export const ToolCallGroup = ({
 
   if (expanded) {
     return (
-      <Box display="flex" flexDirection="column" gap="s">
+      <Box flexDirection="column" gap="s">
         <button
           onClick={() => setExpanded(false)}
           className="dark:text-polar-500 flex items-center gap-1 text-left text-gray-500 hover:text-gray-700 dark:hover:text-gray-400"
@@ -197,7 +197,6 @@ export const ToolCallGroup = ({
         </button>
         <Box
           marginLeft="xl"
-          display="flex"
           flexDirection="column"
           gap="xs"
           borderLeftWidth={2}

--- a/clients/apps/web/src/components/PaymentMethodDisplay.tsx
+++ b/clients/apps/web/src/components/PaymentMethodDisplay.tsx
@@ -32,13 +32,13 @@ export const PaymentMethodDisplay = ({
 }: PaymentMethodDisplayProps) => {
   if (card) {
     return (
-      <Box display="flex" alignItems="center" columnGap="m" flexGrow={1}>
+      <Box alignItems="center" columnGap="m" flexGrow={1}>
         <CreditCardBrandIcon
           width="3.5em"
           brand={card.brand}
           className="dark:border-polar-700 rounded-lg border border-gray-200"
         />
-        <Box display="flex" flexDirection="column">
+        <Box flexDirection="column">
           <Text>{`${capitalize(card.brand)} •••• ${card.last4}`}</Text>
           <Text color="muted" variant="caption">
             Expires {card.exp_month}/{card.exp_year}
@@ -49,9 +49,8 @@ export const PaymentMethodDisplay = ({
   }
 
   return (
-    <Box display="flex" alignItems="center" columnGap="m" flexGrow={1}>
+    <Box alignItems="center" columnGap="m" flexGrow={1}>
       <Box
-        display="flex"
         alignItems="center"
         justifyContent="center"
         width="3.5em"

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -70,7 +70,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
     : null
 
   return (
-    <Box display="flex" flexDirection={{ base: 'column', md: 'row' }} gap="2xl">
+    <Box flexDirection={{ base: 'column', md: 'row' }} gap="2xl">
       <Well className="flex-1 justify-start rounded-2xl bg-gray-50 p-6">
         <WellHeader className="flex flex-row items-center justify-between gap-x-6">
           <Text variant="heading-xxs" as="h2">
@@ -156,7 +156,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
         </WellContent>
         <WellFooter className="mt-auto">
           {payoutAccount ? (
-            <Box display="flex" alignItems="center" columnGap="m">
+            <Box alignItems="center" columnGap="m">
               <Text color="muted">
                 {payoutAccount.country.toUpperCase()} ·{' '}
                 {payoutAccount.currency.toUpperCase()}

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -163,6 +163,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
               </Text>
               <Box display="inline-flex" alignItems="center" columnGap="xs">
                 <Box
+                  display="block"
                   width={6}
                   height={6}
                   borderRadius="full"

--- a/clients/apps/web/src/components/Settings/Billing/BillingAddressSection.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingAddressSection.tsx
@@ -78,7 +78,7 @@ export const BillingAddressSection = ({
             {taxId && <Text color="muted">Tax ID: {taxId}</Text>}
           </Box>
         ) : (
-          <Box paddingVertical="l" textAlign="center">
+          <Box display="block" paddingVertical="l" textAlign="center">
             <Text color="muted">No billing address on file</Text>
           </Box>
         )}

--- a/clients/apps/web/src/components/Settings/Billing/BillingAddressSection.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingAddressSection.tsx
@@ -41,13 +41,8 @@ export const BillingAddressSection = ({
   const taxId = details?.tax_id
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="l">
-      <Box
-        display="flex"
-        alignItems="start"
-        justifyContent="between"
-        columnGap="m"
-      >
+    <Box flexDirection="column" rowGap="l">
+      <Box alignItems="start" justifyContent="between" columnGap="m">
         <SectionDescription
           title="Billing address"
           description="Used on invoices for your Polar subscription"
@@ -57,7 +52,6 @@ export const BillingAddressSection = ({
         </Button>
       </Box>
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="m"
         borderRadius="l"
@@ -69,7 +63,7 @@ export const BillingAddressSection = ({
         {isLoading ? (
           <LoadingBox height={64} borderRadius="m" />
         ) : hasAddress ? (
-          <Box display="flex" flexDirection="column" rowGap="xs">
+          <Box flexDirection="column" rowGap="xs">
             {lines.map((line, idx) => (
               <Text key={idx} color={idx === 0 ? 'default' : 'muted'}>
                 {line}

--- a/clients/apps/web/src/components/Settings/Billing/BillingOrdersTable.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingOrdersTable.tsx
@@ -133,7 +133,7 @@ export const BillingOrdersTable = ({
       size: 56,
       cell: ({ row: { original } }) =>
         original.is_invoice_generated ? (
-          <Box display="flex" justifyContent="end">
+          <Box justifyContent="end">
             <DownloadInvoiceButton
               organizationId={organizationId}
               order={original}
@@ -146,7 +146,6 @@ export const BillingOrdersTable = ({
   if (orders.length === 0) {
     return (
       <Box
-        display="flex"
         flexDirection="column"
         alignItems="center"
         justifyContent="center"

--- a/clients/apps/web/src/components/Settings/Billing/BillingPaymentMethods.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingPaymentMethods.tsx
@@ -168,7 +168,7 @@ export const BillingPaymentMethods = ({
         {isLoading ? (
           <LoadingBox height={64} borderRadius="m" />
         ) : paymentMethods.length === 0 ? (
-          <Box paddingVertical="l" textAlign="center">
+          <Box display="block" paddingVertical="l" textAlign="center">
             <Text color="muted">No payment methods on file</Text>
           </Box>
         ) : (
@@ -184,7 +184,12 @@ export const BillingPaymentMethods = ({
         )}
       </Box>
       {error && (
-        <Box borderRadius="m" backgroundColor="background-danger" padding="l">
+        <Box
+          display="block"
+          borderRadius="m"
+          backgroundColor="background-danger"
+          padding="l"
+        >
           <Text color="danger">{error}</Text>
         </Box>
       )}

--- a/clients/apps/web/src/components/Settings/Billing/BillingPaymentMethods.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingPaymentMethods.tsx
@@ -77,12 +77,7 @@ const PaymentMethodRow = ({
   }
 
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="between"
-      columnGap="m"
-    >
+    <Box alignItems="center" justifyContent="between" columnGap="m">
       <PaymentMethodDisplay
         type={paymentMethod.type}
         card={
@@ -91,7 +86,7 @@ const PaymentMethodRow = ({
             : null
         }
       />
-      <Box display="flex" alignItems="center" columnGap="m">
+      <Box alignItems="center" columnGap="m">
         {paymentMethod.default ? (
           <Status
             status="Default Method"
@@ -140,13 +135,8 @@ export const BillingPaymentMethods = ({
   const paymentMethods = data?.items ?? []
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="l">
-      <Box
-        display="flex"
-        alignItems="start"
-        justifyContent="between"
-        columnGap="m"
-      >
+    <Box flexDirection="column" rowGap="l">
+      <Box alignItems="start" justifyContent="between" columnGap="m">
         <SectionDescription
           title="Payment methods"
           description="Cards used to pay for your Polar subscription"
@@ -156,7 +146,6 @@ export const BillingPaymentMethods = ({
         </Button>
       </Box>
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="m"
         borderRadius="l"

--- a/clients/apps/web/src/components/Settings/Billing/BillingSubscriptionCard.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingSubscriptionCard.tsx
@@ -37,7 +37,7 @@ const Detail = ({
   label: string
   children: React.ReactNode
 }) => (
-  <Box display="flex" flexDirection="column" rowGap="xs">
+  <Box flexDirection="column" rowGap="xs">
     <Text color="muted">{label}</Text>
     <Text>{children}</Text>
   </Box>
@@ -97,7 +97,6 @@ export const BillingSubscriptionCard = ({
 
   return (
     <Box
-      display="flex"
       flexDirection="column"
       rowGap="2xl"
       borderRadius="l"
@@ -107,14 +106,13 @@ export const BillingSubscriptionCard = ({
       padding="xl"
     >
       <Box
-        display="flex"
         flexDirection={{ base: 'column', md: 'row' }}
         rowGap="l"
         justifyContent={{ md: 'between' }}
         alignItems={{ md: 'start' }}
       >
-        <Box display="flex" flexDirection="column" rowGap="s">
-          <Box display="flex" alignItems="center" columnGap="m">
+        <Box flexDirection="column" rowGap="s">
+          <Box alignItems="center" columnGap="m">
             <Text variant="heading-xxs" as="h3">
               {plan.name}
             </Text>
@@ -131,12 +129,11 @@ export const BillingSubscriptionCard = ({
           {plan.description && <Text color="muted">{plan.description}</Text>}
         </Box>
         <Box
-          display="flex"
           flexDirection="column"
           rowGap="xs"
           alignItems={{ base: 'start', md: 'end' }}
         >
-          <Box display="flex" alignItems="baseline" columnGap="xs">
+          <Box alignItems="baseline" columnGap="xs">
             <Text variant="heading-xs" as="span">
               {subscription.amount === 0
                 ? 'Free'
@@ -185,7 +182,6 @@ export const BillingSubscriptionCard = ({
 
       {subscription.discount && (
         <Box
-          display="flex"
           flexDirection="column"
           rowGap="s"
           borderRadius="m"
@@ -193,7 +189,7 @@ export const BillingSubscriptionCard = ({
           backgroundColor="background-card"
           padding="l"
         >
-          <Box display="flex" alignItems="center" columnGap="l">
+          <Box alignItems="center" columnGap="l">
             <Text variant="body" as="h3">
               {subscription.discount.name}
             </Text>
@@ -215,7 +211,6 @@ export const BillingSubscriptionCard = ({
 
       {scheduledPlan && pendingChange && (
         <Box
-          display="flex"
           flexDirection="column"
           rowGap="m"
           columnGap="m"
@@ -224,7 +219,7 @@ export const BillingSubscriptionCard = ({
           backgroundColor="background-card"
           padding="l"
         >
-          <Box display="flex" flexDirection="column" columnGap="s">
+          <Box flexDirection="column" columnGap="s">
             <Text variant="body" as="h3">
               Plan change scheduled
             </Text>
@@ -236,13 +231,7 @@ export const BillingSubscriptionCard = ({
         </Box>
       )}
 
-      <Box
-        display="flex"
-        flexDirection="row"
-        flexWrap="wrap"
-        columnGap="m"
-        rowGap="m"
-      >
+      <Box flexDirection="row" flexWrap="wrap" columnGap="m" rowGap="m">
         <Button onClick={onChangePlan}>Change plan</Button>
       </Box>
     </Box>

--- a/clients/apps/web/src/components/Settings/Billing/StartupProgramCallout.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/StartupProgramCallout.tsx
@@ -95,7 +95,6 @@ export const StartupProgramCallout = ({
 
   return (
     <Box
-      display="flex"
       flexDirection="column"
       justifyContent={{ md: 'between' }}
       alignItems="start"
@@ -105,7 +104,7 @@ export const StartupProgramCallout = ({
       backgroundColor="background-card"
       padding="xl"
     >
-      <Box display="flex" flexDirection="column" rowGap="xs">
+      <Box flexDirection="column" rowGap="xs">
         <Text variant="body" as="h3">
           You&apos;re in the Polar Startup Program
         </Text>

--- a/clients/apps/web/src/components/Settings/IdentityVerificationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/IdentityVerificationSettings.tsx
@@ -9,6 +9,7 @@ const IdentityVerificationSettings = () => {
 
   return (
     <Box
+      display="block"
       borderRadius="l"
       borderWidth={1}
       borderStyle="solid"

--- a/clients/apps/web/src/components/Settings/TreeMultiSelect.tsx
+++ b/clients/apps/web/src/components/Settings/TreeMultiSelect.tsx
@@ -104,20 +104,15 @@ export function TreeMultiSelect<T extends string>({
   }
 
   return (
-    <Box display="flex" flexDirection="column">
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="between"
-        columnGap="m"
-      >
+    <Box flexDirection="column">
+      <Box alignItems="center" justifyContent="between" columnGap="m">
         {title ? <Text variant="label">{title}</Text> : <span />}
         <Button onClick={onToggleAll} variant="secondary" size="sm">
           {allSelected ? 'Unselect all' : 'Select all'}
         </Button>
       </Box>
 
-      <Box display="flex" flexDirection="column" rowGap="xs">
+      <Box flexDirection="column" rowGap="xs">
         {groups.map((group) => {
           const selectedCount = group.options.filter((o) =>
             selected.has(o),
@@ -130,7 +125,7 @@ export function TreeMultiSelect<T extends string>({
                 : 'indeterminate'
 
           return (
-            <Box key={group.key} display="flex" flexDirection="column">
+            <Box key={group.key} flexDirection="column">
               <Box
                 as="label"
                 display="flex"
@@ -146,7 +141,7 @@ export function TreeMultiSelect<T extends string>({
                 <Text variant="mono">{group.label}</Text>
               </Box>
 
-              <Box display="flex" flexDirection="column" pl="xl">
+              <Box flexDirection="column" pl="xl">
                 {group.options.map((option) => (
                   <Box
                     key={option}

--- a/clients/apps/web/src/components/Shared/LoadingBox.tsx
+++ b/clients/apps/web/src/components/Shared/LoadingBox.tsx
@@ -2,6 +2,7 @@ import { Box, type BoxProps } from '@polar-sh/orbit/Box'
 
 export const LoadingBox = (props: BoxProps) => (
   <Box
+    display="block"
     {...props}
     // eslint-disable-next-line polar/no-classname-box
     className="dark:bg-polar-700 animate-pulse bg-gray-100"

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionModal.tsx
@@ -235,7 +235,6 @@ const UpdateProduct = ({
                 padding="m"
                 borderRadius="m"
                 backgroundColor="background-warning"
-                display="flex"
                 flexDirection="column"
                 rowGap="s"
               >

--- a/clients/apps/web/src/components/Upsell/PlanUpsell.tsx
+++ b/clients/apps/web/src/components/Upsell/PlanUpsell.tsx
@@ -196,18 +196,12 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
       borderStyle="solid"
       borderColor="border-primary"
     >
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        padding="2xl"
-      >
-        <Box height="100%" width={240} display="flex" aspectRatio="1 / 1">
+      <Box alignItems="center" justifyContent="center" padding="2xl">
+        <Box height="100%" width={240} aspectRatio="1 / 1">
           <CycleArrow />
         </Box>
       </Box>
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="xl"
         padding="2xl"
@@ -216,7 +210,7 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
         borderStyle="solid"
         borderColor="border-primary"
       >
-        <Box display="flex" flexDirection="column" rowGap="l">
+        <Box flexDirection="column" rowGap="l">
           <Text color="accent" variant="body">
             Lower your transaction fees
           </Text>
@@ -230,7 +224,6 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
           </Text>
         </Box>
         <Box
-          display="flex"
           flexDirection="row"
           alignItems="center"
           columnGap="m"
@@ -253,7 +246,6 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
         </Box>
       </Box>
       <Box
-        display="flex"
         flexDirection="column"
         rowGap="l"
         padding="2xl"
@@ -263,14 +255,14 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
         borderColor="border-primary"
         justifyContent="between"
       >
-        <Box display="flex" flexDirection="column" rowGap="xs">
+        <Box flexDirection="column" rowGap="xs">
           <Text variant="heading-xs" as="h4">
             {plan.name}
           </Text>
           {plan.description && <Text color="muted">{plan.description}</Text>}
         </Box>
-        <Box display="flex" flexDirection="column" rowGap="s">
-          <Box display="flex" alignItems="baseline" columnGap="m">
+        <Box flexDirection="column" rowGap="s">
+          <Box alignItems="baseline" columnGap="m">
             <Text variant="heading-s" as="span">
               {formatStandard(planPrice, planCurrency)}
             </Text>
@@ -289,7 +281,6 @@ export const PlanUpsell = ({ organization }: PlanUpsellProps) => {
         {(plan.features?.length ?? 0) > 0 && (
           <Box
             as="ul"
-            display="flex"
             flexDirection="column"
             rowGap="s"
             borderTopWidth={1}

--- a/clients/packages/orbit/src/components/Box.tsx
+++ b/clients/packages/orbit/src/components/Box.tsx
@@ -22,6 +22,12 @@ type BoxElement =
   | 'ol'
   | 'li'
 
+// Box defaults to `display: flex` for block-level elements — the overwhelmingly
+// common case. Elements whose native display is inline (span, label) or
+// list-item (li) keep their natural display so semantics aren't broken; pass an
+// explicit `display` to override either way.
+const NON_FLEX_DEFAULT_ELEMENTS = new Set<BoxElement>(['span', 'label', 'li'])
+
 type BoxOwnProps<E extends BoxElement = 'div'> = BoxStyleProps & {
   as?: E
   className?: string
@@ -54,6 +60,14 @@ function BoxInner<E extends BoxElement = 'div'>(
     } else {
       domProps[key] = value
     }
+  }
+
+  // Apply the flex-by-default rule when the caller hasn't set `display`.
+  if (
+    styleProps.display === undefined &&
+    !NON_FLEX_DEFAULT_ELEMENTS.has((as ?? 'div') as BoxElement)
+  ) {
+    styleProps.display = 'flex'
   }
 
   const { stylexStyles, inlineStyle, responsiveCSS } = resolveBoxStyles(

--- a/clients/packages/orbit/src/index.ts
+++ b/clients/packages/orbit/src/index.ts
@@ -41,6 +41,8 @@ export type {
   AnimationProperties,
   AnimationToken,
 } from './tokens/animations'
+export type { DurationToken, EasingToken } from './tokens/tokens.stylex'
+export type { TransitionProperty } from './utils/types'
 
 // ─── Primitives ───────────────────────────────────────────────────────────────
 export { createText } from './primitives/createText'

--- a/clients/packages/orbit/src/tokens/tokens.stylex.ts
+++ b/clients/packages/orbit/src/tokens/tokens.stylex.ts
@@ -91,6 +91,27 @@ export const breakpoints = stylex.defineConsts({
   xl: 1280,
 })
 
+// ─── Motion ───────────────────────────────────────────────────────────────────
+// Durations are vars so motion can be globally tuned (or zeroed for
+// prefers-reduced-motion) by overriding the custom properties. Easings are
+// compile-time constants — they never need to vary at runtime.
+// ──────────────────────────────────────────────────────────────────────────────
+
+export const durations = stylex.defineVars({
+  instant: '0ms',
+  fast: '120ms',
+  base: '200ms',
+  slow: '320ms',
+  slower: '480ms',
+})
+
+export const easings = stylex.defineConsts({
+  standard: 'cubic-bezier(0.2, 0, 0, 1)', // general-purpose, symmetric
+  decelerate: 'cubic-bezier(0, 0, 0, 1)', // enter (fast → settle)
+  accelerate: 'cubic-bezier(0.3, 0, 1, 1)', // exit (settle → fast)
+  spring: 'cubic-bezier(0.5, 1.25, 0.4, 1)', // slight overshoot
+})
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type StyleXTokenKeys<T> = Exclude<
@@ -109,3 +130,5 @@ export type ColorToken =
 export type BorderRadiusToken = StyleXTokenKeys<typeof borderRadii>
 export type ShadowToken = StyleXTokenKeys<typeof shadows>
 export type BreakpointKey = keyof typeof breakpoints
+export type DurationToken = StyleXTokenKeys<typeof durations>
+export type EasingToken = keyof typeof easings

--- a/clients/packages/orbit/src/utils/box-styles.ts
+++ b/clients/packages/orbit/src/utils/box-styles.ts
@@ -3,10 +3,25 @@ import {
   backgroundColors,
   borderColors,
   borderRadii,
+  durations,
+  easings,
   shadows,
   spacing,
   textColors,
 } from '../tokens/tokens.stylex'
+
+// Property lists for the curated `transitionProperty` presets. Kept in one
+// place so the scalar (StyleX) path and the responsive path stay in sync.
+export const TRANSITION_PROPERTY_VALUES = {
+  none: 'none',
+  all: 'all',
+  common:
+    'color, background-color, border-color, box-shadow, opacity, transform',
+  colors: 'color, background-color, border-color',
+  opacity: 'opacity',
+  shadow: 'box-shadow',
+  transform: 'transform',
+} as const
 
 /*
   This is where we connect each prop to the corresponding CSS property from our design tokens.
@@ -497,4 +512,39 @@ export const textAlignStyles = stylex.create({
   center: { textAlign: 'center' },
   right: { textAlign: 'right' },
   justify: { textAlign: 'justify' },
+})
+
+// ── Motion ───────────────────────────────────────────────────────────────────
+
+export const transitionPropertyStyles = stylex.create({
+  none: { transitionProperty: TRANSITION_PROPERTY_VALUES.none },
+  all: { transitionProperty: TRANSITION_PROPERTY_VALUES.all },
+  common: { transitionProperty: TRANSITION_PROPERTY_VALUES.common },
+  colors: { transitionProperty: TRANSITION_PROPERTY_VALUES.colors },
+  opacity: { transitionProperty: TRANSITION_PROPERTY_VALUES.opacity },
+  shadow: { transitionProperty: TRANSITION_PROPERTY_VALUES.shadow },
+  transform: { transitionProperty: TRANSITION_PROPERTY_VALUES.transform },
+})
+
+export const transitionDurationStyles = stylex.create({
+  instant: { transitionDuration: durations.instant },
+  fast: { transitionDuration: durations.fast },
+  base: { transitionDuration: durations.base },
+  slow: { transitionDuration: durations.slow },
+  slower: { transitionDuration: durations.slower },
+})
+
+export const transitionTimingFunctionStyles = stylex.create({
+  standard: { transitionTimingFunction: easings.standard },
+  decelerate: { transitionTimingFunction: easings.decelerate },
+  accelerate: { transitionTimingFunction: easings.accelerate },
+  spring: { transitionTimingFunction: easings.spring },
+})
+
+export const transitionDelayStyles = stylex.create({
+  instant: { transitionDelay: durations.instant },
+  fast: { transitionDelay: durations.fast },
+  base: { transitionDelay: durations.base },
+  slow: { transitionDelay: durations.slow },
+  slower: { transitionDelay: durations.slower },
 })

--- a/clients/packages/orbit/src/utils/resolvers.test.ts
+++ b/clients/packages/orbit/src/utils/resolvers.test.ts
@@ -458,6 +458,95 @@ describe('responsive object — undefined keys', () => {
   })
 })
 
+describe('motion — transition tokens', () => {
+  it('transitionDuration scalar pushes the matching style', () => {
+    const { stylexStyles, responsiveCSS } = resolveBoxStyles(
+      { transitionDuration: 'fast' },
+      'scope',
+    )
+    expect(stylexStyles).toHaveLength(1)
+    expect(responsiveCSS).toBeNull()
+  })
+
+  it('transitionProperty keyword expands to a property list', () => {
+    const { responsiveCSS } = resolveBoxStyles(
+      { transitionProperty: { md: 'colors' } },
+      'scope',
+    )
+    expect(responsiveCSS).toContain(
+      'transition-property: color, background-color, border-color',
+    )
+  })
+
+  it('transitionProperty "common" expands transform + shadow + opacity', () => {
+    const { responsiveCSS } = resolveBoxStyles(
+      { transitionProperty: { hover: 'common' } },
+      'scope',
+    )
+    expect(responsiveCSS).toContain('box-shadow')
+    expect(responsiveCSS).toContain('transform')
+    expect(responsiveCSS).toContain('opacity')
+  })
+
+  it('ease is an alias for transitionTimingFunction', () => {
+    const viaEase = resolveBoxStyles({ ease: 'spring' }, 'scope')
+    const viaFull = resolveBoxStyles(
+      { transitionTimingFunction: 'spring' },
+      'scope',
+    )
+    expect(viaEase.stylexStyles).toEqual(viaFull.stylexStyles)
+  })
+
+  it('transitionTimingFunction wins over ease alias when both set', () => {
+    const { stylexStyles } = resolveBoxStyles(
+      { transitionTimingFunction: 'standard', ease: 'spring' },
+      'scope',
+    )
+    const standard = resolveBoxStyles(
+      { transitionTimingFunction: 'standard' },
+      'scope',
+    )
+    expect(stylexStyles).toEqual(standard.stylexStyles)
+  })
+
+  it('responsive transitionTimingFunction emits a cubic-bezier value', () => {
+    const { responsiveCSS } = resolveBoxStyles(
+      { transitionTimingFunction: { md: 'decelerate' } },
+      'scope',
+    )
+    expect(responsiveCSS).toMatch(/transition-timing-function:\s*cubic-bezier/)
+  })
+
+  it('transform arbitrary scalar goes to inlineStyle', () => {
+    const { inlineStyle } = resolveBoxStyles(
+      { transform: 'scale(1.02)' },
+      'scope',
+    )
+    expect(inlineStyle.transform).toBe('scale(1.02)')
+  })
+
+  it('transform responsive (hover) writes a kebab-case rule', () => {
+    const { responsiveCSS } = resolveBoxStyles(
+      { transform: { hover: 'translateY(-2px)' } },
+      'scope',
+    )
+    expect(responsiveCSS).toContain(':hover')
+    expect(responsiveCSS).toContain('transform: translateY(-2px)')
+  })
+
+  it('willChange and transformOrigin convert to kebab-case in responsive CSS', () => {
+    const { responsiveCSS } = resolveBoxStyles(
+      {
+        willChange: { md: 'transform' },
+        transformOrigin: { md: 'top left' },
+      },
+      'scope',
+    )
+    expect(responsiveCSS).toContain('will-change: transform')
+    expect(responsiveCSS).toContain('transform-origin: top left')
+  })
+})
+
 describe('mixed scenarios', () => {
   it('scalar token + scalar arbitrary + responsive arbitrary all coexist', () => {
     const { stylexStyles, inlineStyle, responsiveCSS } = resolveBoxStyles(

--- a/clients/packages/orbit/src/utils/resolvers.ts
+++ b/clients/packages/orbit/src/utils/resolvers.ts
@@ -5,6 +5,8 @@ import type {
   BorderColorToken,
   BorderRadiusToken,
   BreakpointKey,
+  DurationToken,
+  EasingToken,
   ShadowToken,
   SpacingToken,
   TextColorToken,
@@ -14,6 +16,8 @@ import {
   borderColors,
   borderRadii,
   breakpoints,
+  durations,
+  easings,
   shadows,
   spacing,
   textColors,
@@ -61,6 +65,11 @@ import {
   positionStyles,
   rowGapStyles,
   textAlignStyles,
+  TRANSITION_PROPERTY_VALUES,
+  transitionDelayStyles,
+  transitionDurationStyles,
+  transitionPropertyStyles,
+  transitionTimingFunctionStyles,
   userSelectStyles,
   visibilityStyles,
 } from './box-styles'
@@ -187,6 +196,17 @@ function radiusCss(token: BorderRadiusToken): string {
 function shadowCss(token: ShadowToken): string {
   return shadows[token] as string
 }
+function durationCss(token: DurationToken): string {
+  return durations[token] as string
+}
+function easingCss(token: EasingToken): string {
+  return easings[token] as string
+}
+function transitionPropertyCss(
+  value: keyof typeof TRANSITION_PROPERTY_VALUES,
+): string {
+  return TRANSITION_PROPERTY_VALUES[value]
+}
 
 const FLEX_KEYWORD_MAP: Record<string, string> = {
   start: 'flex-start',
@@ -286,6 +306,14 @@ const BOX_STYLE_PROP_MAP: Record<keyof BoxStyleProps, true> = {
   left: true,
   inset: true,
   zIndex: true,
+  transitionProperty: true,
+  transitionDuration: true,
+  transitionTimingFunction: true,
+  ease: true,
+  transitionDelay: true,
+  transform: true,
+  transformOrigin: true,
+  willChange: true,
   opacity: true,
   cursor: true,
   pointerEvents: true,
@@ -591,6 +619,35 @@ export function resolveBoxStyles(
   addArbitraryProp('left', props.left, sizeValue)
   addArbitraryProp('inset', props.inset, sizeValue)
   addArbitraryProp('zIndex', props.zIndex, (v) => v)
+
+  // --- Motion ---
+  addTokenProp(
+    transitionPropertyStyles,
+    'transition-property',
+    props.transitionProperty,
+    transitionPropertyCss,
+  )
+  addTokenProp(
+    transitionDurationStyles,
+    'transition-duration',
+    props.transitionDuration,
+    durationCss,
+  )
+  addTokenProp(
+    transitionTimingFunctionStyles,
+    'transition-timing-function',
+    props.transitionTimingFunction ?? props.ease,
+    easingCss,
+  )
+  addTokenProp(
+    transitionDelayStyles,
+    'transition-delay',
+    props.transitionDelay,
+    durationCss,
+  )
+  addArbitraryProp('transform', props.transform, (v) => v)
+  addArbitraryProp('transformOrigin', props.transformOrigin, (v) => v)
+  addArbitraryProp('willChange', props.willChange, (v) => v)
 
   // --- Visual ---
   addArbitraryProp('opacity', props.opacity, (v) => v)

--- a/clients/packages/orbit/src/utils/types.ts
+++ b/clients/packages/orbit/src/utils/types.ts
@@ -3,6 +3,8 @@ import type {
   BorderColorToken,
   BorderRadiusToken,
   BreakpointKey,
+  DurationToken,
+  EasingToken,
   ShadowToken,
   SpacingToken,
   TextColorToken,
@@ -150,6 +152,32 @@ export interface PositionProps {
   zIndex?: ResponsiveValue<number | string>
 }
 
+/**
+ * Curated `transition-property` presets. Keyword values expand to a real
+ * property list so authors don't hand-write CSS — `colors` is the common case
+ * for token-driven hover states, `common` covers most interactive surfaces.
+ */
+export type TransitionProperty =
+  | 'none'
+  | 'all'
+  | 'common'
+  | 'colors'
+  | 'opacity'
+  | 'shadow'
+  | 'transform'
+
+export interface MotionProps {
+  transitionProperty?: ResponsiveValue<TransitionProperty>
+  transitionDuration?: ResponsiveValue<DurationToken>
+  transitionTimingFunction?: ResponsiveValue<EasingToken>
+  /** Alias for `transitionTimingFunction`. */
+  ease?: ResponsiveValue<EasingToken>
+  transitionDelay?: ResponsiveValue<DurationToken>
+  transform?: ResponsiveValue<string>
+  transformOrigin?: ResponsiveValue<string>
+  willChange?: ResponsiveValue<string>
+}
+
 export interface VisualProps {
   opacity?: ResponsiveValue<number>
   cursor?: ResponsiveValue<
@@ -176,4 +204,5 @@ export type BoxStyleProps = SpacingProps &
   FlexProps &
   GridProps &
   PositionProps &
+  MotionProps &
   VisualProps


### PR DESCRIPTION
- **orbit: add motion tokens and prop support on box**
- **refactor <Box /> to be flex by default**
- **orbit: drop all explicit display="flex" usages**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `Box` flex by default and add motion tokens + transition props to `@polar-sh/orbit` to reduce layout boilerplate and enable consistent, token-driven animations. Removes most `display="flex"` usages and opts components into block/grid where needed.

- New Features
  - Motion tokens: `durations` (`instant`–`slower`) and `easings` (`standard`, `decelerate`, `accelerate`, `spring`).
  - `Box` motion props: `transitionProperty` (presets: `none`, `all`, `common`, `colors`, `opacity`, `shadow`, `transform`), `transitionDuration`, `transitionTimingFunction`/`ease`, `transitionDelay`.
  - Exports: `DurationToken`, `EasingToken`, `TransitionProperty`. Added resolver tests and docs.

- Migration
  - `Box` is now `display: flex` by default for block-level elements. Inline elements (`as="span"`, `label`) and `li` keep native display.
  - Set `display="block"` or `display="grid"` where flex is not desired; use `inline-flex` when needed.
  - Prefer `transitionProperty="colors"` (or `common`) with `transitionDuration="fast"` for hover/focus transitions.

<sup>Written for commit 629f72b55031bb21c04c679f3cec99a9ebab79a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

