### PR TITLE
Implement Grid component in Orbit package

### DIFF
--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -366,22 +366,18 @@ you add a transition:
 </Box>
 ```
 
-**Responsive grid**:
+**Responsive grid** — prefer the `Grid` primitive (see below); it defaults to
+`display: grid` and uses short prop names:
 
 ```tsx
-<Box
-  display="grid"
-  gridTemplateColumns={{
-    base: '1fr',
-    md: 'repeat(2, 1fr)',
-    xl: 'repeat(4, 1fr)',
-  }}
+<Grid
+  templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)', xl: 'repeat(4, 1fr)' }}
   gap="l"
 >
   {items.map((item) => (
     <Card key={item.id} {...item} />
   ))}
-</Box>
+</Grid>
 ```
 
 **Sticky toolbar**:
@@ -459,18 +455,57 @@ Open `clients/packages/orbit/src/utils/types.ts` to confirm — most needs are c
 genuinely missing CSS property comes up, prefer extending `BoxStyleProps` (with token
 support where applicable) over a tailwind escape hatch. Flag this on the PR.
 
+### `Grid`
+
+`Grid` is a `Box` preset for CSS grid. It defaults to `display: grid` and re-exposes the
+grid properties under short, Chakra-style prop names; every other Box prop (`gap`,
+`padding`, color, responsive objects, …) is inherited.
+
+```tsx
+import { Grid } from '@polar-sh/orbit'
+
+<Grid templateColumns="repeat(3, 1fr)" gap="m">
+  …
+</Grid>
+
+// areas + responsive
+<Grid
+  templateAreas={{ base: '"head" "main"', md: '"head head" "nav main"' }}
+  templateColumns={{ base: '1fr', md: '200px 1fr' }}
+  gap="l"
+/>
+```
+
+Prop names: `templateColumns`, `templateRows`, `templateAreas`, `autoFlow`, `autoRows`,
+`autoColumns`, `column`, `row`, and `inline` (renders `inline-grid`).
+
+Use `GridItem` for children that need to span or be placed explicitly:
+
+```tsx
+import { Grid, GridItem } from '@polar-sh/orbit'
+
+<Grid templateColumns="repeat(4, 1fr)" gap="m">
+  <GridItem colSpan={2}>Spans two columns</GridItem>
+  <GridItem colStart={3} colEnd={5} rowSpan={2}>Placed explicitly</GridItem>
+  <GridItem area="sidebar">By template area</GridItem>
+</Grid>
+```
+
+`GridItem` props: `colSpan`/`rowSpan` (number or `"auto"`), `colStart`/`colEnd`/`rowStart`/
+`rowEnd`, and `area` — all responsive. Plus every Box prop.
+
 ### Other Orbit primitives
 
 Use these instead of hand-rolled tailwind components:
 
 ```tsx
 import { Text } from '@polar-sh/orbit' // typography (variant-driven)
-import { Button } from '@polar-sh/orbit'
+import { Button, Grid } from '@polar-sh/orbit'
 import { Avatar, SegmentedControl } from '@polar-sh/orbit'
 ```
 
 Prefer `Box` when you need full control; prefer the named primitive when one exists for
-your use case (Text for any text node, Button for actions).
+your use case (Text for any text node, Button for actions, Grid for grid layouts).
 
 ## Legacy Tailwind (deprecated)
 

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -483,7 +483,6 @@ Use `GridItem` for children that need to span or be placed explicitly:
 
 ```tsx
 import { Grid, GridItem } from '@polar-sh/orbit'
-
 ;<Grid templateColumns="repeat(4, 1fr)" gap="m">
   <GridItem colSpan={2}>Spans two columns</GridItem>
   <GridItem colStart={3} colEnd={5} rowSpan={2}>

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -484,9 +484,11 @@ Use `GridItem` for children that need to span or be placed explicitly:
 ```tsx
 import { Grid, GridItem } from '@polar-sh/orbit'
 
-<Grid templateColumns="repeat(4, 1fr)" gap="m">
+;<Grid templateColumns="repeat(4, 1fr)" gap="m">
   <GridItem colSpan={2}>Spans two columns</GridItem>
-  <GridItem colStart={3} colEnd={5} rowSpan={2}>Placed explicitly</GridItem>
+  <GridItem colStart={3} colEnd={5} rowSpan={2}>
+    Placed explicitly
+  </GridItem>
   <GridItem area="sidebar">By template area</GridItem>
 </Grid>
 ```

--- a/clients/apps/web/src/components/Landing/Pricing.tsx
+++ b/clients/apps/web/src/components/Landing/Pricing.tsx
@@ -2,7 +2,7 @@
 
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { Button } from '@polar-sh/orbit'
+import { Button, Grid } from '@polar-sh/orbit'
 import Link from 'next/link'
 import GetStartedButton from '../Auth/GetStartedButton'
 import { VolumetricSlices } from './graphics/VolumetricSlices'
@@ -72,9 +72,8 @@ export const Pricing = () => (
         </Box>
       </Box>
 
-      <Box
-        display="grid"
-        gridTemplateColumns={{
+      <Grid
+        templateColumns={{
           base: '1fr',
           sm: 'repeat(2, 1fr)',
           xl: 'repeat(3, 1fr)',
@@ -85,16 +84,15 @@ export const Pricing = () => (
           <TierCard key={tier.name} tier={tier} />
         ))}
         <StartupProgramCard />
-      </Box>
+      </Grid>
     </Box>
   </>
 )
 
 const StartupProgramCard = () => (
-  <Box
-    gridColumn={{ base: 'auto', sm: 'span 2' }}
-    display="grid"
-    gridTemplateColumns={{ base: '1fr', sm: 'subgrid' }}
+  <Grid
+    column={{ base: 'auto', sm: 'span 2' }}
+    templateColumns={{ base: '1fr', sm: 'subgrid' }}
     backgroundColor="background-secondary"
     overflow="hidden"
   >
@@ -142,7 +140,7 @@ const StartupProgramCard = () => (
         </Link>
       </Box>
     </Box>
-  </Box>
+  </Grid>
 )
 
 const TierCard = ({ tier }: { tier: Tier }) => (

--- a/clients/apps/web/src/components/Payouts/PayoutStatus.tsx
+++ b/clients/apps/web/src/components/Payouts/PayoutStatus.tsx
@@ -26,8 +26,10 @@ const PayoutStatusTooltip: Partial<Record<schemas['PayoutStatus'], string>> = {
 
 export const PayoutStatus = ({
   payout: { status, attempts },
+  size = 'medium',
 }: {
   payout: schemas['Payout']
+  size?: 'small' | 'medium'
 }) => {
   const tooltipMessage =
     status === 'failed'
@@ -38,6 +40,7 @@ export const PayoutStatus = ({
     <Status
       color={PayoutStatusDisplayColor[status]}
       status={PayoutStatusDisplayTitle[status]}
+      size={size}
     />
   )
 

--- a/clients/apps/web/src/components/Widgets/AccountWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/AccountWidget.tsx
@@ -1,10 +1,10 @@
 import { useOrganizationAccount, useTransactionsSummary } from '@/hooks/queries'
 import { usePayouts } from '@/hooks/queries/payouts'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
+import { PayoutStatus } from '@/components/Payouts/PayoutStatus'
 import { ClientResponseError } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Card } from '@polar-sh/ui/components/atoms/Card'
-import { Status } from '@polar-sh/orbit'
 import { useContext } from 'react'
 import { WidgetContainer } from './WidgetContainer'
 
@@ -56,14 +56,7 @@ export const AccountWidget = ({ className }: AccountWidgetProps) => {
                     year: 'numeric',
                   })}
                 </span>
-                <Status
-                  status={payout.status
-                    .split('_')
-                    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-                    .join(' ')}
-                  color={payout.status === 'succeeded' ? 'green' : 'yellow'}
-                  size="small"
-                />
+                <PayoutStatus payout={payout} size="small" />
               </div>
               <div className="flex flex-row justify-between gap-x-4">
                 <h3>Payout</h3>

--- a/clients/packages/orbit/src/components/Grid.tsx
+++ b/clients/packages/orbit/src/components/Grid.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import * as React from 'react'
+import type { GridPlacement } from '../utils/grid'
+import type { ResponsiveValue } from '../utils/types'
+import { Box, type BoxProps } from './Box'
+
+// Verbose CSS-grid props are re-exposed under the shorter, Chakra-style names
+// below, so they're omitted from the inherited Box props to avoid duplication.
+type OmittedGridProps =
+  | 'display'
+  | 'gridTemplateColumns'
+  | 'gridTemplateRows'
+  | 'gridTemplateAreas'
+  | 'gridColumn'
+  | 'gridRow'
+  | 'gridAutoFlow'
+  | 'gridAutoRows'
+  | 'gridAutoColumns'
+
+export interface GridProps extends Omit<BoxProps, OmittedGridProps> {
+  /** `grid-template-columns`, e.g. `"repeat(3, 1fr)"`. */
+  templateColumns?: ResponsiveValue<string>
+  /** `grid-template-rows`. */
+  templateRows?: ResponsiveValue<string>
+  /** `grid-template-areas`. */
+  templateAreas?: ResponsiveValue<string>
+  /** `grid-auto-flow`. */
+  autoFlow?: BoxProps['gridAutoFlow']
+  /** `grid-auto-rows`. */
+  autoRows?: ResponsiveValue<string>
+  /** `grid-auto-columns`. */
+  autoColumns?: ResponsiveValue<string>
+  /** `grid-column` — a line, or `<start> / <end>`. */
+  column?: ResponsiveValue<GridPlacement>
+  /** `grid-row` — a line, or `<start> / <end>`. */
+  row?: ResponsiveValue<GridPlacement>
+  /** Render as `inline-grid` instead of `grid`. */
+  inline?: boolean
+}
+
+/**
+ * Grid is a Box that lays out its children with CSS grid. It defaults to
+ * `display: grid` and exposes the grid properties under short prop names.
+ * Spacing (`gap`/`rowGap`/`columnGap`) and every other Box prop are inherited.
+ */
+export const Grid = React.forwardRef<HTMLElement, GridProps>(function Grid(
+  {
+    templateColumns,
+    templateRows,
+    templateAreas,
+    autoFlow,
+    autoRows,
+    autoColumns,
+    column,
+    row,
+    inline,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <Box
+      ref={ref}
+      display={inline ? 'inline-grid' : 'grid'}
+      gridTemplateColumns={templateColumns}
+      gridTemplateRows={templateRows}
+      gridTemplateAreas={templateAreas}
+      gridAutoFlow={autoFlow}
+      gridAutoRows={autoRows}
+      gridAutoColumns={autoColumns}
+      gridColumn={column}
+      gridRow={row}
+      {...rest}
+    />
+  )
+})
+
+Grid.displayName = 'Grid'

--- a/clients/packages/orbit/src/components/GridItem.tsx
+++ b/clients/packages/orbit/src/components/GridItem.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import * as React from 'react'
+import type { GridLine } from '../utils/grid'
+import type { ResponsiveValue } from '../utils/types'
+import { Box, type BoxProps } from './Box'
+
+// These grid-placement props are re-exposed under shorter names below.
+type OmittedGridItemProps =
+  | 'gridArea'
+  | 'gridColumn'
+  | 'gridRow'
+  | 'gridColumnStart'
+  | 'gridColumnEnd'
+  | 'gridRowStart'
+  | 'gridRowEnd'
+
+// A span count: how many tracks to cover.
+type Span = ResponsiveValue<number | 'auto'>
+// A single placement line: a line number, `auto`, or `span N`.
+type Line = ResponsiveValue<GridLine>
+
+export interface GridItemProps extends Omit<BoxProps, OmittedGridItemProps> {
+  /** `grid-area`. */
+  area?: ResponsiveValue<string>
+  /** Number of columns to span, or `"auto"`. */
+  colSpan?: Span
+  /** `grid-column-start`. */
+  colStart?: Line
+  /** `grid-column-end`. */
+  colEnd?: Line
+  /** Number of rows to span, or `"auto"`. */
+  rowSpan?: Span
+  /** `grid-row-start`. */
+  rowStart?: Line
+  /** `grid-row-end`. */
+  rowEnd?: Line
+}
+
+function spanValue(value: number | 'auto'): string {
+  return value === 'auto' ? 'auto' : `span ${value} / span ${value}`
+}
+
+// Apply `fn` to a plain value or to each entry of a responsive/pseudo object,
+// preserving the breakpoint keys.
+function mapResponsive<T, U>(
+  value: ResponsiveValue<T> | undefined,
+  fn: (v: T) => U,
+): ResponsiveValue<U> | undefined {
+  if (value === undefined) return undefined
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const out: Record<string, U> = {}
+    for (const [key, v] of Object.entries(value)) {
+      if (v !== undefined) out[key] = fn(v as T)
+    }
+    return out as ResponsiveValue<U>
+  }
+  return fn(value as T)
+}
+
+/**
+ * GridItem positions a single child inside a `Grid`. `colSpan`/`rowSpan` set how
+ * many tracks the item spans; `colStart`/`colEnd`/`rowStart`/`rowEnd` and `area`
+ * place it explicitly. All other Box props are inherited.
+ */
+export const GridItem = React.forwardRef<HTMLElement, GridItemProps>(
+  function GridItem(
+    { area, colSpan, colStart, colEnd, rowSpan, rowStart, rowEnd, ...rest },
+    ref,
+  ) {
+    return (
+      <Box
+        ref={ref}
+        gridArea={area}
+        gridColumn={mapResponsive(colSpan, spanValue)}
+        gridColumnStart={colStart}
+        gridColumnEnd={colEnd}
+        gridRow={mapResponsive(rowSpan, spanValue)}
+        gridRowStart={rowStart}
+        gridRowEnd={rowEnd}
+        {...rest}
+      />
+    )
+  },
+)
+
+GridItem.displayName = 'GridItem'

--- a/clients/packages/orbit/src/index.ts
+++ b/clients/packages/orbit/src/index.ts
@@ -11,6 +11,11 @@ export type {
   DataTableSortingState,
   ReactQueryLoading,
 } from './components/datatable'
+export { Grid } from './components/Grid'
+export type { GridProps } from './components/Grid'
+export { GridItem } from './components/GridItem'
+export type { GridItemProps } from './components/GridItem'
+export type { GridLine, GridPlacement } from './utils/grid'
 export { Input } from './components/Input'
 export type { InputProps } from './components/Input'
 export { List, ListItem } from './components/List'

--- a/clients/packages/orbit/src/utils/box-styles.ts
+++ b/clients/packages/orbit/src/utils/box-styles.ts
@@ -367,6 +367,7 @@ export const displayStyles = stylex.create({
   block: { display: 'block' },
   inline: { display: 'inline' },
   'inline-flex': { display: 'inline-flex' },
+  'inline-grid': { display: 'inline-grid' },
   'inline-block': { display: 'inline-block' },
   none: { display: 'none' },
   contents: { display: 'contents' },

--- a/clients/packages/orbit/src/utils/grid.ts
+++ b/clients/packages/orbit/src/utils/grid.ts
@@ -1,0 +1,12 @@
+// Strongly-typed grid line & placement values, shared by Grid and GridItem.
+//
+// Track *lists* (e.g. `repeat(3, 1fr)`, `1fr 2fr auto`, `minmax(100px, 1fr)`)
+// are open-ended CSS and intentionally stay typed as `string`. The values
+// below, however, have a small finite grammar, so they're constrained to catch
+// typos like `column="foo"`.
+
+/** A single grid line: a (possibly negative) line number, `auto`, or a span. */
+export type GridLine = number | 'auto' | `span ${number}`
+
+/** A `grid-column` / `grid-row` value: a single line, or `<start> / <end>`. */
+export type GridPlacement = GridLine | `${GridLine} / ${GridLine}`

--- a/clients/packages/orbit/src/utils/resolvers.test.ts
+++ b/clients/packages/orbit/src/utils/resolvers.test.ts
@@ -384,6 +384,39 @@ describe('addArbitraryProp — { base: X } goes to scoped <style>, not inline', 
     )
     expect(responsiveCSS).toContain('grid-template-columns: repeat(3, 1fr)')
   })
+
+  it('grid-template-areas arbitrary value (scalar → inlineStyle)', () => {
+    const { inlineStyle } = resolveBoxStyles(
+      { gridTemplateAreas: '"a b" "c d"' },
+      'scope',
+    )
+    expect(inlineStyle.gridTemplateAreas).toBe('"a b" "c d"')
+  })
+
+  it('grid placement longhands (gridArea, gridColumnStart) pass through', () => {
+    const { inlineStyle } = resolveBoxStyles(
+      { gridArea: 'header', gridColumnStart: 2 },
+      'scope',
+    )
+    expect(inlineStyle.gridArea).toBe('header')
+    expect(inlineStyle.gridColumnStart).toBe(2)
+  })
+
+  it('gridColumn span string (as GridItem builds it) is emitted verbatim', () => {
+    const { inlineStyle } = resolveBoxStyles(
+      { gridColumn: 'span 2 / span 2' },
+      'scope',
+    )
+    expect(inlineStyle.gridColumn).toBe('span 2 / span 2')
+  })
+
+  it('inline-grid display maps through as a token style', () => {
+    const { stylexStyles } = resolveBoxStyles(
+      { display: 'inline-grid' },
+      'scope',
+    )
+    expect(stylexStyles).toEqual([{ display: 'inline-grid' }])
+  })
 })
 
 describe('CSS string builder', () => {

--- a/clients/packages/orbit/src/utils/resolvers.ts
+++ b/clients/packages/orbit/src/utils/resolvers.ts
@@ -294,8 +294,14 @@ const BOX_STYLE_PROP_MAP: Record<keyof BoxStyleProps, true> = {
   alignContent: true,
   gridTemplateColumns: true,
   gridTemplateRows: true,
+  gridTemplateAreas: true,
   gridColumn: true,
   gridRow: true,
+  gridArea: true,
+  gridColumnStart: true,
+  gridColumnEnd: true,
+  gridRowStart: true,
+  gridRowEnd: true,
   gridAutoFlow: true,
   gridAutoColumns: true,
   gridAutoRows: true,
@@ -600,8 +606,14 @@ export function resolveBoxStyles(
   // --- Grid ---
   addArbitraryProp('gridTemplateColumns', props.gridTemplateColumns, (v) => v)
   addArbitraryProp('gridTemplateRows', props.gridTemplateRows, (v) => v)
+  addArbitraryProp('gridTemplateAreas', props.gridTemplateAreas, (v) => v)
   addArbitraryProp('gridColumn', props.gridColumn, (v) => v)
   addArbitraryProp('gridRow', props.gridRow, (v) => v)
+  addArbitraryProp('gridArea', props.gridArea, (v) => v)
+  addArbitraryProp('gridColumnStart', props.gridColumnStart, (v) => v)
+  addArbitraryProp('gridColumnEnd', props.gridColumnEnd, (v) => v)
+  addArbitraryProp('gridRowStart', props.gridRowStart, (v) => v)
+  addArbitraryProp('gridRowEnd', props.gridRowEnd, (v) => v)
   addTokenProp(
     gridAutoFlowStyles,
     'grid-auto-flow',

--- a/clients/packages/orbit/src/utils/types.ts
+++ b/clients/packages/orbit/src/utils/types.ts
@@ -89,6 +89,7 @@ export interface LayoutProps {
     | 'block'
     | 'inline'
     | 'inline-flex'
+    | 'inline-grid'
     | 'inline-block'
     | 'none'
     | 'contents'
@@ -131,8 +132,14 @@ export interface FlexProps {
 export interface GridProps {
   gridTemplateColumns?: ResponsiveValue<string>
   gridTemplateRows?: ResponsiveValue<string>
-  gridColumn?: ResponsiveValue<string>
-  gridRow?: ResponsiveValue<string>
+  gridTemplateAreas?: ResponsiveValue<string>
+  gridColumn?: ResponsiveValue<string | number>
+  gridRow?: ResponsiveValue<string | number>
+  gridArea?: ResponsiveValue<string>
+  gridColumnStart?: ResponsiveValue<number | string>
+  gridColumnEnd?: ResponsiveValue<number | string>
+  gridRowStart?: ResponsiveValue<number | string>
+  gridRowEnd?: ResponsiveValue<number | string>
   gridAutoFlow?: ResponsiveValue<
     'row' | 'column' | 'dense' | 'row-dense' | 'column-dense'
   >


### PR DESCRIPTION
- **fix status size in account widget**
- **orbit: implement grid component**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Grid` and `GridItem` to `@polar-sh/orbit` for simpler, typed CSS grid layouts, and migrates the Pricing layout to use them. Also fixes payout status sizing in the account widget.

- **New Features**
  - New `Grid` primitive with short props: `templateColumns`, `templateRows`, `templateAreas`, `autoFlow`, `autoRows`/`autoColumns`, `column`/`row`, `inline`.
  - New `GridItem` for spans and explicit placement; both exported with `GridLine`/`GridPlacement` types.
  - Resolvers support `inline-grid`, `grid-template-areas`, and grid longhands (`gridArea`, `gridColumn(Start|End)`, `gridRow(Start|End)`); tests and docs updated.

- **Bug Fixes**
  - `PayoutStatus` accepts `size` (default `medium`); `AccountWidget` uses `size="small"` for consistent UI.

<sup>Written for commit fd16fa5ebc57e6517d28af21b22f135e63dc4437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

