### PR TITLE
Add Australia GST tax registration support

### DIFF
--- a/server/polar/invoice/seller.py
+++ b/server/polar/invoice/seller.py
@@ -12,6 +12,7 @@ from polar.kit.address import Address
 # Locally-correct label for the tax registration line, by country. Any
 # country missing from this map falls back to "VAT".
 COUNTRY_VAT_LABELS: dict[str, str] = {
+    "AU": "GST",
     "CA": "GST/HST",
     "CL": "RUT",
     "KE": "PIN",

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -276,6 +276,8 @@ module "production" {
       KE = "P052518030C"
       # Canada (GST/HST)
       CA = "720474766 RT9999"
+      # Australia (GST)
+      AU = "300038975137"
     })
     tax_processors                 = "[\"stripe\"]"
     tax_record_processor           = "stripe"


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Adds tax registration support for Australia by configuring the GST tax ID and updating the tax label mapping.

## What

- Added Australia GST tax registration ID (`300038975137`) to the production Terraform configuration
- Added "AU" → "GST" mapping to the `COUNTRY_VAT_LABELS` dictionary in the invoice seller module

## Why

This enables proper tax handling for Australian customers, ensuring their GST registration is correctly configured and displayed with the appropriate label in invoices.

## How

1. Updated `terraform/production/render.tf` to include the Australian GST tax ID in the tax registration IDs map
2. Updated `server/polar/invoice/seller.py` to map Australia's country code to the correct tax label ("GST" instead of the default "VAT")

## Checklist

- [x] This PR addresses a single concern (one feature)
- [x] The diff is reasonably sized and easy to review
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_018sM73ESaEJx6zAEHREBRin

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Australia GST tax registration support. Registers the AU GST ID in production and displays "GST" on invoices for Australian customers.

<sup>Written for commit aa4f87ac5d7b6ba96c60c9dd4273a2ab386f1b12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

