### PR TITLE
Document current preview features

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,7 +78,8 @@
                   "features/benefits/feature-flags",
                   "features/benefits/file-downloads",
                   "features/benefits/github-access",
-                  "features/benefits/license-keys"
+                  "features/benefits/license-keys",
+                  "features/benefits/slack-shared-channel"
                 ]
               },
               {

--- a/docs/features/benefits/slack-shared-channel.mdx
+++ b/docs/features/benefits/slack-shared-channel.mdx
@@ -1,0 +1,47 @@
+---
+title: "Shared Slack Channel"
+sidebarTitle: "Slack"
+description: "Give customers a shared Slack channel via Slack Connect"
+---
+
+The Shared Slack Channel benefit automatically provisions a dedicated Slack channel for each customer and shares it with their workspace through [Slack Connect](https://slack.com/connect).
+
+- A new channel is created in your Slack workspace for every customer who gets the benefit
+- The channel is shared with the customer's own workspace — no need for them to join yours
+- Channels can be archived automatically when the benefit is revoked
+
+<Note>
+  The Shared Slack Channel benefit is currently in preview. If you're on a paid plan, you'll be able
+  to create a Shared Slack Channel benefit.
+</Note>
+
+## Create Shared Slack Channel Benefit
+
+1. Go to [`Benefits`](https://polar.sh/to/dashboard/products/benefits)
+2. Click `+ New Benefit` to create a new benefit
+3. Choose `Shared Slack Channel` as the `Type`
+
+### **Connect your Slack workspace**
+
+The first time you create this benefit, you'll be prompted to connect the Slack workspace where channels should be created. You can reuse the same workspace across multiple benefits.
+
+### **Channel name template**
+
+Channel names are generated from a template, so every customer's channel follows the same naming convention. The template supports the following placeholders:
+
+- `{customer_name}` — the customer's name
+- `{customer_email_local}` — the local part of the customer's email (everything before the `@`)
+- `{metadata.<key>}` — any value stored in the customer's metadata, e.g. `{metadata.company}`
+
+For example, `support-{customer_email_local}` produces a channel like `support-jane` for `jane@acme.com`.
+
+### **Other options**
+
+- **Private channel** — create the channel as private. Recommended, and enabled by default.
+- **Welcome message** — an optional message posted to the channel right after it's created.
+- **Team invitees** — members of your Slack workspace to automatically invite to every channel created for this benefit.
+- **Archive on revoke** — archive the channel when the benefit is revoked (for example, when a subscription is canceled). Enabled by default.
+
+## Customer Experience
+
+When a customer is granted the benefit, they're asked for the email address of an admin in their own Slack workspace. Polar creates the channel, invites your team members, posts your welcome message, and sends a Slack Connect invitation to that admin. Once they accept, the shared channel appears in their workspace and you can start talking right away.

--- a/docs/features/orders.mdx
+++ b/docs/features/orders.mdx
@@ -5,7 +5,7 @@ description: "Every paid transaction on Polar is an order."
 
 An **order** is the record of a single paid transaction on Polar. Every successful checkout, subscription cycle, and subscription change generates an order — it's where the money, the tax, the invoice, and the link back to the [product](/features/products) and [customer](/features/customer-management) live.
 
-If [subscriptions](/features/subscriptions/introduction) are the *relationship* with a customer, orders are the *individual payments* inside that relationship.
+If [subscriptions](/features/subscriptions/introduction) are the _relationship_ with a customer, orders are the _individual payments_ inside that relationship.
 
 ## When orders are created
 
@@ -18,16 +18,79 @@ Polar creates an order in all of these cases:
 
 Each order carries a `billing_reason` that tells you which of these it is: `purchase`, `subscription_create`, `subscription_cycle`, or `subscription_update`.
 
+## Arbitrary charges
+
+Sometimes you need to charge a customer an amount that doesn't originate from a checkout or a subscription renewal — a usage overage, a one-off professional-services fee, or a manual top-up. Polar lets you run these **off-session charges** against a customer's saved payment method, without the customer being present.
+
+<Note>
+  Off-session charges are currently in preview. You'll only be able to run off-session charges if
+  you are on a paid plan.
+</Note>
+
+An off-session charge is a two-step flow: you create a **draft order**, then **finalize** it to attempt the charge. Both endpoints require the `orders:write` scope and the sales-management permission on the organization.
+
+### 1. Create a draft order
+
+`POST /v1/orders/` creates an order in `draft` status with no invoice number — nothing is charged yet. You reference an existing customer and a one-time product, and optionally override the amount and description:
+
+| Field             | Required | Description                                                                                                            |
+| ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `customer_id`     | Yes      | The customer to charge. Must belong to the organization.                                                               |
+| `product_id`      | Yes      | A one-time product to charge for. Only fixed-price and free products are supported.                                    |
+| `amount`          | No       | A custom amount in the smallest currency unit (e.g. `2500` for $25.00). Overrides the product's price; defaults to it. |
+| `currency`        | No       | ISO 4217, lowercase (e.g. `usd`). Defaults to the organization's currency.                                             |
+| `description`     | No       | The line-item text shown on the invoice and receipt. Defaults to the product name.                                     |
+| `organization_id` | No       | Required unless you authenticate with an organization token.                                                           |
+
+The customer must have a complete billing address (so Polar can calculate tax) and at least one saved payment method.
+
+```bash cURL
+curl --request POST \
+  --url https://api.polar.sh/v1/orders/ \
+  --header 'Authorization: Bearer <YOUR_BEARER_TOKEN_HERE>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "customer_id": "<customer_id>",
+    "product_id": "<product_id>",
+    "amount": 2500,
+    "description": "5,000 extra tokens"
+  }'
+```
+
+The response is the draft order, including its `id`. Creating a draft fires the `order.created` webhook but does not yet email the customer.
+
+### 2. Finalize and charge
+
+`POST /v1/orders/{id}/finalize` synchronously attempts the off-session charge. By default it uses the customer's default payment method; pass `payment_method_id` to charge a specific one.
+
+```bash cURL
+curl --request POST \
+  --url https://api.polar.sh/v1/orders/<order_id>/finalize \
+  --header 'Authorization: Bearer <YOUR_BEARER_TOKEN_HERE>' \
+  --header 'Content-Type: application/json' \
+  --data '{}'
+```
+
+On success, the order transitions to `paid`, an invoice number is assigned, any [benefits](/features/benefits/introduction) attached to the product are granted, the customer is emailed their confirmation, and the [`order.paid`](/api-reference/webhooks/order.paid) webhook fires.
+
+If the charge fails, the API returns an error and the order is reverted to `draft` so you can fix the problem and finalize the same order again — no invoice number is consumed by a failed attempt:
+
+| Status | When                                                                                                                                      |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `402`  | The card was declined, the customer has no payment method, or the charge needs a 3DS / SCA challenge that can't be completed off-session. |
+| `403`  | Off-session charges aren't enabled for the organization, or its account can't currently accept payments.                                  |
+| `412`  | The order is no longer in `draft` status (for example, it was already finalized).                                                         |
+
 ## Order status
 
 An order moves through a small set of statuses over its lifetime:
 
-| Status               | Meaning                                                                                   |
-| -------------------- | ----------------------------------------------------------------------------------------- |
-| `pending`            | The order has been created and Polar is attempting to collect payment.                    |
-| `paid`               | The payment succeeded.                                                                    |
-| `refunded`           | The order has been fully refunded.                                                        |
-| `partially_refunded` | Part of the order has been refunded. See [Refunds](/features/refunds).                    |
+| Status               | Meaning                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `pending`            | The order has been created and Polar is attempting to collect payment.                   |
+| `paid`               | The payment succeeded.                                                                   |
+| `refunded`           | The order has been fully refunded.                                                       |
+| `partially_refunded` | Part of the order has been refunded. See [Refunds](/features/refunds).                   |
 | `void`               | The order will not be collected (for example, it's been voided after repeated failures). |
 
 Free orders — those with a total of zero, typically from a $0 subscription or a 100% discount — are marked `paid` immediately with no payment step.
@@ -53,9 +116,9 @@ Polar generates a PDF invoice for every paid order. You can:
 Customers can download and edit their own invoices — adding a company name, VAT number, or billing address — from the [Customer Portal](/features/customer-portal/introduction), without pulling you into a support thread.
 
 <Note>
-  Once an invoice has been generated, its billing details are frozen. If you
-  need to correct a name or address after the fact, the customer should edit
-  their invoice from the Customer Portal, which regenerates it.
+  Once an invoice has been generated, its billing details are frozen. If you need to correct a name
+  or address after the fact, the customer should edit their invoice from the Customer Portal, which
+  regenerates it.
 </Note>
 
 ## Receipts

--- a/docs/features/subscriptions/proration.mdx
+++ b/docs/features/subscriptions/proration.mdx
@@ -10,7 +10,7 @@ You pick the proration behavior either at the organization level (as the default
 
 ## Proration behaviors
 
-Polar supports three proration behaviors:
+Polar supports three standard proration behaviors:
 
 ### Invoice Immediately (`invoice`)
 
@@ -25,15 +25,14 @@ The subscription is updated **immediately**, but the prorated difference is carr
 This is typically the smoothest experience for the customer: their plan changes instantly, and they see the adjustment on their regular renewal invoice.
 
 <Note>
-  If the billing interval changes (for example, monthly to yearly), `prorate`
-  is promoted to `invoice` automatically — there's no "next invoice" on the
-  old cycle to defer the difference to.
+  If the billing interval changes (for example, monthly to yearly), `prorate` is promoted to
+  `invoice` automatically — there's no "next invoice" on the old cycle to defer the difference to.
 </Note>
 
 <Warning>
-  For `invoice` and `prorate`, the subscription update is applied only if the
-  immediate payment (if any) succeeds. If the payment fails, the API returns
-  an error and the subscription stays unchanged.
+  For `invoice` and `prorate`, the subscription update is applied only if the immediate payment (if
+  any) succeeds. If the payment fails, the API returns an error and the subscription stays
+  unchanged.
 </Warning>
 
 ### Next Period (`next_period`)
@@ -43,6 +42,19 @@ The change is **not applied immediately**. It's scheduled as a pending update an
 While a `next_period` update is pending, the subscription's `pending_update` field describes the scheduled change. Submitting a new update always supersedes the pending one: if you scheduled a `next_period` change and then make another update with `invoice` or `prorate`, the pending update is discarded and the new change is applied right away.
 
 This behavior is the safer default for downgrades where you don't want to issue credits, and for any case where you want the current period's terms to stay intact.
+
+### Opting out of proration (`reset`)
+
+The subscription switches to the new plan **immediately**, Polar invoices the **full price of the new plan** right away, and the **billing cycle is reset** to start now. No proration is applied: the customer isn't credited for the unused portion of the old period, and they aren't charged a prorated amount — they pay the full new price and begin a fresh billing period.
+
+Because the cycle restarts, the new period's anchor day becomes the day the change was made, and all future renewals follow the new schedule.
+
+Use this when a plan change should behave like a brand-new subscription — for example, when an upgrade should restart the commitment period rather than carry over the current one.
+
+<Note>
+  The `reset` proration behavior is currently in preview. You'll only be able to use the `reset`
+  proration behavior if you are on a paid plan.
+</Note>
 
 ## Setting the default behavior
 
@@ -82,7 +94,7 @@ with Polar(access_token="<YOUR_BEARER_TOKEN_HERE>") as polar:
 
 </CodeGroup>
 
-Valid values are `invoice`, `prorate`, and `next_period`.
+Valid values are `invoice`, `prorate`, and `next_period`. If your organization has access to the preview `reset` behavior, you can pass `reset` here as well.
 
 ## How the prorated amount is calculated
 
@@ -115,8 +127,8 @@ A customer subscribed to a \$20/month plan on a 30-day month (2,592,000 seconds 
 With `invoice`, a credit invoice for $14.50 is issued immediately. With `prorate`, the credit is applied on the next invoice.
 
 <Note>
-  Because proration is computed from the exact number of seconds remaining,
-  the change time-of-day matters: upgrading at noon credits a different amount
-  than upgrading at midnight. Polar always uses the real length of the current
-  billing period (so 28-, 29-, 30-, and 31-day months are all handled exactly).
+  Because proration is computed from the exact number of seconds remaining, the change time-of-day
+  matters: upgrading at noon credits a different amount than upgrading at midnight. Polar always
+  uses the real length of the current billing period (so 28-, 29-, 30-, and 31-day months are all
+  handled exactly).
 </Note>

--- a/docs/merchant-of-record/fees.mdx
+++ b/docs/merchant-of-record/fees.mdx
@@ -28,6 +28,14 @@ Each paid plan crosses over to save you money at a predictable monthly sales thr
 
 Below your plan's threshold, a lower tier is the better deal. Above it, the paid plan saves money — and you get faster support on top.
 
+## Preview features
+
+Paid plans also unlock early access to features that are still in preview. While in preview, each of these is available only on paid plans:
+
+- [Shared Slack Channel benefit](/features/benefits/slack-shared-channel) — automatically give each customer a shared Slack channel via Slack Connect.
+- [`reset` proration behavior](/features/subscriptions/proration#opting-out-of-proration-reset) — on a plan change, charge the full new-plan price and restart the billing cycle, with no proration.
+- [Off-session charges](/features/orders#arbitrary-charges) — charge a customer's saved payment method for an arbitrary amount, outside of a checkout or renewal.
+
 ## Early Member
 
 Organizations created before **May 27, 2026** stay on the Early Member rate indefinitely. This was the rate we offered while Polar was catching up on feature parity with other Merchant of Record providers, and we've committed to honoring it for everyone who signed up under it.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Docs update to cover current preview features and how to use them. Adds a new Slack benefit page, updates orders and proration guides, wires Slack page into the sidebar, and adds a preview features overview on the fees page.

- **New Features**
  - Orders: documented off-session charges via draft and finalize (`POST /v1/orders/`, `POST /v1/orders/{id}/finalize`), required `orders:write` scope and permissions, outcomes, and cURL examples.
  - Benefits: added “Shared Slack Channel” page with setup (workspace connect, channel name template placeholders, private option, welcome message, team invitees, archive on revoke) and customer flow via Slack Connect.
  - Subscriptions: documented preview `reset` proration behavior (immediate switch, full charge now, cycle reset) and noted availability.
  - Navigation: added `features/benefits/slack-shared-channel` to the sidebar.
  - Merchant of Record: added “Preview features” section on the fees page listing paid-plan access to Slack shared channels, `reset` proration, and off-session charges.

<sup>Written for commit 27752df8ec707b1b56eddeef7c101126f667b5e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

