### PR TITLE
feat(backoffice): support cases page

### DIFF
--- a/server/polar/backoffice/__init__.py
+++ b/server/polar/backoffice/__init__.py
@@ -21,6 +21,7 @@ from .payouts.endpoints import router as payouts_router
 from .products.endpoints import router as products_router
 from .responses import TagResponse
 from .subscriptions.endpoints import router as subscriptions_router
+from .support_cases.endpoints import router as support_cases_router
 from .tasks.endpoints import router as tasks_router
 from .users.endpoints import router as users_router
 from .versioned_static import VersionedStaticFiles
@@ -60,6 +61,7 @@ app.include_router(payouts_router, prefix="/payouts")
 app.include_router(impersonation_router, prefix="/impersonation")
 app.include_router(webhooks_router, prefix="/webhooks")
 app.include_router(feedbacks_router, prefix="/feedbacks")
+app.include_router(support_cases_router, prefix="/support-cases")
 
 
 @app.get("/", name="index")

--- a/server/polar/backoffice/components/_tab_nav.py
+++ b/server/polar/backoffice/components/_tab_nav.py
@@ -15,6 +15,22 @@ class Tab:
     active: bool = False
     count: int | None = None
     badge_variant: str | None = None
+    # A small status dot (e.g. "needs attention"). Takes precedence over count.
+    dot: bool = False
+    # Extra classes on the tab element, e.g. "ml-auto" to push it to the right.
+    extra_classes: str = ""
+
+
+def _render_tab_indicator(tab: Tab) -> None:
+    variant = tab.badge_variant or "neutral"
+    if tab.dot:
+        with tag.span(
+            classes=f"ml-2 inline-block w-1.5 h-1.5 rounded-full bg-{variant}"
+        ):
+            pass
+    elif tab.count is not None:
+        with tag.span(classes=f"badge badge-{variant} ml-2"):
+            text(str(tab.count))
 
 
 @contextlib.contextmanager
@@ -69,6 +85,8 @@ def tab_nav(
             tab_classes = ["tab"]
             if tab.active:
                 tab_classes.append("tab-active")
+            if tab.extra_classes:
+                tab_classes.append(tab.extra_classes)
 
             if tab.url:
                 with tag.a(
@@ -80,16 +98,7 @@ def tab_nav(
                         attr("aria-selected", "true")
 
                     text(tab.label)
-
-                    # Optional count badge
-                    if tab.count is not None:
-                        variant_class = (
-                            f"badge-{tab.badge_variant}"
-                            if tab.badge_variant
-                            else "badge-neutral"
-                        )
-                        with tag.span(classes=f"badge {variant_class} ml-2"):
-                            text(str(tab.count))
+                    _render_tab_indicator(tab)
             else:
                 # No URL provided, render as button for HTMX interactions
                 with tag.button(
@@ -101,15 +110,7 @@ def tab_nav(
                         attr("aria-selected", "true")
 
                     text(tab.label)
-
-                    if tab.count is not None:
-                        variant_class = (
-                            f"badge-{tab.badge_variant}"
-                            if tab.badge_variant
-                            else "badge-neutral"
-                        )
-                        with tag.span(classes=f"badge {variant_class} ml-2"):
-                            text(str(tab.count))
+                    _render_tab_indicator(tab)
 
         yield
 

--- a/server/polar/backoffice/navigation.py
+++ b/server/polar/backoffice/navigation.py
@@ -40,4 +40,7 @@ NAVIGATION = [
     navigation.NavigationItem(
         "Feedback", "feedbacks:list", active_route_name_prefix="feedbacks:"
     ),
+    navigation.NavigationItem(
+        "Cases", "support_cases:list", active_route_name_prefix="support_cases:"
+    ),
 ]

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -72,13 +72,27 @@ from polar.models.organization import (
 )
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseMessageAuthorKind,
+)
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
 from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import OrganizationFeatureSettings
-from polar.organization.service import SNOOZE_MAX_DAYS, SNOOZE_MIN_DAYS
+from polar.organization.service import (
+    SNOOZE_MAX_DAYS,
+    SNOOZE_MIN_DAYS,
+    OrganizationError,
+)
 from polar.organization.service import organization as organization_service
+from polar.organization_review.appeal_case import (
+    AppealCaseError,
+)
+from polar.organization_review.appeal_case import (
+    appeal_case as appeal_case_service,
+)
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import (
     DecisionType,
@@ -95,6 +109,7 @@ from polar.startup_program.service import (
 from polar.startup_program.service import (
     startup_program as startup_program_service,
 )
+from polar.support_case.repository import SupportCaseMessageRepository
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.worker import enqueue_job
 
@@ -120,6 +135,7 @@ from .views.sections.overview_section import OverviewSection
 from .views.sections.payout_account_section import PayoutAccountSection
 from .views.sections.reviews_section import ReviewsSection
 from .views.sections.settings_section import SettingsSection
+from .views.sections.support_case_section import SupportCaseSection
 from .views.sections.team_section import TeamSection
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -239,6 +255,36 @@ async def count_test_sales(
 
 # Defensive cap on the Review-tab in-memory cohort when sorting by priority.
 REVIEW_TAB_MAX_COHORT = 2000
+
+
+def _open_case_org_ids() -> Select[tuple[uuid.UUID]]:
+    """Select of organization ids that have at least one open support case."""
+    return (
+        select(OrganizationReview.organization_id)
+        .join(
+            ReviewAppealSupportCase,
+            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
+        )
+        .where(
+            ReviewAppealSupportCase.deleted_at.is_(None),
+            SupportCaseMessageRepository.is_open_expression(),
+        )
+        .distinct()
+    )
+
+
+async def _orgs_with_open_cases(
+    session: AsyncSession, organizations: Sequence[Organization]
+) -> set[uuid.UUID]:
+    """Org ids (among the given page) with at least one open support case."""
+    org_ids = [org.id for org in organizations]
+    if not org_ids:
+        return set()
+    statement = _open_case_org_ids().where(
+        OrganizationReview.organization_id.in_(org_ids)
+    )
+    result = await session.execute(statement)
+    return set(result.scalars().all())
 
 
 async def _build_review_signals(
@@ -399,6 +445,9 @@ async def list_organizations(
     elif status == "blocked":
         status_filter = OrganizationStatus.BLOCKED
 
+    # "Open cases" is a separate dimension (not an org status).
+    selected_open_cases = status == "open_cases"
+
     # Build query
     stmt = (
         select(Organization)
@@ -413,6 +462,10 @@ async def list_organizations(
     # Apply filters
     if status_filter:
         stmt = stmt.where(Organization.status == status_filter)
+    elif selected_open_cases:
+        # Don't apply the default denied/blocked exclusion: open cases
+        # typically live on denied organizations.
+        stmt = stmt.where(Organization.id.in_(_open_case_org_ids()))
     elif not q:
         # By default, exclude denied and blocked organizations (but not when searching)
         stmt = stmt.where(
@@ -543,6 +596,8 @@ async def list_organizations(
         if is_review_tab:
             signals_by_org = await _build_review_signals(session, organizations)
 
+    open_case_org_ids = await _orgs_with_open_cases(session, organizations)
+
     is_htmx_table_request = request.headers.get("HX-Target") == "org-list"
 
     if is_htmx_table_request:
@@ -555,11 +610,19 @@ async def list_organizations(
             sort,
             direction,
             signals_by_org=signals_by_org,
+            open_case_org_ids=open_case_org_ids,
+            selected_open_cases=selected_open_cases,
         ):
             pass
     else:
         status_counts = await list_view.get_status_counts(deleted_filter)
         countries = await list_view.get_distinct_countries()
+        open_cases_count = (
+            await session.scalar(
+                select(func.count()).select_from(_open_case_org_ids().subquery())
+            )
+            or 0
+        )
         with layout(
             request,
             [("Organizations", str(request.url))],
@@ -583,6 +646,9 @@ async def list_organizations(
                 selected_has_appeal=has_appeal,
                 selected_deleted=deleted_filter,
                 signals_by_org=signals_by_org,
+                open_case_org_ids=open_case_org_ids,
+                selected_open_cases=selected_open_cases,
+                open_cases_count=open_cases_count,
             ):
                 pass
 
@@ -595,6 +661,7 @@ async def get_organization_detail(
     files_page: int = Query(1, ge=1),
     files_limit: int = Query(10, ge=1, le=100),
     session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
 ) -> None:
     """
     Organization detail view with three-column layout.
@@ -663,6 +730,15 @@ async def get_organization_detail(
             organization.id
         )
 
+    # Appeal support case state (drives the nav badge and the review-card link)
+    appeal_case = None
+    appeal_case_open = False
+    if organization.review is not None:
+        appeal_case = await appeal_case_service.get_case(session, organization.review)
+        if appeal_case is not None:
+            message_repository = SupportCaseMessageRepository.from_session(session)
+            appeal_case_open = await message_repository.is_open(appeal_case.id)
+
     # Create views
     detail_view = OrganizationDetailView(
         organization,
@@ -670,6 +746,7 @@ async def get_organization_detail(
         owner_email=owner_email,
         impersonate_user=impersonate_user,
         startup_program_status=startup_program_status,
+        appeal_case_open=appeal_case_open,
     )
 
     # Fetch analytics data for overview section
@@ -835,6 +912,7 @@ async def get_organization_detail(
                     unrefunded_orders_count=unrefunded_orders_count,
                     agent_report=parsed_agent_report,
                     agent_reviewed_at=agent_reviewed_at,
+                    has_appeal_case=appeal_case is not None,
                 )
                 with overview.render(
                     request, setup_data=setup_data, payment_stats=payment_stats
@@ -888,6 +966,37 @@ async def get_organization_detail(
                     organization, agent_reviews=agent_reviews
                 )
                 with reviews_section.render(request):
+                    pass
+            elif section == "support_case":
+                thread = None
+                author_emails: dict[uuid.UUID, str] = {}
+                if organization.review is not None:
+                    thread = await appeal_case_service.get_thread(
+                        session, organization.review, visible_to=None
+                    )
+                if thread is not None:
+                    case_, _is_open, thread_messages = thread
+                    author_ids = {
+                        m.author_user_id
+                        for m in thread_messages
+                        if m.author_user_id is not None
+                    }
+                    if case_.assigned_user_id is not None:
+                        author_ids.add(case_.assigned_user_id)
+                    if author_ids:
+                        email_result = await session.execute(
+                            select(User.id, User.email).where(User.id.in_(author_ids))
+                        )
+                        author_emails = {
+                            row.id: row.email for row in email_result.all()
+                        }
+                support_case_section = SupportCaseSection(
+                    organization,
+                    thread=thread,
+                    author_emails=author_emails,
+                    current_user_id=user_session.user_id,
+                )
+                with support_case_section.render(request):
                     pass
             elif section == "history":
                 # TODO: Implement history section
@@ -1494,6 +1603,247 @@ async def deny_appeal_dialog(
                             text("Cancel")
                     with button(variant="error", type="submit"):
                         text("Deny Appeal")
+
+    return None
+
+
+async def _load_org_with_appeal_case(
+    session: AsyncSession, organization_id: UUID4
+) -> tuple[Organization, ReviewAppealSupportCase]:
+    """Load an organization and its appeal support case, or raise 404."""
+    repository = OrganizationRepository(session)
+    organization = await repository.get_by_id(
+        organization_id,
+        include_blocked=True,
+        options=(joinedload(Organization.review),),
+    )
+    if not organization or organization.review is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    case = await appeal_case_service.get_case(session, organization.review)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Support case not found")
+    return organization, case
+
+
+def _support_case_redirect(
+    request: Request, organization_id: UUID4
+) -> HXRedirectResponse:
+    return HXRedirectResponse(
+        request,
+        str(request.url_for("organizations:detail", organization_id=organization_id))
+        + "?section=support_case",
+        303,
+    )
+
+
+@router.post(
+    "/{organization_id}/appeal-case/reply",
+    name="organizations:appeal_case_reply",
+    response_model=None,
+)
+async def appeal_case_reply(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse:
+    """Post a staff reply (or internal note) to the appeal case."""
+    _, case = await _load_org_with_appeal_case(session, organization_id)
+
+    form_data = await request.form()
+    body = str(form_data.get("body", "")).strip()
+    internal = bool(form_data.get("internal"))
+
+    if body:
+        try:
+            await appeal_case_service.add_reply(
+                session,
+                case,
+                author_kind=SupportCaseMessageAuthorKind.platform,
+                author_user=user_session.user,
+                body=body,
+                internal=internal,
+            )
+        except AppealCaseError as e:
+            await add_toast(request, e.args[0], variant="error")
+
+    return _support_case_redirect(request, organization_id)
+
+
+@router.api_route(
+    "/{organization_id}/appeal-case/approve-dialog",
+    name="organizations:appeal_case_approve_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def appeal_case_approve_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    """Approve the appeal: reactivate the organization and close the case."""
+    organization, case = await _load_org_with_appeal_case(session, organization_id)
+
+    error_message: str | None = None
+
+    if request.method == "POST":
+        form_data = await request.form()
+        reason = str(form_data.get("reason", "")).strip() or None
+        if not reason:
+            error_message = "A reason is required to approve the appeal."
+        else:
+            review_repo = OrganizationReviewRepository.from_session(session)
+            try:
+                await review_repo.record_human_decision(
+                    organization_id=organization_id,
+                    reviewer_id=user_session.user.id,
+                    decision=DecisionType.APPROVE,
+                    review_context=ReviewContext.APPEAL,
+                    reason=reason,
+                )
+                await organization_service.backoffice_approve(
+                    session, organization, reason=reason
+                )
+                await appeal_case_service.record_decision(
+                    session,
+                    case,
+                    approved=True,
+                    staff_user=user_session.user,
+                    reason=reason,
+                )
+            except (OrganizationError, AppealCaseError) as e:
+                # Discard the recorded decision so a failure can't commit
+                # half the approval (decision without org/case update).
+                await session.rollback()
+                error_message = e.args[0]
+            else:
+                return _support_case_redirect(request, organization_id)
+
+    with modal("Approve Appeal", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:appeal_case_approve_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
+            if error_message:
+                with tag.div(classes="alert alert-error"):
+                    text(error_message)
+            with tag.p():
+                text(
+                    "Approving reactivates the organization and closes the "
+                    "support case. The merchant is notified of the decision."
+                )
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text"):
+                        text("Reason (required, shared with the merchant)")
+                with tag.textarea(
+                    name="reason",
+                    classes="textarea textarea-bordered w-full",
+                    placeholder="Why are you approving this appeal?",
+                    rows="3",
+                    required=True,
+                ):
+                    pass
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(variant="primary", type="submit"):
+                    text("Approve Appeal")
+
+    return None
+
+
+@router.api_route(
+    "/{organization_id}/appeal-case/deny-dialog",
+    name="organizations:appeal_case_deny_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def appeal_case_deny_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    """Deny the appeal: keep the organization denied and close the case.
+
+    The organization is already in its denied state (the human-review case is
+    opened after the AI appeal was rejected), so there is no org-status change
+    to make — the decision records the outcome on the case and locks it.
+    """
+    _, case = await _load_org_with_appeal_case(session, organization_id)
+
+    error_message: str | None = None
+
+    if request.method == "POST":
+        form_data = await request.form()
+        reason = str(form_data.get("reason", "")).strip() or None
+        review_repo = OrganizationReviewRepository.from_session(session)
+        try:
+            await review_repo.record_human_decision(
+                organization_id=organization_id,
+                reviewer_id=user_session.user.id,
+                decision=DecisionType.DENY,
+                review_context=ReviewContext.APPEAL,
+                reason=reason,
+            )
+            await appeal_case_service.record_decision(
+                session,
+                case,
+                approved=False,
+                staff_user=user_session.user,
+                reason=reason,
+            )
+        except AppealCaseError as e:
+            # Discard the recorded decision so a failure can't commit it
+            # without the case actually being closed.
+            await session.rollback()
+            error_message = e.args[0]
+        else:
+            return _support_case_redirect(request, organization_id)
+
+    with modal("Deny Appeal", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:appeal_case_deny_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
+            if error_message:
+                with tag.div(classes="alert alert-error"):
+                    text(error_message)
+            with tag.p(classes="font-semibold text-error"):
+                text("This keeps the organization denied and closes the case.")
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text"):
+                        text("Reason (optional, shared with the merchant)")
+                with tag.textarea(
+                    name="reason",
+                    classes="textarea textarea-bordered w-full",
+                    placeholder="Why are you denying this appeal?",
+                    rows="3",
+                ):
+                    pass
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(variant="error", type="submit"):
+                    text("Deny Appeal")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -45,11 +45,13 @@ class OrganizationDetailView:
         owner_email: str | None = None,
         impersonate_user: User | None = None,
         startup_program_status: str | None = None,
+        appeal_case_open: bool = False,
     ):
         self.org = organization
         self.ai_verdict = ai_verdict
         self.owner_email = owner_email
         self.impersonate_user = impersonate_user
+        self.appeal_case_open = appeal_case_open
         # Startup Program status string is derived via the Polar API and
         # populated by the endpoint; ``None`` means "feature disabled" OR
         # "not invited". The card collapses both into the same rendering.
@@ -100,6 +102,16 @@ class OrganizationDetailView:
                 )
                 + "?section=reviews",
                 active=current_section == "reviews",
+            ),
+            Tab(
+                "Support Case",
+                str(
+                    request.url_for("organizations:detail", organization_id=self.org.id)
+                )
+                + "?section=support_case",
+                active=current_section == "support_case",
+                dot=self.appeal_case_open,
+                badge_variant="warning",
             ),
             Tab(
                 "Settings",

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -90,7 +90,7 @@ class OrganizationListView:
         current_sort: str,
         current_direction: str,
         align: str = "left",
-        status_filter: OrganizationStatus | None = None,
+        status_param: str | None = None,
     ) -> Generator[None]:
         """Render a sortable table header with direction indicator."""
         is_active = current_sort == sort_key
@@ -111,8 +111,8 @@ class OrganizationListView:
 
         # Build hx-vals with status filter if present
         hx_vals_dict = {"sort": sort_key, "direction": next_direction}
-        if status_filter is not None:
-            hx_vals_dict["status"] = status_filter.value
+        if status_param is not None:
+            hx_vals_dict["status"] = status_param
 
         hx_vals = json.dumps(hx_vals_dict)
 
@@ -147,7 +147,7 @@ class OrganizationListView:
         has_more: bool,
         current_sort: str,
         current_direction: str,
-        status_filter: OrganizationStatus | None,
+        status_param: str | None,
     ) -> None:
         """Render Previous/Next pagination buttons.
 
@@ -161,8 +161,8 @@ class OrganizationListView:
             "sort": current_sort,
             "direction": current_direction,
         }
-        if status_filter is not None:
-            common_vals["status"] = status_filter.value
+        if status_param is not None:
+            common_vals["status"] = status_param
 
         def _nav_button(target_page: int, label: str, disabled: bool) -> None:
             if disabled:
@@ -197,6 +197,8 @@ class OrganizationListView:
         org: Organization,
         *,
         signals: Signals | None = None,
+        has_open_case: bool = False,
+        link_to_case: bool = False,
     ) -> Generator[None]:
         """Render a single organization row in the table.
 
@@ -205,16 +207,19 @@ class OrganizationListView:
         """
         days_in_status = self.calculate_days_in_status(org)
 
+        detail_url = str(
+            request.url_for("organizations:detail", organization_id=org.id)
+        )
+        # From the Open cases tab, deep-link straight to the case thread.
+        if link_to_case:
+            detail_url += "?section=support_case"
+
         with tag.tr(classes="hover:bg-base-100"):
             # Organization name and status
             with tag.td(classes="py-4 max-w-xs"):
                 with tag.div(classes="flex flex-col gap-1"):
                     with tag.a(
-                        href=str(
-                            request.url_for(
-                                "organizations:detail", organization_id=org.id
-                            )
-                        ),
+                        href=detail_url,
                         classes="font-semibold hover:underline flex items-center gap-2",
                     ):
                         with tag.span(
@@ -249,6 +254,10 @@ class OrganizationListView:
                     ):
                         with tag.span(classes="badge badge-info badge-xs mt-1"):
                             text("Appeal Pending")
+                    # Open support case(s) — generic, not appeal-specific
+                    if has_open_case:
+                        with tag.span(classes="badge badge-warning badge-xs mt-1"):
+                            text("Open case")
 
             # Priority — Review tab only, sits next to Organization
             if signals is not None:
@@ -337,6 +346,9 @@ class OrganizationListView:
         selected_has_appeal: str | None = None,
         selected_deleted: DeletedFilter = "exclude",
         signals_by_org: dict[uuid.UUID, Signals] | None = None,
+        open_case_org_ids: set[uuid.UUID] | None = None,
+        selected_open_cases: bool = False,
+        open_cases_count: int = 0,
     ) -> Generator[None]:
         """Render the complete list view."""
 
@@ -356,7 +368,7 @@ class OrganizationListView:
             Tab(
                 label="All",
                 url=str(request.url_for("organizations:list")),
-                active=status_filter is None,
+                active=status_filter is None and not selected_open_cases,
                 count=sum(status_counts.values()),
             ),
             Tab(
@@ -401,6 +413,15 @@ class OrganizationListView:
                 count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
                 badge_variant="warning",
             ),
+            # Pushed to the right — a separate dimension from the status tabs.
+            Tab(
+                label="Open cases",
+                url=str(request.url_for("organizations:list")) + "?status=open_cases",
+                active=selected_open_cases,
+                count=open_cases_count,
+                badge_variant="warning",
+                extra_classes="ml-auto",
+            ),
         ]
 
         with tab_nav(tabs):
@@ -422,6 +443,8 @@ class OrganizationListView:
             }
             if status_filter is not None:
                 form_attrs["hx_vals"] = json.dumps({"status": status_filter.value})
+            elif selected_open_cases:
+                form_attrs["hx_vals"] = json.dumps({"status": "open_cases"})
 
             with tag.form(**form_attrs):
                 # Search bar with filter toggle
@@ -642,6 +665,8 @@ class OrganizationListView:
             current_sort,
             current_direction,
             signals_by_org,
+            open_case_org_ids,
+            selected_open_cases,
         )
 
         yield
@@ -656,6 +681,8 @@ class OrganizationListView:
         current_sort: str,
         current_direction: str,
         signals_by_org: dict[uuid.UUID, Signals] | None = None,
+        open_case_org_ids: set[uuid.UUID] | None = None,
+        selected_open_cases: bool = False,
     ) -> None:
         """Render the ``#org-list`` block — table with Review-only columns.
 
@@ -663,7 +690,15 @@ class OrganizationListView:
         partial swap), so both paths agree on column count.
         """
         signals_by_org = signals_by_org or {}
+        open_case_org_ids = open_case_org_ids or set()
         is_review_tab = status_filter == OrganizationStatus.REVIEW
+        # "Open cases" isn't an OrganizationStatus, so carry it as the status
+        # query value to preserve the selection across HTMX sort/pagination.
+        status_param = (
+            status_filter.value
+            if status_filter is not None
+            else ("open_cases" if selected_open_cases else None)
+        )
 
         with tag.div(id="org-list", classes="overflow-x-auto"):
             if not organizations:
@@ -682,7 +717,7 @@ class OrganizationListView:
                                 "name",
                                 current_sort,
                                 current_direction,
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -696,7 +731,7 @@ class OrganizationListView:
                                     current_sort,
                                     current_direction,
                                     "center",
-                                    status_filter=status_filter,
+                                    status_param=status_param,
                                 ):
                                     pass
 
@@ -706,7 +741,7 @@ class OrganizationListView:
                                 "country",
                                 current_sort,
                                 current_direction,
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -716,7 +751,7 @@ class OrganizationListView:
                                 "created",
                                 current_sort,
                                 current_direction,
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -727,7 +762,7 @@ class OrganizationListView:
                                 current_sort,
                                 current_direction,
                                 "center",
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -741,7 +776,7 @@ class OrganizationListView:
                                     current_sort,
                                     current_direction,
                                     "center",
-                                    status_filter=status_filter,
+                                    status_param=status_param,
                                 ):
                                     pass
 
@@ -752,7 +787,7 @@ class OrganizationListView:
                                 current_sort,
                                 current_direction,
                                 "right",
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -765,6 +800,8 @@ class OrganizationListView:
                                 request,
                                 org,
                                 signals=signals_by_org.get(org.id),
+                                has_open_case=org.id in open_case_org_ids,
+                                link_to_case=selected_open_cases,
                             ):
                                 pass
 
@@ -774,7 +811,7 @@ class OrganizationListView:
                     has_more,
                     current_sort,
                     current_direction,
-                    status_filter,
+                    status_param,
                 )
 
     @contextlib.contextmanager
@@ -789,6 +826,8 @@ class OrganizationListView:
         current_direction: str = "asc",
         *,
         signals_by_org: dict[uuid.UUID, Signals] | None = None,
+        open_case_org_ids: set[uuid.UUID] | None = None,
+        selected_open_cases: bool = False,
     ) -> Generator[None]:
         """Render only the organization table (for HTMX updates)."""
 
@@ -801,6 +840,8 @@ class OrganizationListView:
             current_sort,
             current_direction,
             signals_by_org,
+            open_case_org_ids,
+            selected_open_cases,
         )
 
         yield

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -40,12 +40,14 @@ class OverviewSection(ChecklistMixin):
         unrefunded_orders_count: int = 0,
         agent_report: AnyAgentReport | None = None,
         agent_reviewed_at: datetime | None = None,
+        has_appeal_case: bool = False,
     ) -> None:
         self.org = organization
         self.orders_count = orders_count
         self.unrefunded_orders_count = unrefunded_orders_count
         self.agent_report = agent_report
         self.agent_reviewed_at = agent_reviewed_at
+        self.has_appeal_case = has_appeal_case
 
     # ------------------------------------------------------------------
     # Full-width: Organization Review card (primary content)
@@ -103,6 +105,36 @@ class OverviewSection(ChecklistMixin):
         """Full-width AI review card — the primary decision content."""
 
         with card(bordered=True):
+            if self.has_appeal_case:
+                support_case_url = (
+                    str(
+                        request.url_for(
+                            "organizations:detail", organization_id=self.org.id
+                        )
+                    )
+                    + "?section=support_case"
+                )
+                with tag.a(
+                    href=support_case_url,
+                    classes="mb-4 flex items-center justify-between gap-3 "
+                    "rounded-lg border border-warning/40 bg-warning/5 px-4 py-3 "
+                    "hover:bg-warning/10 transition-colors",
+                ):
+                    with tag.span(classes="flex items-center gap-2.5 min-w-0"):
+                        with tag.span(classes="icon-message-square text-warning"):
+                            pass
+                        with tag.span(
+                            classes="text-sm font-medium text-base-content/60"
+                        ):
+                            text("Human-review support case")
+                    with tag.span(
+                        classes="flex items-center gap-1 flex-none "
+                        "text-sm text-base-content/60"
+                    ):
+                        text("View case")
+                        with tag.span(classes="icon-arrow-right text-xs"):
+                            pass
+
             # --- No agent report: show fallback from org.review ---
             if self.agent_report is None:
                 if self.org.review:

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -1,0 +1,356 @@
+"""Support case section: the appeal human-review thread and staff actions."""
+
+import contextlib
+from collections.abc import Generator, Sequence
+from urllib.parse import urlencode
+from uuid import UUID
+
+from fastapi import Request
+from tagflow import tag, text
+
+from polar.models import Organization
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+)
+
+from ....components import button, card
+
+_AUTHOR_LABELS: dict[SupportCaseMessageAuthorKind, str] = {
+    SupportCaseMessageAuthorKind.platform: "Support",
+    SupportCaseMessageAuthorKind.merchant: "Merchant",
+    SupportCaseMessageAuthorKind.customer: "Customer",
+    SupportCaseMessageAuthorKind.system: "System",
+}
+
+# Milestone events: title + (lucide icon, node circle classes). These render as
+# timeline milestones, visually distinct from conversation messages.
+_EVENT_TITLES: dict[SupportCaseMessageType, str] = {
+    SupportCaseMessageType.opened: "Human review requested",
+    SupportCaseMessageType.closed: "Case closed",
+    SupportCaseMessageType.appeal_approved: "Appeal approved",
+    SupportCaseMessageType.appeal_denied: "Appeal denied",
+    SupportCaseMessageType.info_requested: "Information requested",
+    SupportCaseMessageType.assigned: "Case assigned",
+    SupportCaseMessageType.released: "Case unassigned",
+}
+
+_DARK_NODE = "bg-neutral text-neutral-content"
+_MUTED_NODE = "bg-base-200 text-base-content/70"
+_EVENT_NODES: dict[SupportCaseMessageType, tuple[str, str]] = {
+    SupportCaseMessageType.opened: ("icon-circle-dot", _DARK_NODE),
+    SupportCaseMessageType.closed: ("icon-square", _DARK_NODE),
+    SupportCaseMessageType.appeal_approved: (
+        "icon-check",
+        "bg-success text-success-content",
+    ),
+    SupportCaseMessageType.appeal_denied: ("icon-x", "bg-error text-error-content"),
+    SupportCaseMessageType.info_requested: (
+        "icon-message-square-text",
+        "bg-info text-info-content",
+    ),
+    SupportCaseMessageType.assigned: ("icon-user-check", _MUTED_NODE),
+    SupportCaseMessageType.released: ("icon-user-x", _MUTED_NODE),
+}
+
+Thread = tuple[ReviewAppealSupportCase, bool, Sequence[SupportCaseMessage]]
+
+
+class SupportCaseSection:
+    """Render the appeal support case: status header, timeline and actions."""
+
+    def __init__(
+        self,
+        organization: Organization,
+        thread: Thread | None = None,
+        author_emails: dict[UUID, str] | None = None,
+        current_user_id: UUID | None = None,
+    ) -> None:
+        self.org = organization
+        self.thread = thread
+        self.author_emails = author_emails or {}
+        self.current_user_id = current_user_id
+
+    @contextlib.contextmanager
+    def render(self, request: Request) -> Generator[None]:
+        with tag.div(classes="space-y-6"):
+            if self.thread is None:
+                with card(bordered=True):
+                    with tag.h2(classes="text-lg font-semibold mb-1"):
+                        text("Appeal Support Case")
+                    with tag.p(classes="text-sm text-base-content/50"):
+                        text("No support case for this organization.")
+                yield
+                return
+
+            case, is_open, messages = self.thread
+            with card(bordered=True):
+                self._render_header(request, case, is_open, messages)
+                self._render_timeline(messages)
+                if is_open:
+                    self._render_composer(request)
+            yield
+
+    # -- Header -------------------------------------------------------------
+
+    def _outcome(
+        self, messages: Sequence[SupportCaseMessage]
+    ) -> SupportCaseMessageType | None:
+        for message in messages:
+            if message.type in (
+                SupportCaseMessageType.appeal_approved,
+                SupportCaseMessageType.appeal_denied,
+            ):
+                return message.type
+        return None
+
+    def _render_header(
+        self,
+        request: Request,
+        case: ReviewAppealSupportCase,
+        is_open: bool,
+        messages: Sequence[SupportCaseMessage],
+    ) -> None:
+        outcome = self._outcome(messages)
+        with tag.div(classes="flex items-start justify-between gap-4 mb-8"):
+            with tag.div(classes="flex items-start gap-4"):
+                with tag.div(
+                    classes="flex-none w-11 h-11 rounded-xl bg-base-200 "
+                    "flex items-center justify-center"
+                ):
+                    with tag.span(
+                        classes="icon-message-square text-lg text-base-content/70"
+                    ):
+                        pass
+                with tag.div(classes="flex flex-col gap-2"):
+                    with tag.h2(classes="text-xl font-semibold leading-none"):
+                        text("Appeal Support Case")
+                    with tag.div(classes="flex items-center gap-2"):
+                        status = "badge-success" if is_open else "badge-neutral"
+                        with tag.div(classes=f"badge {status} badge-sm"):
+                            text("Open" if is_open else "Closed")
+                        if outcome == SupportCaseMessageType.appeal_approved:
+                            with tag.div(classes="badge badge-success badge-sm gap-1"):
+                                with tag.span(classes="icon-check"):
+                                    pass
+                                text("Appeal approved")
+                        elif outcome == SupportCaseMessageType.appeal_denied:
+                            with tag.div(classes="badge badge-error badge-sm gap-1"):
+                                with tag.span(classes="icon-x"):
+                                    pass
+                                text("Appeal denied")
+                        elif is_open:
+                            with tag.div(classes="badge badge-ghost badge-sm"):
+                                text("Awaiting decision")
+                        if is_open:
+                            self._render_assignment_chip(case)
+            if is_open:
+                self._render_decision_actions(request, case)
+
+    def _render_assignment_chip(self, case: ReviewAppealSupportCase) -> None:
+        assignee_id = case.assigned_user_id
+        if assignee_id is None:
+            icon, label = "icon-user", "Unassigned"
+        elif assignee_id == self.current_user_id:
+            icon, label = "icon-user-check", "Assigned to you"
+        else:
+            email = self.author_emails.get(assignee_id, "another agent")
+            icon, label = "icon-user-check", f"Assigned to {email}"
+        with tag.div(classes="badge badge-ghost badge-sm gap-1"):
+            with tag.span(classes=icon):
+                pass
+            text(label)
+
+    def _assignment_urls(
+        self, request: Request, case: ReviewAppealSupportCase
+    ) -> tuple[str, str]:
+        # Assignment is advisory and generic to any case type, so it posts to
+        # the case-keyed support_cases endpoints and returns here afterwards.
+        detail = request.url_for("organizations:detail", organization_id=self.org.id)
+        return_to = f"{detail.path}?section=support_case"
+        take_url = f"{request.url_for('support_cases:take', case_id=case.id)}?{urlencode({'return_to': return_to})}"
+        release_url = f"{request.url_for('support_cases:release', case_id=case.id)}?{urlencode({'return_to': return_to})}"
+        return take_url, release_url
+
+    def _render_decision_actions(
+        self, request: Request, case: ReviewAppealSupportCase
+    ) -> None:
+        approve_url = str(
+            request.url_for(
+                "organizations:appeal_case_approve_dialog",
+                organization_id=self.org.id,
+            )
+        )
+        deny_url = str(
+            request.url_for(
+                "organizations:appeal_case_deny_dialog", organization_id=self.org.id
+            )
+        )
+        take_url, release_url = self._assignment_urls(request, case)
+        assignee_id = case.assigned_user_id
+        with tag.div(classes="flex-none flex items-center gap-2"):
+            if assignee_id == self.current_user_id:
+                with button(size="sm", outline=True, hx_post=release_url):
+                    text("Release")
+            else:
+                label = "Take over" if assignee_id is not None else "Take case"
+                with button(
+                    variant="neutral", size="sm", outline=True, hx_post=take_url
+                ):
+                    text(label)
+            with button(
+                variant="error",
+                size="sm",
+                outline=True,
+                hx_get=deny_url,
+                hx_target="#modal",
+            ):
+                text("Deny appeal")
+            with button(
+                variant="primary", size="sm", hx_get=approve_url, hx_target="#modal"
+            ):
+                text("Approve appeal")
+
+    # -- Timeline -----------------------------------------------------------
+
+    def _render_timeline(self, messages: Sequence[SupportCaseMessage]) -> None:
+        with tag.div(classes="relative"):
+            # The rail line, centered under the icon nodes (w-9 → center 18px).
+            with tag.div(
+                classes="absolute left-[18px] top-5 bottom-5 w-px bg-base-300"
+            ):
+                pass
+            with tag.div(
+                classes="grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-x-6 gap-y-5"
+            ):
+                for message in messages:
+                    self._render_entry(message)
+
+    def _render_entry(self, message: SupportCaseMessage) -> None:
+        is_event = message.type != SupportCaseMessageType.chat
+        internal = not message.audience
+
+        # Left cell: icon node + title + muted metadata.
+        with tag.div(classes="flex gap-3"):
+            icon, node = self._node(message, internal)
+            # Opaque base hides the rail line behind translucent node tints.
+            with tag.div(
+                classes="relative z-10 flex-none w-9 h-9 rounded-full bg-base-100"
+            ):
+                with tag.div(
+                    classes="w-full h-full rounded-full "
+                    f"flex items-center justify-center {node}"
+                ):
+                    with tag.span(classes=f"{icon} text-base"):
+                        pass
+            with tag.div(classes="min-w-0 pt-1"):
+                with tag.div(classes="text-sm font-medium leading-tight"):
+                    text(self._title(message, internal))
+                for line in self._meta_lines(message, is_event, internal):
+                    with tag.div(classes="text-xs text-base-content/40 mt-0.5"):
+                        text(line)
+
+        # Right cell: conversation content (empty for pure milestones).
+        self._render_content(message, is_event, internal)
+
+    def _node(self, message: SupportCaseMessage, internal: bool) -> tuple[str, str]:
+        if message.type != SupportCaseMessageType.chat:
+            return _EVENT_NODES[message.type]
+        if internal:
+            return "icon-lock", "bg-warning/20 text-warning"
+        if message.author_kind == SupportCaseMessageAuthorKind.merchant:
+            return "icon-store", "bg-base-200 text-base-content/70"
+        return "icon-headset", "bg-info/15 text-info"
+
+    def _title(self, message: SupportCaseMessage, internal: bool) -> str:
+        if message.type != SupportCaseMessageType.chat:
+            return _EVENT_TITLES[message.type]
+        if internal:
+            return "Internal note"
+        return _AUTHOR_LABELS.get(message.author_kind, str(message.author_kind))
+
+    def _meta_lines(
+        self, message: SupportCaseMessage, is_event: bool, internal: bool
+    ) -> list[str]:
+        when = message.created_at.strftime("%b %-d, %H:%M UTC")
+        email = (
+            self.author_emails.get(message.author_user_id)
+            if message.author_user_id
+            else None
+        )
+        # The title carries the role for chat; events/notes name the actor. The
+        # email is the concrete identity. One piece of metadata per line.
+        if is_event or internal:
+            who = email or _AUTHOR_LABELS.get(
+                message.author_kind, str(message.author_kind)
+            )
+            return [f"by {who}", when]
+        return [email, when] if email else [when]
+
+    def _render_content(
+        self, message: SupportCaseMessage, is_event: bool, internal: bool
+    ) -> None:
+        if not message.body:
+            # Milestone with no body still occupies its grid cell.
+            with tag.div():
+                pass
+            return
+
+        merchant = message.author_kind == SupportCaseMessageAuthorKind.merchant
+        justify = "justify-end" if merchant else "justify-start"
+        with tag.div(classes=f"flex items-center {justify}"):
+            with tag.div(classes=f"max-w-md text-sm {self._bubble(message, internal)}"):
+                text(message.body)
+
+    def _bubble(self, message: SupportCaseMessage, internal: bool) -> str:
+        if internal:
+            return (
+                "bg-warning/10 border-l-2 border-warning rounded-lg px-3 py-2 "
+                "text-base-content/80"
+            )
+        if message.type == SupportCaseMessageType.appeal_approved:
+            return "bg-success/10 rounded-xl px-4 py-2.5"
+        if message.type == SupportCaseMessageType.appeal_denied:
+            return "bg-error/10 rounded-xl px-4 py-2.5"
+        if message.author_kind == SupportCaseMessageAuthorKind.merchant:
+            return "bg-info/10 rounded-2xl rounded-tr-md px-4 py-2.5"
+        return "bg-base-200 rounded-2xl rounded-tl-md px-4 py-2.5"
+
+    # -- Composer -----------------------------------------------------------
+
+    def _render_composer(self, request: Request) -> None:
+        reply_url = str(
+            request.url_for(
+                "organizations:appeal_case_reply", organization_id=self.org.id
+            )
+        )
+        with tag.div(classes="mt-8 pt-6 border-t border-base-200"):
+            with tag.form(hx_post=reply_url, classes="flex flex-col gap-3"):
+                with tag.textarea(
+                    name="body",
+                    classes="textarea textarea-bordered w-full rounded-lg",
+                    placeholder="Write a reply to the merchant…",
+                    rows="3",
+                    required=True,
+                ):
+                    pass
+                with tag.div(classes="flex items-center justify-between"):
+                    with tag.label(
+                        classes="flex items-center gap-2 cursor-pointer "
+                        "text-sm text-base-content/60"
+                    ):
+                        with tag.input(
+                            type="checkbox",
+                            name="internal",
+                            value="1",
+                            classes="checkbox checkbox-sm",
+                        ):
+                            pass
+                        text("Internal note — not visible to the merchant")
+                    with button(variant="primary", size="sm", type="submit"):
+                        text("Send")
+
+
+__all__ = ["SupportCaseSection"]

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -7,7 +7,7 @@ from sqlalchemy import func, select
 from tagflow import tag, text
 
 from polar.kit.pagination import PaginationParamsQuery
-from polar.models import Organization
+from polar.models import Organization, User
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase
 from polar.models.user_session import UserSession
@@ -26,16 +26,34 @@ from ..responses import HXRedirectResponse
 
 router = APIRouter()
 
-# (case, organization, is_open)
-Row = tuple[ReviewAppealSupportCase, Organization, bool]
+# (case, organization, is_open, assignee_email)
+Row = tuple[ReviewAppealSupportCase, Organization, bool, str | None]
 
 
-def _list_tabs(request: Request, active: str) -> list[Tab]:
+def _list_tabs(request: Request, status: str, assigned: str) -> list[Tab]:
     base = str(request.url_for("support_cases:list"))
+
+    def url(status: str, assigned: str) -> str:
+        return f"{base}?status={status}&assigned={assigned}"
+
+    # Status (left) filters preserve the current assignment. The assignment
+    # filters (right, pushed via ml-auto) toggle: clicking the active one
+    # clears back to everyone, so no redundant "all assignees" tab is needed.
     return [
-        Tab("Open", url=f"{base}?status=open", active=active == "open"),
-        Tab("Closed", url=f"{base}?status=closed", active=active == "closed"),
-        Tab("All", url=f"{base}?status=all", active=active == "all"),
+        Tab("Open", url=url("open", assigned), active=status == "open"),
+        Tab("Closed", url=url("closed", assigned), active=status == "closed"),
+        Tab("All", url=url("all", assigned), active=status == "all"),
+        Tab(
+            "Assigned to me",
+            url=url(status, "all" if assigned == "me" else "me"),
+            active=assigned == "me",
+            extra_classes="ml-auto",
+        ),
+        Tab(
+            "Unassigned",
+            url=url(status, "all" if assigned == "unassigned" else "unassigned"),
+            active=assigned == "unassigned",
+        ),
     ]
 
 
@@ -50,11 +68,17 @@ def _render_table(rows: Sequence[Row]) -> None:
         with tag.table(classes="table table-zebra"):
             with tag.thead():
                 with tag.tr():
-                    for header in ("Organization", "Type", "Status", "Opened"):
+                    for header in (
+                        "Organization",
+                        "Type",
+                        "Status",
+                        "Assignee",
+                        "Opened",
+                    ):
                         with tag.th():
                             text(header)
             with tag.tbody():
-                for case, organization, is_open in rows:
+                for case, organization, is_open, assignee_email in rows:
                     # Not linked yet: the org's support-case section these rows
                     # point to ships in a follow-up PR.
                     with tag.tr():
@@ -65,6 +89,12 @@ def _render_table(rows: Sequence[Row]) -> None:
                                 text("Review appeal")
                         with tag.td():
                             _status_badge(is_open)
+                        with tag.td():
+                            if assignee_email:
+                                text(assignee_email)
+                            else:
+                                with tag.span(classes="text-base-content/40"):
+                                    text("Unassigned")
                         with tag.td(classes="text-base-content/60"):
                             text(case.created_at.strftime("%b %-d, %Y %H:%M UTC"))
 
@@ -113,16 +143,24 @@ async def list_cases(
     request: Request,
     pagination: PaginationParamsQuery,
     status: Annotated[str, Query()] = "open",
+    assigned: Annotated[str, Query()] = "all",
     session: AsyncSession = Depends(get_db_read_session),
+    user_session: UserSession = Depends(get_admin),
 ) -> None:
     is_open = SupportCaseMessageRepository.is_open_expression()
     statement = (
-        select(ReviewAppealSupportCase, Organization, is_open.label("is_open"))
+        select(
+            ReviewAppealSupportCase,
+            Organization,
+            is_open.label("is_open"),
+            User.email.label("assignee_email"),
+        )
         .join(
             OrganizationReview,
             ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
         )
         .join(Organization, OrganizationReview.organization_id == Organization.id)
+        .outerjoin(User, ReviewAppealSupportCase.assigned_user_id == User.id)
         .where(ReviewAppealSupportCase.deleted_at.is_(None))
     )
     count_statement = (
@@ -136,6 +174,15 @@ async def list_cases(
     elif status == "closed":
         statement = statement.where(~is_open)
         count_statement = count_statement.where(~is_open)
+
+    if assigned == "me":
+        mine = ReviewAppealSupportCase.assigned_user_id == user_session.user_id
+        statement = statement.where(mine)
+        count_statement = count_statement.where(mine)
+    elif assigned == "unassigned":
+        unassigned = ReviewAppealSupportCase.assigned_user_id.is_(None)
+        statement = statement.where(unassigned)
+        count_statement = count_statement.where(unassigned)
 
     count = await session.scalar(count_statement) or 0
     result = await session.execute(
@@ -153,7 +200,7 @@ async def list_cases(
         with tag.div(classes="flex flex-col gap-4"):
             with tag.h1(classes="text-4xl"):
                 text("Cases")
-            with tab_nav(_list_tabs(request, status)):
+            with tab_nav(_list_tabs(request, status, assigned)):
                 pass
             if rows:
                 _render_table(rows)

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Request
+from tagflow import tag, text
+
+from ..layout import layout
+
+router = APIRouter()
+
+
+@router.get("/", name="support_cases:list")
+async def list_cases(request: Request) -> None:
+    with layout(
+        request,
+        [("Cases", str(request.url_for("support_cases:list")))],
+        "support_cases:list",
+    ):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.h1(classes="text-4xl"):
+                text("Cases")
+            with tag.div(classes="text-center py-12 text-base-content/50"):
+                text("No cases yet.")

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -1,7 +1,8 @@
 from collections.abc import Sequence
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import UUID4
 from sqlalchemy import func, select
 from tagflow import tag, text
 
@@ -9,12 +10,19 @@ from polar.kit.pagination import PaginationParamsQuery
 from polar.models import Organization
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase
-from polar.postgres import AsyncSession, get_db_read_session
-from polar.support_case.repository import SupportCaseMessageRepository
+from polar.models.user_session import UserSession
+from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+from polar.support_case.repository import (
+    SupportCaseMessageRepository,
+    SupportCaseRepository,
+)
+from polar.support_case.service import support_case as support_case_service
 
 from ..components import datatable
 from ..components._tab_nav import Tab, tab_nav
+from ..dependencies import get_admin
 from ..layout import layout
+from ..responses import HXRedirectResponse
 
 router = APIRouter()
 
@@ -59,6 +67,45 @@ def _render_table(rows: Sequence[Row]) -> None:
                             _status_badge(is_open)
                         with tag.td(classes="text-base-content/60"):
                             text(case.created_at.strftime("%b %-d, %Y %H:%M UTC"))
+
+
+def _safe_return_to(request: Request, return_to: str | None) -> str:
+    """Same-site relative path only, to avoid an open redirect."""
+    if return_to and return_to.startswith("/") and not return_to.startswith("//"):
+        return return_to
+    return str(request.url_for("support_cases:list"))
+
+
+@router.post("/{case_id}/take", name="support_cases:take", response_model=None)
+async def take_case(
+    request: Request,
+    case_id: UUID4,
+    return_to: Annotated[str | None, Query()] = None,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse:
+    """Assign a case to the acting staff member (advisory; any case type)."""
+    case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Support case not found")
+    await support_case_service.assign(session, case, assignee=user_session.user)
+    return HXRedirectResponse(request, _safe_return_to(request, return_to), 303)
+
+
+@router.post("/{case_id}/release", name="support_cases:release", response_model=None)
+async def release_case(
+    request: Request,
+    case_id: UUID4,
+    return_to: Annotated[str | None, Query()] = None,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse:
+    """Clear a case's assignee."""
+    case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Support case not found")
+    await support_case_service.unassign(session, case, actor=user_session.user)
+    return HXRedirectResponse(request, _safe_return_to(request, return_to), 303)
 
 
 @router.get("/", name="support_cases:list")

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -63,7 +63,7 @@ def _status_badge(is_open: bool) -> None:
         text("Open" if is_open else "Closed")
 
 
-def _render_table(rows: Sequence[Row]) -> None:
+def _render_table(request: Request, rows: Sequence[Row]) -> None:
     with tag.div(classes="overflow-x-auto"):
         with tag.table(classes="table table-zebra"):
             with tag.thead():
@@ -79,11 +79,22 @@ def _render_table(rows: Sequence[Row]) -> None:
                             text(header)
             with tag.tbody():
                 for case, organization, is_open, assignee_email in rows:
-                    # Not linked yet: the org's support-case section these rows
-                    # point to ships in a follow-up PR.
-                    with tag.tr():
+                    case_url = (
+                        str(
+                            request.url_for(
+                                "organizations:detail",
+                                organization_id=organization.id,
+                            )
+                        )
+                        + "?section=support_case"
+                    )
+                    with tag.tr(
+                        classes="hover cursor-pointer",
+                        _=f"on click set window.location to '{case_url}'",
+                    ):
                         with tag.td():
-                            text(organization.name)
+                            with tag.a(href=case_url, classes="link"):
+                                text(organization.name)
                         with tag.td():
                             with tag.div(classes="badge badge-outline badge-sm"):
                                 text("Review appeal")
@@ -203,7 +214,7 @@ async def list_cases(
             with tab_nav(_list_tabs(request, status, assigned)):
                 pass
             if rows:
-                _render_table(rows)
+                _render_table(request, rows)
             else:
                 with tag.div(classes="text-center py-12 text-base-content/50"):
                     text("No cases in this view.")

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -1,13 +1,103 @@
-from fastapi import APIRouter, Request
+from collections.abc import Sequence
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy import func, select
 from tagflow import tag, text
 
+from polar.kit.pagination import PaginationParamsQuery
+from polar.models import Organization
+from polar.models.organization_review import OrganizationReview
+from polar.models.support_case import ReviewAppealSupportCase
+from polar.postgres import AsyncSession, get_db_read_session
+from polar.support_case.repository import SupportCaseMessageRepository
+
+from ..components import datatable
+from ..components._tab_nav import Tab, tab_nav
 from ..layout import layout
 
 router = APIRouter()
 
+# (case, organization, is_open)
+Row = tuple[ReviewAppealSupportCase, Organization, bool]
+
+
+def _list_tabs(request: Request, active: str) -> list[Tab]:
+    base = str(request.url_for("support_cases:list"))
+    return [
+        Tab("Open", url=f"{base}?status=open", active=active == "open"),
+        Tab("Closed", url=f"{base}?status=closed", active=active == "closed"),
+        Tab("All", url=f"{base}?status=all", active=active == "all"),
+    ]
+
+
+def _status_badge(is_open: bool) -> None:
+    variant = "badge-success" if is_open else "badge-ghost"
+    with tag.div(classes=f"badge {variant} badge-sm"):
+        text("Open" if is_open else "Closed")
+
+
+def _render_table(rows: Sequence[Row]) -> None:
+    with tag.div(classes="overflow-x-auto"):
+        with tag.table(classes="table table-zebra"):
+            with tag.thead():
+                with tag.tr():
+                    for header in ("Organization", "Type", "Status", "Opened"):
+                        with tag.th():
+                            text(header)
+            with tag.tbody():
+                for case, organization, is_open in rows:
+                    # Not linked yet: the org's support-case section these rows
+                    # point to ships in a follow-up PR.
+                    with tag.tr():
+                        with tag.td():
+                            text(organization.name)
+                        with tag.td():
+                            with tag.div(classes="badge badge-outline badge-sm"):
+                                text("Review appeal")
+                        with tag.td():
+                            _status_badge(is_open)
+                        with tag.td(classes="text-base-content/60"):
+                            text(case.created_at.strftime("%b %-d, %Y %H:%M UTC"))
+
 
 @router.get("/", name="support_cases:list")
-async def list_cases(request: Request) -> None:
+async def list_cases(
+    request: Request,
+    pagination: PaginationParamsQuery,
+    status: Annotated[str, Query()] = "open",
+    session: AsyncSession = Depends(get_db_read_session),
+) -> None:
+    is_open = SupportCaseMessageRepository.is_open_expression()
+    statement = (
+        select(ReviewAppealSupportCase, Organization, is_open.label("is_open"))
+        .join(
+            OrganizationReview,
+            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
+        )
+        .join(Organization, OrganizationReview.organization_id == Organization.id)
+        .where(ReviewAppealSupportCase.deleted_at.is_(None))
+    )
+    count_statement = (
+        select(func.count())
+        .select_from(ReviewAppealSupportCase)
+        .where(ReviewAppealSupportCase.deleted_at.is_(None))
+    )
+    if status == "open":
+        statement = statement.where(is_open)
+        count_statement = count_statement.where(is_open)
+    elif status == "closed":
+        statement = statement.where(~is_open)
+        count_statement = count_statement.where(~is_open)
+
+    count = await session.scalar(count_statement) or 0
+    result = await session.execute(
+        statement.order_by(ReviewAppealSupportCase.created_at.desc())
+        .limit(pagination.limit)
+        .offset((pagination.page - 1) * pagination.limit)
+    )
+    rows: Sequence[Row] = result.all()  # type: ignore[assignment]
+
     with layout(
         request,
         [("Cases", str(request.url_for("support_cases:list")))],
@@ -16,5 +106,12 @@ async def list_cases(request: Request) -> None:
         with tag.div(classes="flex flex-col gap-4"):
             with tag.h1(classes="text-4xl"):
                 text("Cases")
-            with tag.div(classes="text-center py-12 text-base-content/50"):
-                text("No cases yet.")
+            with tab_nav(_list_tabs(request, status)):
+                pass
+            if rows:
+                _render_table(rows)
+            else:
+                with tag.div(classes="text-center py-12 text-base-content/50"):
+                    text("No cases in this view.")
+            with datatable.pagination(request, pagination, count):
+                pass

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
 from uuid import UUID
 
+from sqlalchemy import ColumnElement, select
+
 from polar.kit.repository.base import (
     RepositoryBase,
     RepositorySoftDeletionIDMixin,
@@ -75,6 +77,25 @@ class SupportCaseMessageRepository(
         latest = await self.get_latest_lifecycle_event(case_id)
         assert latest is not None  # always created with an `opened` event
         return latest.type != SupportCaseMessageType.closed
+
+    @staticmethod
+    def is_open_expression() -> ColumnElement[bool]:
+        """SQL form of ``is_open()``, correlated to the enclosing case row.
+        State is the type of the latest lifecycle event
+        Lets a list query derive open/closed in one pass instead of
+        an N+1 of per-case ``is_open()`` calls.
+        """
+        latest_type = (
+            select(SupportCaseMessage.type)
+            .where(
+                SupportCaseMessage.case_id == SupportCase.id,
+                SupportCaseMessage.type.in_(_LIFECYCLE_TYPES),
+            )
+            .order_by(SupportCaseMessage.created_at.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        return latest_type != SupportCaseMessageType.closed
 
 
 class SupportCaseParticipantRepository(


### PR DESCRIPTION
## Summary

**Related Issue**: [#feedback/151](https://github.com/polarsource/feedback/issues/151)

Adds a backoffice "Cases" module: a list of support cases with status and assignment filters, plus take/release endpoints so staff can claim a case.
First of two backoffice PRs (the org-detail surface follows); merge this one first, since it registers the take/release routes the org page will call.

<img width="1891" height="856" alt="Screenshot 2026-06-10 at 18 08 23" src="https://github.com/user-attachments/assets/a3c829dc-3a6f-41cf-bf8c-9e90df2f3991" />


## What

- New mounted `/backoffice/support-cases/` module + "Cases" left-nav entry.
- Cases list: organization, type, status, assignee, opened — with Open/Closed/All status tabs and toggleable "Assigned to me" / "Unassigned" filters.
- `support_cases:take` / `:release` endpoints to assign a case to the acting admin or clear its assignee.
- `SupportCaseMessageRepository.is_open_expression()` — a reusable SQL form of `is_open()`.
- Tab-nav component gains a `dot` indicator and per-tab `extra_classes`.

## Why

Support asked for one place to see open cases and claim them, so two people
don't unknowingly work the same one. Assignment is advisory (visibility, not a
lock).

## How

- Open/closed is derived from the *latest* lifecycle event (via the reusable expression), not "a closed event exists" — so it survives a future reopen.
- Take/release operate on the generic `SupportCase` and redirect to a guarded same-site `return_to`, keeping them reusable across case types.
- List rows aren't linked to the org support-case section yet — that view ships in the follow-up organizations PR.
## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backoffice Cases module and integrates appeal support cases into organization pages. Staff can list, filter, assign, discuss, and resolve cases, with clear UI cues and single-pass open/closed checks.

- **New Features**
  - New `/backoffice/support-cases/` list (linked in the sidebar) with Open/Closed/All and “Assigned to me”/“Unassigned” filters; shows organization, type, status, assignee, and opened date.
  - Case assignment via `support_cases:take` and `support_cases:release`, with a safe `return_to` redirect.
  - Organization detail: new “Support Case” tab with the appeal thread (timeline of events and messages, internal notes), assignee chip, and reply composer; approve/deny appeal dialogs record the decision and close the case.
  - Overview card links to the case when present; the “Support Case” tab shows a warning `dot` when the case is open.
  - Organizations list: added “Open cases” filter with count; rows show an “Open case” badge and deep-link to `?section=support_case`.
  - UI/Data: tab nav supports per-tab `dot` and `extra_classes`; `SupportCaseMessageRepository.is_open_expression()` enables single-query open/closed and org-case counts.

<sup>Written for commit 1342ac07d876c24f4a1ff3d4bdec8cad743f6c4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



