### PR TITLE
organizations: Limit which feature flags are updateable

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24113,7 +24113,7 @@ export interface components {
           )
         | null
       feature_settings?:
-        | components['schemas']['OrganizationFeatureSettings']
+        | components['schemas']['OrganizationFeatureSettingsUpdate']
         | null
       subscription_settings?:
         | components['schemas']['OrganizationSubscriptionSettings']
@@ -24329,6 +24329,38 @@ export interface components {
        * @default false
        */
       slack_benefit_enabled: boolean
+    }
+    /**
+     * OrganizationFeatureSettingsUpdate
+     * @description Feature settings that organizations can update themselves.
+     *
+     *     Other feature settings are managed by Polar staff: they're ignored if
+     *     provided and keep their current value.
+     */
+    OrganizationFeatureSettingsUpdate: {
+      /**
+       * Seat Based Pricing Enabled
+       * @description If this organization has seat-based pricing enabled
+       * @default false
+       */
+      seat_based_pricing_enabled: boolean
+      /**
+       * Member Model Enabled
+       * @description If this organization has the Member model enabled
+       * @default false
+       */
+      member_model_enabled: boolean
+      /**
+       * Checkout Localization Enabled
+       * @description If this organization has checkout localization enabled
+       * @default false
+       */
+      checkout_localization_enabled: boolean
+      /**
+       * Overview Metrics
+       * @description Ordered list of metric slugs shown on the dashboard overview.
+       */
+      overview_metrics?: string[] | null
     }
     /** OrganizationIndividualLegalEntitySchema */
     OrganizationIndividualLegalEntitySchema: {
@@ -25579,7 +25611,7 @@ export interface components {
           )
         | null
       feature_settings?:
-        | components['schemas']['OrganizationFeatureSettings']
+        | components['schemas']['OrganizationFeatureSettingsUpdate']
         | null
       subscription_settings?:
         | components['schemas']['OrganizationSubscriptionSettings']

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -10,7 +10,6 @@ from pydantic import (
     BeforeValidator,
     Field,
     StringConstraints,
-    field_validator,
     model_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
@@ -123,6 +122,15 @@ class OrganizationCapabilities(Schema):
     )
 
 
+def _coerce_overview_metrics(value: Any) -> Any:
+    if isinstance(value, bool):
+        return None
+    return value
+
+
+OverviewMetrics = Annotated[list[str] | None, BeforeValidator(_coerce_overview_metrics)]
+
+
 class OrganizationFeatureSettings(Schema):
     issue_funding_enabled: bool = Field(
         False, description="If this organization has issue funding enabled"
@@ -140,7 +148,7 @@ class OrganizationFeatureSettings(Schema):
         False,
         description="If this organization has checkout localization enabled",
     )
-    overview_metrics: list[str] | None = Field(
+    overview_metrics: OverviewMetrics = Field(
         None,
         description="Ordered list of metric slugs shown on the dashboard overview.",
     )
@@ -162,12 +170,28 @@ class OrganizationFeatureSettings(Schema):
         False, description="Enables the slack shared channel benefit"
     )
 
-    @field_validator("overview_metrics", mode="before")
-    @classmethod
-    def _coerce_overview_metrics(cls, v: Any) -> list[str] | None:
-        if isinstance(v, bool):
-            return None
-        return v
+
+class OrganizationFeatureSettingsUpdate(Schema):
+    """Feature settings that organizations can update themselves.
+
+    Other feature settings are managed by Polar staff: they're ignored if
+    provided and keep their current value.
+    """
+
+    seat_based_pricing_enabled: bool = Field(
+        False, description="If this organization has seat-based pricing enabled"
+    )
+    member_model_enabled: bool = Field(
+        False, description="If this organization has the Member model enabled"
+    )
+    checkout_localization_enabled: bool = Field(
+        False,
+        description="If this organization has checkout localization enabled",
+    )
+    overview_metrics: OverviewMetrics = Field(
+        None,
+        description="Ordered list of metric slugs shown on the dashboard overview.",
+    )
 
 
 class OrganizationDetails(Schema):
@@ -485,7 +509,7 @@ class OrganizationCreate(Schema):
     country: CountryAlpha2Input | None = Field(
         None, description="Two-letter country code (ISO 3166-1 alpha-2)."
     )
-    feature_settings: OrganizationFeatureSettings | None = None
+    feature_settings: OrganizationFeatureSettingsUpdate | None = None
     subscription_settings: OrganizationSubscriptionSettings | None = None
     notification_settings: OrganizationNotificationSettings | None = None
     customer_email_settings: OrganizationCustomerEmailSettings | None = None
@@ -519,7 +543,7 @@ class OrganizationUpdate(Schema):
         None, description="Two-letter country code (ISO 3166-1 alpha-2)."
     )
 
-    feature_settings: OrganizationFeatureSettings | None = None
+    feature_settings: OrganizationFeatureSettingsUpdate | None = None
     subscription_settings: OrganizationSubscriptionSettings | None = None
     notification_settings: OrganizationNotificationSettings | None = None
     customer_email_settings: OrganizationCustomerEmailSettings | None = None

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -306,6 +306,36 @@ class TestUpdateOrganization:
         assert response.status_code == 422
 
     @pytest.mark.auth
+    async def test_non_updatable_feature_flags_ignored(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {
+            "billing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "feature_settings": {
+                    "billing_enabled": False,
+                    "off_session_charges_enabled": True,
+                    "checkout_localization_enabled": True,
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        feature_settings = response.json()["feature_settings"]
+        assert feature_settings["billing_enabled"] is True
+        assert feature_settings["off_session_charges_enabled"] is False
+        assert feature_settings["checkout_localization_enabled"] is True
+
+    @pytest.mark.auth
     async def test_update_customer_portal_settings_without_customer_key(
         self,
         client: AsyncClient,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -39,7 +39,7 @@ from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import (
     OrganizationCreate,
     OrganizationDetails,
-    OrganizationFeatureSettings,
+    OrganizationFeatureSettingsUpdate,
     OrganizationReviewCheck,
     OrganizationReviewCheckKey,
     OrganizationReviewCheckReason,
@@ -205,12 +205,16 @@ class TestCreate:
     ) -> None:
         organization = await organization_service.create(
             session,
-            OrganizationCreate(
-                name="My New Organization",
-                slug="my-new-organization",
-                feature_settings=OrganizationFeatureSettings(
-                    issue_funding_enabled=False
-                ),
+            OrganizationCreate.model_validate(
+                {
+                    "name": "My New Organization",
+                    "slug": "my-new-organization",
+                    "feature_settings": {
+                        "checkout_localization_enabled": True,
+                        "billing_enabled": True,
+                        "off_session_charges_enabled": True,
+                    },
+                }
             ),
             auth_subject,
         )
@@ -218,7 +222,7 @@ class TestCreate:
         assert organization.name == "My New Organization"
 
         assert organization.feature_settings == {
-            "issue_funding_enabled": False,
+            "checkout_localization_enabled": True,
             "member_model_enabled": True,
             "seat_based_pricing_enabled": True,
         }
@@ -3267,7 +3271,7 @@ class TestUpdateSeatBasedPricing:
             session,
             organization,
             OrganizationUpdate(
-                feature_settings=OrganizationFeatureSettings(
+                feature_settings=OrganizationFeatureSettingsUpdate(
                     seat_based_pricing_enabled=True,
                 ),
             ),
@@ -3292,7 +3296,7 @@ class TestUpdateSeatBasedPricing:
                 session,
                 organization,
                 OrganizationUpdate(
-                    feature_settings=OrganizationFeatureSettings(
+                    feature_settings=OrganizationFeatureSettingsUpdate(
                         seat_based_pricing_enabled=True,
                     ),
                 ),
@@ -3315,7 +3319,7 @@ class TestUpdateSeatBasedPricing:
                 session,
                 organization,
                 OrganizationUpdate(
-                    feature_settings=OrganizationFeatureSettings(
+                    feature_settings=OrganizationFeatureSettingsUpdate(
                         seat_based_pricing_enabled=False,
                     ),
                 ),
@@ -3337,7 +3341,7 @@ class TestUpdateSeatBasedPricing:
             session,
             organization,
             OrganizationUpdate(
-                feature_settings=OrganizationFeatureSettings(
+                feature_settings=OrganizationFeatureSettingsUpdate(
                     seat_based_pricing_enabled=True,
                 ),
             ),
@@ -3363,7 +3367,7 @@ class TestUpdateSeatBasedPricing:
             session,
             organization,
             OrganizationUpdate(
-                feature_settings=OrganizationFeatureSettings(
+                feature_settings=OrganizationFeatureSettingsUpdate(
                     checkout_localization_enabled=True,
                 ),
             ),
@@ -3390,13 +3394,104 @@ class TestUpdateSeatBasedPricing:
             session,
             organization,
             OrganizationUpdate(
-                feature_settings=OrganizationFeatureSettings(
+                feature_settings=OrganizationFeatureSettingsUpdate(
                     seat_based_pricing_enabled=True,
                 ),
             ),
         )
 
         assert result.feature_settings["seat_based_pricing_enabled"] is True
+
+
+@pytest.mark.asyncio
+class TestUpdateFeatureSettings:
+    async def test_non_updatable_flag_ignored(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {}
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate.model_validate(
+                {"feature_settings": {"off_session_charges_enabled": True}}
+            ),
+        )
+
+        assert "off_session_charges_enabled" not in result.feature_settings
+
+    async def test_non_updatable_flag_preserved(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {"billing_enabled": True}
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate.model_validate(
+                {
+                    "feature_settings": {
+                        "billing_enabled": False,
+                        "checkout_localization_enabled": True,
+                    }
+                }
+            ),
+        )
+
+        assert result.feature_settings["billing_enabled"] is True
+        assert result.feature_settings["checkout_localization_enabled"] is True
+
+    async def test_enable_member_model_enqueues_backfill(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        organization.feature_settings = {}
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate.model_validate(
+                {"feature_settings": {"member_model_enabled": True}}
+            ),
+        )
+
+        assert result.feature_settings["member_model_enabled"] is True
+        enqueue_job_mock.assert_called_once_with(
+            "organization.backfill_members", organization_id=organization.id
+        )
+
+    async def test_overview_metrics_updated(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        result = await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate.model_validate(
+                {"feature_settings": {"overview_metrics": ["revenue", "orders"]}}
+            ),
+        )
+
+        assert result.feature_settings["overview_metrics"] == ["revenue", "orders"]
+        assert result.feature_settings["member_model_enabled"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Only some should be updateable via the API - the same as are in the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict organization feature flag updates to match the UI. Only specific flags are writable via the API; all others are ignored and their current values are preserved.

- **Migration**
  - `feature_settings` now accepts only: `seat_based_pricing_enabled`, `member_model_enabled` (enqueues a backfill), `checkout_localization_enabled`, and `overview_metrics`.
  - Other flags (e.g., `billing_enabled`, `off_session_charges_enabled`) are ignored; existing values stay unchanged.
  - OpenAPI/clients updated to use `OrganizationFeatureSettingsUpdate` for `feature_settings` on create/update. Regenerate clients if you rely on typed SDKs.

<sup>Written for commit 58a64d1cb3490512c7405d4fd71646f0f44cbc49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

