### PR TITLE
Fix polarsource/feedback#173

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -200,7 +200,20 @@ class BillingEntryService:
         end = format_date(entry.end_timestamp.date(), locale="en_US")
         amount = entry.amount
 
-        price_label = OrderItem.format_price_label(product, price, seats=seats)
+        # Appending the current total seat count implies an amount that doesn't
+        # reconcile with the charge, so omit it for those types to avoid confusion
+        seats_for_label = (
+            None
+            if entry.type
+            in (
+                BillingEntryType.subscription_seats_increase,
+                BillingEntryType.subscription_seats_decrease,
+            )
+            else seats
+        )
+        price_label = OrderItem.format_price_label(
+            product, price, seats=seats_for_label
+        )
 
         match entry.direction:
             case BillingEntryDirection.credit:

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -490,6 +490,11 @@ class TestCreateOrderItemsFromPending:
             assert order_item.amount == 50_00
             assert order_item.proration is True
 
+            # Seat-change prorations charge a delta, not the full seat amount,
+            # so the label must not imply a total seat count (which wouldn't
+            # reconcile with the prorated amount).
+            assert "seat" not in order_item.label
+
             await create_order(
                 save_fixture,
                 customer=customer,


### PR DESCRIPTION
This doesn't impact billing but only the invoices, but it's a fair point that for proration we should rather keep out the seats as the prices won't match up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix invoice line item labels for seat-change proration entries by omitting seat counts, so amounts match the prorated charges. This addresses feedback in polarsource/feedback#173 and only affects invoice display, not billing.

- **Bug Fixes**
  - Omit seat counts in labels for `subscription_seats_increase` and `subscription_seats_decrease` line items to avoid mismatched totals.
  - Added test to ensure proration labels do not include "seat".

<sup>Written for commit ab248611bb5bfb6b199005141b1f9f5b46590f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

