### PR TITLE
refactor orbit's text-component

### DIFF
--- a/clients/apps/orbit/src/app/components/datatable/examples.tsx
+++ b/clients/apps/orbit/src/app/components/datatable/examples.tsx
@@ -110,7 +110,7 @@ const columns: DataTableColumnDef<Order>[] = [
       <DataTableColumnHeader column={column} title="Amount" />
     ),
     cell: ({ row }) => (
-      <Text variant="mono">{formatAmount(row.original.amount)}</Text>
+      <Text monospace>{formatAmount(row.original.amount)}</Text>
     ),
   },
   {

--- a/clients/apps/orbit/src/app/components/datatable/page.tsx
+++ b/clients/apps/orbit/src/app/components/datatable/page.tsx
@@ -30,7 +30,7 @@ const columnsCode = `const columns: DataTableColumnDef<Order>[] = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Amount" />
     ),
-    cell: ({ row }) => <Text variant="mono">{format(row.original.amount)}</Text>,
+    cell: ({ row }) => <Text monospace>{format(row.original.amount)}</Text>,
   },
 ]`
 

--- a/clients/apps/orbit/src/app/components/text/examples.tsx
+++ b/clients/apps/orbit/src/app/components/text/examples.tsx
@@ -196,3 +196,82 @@ export function StateSamples() {
     </Box>
   )
 }
+
+const DOS = [
+  'Pick a variant for the role (body, label, heading-l), never a raw font size.',
+  'Set as on headings so the document outline is correct; the visual size and the heading level are independent.',
+  'Use color="inherit" to adopt a parent Box color, for example to animate hover and active states.',
+  'Pass raw numbers as children with a formatter, and add tabularNums when figures sit in a column.',
+  'Compose layout and spacing with Box around Text.',
+  'For truncation that reveals the full text in a tooltip on hover, use the Truncated component; use truncate for plain clamping.',
+]
+
+const DONTS = [
+  'Do not reach for a class to set size, weight, color or leading. Text owns typography and has no className prop.',
+  'Do not encode hierarchy with size alone. An h2 can use any heading variant.',
+  'Do not pre-format numbers with toLocaleString. Let formatter do it so output stays consistent and SSR safe.',
+  'Do not nest layout containers inside Text. Keep children to text and inline content.',
+  'Do not use a heading variant for non-heading emphasis. Reach for the right variant, monospace or a color token.',
+]
+
+function PracticeList({
+  title,
+  items,
+  tone,
+}: {
+  title: string
+  items: string[]
+  tone: 'success' | 'danger'
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="m"
+      flexGrow={1}
+      flexBasis={0}
+      minWidth={240}
+      padding="xl"
+      borderRadius="m"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    >
+      <Text color={tone}>{title}</Text>
+      <Box
+        as="ul"
+        flexDirection="column"
+        rowGap="m"
+        margin="none"
+        padding="none"
+      >
+        {items.map((item) => (
+          <Box
+            as="li"
+            key={item}
+            display="flex"
+            columnGap="m"
+            alignItems="start"
+          >
+            <Text color={tone}>{tone === 'success' ? '✓' : '✗'}</Text>
+            <Text>{item}</Text>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export function BestPractices() {
+  return (
+    <Box
+      flexDirection={{ base: 'column', md: 'row' }}
+      columnGap="l"
+      rowGap="l"
+      width="100%"
+      alignItems="stretch"
+    >
+      <PracticeList title="Do" tone="success" items={DOS} />
+      <PracticeList title="Avoid" tone="danger" items={DONTS} />
+    </Box>
+  )
+}

--- a/clients/apps/orbit/src/app/components/text/examples.tsx
+++ b/clients/apps/orbit/src/app/components/text/examples.tsx
@@ -83,6 +83,65 @@ export function MonospaceSamples() {
   )
 }
 
+const numberValues = [3290033, 48200, 1500, 42]
+
+export function NumberSamples() {
+  return (
+    <Box flexDirection="column" rowGap="m" width="100%">
+      {numberValues.map((value) => (
+        <Box
+          key={value}
+          alignItems="baseline"
+          justifyContent="between"
+          columnGap="l"
+          paddingBottom="m"
+          borderBottomWidth={1}
+          borderStyle="solid"
+          borderColor="border-secondary"
+        >
+          <Text variant="caption" color="muted" monospace>
+            {value}
+          </Text>
+          <Box alignItems="baseline" columnGap="xl">
+            <Text variant="body" formatter="number" tabularNums>
+              {value}
+            </Text>
+            <Text variant="body" color="muted" formatter="compact" tabularNums>
+              {value}
+            </Text>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+const truncateSentence =
+  'Orbit is the Polar design system: tokens, primitives and components for building product interfaces quickly and consistently.'
+
+export function TruncateSamples() {
+  return (
+    <Box flexDirection="column" rowGap="xl" width="100%" maxWidth={360}>
+      <Box flexDirection="column" rowGap="xs">
+        <Text variant="caption" color="muted">
+          truncate
+        </Text>
+        <Text variant="body" truncate>
+          {truncateSentence}
+        </Text>
+      </Box>
+      <Box flexDirection="column" rowGap="xs">
+        <Text variant="caption" color="muted">
+          truncate={'{2}'}
+        </Text>
+        <Text variant="body" truncate={2}>
+          {truncateSentence}
+        </Text>
+      </Box>
+    </Box>
+  )
+}
+
 export function ColorSamples() {
   return (
     <Box flexDirection="column" rowGap="m" width="100%">

--- a/clients/apps/orbit/src/app/components/text/examples.tsx
+++ b/clients/apps/orbit/src/app/components/text/examples.tsx
@@ -13,7 +13,15 @@ const variants: TextVariant[] = [
   'default',
   'label',
   'caption',
-  'mono',
+]
+
+// monospace is an independent boolean prop, not a variant: it swaps the font
+// family while keeping whatever size/weight the variant defines.
+const monospaceVariants: TextVariant[] = [
+  'heading-s',
+  'body',
+  'default',
+  'label',
 ]
 
 const colors: TextColor[] = [
@@ -40,10 +48,35 @@ export function VariantSamples() {
           borderStyle="solid"
           borderColor="border-secondary"
         >
-          <Text variant="mono" color="default">
+          <Text monospace color="default">
             {variant}
           </Text>
           <Text variant={variant}>The quick brown fox</Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export function MonospaceSamples() {
+  return (
+    <Box flexDirection="column" rowGap="xl" width="100%">
+      {monospaceVariants.map((variant) => (
+        <Box
+          key={variant}
+          flexDirection="column"
+          rowGap="xs"
+          paddingBottom="l"
+          borderBottomWidth={1}
+          borderStyle="solid"
+          borderColor="border-secondary"
+        >
+          <Text variant="caption" color="muted">
+            variant=&quot;{variant}&quot; monospace
+          </Text>
+          <Text variant={variant} monospace>
+            npm install @polar-sh/orbit
+          </Text>
         </Box>
       ))}
     </Box>
@@ -56,7 +89,7 @@ export function ColorSamples() {
       {colors.map((color) => (
         <Box key={color} alignItems="baseline" columnGap="m">
           <Box width={96} flexShrink={0}>
-            <Text variant="mono" color="default">
+            <Text monospace color="default">
               {color}
             </Text>
           </Box>
@@ -82,19 +115,19 @@ export function StateSamples() {
   return (
     <Box flexDirection="column" rowGap="xl" width="100%" maxWidth={360}>
       <Box flexDirection="column" rowGap="xs">
-        <Text variant="mono" color="default">
+        <Text monospace color="default">
           loading
         </Text>
         <Text loading placeholderText="Loading a single line of text" />
       </Box>
       <Box flexDirection="column" rowGap="xs">
-        <Text variant="mono" color="default">
+        <Text monospace color="default">
           loading, placeholderNumberOfLines=3
         </Text>
         <Text loading placeholderNumberOfLines={3} />
       </Box>
       <Box flexDirection="column" rowGap="xs">
-        <Text variant="mono" color="default">
+        <Text monospace color="default">
           lineThrough
         </Text>
         <Text lineThrough color="default">

--- a/clients/apps/orbit/src/app/components/text/page.tsx
+++ b/clients/apps/orbit/src/app/components/text/page.tsx
@@ -10,17 +10,26 @@ import {
 import {
   ColorSamples,
   MonospaceSamples,
+  NumberSamples,
   StateSamples,
+  TruncateSamples,
   VariantSamples,
 } from './examples'
 
-const variantCode = `<Text variant="heading-l" as="h1">Page title</Text>
+const variantCode = `<Text variant="heading-l">Page title</Text>
 <Text variant="body">Comfortable reading copy.</Text>
 <Text variant="label">Field label</Text>`
 
 const monospaceCode = `<Text variant="heading-s" monospace>404</Text>
 <Text variant="body" monospace>npm install @polar-sh/orbit</Text>
 <Text variant="label" monospace>POLAR_TOKEN</Text>`
+
+const numberCode = `<Text variant="heading-s" formatter="number">{3290033}</Text>
+<Text variant="body" formatter="compact">{3290033}</Text>
+<Text formatter={(v) => \`$\${v}\`}>{42}</Text>`
+
+const truncateCode = `<Text variant="body" truncate>One line, then an ellipsis…</Text>
+<Text variant="body" truncate={2}>Clamped to two lines…</Text>`
 
 const colorCode = `<Text color="default">De-emphasised copy</Text>
 <Text color="accent">Accent</Text>
@@ -47,6 +56,26 @@ const textProps: PropRow[] = [
       'Renders the text in the monospace font family while keeping the size and weight from variant. Pair with any variant.',
   },
   {
+    name: 'formatter',
+    type: "'number' | 'compact' | ((value) => string)",
+    description:
+      "Formats the children value for display. 'number' adds grouping separators (3,290,033), 'compact' shortens (3.3M), or pass a function for full control. Pass the raw value as children.",
+  },
+  {
+    name: 'tabularNums',
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Uses tabular (monospaced) figures so numbers line up in columns. Ideal for tables and stat readouts.',
+  },
+  {
+    name: 'truncate',
+    type: 'boolean | number',
+    default: 'false',
+    description:
+      'true clamps to a single line with an ellipsis; a number clamps to that many lines.',
+  },
+  {
     name: 'color',
     type: 'TextColor',
     default: "'default'",
@@ -56,8 +85,9 @@ const textProps: PropRow[] = [
   {
     name: 'as',
     type: "'p' | 'span' | 'label' | 'strong' | 'code' | 'h1'..'h6' | …",
-    default: "'p'",
-    description: 'Underlying element. DOM props for the element are forwarded.',
+    default: 'inferred from variant',
+    description:
+      'Underlying element. Defaults to a sensible element per variant (heading variants render h1 to h6, everything else p). Override for the correct document outline. DOM props are forwarded.',
   },
   {
     name: 'align',
@@ -92,11 +122,6 @@ const textProps: PropRow[] = [
     type: 'boolean',
     default: 'false',
     description: 'Applies a line-through text decoration.',
-  },
-  {
-    name: 'className',
-    type: 'string',
-    description: 'Merged after the variant classes via tailwind-merge.',
   },
 ]
 
@@ -133,10 +158,28 @@ export default function TextPage() {
 
       <Section
         title="Monospace"
-        description="monospace is a boolean prop, not a variant. It swaps in the mono font family while keeping the size and weight from variant, so any text — a heading, body copy or a label — can be monospaced."
+        description="monospace is a boolean prop, not a variant. It swaps in the mono font family while keeping the size and weight from variant, so any text (a heading, body copy or a label) can be monospaced."
       >
         <Example code={monospaceCode} align="stretch">
           <MonospaceSamples />
+        </Example>
+      </Section>
+
+      <Section
+        title="Formatting"
+        description="Pass a raw value as children and a formatter to render it: 'number' for grouping separators, 'compact' for short magnitudes, or a function for anything else. Formatting lives in the component, so call sites never hand-roll toLocaleString. Add tabularNums to align figures in columns."
+      >
+        <Example code={numberCode} align="stretch">
+          <NumberSamples />
+        </Example>
+      </Section>
+
+      <Section
+        title="Truncation"
+        description="truncate owns the overflow CSS: true clamps to one line, a number clamps to that many lines."
+      >
+        <Example code={truncateCode} align="stretch">
+          <TruncateSamples />
         </Example>
       </Section>
 

--- a/clients/apps/orbit/src/app/components/text/page.tsx
+++ b/clients/apps/orbit/src/app/components/text/page.tsx
@@ -8,6 +8,7 @@ import {
   type PropRow,
 } from '@/components/docs'
 import {
+  BestPractices,
   ColorSamples,
   MonospaceSamples,
   NumberSamples,
@@ -130,19 +131,26 @@ export default function TextPage() {
     <>
       <PageHeader
         title="Text"
-        description="Variant-driven typography for every text node. Pick a variant for the role, an optional color token and a semantic element via as. Colors resolve light and dark automatically."
+        description="Variant-driven typography for anything text-related."
       />
 
       <Section
         title="Overview"
-        description="Use Text for any text node rather than tailwind text classes. The variant sets size, weight and font family; color and alignment layer on top."
+        description="Use Text for any text node, never a div with tailwind text classes. You choose what the text is; the component decides how it looks."
       >
         <Prose>
           <Text variant="body" color="default">
-            Headings use the display scale and respond to viewport width. Body,
-            label and caption cover supporting copy, and the monospace prop
-            switches any of them to the mono font. Built-in loading and
-            lineThrough states cover common UI affordances without extra markup.
+            Each prop sits on one axis. variant is the role (size, weight and
+            font family), color is the tone, and as is the element. Orthogonal
+            modifiers layer on without touching the role: monospace,
+            tabularNums, truncate, lineThrough and a formatter for numbers.
+            Colors resolve light and dark automatically, and loading renders a
+            skeleton with no extra markup.
+          </Text>
+          <Text variant="body" color="muted">
+            Text has no className. Size, weight, color and leading are owned by
+            the props above, so compose layout and spacing with Box around Text
+            rather than reaching for utility classes.
           </Text>
         </Prose>
       </Section>
@@ -199,6 +207,13 @@ export default function TextPage() {
         <Example code={stateCode} align="stretch">
           <StateSamples />
         </Example>
+      </Section>
+
+      <Section
+        title="Best practices"
+        description="Keep typographic decisions inside Text. Choose the role and tone; let the component own the rest."
+      >
+        <BestPractices />
       </Section>
 
       <Section title="Props">

--- a/clients/apps/orbit/src/app/components/text/page.tsx
+++ b/clients/apps/orbit/src/app/components/text/page.tsx
@@ -7,12 +7,20 @@ import {
   Section,
   type PropRow,
 } from '@/components/docs'
-import { ColorSamples, StateSamples, VariantSamples } from './examples'
+import {
+  ColorSamples,
+  MonospaceSamples,
+  StateSamples,
+  VariantSamples,
+} from './examples'
 
 const variantCode = `<Text variant="heading-l" as="h1">Page title</Text>
 <Text variant="body">Comfortable reading copy.</Text>
-<Text variant="label">Field label</Text>
-<Text variant="mono">npm install</Text>`
+<Text variant="label">Field label</Text>`
+
+const monospaceCode = `<Text variant="heading-s" monospace>404</Text>
+<Text variant="body" monospace>npm install @polar-sh/orbit</Text>
+<Text variant="label" monospace>POLAR_TOKEN</Text>`
 
 const colorCode = `<Text color="default">De-emphasised copy</Text>
 <Text color="accent">Accent</Text>
@@ -29,7 +37,14 @@ const textProps: PropRow[] = [
     type: 'TextVariant',
     default: "'default'",
     description:
-      'default | body | label | caption | mono | heading-2xl | heading-xl | heading-l | heading-m | heading-s | heading-xs | heading-xxs.',
+      'default | body | label | caption | heading-2xl | heading-xl | heading-l | heading-m | heading-s | heading-xs | heading-xxs.',
+  },
+  {
+    name: 'monospace',
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Renders the text in the monospace font family while keeping the size and weight from variant. Pair with any variant.',
   },
   {
     name: 'color',
@@ -100,7 +115,8 @@ export default function TextPage() {
         <Prose>
           <Text variant="body" color="default">
             Headings use the display scale and respond to viewport width. Body,
-            label, caption and mono cover supporting copy. Built-in loading and
+            label and caption cover supporting copy, and the monospace prop
+            switches any of them to the mono font. Built-in loading and
             lineThrough states cover common UI affordances without extra markup.
           </Text>
         </Prose>
@@ -108,10 +124,19 @@ export default function TextPage() {
 
       <Section
         title="Variants"
-        description="Each variant maps to a typographic role. The token name is shown in mono above each sample."
+        description="Each variant maps to a typographic role. The token name is shown in monospace above each sample."
       >
         <Example code={variantCode} align="stretch">
           <VariantSamples />
+        </Example>
+      </Section>
+
+      <Section
+        title="Monospace"
+        description="monospace is a boolean prop, not a variant. It swaps in the mono font family while keeping the size and weight from variant, so any text — a heading, body copy or a label — can be monospaced."
+      >
+        <Example code={monospaceCode} align="stretch">
+          <MonospaceSamples />
         </Example>
       </Section>
 

--- a/clients/apps/orbit/src/app/foundations/colors/swatches.tsx
+++ b/clients/apps/orbit/src/app/foundations/colors/swatches.tsx
@@ -51,7 +51,7 @@ function SwatchFrame({
     <Box flexDirection="column" rowGap="s">
       {children}
       <Box flexDirection="column" rowGap="xs">
-        <Text variant="mono" color="inherit">
+        <Text monospace color="inherit">
           {token}
         </Text>
         <Text variant="caption" color="default">

--- a/clients/apps/orbit/src/app/foundations/radius/page.tsx
+++ b/clients/apps/orbit/src/app/foundations/radius/page.tsx
@@ -53,7 +53,7 @@ export default function RadiusPage() {
                 backgroundColor="background-inverse"
               />
               <Box flexDirection="column" rowGap="xs">
-                <Text variant="mono" color="inherit">
+                <Text monospace color="inherit">
                   {token}
                 </Text>
                 <Text variant="caption" color="default">

--- a/clients/apps/orbit/src/app/foundations/shadows/page.tsx
+++ b/clients/apps/orbit/src/app/foundations/shadows/page.tsx
@@ -62,7 +62,7 @@ export default function ShadowsPage() {
                 boxShadow={token}
               />
               <Box flexDirection="column" rowGap="xs">
-                <Text variant="mono" color="inherit">
+                <Text monospace color="inherit">
                   {token}
                 </Text>
                 <Text variant="caption" color="default">

--- a/clients/apps/orbit/src/app/foundations/spacing/page.tsx
+++ b/clients/apps/orbit/src/app/foundations/spacing/page.tsx
@@ -48,7 +48,7 @@ export default function SpacingPage() {
           {SCALE.map(({ token, px }) => (
             <Box key={token} alignItems="center" columnGap="l">
               <Box width={64} flexShrink={0}>
-                <Text variant="mono" color="inherit">
+                <Text monospace color="inherit">
                   {token}
                 </Text>
               </Box>

--- a/clients/apps/orbit/src/app/foundations/typography/page.tsx
+++ b/clients/apps/orbit/src/app/foundations/typography/page.tsx
@@ -22,7 +22,6 @@ const VARIANTS: TextVariant[] = [
   'default',
   'label',
   'caption',
-  'mono',
 ]
 
 const COLORS: TextColor[] = [
@@ -48,6 +47,12 @@ const PROPS: PropRow[] = [
     type: 'TextVariant',
     default: 'default',
     description: 'Type-scale style.',
+  },
+  {
+    name: 'monospace',
+    type: 'boolean',
+    default: 'false',
+    description: 'Switches to the mono font family, keeping the variant size.',
   },
   {
     name: 'color',
@@ -104,7 +109,7 @@ export default function TypographyPage() {
 
       <Section
         title="Type scale"
-        description="Headings use the display face at the larger sizes; body, label, caption, and mono cover supporting copy."
+        description="Headings use the display face at the larger sizes; body, label, and caption cover supporting copy. The monospace prop swaps any variant to the mono font."
       >
         <Box flexDirection="column" rowGap="xl">
           {VARIANTS.map((variant) => (
@@ -118,7 +123,7 @@ export default function TypographyPage() {
               <Text variant={variant} as="span">
                 The quick brown fox
               </Text>
-              <Text variant="mono" color="default">
+              <Text monospace color="default">
                 {variant}
               </Text>
             </Box>
@@ -134,7 +139,7 @@ export default function TypographyPage() {
           {COLORS.map((color) => (
             <Box key={color} alignItems="baseline" columnGap="l">
               <Box minWidth={96}>
-                <Text variant="mono" color="default">
+                <Text monospace color="default">
                   {color}
                 </Text>
               </Box>

--- a/clients/apps/orbit/src/app/foundations/typography/page.tsx
+++ b/clients/apps/orbit/src/app/foundations/typography/page.tsx
@@ -55,6 +55,23 @@ const PROPS: PropRow[] = [
     description: 'Switches to the mono font family, keeping the variant size.',
   },
   {
+    name: 'formatter',
+    type: "'number' | 'compact' | function",
+    description: 'Formats the children value, e.g. number to 3,290,033.',
+  },
+  {
+    name: 'tabularNums',
+    type: 'boolean',
+    default: 'false',
+    description: 'Aligns figures in columns with tabular numerals.',
+  },
+  {
+    name: 'truncate',
+    type: 'boolean | number',
+    default: 'false',
+    description: 'Clamps to one line (true) or N lines (number) with ellipsis.',
+  },
+  {
     name: 'color',
     type: 'TextColor',
     default: 'default',

--- a/clients/apps/orbit/src/app/page.tsx
+++ b/clients/apps/orbit/src/app/page.tsx
@@ -54,7 +54,7 @@ function LinkCard({
         cursor="pointer"
       >
         <Box alignItems="center" justifyContent="between">
-          <Text variant="mono" color="muted">
+          <Text monospace color="muted">
             {index}
           </Text>
           <Box
@@ -159,7 +159,7 @@ export default function HomePage() {
           >
             <GridItem>
               <Box flexDirection="column" rowGap="m">
-                <Text variant="mono" color="muted">
+                <Text monospace color="muted">
                   {String(i + 1).padStart(2, '0')}
                 </Text>
                 <Text variant="heading-s" as="h3">

--- a/clients/apps/orbit/src/components/AppShell.tsx
+++ b/clients/apps/orbit/src/components/AppShell.tsx
@@ -49,7 +49,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           flexDirection="column"
           width="100%"
           minWidth={0}
-          maxWidth={940}
+          maxWidth={840}
           marginHorizontal="auto"
           paddingHorizontal={{ base: 'l', md: '3xl' }}
           paddingVertical={{ base: 'xl', md: '3xl' }}

--- a/clients/apps/orbit/src/components/docs/CodeBlock.tsx
+++ b/clients/apps/orbit/src/components/docs/CodeBlock.tsx
@@ -64,7 +64,7 @@ export function CodeBlock({
         {highlighted ? (
           <div dangerouslySetInnerHTML={{ __html: highlighted }} />
         ) : (
-          <Text as="code" variant="mono" color="inherit">
+          <Text as="code" monospace color="inherit">
             <pre className="m-0">{code}</pre>
           </Text>
         )}

--- a/clients/apps/orbit/src/components/docs/PropsTable.tsx
+++ b/clients/apps/orbit/src/components/docs/PropsTable.tsx
@@ -65,7 +65,7 @@ function TypeChip({
       borderRadius="s"
       backgroundColor="background-card"
     >
-      <Text variant="mono" color="accent" as="span">
+      <Text monospace color="accent" as="span">
         {label}
       </Text>
     </Box>
@@ -93,7 +93,7 @@ function TypeChip({
       <TooltipTrigger asChild>{trigger}</TooltipTrigger>
       <TooltipContent>
         <Box maxWidth={360}>
-          <Text variant="mono" color="inherit" wrap="pretty">
+          <Text monospace color="inherit" wrap="pretty">
             {type}
           </Text>
         </Box>
@@ -142,19 +142,19 @@ export function PropsTable({ rows, slug }: { rows: PropRow[]; slug?: string }) {
             borderColor="border-primary"
           >
             <Box alignItems="center" columnGap="s" flexWrap="wrap">
-              <Text variant="mono" color="default">
+              <Text monospace color="default">
                 {row.name}
               </Text>
               <TypeChip type={row.type} source={row.source} />
               {row.default !== undefined && (
                 <Chip>
-                  <Text variant="mono" color="default" as="span">
+                  <Text monospace color="default" as="span">
                     {`default: ${row.default}`}
                   </Text>
                 </Chip>
               )}
               {row.required && (
-                <Text variant="mono" color="danger">
+                <Text monospace color="danger">
                   required
                 </Text>
               )}

--- a/clients/apps/orbit/src/generated/props.json
+++ b/clients/apps/orbit/src/generated/props.json
@@ -2556,17 +2556,19 @@
     {
       "name": "as",
       "type": "E",
+      "description": "Underlying DOM element. Defaults to a sensible element per variant (heading variants render `h1`–`h6`, everything else `p`). Override to keep a correct document outline. DOM props for the element are typed and forwarded.",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 81
+        "line": 162
       }
     },
     {
-      "name": "className",
-      "type": "string",
+      "name": "children",
+      "type": "ReactNode",
+      "description": "The text to render. Prefer plain strings and numbers; inline elements are allowed where you genuinely need them (a `<br>`, an inline link), but reach for Box to compose layout rather than nesting containers inside Text.",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 82
+        "line": 177
       }
     },
     {
@@ -2578,43 +2580,75 @@
       }
     },
     {
-      "name": "lineThrough",
-      "type": "boolean",
+      "name": "formatter",
+      "type": "TextFormatter",
+      "description": "Format the children value for display. 'number' adds grouping separators (3290033 → \"3,290,033\"), 'compact' shortens (3290033 → \"3.3M\"), or pass a function for full control. Pass the raw value as children, not a pre-formatted string.",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 86
+        "line": 219
+      }
+    },
+    {
+      "name": "lineThrough",
+      "type": "boolean",
+      "description": "Apply a line-through decoration, e.g. for a struck-out previous price.",
+      "source": {
+        "path": "clients/packages/orbit/src/primitives/createText.tsx",
+        "line": 196
       }
     },
     {
       "name": "loading",
       "type": "boolean",
+      "description": "Render a pulsing skeleton placeholder instead of children, for content that is still loading.",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 83
+        "line": 182
       }
     },
     {
       "name": "monospace",
       "type": "boolean",
+      "description": "Render in the monospace font family while keeping the variant's size and weight. Orthogonal to `variant`, so any text can be monospaced.",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 87
+        "line": 201
       }
     },
     {
       "name": "placeholderNumberOfLines",
       "type": "number",
+      "description": "When greater than 1, renders a multi-line loading skeleton with that many lines.",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 85
+        "line": 192
       }
     },
     {
       "name": "placeholderText",
       "type": "string",
+      "description": "Sizes the single-line loading skeleton. Falls back to children, then to \"Loading...\".",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 84
+        "line": 187
+      }
+    },
+    {
+      "name": "tabularNums",
+      "type": "boolean",
+      "description": "Align figures for vertical scanning in tables and stat readouts. Pairs well with a numeric `formatter`.",
+      "source": {
+        "path": "clients/packages/orbit/src/primitives/createText.tsx",
+        "line": 206
+      }
+    },
+    {
+      "name": "truncate",
+      "type": "number | boolean",
+      "description": "Truncate overflow. `true` clamps to a single line with an ellipsis; a number clamps to that many lines. The component owns the CSS, so callers never hand-roll line-clamp utilities.",
+      "source": {
+        "path": "clients/packages/orbit/src/primitives/createText.tsx",
+        "line": 212
       }
     },
     {

--- a/clients/apps/orbit/src/generated/props.json
+++ b/clients/apps/orbit/src/generated/props.json
@@ -2550,7 +2550,7 @@
       "type": "\"right\" | \"left\" | \"center\" | \"justify\" | null",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 58
+        "line": 55
       }
     },
     {
@@ -2558,7 +2558,7 @@
       "type": "E",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 84
+        "line": 81
       }
     },
     {
@@ -2566,7 +2566,7 @@
       "type": "string",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 85
+        "line": 82
       }
     },
     {
@@ -2574,7 +2574,7 @@
       "type": "\"disabled\" | \"inherit\" | \"default\" | \"muted\" | \"accent\" | \"danger\" | \"error\" | \"warning\" | \"success\" | \"inverse\" | \"white\" | \"black\" | null",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 44
+        "line": 41
       }
     },
     {
@@ -2582,7 +2582,7 @@
       "type": "boolean",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 89
+        "line": 86
       }
     },
     {
@@ -2590,7 +2590,15 @@
       "type": "boolean",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 86
+        "line": 83
+      }
+    },
+    {
+      "name": "monospace",
+      "type": "boolean",
+      "source": {
+        "path": "clients/packages/orbit/src/primitives/createText.tsx",
+        "line": 87
       }
     },
     {
@@ -2598,7 +2606,7 @@
       "type": "number",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 88
+        "line": 85
       }
     },
     {
@@ -2606,15 +2614,15 @@
       "type": "string",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 87
+        "line": 84
       }
     },
     {
       "name": "variant",
-      "type": "\"body\" | \"caption\" | \"label\" | \"default\" | \"mono\" | \"heading-2xl\" | \"heading-xl\" | \"heading-l\" | \"heading-m\" | \"heading-s\" | \"heading-xs\" | \"heading-xxs\" | null",
+      "type": "\"body\" | \"caption\" | \"label\" | \"default\" | \"heading-2xl\" | \"heading-xl\" | \"heading-l\" | \"heading-m\" | \"heading-s\" | \"heading-xs\" | \"heading-xxs\" | null",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 30
+        "line": 28
       }
     },
     {
@@ -2622,7 +2630,7 @@
       "type": "\"wrap\" | \"nowrap\" | \"balance\" | \"pretty\" | null",
       "source": {
         "path": "clients/packages/orbit/src/primitives/createText.tsx",
-        "line": 64
+        "line": 61
       }
     }
   ],

--- a/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
@@ -250,7 +250,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
             <CopyToClipboardInput
               value={createdToken?.token ?? ''}
               onCopy={() => toast({ title: 'Copied to clipboard' })}
-              variant="mono"
+              monospace
             />
             <Banner color="blue">
               <span className="text-sm">

--- a/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
@@ -142,13 +142,8 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
             borderStyle="solid"
             borderColor="border-primary"
           />
-          <Text
-            variant="caption"
-            color="muted"
-            // eslint-disable-next-line polar/no-classname-text
-            className="text-[11px] font-semibold tracking-wider uppercase"
-          >
-            or
+          <Text variant="caption" color="muted">
+            OR
           </Text>
           <Box
             display="block"
@@ -250,7 +245,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
             <CopyToClipboardInput
               value={createdToken?.token ?? ''}
               onCopy={() => toast({ title: 'Copied to clipboard' })}
-              monospace
+              variant="mono"
             />
             <Banner color="blue">
               <span className="text-sm">

--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -300,7 +300,7 @@ const AccessTokenItem = ({
                 title: 'Copied to clipboard',
               })
             }}
-            variant="mono"
+            monospace
           />
           <Banner color="blue">
             <span className="text-sm">

--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -300,7 +300,7 @@ const AccessTokenItem = ({
                 title: 'Copied to clipboard',
               })
             }}
-            monospace
+            variant="mono"
           />
           <Banner color="blue">
             <span className="text-sm">

--- a/clients/apps/web/src/components/Settings/TreeMultiSelect.tsx
+++ b/clients/apps/web/src/components/Settings/TreeMultiSelect.tsx
@@ -138,7 +138,7 @@ export function TreeMultiSelect<T extends string>({
                   checked={groupChecked}
                   onCheckedChange={() => onToggleGroup(group)}
                 />
-                <Text variant="mono">{group.label}</Text>
+                <Text monospace>{group.label}</Text>
               </Box>
 
               <Box flexDirection="column" pl="xl">
@@ -156,7 +156,7 @@ export function TreeMultiSelect<T extends string>({
                       checked={selected.has(option)}
                       onCheckedChange={() => onToggleOption(option)}
                     />
-                    <Text variant="mono">{option}</Text>
+                    <Text monospace>{option}</Text>
                     {renderOptionSuffix?.(option)}
                   </Box>
                 ))}

--- a/clients/packages/orbit/src/primitives/createText.tsx
+++ b/clients/packages/orbit/src/primitives/createText.tsx
@@ -108,10 +108,6 @@ const VARIANT_DEFAULT_WRAP: Partial<
   'heading-2xl': 'balance',
   'heading-xl': 'balance',
   'heading-l': 'balance',
-  'heading-m': 'balance',
-  'heading-s': 'balance',
-  'heading-xs': 'balance',
-  'heading-xxs': 'balance',
 }
 
 // Pinned locale so server and client render identical strings (an unpinned

--- a/clients/packages/orbit/src/primitives/createText.tsx
+++ b/clients/packages/orbit/src/primitives/createText.tsx
@@ -23,8 +23,6 @@ type TextTag =
   | 'h5'
   | 'h6'
 
-const HEADING_BASE = 'text-black dark:text-white'
-
 const textVariants = cva('', {
   variants: {
     variant: {
@@ -32,14 +30,13 @@ const textVariants = cva('', {
       body: 'text-base',
       label: 'text-xs font-medium',
       caption: 'text-xs leading-snug',
-      mono: 'font-mono text-xs',
-      'heading-2xl': `${HEADING_BASE} font-display text-6xl md:text-8xl`,
-      'heading-xl': `${HEADING_BASE} font-display text-5xl md:text-7xl`,
-      'heading-l': `${HEADING_BASE} font-display text-4xl md:text-5xl`,
-      'heading-m': `${HEADING_BASE} text-3xl md:text-5xl`,
-      'heading-s': `${HEADING_BASE} text-2xl md:text-3xl`,
-      'heading-xs': `${HEADING_BASE} text-xl  md:text-2xl`,
-      'heading-xxs': `${HEADING_BASE} text-lg  md:text-xl`,
+      'heading-2xl': `font-display text-6xl md:text-8xl`,
+      'heading-xl': `font-display text-5xl md:text-7xl`,
+      'heading-l': `font-display text-4xl md:text-5xl`,
+      'heading-m': `text-3xl md:text-5xl`,
+      'heading-s': `text-2xl md:text-3xl`,
+      'heading-xs': `text-xl  md:text-2xl`,
+      'heading-xxs': `text-lg  md:text-xl`,
     },
     color: {
       default: 'text-black dark:text-white',
@@ -87,6 +84,7 @@ type TextProps<E extends TextTag = 'p'> = TextStyleProps & {
   placeholderText?: string
   placeholderNumberOfLines?: number
   lineThrough?: boolean
+  monospace?: boolean
 } & Omit<
     ComponentPropsWithoutRef<E>,
     keyof TextStyleProps | 'className' | 'loading'
@@ -142,6 +140,7 @@ function Text<E extends TextTag = 'p'>({
   placeholderText,
   placeholderNumberOfLines,
   lineThrough,
+  monospace,
   ...props
 }: TextProps<E> & { style?: React.CSSProperties }): JSX.Element {
   const Tag = (as ?? 'p') as ElementType
@@ -175,6 +174,7 @@ function Text<E extends TextTag = 'p'>({
     <Tag
       className={twMerge(
         textVariants({ variant, color, align, wrap }),
+        monospace ? 'font-mono' : undefined,
         className,
       )}
       style={mergedStyle}

--- a/clients/packages/orbit/src/primitives/createText.tsx
+++ b/clients/packages/orbit/src/primitives/createText.tsx
@@ -33,7 +33,7 @@ const textVariants = cva('', {
       'heading-2xl': `font-display text-6xl md:text-8xl`,
       'heading-xl': `font-display text-5xl md:text-7xl`,
       'heading-l': `font-display text-4xl md:text-5xl`,
-      'heading-m': `text-3xl md:text-5xl`,
+      'heading-m': `text-3xl md:text-4xl`,
       'heading-s': `text-2xl md:text-3xl`,
       'heading-xs': `text-xl  md:text-2xl`,
       'heading-xxs': `text-lg  md:text-xl`,
@@ -77,17 +77,149 @@ export type TextVariant = NonNullable<
 export type TextColor = NonNullable<VariantProps<typeof textVariants>['color']>
 export type TextStyleProps = VariantProps<typeof textVariants>
 
+// The role each variant plays decides which element it should render as, so the
+// integrator picks a role and gets a sane document outline for free. Override
+// with `as` when the surrounding structure needs a different heading level.
+// Non-heading roles stay `p` (the historical default) to avoid block/inline
+// layout shifts; heading roles map down the outline so they stop rendering as
+// `<p>`, which is the real accessibility win here.
+const VARIANT_DEFAULT_TAG: Record<TextVariant, TextTag> = {
+  default: 'p',
+  body: 'p',
+  label: 'p',
+  caption: 'p',
+  'heading-2xl': 'h1',
+  'heading-xl': 'h2',
+  'heading-l': 'h3',
+  'heading-m': 'h4',
+  'heading-s': 'h5',
+  'heading-xs': 'h6',
+  'heading-xxs': 'h6',
+}
+
+// Good wrapping is a decision the component makes, not the caller: headings read
+// best balanced across lines, long body copy best avoids orphans. Anything not
+// listed keeps the browser default. Overridden by an explicit `wrap` prop, and
+// skipped entirely when truncating.
+const VARIANT_DEFAULT_WRAP: Partial<
+  Record<TextVariant, NonNullable<TextStyleProps['wrap']>>
+> = {
+  body: 'pretty',
+  'heading-2xl': 'balance',
+  'heading-xl': 'balance',
+  'heading-l': 'balance',
+  'heading-m': 'balance',
+  'heading-s': 'balance',
+  'heading-xs': 'balance',
+  'heading-xxs': 'balance',
+}
+
+// Pinned locale so server and client render identical strings (an unpinned
+// Intl default would risk a hydration mismatch).
+const numberFormatter = new Intl.NumberFormat('en-US')
+const compactFormatter = new Intl.NumberFormat('en-US', { notation: 'compact' })
+
+/**
+ * How to render the value passed as children. A named preset keeps the common
+ * cases discoverable; the function form is the escape hatch for the long tail
+ * (currency, units, locale-specific rules). Either way the output is a string,
+ * so no visual decision leaks out of the component.
+ */
+export type TextFormatter =
+  | 'number'
+  | 'compact'
+  | ((value: string | number) => string)
+
+function applyFormatter(
+  formatter: TextFormatter,
+  value: string | number,
+): string {
+  if (typeof formatter === 'function') return formatter(value)
+  const n = typeof value === 'number' ? value : Number(value)
+  if (Number.isNaN(n)) return String(value)
+  return formatter === 'compact'
+    ? compactFormatter.format(n)
+    : numberFormatter.format(n)
+}
+
 type TextProps<E extends TextTag = 'p'> = TextStyleProps & {
+  /**
+   * The role this text plays, which decides its size, weight and font family.
+   * Headings use the display scale; `body`/`default`/`label`/`caption` cover
+   * supporting copy. Pick the role, never a raw size.
+   */
+  variant?: TextStyleProps['variant']
+  /**
+   * Semantic foreground color that resolves for light and dark automatically.
+   * Use `inherit` to adopt the color of a parent Box.
+   */
+  color?: TextStyleProps['color']
+  /**
+   * Underlying DOM element. Defaults to a sensible element per variant (heading
+   * variants render `h1`–`h6`, everything else `p`). Override to keep a correct
+   * document outline. DOM props for the element are typed and forwarded.
+   */
   as?: E
-  className?: string
+  /**
+   * Horizontal text alignment.
+   */
+  align?: TextStyleProps['align']
+  /**
+   * Line-wrapping behavior. Defaults are baked per role (headings `balance`,
+   * body `pretty`); set this to override. Ignored while truncating.
+   */
+  wrap?: TextStyleProps['wrap']
+  /**
+   * The text to render. Prefer plain strings and numbers; inline elements are
+   * allowed where you genuinely need them (a `<br>`, an inline link), but reach
+   * for Box to compose layout rather than nesting containers inside Text.
+   */
+  children?: ReactNode
+  /**
+   * Render a pulsing skeleton placeholder instead of children, for content that
+   * is still loading.
+   */
   loading?: boolean
+  /**
+   * Sizes the single-line loading skeleton. Falls back to children, then to
+   * "Loading...".
+   */
   placeholderText?: string
+  /**
+   * When greater than 1, renders a multi-line loading skeleton with that many
+   * lines.
+   */
   placeholderNumberOfLines?: number
+  /**
+   * Apply a line-through decoration, e.g. for a struck-out previous price.
+   */
   lineThrough?: boolean
+  /**
+   * Render in the monospace font family while keeping the variant's size and
+   * weight. Orthogonal to `variant`, so any text can be monospaced.
+   */
   monospace?: boolean
+  /**
+   * Align figures for vertical scanning in tables and stat readouts. Pairs well
+   * with a numeric `formatter`.
+   */
+  tabularNums?: boolean
+  /**
+   * Truncate overflow. `true` clamps to a single line with an ellipsis; a
+   * number clamps to that many lines. The component owns the CSS, so callers
+   * never hand-roll line-clamp utilities.
+   */
+  truncate?: boolean | number
+  /**
+   * Format the children value for display. 'number' adds grouping separators
+   * (3290033 → "3,290,033"), 'compact' shortens (3290033 → "3.3M"), or pass a
+   * function for full control. Pass the raw value as children, not a
+   * pre-formatted string.
+   */
+  formatter?: TextFormatter
 } & Omit<
     ComponentPropsWithoutRef<E>,
-    keyof TextStyleProps | 'className' | 'loading'
+    keyof TextStyleProps | 'className' | 'loading' | 'children'
   >
 
 const HEADING_FONT_FEATURES = "'ss07' 1, 'ss08' 1, 'zero' 1, 'liga' 0"
@@ -133,7 +265,6 @@ function Text<E extends TextTag = 'p'>({
   color,
   align,
   wrap,
-  className,
   children,
   style,
   loading,
@@ -141,13 +272,22 @@ function Text<E extends TextTag = 'p'>({
   placeholderNumberOfLines,
   lineThrough,
   monospace,
+  tabularNums,
+  truncate,
+  formatter,
   ...props
 }: TextProps<E> & { style?: React.CSSProperties }): JSX.Element {
-  const Tag = (as ?? 'p') as ElementType
-  const isHeading =
-    typeof variant === 'string' && variant.startsWith('heading-')
+  const resolvedVariant = variant ?? 'default'
+  const Tag = (as ?? VARIANT_DEFAULT_TAG[resolvedVariant]) as ElementType
+  const isHeading = resolvedVariant.startsWith('heading-')
+  const resolvedWrap =
+    wrap ?? (truncate ? undefined : VARIANT_DEFAULT_WRAP[resolvedVariant])
 
-  let content: ReactNode = children
+  let content: ReactNode =
+    formatter !== undefined &&
+    (typeof children === 'string' || typeof children === 'number')
+      ? applyFormatter(formatter, children)
+      : children
   let loadingStyle: React.CSSProperties | undefined
 
   if (loading) {
@@ -166,6 +306,14 @@ function Text<E extends TextTag = 'p'>({
   const mergedStyle: React.CSSProperties = {
     ...(isHeading && { fontFeatureSettings: HEADING_FONT_FEATURES }),
     ...(lineThrough ? { textDecoration: 'line-through' } : {}),
+    ...(typeof truncate === 'number'
+      ? {
+          display: '-webkit-box',
+          WebkitLineClamp: truncate,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+        }
+      : {}),
     ...style,
     ...loadingStyle,
   }
@@ -173,9 +321,10 @@ function Text<E extends TextTag = 'p'>({
   return (
     <Tag
       className={twMerge(
-        textVariants({ variant, color, align, wrap }),
-        monospace ? 'font-mono' : undefined,
-        className,
+        textVariants({ variant, color, align, wrap: resolvedWrap }),
+        monospace && 'font-mono',
+        tabularNums && 'tabular-nums',
+        truncate === true && 'truncate',
       )}
       style={mergedStyle}
       {...(props as object)}


### PR DESCRIPTION
- **orbit: refactor monospace capability on Text component**
- **orbit: refactor <Text /> component for better composition and ergonomics**
- **orbit: polish text component**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the `Text` primitive in `clients/packages/orbit` for better composition. Replaces `variant="mono"` with a `monospace` prop, adds number formatting and truncation, updates docs/examples (incl. best practices), tightens docs layout, and fixes monospace usage in settings.

- **New Features**
  - `monospace` prop replaces `variant="mono"` and works with any variant.
  - `formatter` ('number' | 'compact' | fn) and `tabularNums` for aligned numeric text.
  - `truncate` (boolean or number) for single-line or N-line clamping.
  - Variant-driven defaults: headings render as `h1`–`h6`, others as `p`; default wrap is balanced for headings and pretty for body.

- **Migration**
  - Change `<Text variant="mono">` to `<Text monospace>`.
  - If you relied on headings rendering as `<p>`, set `as` explicitly to keep your outline.
  - Prefer `formatter` with raw numbers instead of pre-formatting; add `tabularNums` in tables.
  - Remove `className` usage on `Text`; use its props and compose layout with `Box`.

<sup>Written for commit 4746c5b3ddd7bd0cfbb67f692cc8309256a75bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

