### PR TITLE
Allow configuring `visibility: public` on public-only benefit types

### DIFF
--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -211,15 +211,15 @@ class BenefitService:
             )
 
         if (
-            "visibility" in benefit_update.model_fields_set
-            and not benefit.type.is_visibility_configurable()
+            benefit_update.visibility is not None
+            and not benefit.type.is_visibility_allowed(benefit_update.visibility)
         ):
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "visibility"),
-                        "msg": "Visibility cannot be changed for this benefit type.",
+                        "msg": "This visibility is not allowed for this benefit type.",
                         "input": benefit_update.visibility,
                     }
                 ]

--- a/server/polar/models/benefit.py
+++ b/server/polar/models/benefit.py
@@ -72,6 +72,13 @@ class BenefitType(StrEnum):
     def is_visibility_configurable(self) -> bool:
         return self in VISIBILITY_CONFIGURABLE_BENEFIT_TYPES
 
+    def is_visibility_allowed(self, visibility: Visibility) -> bool:
+        # Benefits requiring customer action in the portal (e.g. Discord,
+        # GitHub, downloads) must stay visible, so only `public` is allowed.
+        if self.is_visibility_configurable():
+            return True
+        return visibility == Visibility.public
+
     def default_visibility(self) -> Visibility:
         match self:
             # Temporarily disabled untill benefit visibility backfill and ui rollout

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -605,10 +605,8 @@ class TestUpdate:
         assert properties["channel_name_template"] == "vip-{customer_name}"
 
     @pytest.mark.auth
-    @pytest.mark.parametrize("visibility", [Visibility.private, None])
-    async def test_rejects_visibility_update_for_non_configurable_benefit(
+    async def test_rejects_private_visibility_update_for_non_configurable_benefit(
         self,
-        visibility: Visibility | None,
         auth_subject: AuthSubject[User],
         session: AsyncSession,
         redis: Redis,
@@ -628,13 +626,60 @@ class TestUpdate:
         )
 
         update_schema = BenefitDiscordUpdate.model_validate(
-            {"type": BenefitType.discord, "visibility": visibility}
+            {"type": BenefitType.discord, "visibility": Visibility.private}
         )
 
         with pytest.raises(PolarRequestValidationError):
             await benefit_service.update(
                 session, redis, benefit, update_schema, auth_subject
             )
+
+    @pytest.mark.auth
+    @pytest.mark.parametrize(
+        ("visibility", "expected"),
+        [
+            (Visibility.public, Visibility.public),
+            (None, None),
+        ],
+    )
+    async def test_allows_public_visibility_update_for_non_configurable_benefit(
+        self,
+        visibility: Visibility | None,
+        expected: Visibility | None,
+        mocker: MockerFixture,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        mocker.patch.object(
+            benefit_grant_service,
+            "enqueue_benefit_grant_updates",
+            spec=BenefitGrantService.enqueue_benefit_grant_updates,
+        )
+
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.discord,
+            properties={
+                "guild_id": "123",
+                "role_id": "456",
+                "kick_member": False,
+            },
+        )
+
+        update_schema = BenefitDiscordUpdate.model_validate(
+            {"type": BenefitType.discord, "visibility": visibility}
+        )
+
+        updated_benefit = await benefit_service.update(
+            session, redis, benefit, update_schema, auth_subject
+        )
+
+        assert updated_benefit.visibility == expected
 
     @pytest.mark.auth
     async def test_allows_visibility_update_for_custom_benefit(

--- a/server/tests/models/test_benefit.py
+++ b/server/tests/models/test_benefit.py
@@ -36,6 +36,24 @@ class TestBenefitTypeVisibility:
     ) -> None:
         assert benefit_type.default_visibility() == expected
 
+    @pytest.mark.parametrize(
+        ("benefit_type", "visibility", "expected"),
+        [
+            # Configurable types allow any visibility.
+            (BenefitType.custom, Visibility.public, True),
+            (BenefitType.custom, Visibility.private, True),
+            (BenefitType.feature_flag, Visibility.private, True),
+            # Non-configurable types only allow public.
+            (BenefitType.discord, Visibility.public, True),
+            (BenefitType.discord, Visibility.private, False),
+            (BenefitType.downloadables, Visibility.private, False),
+        ],
+    )
+    def test_is_visibility_allowed(
+        self, benefit_type: BenefitType, visibility: Visibility, expected: bool
+    ) -> None:
+        assert benefit_type.is_visibility_allowed(visibility) is expected
+
     def test_resolve_visibility_forces_public_when_not_configurable(self) -> None:
         assert (
             BenefitType.discord.resolve_visibility(Visibility.private)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow setting `visibility: public` on public-only benefit types (e.g., Discord, downloads) while still rejecting `private`. Fixes overly strict validation so APIs/UI can explicitly set public.

- **Bug Fixes**
  - Added `BenefitType.is_visibility_allowed(visibility)` to centralize rules.
  - Updated service validation to allow `public` (and reject `private`) for non-configurable types.
  - Improved error message: “This visibility is not allowed for this benefit type.”
  - Added tests for allowed `public` updates and rejection of `private` on non-configurable types.

<sup>Written for commit 586c6bdfb2d8c329ce9e594ae0941db9cb2e722b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

