### PR TITLE
tf: Update public bucket for test env

### DIFF
--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -202,7 +202,7 @@ module "test" {
     region                        = "us-east-2"
     signature_version             = "v4"
     files_presign_ttl             = "600"
-    files_public_bucket_name      = "polar-public-files"
+    files_public_bucket_name      = "polar-test-public-files"
     customer_invoices_bucket_name = "polar-test-customer-invoices"
     customer_receipts_bucket_name = "polar-test-customer-receipts"
     payout_invoices_bucket_name   = "polar-test-payout-invoices"

--- a/terraform/test/vercel.tf
+++ b/terraform/test/vercel.tf
@@ -33,10 +33,10 @@ module "vercel" {
     next_public_checkout_embed_script_src           = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
     next_public_stripe_payment_method_configuration = var.next_public_stripe_payment_method_configuration
     s3_public_images_bucket_protocol                = "https"
-    s3_public_images_bucket_hostname                = "polar-public-files.s3.amazonaws.com"
+    s3_public_images_bucket_hostname                = "polar-test-public-files.s3.amazonaws.com"
     s3_public_images_bucket_port                    = null
     s3_public_images_bucket_pathname                = "/product_media/**"
-    s3_upload_origins                               = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-public-files.s3.amazonaws.com https://polar-public-files.s3.us-east-2.amazonaws.com"
+    s3_upload_origins                               = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-test-public-files.s3.amazonaws.com https://polar-test-public-files.s3.us-east-2.amazonaws.com"
     polar_checkout_embed_script_allowed_origins     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
     polar_openapi_schema_url                        = "https://api.polar.sh/openapi.json"
     enable_experimental_corepack                    = "1"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the test environment to use the dedicated S3 bucket polar-test-public-files for public assets. Updated Terraform and Vercel configs to use the new hostname and upload origins, keeping test traffic isolated from prod.

<sup>Written for commit da0a0962a7affd16157ea25bc11ca589994015a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

