### PR TITLE
license key: Prevent TOCTOU issue with multiple activations

### DIFF
--- a/server/polar/license_key/repository.py
+++ b/server/polar/license_key/repository.py
@@ -63,14 +63,6 @@ class LicenseKeyRepository(
         )
         return await self.get_one_or_none(statement)
 
-    async def get_by_id_for_update(self, id: UUID) -> LicenseKey | None:
-        statement = (
-            self.get_base_statement()
-            .where(LicenseKey.id == id)
-            .with_for_update(of=LicenseKey)
-        )
-        return await self.get_one_or_none(statement)
-
     async def get_readable_by_key(
         self,
         key: str,

--- a/server/polar/license_key/repository.py
+++ b/server/polar/license_key/repository.py
@@ -63,6 +63,14 @@ class LicenseKeyRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_by_id_for_update(self, id: UUID) -> LicenseKey | None:
+        statement = (
+            self.get_base_statement()
+            .where(LicenseKey.id == id)
+            .with_for_update(of=LicenseKey)
+        )
+        return await self.get_one_or_none(statement)
+
     async def get_readable_by_key(
         self,
         key: str,

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -252,6 +252,11 @@ class LicenseKeyService:
                 "Use the /validate endpoint instead to check license validity."
             )
 
+        repository = LicenseKeyRepository.from_session(session)
+        locked = await repository.get_by_id_for_update(license_key.id)
+        if locked is None:
+            raise ResourceNotFound()
+
         current_activation_count = await self.get_activation_count(
             session,
             license_key=license_key,

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -236,6 +236,12 @@ class LicenseKeyService:
         license_key: LicenseKey,
         activate: LicenseKeyActivate,
     ) -> LicenseKeyActivation:
+        await session.refresh(
+            license_key,
+            attribute_names=["status", "expires_at", "limit_activations"],
+            with_for_update=True,
+        )
+
         if not license_key.is_active():
             raise NotPermitted(
                 "License key is no longer active. "
@@ -251,11 +257,6 @@ class LicenseKeyService:
                 "This license key does not support activations. "
                 "Use the /validate endpoint instead to check license validity."
             )
-
-        repository = LicenseKeyRepository.from_session(session)
-        locked = await repository.get_by_id_for_update(license_key.id)
-        if locked is None:
-            raise ResourceNotFound()
 
         current_activation_count = await self.get_activation_count(
             session,

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -238,9 +238,12 @@ class LicenseKeyService:
     ) -> LicenseKeyActivation:
         await session.refresh(
             license_key,
-            attribute_names=["status", "expires_at", "limit_activations"],
+            attribute_names=["status", "expires_at", "limit_activations", "deleted_at"],
             with_for_update=True,
         )
+
+        if license_key.deleted_at is not None:
+            raise ResourceNotFound()
 
         if not license_key.is_active():
             raise NotPermitted(

--- a/server/tests/license_key/test_endpoints.py
+++ b/server/tests/license_key/test_endpoints.py
@@ -353,6 +353,70 @@ class TestLicenseKeyEndpoints:
         AuthSubjectFixture(subject="user"),
         AuthSubjectFixture(subject="organization"),
     )
+    async def test_activate_limit_reached(
+        self,
+        activate_path: str,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        benefit, granted = await TestLicenseKey.create_benefit_and_grant(
+            session,
+            redis,
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            product=product,
+            properties=BenefitLicenseKeysCreateProperties(
+                prefix="testing",
+                activations=BenefitLicenseKeyActivationCreateProperties(
+                    limit=2, enable_customer_admin=True
+                ),
+            ),
+        )
+        repository = LicenseKeyRepository.from_session(session)
+        lk = await repository.get_by_id(UUID(granted["license_key_id"]))
+        assert lk is not None
+
+        for label in ("first", "second"):
+            activate = await client.post(
+                activate_path,
+                json={
+                    "key": lk.key,
+                    "organization_id": str(organization.id),
+                    "label": label,
+                },
+            )
+            assert activate.status_code == 200
+
+        activate = await client.post(
+            activate_path,
+            json={
+                "key": lk.key,
+                "organization_id": str(organization.id),
+                "label": "third",
+            },
+        )
+        assert activate.status_code == 403
+        data = activate.json()
+        assert "activation limit already reached" in data["detail"]
+
+    @pytest.mark.parametrize(
+        "activate_path",
+        [
+            "/v1/customer-portal/license-keys/activate",
+            "/v1/license-keys/activate",
+        ],
+    )
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
     async def test_activate_license_without_activations_returns_descriptive_error(
         self,
         activate_path: str,

--- a/server/tests/license_key/test_service.py
+++ b/server/tests/license_key/test_service.py
@@ -1,0 +1,113 @@
+import asyncio
+from uuid import UUID
+
+import pytest
+from sqlalchemy import delete, func, select
+
+from polar.config import settings
+from polar.exceptions import NotPermitted
+from polar.kit.db.postgres import (
+    AsyncSessionMaker,
+    create_async_engine,
+    create_async_sessionmaker,
+)
+from polar.license_key.repository import LicenseKeyRepository
+from polar.license_key.schemas import LicenseKeyActivate
+from polar.license_key.service import license_key as license_key_service
+from polar.models import Account, LicenseKey, LicenseKeyActivation, Organization, User
+from polar.models.license_key import LicenseKeyStatus
+from tests.fixtures.database import get_database_url, save_fixture_factory
+from tests.fixtures.random_objects import (
+    create_account,
+    create_benefit,
+    create_customer,
+    create_organization,
+    create_user,
+)
+
+
+async def _attempt_activation(
+    sessionmaker: AsyncSessionMaker, license_key_id: UUID, label: str
+) -> bool:
+    async with sessionmaker() as session:
+        repository = LicenseKeyRepository.from_session(session)
+        license_key = await repository.get_by_id(license_key_id)
+        assert license_key is not None
+        try:
+            await license_key_service.activate(
+                session,
+                license_key=license_key,
+                activate=LicenseKeyActivate(
+                    key=license_key.key,
+                    organization_id=license_key.organization_id,
+                    label=label,
+                    conditions={},
+                    meta={},
+                ),
+            )
+        except NotPermitted:
+            await session.rollback()
+            return False
+        await session.commit()
+        return True
+
+
+@pytest.mark.asyncio
+class TestConcurrentActivation:
+    async def test_limit_enforced_under_concurrency(self, worker_id: str) -> None:
+        engine = create_async_engine(
+            dsn=get_database_url(worker_id),
+            application_name=f"test_{worker_id}_lk_concurrency",
+            pool_size=8,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+
+        async with sessionmaker() as setup_session:
+            save_fixture = save_fixture_factory(setup_session)
+            user = await create_user(save_fixture)
+            account = await create_account(save_fixture, user)
+            organization = await create_organization(save_fixture, account)
+            customer = await create_customer(save_fixture, organization=organization)
+            benefit = await create_benefit(save_fixture, organization=organization)
+            license_key = LicenseKey(
+                organization_id=organization.id,
+                customer_id=customer.id,
+                benefit_id=benefit.id,
+                key="testing-concurrent-activation",
+                status=LicenseKeyStatus.granted,
+                limit_activations=1,
+            )
+            setup_session.add(license_key)
+            await setup_session.commit()
+
+        try:
+            results = await asyncio.gather(
+                *(
+                    _attempt_activation(sessionmaker, license_key.id, f"activation-{i}")
+                    for i in range(5)
+                )
+            )
+
+            async with sessionmaker() as session:
+                activation_count = (
+                    await session.execute(
+                        select(func.count(LicenseKeyActivation.id)).where(
+                            LicenseKeyActivation.license_key_id == license_key.id
+                        )
+                    )
+                ).scalar_one()
+
+            assert results.count(True) == 1
+            assert activation_count == 1
+        finally:
+            async with sessionmaker() as cleanup_session:
+                await cleanup_session.execute(
+                    delete(Organization).where(Organization.id == organization.id)
+                )
+                await cleanup_session.execute(
+                    delete(Account).where(Account.id == account.id)
+                )
+                await cleanup_session.execute(delete(User).where(User.id == user.id))
+                await cleanup_session.commit()
+            await engine.dispose()


### PR DESCRIPTION
This prevents someone from activating two license keys at the same time going over use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in license key activation by locking the license row before validation and creation. Activation limits are enforced under concurrent requests, and deleted keys are now treated as not found.

- **Bug Fixes**
  - Lock `LicenseKey` using `session.refresh(..., with_for_update=True)` before counting and creating activations; deleted keys now raise `ResourceNotFound`.
  - Return 403 when the activation limit is reached; tests cover `/v1/customer-portal/license-keys/activate` and `/v1/license-keys/activate`.
  - Add a concurrency test ensuring only one activation succeeds when `limit_activations=1`.

<sup>Written for commit e257c24caf64fe11f93cd7f93b62099da1a94617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

