### PR TITLE
Properly fix benefit visibility schema regression

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -8268,8 +8268,6 @@ export interface components {
        * @description The description of the benefit. Will be displayed on products having this benefit.
        */
       description?: string | null
-      /** @description The visibility of the benefit in the customer portal. */
-      visibility?: components['schemas']['BenefitVisibility'] | null
       /**
        * Type
        * @constant
@@ -8477,8 +8475,6 @@ export interface components {
        * @description The description of the benefit. Will be displayed on products having this benefit.
        */
       description?: string | null
-      /** @description The visibility of the benefit in the customer portal. */
-      visibility?: components['schemas']['BenefitVisibility'] | null
       /**
        * Type
        * @constant
@@ -8936,8 +8932,6 @@ export interface components {
        * @description The description of the benefit. Will be displayed on products having this benefit.
        */
       description?: string | null
-      /** @description The visibility of the benefit in the customer portal. */
-      visibility?: components['schemas']['BenefitVisibility'] | null
       /**
        * Type
        * @constant
@@ -10660,8 +10654,6 @@ export interface components {
        * @description The description of the benefit. Will be displayed on products having this benefit.
        */
       description?: string | null
-      /** @description The visibility of the benefit in the customer portal. */
-      visibility?: components['schemas']['BenefitVisibility'] | null
       /**
        * Type
        * @constant

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -210,21 +210,6 @@ class BenefitService:
                 ]
             )
 
-        if (
-            "visibility" in benefit_update.model_fields_set
-            and not benefit.type.is_visibility_configurable()
-        ):
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "visibility"),
-                        "msg": "Visibility cannot be changed for this benefit type.",
-                        "input": getattr(benefit_update, "visibility", None),
-                    }
-                ]
-            )
-
         update_dict = benefit_update.model_dump(
             by_alias=True, exclude_unset=True, exclude={"type", "properties"}
         )

--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -211,16 +211,16 @@ class BenefitService:
             )
 
         if (
-            benefit_update.visibility is not None
-            and not benefit.type.is_visibility_allowed(benefit_update.visibility)
+            "visibility" in benefit_update.model_fields_set
+            and not benefit.type.is_visibility_configurable()
         ):
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "visibility"),
-                        "msg": "This visibility is not allowed for this benefit type.",
-                        "input": benefit_update.visibility,
+                        "msg": "Visibility cannot be changed for this benefit type.",
+                        "input": getattr(benefit_update, "visibility", None),
                     }
                 ]
             )

--- a/server/polar/benefit/strategies/base/schemas.py
+++ b/server/polar/benefit/strategies/base/schemas.py
@@ -51,6 +51,9 @@ class BenefitUpdateBase(MetadataInputMixin, Schema):
             "Will be displayed on products having this benefit."
         ),
     )
+
+
+class BenefitUpdateVisibilityMixin(Schema):
     visibility: BenefitVisibility | None = Field(
         None,
         description="The visibility of the benefit in the customer portal.",

--- a/server/polar/benefit/strategies/custom/schemas.py
+++ b/server/polar/benefit/strategies/custom/schemas.py
@@ -11,6 +11,7 @@ from ..base.schemas import (
     BenefitCreateBase,
     BenefitSubscriberBase,
     BenefitUpdateBase,
+    BenefitUpdateVisibilityMixin,
 )
 
 Note = Annotated[
@@ -56,7 +57,7 @@ class BenefitCustomCreate(BenefitCreateBase):
     properties: BenefitCustomCreateProperties
 
 
-class BenefitCustomUpdate(BenefitUpdateBase):
+class BenefitCustomUpdate(BenefitUpdateVisibilityMixin, BenefitUpdateBase):
     type: Literal[BenefitType.custom]
     properties: BenefitCustomProperties | None = None
 

--- a/server/polar/benefit/strategies/feature_flag/schemas.py
+++ b/server/polar/benefit/strategies/feature_flag/schemas.py
@@ -8,6 +8,7 @@ from ..base.schemas import (
     BenefitCreateBase,
     BenefitSubscriberBase,
     BenefitUpdateBase,
+    BenefitUpdateVisibilityMixin,
 )
 
 
@@ -38,7 +39,7 @@ class BenefitFeatureFlagCreate(BenefitCreateBase):
     properties: BenefitFeatureFlagCreateProperties
 
 
-class BenefitFeatureFlagUpdate(BenefitUpdateBase):
+class BenefitFeatureFlagUpdate(BenefitUpdateVisibilityMixin, BenefitUpdateBase):
     type: Literal[BenefitType.feature_flag]
     properties: BenefitFeatureFlagProperties | None = None
 

--- a/server/polar/benefit/strategies/license_keys/schemas.py
+++ b/server/polar/benefit/strategies/license_keys/schemas.py
@@ -10,6 +10,7 @@ from ..base.schemas import (
     BenefitCreateBase,
     BenefitSubscriberBase,
     BenefitUpdateBase,
+    BenefitUpdateVisibilityMixin,
 )
 
 
@@ -69,7 +70,7 @@ class BenefitLicenseKeysCreate(BenefitCreateBase):
     properties: BenefitLicenseKeysCreateProperties
 
 
-class BenefitLicenseKeysUpdate(BenefitUpdateBase):
+class BenefitLicenseKeysUpdate(BenefitUpdateVisibilityMixin, BenefitUpdateBase):
     type: Literal[BenefitType.license_keys]
     properties: BenefitLicenseKeysCreateProperties | None = None
 

--- a/server/polar/benefit/strategies/meter_credit/schemas.py
+++ b/server/polar/benefit/strategies/meter_credit/schemas.py
@@ -11,6 +11,7 @@ from ..base.schemas import (
     BenefitCreateBase,
     BenefitSubscriberBase,
     BenefitUpdateBase,
+    BenefitUpdateVisibilityMixin,
 )
 
 INT_MAX_VALUE = 2_147_483_647
@@ -55,7 +56,7 @@ class BenefitMeterCreditCreate(BenefitCreateBase):
     properties: BenefitMeterCreditCreateProperties
 
 
-class BenefitMeterCreditUpdate(BenefitUpdateBase):
+class BenefitMeterCreditUpdate(BenefitUpdateVisibilityMixin, BenefitUpdateBase):
     type: Literal[BenefitType.meter_credit]
     properties: BenefitMeterCreditCreateProperties | None = None
 

--- a/server/polar/models/benefit.py
+++ b/server/polar/models/benefit.py
@@ -72,13 +72,6 @@ class BenefitType(StrEnum):
     def is_visibility_configurable(self) -> bool:
         return self in VISIBILITY_CONFIGURABLE_BENEFIT_TYPES
 
-    def is_visibility_allowed(self, visibility: Visibility) -> bool:
-        # Benefits requiring customer action in the portal (e.g. Discord,
-        # GitHub, downloads) must stay visible, so only `public` is allowed.
-        if self.is_visibility_configurable():
-            return True
-        return visibility == Visibility.public
-
     def default_visibility(self) -> Visibility:
         match self:
             # Temporarily disabled untill benefit visibility backfill and ui rollout

--- a/server/tests/benefit/test_endpoints.py
+++ b/server/tests/benefit/test_endpoints.py
@@ -477,7 +477,7 @@ class TestUpdateBenefit:
         assert json["properties"]["note"] == "UPDATED NOTE"
 
     @pytest.mark.auth
-    async def test_rejects_visibility_update_for_non_configurable_benefit(
+    async def test_ignores_visibility_update_for_non_configurable_benefit(
         self,
         save_fixture: SaveFixture,
         client: AsyncClient,
@@ -503,7 +503,9 @@ class TestUpdateBenefit:
             },
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 200
+        json = response.json()
+        assert json["visibility"] == Visibility.public
 
     @pytest.mark.auth
     async def test_allows_visibility_update_for_custom_benefit(

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -20,7 +20,11 @@ from polar.benefit.strategies.custom.schemas import (
     BenefitCustomUpdate,
 )
 from polar.benefit.strategies.discord.schemas import BenefitDiscordUpdate
+from polar.benefit.strategies.downloadables.schemas import BenefitDownloadablesUpdate
 from polar.benefit.strategies.feature_flag.schemas import BenefitFeatureFlagUpdate
+from polar.benefit.strategies.github_repository.schemas import (
+    BenefitGitHubRepositoryUpdate,
+)
 from polar.benefit.strategies.slack_shared_channel.schemas import (
     BenefitSlackSharedChannelCreate,
     BenefitSlackSharedChannelCreateProperties,
@@ -28,6 +32,7 @@ from polar.benefit.strategies.slack_shared_channel.schemas import (
 )
 from polar.exceptions import NotPermitted, PolarRequestValidationError
 from polar.kit.pagination import PaginationParams
+from polar.kit.schemas import Schema
 from polar.kit.visibility import Visibility
 from polar.models import Benefit, Organization, SlackApp, User, UserOrganization
 from polar.models.benefit import BenefitType
@@ -604,10 +609,20 @@ class TestUpdate:
         assert properties["slack_integration_id"] == str(integration.id)
         assert properties["channel_name_template"] == "vip-{customer_name}"
 
-    async def test_visibility_field_absent_from_non_configurable_update_schema(
+    @pytest.mark.parametrize(
+        "update_schema",
+        [
+            BenefitDiscordUpdate,
+            BenefitDownloadablesUpdate,
+            BenefitGitHubRepositoryUpdate,
+            BenefitSlackSharedChannelUpdate,
+        ],
+    )
+    def test_visibility_field_absent_from_non_configurable_update_schema(
         self,
+        update_schema: type[Schema],
     ) -> None:
-        assert "visibility" not in BenefitDiscordUpdate.model_fields
+        assert "visibility" not in update_schema.model_fields
 
     @pytest.mark.auth
     async def test_allows_visibility_update_for_custom_benefit(

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -604,82 +604,10 @@ class TestUpdate:
         assert properties["slack_integration_id"] == str(integration.id)
         assert properties["channel_name_template"] == "vip-{customer_name}"
 
-    @pytest.mark.auth
-    async def test_rejects_private_visibility_update_for_non_configurable_benefit(
+    async def test_visibility_field_absent_from_non_configurable_update_schema(
         self,
-        auth_subject: AuthSubject[User],
-        session: AsyncSession,
-        redis: Redis,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user_organization: UserOrganization,
     ) -> None:
-        benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            type=BenefitType.discord,
-            properties={
-                "guild_id": "123",
-                "role_id": "456",
-                "kick_member": False,
-            },
-        )
-
-        update_schema = BenefitDiscordUpdate.model_validate(
-            {"type": BenefitType.discord, "visibility": Visibility.private}
-        )
-
-        with pytest.raises(PolarRequestValidationError):
-            await benefit_service.update(
-                session, redis, benefit, update_schema, auth_subject
-            )
-
-    @pytest.mark.auth
-    @pytest.mark.parametrize(
-        ("visibility", "expected"),
-        [
-            (Visibility.public, Visibility.public),
-            (None, None),
-        ],
-    )
-    async def test_allows_public_visibility_update_for_non_configurable_benefit(
-        self,
-        visibility: Visibility | None,
-        expected: Visibility | None,
-        mocker: MockerFixture,
-        auth_subject: AuthSubject[User],
-        session: AsyncSession,
-        redis: Redis,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        mocker.patch.object(
-            benefit_grant_service,
-            "enqueue_benefit_grant_updates",
-            spec=BenefitGrantService.enqueue_benefit_grant_updates,
-        )
-
-        benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            type=BenefitType.discord,
-            properties={
-                "guild_id": "123",
-                "role_id": "456",
-                "kick_member": False,
-            },
-        )
-
-        update_schema = BenefitDiscordUpdate.model_validate(
-            {"type": BenefitType.discord, "visibility": visibility}
-        )
-
-        updated_benefit = await benefit_service.update(
-            session, redis, benefit, update_schema, auth_subject
-        )
-
-        assert updated_benefit.visibility == expected
+        assert "visibility" not in BenefitDiscordUpdate.model_fields
 
     @pytest.mark.auth
     async def test_allows_visibility_update_for_custom_benefit(

--- a/server/tests/models/test_benefit.py
+++ b/server/tests/models/test_benefit.py
@@ -36,24 +36,6 @@ class TestBenefitTypeVisibility:
     ) -> None:
         assert benefit_type.default_visibility() == expected
 
-    @pytest.mark.parametrize(
-        ("benefit_type", "visibility", "expected"),
-        [
-            # Configurable types allow any visibility.
-            (BenefitType.custom, Visibility.public, True),
-            (BenefitType.custom, Visibility.private, True),
-            (BenefitType.feature_flag, Visibility.private, True),
-            # Non-configurable types only allow public.
-            (BenefitType.discord, Visibility.public, True),
-            (BenefitType.discord, Visibility.private, False),
-            (BenefitType.downloadables, Visibility.private, False),
-        ],
-    )
-    def test_is_visibility_allowed(
-        self, benefit_type: BenefitType, visibility: Visibility, expected: bool
-    ) -> None:
-        assert benefit_type.is_visibility_allowed(visibility) is expected
-
     def test_resolve_visibility_forces_public_when_not_configurable(self) -> None:
         assert (
             BenefitType.discord.resolve_visibility(Visibility.private)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a regression by scoping the benefit visibility field to only configurable benefit types at the schema level. Non-configurable benefits now ignore visibility updates and stay public; the client no longer exposes that field for those updates.

- **Bug Fixes**
  - Added BenefitUpdateVisibilityMixin and applied it to configurable strategies: custom, feature_flag, license_keys, meter_credit.
  - Removed visibility from non-configurable update schemas and generated client; server ignores provided visibility and keeps public.
  - Removed redundant service-side validation and BenefitType.is_visibility_allowed; rely on schemas and default visibility resolution.
  - Updated tests to assert visibility is absent in non-configurable update schemas and that endpoints return 200 with public visibility.

<sup>Written for commit ca6723c8ff97a0333759b816039bcd6cbd0ab859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

