### PR TITLE
Improve /emergency

### DIFF
--- a/.github/workflows/emergency_merge.yml
+++ b/.github/workflows/emergency_merge.yml
@@ -57,7 +57,6 @@ jobs:
           script: |
             const prNumber = context.payload.issue.number;
 
-            // Check PR is open and mergeable
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -69,23 +68,129 @@ jobs:
               return;
             }
 
-            // Determine merge method from comment (default: squash)
             const comment = context.payload.comment.body.trim();
             let method = 'squash';
             if (comment.includes('--merge')) method = 'merge';
             if (comment.includes('--rebase')) method = 'rebase';
 
+            const mergeDirectly = () => github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              merge_method: method,
+            });
+
+            const isInMergeQueue = (error) =>
+              error.status === 405 && /merge queue/i.test(error.message);
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            const mergeAfterDequeue = async (attempt = 1) => {
+              try {
+                await mergeDirectly();
+              } catch (error) {
+                if (!isInMergeQueue(error)) throw error;
+                if (attempt >= 10) {
+                  throw new Error('still in the merge queue after dequeue — try /emergency again');
+                }
+                await sleep(3000);
+                return mergeAfterDequeue(attempt + 1);
+              }
+            };
+
             try {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                merge_method: method,
-              });
+              await mergeDirectly();
               core.info(`PR #${prNumber} merged via ${method}`);
             } catch (error) {
-              core.setFailed(`Failed to merge: ${error.message}`);
+              if (!isInMergeQueue(error)) {
+                core.setFailed(`Failed to merge: ${error.message}`);
+                return;
+              }
+
+              core.info(`PR #${prNumber} is in the merge queue. Removing it to merge immediately`);
+              await github.graphql(
+                `mutation($id: ID!) {
+                  dequeuePullRequest(input: { id: $id }) {
+                    mergeQueueEntry { id }
+                  }
+                }`,
+                { id: pr.node_id },
+              );
+
+              try {
+                await mergeAfterDequeue();
+                core.info(`PR #${prNumber} dequeued and merged via ${method}`);
+              } catch (retryError) {
+                core.setFailed(`Failed to merge: ${retryError.message}`);
+              }
             }
+
+      - name: Eject other PRs from the merge queue
+        id: eject
+        if: success()
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const emergencyPr = context.payload.issue.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: emergencyPr,
+            });
+            const branch = pr.base.ref;
+
+            const { repository } = await github.graphql(
+              `query($owner: String!, $repo: String!, $branch: String!) {
+                repository(owner: $owner, name: $repo) {
+                  mergeQueue(branch: $branch) {
+                    entries(first: 100) {
+                      nodes {
+                        pullRequest { number, id, title, url, author { login } }
+                      }
+                    }
+                  }
+                }
+              }`,
+              { owner: context.repo.owner, repo: context.repo.repo, branch },
+            );
+
+            const entries = repository.mergeQueue?.entries?.nodes ?? [];
+            const ejected = [];
+
+            for (const entry of entries) {
+              const queued = entry.pullRequest;
+              if (!queued || queued.number === emergencyPr) continue;
+
+              await github.graphql(
+                `mutation($id: ID!) {
+                  dequeuePullRequest(input: { id: $id }) {
+                    mergeQueueEntry { id }
+                  }
+                }`,
+                { id: queued.id },
+              );
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: queued.number,
+                body: `🚨 Removed from the merge queue by an emergency merge of #${emergencyPr}. \`${branch}\` has moved on. Re-queue once your branch is up to date.`,
+              });
+              ejected.push({
+                number: queued.number,
+                title: queued.title,
+                url: queued.url,
+                login: queued.author?.login ?? null,
+              });
+            }
+
+            core.setOutput('ejected', JSON.stringify(ejected));
+            core.info(
+              ejected.length
+                ? `Ejected ${ejected.length} PR(s): ${ejected.map((p) => '#' + p.number).join(', ')}`
+                : 'No other PRs were in the merge queue',
+            );
 
       - name: Comment result
         if: always()
@@ -106,22 +211,61 @@ jobs:
 
       - name: Notify Slack
         if: success()
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: actions/github-script@v9
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: C093CJXJXPT
+          EJECTED: ${{ steps.eject.outputs.ejected }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.E2E_SLACK_BOT_TOKEN }}
-          errors: true
-          payload: |
-            {
-              "channel": "C093CJXJXPT",
-              "text": ${{ toJSON(format('Emergency merge by {0}', github.event.comment.user.login)) }},
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ toJSON(format(':rotating_light: *Emergency merge* by *{0}*\n<{1}|#{2}: {3}>', github.event.comment.user.login, github.event.issue.pull_request.html_url, github.event.issue.number, github.event.issue.title)) }}
-                  }
-                }
-              ]
+          script: |
+            const SLACK_IDS = {
+              birkjernstrom: 'U06QG8MBZ9V',
+              emilwidlund: 'U06QN4F6MU5',
+              frankie567: 'U06QWNPA23V',
+              joebon: 'U0ASK3ZH276',
+              maximevast: 'U0B7LAE2CLU',
+              pieterbeulque: 'U09F35ZP6PM',
+              psincraian: 'U0940A8FY5P',
+              sebastianekstrom: 'U09TG87EE5A',
+              strandhvilliam: 'U0B88EUP3F0',
+              victoriabolin: 'U0A4FJW2JEP',
+              yopi: 'U09LR0C0R61',
+            };
+            const mention = (login) => {
+              if (!login) return '`unknown`';
+              const id = SLACK_IDS[login.toLowerCase()];
+              return id ? `<@${id}>` : `\`@${login}\``;
+            };
+
+            const author = context.payload.comment.user.login;
+            const prUrl = context.payload.issue.pull_request.html_url;
+            const prNumber = context.payload.issue.number;
+            const prTitle = context.payload.issue.title;
+
+            let text = `:rotating_light: *Emergency merge* by *${author}*\n<${prUrl}|#${prNumber}: ${prTitle}>`;
+
+            const ejected = JSON.parse(process.env.EJECTED || '[]');
+            if (ejected.length) {
+              const lines = ejected.map(
+                (p) => `• <${p.url}|#${p.number}: ${p.title}> — ${mention(p.login)}`,
+              );
+              text += `\n\n*Ejected from the merge queue. Please re-queue with your merge:*\n${lines.join('\n')}`;
+            }
+
+            const response = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+              },
+              body: JSON.stringify({
+                channel: process.env.SLACK_CHANNEL,
+                text: `Emergency merge by ${author}`,
+                blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }],
+              }),
+            });
+
+            const result = await response.json();
+            if (!result.ok) {
+              core.setFailed(`Slack notification failed: ${result.error}`);
             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the `/emergency` command to merge immediately even if the PR is in GitHub’s merge queue and cleans up the queue. Adds clearer Slack alerts and comments for ejected PR owners.

- **New Features**
  - Detects merge-queue errors, dequeues, and retries the merge up to 10 times with 3s backoff.
  - Ejects other PRs on the same base branch and comments with re-queue guidance.
  - Slack alert lists ejected PRs with links and user mentions (maps known GitHub users to Slack IDs).
  - Supports `--merge` and `--rebase` flags (default is squash).

- **Refactors**
  - Replaced `slackapi/slack-github-action` with a direct Slack API call via `actions/github-script@v9` for better control and error handling.

<sup>Written for commit 3871bc307b8de2554b29b11250b26a7307ce27ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

