### PR TITLE
feat(backoffice): appeals support case on org page

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1695,14 +1695,14 @@ async def appeal_case_approve_dialog(
             error_message = "A reason is required to approve the appeal."
         else:
             review_repo = OrganizationReviewRepository.from_session(session)
-            await review_repo.record_human_decision(
-                organization_id=organization_id,
-                reviewer_id=user_session.user.id,
-                decision=DecisionType.APPROVE,
-                review_context=ReviewContext.APPEAL,
-                reason=reason,
-            )
             try:
+                await review_repo.record_human_decision(
+                    organization_id=organization_id,
+                    reviewer_id=user_session.user.id,
+                    decision=DecisionType.APPROVE,
+                    review_context=ReviewContext.APPEAL,
+                    reason=reason,
+                )
                 await organization_service.backoffice_approve(
                     session, organization, reason=reason
                 )
@@ -1714,6 +1714,9 @@ async def appeal_case_approve_dialog(
                     reason=reason,
                 )
             except (OrganizationError, AppealCaseError) as e:
+                # Discard the recorded decision so a failure can't commit
+                # half the approval (decision without org/case update).
+                await session.rollback()
                 error_message = e.args[0]
             else:
                 return _support_case_redirect(request, organization_id)
@@ -1785,14 +1788,14 @@ async def appeal_case_deny_dialog(
         form_data = await request.form()
         reason = str(form_data.get("reason", "")).strip() or None
         review_repo = OrganizationReviewRepository.from_session(session)
-        await review_repo.record_human_decision(
-            organization_id=organization_id,
-            reviewer_id=user_session.user.id,
-            decision=DecisionType.DENY,
-            review_context=ReviewContext.APPEAL,
-            reason=reason,
-        )
         try:
+            await review_repo.record_human_decision(
+                organization_id=organization_id,
+                reviewer_id=user_session.user.id,
+                decision=DecisionType.DENY,
+                review_context=ReviewContext.APPEAL,
+                reason=reason,
+            )
             await appeal_case_service.record_decision(
                 session,
                 case,
@@ -1801,6 +1804,9 @@ async def appeal_case_deny_dialog(
                 reason=reason,
             )
         except AppealCaseError as e:
+            # Discard the recorded decision so a failure can't commit it
+            # without the case actually being closed.
+            await session.rollback()
             error_message = e.args[0]
         else:
             return _support_case_redirect(request, organization_id)

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -257,6 +257,36 @@ async def count_test_sales(
 REVIEW_TAB_MAX_COHORT = 2000
 
 
+def _open_case_org_ids() -> Select[tuple[uuid.UUID]]:
+    """Select of organization ids that have at least one open support case."""
+    return (
+        select(OrganizationReview.organization_id)
+        .join(
+            ReviewAppealSupportCase,
+            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
+        )
+        .where(
+            ReviewAppealSupportCase.deleted_at.is_(None),
+            SupportCaseMessageRepository.is_open_expression(),
+        )
+        .distinct()
+    )
+
+
+async def _orgs_with_open_cases(
+    session: AsyncSession, organizations: Sequence[Organization]
+) -> set[uuid.UUID]:
+    """Org ids (among the given page) with at least one open support case."""
+    org_ids = [org.id for org in organizations]
+    if not org_ids:
+        return set()
+    statement = _open_case_org_ids().where(
+        OrganizationReview.organization_id.in_(org_ids)
+    )
+    result = await session.execute(statement)
+    return set(result.scalars().all())
+
+
 async def _build_review_signals(
     session: AsyncSession, orgs: Sequence[Organization]
 ) -> dict[uuid.UUID, Signals]:
@@ -415,6 +445,9 @@ async def list_organizations(
     elif status == "blocked":
         status_filter = OrganizationStatus.BLOCKED
 
+    # "Open cases" is a separate dimension (not an org status).
+    selected_open_cases = status == "open_cases"
+
     # Build query
     stmt = (
         select(Organization)
@@ -429,6 +462,10 @@ async def list_organizations(
     # Apply filters
     if status_filter:
         stmt = stmt.where(Organization.status == status_filter)
+    elif selected_open_cases:
+        # Don't apply the default denied/blocked exclusion: open cases
+        # typically live on denied organizations.
+        stmt = stmt.where(Organization.id.in_(_open_case_org_ids()))
     elif not q:
         # By default, exclude denied and blocked organizations (but not when searching)
         stmt = stmt.where(
@@ -559,6 +596,8 @@ async def list_organizations(
         if is_review_tab:
             signals_by_org = await _build_review_signals(session, organizations)
 
+    open_case_org_ids = await _orgs_with_open_cases(session, organizations)
+
     is_htmx_table_request = request.headers.get("HX-Target") == "org-list"
 
     if is_htmx_table_request:
@@ -571,11 +610,19 @@ async def list_organizations(
             sort,
             direction,
             signals_by_org=signals_by_org,
+            open_case_org_ids=open_case_org_ids,
+            selected_open_cases=selected_open_cases,
         ):
             pass
     else:
         status_counts = await list_view.get_status_counts(deleted_filter)
         countries = await list_view.get_distinct_countries()
+        open_cases_count = (
+            await session.scalar(
+                select(func.count()).select_from(_open_case_org_ids().subquery())
+            )
+            or 0
+        )
         with layout(
             request,
             [("Organizations", str(request.url))],
@@ -599,6 +646,9 @@ async def list_organizations(
                 selected_has_appeal=has_appeal,
                 selected_deleted=deleted_filter,
                 signals_by_org=signals_by_org,
+                open_case_org_ids=open_case_org_ids,
+                selected_open_cases=selected_open_cases,
+                open_cases_count=open_cases_count,
             ):
                 pass
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -72,13 +72,27 @@ from polar.models.organization import (
 )
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseMessageAuthorKind,
+)
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_session import UserSession
 from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import OrganizationFeatureSettings
-from polar.organization.service import SNOOZE_MAX_DAYS, SNOOZE_MIN_DAYS
+from polar.organization.service import (
+    SNOOZE_MAX_DAYS,
+    SNOOZE_MIN_DAYS,
+    OrganizationError,
+)
 from polar.organization.service import organization as organization_service
+from polar.organization_review.appeal_case import (
+    AppealCaseError,
+)
+from polar.organization_review.appeal_case import (
+    appeal_case as appeal_case_service,
+)
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import (
     DecisionType,
@@ -95,6 +109,7 @@ from polar.startup_program.service import (
 from polar.startup_program.service import (
     startup_program as startup_program_service,
 )
+from polar.support_case.repository import SupportCaseMessageRepository
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.worker import enqueue_job
 
@@ -120,6 +135,7 @@ from .views.sections.overview_section import OverviewSection
 from .views.sections.payout_account_section import PayoutAccountSection
 from .views.sections.reviews_section import ReviewsSection
 from .views.sections.settings_section import SettingsSection
+from .views.sections.support_case_section import SupportCaseSection
 from .views.sections.team_section import TeamSection
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -595,6 +611,7 @@ async def get_organization_detail(
     files_page: int = Query(1, ge=1),
     files_limit: int = Query(10, ge=1, le=100),
     session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
 ) -> None:
     """
     Organization detail view with three-column layout.
@@ -663,6 +680,15 @@ async def get_organization_detail(
             organization.id
         )
 
+    # Appeal support case state (drives the nav badge and the review-card link)
+    appeal_case = None
+    appeal_case_open = False
+    if organization.review is not None:
+        appeal_case = await appeal_case_service.get_case(session, organization.review)
+        if appeal_case is not None:
+            message_repository = SupportCaseMessageRepository.from_session(session)
+            appeal_case_open = await message_repository.is_open(appeal_case.id)
+
     # Create views
     detail_view = OrganizationDetailView(
         organization,
@@ -670,6 +696,7 @@ async def get_organization_detail(
         owner_email=owner_email,
         impersonate_user=impersonate_user,
         startup_program_status=startup_program_status,
+        appeal_case_open=appeal_case_open,
     )
 
     # Fetch analytics data for overview section
@@ -835,6 +862,7 @@ async def get_organization_detail(
                     unrefunded_orders_count=unrefunded_orders_count,
                     agent_report=parsed_agent_report,
                     agent_reviewed_at=agent_reviewed_at,
+                    has_appeal_case=appeal_case is not None,
                 )
                 with overview.render(
                     request, setup_data=setup_data, payment_stats=payment_stats
@@ -888,6 +916,37 @@ async def get_organization_detail(
                     organization, agent_reviews=agent_reviews
                 )
                 with reviews_section.render(request):
+                    pass
+            elif section == "support_case":
+                thread = None
+                author_emails: dict[uuid.UUID, str] = {}
+                if organization.review is not None:
+                    thread = await appeal_case_service.get_thread(
+                        session, organization.review, visible_to=None
+                    )
+                if thread is not None:
+                    case_, _is_open, thread_messages = thread
+                    author_ids = {
+                        m.author_user_id
+                        for m in thread_messages
+                        if m.author_user_id is not None
+                    }
+                    if case_.assigned_user_id is not None:
+                        author_ids.add(case_.assigned_user_id)
+                    if author_ids:
+                        email_result = await session.execute(
+                            select(User.id, User.email).where(User.id.in_(author_ids))
+                        )
+                        author_emails = {
+                            row.id: row.email for row in email_result.all()
+                        }
+                support_case_section = SupportCaseSection(
+                    organization,
+                    thread=thread,
+                    author_emails=author_emails,
+                    current_user_id=user_session.user_id,
+                )
+                with support_case_section.render(request):
                     pass
             elif section == "history":
                 # TODO: Implement history section
@@ -1494,6 +1553,241 @@ async def deny_appeal_dialog(
                             text("Cancel")
                     with button(variant="error", type="submit"):
                         text("Deny Appeal")
+
+    return None
+
+
+async def _load_org_with_appeal_case(
+    session: AsyncSession, organization_id: UUID4
+) -> tuple[Organization, ReviewAppealSupportCase]:
+    """Load an organization and its appeal support case, or raise 404."""
+    repository = OrganizationRepository(session)
+    organization = await repository.get_by_id(
+        organization_id,
+        include_blocked=True,
+        options=(joinedload(Organization.review),),
+    )
+    if not organization or organization.review is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    case = await appeal_case_service.get_case(session, organization.review)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Support case not found")
+    return organization, case
+
+
+def _support_case_redirect(
+    request: Request, organization_id: UUID4
+) -> HXRedirectResponse:
+    return HXRedirectResponse(
+        request,
+        str(request.url_for("organizations:detail", organization_id=organization_id))
+        + "?section=support_case",
+        303,
+    )
+
+
+@router.post(
+    "/{organization_id}/appeal-case/reply",
+    name="organizations:appeal_case_reply",
+    response_model=None,
+)
+async def appeal_case_reply(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse:
+    """Post a staff reply (or internal note) to the appeal case."""
+    _, case = await _load_org_with_appeal_case(session, organization_id)
+
+    form_data = await request.form()
+    body = str(form_data.get("body", "")).strip()
+    internal = bool(form_data.get("internal"))
+
+    if body:
+        try:
+            await appeal_case_service.add_reply(
+                session,
+                case,
+                author_kind=SupportCaseMessageAuthorKind.platform,
+                author_user=user_session.user,
+                body=body,
+                internal=internal,
+            )
+        except AppealCaseError as e:
+            await add_toast(request, e.args[0], variant="error")
+
+    return _support_case_redirect(request, organization_id)
+
+
+@router.api_route(
+    "/{organization_id}/appeal-case/approve-dialog",
+    name="organizations:appeal_case_approve_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def appeal_case_approve_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    """Approve the appeal: reactivate the organization and close the case."""
+    organization, case = await _load_org_with_appeal_case(session, organization_id)
+
+    error_message: str | None = None
+
+    if request.method == "POST":
+        form_data = await request.form()
+        reason = str(form_data.get("reason", "")).strip() or None
+        if not reason:
+            error_message = "A reason is required to approve the appeal."
+        else:
+            review_repo = OrganizationReviewRepository.from_session(session)
+            await review_repo.record_human_decision(
+                organization_id=organization_id,
+                reviewer_id=user_session.user.id,
+                decision=DecisionType.APPROVE,
+                review_context=ReviewContext.APPEAL,
+                reason=reason,
+            )
+            try:
+                await organization_service.backoffice_approve(
+                    session, organization, reason=reason
+                )
+                await appeal_case_service.record_decision(
+                    session,
+                    case,
+                    approved=True,
+                    staff_user=user_session.user,
+                    reason=reason,
+                )
+            except (OrganizationError, AppealCaseError) as e:
+                error_message = e.args[0]
+            else:
+                return _support_case_redirect(request, organization_id)
+
+    with modal("Approve Appeal", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:appeal_case_approve_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
+            if error_message:
+                with tag.div(classes="alert alert-error"):
+                    text(error_message)
+            with tag.p():
+                text(
+                    "Approving reactivates the organization and closes the "
+                    "support case. The merchant is notified of the decision."
+                )
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text"):
+                        text("Reason (required, shared with the merchant)")
+                with tag.textarea(
+                    name="reason",
+                    classes="textarea textarea-bordered w-full",
+                    placeholder="Why are you approving this appeal?",
+                    rows="3",
+                    required=True,
+                ):
+                    pass
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(variant="primary", type="submit"):
+                    text("Approve Appeal")
+
+    return None
+
+
+@router.api_route(
+    "/{organization_id}/appeal-case/deny-dialog",
+    name="organizations:appeal_case_deny_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def appeal_case_deny_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    """Deny the appeal: keep the organization denied and close the case.
+
+    The organization is already in its denied state (the human-review case is
+    opened after the AI appeal was rejected), so there is no org-status change
+    to make — the decision records the outcome on the case and locks it.
+    """
+    _, case = await _load_org_with_appeal_case(session, organization_id)
+
+    error_message: str | None = None
+
+    if request.method == "POST":
+        form_data = await request.form()
+        reason = str(form_data.get("reason", "")).strip() or None
+        review_repo = OrganizationReviewRepository.from_session(session)
+        await review_repo.record_human_decision(
+            organization_id=organization_id,
+            reviewer_id=user_session.user.id,
+            decision=DecisionType.DENY,
+            review_context=ReviewContext.APPEAL,
+            reason=reason,
+        )
+        try:
+            await appeal_case_service.record_decision(
+                session,
+                case,
+                approved=False,
+                staff_user=user_session.user,
+                reason=reason,
+            )
+        except AppealCaseError as e:
+            error_message = e.args[0]
+        else:
+            return _support_case_redirect(request, organization_id)
+
+    with modal("Deny Appeal", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:appeal_case_deny_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
+            if error_message:
+                with tag.div(classes="alert alert-error"):
+                    text(error_message)
+            with tag.p(classes="font-semibold text-error"):
+                text("This keeps the organization denied and closes the case.")
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text"):
+                        text("Reason (optional, shared with the merchant)")
+                with tag.textarea(
+                    name="reason",
+                    classes="textarea textarea-bordered w-full",
+                    placeholder="Why are you denying this appeal?",
+                    rows="3",
+                ):
+                    pass
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(variant="error", type="submit"):
+                    text("Deny Appeal")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -45,11 +45,13 @@ class OrganizationDetailView:
         owner_email: str | None = None,
         impersonate_user: User | None = None,
         startup_program_status: str | None = None,
+        appeal_case_open: bool = False,
     ):
         self.org = organization
         self.ai_verdict = ai_verdict
         self.owner_email = owner_email
         self.impersonate_user = impersonate_user
+        self.appeal_case_open = appeal_case_open
         # Startup Program status string is derived via the Polar API and
         # populated by the endpoint; ``None`` means "feature disabled" OR
         # "not invited". The card collapses both into the same rendering.
@@ -100,6 +102,16 @@ class OrganizationDetailView:
                 )
                 + "?section=reviews",
                 active=current_section == "reviews",
+            ),
+            Tab(
+                "Support Case",
+                str(
+                    request.url_for("organizations:detail", organization_id=self.org.id)
+                )
+                + "?section=support_case",
+                active=current_section == "support_case",
+                dot=self.appeal_case_open,
+                badge_variant="warning",
             ),
             Tab(
                 "Settings",

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -90,7 +90,7 @@ class OrganizationListView:
         current_sort: str,
         current_direction: str,
         align: str = "left",
-        status_filter: OrganizationStatus | None = None,
+        status_param: str | None = None,
     ) -> Generator[None]:
         """Render a sortable table header with direction indicator."""
         is_active = current_sort == sort_key
@@ -111,8 +111,8 @@ class OrganizationListView:
 
         # Build hx-vals with status filter if present
         hx_vals_dict = {"sort": sort_key, "direction": next_direction}
-        if status_filter is not None:
-            hx_vals_dict["status"] = status_filter.value
+        if status_param is not None:
+            hx_vals_dict["status"] = status_param
 
         hx_vals = json.dumps(hx_vals_dict)
 
@@ -147,7 +147,7 @@ class OrganizationListView:
         has_more: bool,
         current_sort: str,
         current_direction: str,
-        status_filter: OrganizationStatus | None,
+        status_param: str | None,
     ) -> None:
         """Render Previous/Next pagination buttons.
 
@@ -161,8 +161,8 @@ class OrganizationListView:
             "sort": current_sort,
             "direction": current_direction,
         }
-        if status_filter is not None:
-            common_vals["status"] = status_filter.value
+        if status_param is not None:
+            common_vals["status"] = status_param
 
         def _nav_button(target_page: int, label: str, disabled: bool) -> None:
             if disabled:
@@ -443,6 +443,8 @@ class OrganizationListView:
             }
             if status_filter is not None:
                 form_attrs["hx_vals"] = json.dumps({"status": status_filter.value})
+            elif selected_open_cases:
+                form_attrs["hx_vals"] = json.dumps({"status": "open_cases"})
 
             with tag.form(**form_attrs):
                 # Search bar with filter toggle
@@ -690,6 +692,13 @@ class OrganizationListView:
         signals_by_org = signals_by_org or {}
         open_case_org_ids = open_case_org_ids or set()
         is_review_tab = status_filter == OrganizationStatus.REVIEW
+        # "Open cases" isn't an OrganizationStatus, so carry it as the status
+        # query value to preserve the selection across HTMX sort/pagination.
+        status_param = (
+            status_filter.value
+            if status_filter is not None
+            else ("open_cases" if selected_open_cases else None)
+        )
 
         with tag.div(id="org-list", classes="overflow-x-auto"):
             if not organizations:
@@ -708,7 +717,7 @@ class OrganizationListView:
                                 "name",
                                 current_sort,
                                 current_direction,
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -722,7 +731,7 @@ class OrganizationListView:
                                     current_sort,
                                     current_direction,
                                     "center",
-                                    status_filter=status_filter,
+                                    status_param=status_param,
                                 ):
                                     pass
 
@@ -732,7 +741,7 @@ class OrganizationListView:
                                 "country",
                                 current_sort,
                                 current_direction,
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -742,7 +751,7 @@ class OrganizationListView:
                                 "created",
                                 current_sort,
                                 current_direction,
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -753,7 +762,7 @@ class OrganizationListView:
                                 current_sort,
                                 current_direction,
                                 "center",
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -767,7 +776,7 @@ class OrganizationListView:
                                     current_sort,
                                     current_direction,
                                     "center",
-                                    status_filter=status_filter,
+                                    status_param=status_param,
                                 ):
                                     pass
 
@@ -778,7 +787,7 @@ class OrganizationListView:
                                 current_sort,
                                 current_direction,
                                 "right",
-                                status_filter=status_filter,
+                                status_param=status_param,
                             ):
                                 pass
 
@@ -802,7 +811,7 @@ class OrganizationListView:
                     has_more,
                     current_sort,
                     current_direction,
-                    status_filter,
+                    status_param,
                 )
 
     @contextlib.contextmanager

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -197,6 +197,8 @@ class OrganizationListView:
         org: Organization,
         *,
         signals: Signals | None = None,
+        has_open_case: bool = False,
+        link_to_case: bool = False,
     ) -> Generator[None]:
         """Render a single organization row in the table.
 
@@ -205,16 +207,19 @@ class OrganizationListView:
         """
         days_in_status = self.calculate_days_in_status(org)
 
+        detail_url = str(
+            request.url_for("organizations:detail", organization_id=org.id)
+        )
+        # From the Open cases tab, deep-link straight to the case thread.
+        if link_to_case:
+            detail_url += "?section=support_case"
+
         with tag.tr(classes="hover:bg-base-100"):
             # Organization name and status
             with tag.td(classes="py-4 max-w-xs"):
                 with tag.div(classes="flex flex-col gap-1"):
                     with tag.a(
-                        href=str(
-                            request.url_for(
-                                "organizations:detail", organization_id=org.id
-                            )
-                        ),
+                        href=detail_url,
                         classes="font-semibold hover:underline flex items-center gap-2",
                     ):
                         with tag.span(
@@ -249,6 +254,10 @@ class OrganizationListView:
                     ):
                         with tag.span(classes="badge badge-info badge-xs mt-1"):
                             text("Appeal Pending")
+                    # Open support case(s) — generic, not appeal-specific
+                    if has_open_case:
+                        with tag.span(classes="badge badge-warning badge-xs mt-1"):
+                            text("Open case")
 
             # Priority — Review tab only, sits next to Organization
             if signals is not None:
@@ -337,6 +346,9 @@ class OrganizationListView:
         selected_has_appeal: str | None = None,
         selected_deleted: DeletedFilter = "exclude",
         signals_by_org: dict[uuid.UUID, Signals] | None = None,
+        open_case_org_ids: set[uuid.UUID] | None = None,
+        selected_open_cases: bool = False,
+        open_cases_count: int = 0,
     ) -> Generator[None]:
         """Render the complete list view."""
 
@@ -356,7 +368,7 @@ class OrganizationListView:
             Tab(
                 label="All",
                 url=str(request.url_for("organizations:list")),
-                active=status_filter is None,
+                active=status_filter is None and not selected_open_cases,
                 count=sum(status_counts.values()),
             ),
             Tab(
@@ -400,6 +412,15 @@ class OrganizationListView:
                 active=status_filter == OrganizationStatus.OFFBOARDING,
                 count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
                 badge_variant="warning",
+            ),
+            # Pushed to the right — a separate dimension from the status tabs.
+            Tab(
+                label="Open cases",
+                url=str(request.url_for("organizations:list")) + "?status=open_cases",
+                active=selected_open_cases,
+                count=open_cases_count,
+                badge_variant="warning",
+                extra_classes="ml-auto",
             ),
         ]
 
@@ -642,6 +663,8 @@ class OrganizationListView:
             current_sort,
             current_direction,
             signals_by_org,
+            open_case_org_ids,
+            selected_open_cases,
         )
 
         yield
@@ -656,6 +679,8 @@ class OrganizationListView:
         current_sort: str,
         current_direction: str,
         signals_by_org: dict[uuid.UUID, Signals] | None = None,
+        open_case_org_ids: set[uuid.UUID] | None = None,
+        selected_open_cases: bool = False,
     ) -> None:
         """Render the ``#org-list`` block — table with Review-only columns.
 
@@ -663,6 +688,7 @@ class OrganizationListView:
         partial swap), so both paths agree on column count.
         """
         signals_by_org = signals_by_org or {}
+        open_case_org_ids = open_case_org_ids or set()
         is_review_tab = status_filter == OrganizationStatus.REVIEW
 
         with tag.div(id="org-list", classes="overflow-x-auto"):
@@ -765,6 +791,8 @@ class OrganizationListView:
                                 request,
                                 org,
                                 signals=signals_by_org.get(org.id),
+                                has_open_case=org.id in open_case_org_ids,
+                                link_to_case=selected_open_cases,
                             ):
                                 pass
 
@@ -789,6 +817,8 @@ class OrganizationListView:
         current_direction: str = "asc",
         *,
         signals_by_org: dict[uuid.UUID, Signals] | None = None,
+        open_case_org_ids: set[uuid.UUID] | None = None,
+        selected_open_cases: bool = False,
     ) -> Generator[None]:
         """Render only the organization table (for HTMX updates)."""
 
@@ -801,6 +831,8 @@ class OrganizationListView:
             current_sort,
             current_direction,
             signals_by_org,
+            open_case_org_ids,
+            selected_open_cases,
         )
 
         yield

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -40,12 +40,14 @@ class OverviewSection(ChecklistMixin):
         unrefunded_orders_count: int = 0,
         agent_report: AnyAgentReport | None = None,
         agent_reviewed_at: datetime | None = None,
+        has_appeal_case: bool = False,
     ) -> None:
         self.org = organization
         self.orders_count = orders_count
         self.unrefunded_orders_count = unrefunded_orders_count
         self.agent_report = agent_report
         self.agent_reviewed_at = agent_reviewed_at
+        self.has_appeal_case = has_appeal_case
 
     # ------------------------------------------------------------------
     # Full-width: Organization Review card (primary content)
@@ -103,6 +105,36 @@ class OverviewSection(ChecklistMixin):
         """Full-width AI review card — the primary decision content."""
 
         with card(bordered=True):
+            if self.has_appeal_case:
+                support_case_url = (
+                    str(
+                        request.url_for(
+                            "organizations:detail", organization_id=self.org.id
+                        )
+                    )
+                    + "?section=support_case"
+                )
+                with tag.a(
+                    href=support_case_url,
+                    classes="mb-4 flex items-center justify-between gap-3 "
+                    "rounded-lg border border-warning/40 bg-warning/5 px-4 py-3 "
+                    "hover:bg-warning/10 transition-colors",
+                ):
+                    with tag.span(classes="flex items-center gap-2.5 min-w-0"):
+                        with tag.span(classes="icon-message-square text-warning"):
+                            pass
+                        with tag.span(
+                            classes="text-sm font-medium text-base-content/60"
+                        ):
+                            text("Human-review support case")
+                    with tag.span(
+                        classes="flex items-center gap-1 flex-none "
+                        "text-sm text-base-content/60"
+                    ):
+                        text("View case")
+                        with tag.span(classes="icon-arrow-right text-xs"):
+                            pass
+
             # --- No agent report: show fallback from org.review ---
             if self.agent_report is None:
                 if self.org.review:

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -1,0 +1,356 @@
+"""Support case section: the appeal human-review thread and staff actions."""
+
+import contextlib
+from collections.abc import Generator, Sequence
+from urllib.parse import urlencode
+from uuid import UUID
+
+from fastapi import Request
+from tagflow import tag, text
+
+from polar.models import Organization
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+)
+
+from ....components import button, card
+
+_AUTHOR_LABELS: dict[SupportCaseMessageAuthorKind, str] = {
+    SupportCaseMessageAuthorKind.platform: "Support",
+    SupportCaseMessageAuthorKind.merchant: "Merchant",
+    SupportCaseMessageAuthorKind.customer: "Customer",
+    SupportCaseMessageAuthorKind.system: "System",
+}
+
+# Milestone events: title + (lucide icon, node circle classes). These render as
+# timeline milestones, visually distinct from conversation messages.
+_EVENT_TITLES: dict[SupportCaseMessageType, str] = {
+    SupportCaseMessageType.opened: "Human review requested",
+    SupportCaseMessageType.closed: "Case closed",
+    SupportCaseMessageType.appeal_approved: "Appeal approved",
+    SupportCaseMessageType.appeal_denied: "Appeal denied",
+    SupportCaseMessageType.info_requested: "Information requested",
+    SupportCaseMessageType.assigned: "Case assigned",
+    SupportCaseMessageType.released: "Case unassigned",
+}
+
+_DARK_NODE = "bg-neutral text-neutral-content"
+_MUTED_NODE = "bg-base-200 text-base-content/70"
+_EVENT_NODES: dict[SupportCaseMessageType, tuple[str, str]] = {
+    SupportCaseMessageType.opened: ("icon-circle-dot", _DARK_NODE),
+    SupportCaseMessageType.closed: ("icon-square", _DARK_NODE),
+    SupportCaseMessageType.appeal_approved: (
+        "icon-check",
+        "bg-success text-success-content",
+    ),
+    SupportCaseMessageType.appeal_denied: ("icon-x", "bg-error text-error-content"),
+    SupportCaseMessageType.info_requested: (
+        "icon-message-square-text",
+        "bg-info text-info-content",
+    ),
+    SupportCaseMessageType.assigned: ("icon-user-check", _MUTED_NODE),
+    SupportCaseMessageType.released: ("icon-user-x", _MUTED_NODE),
+}
+
+Thread = tuple[ReviewAppealSupportCase, bool, Sequence[SupportCaseMessage]]
+
+
+class SupportCaseSection:
+    """Render the appeal support case: status header, timeline and actions."""
+
+    def __init__(
+        self,
+        organization: Organization,
+        thread: Thread | None = None,
+        author_emails: dict[UUID, str] | None = None,
+        current_user_id: UUID | None = None,
+    ) -> None:
+        self.org = organization
+        self.thread = thread
+        self.author_emails = author_emails or {}
+        self.current_user_id = current_user_id
+
+    @contextlib.contextmanager
+    def render(self, request: Request) -> Generator[None]:
+        with tag.div(classes="space-y-6"):
+            if self.thread is None:
+                with card(bordered=True):
+                    with tag.h2(classes="text-lg font-semibold mb-1"):
+                        text("Appeal Support Case")
+                    with tag.p(classes="text-sm text-base-content/50"):
+                        text("No support case for this organization.")
+                yield
+                return
+
+            case, is_open, messages = self.thread
+            with card(bordered=True):
+                self._render_header(request, case, is_open, messages)
+                self._render_timeline(messages)
+                if is_open:
+                    self._render_composer(request)
+            yield
+
+    # -- Header -------------------------------------------------------------
+
+    def _outcome(
+        self, messages: Sequence[SupportCaseMessage]
+    ) -> SupportCaseMessageType | None:
+        for message in messages:
+            if message.type in (
+                SupportCaseMessageType.appeal_approved,
+                SupportCaseMessageType.appeal_denied,
+            ):
+                return message.type
+        return None
+
+    def _render_header(
+        self,
+        request: Request,
+        case: ReviewAppealSupportCase,
+        is_open: bool,
+        messages: Sequence[SupportCaseMessage],
+    ) -> None:
+        outcome = self._outcome(messages)
+        with tag.div(classes="flex items-start justify-between gap-4 mb-8"):
+            with tag.div(classes="flex items-start gap-4"):
+                with tag.div(
+                    classes="flex-none w-11 h-11 rounded-xl bg-base-200 "
+                    "flex items-center justify-center"
+                ):
+                    with tag.span(
+                        classes="icon-message-square text-lg text-base-content/70"
+                    ):
+                        pass
+                with tag.div(classes="flex flex-col gap-2"):
+                    with tag.h2(classes="text-xl font-semibold leading-none"):
+                        text("Appeal Support Case")
+                    with tag.div(classes="flex items-center gap-2"):
+                        status = "badge-success" if is_open else "badge-neutral"
+                        with tag.div(classes=f"badge {status} badge-sm"):
+                            text("Open" if is_open else "Closed")
+                        if outcome == SupportCaseMessageType.appeal_approved:
+                            with tag.div(classes="badge badge-success badge-sm gap-1"):
+                                with tag.span(classes="icon-check"):
+                                    pass
+                                text("Appeal approved")
+                        elif outcome == SupportCaseMessageType.appeal_denied:
+                            with tag.div(classes="badge badge-error badge-sm gap-1"):
+                                with tag.span(classes="icon-x"):
+                                    pass
+                                text("Appeal denied")
+                        elif is_open:
+                            with tag.div(classes="badge badge-ghost badge-sm"):
+                                text("Awaiting decision")
+                        if is_open:
+                            self._render_assignment_chip(case)
+            if is_open:
+                self._render_decision_actions(request, case)
+
+    def _render_assignment_chip(self, case: ReviewAppealSupportCase) -> None:
+        assignee_id = case.assigned_user_id
+        if assignee_id is None:
+            icon, label = "icon-user", "Unassigned"
+        elif assignee_id == self.current_user_id:
+            icon, label = "icon-user-check", "Assigned to you"
+        else:
+            email = self.author_emails.get(assignee_id, "another agent")
+            icon, label = "icon-user-check", f"Assigned to {email}"
+        with tag.div(classes="badge badge-ghost badge-sm gap-1"):
+            with tag.span(classes=icon):
+                pass
+            text(label)
+
+    def _assignment_urls(
+        self, request: Request, case: ReviewAppealSupportCase
+    ) -> tuple[str, str]:
+        # Assignment is advisory and generic to any case type, so it posts to
+        # the case-keyed support_cases endpoints and returns here afterwards.
+        detail = request.url_for("organizations:detail", organization_id=self.org.id)
+        return_to = f"{detail.path}?section=support_case"
+        take_url = f"{request.url_for('support_cases:take', case_id=case.id)}?{urlencode({'return_to': return_to})}"
+        release_url = f"{request.url_for('support_cases:release', case_id=case.id)}?{urlencode({'return_to': return_to})}"
+        return take_url, release_url
+
+    def _render_decision_actions(
+        self, request: Request, case: ReviewAppealSupportCase
+    ) -> None:
+        approve_url = str(
+            request.url_for(
+                "organizations:appeal_case_approve_dialog",
+                organization_id=self.org.id,
+            )
+        )
+        deny_url = str(
+            request.url_for(
+                "organizations:appeal_case_deny_dialog", organization_id=self.org.id
+            )
+        )
+        take_url, release_url = self._assignment_urls(request, case)
+        assignee_id = case.assigned_user_id
+        with tag.div(classes="flex-none flex items-center gap-2"):
+            if assignee_id == self.current_user_id:
+                with button(size="sm", outline=True, hx_post=release_url):
+                    text("Release")
+            else:
+                label = "Take over" if assignee_id is not None else "Take case"
+                with button(
+                    variant="neutral", size="sm", outline=True, hx_post=take_url
+                ):
+                    text(label)
+            with button(
+                variant="error",
+                size="sm",
+                outline=True,
+                hx_get=deny_url,
+                hx_target="#modal",
+            ):
+                text("Deny appeal")
+            with button(
+                variant="primary", size="sm", hx_get=approve_url, hx_target="#modal"
+            ):
+                text("Approve appeal")
+
+    # -- Timeline -----------------------------------------------------------
+
+    def _render_timeline(self, messages: Sequence[SupportCaseMessage]) -> None:
+        with tag.div(classes="relative"):
+            # The rail line, centered under the icon nodes (w-9 → center 18px).
+            with tag.div(
+                classes="absolute left-[18px] top-5 bottom-5 w-px bg-base-300"
+            ):
+                pass
+            with tag.div(
+                classes="grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-x-6 gap-y-5"
+            ):
+                for message in messages:
+                    self._render_entry(message)
+
+    def _render_entry(self, message: SupportCaseMessage) -> None:
+        is_event = message.type != SupportCaseMessageType.chat
+        internal = not message.audience
+
+        # Left cell: icon node + title + muted metadata.
+        with tag.div(classes="flex gap-3"):
+            icon, node = self._node(message, internal)
+            # Opaque base hides the rail line behind translucent node tints.
+            with tag.div(
+                classes="relative z-10 flex-none w-9 h-9 rounded-full bg-base-100"
+            ):
+                with tag.div(
+                    classes="w-full h-full rounded-full "
+                    f"flex items-center justify-center {node}"
+                ):
+                    with tag.span(classes=f"{icon} text-base"):
+                        pass
+            with tag.div(classes="min-w-0 pt-1"):
+                with tag.div(classes="text-sm font-medium leading-tight"):
+                    text(self._title(message, internal))
+                for line in self._meta_lines(message, is_event, internal):
+                    with tag.div(classes="text-xs text-base-content/40 mt-0.5"):
+                        text(line)
+
+        # Right cell: conversation content (empty for pure milestones).
+        self._render_content(message, is_event, internal)
+
+    def _node(self, message: SupportCaseMessage, internal: bool) -> tuple[str, str]:
+        if message.type != SupportCaseMessageType.chat:
+            return _EVENT_NODES[message.type]
+        if internal:
+            return "icon-lock", "bg-warning/20 text-warning"
+        if message.author_kind == SupportCaseMessageAuthorKind.merchant:
+            return "icon-store", "bg-base-200 text-base-content/70"
+        return "icon-headset", "bg-info/15 text-info"
+
+    def _title(self, message: SupportCaseMessage, internal: bool) -> str:
+        if message.type != SupportCaseMessageType.chat:
+            return _EVENT_TITLES[message.type]
+        if internal:
+            return "Internal note"
+        return _AUTHOR_LABELS.get(message.author_kind, str(message.author_kind))
+
+    def _meta_lines(
+        self, message: SupportCaseMessage, is_event: bool, internal: bool
+    ) -> list[str]:
+        when = message.created_at.strftime("%b %-d, %H:%M UTC")
+        email = (
+            self.author_emails.get(message.author_user_id)
+            if message.author_user_id
+            else None
+        )
+        # The title carries the role for chat; events/notes name the actor. The
+        # email is the concrete identity. One piece of metadata per line.
+        if is_event or internal:
+            who = email or _AUTHOR_LABELS.get(
+                message.author_kind, str(message.author_kind)
+            )
+            return [f"by {who}", when]
+        return [email, when] if email else [when]
+
+    def _render_content(
+        self, message: SupportCaseMessage, is_event: bool, internal: bool
+    ) -> None:
+        if not message.body:
+            # Milestone with no body still occupies its grid cell.
+            with tag.div():
+                pass
+            return
+
+        merchant = message.author_kind == SupportCaseMessageAuthorKind.merchant
+        justify = "justify-end" if merchant else "justify-start"
+        with tag.div(classes=f"flex items-center {justify}"):
+            with tag.div(classes=f"max-w-md text-sm {self._bubble(message, internal)}"):
+                text(message.body)
+
+    def _bubble(self, message: SupportCaseMessage, internal: bool) -> str:
+        if internal:
+            return (
+                "bg-warning/10 border-l-2 border-warning rounded-lg px-3 py-2 "
+                "text-base-content/80"
+            )
+        if message.type == SupportCaseMessageType.appeal_approved:
+            return "bg-success/10 rounded-xl px-4 py-2.5"
+        if message.type == SupportCaseMessageType.appeal_denied:
+            return "bg-error/10 rounded-xl px-4 py-2.5"
+        if message.author_kind == SupportCaseMessageAuthorKind.merchant:
+            return "bg-info/10 rounded-2xl rounded-tr-md px-4 py-2.5"
+        return "bg-base-200 rounded-2xl rounded-tl-md px-4 py-2.5"
+
+    # -- Composer -----------------------------------------------------------
+
+    def _render_composer(self, request: Request) -> None:
+        reply_url = str(
+            request.url_for(
+                "organizations:appeal_case_reply", organization_id=self.org.id
+            )
+        )
+        with tag.div(classes="mt-8 pt-6 border-t border-base-200"):
+            with tag.form(hx_post=reply_url, classes="flex flex-col gap-3"):
+                with tag.textarea(
+                    name="body",
+                    classes="textarea textarea-bordered w-full rounded-lg",
+                    placeholder="Write a reply to the merchant…",
+                    rows="3",
+                    required=True,
+                ):
+                    pass
+                with tag.div(classes="flex items-center justify-between"):
+                    with tag.label(
+                        classes="flex items-center gap-2 cursor-pointer "
+                        "text-sm text-base-content/60"
+                    ):
+                        with tag.input(
+                            type="checkbox",
+                            name="internal",
+                            value="1",
+                            classes="checkbox checkbox-sm",
+                        ):
+                            pass
+                        text("Internal note — not visible to the merchant")
+                    with button(variant="primary", size="sm", type="submit"):
+                        text("Send")
+
+
+__all__ = ["SupportCaseSection"]

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -63,7 +63,7 @@ def _status_badge(is_open: bool) -> None:
         text("Open" if is_open else "Closed")
 
 
-def _render_table(rows: Sequence[Row]) -> None:
+def _render_table(request: Request, rows: Sequence[Row]) -> None:
     with tag.div(classes="overflow-x-auto"):
         with tag.table(classes="table table-zebra"):
             with tag.thead():
@@ -79,11 +79,22 @@ def _render_table(rows: Sequence[Row]) -> None:
                             text(header)
             with tag.tbody():
                 for case, organization, is_open, assignee_email in rows:
-                    # Not linked yet: the org's support-case section these rows
-                    # point to ships in a follow-up PR.
-                    with tag.tr():
+                    case_url = (
+                        str(
+                            request.url_for(
+                                "organizations:detail",
+                                organization_id=organization.id,
+                            )
+                        )
+                        + "?section=support_case"
+                    )
+                    with tag.tr(
+                        classes="hover cursor-pointer",
+                        _=f"on click set window.location to '{case_url}'",
+                    ):
                         with tag.td():
-                            text(organization.name)
+                            with tag.a(href=case_url, classes="link"):
+                                text(organization.name)
                         with tag.td():
                             with tag.div(classes="badge badge-outline badge-sm"):
                                 text("Review appeal")
@@ -203,7 +214,7 @@ async def list_cases(
             with tab_nav(_list_tabs(request, status, assigned)):
                 pass
             if rows:
-                _render_table(rows)
+                _render_table(request, rows)
             else:
                 with tag.div(classes="text-center py-12 text-base-content/50"):
                     text("No cases in this view.")


### PR DESCRIPTION
## Summary

**Related Issue**: [#feedback/151](https://github.com/polarsource/feedback/issues/151)

Backoffice surface for handling organization-review appeals as support cases, plus an "Open cases" filter on the organization list. Stacked on the Cases-module PR (#12316) — it relies on the take/release routes registered there.

## What

- A "Support Case" section on the organization detail page: the appeal thread timeline, a staff reply / internal-note composer, approve/deny decision dialogs, and take/release assignment controls.
<img width="1282" height="747" alt="Screenshot 2026-06-10 at 16 14 06" src="https://github.com/user-attachments/assets/3dd64dc2-0129-42e8-9059-280e6ecbbf21" />

- A status dot on the Support Case tab and a "has appeal" indicator on the overview.
<img width="1891" height="856" alt="Screenshot 2026-06-10 at 18 45 37" src="https://github.com/user-attachments/assets/8bb7fa19-2e0e-4042-908d-cfde113e202e" />

- An "Open cases" tab on the organization list that filters to orgs with an open support case, badges those rows, and deep-links them to the section.
<img width="1891" height="856" alt="Screenshot 2026-06-10 at 18 45 20" src="https://github.com/user-attachments/assets/0ca4e92a-a2d0-4d37-a20d-bdb1a3b7f7b5" />


## Why

Support handles appeals in the backoffice, so they need to read the thread, reply, decide, and claim a case in one place — and spot which organizations have an open case at a glance from the list.

## How

The section renders from the existing case thread (platform sees all messages, including internal notes); decisions go through `appeal_case_service`, and assignment posts to the generic `support_cases` take/release routes. Both the list filter and the open-cases tab derive open/closed from the repository's `is_open_expression` rather than re-checking for a `closed` event.
## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an appeal Support Case experience to the organization detail page and an “Open cases” filter on the organization list to surface active reviews.

- New Features
  - New “Support Case” tab on org detail: timeline of messages/events, staff reply and internal note composer, approve/deny dialogs, and take/release assignment (via `support_cases` routes).
  - Nav tab shows a warning dot when the case is open; the Overview card shows a banner linking to the case.
  - Organization list gains an “Open cases” tab that filters to orgs with an open case, shows a count, badges affected rows, and deep-links to the case section; includes denied/blocked orgs and persists across sort/pagination.
  - Case state and thread load through `appeal_case_service`; openness is derived via `SupportCaseMessageRepository.is_open_expression()`. Decisions record via `OrganizationReviewRepository` and, on approval, `organization_service.backoffice_approve`.
  - The backoffice `support_cases` table now links each row to the organization’s Support Case section.

<sup>Written for commit e5c5ab5f4ca3f9b73541249370b0469324c9eddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

