### PR TITLE
Allow relative `Location:` redirects

### DIFF
--- a/server/polar/kit/http.py
+++ b/server/polar/kit/http.py
@@ -96,7 +96,11 @@ async def check_url_reachable(
     async def _check_redirect(response: httpx.Response) -> None:
         if response.is_redirect:
             location = response.headers.get("location", "")
-            await validate_crawlable_url(location)
+            # `Location` may be a relative reference (RFC 7231). Resolve it
+            # against the current URL — the same resolution httpx uses to
+            # follow the redirect — so we validate the URL actually fetched.
+            absolute_location = response.url.join(location)
+            await validate_crawlable_url(str(absolute_location))
 
     try:
         async with httpx.AsyncClient(

--- a/server/tests/kit/test_http.py
+++ b/server/tests/kit/test_http.py
@@ -1,10 +1,14 @@
 import socket
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from polar.kit.http import (
     SSRFBlockedError,
+    check_url_reachable,
     get_safe_return_url,
     resolve_and_validate_ip,
 )
@@ -120,3 +124,87 @@ class TestResolveAndValidateIp:
         ):
             with pytest.raises(SSRFBlockedError, match="DNS resolution failed"):
                 await resolve_and_validate_ip("nonexistent.invalid")
+
+
+@contextmanager
+def _mock_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> Iterator[None]:
+    """Patch the client used by `check_url_reachable` to route through a mock."""
+    real_async_client = httpx.AsyncClient
+
+    def factory(**kwargs: object) -> httpx.AsyncClient:
+        return real_async_client(transport=httpx.MockTransport(handler), **kwargs)  # type: ignore[arg-type]
+
+    with patch("polar.kit.http.httpx.AsyncClient", new=factory):
+        yield
+
+
+class TestCheckUrlReachable:
+    @pytest.mark.asyncio
+    async def test_follows_relative_redirect_location(self) -> None:
+        """A relative `Location` (e.g. `/login`) must be resolved, not rejected.
+
+        A relative location previously failed `HttpUrl` parsing and wrongly
+        marked the site unreachable; it must be resolved against the request
+        URL before being followed.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url == "https://example.com/":
+                # Relative location — resolved against the request URL.
+                return httpx.Response(307, headers={"location": "/login"})
+            if url == "https://example.com/login":
+                return httpx.Response(200)
+            raise AssertionError(f"unexpected URL: {url}")
+
+        with patch(
+            "anyio.getaddrinfo",
+            new=AsyncMock(return_value=_fake_getaddrinfo("93.184.216.34")),
+        ):
+            with _mock_transport(handler):
+                result = await check_url_reachable("https://example.com")
+
+        assert result.reachable is True
+        assert result.status == 200
+
+    @pytest.mark.asyncio
+    async def test_blocks_redirect_to_private_host(self) -> None:
+        """SSRF protection still holds: a redirect to a private IP is blocked."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url) == "https://example.com/":
+                return httpx.Response(
+                    302, headers={"location": "https://internal.example.com/"}
+                )
+            raise AssertionError(f"should not follow redirect to {request.url}")
+
+        async def fake_getaddrinfo(
+            host: str, *args: object, **kwargs: object
+        ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+            if host == "internal.example.com":
+                return _fake_getaddrinfo("10.0.0.1")
+            return _fake_getaddrinfo("93.184.216.34")
+
+        with patch("anyio.getaddrinfo", new=fake_getaddrinfo):
+            with _mock_transport(handler):
+                result = await check_url_reachable("https://example.com")
+
+        assert result.reachable is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_unreachable_on_4xx(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        with patch(
+            "anyio.getaddrinfo",
+            new=AsyncMock(return_value=_fake_getaddrinfo("93.184.216.34")),
+        ):
+            with _mock_transport(handler):
+                result = await check_url_reachable("https://example.com")
+
+        assert result.reachable is False
+        assert result.status == 404


### PR DESCRIPTION
Some organization URL's send a HTTP header `Location: /login` which is allowed, but we handle it incorrectly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix URL reachability checks to correctly follow relative redirect locations by resolving them against the current URL. Prevents false “unreachable” results for sites that redirect to paths like `/login`, while keeping SSRF protections intact.

- **Bug Fixes**
  - Resolve relative `Location` headers to absolute URLs with `response.url.join()` before validation in `check_url_reachable`.
  - Added tests for relative redirects, SSRF-blocked private IP redirects, and 4xx responses.

<sup>Written for commit a6248c3f7eb268ca8e39d215fdd048b8105b8c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

