### PR TITLE
Use browser-reachable URL for the auth-complete redirect

### DIFF
--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -1,4 +1,4 @@
-import { getPublicServerURL, getServerURL } from '@/utils/api'
+import { getPublicServerURL } from '@/utils/api'
 import { Client, operations, schemas } from '@polar-sh/client'
 import { redirect } from 'next/navigation'
 
@@ -91,7 +91,7 @@ export const checkAuthenticationSession = async (
     authenticationSession.identity_id &&
     authenticationSession.available_factors.length === 0
   ) {
-    redirect(`${getServerURL()}/v1/auth/complete`)
+    redirect(`${getPublicServerURL()}/v1/auth/complete`)
   }
 
   return authenticationSession


### PR DESCRIPTION
Fix broken browser redirect in auth to http://api:8000/v1/auth/complete locally/in dev.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the public API URL for the `/v1/auth/complete` redirect so the browser can reach it. Swaps `getServerURL()` for `getPublicServerURL()` to avoid sending users to an internal server URL during SSR, matching the other auth redirects.

<sup>Written for commit a961a3373b81baf46bc144fa5e72171e1d205f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

