### PR TITLE
Add preview access feature flag

### DIFF
--- a/clients/apps/web/src/components/Landing/Pricing.tsx
+++ b/clients/apps/web/src/components/Landing/Pricing.tsx
@@ -23,7 +23,7 @@ const TIERS: Tier[] = [
     free: true,
     desc: 'Free to start validating ideas.',
     fees: ['5.00% + 50¢ per transaction'],
-    features: ['All features to sell', 'Standard Support'],
+    features: ['All features to sell', 'Standard support'],
   },
   {
     name: 'Pro',
@@ -31,7 +31,11 @@ const TIERS: Tier[] = [
     period: '/month',
     desc: 'For builders & early teams.',
     fees: ['3.80% + 40¢ per transaction'],
-    features: ['All features on Starter', 'Prioritized Support'],
+    features: [
+      'All features on Starter',
+      'Preview access to new features',
+      'Prioritized support',
+    ],
   },
   {
     name: 'Growth',
@@ -39,7 +43,11 @@ const TIERS: Tier[] = [
     period: '/month',
     desc: 'For scaling startups.',
     fees: ['3.60% + 35¢ per transaction'],
-    features: ['All features on Pro', 'Prioritized Support'],
+    features: [
+      'All features on Pro',
+      'Preview access to new features',
+      'Prioritized support',
+    ],
   },
   {
     name: 'Scale',
@@ -47,7 +55,12 @@ const TIERS: Tier[] = [
     period: '/month',
     desc: 'For fast growing businesses.',
     fees: ['3.40% + 30¢ per transaction'],
-    features: ['All features on Growth', 'Slack Channel', 'P1 Support'],
+    features: [
+      'All features on Growth',
+      'Preview access to new features',
+      'Shared Slack channel',
+      'P1 Support',
+    ],
   },
 ]
 

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24966,6 +24966,12 @@ export interface components {
        * @default false
        */
       slack_benefit_enabled: boolean
+      /**
+       * Preview Access Enabled
+       * @description If this organization has preview access to new features enabled
+       * @default false
+       */
+      preview_access_enabled: boolean
     }
     /**
      * OrganizationFeatureSettingsUpdate

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -81,6 +81,12 @@ BenefitGrantWebhookPayload = (
 class PolarSelfService:
     INITIAL_MEMBER_DELAY_MS = 1000
 
+    PREVIEW_ACCESS_FEATURE_FLAGS = (
+        "reset_proration_behavior_enabled",
+        "off_session_charges_enabled",
+        "slack_benefit_enabled",
+    )
+
     @property
     def is_configured(self) -> bool:
         return settings.POLAR_SELF_ENABLED
@@ -655,6 +661,7 @@ class PolarSelfService:
             if not isinstance(benefit_type, str) or benefit_type not in (
                 "transaction_fee",
                 "support",
+                "preview_access",
             ):
                 return
 
@@ -669,6 +676,10 @@ class PolarSelfService:
                     )
                 case "support":
                     await self._apply_support(session, organization_id, active_grant)
+                case "preview_access":
+                    await self._apply_preview_access(
+                        session, organization_id, active_grant
+                    )
 
     async def handle_order_created_event(
         self, payload: WebhookOrderCreatedPayload
@@ -955,6 +966,31 @@ class PolarSelfService:
                 tenant_external_id=str(organization_id),
                 tier_external_id=effective_tier_external_id,
             )
+
+    async def _apply_preview_access(
+        self,
+        session: AsyncSession,
+        organization_id: uuid.UUID,
+        grant: "BenefitGrant | None",
+    ) -> None:
+        enabled = grant is not None
+
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(
+            organization_id, include_blocked=True
+        )
+        if organization is None:
+            return
+
+        with logfire.span(
+            "polar_self.webhook.preview_access.applied",
+            organization_id=str(organization_id),
+            enabled=enabled,
+        ):
+            organization.feature_settings = {
+                **organization.feature_settings,
+                **{flag: enabled for flag in self.PREVIEW_ACCESS_FEATURE_FLAGS},
+            }
 
     async def _fetch_active_grant(
         self, customer_id: str, benefit_type: str

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -85,6 +85,7 @@ class PolarSelfService:
         "reset_proration_behavior_enabled",
         "off_session_charges_enabled",
         "slack_benefit_enabled",
+        "preview_access_enabled",
     )
 
     @property

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -169,6 +169,10 @@ class OrganizationFeatureSettings(Schema):
     slack_benefit_enabled: bool = Field(
         False, description="Enables the slack shared channel benefit"
     )
+    preview_access_enabled: bool = Field(
+        False,
+        description="If this organization has preview access to new features enabled",
+    )
 
 
 class OrganizationFeatureSettingsUpdate(Schema):

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -61,6 +61,7 @@ _PREVIEW_FLAGS_ENABLED = {
     "reset_proration_behavior_enabled": True,
     "off_session_charges_enabled": True,
     "slack_benefit_enabled": True,
+    "preview_access_enabled": True,
 }
 _PREVIEW_FLAGS_DISABLED = {flag: False for flag in _PREVIEW_FLAGS_ENABLED}
 _CUSTOMER_ID = _CUSTOMER_DICT["id"]

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -13,6 +13,7 @@ from polar_sdk.models import (
     SubscriptionProrationBehavior,
     WebhookBenefitGrantCreatedPayload,
     WebhookBenefitGrantRevokedPayload,
+    WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
 )
 from pytest_mock import MockerFixture
@@ -56,6 +57,12 @@ _CUSTOMER_DICT: dict[str, Any] = {
 }
 
 _BENEFIT_ID = "00000000-0000-0000-0000-0000000000b1"
+_PREVIEW_FLAGS_ENABLED = {
+    "reset_proration_behavior_enabled": True,
+    "off_session_charges_enabled": True,
+    "slack_benefit_enabled": True,
+}
+_PREVIEW_FLAGS_DISABLED = {flag: False for flag in _PREVIEW_FLAGS_ENABLED}
 _CUSTOMER_ID = _CUSTOMER_DICT["id"]
 
 
@@ -145,6 +152,10 @@ def _make_support_grant(
     )
 
 
+def _make_preview_grant(*, benefit_id: str = _BENEFIT_ID) -> BenefitGrant:
+    return _make_grant(benefit_id=benefit_id, metadata={"type": "preview_access"})
+
+
 def _make_payload(
     event_type: str,
     *,
@@ -210,6 +221,25 @@ def organization_repository_mock(mocker: MockerFixture) -> MagicMock:
     active_organization = MagicMock(spec=Organization)
     active_organization.is_active.return_value = True
     repository.get_by_id = AsyncMock(return_value=active_organization)
+    mocker.patch(
+        "polar.integrations.polar.service.OrganizationRepository.from_session",
+        return_value=repository,
+    )
+    return repository
+
+
+@pytest.fixture
+def preview_access_org_repository_mock(mocker: MockerFixture) -> MagicMock:
+    """Repository whose loaded organization carries a real feature_settings dict.
+
+    ``organization_repository_mock`` returns a bare ``MagicMock`` whose
+    ``feature_settings`` is itself a mock, which can't be dict-unpacked. The
+    preview-access path reassigns that dict, so it needs a real one.
+    """
+    repository = MagicMock()
+    organization = MagicMock(spec=Organization)
+    organization.feature_settings = {}
+    repository.get_by_id = AsyncMock(return_value=organization)
     mocker.patch(
         "polar.integrations.polar.service.OrganizationRepository.from_session",
         return_value=repository,
@@ -853,6 +883,118 @@ class TestHandleBenefitGrantEvent:
 
         list_grants_mock.assert_not_awaited()
         set_platform_fee_mock.assert_not_awaited()
+
+    async def test_preview_access_created_enables_flags(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        list_grants_mock.return_value = [_make_preview_grant()]
+        payload = WebhookBenefitGrantCreatedPayload.model_validate(
+            _make_payload("benefit_grant.created", metadata={"type": "preview_access"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        list_grants_mock.assert_awaited_once_with(customer_id=_CUSTOMER_ID)
+        organization = preview_access_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == _PREVIEW_FLAGS_ENABLED
+
+    async def test_preview_access_updated_enables_flags(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        list_grants_mock.return_value = [_make_preview_grant()]
+        payload = WebhookBenefitGrantUpdatedPayload.model_validate(
+            _make_payload("benefit_grant.updated", metadata={"type": "preview_access"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        organization = preview_access_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == _PREVIEW_FLAGS_ENABLED
+
+    async def test_preview_access_revoked_disables_flags(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        list_grants_mock.return_value = []
+        payload = WebhookBenefitGrantRevokedPayload.model_validate(
+            _make_payload("benefit_grant.revoked", metadata={"type": "preview_access"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        organization = preview_access_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == _PREVIEW_FLAGS_DISABLED
+
+    async def test_preview_access_revoked_with_remaining_grant_keeps_flags(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        # Overlapping grant still active when the revoke event arrives.
+        list_grants_mock.return_value = [_make_preview_grant(benefit_id="other")]
+        payload = WebhookBenefitGrantRevokedPayload.model_validate(
+            _make_payload("benefit_grant.revoked", metadata={"type": "preview_access"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        organization = preview_access_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == _PREVIEW_FLAGS_ENABLED
+
+
+@pytest.mark.asyncio
+class TestApplyPreviewAccess:
+    async def test_active_grant_enables_and_preserves_other_flags(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+    ) -> None:
+        organization = preview_access_org_repository_mock.get_by_id.return_value
+        organization.feature_settings = {"member_model_enabled": True}
+
+        await polar_self._apply_preview_access(
+            session_mock, ORG_A, _make_preview_grant()
+        )
+
+        preview_access_org_repository_mock.get_by_id.assert_awaited_once_with(
+            ORG_A, include_blocked=True
+        )
+        assert organization.feature_settings == {
+            "member_model_enabled": True,
+            **_PREVIEW_FLAGS_ENABLED,
+        }
+
+    async def test_no_grant_disables_flags(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+    ) -> None:
+        organization = preview_access_org_repository_mock.get_by_id.return_value
+        organization.feature_settings = {**_PREVIEW_FLAGS_ENABLED}
+
+        await polar_self._apply_preview_access(session_mock, ORG_A, None)
+
+        assert organization.feature_settings == _PREVIEW_FLAGS_DISABLED
+
+    async def test_missing_organization_is_silent_noop(
+        self,
+        session_mock: AsyncSession,
+        preview_access_org_repository_mock: MagicMock,
+    ) -> None:
+        preview_access_org_repository_mock.get_by_id.return_value = None
+
+        await polar_self._apply_preview_access(
+            session_mock, ORG_A, _make_preview_grant()
+        )
 
 
 def _make_product(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a "Preview access" benefit that toggles org feature flags via webhook events and surfaces it on paid tiers. Adds a catch-all `preview_access_enabled` flag for future-proofing.

- **New Features**
  - Backend: Handles `preview_access` grants on created/updated/revoked to enable/disable flags: `reset_proration_behavior_enabled`, `off_session_charges_enabled`, `slack_benefit_enabled`, `preview_access_enabled`. Preserves other `feature_settings` and exposes `preview_access_enabled` in the client API.
  - UI: Pricing shows “Preview access to new features” on Pro, Growth, and Scale. Copy tweaks (“Standard support”, “Prioritized support”, “Shared Slack channel”).

<sup>Written for commit e69107ac462df2e08ef9caaba6b9f86517125098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

