### PR TITLE
feat(organization): add FF gated appeal case flow

### DIFF
--- a/clients/apps/web/src/components/Organization/AppealForm.tsx
+++ b/clients/apps/web/src/components/Organization/AppealForm.tsx
@@ -10,6 +10,11 @@ import { Button } from '@polar-sh/orbit'
 import { Textarea } from '@polar-sh/orbit/ui/textarea'
 import { Loader2 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
+import HumanReviewCase from './HumanReviewCase'
+
+// Gates the merchant-facing human-review case flow shown after a denied
+// appeal. Hardcoded off until the dedicated flow is finished.
+const NEW_CASE_FLOW_ENABLED = false
 
 interface AppealFormProps {
   organization: schemas['Organization']
@@ -94,7 +99,9 @@ const AppealForm: React.FC<AppealFormProps> = ({
             {decision === 'approved'
               ? 'Your appeal has been approved. Payment access has been restored.'
               : decision === 'rejected'
-                ? "Your appeal wasn't approved. If you believe this is wrong, please contact support — we can take another look."
+                ? NEW_CASE_FLOW_ENABLED
+                  ? "Your appeal wasn't approved."
+                  : "Your appeal wasn't approved. If you believe this is wrong, please contact support — we can take another look."
                 : pollingTimedOut
                   ? "This is taking longer than expected. Refresh the page in a few minutes — if it still hasn't updated, please contact support."
                   : 'We are reviewing your appeal. This usually takes about a minute.'}
@@ -114,6 +121,10 @@ const AppealForm: React.FC<AppealFormProps> = ({
               {submittedReason}
             </p>
           </div>
+        )}
+
+        {decision === 'rejected' && NEW_CASE_FLOW_ENABLED && (
+          <HumanReviewCase organization={organization} />
         )}
       </div>
     )

--- a/clients/apps/web/src/components/Organization/HumanReviewCase.tsx
+++ b/clients/apps/web/src/components/Organization/HumanReviewCase.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import {
+  useAppealCase,
+  useReplyToAppealCase,
+  useRequestHumanReview,
+} from '@/hooks/queries/org'
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Textarea } from '@polar-sh/orbit/ui/textarea'
+import { Loader2 } from 'lucide-react'
+import React, { useState } from 'react'
+
+const EVENT_LABELS: Record<string, string> = {
+  opened: 'Requested human review',
+  closed: 'Case closed',
+  appeal_approved: 'Appeal approved',
+  appeal_denied: 'Appeal denied',
+  info_requested: 'Information requested',
+}
+
+const authorLabel = (kind: schemas['SupportCaseMessageAuthorKind']): string => {
+  switch (kind) {
+    case 'merchant':
+      return 'You'
+    case 'platform':
+      return 'Polar Support'
+    default:
+      return 'System'
+  }
+}
+
+const RequestForm: React.FC<{ organizationId: string }> = ({
+  organizationId,
+}) => {
+  const [showForm, setShowForm] = useState(false)
+  const [reason, setReason] = useState('')
+  const mutation = useRequestHumanReview(organizationId)
+
+  const count = reason.length
+  const isValid = count >= 50 && count <= 5000
+
+  if (!showForm) {
+    return (
+      <Text color="muted">
+        Still believe this is wrong?{' '}
+        <button
+          type="button"
+          onClick={() => setShowForm(true)}
+          className="cursor-pointer underline hover:no-underline"
+        >
+          Ask for human review
+        </button>
+        .
+      </Text>
+    )
+  }
+
+  return (
+    <Box
+      as="form"
+      display="flex"
+      flexDirection="column"
+      rowGap="m"
+      onSubmit={(e: React.FormEvent) => {
+        e.preventDefault()
+        if (isValid) mutation.mutate({ reason })
+      }}
+    >
+      <Text variant="label">
+        Tell our team why your organization should be approved
+      </Text>
+      <Textarea
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        className="dark:bg-polar-800 min-h-32 w-full bg-white"
+        placeholder="Add any context about your business that a human reviewer should know…"
+        maxLength={5000}
+      />
+      <Box display="flex" justifyContent="between">
+        <Text variant="caption" color={count > 5000 ? 'danger' : 'muted'}>
+          Minimum 50 characters
+        </Text>
+        <Text variant="caption" color={count > 5000 ? 'danger' : 'muted'}>
+          {count}/5000
+        </Text>
+      </Box>
+      <Box display="flex" justifyContent="end" columnGap="m">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => setShowForm(false)}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!isValid || mutation.isPending}>
+          {mutation.isPending && (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          )}
+          Submit request
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+const Message: React.FC<{ message: schemas['SupportCaseMessage'] }> = ({
+  message,
+}) => {
+  if (message.type !== 'chat') {
+    return (
+      <Text variant="caption" color="muted" align="center">
+        {EVENT_LABELS[message.type] ?? message.type}
+        {message.body ? ` — ${message.body}` : ''}
+      </Text>
+    )
+  }
+
+  const fromMerchant = message.author_kind === 'merchant'
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      rowGap="xs"
+      padding="m"
+      borderRadius="m"
+      backgroundColor={
+        fromMerchant ? 'background-secondary' : 'background-card'
+      }
+    >
+      <Text variant="label">{authorLabel(message.author_kind)}</Text>
+      <Text>{message.body}</Text>
+    </Box>
+  )
+}
+
+const ReplyBox: React.FC<{ organizationId: string }> = ({ organizationId }) => {
+  const [body, setBody] = useState('')
+  const mutation = useReplyToAppealCase(organizationId)
+
+  const submit = async () => {
+    if (body.trim().length === 0) return
+    const result = await mutation.mutateAsync({ body })
+    if (!result.error) setBody('')
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" rowGap="m">
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        className="dark:bg-polar-800 min-h-24 w-full bg-white"
+        placeholder="Write a reply…"
+        maxLength={5000}
+      />
+      <Box display="flex" justifyContent="end">
+        <Button
+          type="button"
+          onClick={submit}
+          disabled={body.trim().length === 0 || mutation.isPending}
+        >
+          {mutation.isPending && (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          )}
+          Send
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+interface HumanReviewCaseProps {
+  organization: schemas['Organization']
+}
+
+const HumanReviewCase: React.FC<HumanReviewCaseProps> = ({ organization }) => {
+  const { data: thread, isLoading, isError } = useAppealCase(organization.id)
+
+  if (isLoading) {
+    return (
+      <Loader2 className="dark:text-polar-400 h-4 w-4 animate-spin text-gray-500" />
+    )
+  }
+
+  if (isError || !thread) {
+    return <RequestForm organizationId={organization.id} />
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" rowGap="l">
+      <Box display="flex" flexDirection="column" rowGap="m">
+        {thread.messages.map((message) => (
+          <Message key={message.id} message={message} />
+        ))}
+      </Box>
+      {thread.is_open ? (
+        <ReplyBox organizationId={organization.id} />
+      ) : (
+        <Text variant="caption" color="muted">
+          This case is closed.
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+export default HumanReviewCase

--- a/clients/apps/web/src/hooks/queries/org.ts
+++ b/clients/apps/web/src/hooks/queries/org.ts
@@ -370,6 +370,45 @@ export const useOrganizationReviewStatus = (
     initialData,
   })
 
+export const useRequestHumanReview = (id: string) =>
+  useMutation({
+    mutationFn: ({ reason }: { reason: string }) =>
+      api.POST('/v1/organizations/{id}/appeal/human-review', {
+        params: { path: { id } },
+        body: { reason },
+      }),
+    onSuccess: async (result) => {
+      if (result.error) return
+      getQueryClient().invalidateQueries({ queryKey: ['appealCase', id] })
+    },
+  })
+
+export const useAppealCase = (id: string, enabled: boolean = true) =>
+  useQuery({
+    queryKey: ['appealCase', id],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/organizations/{id}/appeal/case', {
+          params: { path: { id } },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: enabled && !!id,
+  })
+
+export const useReplyToAppealCase = (id: string) =>
+  useMutation({
+    mutationFn: ({ body }: { body: string }) =>
+      api.POST('/v1/organizations/{id}/appeal/case/messages', {
+        params: { path: { id } },
+        body: { body },
+      }),
+    onSuccess: async (result) => {
+      if (result.error) return
+      getQueryClient().invalidateQueries({ queryKey: ['appealCase', id] })
+    },
+  })
+
 export const useDeleteOrganization = () =>
   useMutation({
     mutationFn: (variables: { id: string }) => {


### PR DESCRIPTION
## Summary

**Related Issue**: #[feedback/151](https://github.com/polarsource/feedback/issues/151)

<!-- Brief description of what this PR does -->

## What

Merchant facing flow for the new support case applied to organization appeal. Gated behind a boolean for now as it needs polishing and attachment is not handled yet.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a switch-gated human review case flow for denied organization appeals, giving merchants an in-product support thread. Currently hardcoded off via `NEW_CASE_FLOW_ENABLED`; when off, the existing “contact support” path remains. Attachments not supported yet.

- **New Features**
  - `AppealForm.tsx`: shows `HumanReviewCase` after a rejected appeal when the switch is on; adjusts rejection copy.
  - `HumanReviewCase.tsx`: request form (50–5000 chars), timeline/event messages, and chat replies while the case is open; shows closed state.
  - Hooks in `org.ts`: `useAppealCase`, `useRequestHumanReview`, `useReplyToAppealCase` calling `/v1/organizations/{id}/appeal/*` and invalidating `appealCase` on success.

<sup>Written for commit f607c5c14d4479894d8bf1d748dfe1918f3adc6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

