### PR TITLE
Add backfill script for benefit visibility

### DIFF
--- a/server/scripts/backfill_benefit_visibility.py
+++ b/server/scripts/backfill_benefit_visibility.py
@@ -1,0 +1,55 @@
+"""Backfill the visibility column for existing benefits.
+
+All existing benefits are set to public so nothing is unexpectedly hidden in
+the customer portal. New benefits created after this backfill get their
+visibility from `BenefitType.resolve_visibility()` in `BenefitService.user_create`
+(e.g. feature flags defaulting to private once that rollout is enabled).
+
+The update is idempotent: once a row has visibility set it no longer matches
+the filter, so the script can be safely re-run or resumed.
+"""
+
+import typer
+from sqlalchemy import select, update
+
+from polar.kit.visibility import Visibility
+from polar.models import Benefit
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+subquery = (
+    select(Benefit.id)
+    .where(Benefit.visibility.is_(None))
+    .order_by(Benefit.id)
+    .limit(limit_bindparam())
+    .scalar_subquery()
+)
+
+update_statement = (
+    update(Benefit).values(visibility=Visibility.public).where(Benefit.id.in_(subquery))
+)
+
+
+@cli.command()
+@typer_async
+async def backfill_benefit_visibility(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    await run_batched_update(
+        update_statement,
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/scripts/test_backfill_benefit_visibility.py
+++ b/server/tests/scripts/test_backfill_benefit_visibility.py
@@ -1,0 +1,60 @@
+import uuid
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import CursorResult, select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.visibility import Visibility
+from polar.models import Benefit, Organization
+from polar.models.benefit import BenefitType
+from scripts.backfill_benefit_visibility import update_statement
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit
+
+
+async def _visibility(
+    session: AsyncSession, benefit_id: uuid.UUID
+) -> Visibility | None:
+    result = await session.execute(
+        select(Benefit.visibility).where(Benefit.id == benefit_id)
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_backfill_benefit_visibility(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    organization: Organization,
+) -> None:
+    custom = await create_benefit(
+        save_fixture, organization=organization, type=BenefitType.custom
+    )
+    feature_flag = await create_benefit(
+        save_fixture, organization=organization, type=BenefitType.feature_flag
+    )
+    discord = await create_benefit(
+        save_fixture,
+        organization=organization,
+        type=BenefitType.discord,
+        properties={"guild_id": "123", "role_id": "456", "kick_member": False},
+    )
+    already_set = await create_benefit(
+        save_fixture, organization=organization, type=BenefitType.custom
+    )
+    already_set.visibility = Visibility.private
+    await save_fixture(already_set)
+
+    result = await session.execute(update_statement, {"limit": 1000})
+    await session.commit()
+    assert cast(CursorResult[Any], result).rowcount == 3
+
+    assert await _visibility(session, custom.id) == Visibility.public
+    assert await _visibility(session, feature_flag.id) == Visibility.public
+    assert await _visibility(session, discord.id) == Visibility.public
+    assert await _visibility(session, already_set.id) == Visibility.private
+
+    result = await session.execute(update_statement, {"limit": 1000})
+    await session.commit()
+    assert cast(CursorResult[Any], result).rowcount == 0


### PR DESCRIPTION
Part 3 of benefit visibility rollout.

Backfill script to set all current NULL values to `public` in the benefit visibility column.

After previous PR all newly created benefits should be set to public automatically, and after this backfill no NULL visibility values should ever exist.

The next step is a migration script to set the column to NOT NULL, then finally I'll push the final rollout PR

Please let me know if you have any advice or feedback.


- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [X] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills `Benefit.visibility` by setting all NULL values to `public` so no existing benefits are hidden in the customer portal during the visibility rollout.

- **New Features**
  - Adds `server/scripts/backfill_benefit_visibility.py` to update NULLs to `Visibility.public` in batched chunks.
  - Idempotent and safe to re-run; only rows with NULL visibility are updated.
  - Tests in `server/tests/scripts/test_backfill_benefit_visibility.py` verify update behavior and idempotency.

<sup>Written for commit cfe62d5b45162caccd125b4bcf021b6d9a103401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

