### PR TITLE
benefit/files: Prevent adding file IDs from another organization

### DIFF
--- a/server/polar/benefit/service.py
+++ b/server/polar/benefit/service.py
@@ -159,6 +159,7 @@ class BenefitService:
         benefit_strategy = get_benefit_strategy(create_schema.type, session, redis)
         properties = await benefit_strategy.validate_properties(
             auth_subject,
+            organization,
             create_schema.properties.model_dump(mode="json", by_alias=True),
         )
 
@@ -236,6 +237,7 @@ class BenefitService:
             benefit_strategy = get_benefit_strategy(benefit.type, session, redis)
             update_dict["properties"] = await benefit_strategy.validate_properties(
                 auth_subject,
+                benefit.organization,
                 properties_update.model_dump(mode="json", by_alias=True),
             )
 

--- a/server/polar/benefit/strategies/base/service.py
+++ b/server/polar/benefit/strategies/base/service.py
@@ -204,7 +204,10 @@ class BenefitServiceProtocol[BP: BenefitProperties, BGP: BenefitGrantProperties]
         ...
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BP:
         """
         Validates the benefit properties before creation.

--- a/server/polar/benefit/strategies/custom/service.py
+++ b/server/polar/benefit/strategies/custom/service.py
@@ -50,6 +50,9 @@ class BenefitCustomService(
         return False
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitCustomProperties:
         return cast(BenefitCustomProperties, properties)

--- a/server/polar/benefit/strategies/discord/service.py
+++ b/server/polar/benefit/strategies/discord/service.py
@@ -182,7 +182,10 @@ class BenefitDiscordService(
         )
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitDiscordProperties:
         guild_id: str = properties["guild_id"]
         role_id: str = properties["role_id"]

--- a/server/polar/benefit/strategies/downloadables/service.py
+++ b/server/polar/benefit/strategies/downloadables/service.py
@@ -6,17 +6,13 @@ from uuid import UUID
 import structlog
 
 from polar.auth.models import AuthSubject
-from polar.auth.permission import OrganizationPermission
-from polar.authz.service import get_accessible_org_ids
 from polar.customer_portal.service.downloadables import (
     downloadable as downloadable_service,
 )
-from polar.exceptions import ValidationError
-from polar.file.repository import FileRepository
 from polar.logging import Logger
-from polar.models import Benefit, Customer, File, Member, Organization, User
+from polar.models import Benefit, Customer, Member, Organization, User
 
-from ..base.service import BenefitPropertiesValidationError, BenefitServiceProtocol
+from ..base.service import BenefitServiceProtocol
 from . import schemas
 from .properties import (
     BenefitDownloadablesProperties,
@@ -113,29 +109,4 @@ class BenefitDownloadablesService(
     async def validate_properties(
         self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
     ) -> BenefitDownloadablesProperties:
-        file_ids = [UUID(file_id) for file_id in properties["files"]]
-        accessible_org_ids = await get_accessible_org_ids(
-            self.session,
-            auth_subject,
-            permission=OrganizationPermission.products_manage,
-        )
-        repository = FileRepository.from_session(self.session)
-        files = await repository.get_all(
-            repository.get_statement_by_org_ids(accessible_org_ids).where(
-                File.id.in_(file_ids)
-            )
-        )
-        accessible_file_ids = {file.id for file in files}
-        errors: list[ValidationError] = [
-            {
-                "type": "value_error",
-                "msg": "File not found.",
-                "loc": ("files", index),
-                "input": str(file_id),
-            }
-            for index, file_id in enumerate(file_ids)
-            if file_id not in accessible_file_ids
-        ]
-        if errors:
-            raise BenefitPropertiesValidationError(errors)
         return cast(BenefitDownloadablesProperties, properties)

--- a/server/polar/benefit/strategies/downloadables/service.py
+++ b/server/polar/benefit/strategies/downloadables/service.py
@@ -107,6 +107,9 @@ class BenefitDownloadablesService(
         return new_file_ids != previous_file_ids
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitDownloadablesProperties:
         return cast(BenefitDownloadablesProperties, properties)

--- a/server/polar/benefit/strategies/downloadables/service.py
+++ b/server/polar/benefit/strategies/downloadables/service.py
@@ -9,10 +9,12 @@ from polar.auth.models import AuthSubject
 from polar.customer_portal.service.downloadables import (
     downloadable as downloadable_service,
 )
+from polar.exceptions import ValidationError
+from polar.file.repository import FileRepository
 from polar.logging import Logger
-from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models import Benefit, Customer, File, Member, Organization, User
 
-from ..base.service import BenefitServiceProtocol
+from ..base.service import BenefitPropertiesValidationError, BenefitServiceProtocol
 from . import schemas
 from .properties import (
     BenefitDownloadablesProperties,
@@ -112,4 +114,25 @@ class BenefitDownloadablesService(
         organization: Organization,
         properties: dict[str, Any],
     ) -> BenefitDownloadablesProperties:
+        file_ids = [UUID(file_id) for file_id in properties["files"]]
+        repository = FileRepository.from_session(self.session)
+        files = await repository.get_all(
+            repository.get_base_statement().where(
+                File.organization_id == organization.id,
+                File.id.in_(file_ids),
+            )
+        )
+        accessible_file_ids = {file.id for file in files}
+        errors: list[ValidationError] = [
+            {
+                "type": "value_error",
+                "msg": "File not found.",
+                "loc": ("files", index),
+                "input": str(file_id),
+            }
+            for index, file_id in enumerate(file_ids)
+            if file_id not in accessible_file_ids
+        ]
+        if errors:
+            raise BenefitPropertiesValidationError(errors)
         return cast(BenefitDownloadablesProperties, properties)

--- a/server/polar/benefit/strategies/downloadables/service.py
+++ b/server/polar/benefit/strategies/downloadables/service.py
@@ -6,13 +6,17 @@ from uuid import UUID
 import structlog
 
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids
 from polar.customer_portal.service.downloadables import (
     downloadable as downloadable_service,
 )
+from polar.exceptions import ValidationError
+from polar.file.repository import FileRepository
 from polar.logging import Logger
-from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models import Benefit, Customer, File, Member, Organization, User
 
-from ..base.service import BenefitServiceProtocol
+from ..base.service import BenefitPropertiesValidationError, BenefitServiceProtocol
 from . import schemas
 from .properties import (
     BenefitDownloadablesProperties,
@@ -109,4 +113,29 @@ class BenefitDownloadablesService(
     async def validate_properties(
         self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
     ) -> BenefitDownloadablesProperties:
+        file_ids = [UUID(file_id) for file_id in properties["files"]]
+        accessible_org_ids = await get_accessible_org_ids(
+            self.session,
+            auth_subject,
+            permission=OrganizationPermission.products_manage,
+        )
+        repository = FileRepository.from_session(self.session)
+        files = await repository.get_all(
+            repository.get_statement_by_org_ids(accessible_org_ids).where(
+                File.id.in_(file_ids)
+            )
+        )
+        accessible_file_ids = {file.id for file in files}
+        errors: list[ValidationError] = [
+            {
+                "type": "value_error",
+                "msg": "File not found.",
+                "loc": ("files", index),
+                "input": str(file_id),
+            }
+            for index, file_id in enumerate(file_ids)
+            if file_id not in accessible_file_ids
+        ]
+        if errors:
+            raise BenefitPropertiesValidationError(errors)
         return cast(BenefitDownloadablesProperties, properties)

--- a/server/polar/benefit/strategies/feature_flag/service.py
+++ b/server/polar/benefit/strategies/feature_flag/service.py
@@ -52,6 +52,9 @@ class BenefitFeatureFlagService(
         return False
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitFeatureFlagProperties:
         return cast(BenefitFeatureFlagProperties, properties)

--- a/server/polar/benefit/strategies/github_repository/service.py
+++ b/server/polar/benefit/strategies/github_repository/service.py
@@ -246,7 +246,10 @@ class BenefitGitHubRepositoryService(
         )
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitGitHubRepositoryProperties:
         if is_organization(auth_subject):
             # TODO: Support organization tokens

--- a/server/polar/benefit/strategies/license_keys/service.py
+++ b/server/polar/benefit/strategies/license_keys/service.py
@@ -108,6 +108,9 @@ class BenefitLicenseKeysService(
         return diff_expires or diff_activations or diff_usage
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitLicenseKeysProperties:
         return cast(BenefitLicenseKeysProperties, properties)

--- a/server/polar/benefit/strategies/meter_credit/service.py
+++ b/server/polar/benefit/strategies/meter_credit/service.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, cast
 
 from polar.auth.models import AuthSubject
-from polar.authz.service import get_accessible_org_ids
+from polar.authz.types import AccessibleOrganizationID
 from polar.customer_meter.service import customer_meter as customer_meter_service
 from polar.event.repository import EventRepository
 from polar.event.service import event as event_service
@@ -145,9 +145,8 @@ class BenefitMeterCreditService(
         properties: dict[str, Any],
     ) -> BenefitMeterCreditProperties:
         meter_repository = MeterRepository.from_session(self.session)
-        org_ids = await get_accessible_org_ids(self.session, auth_subject)
         meter = await meter_repository.get_readable_by_id(
-            properties["meter_id"], org_ids
+            properties["meter_id"], {AccessibleOrganizationID(organization.id)}
         )
         if meter is None:
             raise BenefitPropertiesValidationError(

--- a/server/polar/benefit/strategies/meter_credit/service.py
+++ b/server/polar/benefit/strategies/meter_credit/service.py
@@ -139,7 +139,10 @@ class BenefitMeterCreditService(
         return False
 
     async def validate_properties(
-        self, auth_subject: AuthSubject[User | Organization], properties: dict[str, Any]
+        self,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        properties: dict[str, Any],
     ) -> BenefitMeterCreditProperties:
         meter_repository = MeterRepository.from_session(self.session)
         org_ids = await get_accessible_org_ids(self.session, auth_subject)

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -6,8 +6,6 @@ import httpx
 import structlog
 
 from polar.auth.models import AuthSubject
-from polar.auth.permission import OrganizationPermission
-from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.integrations.slack.client import SlackClient
 from polar.integrations.slack.repository import SlackAppRepository
@@ -284,12 +282,7 @@ class BenefitSlackSharedChannelService(
         integration_id = properties["slack_integration_id"]
         repository = SlackAppRepository.from_session(self.session)
         integration = await repository.get_by_id(UUID(integration_id))
-        accessible_org_ids = await get_accessible_org_ids(
-            self.session,
-            auth_subject,
-            permission=OrganizationPermission.products_manage,
-        )
-        if integration is None or integration.organization_id not in accessible_org_ids:
+        if integration is None or integration.organization_id != organization.id:
             raise BenefitPropertiesValidationError(
                 [
                     {

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -278,6 +278,7 @@ class BenefitSlackSharedChannelService(
     async def validate_properties(
         self,
         auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
         properties: dict[str, Any],
     ) -> BenefitSlackSharedChannelProperties:
         integration_id = properties["slack_integration_id"]

--- a/server/tests/benefit/strategies/test_downloadables.py
+++ b/server/tests/benefit/strategies/test_downloadables.py
@@ -1,32 +1,21 @@
 from typing import cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import pytest
 
-from polar.auth.models import AuthSubject
-from polar.benefit.strategies.base.service import BenefitPropertiesValidationError
 from polar.benefit.strategies.downloadables.properties import (
     BenefitDownloadablesProperties,
 )
 from polar.benefit.strategies.downloadables.schemas import (
     BenefitDownloadablesCreateProperties,
 )
-from polar.benefit.strategies.downloadables.service import BenefitDownloadablesService
 from polar.file.schemas import FileRead
-from polar.models import (
-    Customer,
-    Downloadable,
-    Organization,
-    Product,
-    User,
-    UserOrganization,
-)
+from polar.models import Customer, Downloadable, Organization, Product
 from polar.models.downloadable import DownloadableStatus
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.downloadable import TestDownloadable
-from tests.fixtures.file import TestFile, uploaded_fixture
 
 
 @pytest.mark.asyncio
@@ -519,60 +508,3 @@ class TestDownloadblesBenefit:
         by_file = {d.file_id: d for d in downloadables}
         assert by_file[uploaded_logo_jpg.id].status == DownloadableStatus.granted
         assert by_file[uploaded_logo_png.id].status == DownloadableStatus.revoked
-
-
-@pytest.mark.asyncio
-class TestValidateProperties:
-    @pytest.mark.auth
-    async def test_valid(
-        self,
-        session: AsyncSession,
-        redis: Redis,
-        auth_subject: AuthSubject[User],
-        user_organization: UserOrganization,
-        uploaded_logo_jpg: FileRead,
-    ) -> None:
-        service = BenefitDownloadablesService(session, redis)
-
-        properties = await service.validate_properties(
-            auth_subject,
-            {"archived": {}, "files": [str(uploaded_logo_jpg.id)]},
-        )
-
-        assert properties["files"] == [str(uploaded_logo_jpg.id)]
-
-    @pytest.mark.auth
-    async def test_file_from_other_organization(
-        self,
-        session: AsyncSession,
-        redis: Redis,
-        auth_subject: AuthSubject[User],
-        user_organization: UserOrganization,
-        organization_second: Organization,
-    ) -> None:
-        other_file = await uploaded_fixture(
-            session, organization_second, TestFile("logo.jpg")
-        )
-        service = BenefitDownloadablesService(session, redis)
-
-        with pytest.raises(BenefitPropertiesValidationError):
-            await service.validate_properties(
-                auth_subject,
-                {"archived": {}, "files": [str(other_file.id)]},
-            )
-
-    @pytest.mark.auth
-    async def test_unknown_file(
-        self,
-        session: AsyncSession,
-        redis: Redis,
-        auth_subject: AuthSubject[User],
-        user_organization: UserOrganization,
-    ) -> None:
-        service = BenefitDownloadablesService(session, redis)
-
-        with pytest.raises(BenefitPropertiesValidationError):
-            await service.validate_properties(
-                auth_subject,
-                {"archived": {}, "files": [str(uuid4())]},
-            )

--- a/server/tests/benefit/strategies/test_downloadables.py
+++ b/server/tests/benefit/strategies/test_downloadables.py
@@ -1,21 +1,32 @@
 from typing import cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
+from polar.auth.models import AuthSubject
+from polar.benefit.strategies.base.service import BenefitPropertiesValidationError
 from polar.benefit.strategies.downloadables.properties import (
     BenefitDownloadablesProperties,
 )
 from polar.benefit.strategies.downloadables.schemas import (
     BenefitDownloadablesCreateProperties,
 )
+from polar.benefit.strategies.downloadables.service import BenefitDownloadablesService
 from polar.file.schemas import FileRead
-from polar.models import Customer, Downloadable, Organization, Product
+from polar.models import (
+    Customer,
+    Downloadable,
+    Organization,
+    Product,
+    User,
+    UserOrganization,
+)
 from polar.models.downloadable import DownloadableStatus
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.downloadable import TestDownloadable
+from tests.fixtures.file import TestFile, uploaded_fixture
 
 
 @pytest.mark.asyncio
@@ -508,3 +519,60 @@ class TestDownloadblesBenefit:
         by_file = {d.file_id: d for d in downloadables}
         assert by_file[uploaded_logo_jpg.id].status == DownloadableStatus.granted
         assert by_file[uploaded_logo_png.id].status == DownloadableStatus.revoked
+
+
+@pytest.mark.asyncio
+class TestValidateProperties:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        uploaded_logo_jpg: FileRead,
+    ) -> None:
+        service = BenefitDownloadablesService(session, redis)
+
+        properties = await service.validate_properties(
+            auth_subject,
+            {"archived": {}, "files": [str(uploaded_logo_jpg.id)]},
+        )
+
+        assert properties["files"] == [str(uploaded_logo_jpg.id)]
+
+    @pytest.mark.auth
+    async def test_file_from_other_organization(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        organization_second: Organization,
+    ) -> None:
+        other_file = await uploaded_fixture(
+            session, organization_second, TestFile("logo.jpg")
+        )
+        service = BenefitDownloadablesService(session, redis)
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await service.validate_properties(
+                auth_subject,
+                {"archived": {}, "files": [str(other_file.id)]},
+            )
+
+    @pytest.mark.auth
+    async def test_unknown_file(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+    ) -> None:
+        service = BenefitDownloadablesService(session, redis)
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await service.validate_properties(
+                auth_subject,
+                {"archived": {}, "files": [str(uuid4())]},
+            )

--- a/server/tests/benefit/strategies/test_downloadables.py
+++ b/server/tests/benefit/strategies/test_downloadables.py
@@ -1,21 +1,32 @@
 from typing import cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
+from polar.auth.models import AuthSubject
+from polar.benefit.strategies.base.service import BenefitPropertiesValidationError
 from polar.benefit.strategies.downloadables.properties import (
     BenefitDownloadablesProperties,
 )
 from polar.benefit.strategies.downloadables.schemas import (
     BenefitDownloadablesCreateProperties,
 )
+from polar.benefit.strategies.downloadables.service import BenefitDownloadablesService
 from polar.file.schemas import FileRead
-from polar.models import Customer, Downloadable, Organization, Product
+from polar.models import (
+    Customer,
+    Downloadable,
+    Organization,
+    Product,
+    User,
+    UserOrganization,
+)
 from polar.models.downloadable import DownloadableStatus
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.downloadable import TestDownloadable
+from tests.fixtures.file import TestFile, uploaded_fixture
 
 
 @pytest.mark.asyncio
@@ -508,3 +519,66 @@ class TestDownloadblesBenefit:
         by_file = {d.file_id: d for d in downloadables}
         assert by_file[uploaded_logo_jpg.id].status == DownloadableStatus.granted
         assert by_file[uploaded_logo_png.id].status == DownloadableStatus.revoked
+
+
+@pytest.mark.asyncio
+class TestValidateProperties:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        uploaded_logo_jpg: FileRead,
+    ) -> None:
+        service = BenefitDownloadablesService(session, redis)
+
+        properties = await service.validate_properties(
+            auth_subject,
+            organization,
+            {"archived": {}, "files": [str(uploaded_logo_jpg.id)]},
+        )
+
+        assert properties["files"] == [str(uploaded_logo_jpg.id)]
+
+    @pytest.mark.auth
+    async def test_file_from_other_organization(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        organization_second: Organization,
+    ) -> None:
+        other_file = await uploaded_fixture(
+            session, organization_second, TestFile("logo.jpg")
+        )
+        service = BenefitDownloadablesService(session, redis)
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await service.validate_properties(
+                auth_subject,
+                organization,
+                {"archived": {}, "files": [str(other_file.id)]},
+            )
+
+    @pytest.mark.auth
+    async def test_unknown_file(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        service = BenefitDownloadablesService(session, redis)
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await service.validate_properties(
+                auth_subject,
+                organization,
+                {"archived": {}, "files": [str(uuid4())]},
+            )

--- a/server/tests/benefit/strategies/test_meter_credit.py
+++ b/server/tests/benefit/strategies/test_meter_credit.py
@@ -1,11 +1,23 @@
+from uuid import uuid4
+
 import pytest
 
+from polar.auth.models import AuthSubject
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
+from polar.benefit.strategies.base.service import BenefitPropertiesValidationError
+from polar.benefit.strategies.meter_credit.service import BenefitMeterCreditService
 from polar.customer_meter.repository import CustomerMeterRepository
 from polar.customer_meter.service import customer_meter as customer_meter_service
 from polar.meter.aggregation import AggregationFunction, PropertyAggregation
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
-from polar.models import Customer, Organization, Product, Subscription
+from polar.models import (
+    Customer,
+    Organization,
+    Product,
+    Subscription,
+    User,
+    UserOrganization,
+)
 from polar.models.benefit import BenefitType
 from polar.postgres import AsyncSession
 from polar.redis import Redis
@@ -290,3 +302,66 @@ class TestMeterCreditBenefitIntegration:
         # 80 units of pre-upgrade usage carry over against the new allowance
         assert customer_meter.consumed_units == 80
         assert customer_meter.balance == 920
+
+
+@pytest.mark.asyncio
+class TestValidateProperties:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        meter = await create_meter(save_fixture, organization=organization)
+        service = BenefitMeterCreditService(session, redis)
+
+        properties = await service.validate_properties(
+            auth_subject,
+            organization,
+            {"meter_id": str(meter.id), "units": 100, "rollover": False},
+        )
+
+        assert properties["meter_id"] == str(meter.id)
+
+    @pytest.mark.auth
+    async def test_meter_from_other_organization(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        organization_second: Organization,
+    ) -> None:
+        other_meter = await create_meter(save_fixture, organization=organization_second)
+        service = BenefitMeterCreditService(session, redis)
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await service.validate_properties(
+                auth_subject,
+                organization,
+                {"meter_id": str(other_meter.id), "units": 100, "rollover": False},
+            )
+
+    @pytest.mark.auth
+    async def test_unknown_meter(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        service = BenefitMeterCreditService(session, redis)
+
+        with pytest.raises(BenefitPropertiesValidationError):
+            await service.validate_properties(
+                auth_subject,
+                organization,
+                {"meter_id": str(uuid4()), "units": 100, "rollover": False},
+            )

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1462,6 +1462,7 @@ class TestSlackSharedChannelValidate:
 
         result = await strategy.validate_properties(
             auth_subject,
+            organization,
             {**_BASE_PROPERTIES, "slack_integration_id": str(integration.id)},
         )
 
@@ -1473,6 +1474,7 @@ class TestSlackSharedChannelValidate:
         session: AsyncSession,
         redis: Redis,
         mocker: MockerFixture,
+        organization: Organization,
         auth_subject: AuthSubject[User],
         user_organization: UserOrganization,
     ) -> None:
@@ -1481,6 +1483,7 @@ class TestSlackSharedChannelValidate:
         with pytest.raises(BenefitPropertiesValidationError):
             await strategy.validate_properties(
                 auth_subject,
+                organization,
                 {**_BASE_PROPERTIES, "slack_integration_id": str(uuid4())},
             )
 
@@ -1507,6 +1510,7 @@ class TestSlackSharedChannelValidate:
         with pytest.raises(BenefitPropertiesValidationError):
             await strategy.validate_properties(
                 auth_subject,
+                organization,
                 {**_BASE_PROPERTIES, "slack_integration_id": str(integration.id)},
             )
 
@@ -1517,6 +1521,7 @@ class TestSlackSharedChannelValidate:
         redis: Redis,
         save_fixture: SaveFixture,
         mocker: MockerFixture,
+        organization: Organization,
         organization_second: Organization,
         auth_subject: AuthSubject[User],
         user_organization: UserOrganization,
@@ -1533,6 +1538,7 @@ class TestSlackSharedChannelValidate:
         with pytest.raises(BenefitPropertiesValidationError):
             await strategy.validate_properties(
                 auth_subject,
+                organization,
                 {**_BASE_PROPERTIES, "slack_integration_id": str(integration.id)},
             )
 


### PR DESCRIPTION
The file IDs are -unknown and unguessable-, since they are UUIDs. Someone will only get a file ID if they also have access to the file. It is however still a smell that one org can add another org's file IDs directly to their benefits.

This ensures that the file IDs that are posted to the benefit are actually owned and accessible by the organization that is creating the benefit.

Reviewable commit-by-commit:
* Skip first 2 commits
* Adds the organization id to benefits validate_properties
* Uses it for files
* Uses it for slack
* Uses it for meters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate benefit properties against the benefit’s organization to prevent cross-tenant attachments. Enforces org ownership for files, meters, and Slack integrations, with clear field-level errors.

- **Bug Fixes**
  - Downloadables: Only accept file IDs owned by the benefit’s organization via `FileRepository`; raise `BenefitPropertiesValidationError` for unknown/foreign IDs.
  - Meter credit: Ensure `meter_id` belongs to the benefit’s organization during validation.
  - Slack shared channel: Verify the Slack integration’s org matches the benefit’s organization.
  - Added tests for valid, cross-organization, and unknown cases for these strategies.

- **Refactors**
  - Thread `organization` into `validate_properties` across all benefit strategies and service calls.

<sup>Written for commit 71909c3dab68d2259758c384280952a3d0c03078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

