### PR TITLE
rbac: Disallow members from issuing org tokens with more access

### DIFF
--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -17,6 +17,7 @@ for a future self-serve transfer flow and will be owner-only when introduced.
 
 from enum import StrEnum
 
+from polar.auth.scope import Scope
 from polar.models.user_organization import OrganizationRole
 
 
@@ -112,3 +113,86 @@ def roles_with_permission(
 ) -> set[OrganizationRole]:
     """Return the set of roles that grant the given permission."""
     return {role for role, perms in ROLE_PERMISSIONS.items() if permission in perms}
+
+
+# Maps each API `Scope` to the `OrganizationPermission`s that gate it, so an
+# organization-subject token issued by a member can be limited to the scopes
+# their role permits (org tokens bypass the role gate at request time, so a
+# member would otherwise escalate past their role). A scope is allowed for a
+# role iff every permission gating it is held by the role; this is the union of
+# permissions enforced by any endpoint reachable with the scope, so a scope
+# fronting an admin-only permission anywhere is withheld from members. An empty
+# set means no role-permission gates the scope (user-account scopes, or org
+# scopes gated only by membership today), so it is allowed for every role.
+_O = OrganizationPermission
+SCOPE_PERMISSIONS: dict[Scope, set[OrganizationPermission]] = {
+    Scope.openid: set(),
+    Scope.profile: set(),
+    Scope.email: set(),
+    Scope.user_read: set(),
+    Scope.user_write: set(),
+    Scope.notifications_read: set(),
+    Scope.notifications_write: set(),
+    Scope.notification_recipients_read: set(),
+    Scope.notification_recipients_write: set(),
+    Scope.customer_portal_read: set(),
+    Scope.customer_portal_write: set(),
+    Scope.member_sessions_write: set(),
+    Scope.wallets_read: set(),
+    Scope.wallets_write: set(),
+    Scope.customer_sessions_write: set(),
+    Scope.organizations_read: {_O.organization_manage},
+    Scope.organizations_write: {_O.organization_manage},
+    Scope.webhooks_read: {_O.organization_manage},
+    Scope.webhooks_write: {_O.organization_manage},
+    Scope.organization_access_tokens_read: {_O.organization_manage},
+    Scope.organization_access_tokens_write: {_O.organization_manage},
+    Scope.members_write: {_O.members_manage},
+    Scope.transactions_read: {_O.finance_read},
+    Scope.transactions_write: {_O.finance_manage},
+    Scope.payouts_read: {_O.finance_read},
+    Scope.payouts_write: {_O.finance_manage},
+    Scope.members_read: {_O.members_read},
+    Scope.products_read: {_O.products_read},
+    Scope.products_write: {_O.products_manage},
+    Scope.benefits_read: {_O.products_read},
+    Scope.benefits_write: {_O.products_manage},
+    Scope.discounts_read: {_O.products_read},
+    Scope.discounts_write: {_O.products_manage},
+    Scope.checkout_links_read: {_O.products_read},
+    Scope.checkout_links_write: {_O.products_manage},
+    Scope.files_read: {_O.products_read},
+    Scope.files_write: {_O.products_manage},
+    Scope.meters_read: {_O.products_read},
+    Scope.meters_write: {_O.products_manage},
+    Scope.license_keys_read: {_O.products_read},
+    Scope.license_keys_write: {_O.products_manage},
+    Scope.custom_fields_read: {_O.custom_fields_read},
+    Scope.custom_fields_write: {_O.custom_fields_manage},
+    Scope.customers_read: {_O.customers_read},
+    Scope.customers_write: {_O.customers_manage},
+    Scope.customer_seats_read: {_O.customers_read},
+    Scope.customer_seats_write: {_O.customers_manage},
+    Scope.checkouts_read: {_O.sales_read},
+    Scope.checkouts_write: {_O.sales_manage},
+    Scope.subscriptions_read: {_O.sales_read},
+    Scope.subscriptions_write: {_O.sales_manage},
+    Scope.orders_read: {_O.sales_read},
+    Scope.orders_write: {_O.sales_manage},
+    Scope.refunds_read: {_O.sales_read},
+    Scope.refunds_write: {_O.sales_manage},
+    Scope.payments_read: {_O.sales_read},
+    Scope.disputes_read: {_O.sales_read},
+    Scope.metrics_read: {_O.analytics_read},
+    Scope.metrics_write: {_O.analytics_manage},
+    Scope.events_read: {_O.analytics_read},
+    Scope.events_write: {_O.events_ingest},
+    Scope.customer_meters_read: {_O.analytics_read},
+}
+
+
+def allowed_scopes_for_role(role: OrganizationRole) -> set[Scope]:
+    """Return the scopes a role may exercise through an organization-subject
+    token: those whose gating permissions are all held by the role."""
+    perms = ROLE_PERMISSIONS[role]
+    return {scope for scope, required in SCOPE_PERMISSIONS.items() if required <= perms}

--- a/server/polar/oauth2/grants/authorization_code.py
+++ b/server/polar/oauth2/grants/authorization_code.py
@@ -26,9 +26,11 @@ from polar.models import (
     User,
     UserOrganization,
 )
+from polar.models.user_organization import OrganizationRole
 
 from ..constants import AUTHORIZATION_CODE_PREFIX, JWT_CONFIG
 from ..requests import StarletteOAuth2Request
+from ..scopes import restrict_scope_to_role
 from ..service.oauth2_grant import oauth2_grant as oauth2_grant_service
 from ..sub_type import SubType, SubTypeValue
 from ..userinfo import UserInfo, generate_user_info
@@ -238,10 +240,13 @@ class ValidateSubAndPrompt:
                 sub_uuid = uuid.UUID(sub)
             except ValueError as e:
                 raise InvalidSubError() from e
-            organization = self._get_organization_admin(sub_uuid, user)
-            if organization is None:
+            membership = self._get_organization_membership(sub_uuid, user)
+            if membership is None:
                 raise InvalidSubError()
+            organization, role = membership
             grant.sub = organization
+            if payload.scope:
+                payload.data["scope"] = restrict_scope_to_role(payload.scope, role)
 
     def _validate_scope_consent(
         self,
@@ -308,11 +313,11 @@ class ValidateSubAndPrompt:
         if grant.sub is None:
             raise InvalidSubError()
 
-    def _get_organization_admin(
+    def _get_organization_membership(
         self, organization_id: uuid.UUID, user: User
-    ) -> Organization | None:
+    ) -> tuple[Organization, OrganizationRole] | None:
         statement = (
-            select(Organization)
+            select(Organization, UserOrganization.role)
             .join(
                 UserOrganization,
                 onclause=and_(
@@ -323,4 +328,7 @@ class ValidateSubAndPrompt:
             .where(Organization.id == organization_id)
         )
         result = self._session.execute(statement)
-        return result.unique().scalar_one_or_none()
+        row = result.unique().one_or_none()
+        if row is None:
+            return None
+        return row[0], row[1]

--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -16,13 +16,17 @@ from polar.config import settings
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
 from polar.models import Organization, User, UserOrganization, UserSession
+from polar.models.user_organization import OrganizationRole
 
+from ..scopes import restrict_scope_to_role
 from ..sub_type import SubType, SubTypeValue
 
 
 class WebGrant(BaseGrant, TokenEndpointMixin):
     GRANT_TYPE = "web"
     TOKEN_ENDPOINT_AUTH_METHODS = ["client_secret_basic", "client_secret_post"]
+
+    _organization_role: OrganizationRole | None = None
 
     def validate_token_request(self) -> None:
         client = self._validate_request_client()
@@ -35,6 +39,9 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
         client = self.request.client
         sub_type_value = self.request.user
         scope = self.request.payload.scope or client.scope
+
+        if self._organization_role is not None:
+            scope = restrict_scope_to_role(scope, self._organization_role)
 
         token = self.generate_token(
             user=sub_type_value, scope=scope, include_refresh_token=False
@@ -98,19 +105,20 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
                 sub_uuid = uuid.UUID(sub)
             except ValueError as e:
                 raise InvalidRequestError("Invalid 'sub' UUID") from e
-            organization = self._get_organization_admin(sub_uuid, user)
-            if organization is None:
+            membership = self._get_organization_membership(sub_uuid, user)
+            if membership is None:
                 raise InvalidGrantError()
+            organization, self._organization_role = membership
             sub_value = organization
 
         assert sub_value is not None
         return sub_type, sub_value
 
-    def _get_organization_admin(
+    def _get_organization_membership(
         self, organization_id: uuid.UUID, user: User
-    ) -> Organization | None:
+    ) -> tuple[Organization, OrganizationRole] | None:
         statement = (
-            select(Organization)
+            select(Organization, UserOrganization.role)
             .join(
                 UserOrganization,
                 onclause=and_(
@@ -121,4 +129,7 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
             .where(Organization.id == organization_id)
         )
         result = self.server.session.execute(statement)
-        return result.unique().scalar_one_or_none()
+        row = result.unique().one_or_none()
+        if row is None:
+            return None
+        return row[0], row[1]

--- a/server/polar/oauth2/scopes.py
+++ b/server/polar/oauth2/scopes.py
@@ -1,0 +1,8 @@
+from polar.auth.permission import allowed_scopes_for_role
+from polar.auth.scope import Scope
+from polar.models.user_organization import OrganizationRole
+
+
+def restrict_scope_to_role(scope: str, role: OrganizationRole) -> str:
+    allowed = allowed_scopes_for_role(role)
+    return " ".join(s for s in scope.split() if Scope(s) in allowed)

--- a/server/tests/authz/test_permission.py
+++ b/server/tests/authz/test_permission.py
@@ -1,0 +1,77 @@
+from polar.auth.permission import (
+    ROLE_PERMISSIONS,
+    SCOPE_PERMISSIONS,
+    OrganizationPermission,
+    allowed_scopes_for_role,
+)
+from polar.auth.scope import Scope
+from polar.models.user_organization import OrganizationRole
+from polar.oauth2.scopes import restrict_scope_to_role
+
+ADMIN_ONLY_SCOPES = {
+    Scope.organizations_read,
+    Scope.organizations_write,
+    Scope.members_write,
+    Scope.webhooks_read,
+    Scope.webhooks_write,
+    Scope.organization_access_tokens_read,
+    Scope.organization_access_tokens_write,
+    Scope.transactions_read,
+    Scope.transactions_write,
+    Scope.payouts_read,
+    Scope.payouts_write,
+}
+
+
+def test_scope_permissions_covers_every_scope() -> None:
+    assert set(SCOPE_PERMISSIONS) == set(Scope)
+
+
+def test_owner_and_admin_allow_every_scope() -> None:
+    assert allowed_scopes_for_role(OrganizationRole.owner) == set(Scope)
+    assert allowed_scopes_for_role(OrganizationRole.admin) == set(Scope)
+
+
+def test_member_excludes_admin_only_scopes() -> None:
+    member_scopes = allowed_scopes_for_role(OrganizationRole.member)
+    assert set(Scope) - member_scopes == ADMIN_ONLY_SCOPES
+
+
+def test_member_keeps_resource_scopes() -> None:
+    member_scopes = allowed_scopes_for_role(OrganizationRole.member)
+    for scope in (
+        Scope.products_write,
+        Scope.customers_write,
+        Scope.orders_write,
+        Scope.metrics_read,
+        Scope.events_write,
+        Scope.members_read,
+        Scope.openid,
+    ):
+        assert scope in member_scopes
+
+
+def test_member_only_permissions_never_gate_admin_only_scope() -> None:
+    member_permissions = ROLE_PERMISSIONS[OrganizationRole.member]
+    admin_only = {
+        OrganizationPermission.organization_manage,
+        OrganizationPermission.members_manage,
+        OrganizationPermission.finance_read,
+        OrganizationPermission.finance_manage,
+    }
+    for scope in ADMIN_ONLY_SCOPES:
+        assert SCOPE_PERMISSIONS[scope] & admin_only
+        assert not SCOPE_PERMISSIONS[scope] <= member_permissions
+
+
+def test_restrict_scope_to_role_filters_member_scopes() -> None:
+    restricted = restrict_scope_to_role(
+        "products:write organizations:write transactions:read members:read",
+        OrganizationRole.member,
+    )
+    assert restricted.split() == ["products:write", "members:read"]
+
+
+def test_restrict_scope_to_role_keeps_all_for_owner() -> None:
+    scope = "products:write organizations:write transactions:read"
+    assert restrict_scope_to_role(scope, OrganizationRole.owner) == scope

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -18,6 +18,7 @@ from polar.models import (
     UserOrganization,
     UserSession,
 )
+from polar.models.user_organization import OrganizationRole
 from polar.oauth2.service.oauth2_grant import oauth2_grant as oauth2_grant_service
 from polar.oauth2.sub_type import SubType
 from tests.fixtures.auth import AuthSubjectFixture
@@ -116,6 +117,33 @@ async def web_grant_oauth2_client(
             "grant_types": ["web"],
             "response_types": [],
             "scope": "openid profile email",
+        }
+    )
+    await save_fixture(oauth2_client)
+    return oauth2_client
+
+
+@pytest_asyncio.fixture
+async def web_grant_oauth2_client_broad_scope(
+    save_fixture: SaveFixture, user: User
+) -> OAuth2Client:
+    oauth2_client = OAuth2Client(
+        client_id="polar_ci_456",
+        client_secret="polar_cs_456",
+        registration_access_token="polar_crt_456",
+        user=user,
+    )
+    oauth2_client.set_client_metadata(
+        {
+            "client_name": "Broad Scope Client",
+            "redirect_uris": ["http://127.0.0.1:8000/docs/oauth2-redirect"],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": ["web"],
+            "response_types": [],
+            "scope": (
+                "openid products:write organizations:write "
+                "transactions:read members:read"
+            ),
         }
     )
     await save_fixture(oauth2_client)
@@ -740,6 +768,33 @@ class TestOAuth2Authorize:
         assert response.status_code == 302
         location = response.headers["location"]
         assert "error=consent_required" in location
+
+    @pytest.mark.auth
+    async def test_organization_member_restricted_scopes(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        oauth2_client: OAuth2Client,
+    ) -> None:
+        member = UserOrganization(
+            user=user, organization=organization, role=OrganizationRole.member
+        )
+        await save_fixture(member)
+        params = {
+            "client_id": oauth2_client.client_id,
+            "response_type": "code",
+            "redirect_uri": "http://127.0.0.1:8000/docs/oauth2-redirect",
+            "scope": "openid products:write organizations:write transactions:read",
+            "sub_type": "organization",
+            "sub": str(organization.id),
+            "prompt": "consent",
+        }
+        response = await client.get("/v1/oauth2/authorize", params=params)
+
+        json = response.json()
+        assert set(json["scopes"]) == {"openid", "products:write"}
 
 
 @pytest.mark.asyncio
@@ -1383,3 +1438,92 @@ class TestOAuth2Token:
         access_token = json["access_token"]
         assert access_token.startswith("polar_at_o_")
         assert "refresh_token" not in json
+
+    async def test_web_grant_sub_organization_member_restricted_scopes(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        web_grant_oauth2_client_broad_scope: OAuth2Client,
+    ) -> None:
+        member = UserOrganization(
+            user=user, organization=organization, role=OrganizationRole.member
+        )
+        await save_fixture(member)
+
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client_broad_scope.client_id,
+            "client_secret": web_grant_oauth2_client_broad_scope.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["access_token"].startswith("polar_at_o_")
+        assert set(json["scope"].split()) == {
+            "openid",
+            "products:write",
+            "members:read",
+        }
+
+    async def test_web_grant_sub_organization_owner_keeps_scopes(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+        web_grant_oauth2_client_broad_scope: OAuth2Client,
+    ) -> None:
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client_broad_scope.client_id,
+            "client_secret": web_grant_oauth2_client_broad_scope.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 200
+        json = response.json()
+        assert set(json["scope"].split()) == {
+            "openid",
+            "products:write",
+            "organizations:write",
+            "transactions:read",
+            "members:read",
+        }


### PR DESCRIPTION
Now that we have RBAC, a member role should not be able to issue tokens org tokens that gets more access than they have themselves.

Org tokens are not gated by the role of the issuer.

This ensures that someone cannot create tokens that has more access than they themselves already have.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents organization members from issuing org tokens with more access than their role. Org-subject tokens now auto-trim scopes to the issuer’s role to block privilege escalation.

- **Bug Fixes**
  - Added scope-to-permission map and `allowed_scopes_for_role`, plus `restrict_scope_to_role` to filter requested scopes.
  - Updated Authorization Code and Web grants to resolve org membership/role and restrict scopes when `sub_type=organization`.
  - Added tests for member-restricted scopes and for owner/admin keeping full scopes.

<sup>Written for commit c6e36b809b7c0ea49e6bf8a6ba93a6452bc04c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

