### PR TITLE
clients/web: add a white background around TOTP QR code enrollment

### DIFF
--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -58,7 +58,7 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
         </p>
 
         <div className="flex flex-col items-center gap-0">
-          <div className="dark:bg-polar-800 flex justify-center rounded-lg bg-white p-4">
+          <div className="flex justify-center rounded-lg bg-white p-4">
             <QRCode value={enrollment.provisioning_uri} size={200} />
           </div>
 


### PR DESCRIPTION
- clients/web: add a white background around TOTP QR code enrollment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force a white background around the TOTP enrollment QR code across themes to improve scan reliability. Removes the dark-mode background override so the QR code keeps a proper white quiet zone.

<sup>Written for commit bcfee445c00335f3a497ba74ef7ed82ee77aa7c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

