### PR TITLE
Fix polarsource/feedback#172

### DIFF
--- a/server/polar/kit/http.py
+++ b/server/polar/kit/http.py
@@ -99,7 +99,13 @@ async def check_url_reachable(
             # `Location` may be a relative reference (RFC 7231). Resolve it
             # against the current URL — the same resolution httpx uses to
             # follow the redirect — so we validate the URL actually fetched.
-            absolute_location = response.url.join(location)
+            try:
+                absolute_location = response.url.join(location)
+            except httpx.InvalidURL as e:
+                # A malformed `Location` (e.g. an invalid port) can't be
+                # followed. `InvalidURL` isn't an `httpx.HTTPError`, so convert
+                # it to the handled type instead of letting it escape.
+                raise UnsafeCrawlableUrl(f"Invalid redirect URL: {e}") from e
             await validate_crawlable_url(str(absolute_location))
 
     try:

--- a/server/tests/kit/test_http.py
+++ b/server/tests/kit/test_http.py
@@ -195,6 +195,32 @@ class TestCheckUrlReachable:
         assert result.error is not None
 
     @pytest.mark.asyncio
+    async def test_malformed_redirect_location(self) -> None:
+        """A malformed `Location` (e.g. invalid port) is unreachable, not a 500.
+
+        `response.url.join(location)` raises `httpx.InvalidURL` for such
+        headers; since that isn't an `httpx.HTTPError`, it must be converted
+        to a graceful `reachable=False` result rather than escaping.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url) == "https://example.com/":
+                return httpx.Response(
+                    302, headers={"location": "https://example.com:abc/login"}
+                )
+            raise AssertionError(f"should not follow redirect to {request.url}")
+
+        with patch(
+            "anyio.getaddrinfo",
+            new=AsyncMock(return_value=_fake_getaddrinfo("93.184.216.34")),
+        ):
+            with _mock_transport(handler):
+                result = await check_url_reachable("https://example.com")
+
+        assert result.reachable is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
     async def test_unreachable_on_4xx(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(404)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gracefully handle malformed redirect Location headers in URL reachability checks. We now convert `httpx.InvalidURL` during redirect resolution into `UnsafeCrawlableUrl`, marking the URL as unreachable instead of causing a 500.

- **Bug Fixes**
  - Catch `httpx.InvalidURL` when joining redirect `Location` and raise `UnsafeCrawlableUrl` with a clear message.
  - Add a test for a redirect with an invalid port to ensure we return reachable=False with an error and do not follow the redirect.

<sup>Written for commit 6fb747ba6dfe8df8e1533c0f935dc106988dd72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

