### PR TITLE
feat(support-case): display downloadable attachment to org appeal case

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -74,6 +74,7 @@ from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     ReviewAppealSupportCase,
+    SupportCaseAttachment,
     SupportCaseMessageAuthorKind,
 )
 from polar.models.transaction import TransactionType
@@ -109,7 +110,10 @@ from polar.startup_program.service import (
 from polar.startup_program.service import (
     startup_program as startup_program_service,
 )
-from polar.support_case.repository import SupportCaseMessageRepository
+from polar.support_case.repository import (
+    SupportCaseAttachmentRepository,
+    SupportCaseMessageRepository,
+)
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.worker import enqueue_job
 
@@ -970,6 +974,9 @@ async def get_organization_detail(
             elif section == "support_case":
                 thread = None
                 author_emails: dict[uuid.UUID, str] = {}
+                attachments_by_message: dict[
+                    uuid.UUID, list[SupportCaseAttachment]
+                ] = {}
                 if organization.review is not None:
                     thread = await appeal_case_service.get_thread(
                         session, organization.review, visible_to=None
@@ -990,11 +997,20 @@ async def get_organization_detail(
                         author_emails = {
                             row.id: row.email for row in email_result.all()
                         }
+                    attachments = await SupportCaseAttachmentRepository.from_session(
+                        session
+                    ).list_by_case(case_.id)
+                    for attachment in attachments:
+                        if attachment.message_id is not None:
+                            attachments_by_message.setdefault(
+                                attachment.message_id, []
+                            ).append(attachment)
                 support_case_section = SupportCaseSection(
                     organization,
                     thread=thread,
                     author_emails=author_emails,
                     current_user_id=user_session.user_id,
+                    attachments_by_message=attachments_by_message,
                 )
                 with support_case_section.render(request):
                     pass

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -11,6 +11,7 @@ from tagflow import tag, text
 from polar.models import Organization
 from polar.models.support_case import (
     ReviewAppealSupportCase,
+    SupportCaseAttachment,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
     SupportCaseMessageType,
@@ -67,11 +68,13 @@ class SupportCaseSection:
         thread: Thread | None = None,
         author_emails: dict[UUID, str] | None = None,
         current_user_id: UUID | None = None,
+        attachments_by_message: dict[UUID, list[SupportCaseAttachment]] | None = None,
     ) -> None:
         self.org = organization
         self.thread = thread
         self.author_emails = author_emails or {}
         self.current_user_id = current_user_id
+        self.attachments_by_message = attachments_by_message or {}
 
     @contextlib.contextmanager
     def render(self, request: Request) -> Generator[None]:
@@ -292,7 +295,8 @@ class SupportCaseSection:
     def _render_content(
         self, message: SupportCaseMessage, is_event: bool, internal: bool
     ) -> None:
-        if not message.body:
+        attachments = self.attachments_by_message.get(message.id, [])
+        if not message.body and not attachments:
             # Milestone with no body still occupies its grid cell.
             with tag.div():
                 pass
@@ -300,9 +304,39 @@ class SupportCaseSection:
 
         merchant = message.author_kind == SupportCaseMessageAuthorKind.merchant
         justify = "justify-end" if merchant else "justify-start"
-        with tag.div(classes=f"flex items-center {justify}"):
-            with tag.div(classes=f"max-w-md text-sm {self._bubble(message, internal)}"):
-                text(message.body)
+        with tag.div(classes="flex flex-col gap-2"):
+            if message.body:
+                with tag.div(classes=f"flex {justify}"):
+                    with tag.div(
+                        classes=f"max-w-md text-sm {self._bubble(message, internal)}"
+                    ):
+                        text(message.body)
+            for attachment in attachments:
+                with tag.div(classes=f"flex {justify}"):
+                    self._render_attachment(attachment)
+
+    def _render_attachment(self, attachment: SupportCaseAttachment) -> None:
+        file = attachment.file
+        with tag.div(
+            classes="flex items-center gap-2 max-w-md rounded-lg border "
+            "border-base-200 bg-base-100 px-3 py-2"
+        ):
+            with tag.span(classes="icon-paperclip text-base-content/40"):
+                pass
+            with tag.div(classes="min-w-0"):
+                with tag.div(classes="text-sm font-medium truncate"):
+                    text(file.name)
+                with tag.div(classes="text-xs text-base-content/50"):
+                    text(self._format_size(file.size))
+
+    @staticmethod
+    def _format_size(size: int) -> str:
+        value = float(size)
+        for unit in ("B", "KB", "MB", "GB"):
+            if value < 1024:
+                return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+            value /= 1024
+        return f"{value:.1f} TB"
 
     def _bubble(self, message: SupportCaseMessage, internal: bool) -> str:
         if internal:

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -91,7 +91,7 @@ class SupportCaseSection:
             case, is_open, messages = self.thread
             with card(bordered=True):
                 self._render_header(request, case, is_open, messages)
-                self._render_timeline(messages)
+                self._render_timeline(request, messages)
                 if is_open:
                     self._render_composer(request)
             yield
@@ -218,7 +218,9 @@ class SupportCaseSection:
 
     # -- Timeline -----------------------------------------------------------
 
-    def _render_timeline(self, messages: Sequence[SupportCaseMessage]) -> None:
+    def _render_timeline(
+        self, request: Request, messages: Sequence[SupportCaseMessage]
+    ) -> None:
         with tag.div(classes="relative"):
             # The rail line, centered under the icon nodes (w-9 → center 18px).
             with tag.div(
@@ -229,9 +231,9 @@ class SupportCaseSection:
                 classes="grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-x-6 gap-y-5"
             ):
                 for message in messages:
-                    self._render_entry(message)
+                    self._render_entry(request, message)
 
-    def _render_entry(self, message: SupportCaseMessage) -> None:
+    def _render_entry(self, request: Request, message: SupportCaseMessage) -> None:
         is_event = message.type != SupportCaseMessageType.chat
         internal = not message.audience
 
@@ -256,7 +258,7 @@ class SupportCaseSection:
                         text(line)
 
         # Right cell: conversation content (empty for pure milestones).
-        self._render_content(message, is_event, internal)
+        self._render_content(request, message, is_event, internal)
 
     def _node(self, message: SupportCaseMessage, internal: bool) -> tuple[str, str]:
         if message.type != SupportCaseMessageType.chat:
@@ -293,7 +295,11 @@ class SupportCaseSection:
         return [email, when] if email else [when]
 
     def _render_content(
-        self, message: SupportCaseMessage, is_event: bool, internal: bool
+        self,
+        request: Request,
+        message: SupportCaseMessage,
+        is_event: bool,
+        internal: bool,
     ) -> None:
         attachments = self.attachments_by_message.get(message.id, [])
         if not message.body and not attachments:
@@ -313,13 +319,22 @@ class SupportCaseSection:
                         text(message.body)
             for attachment in attachments:
                 with tag.div(classes=f"flex {justify}"):
-                    self._render_attachment(attachment)
+                    self._render_attachment(request, attachment)
 
-    def _render_attachment(self, attachment: SupportCaseAttachment) -> None:
+    def _render_attachment(
+        self, request: Request, attachment: SupportCaseAttachment
+    ) -> None:
         file = attachment.file
-        with tag.div(
+        url = str(
+            request.url_for(
+                "support_cases:attachment_download", attachment_id=attachment.id
+            )
+        )
+        with tag.a(
+            href=url,
+            target="_blank",
             classes="flex items-center gap-2 max-w-md rounded-lg border "
-            "border-base-200 bg-base-100 px-3 py-2"
+            "border-base-200 bg-base-100 px-3 py-2 hover:bg-base-200",
         ):
             with tag.span(classes="icon-paperclip text-base-content/40"):
                 pass

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -2,17 +2,21 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
 from pydantic import UUID4
 from sqlalchemy import func, select
+from sqlalchemy.orm import joinedload
 from tagflow import tag, text
 
+from polar.file.service import file as file_service
 from polar.kit.pagination import PaginationParamsQuery
 from polar.models import Organization, User
 from polar.models.organization_review import OrganizationReview
-from polar.models.support_case import ReviewAppealSupportCase
+from polar.models.support_case import ReviewAppealSupportCase, SupportCaseAttachment
 from polar.models.user_session import UserSession
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.support_case.repository import (
+    SupportCaseAttachmentRepository,
     SupportCaseMessageRepository,
     SupportCaseRepository,
 )
@@ -147,6 +151,27 @@ async def release_case(
         raise HTTPException(status_code=404, detail="Support case not found")
     await support_case_service.unassign(session, case, actor=user_session.user)
     return HXRedirectResponse(request, _safe_return_to(request, return_to), 303)
+
+
+@router.get(
+    "/attachments/{attachment_id}/download",
+    name="support_cases:attachment_download",
+    response_model=None,
+)
+async def download_attachment(
+    attachment_id: UUID4,
+    session: AsyncSession = Depends(get_db_read_session),
+    user_session: UserSession = Depends(get_admin),
+) -> RedirectResponse:
+    """Redirect to a presigned download URL for a case attachment."""
+    del user_session  # admin gate only
+    attachment = await SupportCaseAttachmentRepository.from_session(session).get_by_id(
+        attachment_id, options=(joinedload(SupportCaseAttachment.file),)
+    )
+    if attachment is None:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+    url, _ = file_service.generate_download_url(attachment.file)
+    return RedirectResponse(url)
 
 
 @router.get("/", name="support_cases:list")

--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -23,6 +23,7 @@ from polar.kit.extensions.sqlalchemy.types import StringEnum
 
 if TYPE_CHECKING:
     from polar.models.customer import Customer
+    from polar.models.file import File
     from polar.models.organization import Organization
     from polar.models.organization_review import OrganizationReview
     from polar.models.user import User
@@ -326,3 +327,7 @@ class SupportCaseAttachment(RecordModel):
     @declared_attr
     def case(cls) -> Mapped["SupportCase"]:
         return relationship("SupportCase", lazy="raise", back_populates="attachments")
+
+    @declared_attr
+    def file(cls) -> Mapped["File"]:
+        return relationship("File", lazy="raise")

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import ColumnElement, select
+from sqlalchemy.orm import joinedload
 
 from polar.kit.repository.base import (
     RepositoryBase,
@@ -11,6 +12,7 @@ from polar.kit.repository.base import (
 from polar.models.support_case import (
     ReviewAppealSupportCase,
     SupportCase,
+    SupportCaseAttachment,
     SupportCaseAudience,
     SupportCaseMessage,
     SupportCaseMessageType,
@@ -96,6 +98,26 @@ class SupportCaseMessageRepository(
             .scalar_subquery()
         )
         return latest_type != SupportCaseMessageType.closed
+
+
+class SupportCaseAttachmentRepository(
+    RepositorySoftDeletionIDMixin[SupportCaseAttachment, UUID],
+    RepositorySoftDeletionMixin[SupportCaseAttachment],
+    RepositoryBase[SupportCaseAttachment],
+):
+    model = SupportCaseAttachment
+
+    async def list_by_case(
+        self, case_id: UUID
+    ) -> Sequence[SupportCaseAttachment]:
+        """A case's attachments (oldest first) with their file eager-loaded."""
+        statement = (
+            self.get_base_statement()
+            .where(SupportCaseAttachment.case_id == case_id)
+            .options(joinedload(SupportCaseAttachment.file))
+            .order_by(SupportCaseAttachment.created_at.asc())
+        )
+        return await self.get_all(statement)
 
 
 class SupportCaseParticipantRepository(

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -107,9 +107,7 @@ class SupportCaseAttachmentRepository(
 ):
     model = SupportCaseAttachment
 
-    async def list_by_case(
-        self, case_id: UUID
-    ) -> Sequence[SupportCaseAttachment]:
+    async def list_by_case(self, case_id: UUID) -> Sequence[SupportCaseAttachment]:
         """A case's attachments (oldest first) with their file eager-loaded."""
         statement = (
             self.get_base_statement()


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/9abe81a0-55fb-43c2-b046-44e54f0c2888




## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display attachments in the organization appeal support case timeline. Add a download route that redirects to a presigned file URL.

- **New Features**
  - Render case attachments under their message with filename and size; links open in a new tab.
  - Added `GET /backoffice/support-cases/attachments/{attachment_id}/download` (`support_cases:attachment_download`) that redirects to a presigned URL from `file_service.generate_download_url`.
  - Introduced `SupportCaseAttachmentRepository.list_by_case` with eager-loaded `file` via `joinedload`.
  - Added `SupportCaseAttachment.file` relationship on the model.
  - Wired attachments into the org detail `support_case` section via `attachments_by_message`.

<sup>Written for commit b5d005005eecc126e39c483e4e04cc684a9abf6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

