### PR TITLE
oauth2: Only allow issuing oauth tokens for permission

### DIFF
--- a/server/polar/oauth2/endpoints/oauth2.py
+++ b/server/polar/oauth2/endpoints/oauth2.py
@@ -6,7 +6,9 @@ from fastapi.openapi.constants import REF_TEMPLATE
 
 from polar.auth.dependencies import WebUserOrAnonymous
 from polar.auth.models import is_user
+from polar.auth.permission import OrganizationPermission
 from polar.authz.dependencies import AuthorizeWebUserRead, AuthorizeWebUserWrite
+from polar.authz.service import get_accessible_org_ids
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models import OAuth2Token, Organization
 from polar.openapi import APITag
@@ -169,10 +171,20 @@ async def authorize(
     organizations: Sequence[Organization] | None = None
     if grant.sub_type == SubType.organization:
         assert is_user(auth_subject)
+        manageable_org_ids = await get_accessible_org_ids(
+            session,
+            auth_subject,
+            permission=OrganizationPermission.organization_manage,
+        )
         organization_repository = OrganizationRepository.from_session(session)
-        organizations = await organization_repository.get_all_by_user(
+        all_organizations = await organization_repository.get_all_by_user(
             auth_subject.subject.id
         )
+        organizations = [
+            organization
+            for organization in all_organizations
+            if organization.id in manageable_org_ids
+        ]
 
     payload = grant.request.payload
     assert payload is not None

--- a/server/polar/oauth2/grants/authorization_code.py
+++ b/server/polar/oauth2/grants/authorization_code.py
@@ -14,9 +14,11 @@ from authlib.oauth2.rfc7636 import CodeChallenge as _CodeChallenge
 from authlib.oidc.core.errors import ConsentRequiredError, LoginRequiredError
 from authlib.oidc.core.grants import OpenIDCode as _OpenIDCode
 from authlib.oidc.core.grants import OpenIDToken as _OpenIDToken
-from sqlalchemy import and_, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.kit.crypto import generate_token, get_token_hash
 from polar.models import (
@@ -24,7 +26,6 @@ from polar.models import (
     OAuth2Client,
     Organization,
     User,
-    UserOrganization,
 )
 
 from ..constants import AUTHORIZATION_CODE_PREFIX, JWT_CONFIG
@@ -311,16 +312,14 @@ class ValidateSubAndPrompt:
     def _get_organization_admin(
         self, organization_id: uuid.UUID, user: User
     ) -> Organization | None:
-        statement = (
-            select(Organization)
-            .join(
-                UserOrganization,
-                onclause=and_(
-                    UserOrganization.user_id == user.id,
-                    UserOrganization.is_deleted.is_(False),
-                ),
-            )
-            .where(Organization.id == organization_id)
+        statement = select(Organization).where(
+            Organization.id == organization_id,
+            Organization.id.in_(
+                select_user_org_ids(
+                    user.id,
+                    permission=OrganizationPermission.organization_manage,
+                )
+            ),
         )
         result = self._session.execute(statement)
         return result.unique().scalar_one_or_none()

--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -10,12 +10,14 @@ from authlib.oauth2.rfc6749.errors import (
 )
 from authlib.oauth2.rfc6749.grants import BaseGrant, TokenEndpointMixin
 from authlib.oauth2.rfc6749.hooks import hooked
-from sqlalchemy import and_, select
+from sqlalchemy import select
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
-from polar.models import Organization, User, UserOrganization, UserSession
+from polar.models import Organization, User, UserSession
 
 from ..sub_type import SubType, SubTypeValue
 
@@ -109,16 +111,14 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
     def _get_organization_admin(
         self, organization_id: uuid.UUID, user: User
     ) -> Organization | None:
-        statement = (
-            select(Organization)
-            .join(
-                UserOrganization,
-                onclause=and_(
-                    UserOrganization.user_id == user.id,
-                    UserOrganization.is_deleted.is_(False),
-                ),
-            )
-            .where(Organization.id == organization_id)
+        statement = select(Organization).where(
+            Organization.id == organization_id,
+            Organization.id.in_(
+                select_user_org_ids(
+                    user.id,
+                    permission=OrganizationPermission.organization_manage,
+                )
+            ),
         )
         result = self.server.session.execute(statement)
         return result.unique().scalar_one_or_none()

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -18,6 +18,7 @@ from polar.models import (
     UserOrganization,
     UserSession,
 )
+from polar.models.user_organization import OrganizationRole
 from polar.oauth2.service.oauth2_grant import oauth2_grant as oauth2_grant_service
 from polar.oauth2.sub_type import SubType
 from tests.fixtures.auth import AuthSubjectFixture
@@ -741,6 +742,36 @@ class TestOAuth2Authorize:
         location = response.headers["location"]
         assert "error=consent_required" in location
 
+    @pytest.mark.auth
+    async def test_organization_list_excludes_member_without_manage(
+        self,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        oauth2_client: OAuth2Client,
+        save_fixture: SaveFixture,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization,
+                role=OrganizationRole.member,
+            )
+        )
+        params = {
+            "client_id": oauth2_client.client_id,
+            "response_type": "code",
+            "redirect_uri": "http://127.0.0.1:8000/docs/oauth2-redirect",
+            "scope": "openid profile email",
+            "sub_type": "organization",
+        }
+        response = await client.get("/v1/oauth2/authorize", params=params)
+
+        assert response.status_code == 200
+        json = response.json()
+        org_ids = {o["id"] for o in (json.get("organizations") or [])}
+        assert str(organization.id) not in org_ids
+
 
 @pytest.mark.asyncio
 class TestOAuth2Consent:
@@ -832,6 +863,73 @@ class TestOAuth2Consent:
         oauth2_client: OAuth2Client,
         sync_session: Session,
     ) -> None:
+        params = {
+            "client_id": oauth2_client.client_id,
+            "response_type": "code",
+            "redirect_uri": "http://127.0.0.1:8000/docs/oauth2-redirect",
+            "scope": "openid profile email",
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+        response = await client.post(
+            "/v1/oauth2/consent", params=params, data={"action": "allow"}
+        )
+
+        assert response.status_code == 400
+        json = response.json()
+        assert json["error"] == "invalid_sub"
+
+    @pytest.mark.auth
+    async def test_organization_member_without_manage_forbidden(
+        self,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        oauth2_client: OAuth2Client,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization,
+                role=OrganizationRole.member,
+            )
+        )
+        params = {
+            "client_id": oauth2_client.client_id,
+            "response_type": "code",
+            "redirect_uri": "http://127.0.0.1:8000/docs/oauth2-redirect",
+            "scope": "openid profile email",
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+        response = await client.post(
+            "/v1/oauth2/consent", params=params, data={"action": "allow"}
+        )
+
+        assert response.status_code == 400
+        json = response.json()
+        assert json["error"] == "invalid_sub"
+
+    @pytest.mark.auth
+    async def test_organization_manage_in_other_org_forbidden(
+        self,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        oauth2_client: OAuth2Client,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
         params = {
             "client_id": oauth2_client.client_id,
             "response_type": "code",
@@ -1383,3 +1481,129 @@ class TestOAuth2Token:
         access_token = json["access_token"]
         assert access_token.startswith("polar_at_o_")
         assert "refresh_token" not in json
+
+    async def test_web_grant_sub_organization_member_without_manage_forbidden(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        web_grant_oauth2_client: OAuth2Client,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization,
+                role=OrganizationRole.member,
+            )
+        )
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client.client_id,
+            "client_secret": web_grant_oauth2_client.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 400
+
+    async def test_web_grant_sub_organization_admin(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        web_grant_oauth2_client: OAuth2Client,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization,
+                role=OrganizationRole.admin,
+            )
+        )
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client.client_id,
+            "client_secret": web_grant_oauth2_client.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["access_token"].startswith("polar_at_o_")
+
+    async def test_web_grant_sub_organization_manage_in_other_org_forbidden(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        web_grant_oauth2_client: OAuth2Client,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client.client_id,
+            "client_secret": web_grant_oauth2_client.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 400


### PR DESCRIPTION
We only allow you to use the Oauth2 flow to issue an token when the user conducting the flow has the organization manage role. This is basically only admins today.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict OAuth2 org-scoped tokens to users with the `organization_manage` permission. Non-managers can’t see organizations during authorize and can’t obtain org tokens via auth code or web grants.

- **Bug Fixes**
  - Authorize filters organizations to those the user can manage via `get_accessible_org_ids`.
  - Authorization Code and Web grants validate the org sub with `select_user_org_ids(..., permission=OrganizationPermission.organization_manage)`.
  - Tests cover: member excluded in authorize, consent/web grant rejected for members or managers of other orgs, and admin success path.

<sup>Written for commit 6484af52d3a5d49109ef77fde8352e633e55b3c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

